### PR TITLE
Switch from cudf::size_type to int64_t for string offsets (expressions)

### DIFF
--- a/src/cuda/expression_executor/CMakeLists.txt
+++ b/src/cuda/expression_executor/CMakeLists.txt
@@ -2,5 +2,6 @@ set(CUDA_SOURCES
         ${CUDA_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/gpu_dispatch_string.cu
         ${CMAKE_CURRENT_SOURCE_DIR}/gpu_dispatch_materialize.cu
+        ${CMAKE_CURRENT_SOURCE_DIR}/gpu_dispatch_select.cu
         PARENT_SCOPE
 )

--- a/src/cuda/expression_executor/gpu_dispatch_materialize.cu
+++ b/src/cuda/expression_executor/gpu_dispatch_materialize.cu
@@ -21,9 +21,10 @@ struct MaterializeNumeric
   static std::unique_ptr<cudf::column> Do(const T* input_data,
                                           const uint64_t* row_ids,
                                           uint64_t row_id_count,
-                                          rmm::device_async_resource_ref mr)
+                                          rmm::device_async_resource_ref mr,
+                                          rmm::cuda_stream_view stream = rmm::cuda_stream_default)
   {
-    auto stream = cudf::get_default_stream();
+    // Define the thrust execution policy
     rmm::mr::thrust_allocator<uint8_t> thrust_allocator(stream, mr);
     auto exec = thrust::cuda::par(thrust_allocator).on(stream);
 
@@ -55,9 +56,9 @@ struct MaterializeString
     {}
 
     // Operator
-    __device__ __forceinline__ cudf::size_type operator()(uint64_t row_id) const
+    __device__ __forceinline__ int64_t operator()(uint64_t row_id) const
     {
-      return static_cast<cudf::size_type>(input_offsets[row_id + 1] - input_offsets[row_id]);
+      return static_cast<int64_t>(input_offsets[row_id + 1] - input_offsets[row_id]);
     }
   };
 
@@ -68,14 +69,14 @@ struct MaterializeString
     const uint64_t* row_ids;
     const uint64_t* input_offsets;
     const uint8_t* input_data;
-    cudf::size_type* output_offsets;
+    int64_t* output_offsets;
     uint8_t* output_data;
 
     // Constructor
     CopyData(const uint64_t* row_ids,
              const uint64_t* input_offsets,
              const uint8_t* input_data,
-             cudf::size_type* output_offsets,
+             int64_t* output_offsets,
              uint8_t* output_data)
         : row_ids(row_ids)
         , input_offsets(input_offsets)
@@ -101,21 +102,21 @@ struct MaterializeString
                                           const uint64_t* input_offsets,
                                           const uint64_t* row_ids,
                                           uint64_t row_id_count,
-                                          rmm::device_async_resource_ref mr)
+                                          rmm::device_async_resource_ref mr,
+                                          rmm::cuda_stream_view stream = rmm::cuda_stream_default)
   {
     static_assert(std::is_same_v<int32_t, cudf::size_type>); // Sanity check
 
-    auto stream = cudf::get_default_stream();
+    // Define the thrust execution policy
     rmm::mr::thrust_allocator<uint8_t> thrust_allocator(stream, mr);
     auto exec             = thrust::cuda::par(thrust_allocator).on(stream);
     uint64_t offset_count = row_id_count + 1;
 
     // Allocate temporary string length and output offsets buffer
-    rmm::device_uvector<cudf::size_type> temp_string_lengths(offset_count, stream, mr);
-    rmm::device_uvector<cudf::size_type> output_offsets(offset_count, stream, mr);
+    rmm::device_uvector<int64_t> temp_string_lengths(offset_count, stream, mr);
+    rmm::device_uvector<int64_t> output_offsets(offset_count, stream, mr);
     // Set the last string length to 0, so that the exclusive scan places the total sum at the end
-    CUDF_CUDA_TRY(
-      cudaMemset(temp_string_lengths.data() + row_id_count, 0, sizeof(cudf::size_type)));
+    CUDF_CUDA_TRY(cudaMemset(temp_string_lengths.data() + row_id_count, 0, sizeof(int64_t)));
 
     // Gather the string lengths
     thrust::transform(exec,
@@ -129,15 +130,8 @@ struct MaterializeString
                            temp_string_lengths.begin(),
                            temp_string_lengths.end(),
                            output_offsets.begin(),
-                           static_cast<cudf::size_type>(0));
+                           static_cast<int64_t>(0));
     const auto output_bytes = output_offsets.back_element(stream);
-
-    // Check for overflow
-    if (output_bytes < 0)
-    {
-      throw InternalException("Dispatch[Materialize]: String data greater than INT32_MAX "
-                              "detedted!");
-    }
 
     // Allocate output data buffer
     rmm::device_uvector<uint8_t> output_data(output_bytes, stream, mr);
@@ -150,7 +144,7 @@ struct MaterializeString
       CopyData(row_ids, input_offsets, input_data, output_offsets.data(), output_data.data()));
 
     // Return a cudf::column
-    auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+    auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT64},
                                                       static_cast<cudf::size_type>(offset_count),
                                                       output_offsets.release(),
                                                       rmm::device_buffer{0, stream, mr},
@@ -165,7 +159,8 @@ struct MaterializeString
 
 // Materialize a GPUColumn directly into a cudf::column
 std::unique_ptr<cudf::column> GpuDispatcher::DispatchMaterialize(const GPUColumn* input,
-                                                                 rmm::device_async_resource_ref mr)
+                                                                 rmm::device_async_resource_ref mr,
+                                                                 rmm::cuda_stream_view stream)
 {
   D_ASSERT(input->row_ids != nullptr);
   D_ASSERT(input->row_ids->size() > 0);
@@ -179,38 +174,46 @@ std::unique_ptr<cudf::column> GpuDispatcher::DispatchMaterialize(const GPUColumn
       return MaterializeNumeric<int32_t>::Do(reinterpret_cast<const int32_t*>(input_data),
                                              input->row_ids,
                                              input->row_id_count,
-                                             mr);
+                                             mr,
+                                             stream);
     case GPUColumnTypeId::INT64:
       return MaterializeNumeric<uint64_t>::Do(reinterpret_cast<const uint64_t*>(input_data),
                                               input->row_ids,
                                               input->row_id_count,
-                                              mr);
+                                              mr,
+                                              stream);
     case GPUColumnTypeId::FLOAT32:
       return MaterializeNumeric<float_t>::Do(reinterpret_cast<const float_t*>(input_data),
                                              input->row_ids,
                                              input->row_id_count,
-                                             mr);
+                                             mr,
+                                             stream);
     case GPUColumnTypeId::FLOAT64:
       return MaterializeNumeric<double_t>::Do(reinterpret_cast<const double_t*>(input_data),
                                               input->row_ids,
                                               input->row_id_count,
-                                              mr);
+                                              mr,
+                                              stream);
     case GPUColumnTypeId::BOOLEAN:
       return MaterializeNumeric<bool>::Do(reinterpret_cast<const bool*>(input_data),
                                           input->row_ids,
                                           input->row_id_count,
-                                          mr);
+                                          mr,
+                                          stream);
     case GPUColumnTypeId::DATE:
-      return MaterializeNumeric<cudf::timestamp_D>::Do(reinterpret_cast<const cudf::timestamp_D*>(input_data),
-                                                       input->row_ids,
-                                                       input->row_id_count,
-                                                       mr);
+      return MaterializeNumeric<cudf::timestamp_D>::Do(
+        reinterpret_cast<const cudf::timestamp_D*>(input_data),
+        input->row_ids,
+        input->row_id_count,
+        mr,
+        stream);
     case GPUColumnTypeId::VARCHAR:
       return MaterializeString::Do(input_data,
                                    input_offsets,
                                    input->row_ids,
                                    input->row_id_count,
-                                   mr);
+                                   mr,
+                                   stream);
     default:
       throw InternalException("Unsupported sirius column type in `Dispatch[Materialize]`: %d",
                               static_cast<int>(input->data_wrapper.type.id()));

--- a/src/cuda/expression_executor/gpu_dispatch_select.cu
+++ b/src/cuda/expression_executor/gpu_dispatch_select.cu
@@ -1,0 +1,45 @@
+#include "expression_executor/gpu_dispatcher.hpp"
+#include "gpu_buffer_manager.hpp"
+#include <cub/cub.cuh>
+#include <tuple>
+
+namespace duckdb
+{
+namespace sirius
+{
+
+//----------Select----------//
+std::tuple<uint64_t*, uint64_t> GpuDispatcher::DispatchSelect(const cudf::column_view& bitmap,
+                                                              rmm::device_async_resource_ref mr,
+                                                              rmm::cuda_stream_view stream)
+{
+  // The row ids are owned by the query executor and so must be managed by the buffer manager
+  auto* gpu_buffer_manager = &GPUBufferManager::GetInstance();
+  uint64_t* row_ids = gpu_buffer_manager->customCudaMalloc<uint64_t>(bitmap.size(), 0, false);
+  rmm::device_scalar<uint64_t> d_num_selected(0, stream, mr);
+
+  size_t temp_storage_bytes = 0;
+  uint64_t num_selected     = 0;
+  cub::DeviceSelect::Flagged(nullptr,
+                             temp_storage_bytes,
+                             thrust::make_counting_iterator<uint64_t>(0),
+                             bitmap.data<bool>(),
+                             row_ids,
+                             d_num_selected.data(),
+                             bitmap.size(),
+                             stream);
+  rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
+  cub::DeviceSelect::Flagged(temp_storage.data(),
+                             temp_storage_bytes,
+                             thrust::make_counting_iterator<uint64_t>(0),
+                             bitmap.data<bool>(),
+                             row_ids,
+                             d_num_selected.data(),
+                             bitmap.size(),
+                             stream);
+  num_selected = d_num_selected.value(stream);
+  return std::make_tuple(row_ids, num_selected);
+}
+
+} // namespace sirius
+} // namespace duckdb

--- a/src/cuda/expression_executor/gpu_dispatch_string.cu
+++ b/src/cuda/expression_executor/gpu_dispatch_string.cu
@@ -1,5 +1,4 @@
 #include "expression_executor/gpu_dispatcher.hpp"
-#include "gpu_buffer_manager.hpp"
 #include "gpu_physical_strings_matching.hpp"
 #include "gpu_physical_substring.hpp"
 #include <cub/cub.cuh>
@@ -8,7 +7,6 @@
 #include <cudf/unary.hpp>
 #include <memory>
 #include <thrust/iterator/counting_iterator.h>
-#include <tuple>
 
 namespace duckdb
 {
@@ -21,14 +19,16 @@ namespace sirius
 std::unique_ptr<cudf::column> GpuDispatcher::DispatchSubstring(const cudf::column_view& input,
                                                                uint64_t start_idx,
                                                                uint64_t len,
-                                                               rmm::device_async_resource_ref mr)
+                                                               rmm::device_async_resource_ref mr,
+                                                               rmm::cuda_stream_view stream)
 {
   return DoSubstring(input.data<char>(),
                      input.size(),
-                     input.child(0).data<cudf::size_type>(),
-                     static_cast<cudf::size_type>(start_idx),
-                     static_cast<cudf::size_type>(len),
-                     mr);
+                     input.child(0).data<int64_t>(),
+                     static_cast<int64_t>(start_idx),
+                     static_cast<int64_t>(len),
+                     mr,
+                     stream);
 };
 
 //----------String Matching----------//
@@ -36,21 +36,22 @@ template <StringMatchingType MatchType>
 std::unique_ptr<cudf::column>
 GpuDispatcher::DispatchStringMatching(const cudf::column_view& input,
                                       const std::string& match_str,
-                                      rmm::device_async_resource_ref mr)
+                                      rmm::device_async_resource_ref mr,
+                                      rmm::cuda_stream_view stream)
 {
-  auto stream = cudf::get_default_stream();
   cudf::strings_column_view input_view(input);
-  const auto byte_count = static_cast<cudf::size_type>(input_view.chars_size(stream));
+  const auto byte_count = input_view.chars_size(stream);
 
   if constexpr (MatchType == StringMatchingType::LIKE || MatchType == StringMatchingType::NOT_LIKE)
   {
     std::vector<std::string> match_terms = string_split(match_str, SPLIT_DELIMITER);
-    auto result = DoMultiStringMatching(input.data<char>(),
+    auto result                          = DoMultiStringMatching(input.data<char>(),
                                         input.size(),
-                                        input.child(0).data<cudf::size_type>(),
+                                        input.child(0).data<int64_t>(),
                                         byte_count,
                                         match_terms,
-                                        mr);
+                                        mr,
+                                        stream);
     if constexpr (MatchType == StringMatchingType::LIKE)
     {
       return std::move(result);
@@ -63,53 +64,22 @@ GpuDispatcher::DispatchStringMatching(const cudf::column_view& input,
   {
     return DoStringMatching(input.data<char>(),
                             input.size(),
-                            input.child(0).data<cudf::size_type>(),
+                            input.child(0).data<int64_t>(),
                             byte_count,
                             match_str,
-                            mr);
+                            mr,
+                            stream);
   }
   else if constexpr (MatchType == StringMatchingType::PREFIX)
   {
     return DoPrefixMatching(input.data<char>(),
                             input.size(),
-                            input.child(0).data<cudf::size_type>(),
+                            input.child(0).data<int64_t>(),
                             byte_count,
                             match_str,
-                            mr);
+                            mr,
+                            stream);
   }
-}
-
-std::tuple<uint64_t*, uint64_t> GpuDispatcher::DispatchSelect(const cudf::column_view& bitmap,
-                                                              rmm::device_async_resource_ref mr)
-{
-  auto stream              = cudf::get_default_stream();
-  auto* gpu_buffer_manager = &GPUBufferManager::GetInstance();
-
-  // The row ids are owned by the query executor and so must be managed by the buffer manager
-  uint64_t* row_ids = gpu_buffer_manager->customCudaMalloc<uint64_t>(bitmap.size(), 0, false);
-  rmm::device_scalar<uint64_t> d_num_selected(0, stream, mr);
-
-  size_t temp_storage_bytes = 0;
-  uint64_t num_selected     = 0;
-  cub::DeviceSelect::Flagged(nullptr,
-                             temp_storage_bytes,
-                             thrust::make_counting_iterator<uint64_t>(0),
-                             bitmap.data<bool>(),
-                             row_ids,
-                             d_num_selected.data(),
-                             bitmap.size(),
-                             cudf::get_default_stream());
-  rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
-  cub::DeviceSelect::Flagged(temp_storage.data(),
-                             temp_storage_bytes,
-                             thrust::make_counting_iterator<uint64_t>(0),
-                             bitmap.data<bool>(),
-                             row_ids,
-                             d_num_selected.data(),
-                             bitmap.size(),
-                             cudf::get_default_stream());
-  num_selected = d_num_selected.value(stream);
-  return std::make_tuple(row_ids, num_selected);
 }
 
 //----------Instantiations----------//
@@ -117,7 +87,8 @@ std::tuple<uint64_t*, uint64_t> GpuDispatcher::DispatchSelect(const cudf::column
   template std::unique_ptr<cudf::column>                                                           \
   GpuDispatcher::DispatchStringMatching<StringMatchingType::T>(const cudf::column_view& input,     \
                                                                const std::string& match_str,       \
-                                                               rmm::device_async_resource_ref mr);
+                                                               rmm::device_async_resource_ref mr,  \
+                                                               rmm::cuda_stream_view stream);
 
 INSTANTIATE_STR_MATCHING(CONTAINS)
 INSTANTIATE_STR_MATCHING(LIKE)

--- a/src/cuda/operator/strings_matching.cu
+++ b/src/cuda/operator/strings_matching.cu
@@ -1,4 +1,5 @@
 #include "cuda_helper.cuh"
+#include "cuda_stream_view.hpp"
 #include "gpu_physical_strings_matching.hpp"
 #include "gpu_buffer_manager.hpp"
 #include "log/logging.hpp"
@@ -56,12 +57,12 @@ template __global__ void determine_start_kernel<uint64_t>(const uint64_t* indice
                                                           uint64_t num_workers,
                                                           uint64_t chunk_size,
                                                           uint64_t last_char);
-template __global__ void determine_start_kernel<cudf::size_type>(const cudf::size_type* indices,
-                                                                 cudf::size_type num_strings,
-                                                                 cudf::size_type* worker_start_term,
-                                                                 cudf::size_type num_workers,
-                                                                 cudf::size_type chunk_size,
-                                                                 cudf::size_type last_char);
+template __global__ void determine_start_kernel<int64_t>(const int64_t* indices,
+                                                         int64_t num_strings,
+                                                         int64_t* worker_start_term,
+                                                         int64_t num_workers,
+                                                         int64_t chunk_size,
+                                                         int64_t last_char);
 
 template<typename IdxT>
 __global__ void single_term_kmp_kernel(const char* char_data, const IdxT* indices, const int* kmp_automato, const IdxT* worker_start_term, bool* results, 
@@ -117,17 +118,17 @@ template __global__ void single_term_kmp_kernel<uint64_t>(const char* char_data,
                                                           uint64_t sub_chunk_size,
                                                           uint64_t last_char,
                                                           uint64_t num_strings);
-template __global__ void single_term_kmp_kernel<cudf::size_type>(const char* char_data,
-                                                                 const cudf::size_type* indices,
-                                                                 const int* kmp_automato,
-                                                                 const cudf::size_type* worker_start_term,
-                                                                 bool* results,
-                                                                 cudf::size_type pattern_size,
-                                                                 cudf::size_type num_workers,
-                                                                 cudf::size_type chunk_size,
-                                                                 cudf::size_type sub_chunk_size,
-                                                                 cudf::size_type last_char,
-                                                                 cudf::size_type num_strings);
+template __global__ void single_term_kmp_kernel<int64_t>(const char* char_data,
+                                                         const int64_t* indices,
+                                                         const int* kmp_automato,
+                                                         const int64_t* worker_start_term,
+                                                         bool* results,
+                                                         int64_t pattern_size,
+                                                         int64_t num_workers,
+                                                         int64_t chunk_size,
+                                                         int64_t sub_chunk_size,
+                                                         int64_t last_char,
+                                                         int64_t num_strings);
 
 __global__ void write_matching_rows(bool* results, uint64_t num_strings, uint64_t* matching_rows, uint64_t* count) {
   uint64_t tile_size = gridDim.x * blockDim.x;
@@ -305,19 +306,19 @@ template __global__ void multi_term_kmp_kernel<uint64_t>(const char* char_data,
                                                          uint64_t sub_chunk_size,
                                                          uint64_t last_char,
                                                          uint64_t num_strings);
-template __global__ void multi_term_kmp_kernel<cudf::size_type>(const char* char_data,
-                                                                const cudf::size_type* indices,
-                                                                const int* kmp_automato,
-                                                                cudf::size_type* worker_start_term,
-                                                                cudf::size_type* curr_term_answer,
-                                                                cudf::size_type* prev_term_answer,
-                                                                bool* found_term,
-                                                                int pattern_size,
-                                                                cudf::size_type num_workers,
-                                                                cudf::size_type chunk_size,
-                                                                cudf::size_type sub_chunk_size,
-                                                                cudf::size_type last_char,
-                                                                cudf::size_type num_strings);
+template __global__ void multi_term_kmp_kernel<int64_t>(const char* char_data,
+                                                        const int64_t* indices,
+                                                        const int* kmp_automato,
+                                                        int64_t* worker_start_term,
+                                                        int64_t* curr_term_answer,
+                                                        int64_t* prev_term_answer,
+                                                        bool* found_term,
+                                                        int pattern_size,
+                                                        int64_t num_workers,
+                                                        int64_t chunk_size,
+                                                        int64_t sub_chunk_size,
+                                                        int64_t last_char,
+                                                        int64_t num_strings);
 
 template<typename IdxT>
 __global__ void initialize_term_answers(IdxT* curr_term_answer, IdxT num_chars, IdxT num_strings) {
@@ -331,9 +332,8 @@ __global__ void initialize_term_answers(IdxT* curr_term_answer, IdxT num_chars, 
 template __global__ void initialize_term_answers<uint64_t>(uint64_t* curr_term_answer,
                                                            uint64_t num_chars,
                                                            uint64_t num_strings);
-template __global__ void initialize_term_answers<cudf::size_type>(cudf::size_type* curr_term_answer,
-                                                                  cudf::size_type num_chars,
-                                                                  cudf::size_type num_strings);
+template __global__ void
+initialize_term_answers<int64_t>(int64_t* curr_term_answer, int64_t num_chars, int64_t num_strings);
 
 void MultiStringMatching(char* char_data, uint64_t* str_indices, std::vector<std::string> all_terms,
        uint64_t* &row_id, uint64_t* &count, uint64_t num_chars, uint64_t num_strings, int not_equal) {
@@ -509,13 +509,13 @@ template __global__ void prefix_kernel<uint64_t>(const char* char_data,
                                                  const char* prefix_chars,
                                                  uint64_t num_prefix_chars,
                                                  bool* results);
-template __global__ void prefix_kernel<cudf::size_type>(const char* char_data,
-                                                        cudf::size_type num_chars,
-                                                        const cudf::size_type* str_indices,
-                                                        cudf::size_type num_strings,
-                                                        const char* prefix_chars,
-                                                        cudf::size_type num_prefix_chars,
-                                                        bool* results);
+template __global__ void prefix_kernel<int64_t>(const char* char_data,
+                                                int64_t num_chars,
+                                                const int64_t* str_indices,
+                                                int64_t num_strings,
+                                                const char* prefix_chars,
+                                                int64_t num_prefix_chars,
+                                                bool* results);
 
 void PrefixMatching(char* char_data, uint64_t* str_indices, std::string match_prefix, uint64_t* &row_id, uint64_t* &count, 
   uint64_t num_chars, uint64_t num_strings, int not_equal) {
@@ -589,17 +589,16 @@ void PrefixMatching(char* char_data, uint64_t* str_indices, std::string match_pr
 //----------String Matching----------//
 std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
                                                cudf::size_type input_count,
-                                               const cudf::size_type* input_offsets,
-                                               cudf::size_type byte_count,
+                                               const int64_t* input_offsets,
+                                               int64_t byte_count,
                                                const std::string& match_string,
-                                               rmm::device_async_resource_ref mr)
+                                               rmm::device_async_resource_ref mr,
+                                               rmm::cuda_stream_view stream)
 {
   static_assert(std::is_same_v<int32_t, cudf::size_type>); // Sanity check
 
-  auto stream = cudf::get_default_stream();
-
   // Compute the automato for this string
-  const auto match_length      = static_cast<cudf::size_type>(match_string.size());
+  const auto match_length      = static_cast<int32_t>(match_string.size());
   const auto* match_char       = match_string.c_str();
   const auto kmp_automato_size = match_length * CHARS_IN_BYTE;
   std::vector<int32_t> kmp_automato(kmp_automato_size, 0);
@@ -619,11 +618,10 @@ std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
   }
 
   // Copy match string to device memory
-  const auto match_byte_count = static_cast<cudf::size_type>(match_string.size());
-  rmm::device_uvector<char> d_match_string(match_byte_count, stream, mr);
+  rmm::device_uvector<char> d_match_string(match_length, stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_match_string.data(),
                                 match_string.data(),
-                                match_byte_count,
+                                match_length * sizeof(char),
                                 cudaMemcpyHostToDevice,
                                 stream));
 
@@ -636,8 +634,8 @@ std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
                                 stream));
 
   // Allocate start terms memory and the boolean output buffer
-  const auto workers_needed = cuda::ceil_div(byte_count, CHUNK_SIZE);
-  rmm::device_uvector<int32_t> d_worker_start_term(workers_needed, stream, mr);
+  const auto workers_needed = cuda::ceil_div(byte_count, static_cast<int64_t>(CHUNK_SIZE));
+  rmm::device_uvector<int64_t> d_worker_start_term(workers_needed, stream, mr);
   rmm::device_uvector<bool> output(input_count, stream, mr);
 
   // Initialize the output buffer to false
@@ -645,9 +643,9 @@ std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
 
   // Launch kernel to determine the start offset for each worker
   LAUNCH_KERNEL_DIV(determine_start_kernel,
-                    cudf::size_type,
+                    int64_t,
                     workers_needed,
-                    THREADS_PER_BLOCK_STRINGS,
+                    static_cast<int64_t>(THREADS_PER_BLOCK_STRINGS),
                     stream)
   (input_offsets,
    input_count,
@@ -658,7 +656,7 @@ std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
 
   // Launch KMP kernel
   LAUNCH_KERNEL_DIRECT(single_term_kmp_kernel,
-                       cudf::size_type,
+                       int64_t,
                        workers_needed,
                        THREADS_PER_BLOCK_STRINGS,
                        stream)
@@ -681,20 +679,19 @@ std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
 //----------Multi-Term String Matching----------//
 std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
                                                     cudf::size_type input_count,
-                                                    const cudf::size_type* input_offsets,
-                                                    cudf::size_type byte_count,
+                                                    const int64_t* input_offsets,
+                                                    int64_t byte_count,
                                                     const std::vector<std::string>& match_strings,
-                                                    rmm::device_async_resource_ref mr)
+                                                    rmm::device_async_resource_ref mr,
+                                                    rmm::cuda_stream_view stream)
 {
   static_assert(std::is_same_v<int32_t, cudf::size_type>); // Sanity check
-
-  auto stream = cudf::get_default_stream();
 
   // Compute the automato for each term
   std::vector<rmm::device_uvector<int32_t>> d_kmp_automatos;
   for (const auto& match_string : match_strings)
   {
-    const auto match_length      = static_cast<cudf::size_type>(match_string.size());
+    const auto match_length      = static_cast<int32_t>(match_string.size());
     const auto* match_char       = match_string.c_str();
     const auto kmp_automato_size = match_length * CHARS_IN_BYTE;
     std::vector<int32_t> kmp_automato(kmp_automato_size, 0);
@@ -723,26 +720,25 @@ std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
   }
 
   // Allocate start terms memory, rotating answer indices, and the boolean output buffer
-  const auto workers_needed = cuda::ceil_div(byte_count, CHUNK_SIZE);
-  rmm::device_uvector<int32_t> d_worker_start_term(workers_needed, stream, mr);
-  rmm::device_uvector<cudf::size_type> d_answer_idxs(input_count, stream, mr);
-  rmm::device_uvector<cudf::size_type> d_prev_answer_idxs(input_count, stream, mr);
+  const auto workers_needed = cuda::ceil_div(byte_count, static_cast<int64_t>(CHUNK_SIZE));
+  rmm::device_uvector<int64_t> d_worker_start_term(workers_needed, stream, mr);
+  rmm::device_uvector<int64_t> d_answer_idxs(input_count, stream, mr);
+  rmm::device_uvector<int64_t> d_prev_answer_idxs(input_count, stream, mr);
   rmm::device_uvector<bool> output(input_count, stream, mr);
 
   // Initialize answer indices to zero, and copy offsets to previous answer indices
-  CUDF_CUDA_TRY(
-    cudaMemsetAsync(d_answer_idxs.data(), 0, input_count * sizeof(cudf::size_type), stream));
+  CUDF_CUDA_TRY(cudaMemsetAsync(d_answer_idxs.data(), 0, input_count * sizeof(int64_t), stream));
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_prev_answer_idxs.data(),
                                 input_offsets,
-                                input_count * sizeof(cudf::size_type),
+                                input_count * sizeof(int64_t),
                                 cudaMemcpyDeviceToDevice,
                                 stream));
 
   // Launch kernel to determine the start offset for each worker
   LAUNCH_KERNEL_DIV(determine_start_kernel,
-                    cudf::size_type,
+                    int64_t,
                     workers_needed,
-                    THREADS_PER_BLOCK_STRINGS,
+                    static_cast<int64_t>(THREADS_PER_BLOCK_STRINGS),
                     stream)
   (input_offsets,
    input_count,
@@ -756,13 +752,13 @@ std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
   auto* prev_answer_idxs_ptr = d_prev_answer_idxs.data();
   for (int32_t i = 0; i < match_strings.size(); i++)
   {
-    const auto curr_term_length    = static_cast<cudf::size_type>(match_strings[i].size());
+    const auto curr_term_length    = static_cast<int32_t>(match_strings[i].size());
     const auto* curr_term_automato = d_kmp_automatos[i].data();
 
     // Preprocessing
     CUDF_CUDA_TRY(cudaMemsetAsync(output.data(), 0, input_count * sizeof(bool), stream));
     LAUNCH_KERNEL_DIV(initialize_term_answers,
-                      cudf::size_type,
+                      int64_t,
                       input_count,
                       THREADS_PER_BLOCK_STRINGS,
                       stream)
@@ -770,7 +766,7 @@ std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
 
     // Launch the KMP kernel for the current term
     LAUNCH_KERNEL_DIRECT(multi_term_kmp_kernel,
-                         cudf::size_type,
+                         int64_t,
                          workers_needed,
                          THREADS_PER_BLOCK_STRINGS,
                          stream)
@@ -803,17 +799,16 @@ std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
 //----------Prefix Matching----------//
 std::unique_ptr<cudf::column> DoPrefixMatching(const char* input_data,
                                                cudf::size_type input_count,
-                                               const cudf::size_type* input_offsets,
-                                               cudf::size_type byte_count,
+                                               const int64_t* input_offsets,
+                                               int64_t byte_count,
                                                const std::string& match_prefix,
-                                               rmm::device_async_resource_ref mr)
+                                               rmm::device_async_resource_ref mr,
+                                               rmm::cuda_stream_view stream)
 {
   static_assert(std::is_same_v<int32_t, cudf::size_type>); // Sanity check
 
-  auto stream = cudf::get_default_stream();
-
   // Copy prefix string to device memory
-  const auto prefix_byte_count = static_cast<cudf::size_type>(match_prefix.size());
+  const auto prefix_byte_count = static_cast<int32_t>(match_prefix.size());
   rmm::device_uvector<char> d_match_prefix(prefix_byte_count, stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_match_prefix.data(),
                                 match_prefix.data(),
@@ -825,7 +820,7 @@ std::unique_ptr<cudf::column> DoPrefixMatching(const char* input_data,
   rmm::device_uvector<bool> output(input_count, stream, mr);
 
   // Launch kernel to perform prefix matching
-  LAUNCH_KERNEL_DIV(prefix_kernel, cudf::size_type, input_count, BLOCK_THREADS, stream)
+  LAUNCH_KERNEL_DIV(prefix_kernel, int64_t, input_count, BLOCK_THREADS, stream)
   (input_data,
    byte_count,
    input_offsets,

--- a/src/expression_executor/specializations/gpu_execute_between.cpp
+++ b/src/expression_executor/specializations/gpu_execute_between.cpp
@@ -33,19 +33,19 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundBetweenE
                                           lower->view(),
                                           cudf::binary_operator::GREATER_EQUAL,
                                           cudf::data_type{cudf::type_id::BOOL8},
-                                          cudf::get_default_stream(),
+                                          execution_stream,
                                           resource_ref);
   auto upper_cmp = cudf::binary_operation(input->view(),
                                           upper->view(),
                                           cudf::binary_operator::LESS_EQUAL,
                                           cudf::data_type{cudf::type_id::BOOL8},
-                                          cudf::get_default_stream(),
+                                          execution_stream,
                                           resource_ref);
   return cudf::binary_operation(lower_cmp->view(),
                                 upper_cmp->view(),
                                 cudf::binary_operator::LOGICAL_AND,
                                 cudf::data_type{cudf::type_id::BOOL8},
-                                cudf::get_default_stream(),
+                                execution_stream,
                                 resource_ref);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_case.cpp
+++ b/src/expression_executor/specializations/gpu_execute_case.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundCaseExpr
       auto any_result = cudf::reduce(current_mask->view(),
                                      *cudf::make_any_aggregation<cudf::reduce_aggregation>(),
                                      cudf::data_type(cudf::type_id::BOOL8),
-                                     cudf::get_default_stream(),
+                                     execution_stream,
                                      resource_ref);
       if (static_cast<cudf::scalar_type_t<bool>*>(any_result.get())->value())
       {
@@ -84,7 +84,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundCaseExpr
     current_output    = cudf::copy_if_else(current_then->view(),
                                         current_output->view(),
                                         current_mask->view(),
-                                        cudf::get_default_stream(),
+                                        execution_stream,
                                         resource_ref);
   }
   return std::move(current_output);

--- a/src/expression_executor/specializations/gpu_execute_cast.cpp
+++ b/src/expression_executor/specializations/gpu_execute_cast.cpp
@@ -17,7 +17,7 @@ GpuExpressionExecutor::InitializeState(const BoundCastExpression& expr,
 }
 
 
-// KEVIN: potential optimization path: if the child is a constant, skip Execute() for it
+// Note that constants are CASTed before they reach the execution engine
 std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundCastExpression& expr,
                                                              GpuExpressionState* state)
 {
@@ -30,7 +30,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundCastExpr
   // Execute the cast
   return cudf::cast(child->view(),
                     cudf::data_type{return_type_id},
-                    cudf::get_default_stream(),
+                    execution_stream,
                     resource_ref);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -44,24 +44,24 @@ struct ComparisonDispatcher
     {
       // Create a string scalar from the constant value
       auto string_scalar =
-        cudf::string_scalar(right_value, true, cudf::get_default_stream(), executor.resource_ref);
+        cudf::string_scalar(right_value, true, executor.execution_stream, executor.resource_ref);
       return cudf::binary_operation(left,
                                     string_scalar,
                                     ComparisonOp,
                                     return_type,
-                                    cudf::get_default_stream(),
+                                    executor.execution_stream,
                                     executor.resource_ref);
     }
     else
     {
       // Create a numeric scalar from the constant value
       auto numeric_scalar =
-        cudf::numeric_scalar(right_value, true, cudf::get_default_stream(), executor.resource_ref);
+        cudf::numeric_scalar(right_value, true, executor.execution_stream, executor.resource_ref);
       return cudf::binary_operation(left,
                                     numeric_scalar,
                                     ComparisonOp,
                                     return_type,
-                                    cudf::get_default_stream(),
+                                    executor.execution_stream,
                                     executor.resource_ref);
     }
   }
@@ -118,7 +118,7 @@ struct ComparisonDispatcher
                                   right->view(),
                                   ComparisonOp,
                                   return_type,
-                                  cudf::get_default_stream(),
+                                  executor.execution_stream,
                                   executor.resource_ref);
   }
 };

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundConjunct
                                                  output_column->view(),
                                                  cudf::binary_operator::LOGICAL_AND,
                                                  return_type,
-                                                 cudf::get_default_stream(),
+                                                 execution_stream,
                                                  resource_ref);
           break;
         case ExpressionType::CONJUNCTION_OR:
@@ -57,7 +57,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundConjunct
                                                  output_column->view(),
                                                  cudf::binary_operator::LOGICAL_OR,
                                                  return_type,
-                                                 cudf::get_default_stream(),
+                                                 execution_stream,
                                                  resource_ref);
           break;
         default:

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "expression_executor/gpu_expression_executor_state.hpp"
@@ -30,7 +31,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundConjunct
   std::unique_ptr<cudf::column> output_column;
   for (idx_t i = 0; i < expr.children.size(); i++)
   {
-    D_ASSERT(state->intermediate_columns[i].data_wrapper.type.id() == GPUColumnTypeId::BOOLEAN);
+    D_ASSERT(state->child_states[i]->expr.return_type = LogicalType::BOOLEAN;);
 
     auto current_result = Execute(*expr.children[i], state->child_states[i].get());
 

--- a/src/expression_executor/specializations/gpu_execute_constant.cpp
+++ b/src/expression_executor/specializations/gpu_execute_constant.cpp
@@ -1,3 +1,4 @@
+#include "cuda_stream_view.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
@@ -21,21 +22,21 @@ template <typename T>
 struct MakeColumnFromConstant
 {
   static std::unique_ptr<cudf::column>
-  Do(const BoundConstantExpression& expr, cudf::size_type count, rmm::device_async_resource_ref mr)
+  Do(const BoundConstantExpression& expr, cudf::size_type count, rmm::device_async_resource_ref mr, rmm::cuda_stream_view stream)
   {
     if constexpr (std::is_same<T, std::string>())
     {
       cudf::string_scalar scalar(expr.value.GetValue<std::string>(),
                                  true,
-                                 cudf::get_default_stream(),
+                                 stream,
                                  mr);
-      return cudf::make_column_from_scalar(scalar, count, cudf::get_default_stream(), mr);
+      return cudf::make_column_from_scalar(scalar, count, stream, mr);
     }
     else
     {
       auto scalar =
-        cudf::numeric_scalar<T>(expr.value.GetValue<T>(), true, cudf::get_default_stream(), mr);
-      return cudf::make_column_from_scalar(scalar, count, cudf::get_default_stream(), mr);
+        cudf::numeric_scalar<T>(expr.value.GetValue<T>(), true, stream, mr);
+      return cudf::make_column_from_scalar(scalar, count, stream, mr);
     }
   }
 };
@@ -49,17 +50,17 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundConstant
   switch (GpuExpressionState::GetCudfType(expr.return_type).id())
   {
     case cudf::type_id::INT32:
-      return MakeColumnFromConstant<int32_t>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<int32_t>::Do(expr, input_count, resource_ref, execution_stream);
     case cudf::type_id::UINT64:
-      return MakeColumnFromConstant<uint64_t>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<uint64_t>::Do(expr, input_count, resource_ref, execution_stream);
     case cudf::type_id::FLOAT32:
-      return MakeColumnFromConstant<float_t>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<float_t>::Do(expr, input_count, resource_ref, execution_stream);
     case cudf::type_id::FLOAT64:
-      return MakeColumnFromConstant<double_t>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<double_t>::Do(expr, input_count, resource_ref, execution_stream);
     case cudf::type_id::BOOL8:
-      return MakeColumnFromConstant<bool>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<bool>::Do(expr, input_count, resource_ref, execution_stream);
     case cudf::type_id::STRING:
-      return MakeColumnFromConstant<std::string>::Do(expr, input_count, resource_ref);
+      return MakeColumnFromConstant<std::string>::Do(expr, input_count, resource_ref, execution_stream);
     default:
       throw InternalException("Execute[Constant]: Unknown type!");
   }

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -91,7 +91,7 @@ struct StringMatchingDispatcher
         auto like = cudf::strings::like(cudf::strings_column_view(input_view),
                                         cudf::string_scalar(match_str),
                                         cudf::string_scalar(""),
-                                        cudf::get_default_stream(),
+                                        executor.execution_stream,
                                         executor.resource_ref);
 
         // LIKE or NOT LIKE?
@@ -104,26 +104,26 @@ struct StringMatchingDispatcher
           // Negate the match result
           return cudf::unary_operation(like->view(),
                                        cudf::unary_operator::NOT,
-                                       cudf::get_default_stream(),
+                                       executor.execution_stream,
                                        executor.resource_ref);
         }
       }
       else if constexpr (MatchType == StringMatchingType::CONTAINS)
       {
         const auto match_str_scalar =
-          cudf::string_scalar(match_str, true, cudf::get_default_stream(), executor.resource_ref);
+          cudf::string_scalar(match_str, true, executor.execution_stream, executor.resource_ref);
         return cudf::strings::contains(input_view,
                                        match_str_scalar,
-                                       cudf::get_default_stream(),
+                                       executor.execution_stream,
                                        executor.resource_ref);
       }
       else if constexpr (MatchType == StringMatchingType::PREFIX)
       {
         const auto match_str_scalar =
-          cudf::string_scalar(match_str, true, cudf::get_default_stream(), executor.resource_ref);
+          cudf::string_scalar(match_str, true, executor.execution_stream, executor.resource_ref);
         return cudf::strings::starts_with(input_view,
                                           match_str_scalar,
-                                          cudf::get_default_stream(),
+                                          executor.execution_stream,
                                           executor.resource_ref);
       }
     }
@@ -156,12 +156,12 @@ struct NumericBinaryFunctionDispatcher
                                                      const cudf::data_type& return_type)
   {
     auto left_numeric_scalar =
-      cudf::numeric_scalar(left_value, true, cudf::get_default_stream(), executor.resource_ref);
+      cudf::numeric_scalar(left_value, true, executor.execution_stream, executor.resource_ref);
     return cudf::binary_operation(left_numeric_scalar,
                                   right,
                                   BinOp,
                                   return_type,
-                                  cudf::get_default_stream(),
+                                  executor.execution_stream,
                                   executor.resource_ref);
   }
 
@@ -172,12 +172,12 @@ struct NumericBinaryFunctionDispatcher
                                                       const cudf::data_type& return_type)
   {
     auto right_numeric_scalar =
-      cudf::numeric_scalar(right_value, true, cudf::get_default_stream(), executor.resource_ref);
+      cudf::numeric_scalar(right_value, true, executor.execution_stream, executor.resource_ref);
     return cudf::binary_operation(left,
                                   right_numeric_scalar,
                                   BinOp,
                                   return_type,
-                                  cudf::get_default_stream(),
+                                  executor.execution_stream,
                                   executor.resource_ref);
   }
 
@@ -247,29 +247,32 @@ struct NumericBinaryFunctionDispatcher
                                   right->view(),
                                   BinOp,
                                   GpuExpressionState::GetCudfType(expr.return_type),
-                                  cudf::get_default_stream(),
+                                  executor.execution_stream,
                                   executor.resource_ref);
   }
 };
 
 //----------DatetimeExtractFunctionDispatcher----------//
 template <cudf::datetime::datetime_component COMP>
-struct DatetimeExtractFunctionDispatcher {
+struct DatetimeExtractFunctionDispatcher
+{
   // The executor
   GpuExpressionExecutor& executor;
 
   // Constructor
   explicit DatetimeExtractFunctionDispatcher(GpuExpressionExecutor& exec)
-      : executor(exec) {}
+      : executor(exec)
+  {}
 
   // Dispatch operator
   std::unique_ptr<cudf::column> operator()(const BoundFunctionExpression& expr,
-                                           GpuExpressionState* state) {
+                                           GpuExpressionState* state)
+  {
     D_ASSERT(expr.children.size() == 1);
     auto input = executor.Execute(*expr.children[0], state->child_states[0].get());
     return cudf::datetime::extract_datetime_component(input->view(),
                                                       COMP,
-                                                      cudf::get_default_stream(),
+                                                      executor.execution_stream,
                                                       executor.resource_ref);
   }
 };
@@ -332,7 +335,12 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
       const auto cudf_start = start_expr.value.GetValue<cudf::size_type>() - 1;
       const auto cudf_end   = len_expr.value.GetValue<cudf::size_type>() + cudf_start;
 
-      return cudf::strings::slice_strings(input_view, cudf_start, cudf_end);
+      return cudf::strings::slice_strings(input_view,
+                                          cudf_start,
+                                          cudf_end,
+                                          1, // Step
+                                          execution_stream,
+                                          resource_ref);
     }
     else
     {
@@ -342,7 +350,8 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
       return GpuDispatcher::DispatchSubstring(input->view(),
                                               sirius_start,
                                               sirius_len,
-                                              resource_ref);
+                                              resource_ref,
+                                              execution_stream);
     }
   }
   else if (func_str == LIKE_FUNC_STR)
@@ -367,15 +376,18 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
   }
 
   //----------Datetime Extract Functions----------//
-  else if (func_str == YEAR_FUNC_STR) {
+  else if (func_str == YEAR_FUNC_STR)
+  {
     DatetimeExtractFunctionDispatcher<cudf::datetime::datetime_component::YEAR> dispatcher(*this);
     return dispatcher(expr, state);
   }
-  else if (func_str == MONTH_FUNC_STR) {
+  else if (func_str == MONTH_FUNC_STR)
+  {
     DatetimeExtractFunctionDispatcher<cudf::datetime::datetime_component::MONTH> dispatcher(*this);
     return dispatcher(expr, state);
   }
-  else if (func_str == DAY_FUNC_STR) {
+  else if (func_str == DAY_FUNC_STR)
+  {
     DatetimeExtractFunctionDispatcher<cudf::datetime::datetime_component::DAY> dispatcher(*this);
     return dispatcher(expr, state);
   }

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -26,8 +26,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundReferenc
       throw NotImplementedException(
         "Execute[Reference]: row_id_counts larger than int32_t are not supported in libcudf");
     }
-    // DispatchMaterialize will handle byte overflow from the materialized offsets
-    return GpuDispatcher::DispatchMaterialize(input_column.get(), resource_ref);
+    return GpuDispatcher::DispatchMaterialize(input_column.get(), resource_ref, execution_stream);
   }
   if (input_column->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR &&
       input_column->data_wrapper.num_bytes > INT32_MAX)
@@ -45,7 +44,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundReferenc
   // buffer manager)
   auto input_column_view = input_column->convertToCudfColumn();
   return std::make_unique<cudf::column>(input_column_view,
-                                        cudf::get_default_stream(),
+                                        execution_stream,
                                         resource_ref);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -28,12 +28,6 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundReferenc
     }
     return GpuDispatcher::DispatchMaterialize(input_column.get(), resource_ref, execution_stream);
   }
-  if (input_column->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR &&
-      input_column->data_wrapper.num_bytes > INT32_MAX)
-  {
-    throw NotImplementedException(
-      "Execute[Reference]: string offsets larger than int32_t are not supported in libcudf");
-  }
   if (input_column->column_length > INT32_MAX)
   {
     throw NotImplementedException(

--- a/src/include/expression_executor/gpu_dispatcher.hpp
+++ b/src/include/expression_executor/gpu_dispatcher.hpp
@@ -22,41 +22,33 @@ enum class StringMatchingType : uint8_t
 //----------Gpu Dispatcher----------//
 struct GpuDispatcher
 {
-    //----------Materialize----------//
-  static std::unique_ptr<cudf::column> DispatchMaterialize(const GPUColumn* input,
-                                                           rmm::device_async_resource_ref mr);
+  //----------Materialize----------//
+  static std::unique_ptr<cudf::column>
+  DispatchMaterialize(const GPUColumn* input,
+                      rmm::device_async_resource_ref mr,
+                      rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   //----------Substring----------//
-  static std::unique_ptr<cudf::column> DispatchSubstring(const cudf::column_view& input,
-                                                         uint64_t start_idx,
-                                                         uint64_t len,
-                                                         rmm::device_async_resource_ref mr);
+  static std::unique_ptr<cudf::column>
+  DispatchSubstring(const cudf::column_view& input,
+                    uint64_t start_idx,
+                    uint64_t len,
+                    rmm::device_async_resource_ref mr,
+                    rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   //----------String Matching----------//
-  template<StringMatchingType MatchType>
-  static std::unique_ptr<cudf::column> DispatchStringMatching(const cudf::column_view& input,
-                                                              const std::string& match_str,
-                                                              rmm::device_async_resource_ref mr);
+  template <StringMatchingType MatchType>
+  static std::unique_ptr<cudf::column>
+  DispatchStringMatching(const cudf::column_view& input,
+                         const std::string& match_str,
+                         rmm::device_async_resource_ref mr,
+                         rmm::cuda_stream_view = rmm::cuda_stream_default);
 
   //----------Selection----------//
-  static std::tuple<uint64_t*, uint64_t> DispatchSelect(const cudf::column_view& bitmap,
-                                                        rmm::device_async_resource_ref mr);
-
-  //----------Utilities----------//
-  // For substring
-  static std::unique_ptr<cudf::column> MakeColumnFromPtrs(char* data,
-                                                          uint64_t* offsets,
-                                                          uint64_t count,
-                                                          rmm::device_async_resource_ref mr);
-  // For matching
-  static std::unique_ptr<cudf::column> MakeColumnFromRowIds(uint64_t* row_ids,
-                                                            uint64_t row_id_count,
-                                                            uint64_t input_count,
-                                                            rmm::device_async_resource_ref mr);
-
-  // For extracting data from cudf::column types for sirius string APIs
-  static std::tuple<uint64_t, char*, uint64_t*, uint64_t>
-  PrepareStringData(const cudf::column_view& input);
+  static std::tuple<uint64_t*, uint64_t>
+  DispatchSelect(const cudf::column_view& bitmap,
+                 rmm::device_async_resource_ref mr,
+                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 };
 
 } // namespace sirius

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -46,6 +46,8 @@ struct GpuExpressionExecutor
   rmm::device_async_resource_ref resource_ref = GPUBufferManager::GetInstance().mr;
   // The input count for the current relation (needed for materializing constants)
   cudf::size_type input_count;
+  // The stream in which to execute the given set of expressions
+  rmm::cuda_stream_view execution_stream;
   // Static flag indicating whether to use cudf or sirius for string functions
   static constexpr bool use_cudf = USE_CUDF_EXPR;
 
@@ -62,12 +64,15 @@ struct GpuExpressionExecutor
   // Execute the set of expressions with the given input relation and store the result in the output
   // relation (Provides the main interface with client code for Projections).
   void Execute(const GPUIntermediateRelation& input_relation,
-               GPUIntermediateRelation& output_relation);
+               GPUIntermediateRelation& output_relation,
+               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   // Execute the set of expressions with the given input relation and compact into the output
   // relation based on the resulting selection vector (Provides the main interface with client code
   // for Filters).
-  void Select(GPUIntermediateRelation& input_relation, GPUIntermediateRelation& output_relation);
+  void Select(GPUIntermediateRelation& input_relation,
+              GPUIntermediateRelation& output_relation,
+              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   // Execute the expression at the given index and return the result
   std::unique_ptr<cudf::column> ExecuteExpression(idx_t expression_idx);

--- a/src/include/operator/gpu_physical_strings_matching.hpp
+++ b/src/include/operator/gpu_physical_strings_matching.hpp
@@ -15,23 +15,29 @@ void HandleMultiStringMatching(shared_ptr<GPUColumn> string_column, std::string 
 void HandlePrefixMatching(shared_ptr<GPUColumn> string_column, std::string match_prefix, uint64_t* &row_id, uint64_t* &count, int not_equal);
 
 // For CuDF compatibility
-std::unique_ptr<cudf::column> DoStringMatching(const char* input_data,
-                                               cudf::size_type input_count,
-                                               const cudf::size_type* input_offsets,
-                                               cudf::size_type byte_count,
-                                               const std::string& match_string,
-                                               rmm::device_async_resource_ref mr);
-std::unique_ptr<cudf::column> DoMultiStringMatching(const char* input_data,
-                                                    cudf::size_type input_count,
-                                                    const cudf::size_type* input_offsets,
-                                                    cudf::size_type byte_count,
-                                                    const std::vector<std::string>& match_strings,
-                                                    rmm::device_async_resource_ref mr);
-std::unique_ptr<cudf::column> DoPrefixMatching(const char* input_data,
-                                               cudf::size_type input_count,
-                                               const cudf::size_type* input_offsets,
-                                               cudf::size_type byte_count,
-                                               const std::string& match_prefix,
-                                               rmm::device_async_resource_ref mr);
+std::unique_ptr<cudf::column>
+DoStringMatching(const char* input_data,
+                 cudf::size_type input_count,
+                 const int64_t* input_offsets,
+                 int64_t byte_count,
+                 const std::string& match_string,
+                 rmm::device_async_resource_ref mr,
+                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::column>
+DoMultiStringMatching(const char* input_data,
+                      cudf::size_type input_count,
+                      const int64_t* input_offsets,
+                      int64_t byte_count,
+                      const std::vector<std::string>& match_strings,
+                      rmm::device_async_resource_ref mr,
+                      rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::column>
+DoPrefixMatching(const char* input_data,
+                 cudf::size_type input_count,
+                 const int64_t* input_offsets,
+                 int64_t byte_count,
+                 const std::string& match_prefix,
+                 rmm::device_async_resource_ref mr,
+                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 } // namespace duckdb

--- a/src/include/operator/gpu_physical_substring.hpp
+++ b/src/include/operator/gpu_physical_substring.hpp
@@ -11,9 +11,10 @@ shared_ptr<GPUColumn> HandleSubString(shared_ptr<GPUColumn> string_column, uint6
 // For CuDF compatibility
 std::unique_ptr<cudf::column> DoSubstring(const char* input_data,
                                           cudf::size_type input_count,
-                                          const cudf::size_type* input_offsets,
-                                          cudf::size_type start_idx,
-                                          cudf::size_type length,
-                                          rmm::device_async_resource_ref mr);
+                                          const int64_t* input_offsets,
+                                          int64_t start_idx,
+                                          int64_t length,
+                                          rmm::device_async_resource_ref mr,
+                                          rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 } // namespace duckdb


### PR DESCRIPTION
This PR extends the replacement of string offsets for `cudf::columns` from `cudf::size_type` to `int64_t` in the expression executor. Most code changes revolve around 1) substring and 2) string matching. 

In anticipation of batch processing, the expression executor now receives a stream argument when `Execute()` or `Select()` are invoked and executes all operations in the given stream. The default stream argument is the default stream, so no obstruction to existing functionality will be observed.