### PR TITLE
Basic CPU Cache

### DIFF
--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -27,7 +27,7 @@ jobs:
           source ~/miniconda3/etc/profile.d/conda.sh
           conda activate libcudf-env
           make -j$(nproc)
-      - name: Run unit tests
+      - name: Run C++ unit tests
         run: |
           ./build/release/extension/sirius/test/cpp/sirius_unittest
       - name: Prepare SQL test datasets
@@ -41,7 +41,7 @@ jobs:
           wget https://pages.cs.wisc.edu/~yxy/sirius-datasets/test_hits.tsv.gz
           gzip -d test_hits.tsv.gz
           cd ..
-      - name: Run SQL tests
+      - name: Run sqllogic tests
         run: |
           make test | tee test.log
           if grep -q "Error in GPUExecuteQuery" test.log; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(EXTENSION_SOURCES
   src/gpu_physical_plan_generator.cpp
   src/gpu_buffer_manager.cpp
   src/gpu_columns.cpp
+  src/cpu_cache.cpp
   src/gpu_query_result.cpp
   src/config.cpp
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -292,10 +292,16 @@ make -j {nproc}
 build/release/extension/sirius/test/cpp/sirius_unittest
 ```
 
-To run tests associated with specific tag you can run something like this:
+To run tests associated with specific tag or to run a specific test you can execute the the test script like this:
 ```
 make -j {nproc}
-build/release/extension/sirius/test/cpp/sirius_unittest "[pipeline]"
+build/release/extension/sirius/test/cpp/sirius_unittest "[cpu_cache]"
+build/release/extension/sirius/test/cpp/sirius_unittest "test_cpu_cache_basic_string_single_col"
+```
+
+Any logs produced during test execution are saved in: 
+```
+build/release/extension/sirius/test/cpp/log
 ```
 
 Just like duckdb, we are using [Catch2](https://github.com/catchorg/Catch2) as our testing framework so more details about writing and running tests can be found there.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -270,7 +270,10 @@ con.execute('''
 ```
 
 ## Correctness Testing
-Sirius provides a unit test that compares Sirius against DuckDB for correctness across many test queries. To run the unittest, generate the datasets using the method described [here](#generating-and-loading-test-datasets) and run the unittest using the following command:
+
+### SQLLogic Tests
+
+Sirius provides a unit test that compares Sirius against DuckDB for correctness across many test queries. Note that these tests are meant to be end to end tests as they run SQL queries using Sirius and compare that against the expected result. To run the unittest, generate the datasets using the method described [here](#generating-and-loading-test-datasets) and run the unittest using the following command:
 ```
 make test
 ```
@@ -280,6 +283,22 @@ To run a specific test run the command from the root directory:
 make -j {nproc}
 build/release/test/unittest --test-dir . test/sql/tpch-sirius.test
 ```
+
+### C++ Tests
+
+Sirius also implements C++ tests for all of the APIs it implements. These tests are meant to be individual unit tests for each of the classes/functions used to run Sirius. You can find examples on how to implement these unit tests in `test/cpp`. You can run all of the unit tests using:
+```
+make -j {nproc}
+build/release/extension/sirius/test/cpp/sirius_unittest
+```
+
+To run tests associated with specific tag you can run something like this:
+```
+make -j {nproc}
+build/release/extension/sirius/test/cpp/sirius_unittest "[pipeline]"
+```
+
+Just like duckdb, we are using [Catch2](https://github.com/catchorg/Catch2) as our testing framework so more details about writing and running tests can be found there.  
 
 ## Performance Testing
 Make sure to build the duckdb-python package before running this test using the method described [here](https://github.com/sirius-db/sirius?tab=readme-ov-file#building-sirius). To test Sirius performance against DuckDB across all 22 TPC-H queries, run the following command (replace {SF} with the desired scale factor):

--- a/src/cpu_cache.cpp
+++ b/src/cpu_cache.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpu_cache.hpp"
+
+#include "duckdb/common/assert.hpp"
+
+namespace duckdb {
+    
+MallocCPUCache::MallocCPUCache(size_t pinned_memory_size, size_t num_streams) : pinned_memory_capacity(pinned_memory_size), 
+    pinned_memory_offset(0), num_streams(num_streams), next_chunk_id(0), copy_stream_sequence(0) {
+
+    // Allocate the specified amount of pinned memory    
+    pinned_memory_buffer = allocatePinnedCPUMemory(pinned_memory_capacity);
+    if (pinned_memory_buffer == nullptr) {
+        throw InternalException("Failed to allocate pinned memory for CPU cache");
+    }
+
+    // Create multiple streams that can be used to copy data
+    streams = new cudaStream_t[num_streams];
+    for (size_t i = 0; i < num_streams; i++) {
+        cudaStreamCreate(&streams[i]);
+    }
+}
+
+MallocCPUCache::~MallocCPUCache() {
+    // Free the pinned memory buffer
+    if (pinned_memory_buffer) {
+        cudaFreeHost(pinned_memory_buffer);
+        pinned_memory_buffer = nullptr;
+    }
+
+    // Destroy the streams
+    for (size_t i = 0; i < num_streams; i++) {
+        cudaStreamDestroy(streams[i]);
+    }
+    delete[] streams;
+}
+
+std::pair<uint8_t*, int> MallocCPUCache::get_cache_buffer(size_t size) { 
+    // First see if there is space in the pinned memory to create a new segment
+    if(pinned_memory_offset.load(std::memory_order_relaxed) < pinned_memory_capacity) { 
+        size_t current_offset = pinned_memory_offset.fetch_add(size, std::memory_order_relaxed);
+        if(current_offset + size <= pinned_memory_capacity) {
+            // Create a new occupied segment in the pinned memory pool
+            shared_ptr<SegmentMetadata> segment = make_shared_ptr<SegmentMetadata>();
+            segment->segment_start_ptr = pinned_memory_buffer + current_offset;
+            segment->segment_size = size;
+            segment->occupied.store(true, std::memory_order_relaxed);
+            
+            // Save this new segment to segments vector
+            int segment_id = 0;
+            {
+                std::unique_lock lock(segment_lock);
+
+                segment_id = segments.size();
+                segment->segment_id = segment_id;
+                segments.push_back(segment);
+            }
+
+            return std::make_pair(segment->segment_start_ptr, segment_id);
+        } 
+    }
+
+    // If not find an empty segment large enough to hold the requested buffer
+    bool unoccupied_segment_value = false;
+    bool occupied_segment_value = true;
+    {
+        std::shared_lock lock(segment_lock);
+
+        for(auto &segment : segments) { 
+            // Check if the segment is free and large enough to hold the requested buffer
+            if(segment->segment_size < size) {
+                continue;
+            }
+
+            // See if this segment is already occupied
+            if(segment->occupied.load(std::memory_order_relaxed)) {
+                continue;
+            }
+
+            // If not try to occupy the segment using a CAS
+            if(segment->occupied.compare_exchange_strong(unoccupied_segment_value, occupied_segment_value, std::memory_order_relaxed)) {
+                return std::make_pair(segment->segment_start_ptr, segment->segment_id);
+            }
+        }
+    }
+
+    // If no such segement exists then malloc a page in pinned memory
+    return std::make_pair(allocatePageableCPUMemory(size), -1);
+}
+
+shared_ptr<GPUColumn> MallocCPUCache::cache_column_to_cpu(shared_ptr<GPUColumn> gpu_column, cudaStream_t& copy_stream) { 
+    // First determine the number of bytes needed to cache this column on the CPU
+    shared_ptr<GPUColumn> cpu_cached_column = make_shared_ptr<GPUColumn>(gpu_column);
+    size_t cpu_buffer_size = 0; 
+    if(cpu_cached_column->row_ids != nullptr) {
+        cpu_buffer_size += cpu_cached_column->row_id_count * sizeof(uint64_t);
+    }
+    if(cpu_cached_column->data_wrapper.validity_mask != nullptr) {
+        cpu_buffer_size += cpu_cached_column->data_wrapper.mask_bytes;
+    }
+    if(cpu_cached_column->data_wrapper.is_string_data) {
+        cpu_buffer_size += cpu_cached_column->data_wrapper.size * sizeof(uint64_t); // Add space to store string offset
+    }
+    cpu_buffer_size += cpu_cached_column->data_wrapper.num_bytes;
+
+    // Allocate a buffer of the requested size from the buffer pool
+    std::pair<uint8_t*, int> cpu_buffer_info = get_cache_buffer(cpu_buffer_size);
+    uint8_t* cpu_store_buffer = cpu_buffer_info.first;
+    cpu_cached_column->segment_start_ptr = cpu_store_buffer;
+    cpu_cached_column->segment_id = cpu_buffer_info.second;
+
+    // Now copy over the data from GPU to CPU asychronously using the provided stream
+    if(cpu_cached_column->row_ids != nullptr) { 
+        size_t row_id_bytes = cpu_cached_column->row_id_count * sizeof(uint64_t);
+        cudaMemcpyAsync(cpu_store_buffer, (uint8_t*) cpu_cached_column->row_ids, row_id_bytes, cudaMemcpyDeviceToHost, copy_stream);
+        cpu_cached_column->row_ids = reinterpret_cast<uint64_t*>(cpu_store_buffer);
+        cpu_store_buffer += row_id_bytes;
+    }
+
+    if(cpu_cached_column->data_wrapper.validity_mask != nullptr) { 
+        size_t mask_bytes = cpu_cached_column->data_wrapper.mask_bytes;
+        cudaMemcpyAsync(cpu_store_buffer, (uint8_t*) cpu_cached_column->data_wrapper.validity_mask, mask_bytes, cudaMemcpyDeviceToHost, copy_stream);
+        cpu_cached_column->data_wrapper.validity_mask = reinterpret_cast<cudf::bitmask_type*>(cpu_store_buffer);
+        cpu_store_buffer += mask_bytes;
+    }
+
+    if(cpu_cached_column->data_wrapper.is_string_data) { 
+        size_t offset_bytes = cpu_cached_column->data_wrapper.size * sizeof(uint64_t);
+        cudaMemcpyAsync(cpu_store_buffer, (uint8_t*) cpu_cached_column->data_wrapper.offset, offset_bytes, cudaMemcpyDeviceToHost, copy_stream);
+        cpu_cached_column->data_wrapper.offset = reinterpret_cast<uint64_t*>(cpu_store_buffer);
+        cpu_store_buffer += offset_bytes;
+    }
+
+    size_t data_bytes = cpu_cached_column->data_wrapper.num_bytes;
+    cudaMemcpyAsync(cpu_store_buffer, (uint8_t*) cpu_cached_column->data_wrapper.data, data_bytes, cudaMemcpyDeviceToHost, copy_stream);
+    cpu_cached_column->data_wrapper.data = cpu_store_buffer;
+
+    // Return the cached column
+    return cpu_cached_column;
+}
+
+uint32_t MallocCPUCache::moveDataToCPU(shared_ptr<GPUIntermediateRelation> relationship) { 
+    // Generate a unique id for this chunk
+    uint32_t chunk_id = next_chunk_id.fetch_add(1);
+
+    // For each column in the relationship, copy it over from gpu memory using a different stream for each column
+    uint32_t num_columns = relationship->columns.size();
+    uint32_t stream_sequence_num = copy_stream_sequence.fetch_add(num_columns);
+    shared_ptr<GPUIntermediateRelation> cpu_rel = make_shared_ptr<GPUIntermediateRelation>(num_columns);
+    #pragma unroll
+    for(uint32_t i = 0; i < num_columns; i++) { 
+        uint32_t column_stream_idx = (stream_sequence_num + i) % num_streams;
+        cudaStream_t& col_copy_stream = streams[column_stream_idx];
+        cpu_rel->columns[i] = cache_column_to_cpu(relationship->columns[i], col_copy_stream);
+    }
+
+    // Now synchronize all the streams to ensure that the copy is complete before we return
+    #pragma unroll
+    for (size_t i = 0; i < num_columns; i++) {
+        uint32_t column_stream_idx = (stream_sequence_num + i) % num_streams;
+        cudaStreamSynchronize(streams[column_stream_idx]);
+    }
+
+    // Save the cached relationship in the map and return the key to the caller
+    all_cached_relationships[chunk_id] = cpu_rel;
+    return chunk_id;
+}
+
+shared_ptr<GPUColumn> MallocCPUCache::move_cached_column_to_gpu(shared_ptr<GPUColumn> cpu_column, cudaStream_t& copy_stream, bool evict_from_cpu) { 
+    // Create the gpu column by copying over all of the metadata
+    GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
+    shared_ptr<GPUColumn> gpu_column = make_shared_ptr<GPUColumn>(cpu_column);
+    gpu_column->segment_id = -1; 
+
+    // First copy over the row ids if they exist
+    if(gpu_column->row_ids != nullptr) {
+        size_t row_id_bytes = gpu_column->row_id_count * sizeof(uint64_t);
+        gpu_column->row_ids = gpuBufferManager->customCudaMalloc<uint64_t>(gpu_column->row_id_count, 0, 0);
+        cudaMemcpyAsync(gpu_column->row_ids, cpu_column->row_ids, row_id_bytes, cudaMemcpyHostToDevice, copy_stream);
+    }
+
+    // Now copy over the validity mask if it exists
+    if(gpu_column->data_wrapper.validity_mask != nullptr) {
+        size_t mask_bytes = gpu_column->data_wrapper.mask_bytes;
+        gpu_column->data_wrapper.validity_mask = reinterpret_cast<cudf::bitmask_type*>(gpuBufferManager->customCudaMalloc<uint8_t>(mask_bytes, 0, 0));
+        cudaMemcpyAsync(gpu_column->data_wrapper.validity_mask, cpu_column->data_wrapper.validity_mask, mask_bytes, cudaMemcpyHostToDevice, copy_stream);
+    }
+
+    // If it is a string column also copy over the offsets
+    if(gpu_column->data_wrapper.is_string_data) {
+        size_t offset_bytes = gpu_column->data_wrapper.size * sizeof(uint64_t);
+        gpu_column->data_wrapper.offset = gpuBufferManager->customCudaMalloc<uint64_t>(gpu_column->data_wrapper.size, 0, 0);
+        cudaMemcpyAsync(gpu_column->data_wrapper.offset, cpu_column->data_wrapper.offset, offset_bytes, cudaMemcpyHostToDevice, copy_stream);
+    }
+
+    // Finally copy over the actual data
+    size_t data_bytes = cpu_column->data_wrapper.num_bytes;
+    gpu_column->data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(data_bytes, 0, 0);
+    cudaMemcpyAsync(gpu_column->data_wrapper.data, cpu_column->data_wrapper.data, data_bytes, cudaMemcpyHostToDevice, copy_stream);
+
+    // If evict is specified then also clear the CPU memory associated with this column
+    if(evict_from_cpu) {
+        if(cpu_column->segment_id != -1) { 
+            // If the column was cached in a segment in the pinned memory pool then mark that segment as free
+            std::shared_lock lock(segment_lock);
+            segments[cpu_column->segment_id]->occupied.store(false, std::memory_order_relaxed);
+        } else {
+            // Just free the pageable memory that was allocated for this segment
+            freePageableCPUMemory(cpu_column->segment_start_ptr);
+        }
+    }
+
+    return gpu_column;
+}
+
+shared_ptr<GPUIntermediateRelation> MallocCPUCache::moveDataToGPU(uint32_t chunk_id, bool evict_from_cpu) { 
+    // First load the chunk from the map and if specified evict it from the map
+    D_ASSERT(all_cached_relationships.find(chunk_id) != all_cached_relationships.end());
+    shared_ptr<GPUIntermediateRelation> cpu_rel = all_cached_relationships[chunk_id];
+    if(evict_from_cpu) { 
+        all_cached_relationships.erase(chunk_id);
+    }
+
+    // For each column in the relationship, copy it over to gpu memory using a different stream for each column
+    uint32_t num_columns = cpu_rel->columns.size();
+    uint32_t stream_sequence_num = copy_stream_sequence.fetch_add(num_columns);
+    shared_ptr<GPUIntermediateRelation> gpu_rel = make_shared_ptr<GPUIntermediateRelation>(num_columns);
+    #pragma unroll
+    for(uint32_t i = 0; i < num_columns; i++) { 
+        uint32_t column_stream_idx = (stream_sequence_num + i) % num_streams;
+        cudaStream_t& col_copy_stream = streams[column_stream_idx];
+        gpu_rel->columns[i] = move_cached_column_to_gpu(cpu_rel->columns[i], col_copy_stream, evict_from_cpu);
+    }
+
+    // Now synchronize all the streams to ensure that the copy is complete before we return
+    #pragma unroll
+    for (size_t i = 0; i < num_columns; i++) {
+        uint32_t column_stream_idx = (stream_sequence_num + i) % num_streams;
+        cudaStreamSynchronize(streams[column_stream_idx]);
+    }
+
+    return gpu_rel;
+}
+
+}

--- a/src/gpu_buffer_manager.cpp
+++ b/src/gpu_buffer_manager.cpp
@@ -172,7 +172,8 @@ GPUBufferManager::customCudaHostAlloc<ConstantFilter*>(size_t size);
 
 GPUBufferManager::GPUBufferManager(size_t cache_size_per_gpu, size_t processing_size_per_gpu, size_t processing_size_per_cpu) : 
     cache_size_per_gpu(cache_size_per_gpu), processing_size_per_gpu(processing_size_per_gpu), processing_size_per_cpu(processing_size_per_cpu) {
-    SIRIUS_LOG_INFO("Initializing GPU buffer manager with use pin of {}", Config::USE_PIN_MEM_FOR_CPU_PROCESSING);
+    SIRIUS_LOG_INFO("Initializing GPU buffer manager with params: Use Pin - {}, GPU Cache Size - {}, GPU Processing Size - {}, CPU Processing Size - {}", 
+        Config::USE_PIN_MEM_FOR_CPU_PROCESSING, cache_size_per_gpu, processing_size_per_gpu, processing_size_per_cpu);
     gpuCache = new uint8_t*[NUM_GPUS];
     cpuCache = new uint8_t*[NUM_GPUS];
     gpuProcessing = new uint8_t*[NUM_GPUS];

--- a/src/gpu_columns.cpp
+++ b/src/gpu_columns.cpp
@@ -555,6 +555,18 @@ GPUColumn::convertCudfOffsetToSiriusOffset(int32_t* cudf_offset) {
     data_wrapper.offset = convertInt32ToUInt64(cudf_offset, column_length + 1);
 }
 
+size_t GPUColumn::getTotalColumnSize() { 
+    // First get the base data size
+    size_t total_bytes = data_wrapper.num_bytes; 
+    if(data_wrapper.is_string_data) { // For strings add in the offset size
+        total_bytes += (data_wrapper.size + 1) * sizeof(uint64_t);
+    }
+
+    // Now add in the bitmask and row ids size
+    total_bytes += data_wrapper.mask_bytes + row_id_count * sizeof(uint64_t);
+    return total_bytes;
+}
+
 GPUIntermediateRelation::GPUIntermediateRelation(size_t column_count) :
         column_count(column_count) {
     column_names.resize(column_count);

--- a/src/include/cpu_cache.hpp
+++ b/src/include/cpu_cache.hpp
@@ -68,12 +68,13 @@ private:
     std::pair<uint8_t*, int> get_cache_buffer(size_t size);
 
     // Helper method to cache a column with data on the GPU into the CPU cache using the provided stream. 
-    // It returns a GPUColumn object representing the cached column with data now on the CPU
-    shared_ptr<GPUColumn> cache_column_to_cpu(shared_ptr<GPUColumn> gpu_column, cudaStream_t& copy_stream);
+    // It returns a GPUColumn object representing the cached column with data now on the CPU. Also sets the
+    // event that can be used to track when the copy is complete
+    shared_ptr<GPUColumn> cache_column_to_cpu(shared_ptr<GPUColumn> gpu_column, cudaStream_t& copy_stream, cudaEvent_t& copy_complete_event);
 
     /// Helper method to move a cached column from CPU back to GPU memory using the provided stream. If evict is specified
-    /// then we also free the CPU memory associated with caching this column
-    shared_ptr<GPUColumn> move_cached_column_to_gpu(shared_ptr<GPUColumn> cpu_column, cudaStream_t& copy_stream, bool evict_from_cpu);
+    /// then we also free the CPU memory associated with caching this column. ALso sets the event that can be used to track when the copy is complete
+    shared_ptr<GPUColumn> move_cached_column_to_gpu(shared_ptr<GPUColumn> cpu_column, cudaStream_t& copy_stream, cudaEvent_t& copy_complete_event);
 
     uint8_t* pinned_memory_buffer; // Pointer to the pinned memory buffer
     size_t pinned_memory_capacity; // Total capacity of the pinned memory buffer

--- a/src/include/cpu_cache.hpp
+++ b/src/include/cpu_cache.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "gpu_columns.hpp"
+#include "gpu_buffer_manager.hpp"
+
+#include <atomic>
+#include <vector>
+#include <utility>
+#include <unordered_map>
+#include <shared_mutex>
+
+using namespace std;
+
+namespace duckdb {
+
+class CPUCache {
+public:
+    // Copies over the columns in the relationship to CPU and returns an id for the saved chunk. Note 
+    // that this method just copies the data to CPU memory and does not free the allocated GPU memory
+    virtual uint32_t moveDataToCPU(shared_ptr<GPUIntermediateRelation> relationship) = 0;
+
+    // Copies over the columns in the relationship onto the GPU based on the chunk id. The chunk id should
+    // have been previously returned by moveDataToCPU. Note that the method only frees the allocated CPU memory
+    // if evict_from_cpu is set to true
+    virtual shared_ptr<GPUIntermediateRelation> moveDataToGPU(uint32_t chunk_id, bool evict_from_cpu) = 0;
+};
+
+class SegmentMetadata {
+public:
+    SegmentMetadata() = default;
+    ~SegmentMetadata() = default;
+
+    uint8_t* segment_start_ptr;
+    size_t segment_size;
+    int segment_id; 
+    std::atomic<bool> occupied;
+};
+
+// In Memory Cache that first tries to cache GPU data in pinned memory and then falls back to pageable memory
+// if pinned memory is full. It utilizes multiple streams to copy parallelize copying across columns
+class MallocCPUCache : public CPUCache {
+public:
+    MallocCPUCache(size_t pinned_memory_size, size_t num_streams = 1);
+    ~MallocCPUCache();
+
+    uint32_t moveDataToCPU(shared_ptr<GPUIntermediateRelation> relationship) override;
+    shared_ptr<GPUIntermediateRelation> moveDataToGPU(uint32_t chunk_id, bool evict_from_cpu) override;
+
+private:
+    // Helper method to get a buffer of the specified size from the pinned memory pool. Returns a pointer to the
+    // buffer as well as the segment id associated with that buffer
+    std::pair<uint8_t*, int> get_cache_buffer(size_t size);
+
+    // Helper method to cache a column with data on the GPU into the CPU cache using the provided stream. 
+    // It returns a GPUColumn object representing the cached column with data now on the CPU
+    shared_ptr<GPUColumn> cache_column_to_cpu(shared_ptr<GPUColumn> gpu_column, cudaStream_t& copy_stream);
+
+    /// Helper method to move a cached column from CPU back to GPU memory using the provided stream. If evict is specified
+    /// then we also free the CPU memory associated with caching this column
+    shared_ptr<GPUColumn> move_cached_column_to_gpu(shared_ptr<GPUColumn> cpu_column, cudaStream_t& copy_stream, bool evict_from_cpu);
+
+    uint8_t* pinned_memory_buffer; // Pointer to the pinned memory buffer
+    size_t pinned_memory_capacity; // Total capacity of the pinned memory buffer
+    std::atomic<int32_t> pinned_memory_offset; // Offset on the amount of pinned memory consumed so far
+    size_t num_streams; // Number of streams to use for copying
+    cudaStream_t* streams; // Pointer to streams that we can use
+    std::atomic<uint32_t> next_chunk_id; // Atomic counter to generate unique chunk ids
+    std::atomic<uint32_t> copy_stream_sequence; // Atomic counter to determine which stream to use for the next copy operation
+    std::unordered_map<uint32_t, shared_ptr<GPUIntermediateRelation>> all_cached_relationships; // Map storing the cached chunks
+    std::vector<shared_ptr<SegmentMetadata>> segments; // Vector storing the segments in the pinned memory pool
+    std::shared_mutex segment_lock; // Mutex to protect access to the segments vector
+};
+
+} // namespace duckdb

--- a/src/include/gpu_columns.hpp
+++ b/src/include/gpu_columns.hpp
@@ -209,6 +209,9 @@ public:
     size_t column_length; // number of rows in the column (currently equals to column_length)
     bool is_unique; // indicator whether the column has unique values
 
+    uint8_t* segment_start_ptr{nullptr}; // Pointer to the start of the segment where this column is stored, if this column is cached on CPU
+    int segment_id{-1}; // Metadata used by the CPU cache to identify where in the CPU this column is cached
+
     cudf::column_view convertToCudfColumn();
     int32_t* convertSiriusOffsetToCudfOffset(); // convert the offset of GPUColumn to the offset of the cudf column
     int32_t* convertSiriusRowIdsToCudfRowIds(); // convert the row_ids of the GPUColumn to the row_ids of the cudf column

--- a/src/include/gpu_columns.hpp
+++ b/src/include/gpu_columns.hpp
@@ -222,6 +222,9 @@ public:
     //cudf mask is int32_t type, but has the granularity of 64B
     //duckdb mask is uint64_t type and the granularity of 8B
     // void convertCudfMaskToSiriusMask(std::unique_ptr<rmm::device_buffer> cudf_mask, cudf::size_type col_size, GPUBufferManager* gpuBufferManager);
+
+    // Returns the total number of bytes to store all of the column details
+    size_t getTotalColumnSize();
 };
 
 class GPUIntermediateRelation {

--- a/test/cpp/memory_management/CMakeLists.txt
+++ b/test/cpp/memory_management/CMakeLists.txt
@@ -12,13 +12,7 @@
 # the License.
 # =============================================================================
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-add_subdirectory(pipeline)
-add_subdirectory(utils)
-add_subdirectory(memory_management)
-
 set(TEST_SOURCES
   ${TEST_SOURCES}
-  ${CMAKE_CURRENT_SOURCE_DIR}/unittest.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_cache.cpp
   PARENT_SCOPE)

--- a/test/cpp/memory_management/test_cpu_cache.cpp
+++ b/test/cpp/memory_management/test_cpu_cache.cpp
@@ -20,38 +20,248 @@
 #include "gpu_buffer_manager.hpp"
 #include "gpu_columns.hpp"
 #include "cpu_cache.hpp"
+#include "log/logging.hpp"
 
 using namespace duckdb;
 
-TEST_CASE("test_cpu_cache_basic_fixed", "[cpu_cache]") {
+constexpr size_t CPU_CACHE_TEST_MEM_SF = 8; // Factor used to determine the initial size of the CPU cache
+size_t calculate_test_cpu_cache_size(size_t bytes_to_cache) {
+   return std::pow(2.0, std::ceil(std::log2(CPU_CACHE_TEST_MEM_SF * bytes_to_cache)));
+}
+
+TEST_CASE("test_cpu_cache_basic_fixed_single_col", "[cpu_cache]") {
     // Initialize the buffer manager
     size_t num_records = 1024;
-    size_t column_bytes = num_records * sizeof(int32_t);
-    size_t memory_buffer_sizes = 2 * column_bytes;
-    GPUBufferManager::GetInstance(memory_buffer_sizes, memory_buffer_sizes, memory_buffer_sizes);
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
 
-    // Create a cpu cache with enough pinned memory and one stream
-    MallocCPUCache cpu_cache(memory_buffer_sizes, 1);
-
-    // Now create a GPU column representing a single integer column
-    int32_t* column_data = callCudaMalloc<int32_t>(num_records, 0);
-    duckdb::shared_ptr<GPUColumn> gpu_column = make_shared_ptr<GPUColumn>(num_records, GPUColumnType(GPUColumnTypeId::INT32), (uint8_t*) column_data, nullptr);
+    // Create a GPU column representing a single integer column
+    duckdb::shared_ptr<GPUColumn> gpu_column = create_column_with_random_data(GPUColumnTypeId::INT32, num_records);
     duckdb::shared_ptr<GPUIntermediateRelation> relationship = make_shared_ptr<GPUIntermediateRelation>(1);
     relationship->columns[0] = gpu_column;
 
     // Now cache the column to CPU
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(2 * gpu_column->getTotalColumnSize());
+    MallocCPUCache cpu_cache(cpu_cache_bytes, 1);
     uint32_t chunk_id = cpu_cache.moveDataToCPU(relationship);
+    REQUIRE(chunk_id == 0);
+
+    // Cache the column again and make sure we get an incremented chunk id
+    uint32_t copy_chunk_id = cpu_cache.moveDataToCPU(relationship);
+    REQUIRE(copy_chunk_id == 1);
+
+    // Now load the column and the duplicate back from the CPU cache to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
+    REQUIRE(loaded_relationship->columns.size() == 1);
+    duckdb::shared_ptr<GPUColumn> reloaded_column = loaded_relationship->columns[0];
+
+    duckdb::shared_ptr<GPUIntermediateRelation> copy_loaded_relationship = cpu_cache.moveDataToGPU(copy_chunk_id, false);
+    REQUIRE(copy_loaded_relationship->columns.size() == 1);
+    duckdb::shared_ptr<GPUColumn> copy_reloaded_column = copy_loaded_relationship->columns[0];
+
+    // Verify that we got the expected result
+    REQUIRE(reloaded_column->segment_id == -1);
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    verify_gpu_column_equality(reloaded_column, gpu_column);
+    verify_gpu_column_equality(copy_reloaded_column, gpu_column);
+
+    // Verify that we get an error trying to move an evicted column but can remove a non evicted column
+    REQUIRE_NOTHROW(cpu_cache.moveDataToGPU(copy_chunk_id, true));
+    REQUIRE_THROWS(cpu_cache.moveDataToGPU(chunk_id, true));
+}
+
+TEST_CASE("test_cpu_cache_basic_string_single_col", "[cpu_cache]") {
+    // Initialize the buffer manager
+    size_t num_records = 1024;
+    size_t chars_per_record = 8;
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
+
+    // Now create a GPU column representing a single string column
+    duckdb::shared_ptr<GPUColumn> gpu_column = create_column_with_random_data(GPUColumnTypeId::VARCHAR, num_records, chars_per_record);
+    duckdb::shared_ptr<GPUIntermediateRelation> gpu_relationship = make_shared_ptr<GPUIntermediateRelation>(1);
+    gpu_relationship->columns[0] = gpu_column;
+
+    // Now cache the column to CPU
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(gpu_column->getTotalColumnSize());
+    MallocCPUCache cpu_cache(cpu_cache_bytes, 1);
+    uint32_t chunk_id = cpu_cache.moveDataToCPU(gpu_relationship);
     REQUIRE(chunk_id == 0);
 
     // Now load the column back from the CPU cache to the GPU
     duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
     REQUIRE(loaded_relationship->columns.size() == 1);
-    duckdb::shared_ptr<GPUColumn> cpu_column = loaded_relationship->columns[0];
+    duckdb::shared_ptr<GPUColumn> reloaded_column = loaded_relationship->columns[0];
 
     // Verify that we got the expected result
-    verify_cuda_errors("CUDA Errors in Caching Test");
-    verify_gpu_column_equality(cpu_column, gpu_column);
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    verify_gpu_column_equality(reloaded_column, gpu_column);
+}
 
-    // Cleanup all allocated memory
-    callCudaFree<int32_t>(column_data, 0);
+TEST_CASE("test_cpu_cache_multiple_col_diff_streams", "[cpu_cache]") {
+    // Initialize the buffer manager
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
+
+    // Create a relationship with multiple string and integer columns
+    size_t num_records = 1024; size_t chars_per_record = 8;
+    size_t num_int_cols = 2; size_t num_string_cols = 2;
+
+    size_t num_total_cols = num_int_cols + num_string_cols;
+    duckdb::shared_ptr<GPUIntermediateRelation> gpu_relationship = make_shared_ptr<GPUIntermediateRelation>(num_total_cols);
+
+    size_t total_relationship_bytes = 0;
+    for(size_t i = 0; i < num_int_cols; i++) { 
+        gpu_relationship->columns[i] = create_column_with_random_data(GPUColumnTypeId::INT32, num_records);
+        total_relationship_bytes += gpu_relationship->columns[i]->getTotalColumnSize();
+    }
+    for(size_t i = 0; i < num_string_cols; i++) { 
+        gpu_relationship->columns[num_int_cols + i] = create_column_with_random_data(GPUColumnTypeId::VARCHAR, num_records, chars_per_record);
+        total_relationship_bytes += gpu_relationship->columns[num_int_cols + i]->getTotalColumnSize();
+    }
+
+    // Create two caches - one with single stream and the other with multiple streams
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(total_relationship_bytes);
+    MallocCPUCache single_stream_cpu_cache(cpu_cache_bytes, 1);
+    MallocCPUCache multiple_stream_cpu_cache(cpu_cache_bytes, num_total_cols);
+
+    // Cache the column on both of the caches
+    uint32_t single_chunk_id = single_stream_cpu_cache.moveDataToCPU(gpu_relationship);
+    REQUIRE(single_chunk_id == 0);
+    uint32_t multiple_chunk_id = multiple_stream_cpu_cache.moveDataToCPU(gpu_relationship);
+    REQUIRE(multiple_chunk_id == 0); 
+
+    // Now load the column back from the CPU caches to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> single_loaded_relationship = single_stream_cpu_cache.moveDataToGPU(single_chunk_id, true);
+    REQUIRE(single_loaded_relationship->columns.size() == num_total_cols);
+    duckdb::shared_ptr<GPUIntermediateRelation> multi_loaded_relationship = multiple_stream_cpu_cache.moveDataToGPU(multiple_chunk_id, true);
+    REQUIRE(multi_loaded_relationship->columns.size() == num_total_cols);
+
+    // Verify that we got the expected result by comparing column by column
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    for(size_t i = 0; i < num_total_cols; i++) { 
+        verify_gpu_column_equality(single_loaded_relationship->columns[i], gpu_relationship->columns[i]);
+        verify_gpu_column_equality(multi_loaded_relationship->columns[i], gpu_relationship->columns[i]);
+    }
+}
+
+TEST_CASE("test_cpu_cache_multiple_cols_with_only_row_ids", "[cpu_cache]") {
+    // Initialize the buffer manager
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
+
+    // Create a relationship with multiple string and integer columns
+    size_t num_records = 1024; size_t chars_per_record = 8;
+    size_t num_int_cols = 2; size_t num_string_cols = 2;
+
+    size_t num_total_cols = num_int_cols + num_string_cols;
+    duckdb::shared_ptr<GPUIntermediateRelation> gpu_relationship = make_shared_ptr<GPUIntermediateRelation>(num_total_cols);
+
+    size_t total_relationship_bytes = 0;
+    for(size_t i = 0; i < num_int_cols; i++) { 
+        size_t num_row_ids = rand() % num_records;
+        gpu_relationship->columns[i] = create_column_with_random_data(GPUColumnTypeId::INT32, num_records, 1, num_row_ids);
+        total_relationship_bytes += gpu_relationship->columns[i]->getTotalColumnSize();
+    }
+    for(size_t i = 0; i < num_string_cols; i++) { 
+        size_t num_row_ids = rand() % num_records;
+        gpu_relationship->columns[num_int_cols + i] = create_column_with_random_data(GPUColumnTypeId::VARCHAR, num_records, chars_per_record, num_row_ids);
+        total_relationship_bytes += gpu_relationship->columns[num_int_cols + i]->getTotalColumnSize();
+    }
+
+    // Create two caches - one with single stream and the other with multiple streams
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(total_relationship_bytes);
+    MallocCPUCache cpu_cache(cpu_cache_bytes, num_total_cols);
+
+    // Cache the column on both of the caches
+    uint32_t chunk_id = cpu_cache.moveDataToCPU(gpu_relationship);
+    REQUIRE(chunk_id == 0); 
+
+    // Now load the column back from the CPU caches to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
+    REQUIRE(loaded_relationship->columns.size() == num_total_cols);
+
+    // Verify that we got the expected result by comparing column by column
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    for(size_t i = 0; i < num_total_cols; i++) { 
+        verify_gpu_column_equality(loaded_relationship->columns[i], gpu_relationship->columns[i]);
+    }
+}
+
+TEST_CASE("test_cpu_cache_multiple_cols_with_only_validitiy_mask", "[cpu_cache]") {
+    // Initialize the buffer manager
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
+
+    // Create a relationship with multiple string and integer columns
+    size_t num_records = 1024; size_t chars_per_record = 8;
+    size_t num_int_cols = 2; size_t num_string_cols = 2;
+
+    size_t num_total_cols = num_int_cols + num_string_cols;
+    duckdb::shared_ptr<GPUIntermediateRelation> gpu_relationship = make_shared_ptr<GPUIntermediateRelation>(num_total_cols);
+
+    size_t total_relationship_bytes = 0;
+    for(size_t i = 0; i < num_int_cols; i++) { 
+        gpu_relationship->columns[i] = create_column_with_random_data(GPUColumnTypeId::INT32, num_records, 1, 0, true);
+        total_relationship_bytes += gpu_relationship->columns[i]->getTotalColumnSize();
+    }
+    for(size_t i = 0; i < num_string_cols; i++) { 
+        gpu_relationship->columns[num_int_cols + i] = create_column_with_random_data(GPUColumnTypeId::VARCHAR, num_records, chars_per_record, 0, true);
+        total_relationship_bytes += gpu_relationship->columns[num_int_cols + i]->getTotalColumnSize();
+    }
+
+    // Create two caches - one with single stream and the other with multiple streams
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(total_relationship_bytes);
+    MallocCPUCache cpu_cache(cpu_cache_bytes, num_total_cols);
+
+    // Cache the column on both of the caches
+    uint32_t chunk_id = cpu_cache.moveDataToCPU(gpu_relationship);
+    REQUIRE(chunk_id == 0); 
+
+    // Now load the column back from the CPU caches to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
+    REQUIRE(loaded_relationship->columns.size() == num_total_cols);
+
+    // Verify that we got the expected result by comparing column by column
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    for(size_t i = 0; i < num_total_cols; i++) { 
+        verify_gpu_column_equality(loaded_relationship->columns[i], gpu_relationship->columns[i]);
+    }
+}
+
+TEST_CASE("test_cpu_cache_multiple_cols_with_row_ids_and_validitiy_mask", "[cpu_cache]") {
+    // Initialize the buffer manager
+    GPUBufferManager* gpuBufferManager = initialize_test_buffer_manager();
+
+    // Create a relationship with multiple string and integer columns
+    size_t num_records = 1024; size_t chars_per_record = 8;
+    size_t num_int_cols = 2; size_t num_string_cols = 2;
+
+    size_t num_total_cols = num_int_cols + num_string_cols;
+    duckdb::shared_ptr<GPUIntermediateRelation> gpu_relationship = make_shared_ptr<GPUIntermediateRelation>(num_total_cols);
+
+    size_t total_relationship_bytes = 0;
+    for(size_t i = 0; i < num_int_cols; i++) { 
+        size_t num_row_ids = rand() % num_records;
+        gpu_relationship->columns[i] = create_column_with_random_data(GPUColumnTypeId::INT32, num_records, 1, num_row_ids, true);
+        total_relationship_bytes += gpu_relationship->columns[i]->getTotalColumnSize();
+    }
+    for(size_t i = 0; i < num_string_cols; i++) { 
+        size_t num_row_ids = rand() % num_records;
+        gpu_relationship->columns[num_int_cols + i] = create_column_with_random_data(GPUColumnTypeId::VARCHAR, num_records, chars_per_record, num_row_ids, true);
+        total_relationship_bytes += gpu_relationship->columns[num_int_cols + i]->getTotalColumnSize();
+    }
+
+    // Create two caches - one with single stream and the other with multiple streams
+    size_t cpu_cache_bytes = calculate_test_cpu_cache_size(total_relationship_bytes);
+    MallocCPUCache cpu_cache(cpu_cache_bytes, num_total_cols);
+
+    // Cache the column on both of the caches
+    uint32_t chunk_id = cpu_cache.moveDataToCPU(gpu_relationship);
+    REQUIRE(chunk_id == 0); 
+
+    // Now load the column back from the CPU caches to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
+    REQUIRE(loaded_relationship->columns.size() == num_total_cols);
+
+    // Verify that we got the expected result by comparing column by column
+    verify_cuda_errors("CUDA Errors in CPU Caching Test");
+    for(size_t i = 0; i < num_total_cols; i++) { 
+        verify_gpu_column_equality(loaded_relationship->columns[i], gpu_relationship->columns[i]);
+    }
 }

--- a/test/cpp/memory_management/test_cpu_cache.cpp
+++ b/test/cpp/memory_management/test_cpu_cache.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "utils/utils.hpp"
+
+#include "gpu_buffer_manager.hpp"
+#include "gpu_columns.hpp"
+#include "cpu_cache.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("test_cpu_cache_basic_fixed", "[cpu_cache]") {
+    // Initialize the buffer manager
+    size_t num_records = 1024;
+    size_t column_bytes = num_records * sizeof(int32_t);
+    size_t memory_buffer_sizes = 2 * column_bytes;
+    GPUBufferManager::GetInstance(memory_buffer_sizes, memory_buffer_sizes, memory_buffer_sizes);
+
+    // Create a cpu cache with enough pinned memory and one stream
+    MallocCPUCache cpu_cache(memory_buffer_sizes, 1);
+
+    // Now create a GPU column representing a single integer column
+    int32_t* column_data = callCudaMalloc<int32_t>(num_records, 0);
+    duckdb::shared_ptr<GPUColumn> gpu_column = make_shared_ptr<GPUColumn>(num_records, GPUColumnType(GPUColumnTypeId::INT32), (uint8_t*) column_data, nullptr);
+    duckdb::shared_ptr<GPUIntermediateRelation> relationship = make_shared_ptr<GPUIntermediateRelation>(1);
+    relationship->columns[0] = gpu_column;
+
+    // Now cache the column to CPU
+    uint32_t chunk_id = cpu_cache.moveDataToCPU(relationship);
+    REQUIRE(chunk_id == 0);
+
+    // Now load the column back from the CPU cache to the GPU
+    duckdb::shared_ptr<GPUIntermediateRelation> loaded_relationship = cpu_cache.moveDataToGPU(chunk_id, true);
+    REQUIRE(loaded_relationship->columns.size() == 1);
+    duckdb::shared_ptr<GPUColumn> cpu_column = loaded_relationship->columns[0];
+
+    // Verify that we got the expected result
+    verify_cuda_errors("CUDA Errors in Caching Test");
+    verify_gpu_column_equality(cpu_column, gpu_column);
+
+    // Cleanup all allocated memory
+    callCudaFree<int32_t>(column_data, 0);
+}

--- a/test/cpp/pipeline/test_chunk_merge.cpp
+++ b/test/cpp/pipeline/test_chunk_merge.cpp
@@ -98,9 +98,8 @@ void merge_and_verify(GPUBufferManager* gpu_buffer_manager, const vector<shared_
 }
 
 void test_chunk_merge() {
-  // Initialize
-  static constexpr size_t buffer_size = 1024L * 1024;
-  GPUBufferManager* gpu_buffer_manager = &(GPUBufferManager::GetInstance(buffer_size, buffer_size, buffer_size));
+  // Initialize the buffer manager
+  GPUBufferManager* gpu_buffer_manager = initialize_test_buffer_manager();
 
   // Prepare input data
   vector<GPUColumnType> types{GPUColumnType(GPUColumnTypeId::INT32),

--- a/test/cpp/utils/utils.cpp
+++ b/test/cpp/utils/utils.cpp
@@ -19,6 +19,9 @@
 #include "catch.hpp"
 #include "gpu_materialize.hpp"
 
+#include <cuda_runtime.h>
+#include <cuda.h>
+
 namespace duckdb {
 
 std::mt19937_64& global_rng() {
@@ -171,6 +174,62 @@ void free_cpu_buffer(const vector<GPUColumnType>& types, uint8_t** host_data, ui
   }
   delete[] host_data;
   delete[] host_offset;
+}
+
+void verify_cuda_errors(const char *msg) {
+    cudaError_t __err = cudaGetLastError();
+    if (__err != cudaSuccess) {
+        printf("CUDA error: %s (%s at %s:%d)\n",
+                msg, cudaGetErrorString(__err),
+                __FILE__, __LINE__);
+        REQUIRE(1 == 2);
+    }   
+}
+
+void verify_gpu_buffer_equality(uint8_t* buffer_1, uint8_t* buffer_2, size_t num_bytes) { 
+  // If the first buffer is null then verify that the second one is null as well
+  if(buffer_1 == nullptr) {
+    REQUIRE(buffer_2 == nullptr);
+    return;
+  }
+
+  // Allocate temporary host buffers to copy the data back
+  uint8_t* host_buffer_1 = (uint8_t*) malloc(num_bytes);
+  uint8_t* host_buffer_2 = (uint8_t*) malloc(num_bytes);
+
+  // Copy the data back to the host
+  cudaMemcpy(host_buffer_1, buffer_1, num_bytes, cudaMemcpyDeviceToHost);
+  cudaMemcpy(host_buffer_2, buffer_2, num_bytes, cudaMemcpyDeviceToHost);
+
+  // Now compare the two buffers
+  REQUIRE(memcmp(host_buffer_1, host_buffer_2, num_bytes) == 0);
+
+  // Free the temporary host buffers
+  free(host_buffer_1);
+  free(host_buffer_2);
+}
+
+void verify_gpu_column_equality(shared_ptr<GPUColumn> col1, shared_ptr<GPUColumn> col2) { 
+  // First verify that all of the metadata is the same
+  REQUIRE(col1->column_length == col2->column_length);
+  REQUIRE(col1->row_id_count == col2->row_id_count);
+  REQUIRE(col1->is_unique == col2->is_unique);
+
+  DataWrapper col1_data = col1->data_wrapper;
+  DataWrapper col2_data = col2->data_wrapper;
+  REQUIRE(col1_data.type.id() == col2_data.type.id());
+  REQUIRE(col1_data.size == col2_data.size);
+  REQUIRE(col1_data.num_bytes == col2_data.num_bytes);
+  REQUIRE(col1_data.is_string_data == col2_data.is_string_data);
+  REQUIRE(col1_data.mask_bytes == col2_data.mask_bytes);
+
+  // Now verify all of the buffers are the same
+  verify_gpu_buffer_equality((uint8_t*) col1->row_ids, (uint8_t*) col2->row_ids, col1->row_id_count * sizeof(uint64_t));
+  verify_gpu_buffer_equality(col1_data.data, col2_data.data, col1_data.num_bytes);
+  verify_gpu_buffer_equality((uint8_t*) col1_data.validity_mask, (uint8_t*) col2_data.validity_mask, col1_data.mask_bytes);
+  if(col1_data.is_string_data) {
+    verify_gpu_buffer_equality((uint8_t*) col1_data.offset, (uint8_t*) col2_data.offset, col1_data.size * sizeof(uint64_t));
+  }
 }
 
 }

--- a/test/cpp/utils/utils.hpp
+++ b/test/cpp/utils/utils.hpp
@@ -25,12 +25,20 @@
 
 namespace duckdb {
 
+// The buffer manager is shared across all threads so we need to allocate the memory needed by all tests
+// upfront when initializating the buffer manager
+constexpr size_t TEST_BUFFER_MANAGER_MEMORY_BYTES = 2L * 1024L * 1024L * 1024L; // 2 GB for testing
+
 std::mt19937_64& global_rng();
 
 template <typename T>
 T rand_int(T low, T high);
 
 std::string rand_str(int len);
+
+GPUBufferManager* initialize_test_buffer_manager();
+
+void fill_gpu_buffer_with_random_data(uint8_t* gpu_buffer, size_t num_bytes);
 
 shared_ptr<GPUIntermediateRelation> create_table(
   GPUBufferManager* gpu_buffer_manager, const vector<GPUColumnType>& types, const int num_rows,
@@ -46,5 +54,8 @@ void verify_cuda_errors(const char *msg);
 void verify_gpu_buffer_equality(uint8_t* buffer_1, uint8_t* buffer_2, size_t num_bytes);
 
 void verify_gpu_column_equality(shared_ptr<GPUColumn> col1, shared_ptr<GPUColumn> col2);
+
+shared_ptr<GPUColumn> create_column_with_random_data(GPUColumnTypeId col_type, size_t num_records, 
+  size_t chars_per_record = 1, size_t num_materialize_row_ids = 0, bool has_null_mask = false);
 
 }

--- a/test/cpp/utils/utils.hpp
+++ b/test/cpp/utils/utils.hpp
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include "catch.hpp"
+
 #include "gpu_buffer_manager.hpp"
+#include "gpu_columns.hpp"
 
 #include <random>
 
@@ -37,5 +40,11 @@ void verify_table(GPUBufferManager* gpu_buffer_manager, GPUIntermediateRelation&
                   uint8_t** expected_host_data, uint64_t** expected_host_offset);
 
 void free_cpu_buffer(const vector<GPUColumnType>& types, uint8_t** host_data, uint64_t** host_offset);
+
+void verify_cuda_errors(const char *msg); 
+
+void verify_gpu_buffer_equality(uint8_t* buffer_1, uint8_t* buffer_2, size_t num_bytes);
+
+void verify_gpu_column_equality(shared_ptr<GPUColumn> col1, shared_ptr<GPUColumn> col2);
 
 }


### PR DESCRIPTION
Introduces the following implementation for a CPUCache: 
```
class CPUCache {
public:
    virtual uint32_t moveDataToCPU(shared_ptr<GPUIntermediateRelation> relationship) = 0;
    virtual shared_ptr<GPUIntermediateRelation> moveDataToGPU(uint32_t chunk_id, bool evict_from_cpu) = 0;
};
```

as well as implements `MallocCPUCache` a malloc based cache that implements the above interface. Also adds in unit tests for the `MallocCPUCache` implementation