### PR TITLE
Switch file download link

### DIFF
--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -34,7 +34,7 @@ jobs:
           ./dbgen -s 1 && mkdir s1 && mv *.tbl s1
           cd ..
           cd test_datasets
-          wget https://sirius-datasets.s3.us-east-2.amazonaws.com/test_hits.tsv.gz
+          wget https://pages.cs.wisc.edu/~yxy/sirius-datasets/test_hits.tsv.gz
           gzip -d test_hits.tsv.gz
           cd ..
       - name: Run tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,7 +174,7 @@ To load the TPC-H dataset to duckdb:
 To download the dataset run:
 ```
 cd test_datasets
-wget https://sirius-datasets.s3.us-east-2.amazonaws.com/test_hits.tsv.gz
+wget https://pages.cs.wisc.edu/~yxy/sirius-datasets/test_hits.tsv.gz
 gzip -d test_hits.tsv.gz
 cd ..
 ```


### PR DESCRIPTION
Switch the download link for the Clickbench dataset from the S3 bucket to pages.cs.wisc.edu so that we don't pay the cost of moving data out of AWS