### PR TITLE
Expression executor can now handle mixed input columns lengths

### DIFF
--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -54,6 +54,9 @@ void GpuExpressionExecutor::Initialize(const Expression& expr, GpuExpressionExec
 
 void GpuExpressionExecutor::SetInputColumns(const GPUIntermediateRelation& input_relation)
 {
+  input_count           = 0;
+  has_null_input_column = false;
+
   // Shallow copy the columns
   input_columns = input_relation.columns;
 
@@ -64,62 +67,140 @@ void GpuExpressionExecutor::SetInputColumns(const GPUIntermediateRelation& input
   }
   else
   {
-    // All columns should have the same count
-    //TODO: This is assuming that all columns have the same size, which is not always true if the pipeline source is the hash table from RIGHT join
-    const auto col = input_columns[0];
-    // The input column may be null, in which case the expression evaluation should be a no-op
-    input_count = col == nullptr            ? 0
-                  : col->row_ids == nullptr ? static_cast<cudf::size_type>(col->column_length)
-                                            : static_cast<cudf::size_type>(col->row_id_count);
+    // All columns that are not null should have the same count
+    for (const auto& col : input_columns)
+    {
+      const auto temp_count = col == nullptr ? 0
+                              : col->row_ids == nullptr
+                                ? static_cast<cudf::size_type>(col->column_length)
+                                : static_cast<cudf::size_type>(col->row_id_count);
+      if (temp_count > 0)
+      {
+        input_count = temp_count;
+      }
+      else
+      {
+        has_null_input_column = true;
+      }
+    }
   }
+}
+
+// Helper template function for HasNullLeaf()
+template <typename ExpressionT>
+bool GpuExpressionExecutor::HasNullLeafLoop(const ExpressionT& expr) const
+{
+  for (const auto& child : expr.children)
+  {
+    if (HasNullLeaf(*child))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GpuExpressionExecutor::HasNullLeaf(const Expression& expr) const
+{
+  // Check if the expression is a null reference
+  switch (expr.GetExpressionClass())
+  {
+    case ExpressionClass::BOUND_BETWEEN: {
+      const auto& between_expr = expr.Cast<BoundBetweenExpression>();
+      return HasNullLeaf(*between_expr.input) || HasNullLeaf(*between_expr.lower) ||
+             HasNullLeaf(*between_expr.upper);
+    }
+    case ExpressionClass::BOUND_CASE: {
+      const auto& case_expr = expr.Cast<BoundCaseExpression>();
+      for (const auto& case_check : case_expr.case_checks)
+      {
+        if (HasNullLeaf(*case_check.when_expr) || HasNullLeaf(*case_check.then_expr))
+        {
+          return true;
+        }
+      }
+      return HasNullLeaf(*case_expr.else_expr);
+    }
+    case ExpressionClass::BOUND_CAST: {
+      const auto& cast_expr = expr.Cast<BoundCastExpression>();
+      return HasNullLeaf(*cast_expr.child);
+    }
+    case ExpressionClass::BOUND_COMPARISON: {
+      const auto& comp_expr = expr.Cast<BoundComparisonExpression>();
+      return HasNullLeaf(*comp_expr.left) || HasNullLeaf(*comp_expr.right);
+    }
+    case ExpressionClass::BOUND_CONJUNCTION: {
+      return HasNullLeafLoop(expr.Cast<BoundConjunctionExpression>());
+    }
+    case ExpressionClass::BOUND_CONSTANT: {
+      // Base case
+      return false;
+    }
+    case ExpressionClass::BOUND_FUNCTION: {
+      return HasNullLeafLoop(expr.Cast<BoundFunctionExpression>());
+    }
+    case ExpressionClass::BOUND_OPERATOR: {
+      return HasNullLeafLoop(expr.Cast<BoundOperatorExpression>());
+    }
+    case ExpressionClass::BOUND_REF: {
+      // Base case
+      const auto& ref_expr = expr.Cast<BoundReferenceExpression>();
+      const auto& col      = input_columns[ref_expr.index];
+      return col == nullptr || col->data_wrapper.data == nullptr;
+    }
+    default:
+      throw InternalException("HasNullLeaf called on an expression [" + expr.ToString() +
+                              "] with unsupported expression class!");
+  }
+  return false;
 }
 
 void GpuExpressionExecutor::Execute(const GPUIntermediateRelation& input_relation,
                                     GPUIntermediateRelation& output_relation)
 {
-  D_ASSERT(expressions.size() == output_relation.columns);
+  D_ASSERT(expressions.size() == output_relation.columns.size());
   D_ASSERT(!expressions.empty());
+
   SetInputColumns(input_relation);
 
   // Loop over expressions to execute
   for (idx_t i = 0; i < expressions.size(); ++i)
   {
+    const auto& expr = *expressions[i];
+
     // If the expression is a reference, just pass it through
-    if (expressions[i]->expression_class == ExpressionClass::BOUND_REF)
+    if (expr.expression_class == ExpressionClass::BOUND_REF)
     {
-      auto input_idx             = expressions[i]->Cast<BoundReferenceExpression>().index;
+      auto input_idx             = expr.Cast<BoundReferenceExpression>().index;
       output_relation.columns[i] = input_relation.columns[input_idx];
       continue;
     }
 
-    // Make placeholder column
+    // Make placeholder output column
     output_relation.columns[i] =
-      make_shared_ptr<GPUColumn>(0,
-                                 convertLogicalTypeToColumnType(expressions[i]->return_type),
-                                 nullptr);
+      make_shared_ptr<GPUColumn>(0, convertLogicalTypeToColumnType(expr.return_type), nullptr);
 
-    // If input count is zero, no-op
-    if (input_count == 0)
+    // Skip execution if the input count is zero or if there is a null leaf
+    if (input_count == 0 || (has_null_input_column && HasNullLeaf(expr)))
     {
       continue;
     }
 
-    // Execute the expression
+    // Otherwise, execute the expression
     auto result = ExecuteExpression(i);
 
     // Cast the `result` from libcudf to `return_type` if `result` has different types.
     // E.g., `extract(year from col)` from libcudf returns int16_t but duckdb requires int64_t
     auto cudf_return_type = GpuExpressionState::GetCudfType(expressions[i]->return_type);
-    if (result->type().id() != cudf_return_type.id()) {
-      result = cudf::cast(result->view(),
-                          cudf_return_type,
-                          cudf::get_default_stream(),
-                          resource_ref);
+    if (result->type().id() != cudf_return_type.id())
+    {
+      result =
+        cudf::cast(result->view(), cudf_return_type, cudf::get_default_stream(), resource_ref);
     }
 
     // Transfer to output relation (zero copy)
     output_relation.columns[i]->setFromCudfColumn(*result,
-                                                  false,
+                                                  false, // How to know?
                                                   nullptr,
                                                   0,
                                                   &GPUBufferManager::GetInstance());
@@ -134,12 +215,12 @@ void GpuExpressionExecutor::Select(GPUIntermediateRelation& input_relation,
 
   SetInputColumns(input_relation);
 
-  // If input count is zero, no-op
-  if (input_count == 0)
+  // If the input count is zero or if there is a null leaf, just materialize
+  if (input_count == 0 || (has_null_input_column && HasNullLeaf(*expressions[0])))
   {
     HandleMaterializeRowIDs(input_relation,
                             output_relation,
-                            input_count,
+                            0,
                             nullptr,
                             &GPUBufferManager::GetInstance(),
                             true);

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -93,11 +93,11 @@ struct ComparisonDispatcher
                                               return_type);
         case cudf::type_id::FLOAT32:
           return DoScalarComparison<float_t>(left->view(),
-                                             right_value.GetValue<float>(),
+                                             right_value.GetValue<float_t>(),
                                              return_type);
         case cudf::type_id::FLOAT64:
           return DoScalarComparison<double_t>(left->view(),
-                                              right_value.GetValue<double>(),
+                                              right_value.GetValue<double_t>(),
                                               return_type);
         case cudf::type_id::BOOL8:
           return DoScalarComparison<bool>(left->view(), right_value.GetValue<bool>(), return_type);

--- a/src/include/expression_executor/gpu_dispatcher.hpp
+++ b/src/include/expression_executor/gpu_dispatcher.hpp
@@ -22,7 +22,7 @@ enum class StringMatchingType : uint8_t
 //----------Gpu Dispatcher----------//
 struct GpuDispatcher
 {
-    //----------Materialize----------//
+  //----------Materialize----------//
   static std::unique_ptr<cudf::column> DispatchMaterialize(const GPUColumn* input,
                                                            rmm::device_async_resource_ref mr);
 
@@ -33,7 +33,7 @@ struct GpuDispatcher
                                                          rmm::device_async_resource_ref mr);
 
   //----------String Matching----------//
-  template<StringMatchingType MatchType>
+  template <StringMatchingType MatchType>
   static std::unique_ptr<cudf::column> DispatchStringMatching(const cudf::column_view& input,
                                                               const std::string& match_str,
                                                               rmm::device_async_resource_ref mr);
@@ -41,22 +41,6 @@ struct GpuDispatcher
   //----------Selection----------//
   static std::tuple<uint64_t*, uint64_t> DispatchSelect(const cudf::column_view& bitmap,
                                                         rmm::device_async_resource_ref mr);
-
-  //----------Utilities----------//
-  // For substring
-  static std::unique_ptr<cudf::column> MakeColumnFromPtrs(char* data,
-                                                          uint64_t* offsets,
-                                                          uint64_t count,
-                                                          rmm::device_async_resource_ref mr);
-  // For matching
-  static std::unique_ptr<cudf::column> MakeColumnFromRowIds(uint64_t* row_ids,
-                                                            uint64_t row_id_count,
-                                                            uint64_t input_count,
-                                                            rmm::device_async_resource_ref mr);
-
-  // For extracting data from cudf::column types for sirius string APIs
-  static std::tuple<uint64_t, char*, uint64_t*, uint64_t>
-  PrepareStringData(const cudf::column_view& input);
 };
 
 } // namespace sirius

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -46,6 +46,8 @@ struct GpuExpressionExecutor
   rmm::device_async_resource_ref resource_ref = GPUBufferManager::GetInstance().mr;
   // The input count for the current relation (needed for materializing constants)
   cudf::size_type input_count;
+  // Whether some input column is empty
+  bool has_null_input_column;
   // Static flag indicating whether to use cudf or sirius for string functions
   static constexpr bool use_cudf = USE_CUDF_EXPR;
 
@@ -58,6 +60,12 @@ struct GpuExpressionExecutor
 
   // Set the input count and columns for the expression executor
   void SetInputColumns(const GPUIntermediateRelation& input_relation);
+
+  // Before evaluating an expression, check the leaves for nullptrs
+  // (Assumes the input columns have already been set)
+  bool HasNullLeaf(const Expression& expr) const;
+  template <typename ExpressionT>
+  bool HasNullLeafLoop(const ExpressionT& expr) const;
 
   // Execute the set of expressions with the given input relation and store the result in the output
   // relation (Provides the main interface with client code for Projections).


### PR DESCRIPTION
This PR introduces the ability for the expression executor to handle cases in which some columns are empty and some are not, and those expressions with nonempty input columns must be evaluated and those with some empty input column must not.

E.g.,
Input columns: A, B, C, C is empty (count = 0)
Input expressions: A < B, B < C
Result: A < B is evaluated, the output column for B < C is empty.

There were 2 design options:
1) return nullptr from ExecuteReference and pull the nullptr through the expression tree to the root
2) traverse the expression tree up front to determine if an input column for an expression is empty

I chose option (2) because option (1) might still execute wasted GPU logic while pulling the nullptr through the expression tree. For example, (A + B) < C, C is empty. If option (1) were chosen, A + B would be evaluated before the execution of the root expression sees that the right input C is empty. Option (2) does, however, traverse the expression tree twice on the CPU, but this is fast and is only done when at least one input column in the input relation is empty.

I also deleted some dead code from the gpu_dispatcher.hpp header.