### PR TITLE
Topology aware memory manager initialization 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(EXTENSION_SOURCES
   src/memory/memory_reservation.cpp
   src/memory/fixed_size_host_memory_resource.cpp
   src/memory/null_device_memory_resource.cpp
+  src/memory/topology_discovery.cpp
   src/parallel/task_executor.cpp
 )
 add_subdirectory(src/operator)

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,190 +3,179 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/rapidsai/
+    - url: https://conda.anaconda.org/nvidia/
     - url: https://conda.anaconda.org/conda-forge/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-h4852527_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-h9d8b0ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-h4852527_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.2-hc85cc9f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-hb991d5c_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.3-hc85cc9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_15.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl_linux-64-13.0.85-1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-64-13.0.88-0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-crt-tools-13.0.88-0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-13.0.96-ha533d76_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-13.0.96-h3b4bcfc_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-64-13.0.96-hbe36340_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-static-13.0.96-h3b4bcfc_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-64-13.0.96-hbe36340_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-13.0.96-h73695a4_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-64-13.0.96-hbe36340_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-13.0.88-hb25713b_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-64-13.0.88-0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-impl-13.0.88-hbe36340_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-tools-13.0.88-h3b4bcfc_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc_linux-64-13.0.88-he6262bf_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-13.0.87-ha2c4e13_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-13.0.88-hb0a779f_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-64-13.0.88-0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-impl-13.0.88-h3b4bcfc_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-tools-13.0.88-h3b4bcfc_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dlpack-0.8-h59595ed_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h76bdaa0_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hd9e9e21_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-he663afc_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hed40740_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h319ec69_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-he6f32d1_14.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-h1aa0949_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.15.1.6-h2e68323_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.15.1.6-h2e68323_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.4.0.35-h50d9014_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.4.0.35-h50d9014_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-h85bb3a7_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_15.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.10.00-cuda13_0_251008_fb6220c4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-h7bcfba5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-h7bcfba5_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjitlink-13.0.88-hb0a779f_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-64-13.0.88-0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-hd08acf3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h85bb3a7_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/rapids-logger-0.1.1-h98325ef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.12.0-he64ecbb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-hf1166c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-ha36da51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-hf1166c9_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/arm-variant-1.2.0-sbsa.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.11.0-hdceaead_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.2-hc9d863e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-h92dcf8a_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.3-hc9d863e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_15.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cccl_linux-aarch64-13.0.85-h119d96e_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-crt-tools-13.0.88-h119d96e_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-13.0.96-h7bee0a1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-dev-13.0.96-h48dd3d1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-static-13.0.96-h48dd3d1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h48dd3d1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-aarch64-13.0.96-h7bee0a1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-13.0.88-h331fd37_100.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-impl-13.0.88-h48dd3d1_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-tools-13.0.88-h48dd3d1_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h7533faf_100.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvml-dev-13.0.87-h691c0af_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvrtc-13.0.88-h492901c_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-impl-13.0.88-h48dd3d1_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-tools-13.0.88-h48dd3d1_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.11.0-h7b35c40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dlpack-0.8-h2f0025b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h7408ef6_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-h2b96704_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_13.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha28f942_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h72695c8_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-h0724e97_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hadc3402_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-hef95cfa_14.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-hd32f0e1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_104.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-1.15.1.6-h1c78503_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-dev-1.15.1.6-h1c78503_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-10.4.0.35-h384c9aa_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-dev-10.4.0.35-h384c9aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.17.0-h7bfdcfb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.1-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-he277a41_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h370b906_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-he277a41_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.3-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_15.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.10.00-cuda13_0_251008_fb6220c4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.67.0-ha888d0e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnuma-2.0.18-h86ecc28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-he387df4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-he387df4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libnvjitlink-13.0.88-h492901c_0.conda
+      - conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h119d96e_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-h48d3638_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-h3f4de04_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h370b906_107.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hf1166c9_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_115.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.0-h8e36d6e_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/rapids-logger-0.1.1-h4f43097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.12.0-hb434046_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unzip-6.0-he30d5cf_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -219,90 +208,71 @@ packages:
   license_family: BSD
   size: 23712
   timestamp: 1650670790230
-- conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
+- conda: https://conda.anaconda.org/nvidia/noarch/arm-variant-1.2.0-sbsa.conda
   sha256: 0658cac65071ace5beded633851681e6f0b381040c8ce313bbe2a0ab410c5072
   md5: b7d6244b9c7a660f10336645e73c2cd2
   license: BSD-3-Clause
   license_family: BSD
   size: 7126
   timestamp: 1742928603302
-- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-  sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
-  md5: 791365c5f65975051e4e017b5da3abf5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 68072
-  timestamp: 1756738968573
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-  sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
-  md5: 1ef6c06fec1b6f5ee99ffe2152e53568
-  depends:
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 74992
-  timestamp: 1660065534958
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-h4852527_0.conda
-  sha256: 65585ee55d645c419d0d5acce0343ba13e2036b4d3d823bf23e1cd70d344a91d
-  md5: 6e3c04f73d7bdc7e002de785a61cdc18
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
+  sha256: 1625ea421e0f44dbdde01e3e7d2c4958bea6c55731e6ac6954ba912d339982c2
+  md5: d351e4894d6c4d9d8775bf169a97089d
   depends:
   - binutils_impl_linux-64 >=2.45,<2.46.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 35135
-  timestamp: 1763060477972
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-hf1166c9_0.conda
-  sha256: 3311fbbbb8ad75805e71456e636a5e06e9c3fc4bcde9e7370a73c0c7d2e80968
-  md5: de20858145deac8164920624c8b4bd9f
+  size: 35316
+  timestamp: 1764007880473
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_104.conda
+  sha256: 9bc583e5f93353723d7889ec18b9bca2c1cecf6fec14ea27ae5f758a28258cf9
+  md5: c8a3dbfe30387152a796e2d1d4196131
   depends:
   - binutils_impl_linux-aarch64 >=2.45,<2.46.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 35254
-  timestamp: 1763060538971
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-h9d8b0ac_0.conda
-  sha256: 1733bd616f0e7afdc926e4eb80b00483ebdc51bc6aadf7c4b7242ed93044e25b
-  md5: 0f846eecce9004022f9706252b143b0f
+  size: 35396
+  timestamp: 1764007964053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
+  sha256: 054a77ccab631071a803737ea8e5d04b5b18e57db5b0826a04495bd3fdf39a7c
+  md5: a7a67bf132a4a2dea92a7cb498cdc5b1
   depends:
-  - ld_impl_linux-64 2.45 h1aa0949_0
+  - ld_impl_linux-64 2.45 default_hbd61a6d_104
   - sysroot_linux-64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 3781434
-  timestamp: 1763060453906
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-ha36da51_0.conda
-  sha256: 567187fdd6ae9620e596182a73b5ee9c656fd4f140f4832c1b219028eb266813
-  md5: 8bb3fc4ebebaa0133c32197514b92449
+  size: 3747046
+  timestamp: 1764007847963
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_104.conda
+  sha256: b7694c53943941a5234406b77b168e28d92227f8e69c697edda3faf436dd26c1
+  md5: 8107322440b07ab4234815368d1785a9
   depends:
-  - ld_impl_linux-aarch64 2.45 hd32f0e1_0
+  - ld_impl_linux-aarch64 2.45 default_h1979696_104
   - sysroot_linux-aarch64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 4116902
-  timestamp: 1763060519935
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-h4852527_0.conda
-  sha256: ffcb163c3f3b87d6aaa2608ff6027fe21bdcf9844f204112c7ef0f9eb65a848e
-  md5: 01c3e6f0d3266733368ca1b64f1415d8
+  size: 4850743
+  timestamp: 1764007931341
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
+  sha256: ed23fee4db69ad82320cca400fc77404c3874cd866606651a20bf743acd1a9b1
+  md5: e30e71d685e23cc1e5ac1c1990ba1f81
   depends:
-  - binutils_impl_linux-64 2.45 h9d8b0ac_0
+  - binutils_impl_linux-64 2.45 default_hfdba357_104
   license: GPL-3.0-only
   license_family: GPL
-  size: 36086
-  timestamp: 1763060480570
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-hf1166c9_0.conda
-  sha256: 9b4a907f125ebd17b0ddc79bdfc0ae083e99a1b59699a76ef7c4947e18e62860
-  md5: 4bb889c57d94597765ad8721ae1085f0
+  size: 36180
+  timestamp: 1764007883258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_104.conda
+  sha256: c93628f369264e5c7375915a5f589624d3211b5f4eb26a49395b1824976aeeb9
+  md5: ddc3eece92177305e59ed62f95342d4b
   depends:
-  - binutils_impl_linux-aarch64 2.45 ha36da51_0
+  - binutils_impl_linux-aarch64 2.45 default_h5f4c503_104
   license: GPL-3.0-only
   license_family: GPL
-  size: 36183
-  timestamp: 1763060541682
+  size: 36380
+  timestamp: 1764007966890
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
   sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
   md5: 51a19bba1b8ebfb60df25cde030b7ebc
@@ -371,13 +341,13 @@ packages:
   license: ISC
   size: 152432
   timestamp: 1762967197890
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.2-hc85cc9f_0.conda
-  sha256: 2176c4bce9f602cee0efbae86283a1a75733921ecc0916c8d2f49df2aee1a0f0
-  md5: 3d5d0a07f07ba1fc43f52b5e33e3cd7c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.3-hc85cc9f_0.conda
+  sha256: 5b47d55df169ef390ba21e2c20385473b51cade9a3248edd0d27c550aeb2dadc
+  md5: 21eca3ff0e576568afbce5409a92a0f8
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.14.1,<9.0a0
+  - libcurl >=8.17.0,<9.0a0
   - libexpat >=2.7.1,<3.0a0
   - libgcc >=14
   - liblzma >=5.8.1,<6.0a0
@@ -389,14 +359,14 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 21290609
-  timestamp: 1759261133874
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.2-hc9d863e_0.conda
-  sha256: 7b55dfccde7fa4a16572648302330f073b124312228cabade745ff455ebcfe64
-  md5: 92b5d21ff60ab639abdb13e195a99ba7
+  size: 21260270
+  timestamp: 1763512297910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.3-hc9d863e_0.conda
+  sha256: 11a1c62e29c7d680c326904f1cea7375a4da2cefe759ffe06536194637d95675
+  md5: 9de934b24a6e2c3d7cecd8d0be036e84
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.14.1,<9.0a0
+  - libcurl >=8.17.0,<9.0a0
   - libexpat >=2.7.1,<3.0a0
   - libgcc >=14
   - liblzma >=5.8.1,<6.0a0
@@ -408,342 +378,349 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 20534912
-  timestamp: 1759261475840
-- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-hb991d5c_7.conda
-  sha256: d2fc6de5c21d92bf6a4c2f51040662ea34ed94baa7c2758ba685fd3b0032f7cb
-  md5: 39586596e88259bae48f904fb1025b77
+  size: 20521629
+  timestamp: 1763512243490
+- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_15.conda
+  sha256: 24709cfc0b12ef8248ec4ebf854bacfeb36868e1757a89d3e01c636f110f886b
+  md5: 93b9b94788b52e6f79cf6ae88de40c76
   depends:
   - gcc_impl_linux-64 >=14.3.0,<14.3.1.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 33231
-  timestamp: 1759965946160
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-h92dcf8a_7.conda
-  sha256: caa39c2a763a9df5517e7997527e0174ff7b45b9401cbc1c433260a38cf3eb27
-  md5: 56c17840d46efe245687761d82b3ff57
+  size: 30973
+  timestamp: 1764836751487
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_15.conda
+  sha256: 79af3f48724988e059468a7293bc524732038a3e1d122e4e358c64342cc46d3c
+  md5: d8ef968a2027db34adc6450eed26a9a5
   depends:
   - gcc_impl_linux-aarch64 >=14.3.0,<14.3.1.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 33230
-  timestamp: 1759967693238
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
-  sha256: a6e372858d440e3adcea6902a013f9e5df5794ac414532bf21340919565406fc
-  md5: 9cdd4053158422e3ef9d7a3feb31e40d
+  size: 30750
+  timestamp: 1764836639741
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl_linux-64-13.0.85-1.conda
+  sha256: 693bee3487a484e1d6cb3f7f994d5433df7a698e94116272dc04da25cc542a26
+  md5: fa3fb6896ca529d1863301b831ccf985
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1143068
-  timestamp: 1757017456077
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
-  sha256: 89d1251bfb27d9d861764cd1daae2b835588045ba920debab66a79e208484032
-  md5: 6739a8321047a32fe33edc982b570c9c
+  size: 1151590
+  timestamp: 1755226921988
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cccl_linux-aarch64-13.0.85-h119d96e_1.conda
+  sha256: ae0d6ee9a719c8d54e5c35f7e8c9562431be87adc85f21ef15b62921e1ad94b8
+  md5: 5482d83595b1c801a1f5479f44de2ff6
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  constrains:
+  - arm-variant * sbsa
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 1147814
+  timestamp: 1755227272989
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-64-13.0.88-0.conda
+  sha256: 83fc861daf59475c31e69ffd7ee58f9c4049099a01cdd6bde59bd9edc992a97e
+  md5: 593db12a0b0152b3017184863c8388f7
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 86152
+  timestamp: 1755730598660
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+  sha256: 02fb970d0a8238700fd0fa7ab9a6daf94909a33854b9bc5253da1da48aee5fc4
+  md5: eddca933593f2d106860f7f7a562e516
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1141138
-  timestamp: 1757017459617
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: dff9f97d3c8f47e1e4b6d486401d11a2d8aa9474a07adbd177b042a8cb640e1f
-  md5: 99dddaab1ca61632434f37079fce52e9
+  size: 86211
+  timestamp: 1755731173145
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-crt-tools-13.0.88-0.conda
+  sha256: 4cc402d170d9519470df95a5a593cdce4eea82f55586a90ee521ad5b752a2300
+  md5: c12257073b2cab320ac2070f04725c51
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 95746
-  timestamp: 1757021345670
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 5ffbb6e143bd16951c1bc71d32f8137f9ed890df9420e1c9d5d30c12823b951e
-  md5: 766775e40dac3236cd90077f460552db
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 95711
-  timestamp: 1757021337458
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
-  sha256: c7fc9f3c3f0c51678dc92b1caa46dbce35a1dc6e6176771f0a87272a22a35256
-  md5: d72c22960bc7ec9144bedaeb6138a261
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29931
-  timestamp: 1757021356880
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
-  sha256: 564b166a587e62c92c6e0b4044955cedab42168ae2730f74694fe89ef61b9fd3
-  md5: 75359c125cfd48ee457a6659b561a764
+  size: 20243
+  timestamp: 1755730602108
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-crt-tools-13.0.88-h119d96e_0.conda
+  sha256: c7c5c73727370965724817412fef6493f496fe3374e6a02fb1614dc563787060
+  md5: 9b7eb28a43190a5587da9d7ae40048ab
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 30038
-  timestamp: 1757021339160
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
-  sha256: 22f6466441812649da65ef47792854e9552e566d7ac6c3682d81dbb480de529c
-  md5: b585052893126ed45c015bcab43ff12a
+  size: 20317
+  timestamp: 1755731197964
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-13.0.96-ha533d76_1.conda
+  sha256: 139c939d14fa7db1c84b88e199f2ea4be1e3cac2ff1aaa786e8c8e575848a750
+  md5: 9767138ad770a6ac7da2b54a5c86c3ba
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart_linux-64 13.0.96 h376f20c_0
+  - cuda-cudart_linux-64 13.0.96 h73695a4_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24027
-  timestamp: 1760034148822
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
-  sha256: 0387b104ebf74f83ed911cd90aebb064ed1d2ffb147c36cb6c268415302431a8
-  md5: fd19003beb0686dd8e47466bbab1b11f
+  size: 18865
+  timestamp: 1758935647523
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-13.0.96-h7bee0a1_1.conda
+  sha256: 9b5a3ba4facf556967d8b6bdc435a5ae267218d988e88c6e9e13b3a7e11ce485
+  md5: f9267770e2868d14e4212fc162b69e18
   depends:
   - arm-variant * sbsa
-  - cuda-cudart_linux-aarch64 13.0.96 h8f3c8d4_0
+  - cuda-cudart_linux-aarch64 13.0.96 h7bee0a1_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24195
-  timestamp: 1760034124717
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
-  sha256: 5af0357651051bc0a308eb007955d928dd6d6a5aafdc96e2868526fc2c87bda8
-  md5: 5e325914e6b2ed97a412e54755268217
+  size: 18900
+  timestamp: 1758936422603
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-13.0.96-h3b4bcfc_1.conda
+  sha256: cfa6a91e5ec9a761e440dad558c70762fe157375455ed4c9f261b87876b55c91
+  md5: 1c9383655b782f7803e5a22189caf572
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart 13.0.96 hecca717_0
-  - cuda-cudart-dev_linux-64 13.0.96 h376f20c_0
-  - cuda-cudart-static 13.0.96 hecca717_0
+  - cuda-cudart 13.0.96 ha533d76_1
+  - cuda-cudart-dev_linux-64 13.0.96 hbe36340_1
+  - cuda-cudart-static 13.0.96 h3b4bcfc_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24515
-  timestamp: 1760034188804
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
-  sha256: 2965f65bc5031da466cd26b7a9e056e67cae206ff04483958617a591928f610f
-  md5: 647578ce75f6ac021ad50daf7dd6c5ef
+  size: 18838
+  timestamp: 1758935673163
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-dev-13.0.96-h48dd3d1_1.conda
+  sha256: 2c028ace621ddfd80a3c71302a1db291a81bae792ca5f861d6de2be38e2d4bea
+  md5: be56a3a17519f444254143cbbd7ae57d
   depends:
   - arm-variant * sbsa
-  - cuda-cudart 13.0.96 h8f3c8d4_0
-  - cuda-cudart-dev_linux-aarch64 13.0.96 h8f3c8d4_0
-  - cuda-cudart-static 13.0.96 h8f3c8d4_0
+  - cuda-cudart 13.0.96 h7bee0a1_1
+  - cuda-cudart-dev_linux-aarch64 13.0.96 h48dd3d1_1
+  - cuda-cudart-static 13.0.96 h48dd3d1_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24661
-  timestamp: 1760034143509
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
-  sha256: 9730992d8a9696cb740420a40340e8ae142e26ec42e0cb3a74c6bfb9f3d43d75
-  md5: 452f0e77df30da17b08e3295ef279df2
+  size: 18862
+  timestamp: 1758936655607
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-64-13.0.96-hbe36340_1.conda
+  sha256: 1d55c7decfec0b60b1c7121f13c7bef7973bd62af7c0e6d16e492e9c5986dc84
+  md5: cd857146e298eb03a259d4168db5f43b
   depends:
   - cuda-cccl_linux-64
   - cuda-cudart-static_linux-64
   - cuda-cudart_linux-64
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 385615
-  timestamp: 1760034157020
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: a56da2191e818e0e54be0c9956fec02e26940b0ac6ca1747c1badae2804cae40
-  md5: c9fa4020ff1370f7b5216c24f222d584
+  size: 379132
+  timestamp: 1758935653518
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
+  sha256: b1f23f26f99dc08059051a805d66de127e0d693fb3acc4d9385fe3e0964235c5
+  md5: b2419e4945d11525819e5b2881f8fa96
   depends:
-  - arm-variant * sbsa
   - cuda-cccl_linux-aarch64
   - cuda-cudart-static_linux-aarch64
   - cuda-cudart_linux-aarch64
   - cuda-version >=13.0,<13.1.0a0
+  constrains:
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 385612
-  timestamp: 1760034129929
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
-  sha256: c158fb5fdb660181e480d50dcc9df40febeb313a9bbed71954093305373994ba
-  md5: 36d04d463e960a0273fdb788c11b87e4
+  size: 378348
+  timestamp: 1758936475543
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-static-13.0.96-h3b4bcfc_1.conda
+  sha256: 18feb9e3bd54fe8ac55b829b8f13e21c8e4c1c9b9961bb0d1f5e9b3df4c6f529
+  md5: 0dad74d4f50ebdfad8569d54c15da3f1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart-static_linux-64 13.0.96 h376f20c_0
+  - cuda-cudart-static_linux-64 13.0.96 hbe36340_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24031
-  timestamp: 1760034170778
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
-  sha256: 5e5c99dfb2dc675e84d46ebcb560eeefcf20f30c7447af8d6bd1257e2b91540c
-  md5: 51205a311969eaea7b25773345b03395
+  size: 18366
+  timestamp: 1758935661834
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-static-13.0.96-h48dd3d1_1.conda
+  sha256: de764d3e6db5522741c6d24435610d4b60efe3410464a362d4f75ec2a8ac1efd
+  md5: 7677f80dfc3b54c652cf58a683932650
   depends:
   - arm-variant * sbsa
-  - cuda-cudart-static_linux-aarch64 13.0.96 h8f3c8d4_0
+  - cuda-cudart-static_linux-aarch64 13.0.96 h48dd3d1_1
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24201
-  timestamp: 1760034133545
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
-  sha256: b1b626540ff0e19f15036433f9c64aad5cc37b503e0cc7cbd4abeef678db63ab
-  md5: 3317a47036e9e0c31462454635c50457
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1077227
-  timestamp: 1760034117715
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: 773eed1956cafeadb6460699fe98db274b1732c164ce82b02a2d10810994d3d2
-  md5: 038c4cf5847929f1269dd01aedc32a4f
-  depends:
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  constrains:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1080940
-  timestamp: 1760034110333
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
-  sha256: a24fc5d9d229328c4165c1e08a53717a804b70832ef5365ed3071c7e8ef2d72f
-  md5: c4bbc81db4cf35b6766436f2d774ead5
+  size: 18389
+  timestamp: 1758936542956
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-64-13.0.96-hbe36340_1.conda
+  sha256: a799d615b382262ca42742d181742b5116ba4bb4fd449a855a4ba37ae83c0bcb
+  md5: 3d616429d24cefcf7091fc583035578f
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 185278
-  timestamp: 1760034128147
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: c1be1727a13bcaf6ef9a76e1d1d00845e37556a40530d559406939fbc618fdb2
-  md5: ae0425af7774272e8926e6d3b4ca4f50
+  size: 1070826
+  timestamp: 1758935626303
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h48dd3d1_1.conda
+  sha256: 03bae57c2c4c851218f19d38db52849b71c24fc7ea2b8f64d275750c53e459f3
+  md5: 4c4650cc9d29182be88f661dca64f11c
   depends:
+  - cuda-version >=13.0,<13.1.0a0
+  constrains:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 199749
-  timestamp: 1760034117080
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
-  sha256: 00baf846f6e109df717f8b1602118ad1c46e3ba9b1864d676e420e3544d416ac
-  md5: f44904debd095f95ad8e523f7d26eff9
+  size: 1075561
+  timestamp: 1758936253135
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-13.0.96-h73695a4_1.conda
+  sha256: 6b92589cd90f08956df56e8a14237412e59e05368e31770f4aacb2df5f8d5d3f
+  md5: 194257b0bc6106412711820cb13f9648
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 38400
-  timestamp: 1760034138622
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: 56b88567441810285d448e7332b00ee9253a3713e620c84594d11bc5e7b0a1bd
-  md5: ebeb2cae11008509872411f0301a603c
+  size: 179667
+  timestamp: 1758935634601
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-aarch64-13.0.96-h7bee0a1_1.conda
+  sha256: 76c0c3323d0c4bbec2f438513ac33853d1bca4c03227245144594f5205da3b98
+  md5: 16c24c0f22ffda329ca59e9b65d20f78
   depends:
+  - cuda-version >=13.0,<13.1.0a0
+  constrains:
   - arm-variant * sbsa
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 195306
+  timestamp: 1758936312952
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-64-13.0.96-hbe36340_1.conda
+  sha256: 63fde5fa64a218f92e57d88aecc80069f4f6b3a5a7e438a4ab64be466ba5cd21
+  md5: cde8561315b098ff88da28b601b53148
+  depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 40113
-  timestamp: 1760034119535
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
-  sha256: a616d6b91f7bc58f0a2bca5871e1d94abe120c1baab090826762a7df36bb42a3
-  md5: a41247f1d8976ca80c81d457bafee5db
+  size: 33221
+  timestamp: 1758935640846
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
+  sha256: 08ba6bb0b4b402259c46897c49f7e1ae5ad85926adba12c3b019b36bfbc7fdc1
+  md5: 8306d9777b02d93c56105e481cfabd0c
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  constrains:
+  - arm-variant * sbsa
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 34839
+  timestamp: 1758936366549
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-13.0.88-hb25713b_0.conda
+  sha256: 75c1aa395b1dded1bf4728b860dde396a0db550463773132cd4ab4f00ff04f69
+  md5: 804a71652dce48990f158cf236de5a22
   depends:
   - cuda-nvcc_linux-64 13.0.88.*
   - gcc_linux-64
   - gxx_linux-64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24902
-  timestamp: 1762289415743
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
-  sha256: d18550073d02ba6fa43be7ba49829f3b9ddfe3a98e4bb9854541a0f5f8c470e3
-  md5: f21892aa190d6862ec3c381ad6ae1e80
+  size: 17032
+  timestamp: 1755730844448
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-13.0.88-h331fd37_100.conda
+  sha256: 1a713efbc240717ad1e73ccd7e35c61b2ea38b1de87f2591fe6e88ff84dfae43
+  md5: 48717a752b38617e77025a4fefa6e687
   depends:
   - cuda-nvcc_linux-aarch64 13.0.88.*
   - gcc_linux-aarch64
   - gxx_linux-aarch64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24944
-  timestamp: 1762289394229
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
-  sha256: 9da527d5f0f4aa801d087def466deecec166fe89713aaccb94ef6dc392fcb912
-  md5: 592146b39bcd34626389655523d8d39f
+  size: 17060
+  timestamp: 1755733629542
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-64-13.0.88-0.conda
+  sha256: b040b6bd5060a4a4b4fb47f60a16838ba55bceb50efb0193ffd92e95581048ac
+  md5: cb0453a6630efd252b8712bde30d65ef
   depends:
-  - cuda-crt-dev_linux-64 13.0.88 ha770c72_0
-  - cuda-nvvm-dev_linux-64 13.0.88 ha770c72_0
+  - cuda-crt-dev_linux-64 13.0.88 0
+  - cuda-nvvm-dev_linux-64 13.0.88 0
   - cuda-version >=13.0,<13.1.0a0
   - libgcc >=6
-  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
+  - libnvptxcompiler-dev_linux-64 13.0.88 0
   constrains:
-  - gcc_impl_linux-64 >=6,<16.0a0
+  - gcc_impl_linux-64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28946
-  timestamp: 1757021683159
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
-  sha256: c44ddb96258a53762ef6a28ad1023f0096d04233397f496c27f4b113186bfca0
-  md5: 2dbf71edc5f9ea2dd38d52814bedffe3
+  size: 19197
+  timestamp: 1755730784704
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+  sha256: 82f644f2ba4a9a9640f682b301c30db0f02ef1c885091575ba49f4ccde803382
+  md5: dcd6b610517829cf98f8b25cadac60a9
   depends:
   - arm-variant * sbsa
-  - cuda-crt-dev_linux-aarch64 13.0.88 h579c4fd_0
-  - cuda-nvvm-dev_linux-aarch64 13.0.88 h579c4fd_0
+  - cuda-crt-dev_linux-aarch64 13.0.88 h119d96e_0
+  - cuda-nvvm-dev_linux-aarch64 13.0.88 h119d96e_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=6
-  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
+  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h119d96e_0
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  - gcc_impl_linux-aarch64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29072
-  timestamp: 1757021613549
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
-  sha256: 259e1ae6a7729ef77b515e9a491f9f820ef0db1837b43f7156c58161fdb451ed
-  md5: 5eafe62a4236322ca351653d3dadab20
+  size: 19292
+  timestamp: 1755732024042
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-impl-13.0.88-hbe36340_0.conda
+  sha256: 1f8e8d3fc4ce98a6d882cedcb2345e4e9abcf96988ff6d0822d622baa7334fa0
+  md5: 477bbfe005c23b88ff225b2ef4df06b7
   depends:
-  - cuda-cudart >=13.0.88,<14.0a0
+  - cuda-cudart >=13.0.48,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-64 13.0.88 he91c749_0
-  - cuda-nvcc-tools 13.0.88 he02047a_0
-  - cuda-nvvm-impl 13.0.88 h4bc722e_0
+  - cuda-nvcc-dev_linux-64 13.0.88 0
+  - cuda-nvcc-tools 13.0.88 h3b4bcfc_0
+  - cuda-nvvm-impl 13.0.88 h3b4bcfc_0
   - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev 13.0.88 ha770c72_0
   constrains:
-  - gcc_impl_linux-64 >=6,<16.0a0
+  - gcc_impl_linux-64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28077
-  timestamp: 1757021695541
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
-  sha256: 81b16bd2edf9a581be49e03f8bf0d8ff048d47aff4278bfe38f49ee4a379a10c
-  md5: 58b623409f1b5bdea63bc46849ff1852
+  size: 19650
+  timestamp: 1755730789182
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-impl-13.0.88-h48dd3d1_0.conda
+  sha256: 9345eaea54d81e2527278b93e51ad132a6f1f99196d5adcb6f8f95ac11813744
+  md5: 425b87c0a6ea1c5f57c749379995de68
   depends:
   - arm-variant * sbsa
-  - cuda-cudart >=13.0.88,<14.0a0
+  - cuda-cudart >=13.0.48,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-aarch64 13.0.88 h4310d6a_0
-  - cuda-nvcc-tools 13.0.88 h614329b_0
-  - cuda-nvvm-impl 13.0.88 h7b14b0b_0
+  - cuda-nvcc-dev_linux-aarch64 13.0.88 h119d96e_0
+  - cuda-nvcc-tools 13.0.88 h48dd3d1_0
+  - cuda-nvvm-impl 13.0.88 h48dd3d1_0
   - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev 13.0.88 h579c4fd_0
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  - gcc_impl_linux-aarch64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28154
-  timestamp: 1757021621068
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
-  sha256: b9cd738b3bb8eeba112c423acc3a922a6526ed6b7c72d1857cf3ade55073dc76
-  md5: 994f869d05c03cc1b5a9fc9911183a62
+  size: 19679
+  timestamp: 1755732061531
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-tools-13.0.88-h3b4bcfc_0.conda
+  sha256: 627dd65f6699336acb3bfdc9ff44dfb0d2e43ed7f2601a00da23fdd495998f91
+  md5: 14deb60892cb99fcc8e4be9ca006ecda
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-crt-tools 13.0.88 ha770c72_0
-  - cuda-nvvm-tools 13.0.88 h4bc722e_0
+  - cuda-crt-tools 13.0.88 0
+  - cuda-nvvm-tools 13.0.88 h3b4bcfc_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  - libstdcxx >=12
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
-  - gcc_impl_linux-64 >=6,<16.0a0
+  - gcc_impl_linux-64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28824961
-  timestamp: 1757021588514
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
-  sha256: e425fc791c68c4cb4d849cff2487bf3d7021405dc94fcbc5e00eb975bec33a1f
-  md5: b1e9a6c10d9cfb3e5ab63e8e4a3c1a47
+  size: 29054509
+  timestamp: 1755730735142
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-tools-13.0.88-h48dd3d1_0.conda
+  sha256: 5651e7238e1564012be1b122fef367cefa32279aa7cd2535d8daf57818a07d46
+  md5: c57cc1d9634e1f44bd02aead09e5c6d6
   depends:
   - arm-variant * sbsa
-  - cuda-crt-tools 13.0.88 h579c4fd_0
-  - cuda-nvvm-tools 13.0.88 h7b14b0b_0
+  - cuda-crt-tools 13.0.88 h119d96e_0
+  - cuda-nvvm-tools 13.0.88 h48dd3d1_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  - libstdcxx >=12
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<16.0a0
+  - gcc_impl_linux-aarch64 >=6,<15.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 25207775
-  timestamp: 1757021545690
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
-  sha256: 99e27429c56f1b0120d32cef1996c5124f96f439291ce379dc00ee10b1e576c6
-  md5: 5ae59e3f3be0a3ba8ae96acd435a1d48
+  size: 25295549
+  timestamp: 1755731805173
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc_linux-64-13.0.88-he6262bf_0.conda
+  sha256: 62ac58810ae67641fb54b0d4f40f7957470cede4b846181657a39aab9bea7364
+  md5: 670b3e9dcbab5a9a68a96f932cdf0252
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-cudart-dev_linux-64 13.0.*
@@ -753,11 +730,11 @@ packages:
   - cuda-nvcc-tools 13.0.88.*
   - sysroot_linux-64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26850
-  timestamp: 1762289415201
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
-  sha256: 80754283b3ebeaa21fc797cd800e1849a6b3f280acb8ff9778f4160d4b2c5530
-  md5: 2cecef0f16fdc6892f39ef44132de812
+  size: 20437
+  timestamp: 1755730840514
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h7533faf_100.conda
+  sha256: b6be55f7f2bfe130fd9e440cece1382aa2ab51c165e890a372978b7b9d07b814
+  md5: 5529f5098152ca49349ebc9aa0c3957b
   depends:
   - arm-variant * sbsa
   - cuda-cudart-dev_linux-aarch64 13.0.*
@@ -765,98 +742,126 @@ packages:
   - cuda-nvcc-dev_linux-aarch64 13.0.88.*
   - cuda-nvcc-impl 13.0.88.*
   - cuda-nvcc-tools 13.0.88.*
-  - sysroot_linux-aarch64 >=2.17,<3.0a0
+  - sysroot_linux-aarch64 >=2.26,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26954
-  timestamp: 1762289393657
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
-  sha256: e84b749251df8111359420c313b800fa896d18d44c07c7c3eec1abd155bb6b69
-  md5: dd4b7cf241cc912e4ade183911c24b7f
+  size: 20448
+  timestamp: 1755733596514
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-13.0.87-ha2c4e13_0.conda
+  sha256: 069cf822fa1c07bd2de7bc75a4235b1d607ca8f33ef10e6bd7ea8b86c35d4289
+  md5: ac896c03c13c91b4215ecdda312fd9c3
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 68354405
-  timestamp: 1757018387981
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
-  sha256: 723785ec1502d3f10c23e647358f9dcdfa9affc2b0542e6cdbe0770533f5e372
-  md5: f368bf1ceda5c36745b408b88fdd71a8
+  size: 144432
+  timestamp: 1755643102140
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvml-dev-13.0.87-h691c0af_0.conda
+  sha256: 1f79a2d0a4522db3912d773631daaaa5fd7105f96367b5e3eaef7b82dfcbd41a
+  md5: a66df1d62716b69f48380ec6cab63005
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 32555050
-  timestamp: 1757018424779
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: 65b4851cf4ad2fc906875d70ce85faf612d26fc0bb7dfe4266e5cc84994eab23
-  md5: 155fa228684274e8fe1227186a04d7f2
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27954
-  timestamp: 1757021367553
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 37201c22627900dfd0591ec6d8325814df64f7713c8ac87af96c1ae042067aa2
-  md5: dfe7a4d9546dd7cd3face2640e321897
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28061
-  timestamp: 1757021345227
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
-  sha256: 1972fd15941a0f33c59e1f6b93045945cb1678b6efa0f8101c1cb24112093af5
-  md5: bd78fee8953411bfe1e70b184756fa42
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 21662718
-  timestamp: 1757021391692
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
-  sha256: 1d5c24588585639fd4b340b42dc2180dae7eae045f14ede1ccc7f5038cc124a0
-  md5: f615684b985e74817ee584446d6c23dd
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20784164
-  timestamp: 1757021384178
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
-  sha256: 248e9c7df5fe8aebe403dadc3ae79ae710d518d760ea9c0e9714c3b5e21800a5
-  md5: 07a6762db5ed5ff0887a24ad1675375b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24519392
-  timestamp: 1757021447444
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
-  sha256: ab31f55fd176e886d2ce3ee730f0a775dd9c4bb7374e6692a44045170834d322
-  md5: 302f4b10ac0b239c5d74fc1ca46966a7
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=12
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 23566779
-  timestamp: 1757021431631
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
-  sha256: b0511bf95bf784096866c8add22afe365ff534c5d87f033119653d6d3c57d4bc
-  md5: 2f875735837c072c78894980f96c50df
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
-  - __cuda >=13
-  - cudatoolkit 13.0|13.0.*
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 21542
-  timestamp: 1754337583956
+  size: 149047
+  timestamp: 1755643584727
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-13.0.88-hb0a779f_0.conda
+  sha256: 848321bbf579b833c6daa02f873631e9862b8ca03c6dd1b5132612d548913cb2
+  md5: 5c609a74ab01d6cdb4da1d6660180ad8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 68552113
+  timestamp: 1755727144335
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvrtc-13.0.88-h492901c_0.conda
+  sha256: f45066022b48b28ce2f13c5fc076883f531f33cffc22a08c457d1ec02d99e397
+  md5: d5e5b82b0d4e996c3ea73b1c1ced47cd
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 32661539
+  timestamp: 1755727509774
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-64-13.0.88-0.conda
+  sha256: 12e60b492da45abed7bbef783d9c35153eb92b71045e8cb479598af95ad2022e
+  md5: ca70a9683c049e61afc731f1d23c28f0
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 18285
+  timestamp: 1755730605214
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+  sha256: 96f2f185f317d3559599eda495945a2c3d821baa76770c47c13276b119572b32
+  md5: e9ba081fc9cb7327f879bedd943dd2d7
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 18368
+  timestamp: 1755731221222
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-impl-13.0.88-h3b4bcfc_0.conda
+  sha256: 18a68b641e3dcc21383348f813e3bd518d9bbdea8e465cfef4529f6090131e4e
+  md5: 2f0b8594f3d0906111e08b2bc2a02ee8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 21666629
+  timestamp: 1755730614089
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-impl-13.0.88-h48dd3d1_0.conda
+  sha256: 73bbf2cf836c4e2ecd178578fabc3289fbac531c2d8227d93ee2919de089b6a1
+  md5: 10d5ae8213734f2b43b2496a41a91b6b
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 20805725
+  timestamp: 1755731294887
+- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-tools-13.0.88-h3b4bcfc_0.conda
+  sha256: 01c29b779afb01bb1fef6d679ddd9e978a48bd91fbe8b467ab0a4eb7a1449dfd
+  md5: 034e42270ccb1c39768e8ed21a4dcc5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 24556461
+  timestamp: 1755730652805
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-tools-13.0.88-h48dd3d1_0.conda
+  sha256: 172a201b66dc34a7a9c77427452c8bfcf2912bf926fffa0c570d9b395f1befae
+  md5: a289a9ba063f3416a42ed1b034bf5df3
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 23578354
+  timestamp: 1755731446917
+- conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
+  sha256: 1bd1132ecf4664f557abeb874ebc4f3cbb95b7c06bffb74360839bdac88b18fb
+  md5: 229ffe48651b3c76d1a646d9669f63ca
+  constrains:
+  - cudatoolkit 13.0|13.0.*
+  - __cuda >=13
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 17370
+  timestamp: 1759480541986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
   sha256: 3fcc97ae3e89c150401a50a4de58794ffc67b1ed0e1851468fcc376980201e25
   md5: 5da8c935dca9186673987f79cef0b2a5
@@ -899,146 +904,138 @@ packages:
   license_family: MIT
   size: 15146
   timestamp: 1700452982288
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h76bdaa0_7.conda
-  sha256: 5eae0f13f8012215c18fba5b74e10686c4720f5c6038a6cfbedcb91fe59eea3d
-  md5: cd5d2db69849f2fc7b592daf86c3015a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_15.conda
+  sha256: 939aa3a61a7cdf5fd624b8406cf2246dc156748b02522217f8ab01804ae6b4f3
+  md5: 893d79ba69d21198012ff8212a8c563a
   depends:
   - conda-gcc-specs
-  - gcc_impl_linux-64 14.3.0.*
+  - gcc_impl_linux-64 14.3.0 h319ec69_15
   license: BSD-3-Clause
-  license_family: BSD
-  size: 31025
-  timestamp: 1759966082917
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h7408ef6_7.conda
-  sha256: 7ee4d06e90cd6bd7ecb577114227c04437198a6e2a8d4bffaf622cc4ec32e0b4
-  md5: 740c5cc1972c559addbf3b39ee84dfc5
+  size: 28650
+  timestamp: 1764836909143
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_15.conda
+  sha256: ecc12d2bdf7bd30d8fd84b3ec6bf6968af296fbcb49567f86e18c78a2653ae8d
+  md5: e810ed1b6477bb035562e379192c5a1f
   depends:
   - conda-gcc-specs
-  - gcc_impl_linux-aarch64 14.3.0.*
+  - gcc_impl_linux-aarch64 14.3.0 hadc3402_15
   license: BSD-3-Clause
-  license_family: BSD
-  size: 31238
-  timestamp: 1759967809504
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hd9e9e21_7.conda
-  sha256: bddd2b13469334fdd474281753cf0b347ac16c3e123ecfdce556ba16fbda9454
-  md5: 54876317578ad4bf695aad97ff8398d9
+  size: 28730
+  timestamp: 1764836783909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h319ec69_15.conda
+  sha256: 9eea0459c4ea20e22be9eb77237043fe6648caf7c092652033b7e8b20c1de51c
+  md5: 042695cf5fb55a63294f3575c33a468c
   depends:
-  - binutils_impl_linux-64 >=2.40
+  - binutils_impl_linux-64 >=2.45
   - libgcc >=14.3.0
-  - libgcc-devel_linux-64 14.3.0 h85bb3a7_107
+  - libgcc-devel_linux-64 14.3.0 hf649bbc_115
   - libgomp >=14.3.0
-  - libsanitizer 14.3.0 hd08acf3_7
+  - libsanitizer 14.3.0 h8f1669f_15
   - libstdcxx >=14.3.0
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_115
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 69987984
-  timestamp: 1759965829687
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-h2b96704_7.conda
-  sha256: b23278d9d9c635dfca1a9922874159e5fce704faa3ba48869464034e956dcb0f
-  md5: 2b5709c68ce0f325540df7a2792480de
+  size: 76389083
+  timestamp: 1764836637441
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hadc3402_15.conda
+  sha256: dc422160f22e0ff9eb94a01f59cdab308872ee5e69a06303882fc59a80ec74a0
+  md5: 2889b9b96ee6dbd70bbf8964f5de6680
   depends:
-  - binutils_impl_linux-aarch64 >=2.40
+  - binutils_impl_linux-aarch64 >=2.45
   - libgcc >=14.3.0
-  - libgcc-devel_linux-aarch64 14.3.0 h370b906_107
+  - libgcc-devel_linux-aarch64 14.3.0 h25ba3ff_115
   - libgomp >=14.3.0
-  - libsanitizer 14.3.0 h48d3638_7
+  - libsanitizer 14.3.0 hedb4206_15
   - libstdcxx >=14.3.0
+  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_115
   - sysroot_linux-aarch64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 68874516
-  timestamp: 1759967603214
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_13.conda
-  sha256: 4506002b7ce76d8c0b4d067c78cb0870843b20c14f3a5549d446ce15357e58a5
-  md5: fef26f75fa5d301cd3f47257eab30dd1
+  size: 68056499
+  timestamp: 1764836536614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_14.conda
+  sha256: 4e99d5903113dfbb36a0a1510450c6a6e3ffc4a4c69d2d1e03c3efa1f1ba4e8f
+  md5: fe0c2ac970a0b10835f3432a3dfd4542
   depends:
   - gcc_impl_linux-64 14.3.0.*
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
   license_family: BSD
-  size: 27974
-  timestamp: 1763063939251
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_13.conda
-  sha256: a81163524b98a2509f3a19c146c5c9d90a2a47fa5417605dce3df569f6de7695
-  md5: 29142ddf6e936333b80d6383809e8337
+  size: 27980
+  timestamp: 1763757768300
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_14.conda
+  sha256: 7ef2b23a2a2453d23afaf0b5878d0afd7c80654a8a49e6070404a34f6cac7735
+  md5: 640d2d54860f54ca66eb4aa5cd243fca
   depends:
   - gcc_impl_linux-aarch64 14.3.0.*
   - binutils_linux-aarch64
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
-  size: 27751
-  timestamp: 1763063891972
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-he448592_7.conda
-  sha256: 7acf0ee3039453aa69f16da063136335a3511f9c157e222def8d03c8a56a1e03
-  md5: 91dc0abe7274ac5019deaa6100643265
+  size: 27754
+  timestamp: 1763757746591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_15.conda
+  sha256: 2acf26462f5ed61727e54a8fd2d55cdf50c13558f2692485b4da87e257439965
+  md5: 0b1faa0b6a877261a8b4ec692d41b7c4
   depends:
-  - gcc 14.3.0.*
-  - gxx_impl_linux-64 14.3.0.*
+  - gcc 14.3.0 h0dff253_15
+  - gxx_impl_linux-64 14.3.0 h2185e75_15
   license: BSD-3-Clause
-  license_family: BSD
-  size: 30403
-  timestamp: 1759966121169
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha28f942_7.conda
-  sha256: 7f38940a42d43bf7b969625686b64a11d52348d899d4487ed50673a09e7faece
-  md5: dac1f319c6157797289c174d062f87a1
+  size: 27999
+  timestamp: 1764836941729
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_15.conda
+  sha256: 9136315161c07f414f378b0420e39113be10396b2ddd42820b3d462157c77471
+  md5: 8d11fa1414490069c774fd548cbcb071
   depends:
-  - gcc 14.3.0.*
-  - gxx_impl_linux-aarch64 14.3.0.*
+  - gcc 14.3.0 h2e72a27_15
+  - gxx_impl_linux-aarch64 14.3.0 h0d4f5d4_15
   license: BSD-3-Clause
-  license_family: BSD
-  size: 30526
-  timestamp: 1759967828504
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-he663afc_7.conda
-  sha256: 597579f6ce995c2a53dcb290c75d94819ca92f898687162f992a208a5ea1b65b
-  md5: 2700e7aad63bca8c26c2042a6a7214d6
+  size: 28152
+  timestamp: 1764836809459
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_15.conda
+  sha256: 3b4e2b0977e29af8baff5867009717d360879c9e95bda0118a3339cd4445e45a
+  md5: a27be47954f8b96b0e4c383632bc80f9
   depends:
-  - gcc_impl_linux-64 14.3.0 hd9e9e21_7
-  - libstdcxx-devel_linux-64 14.3.0 h85bb3a7_107
+  - gcc_impl_linux-64 14.3.0 h319ec69_15
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_115
   - sysroot_linux-64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 15187856
-  timestamp: 1759966051354
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h72695c8_7.conda
-  sha256: aae49d3818b64f8a3db606b74f0ef4a535b7b2cd219aa1b9b6aa740af33028d9
-  md5: a8b4515fbfd9b625b720f4bb2b77bbb4
+  size: 14753044
+  timestamp: 1764836860648
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_15.conda
+  sha256: 52f055176320a12e1cbb429848575f90f60ecab174a22d91fa57bdab3c49381a
+  md5: 69e200514a79fa79796fec4e40644ad8
   depends:
-  - gcc_impl_linux-aarch64 14.3.0 h2b96704_7
-  - libstdcxx-devel_linux-aarch64 14.3.0 h370b906_107
+  - gcc_impl_linux-aarch64 14.3.0 hadc3402_15
+  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_115
   - sysroot_linux-aarch64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 13742475
-  timestamp: 1759967779809
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hed40740_13.conda
-  sha256: c143d5e78374305b9838335a5415a1af237357516ef2afdc0d0725263a2e0819
-  md5: 7941726e8d0211bfb536025fb0cd9090
+  size: 13536240
+  timestamp: 1764836744606
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-he6f32d1_14.conda
+  sha256: ae338fa6e156a79cf69db2e296ec862fd41e09ed42ab6c1cbab5fbf50a750307
+  md5: 9c792be16fc0c2b5ed6d1f3b768876e8
   depends:
   - gxx_impl_linux-64 14.3.0.*
-  - gcc_linux-64 ==14.3.0 h298d278_13
+  - gcc_linux-64 ==14.3.0 h298d278_14
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 27078
-  timestamp: 1763063939251
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-h0724e97_13.conda
-  sha256: 24b0f8795d3ef4bb3a002704eae3e69481b296af0644cc40d5407fecea507810
-  md5: 9bc4b02b577d4e8ce8bf295c3c39ef6e
+  size: 27404
+  timestamp: 1764713544855
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-hef95cfa_14.conda
+  sha256: 899e11c611d3bc315d88333be8547124f1e47092798065bb497e9a98d103d658
+  md5: ba095fd345f927689347487a8020a598
   depends:
   - gxx_impl_linux-aarch64 14.3.0.*
-  - gcc_linux-aarch64 ==14.3.0 h118592a_13
+  - gcc_linux-aarch64 ==14.3.0 h118592a_14
   - binutils_linux-aarch64
   - sysroot_linux-aarch64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 26869
-  timestamp: 1763063891972
+  size: 27162
+  timestamp: 1764713836536
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
   sha256: 305c22a251db227679343fd73bfde121e555d466af86e537847f4c8b9436be0d
   md5: ff007ab0f0fdc53d245972bba8a6d40c
@@ -1102,9 +1099,9 @@ packages:
   license_family: MIT
   size: 1474620
   timestamp: 1719463205834
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-h1aa0949_0.conda
-  sha256: 32321d38b8785ef8ddcfef652ee370acee8d944681014d47797a18637ff16854
-  md5: 1450224b3e7d17dfeb985364b77a4d47
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+  sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
+  md5: a6abd2796fc332536735f68ba23f7901
   depends:
   - __glibc >=2.17,<3.0.a0
   - zstd >=1.5.7,<1.6.0a0
@@ -1112,40 +1109,19 @@ packages:
   - binutils_impl_linux-64 2.45
   license: GPL-3.0-only
   license_family: GPL
-  size: 753744
-  timestamp: 1763060439129
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-hd32f0e1_0.conda
-  sha256: 03bb2218867ec25acc81a613101504e1ea308a2714916e45e21636aa08fad181
-  md5: a2a812fed68dd21a013c3db1f5712d77
+  size: 725545
+  timestamp: 1764007826689
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_104.conda
+  sha256: 7a13072581fa23f658a04f62f62c4677c57d3c9696fbc01cc954a88fc354b44d
+  md5: 28035705fe0c977ea33963489cd008ad
   depends:
   - zstd >=1.5.7,<1.6.0a0
   constrains:
   - binutils_impl_linux-aarch64 2.45
   license: GPL-3.0-only
   license_family: GPL
-  size: 790008
-  timestamp: 1763060508415
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
-  sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
-  md5: 09c264d40c67b82b49a3f3b89037bd2e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - attr >=2.5.2,<2.6.0a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 121429
-  timestamp: 1762349484074
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
-  sha256: 154eefd8f94010d89ba76a057949b9b1f75c7379bd0d19d4657c952bedcf5904
-  md5: 10fe36ec0a9f7b1caae0331c9ba50f61
-  depends:
-  - attr >=2.5.1,<2.6.0a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 108542
-  timestamp: 1762350753349
+  size: 875534
+  timestamp: 1764007911054
 - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
   sha256: 5a0f46e495db551df41dc77d7f21db9a46379234ff1fe27da4b2d97aff2d3c29
   md5: 1f5770d57804ddc301616ad3b8ca5330
@@ -1189,118 +1165,112 @@ packages:
   license: Apache-2.0
   size: 245606959
   timestamp: 1759942682160
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
-  sha256: 2cddb2fc468c8469b0dc932cb9792940187f64caacf2a59367a4db86dccbe27e
-  md5: bdd53a936c0bba2ff2a28268dde33b6c
+- conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.15.1.6-h2e68323_0.conda
+  sha256: 819393a7cdbf7e542a8ac5057e2fb686de51d14c2caa32bd54bfea2472ded288
+  md5: ed84caa5bae55c6589e1aa88f05da6eb
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - rdma-core >=59.0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 977986
-  timestamp: 1757021650640
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
-  sha256: 21b70a25a0cdc0ef64411af25ab19b6229a4f15543b20ffc84fe60b043f50f5d
-  md5: 078227cbdf7463d09dc2e560f042e055
+  size: 979863
+  timestamp: 1754617120479
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-1.15.1.6-h1c78503_0.conda
+  sha256: 8d1d2255b03ee60622e050579ae0d1ac95a669b96c6351e8b21d58544cb3eb72
+  md5: 14195c61e97a83e9c70b6b1aa026d852
   depends:
-  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - rdma-core >=59.0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 908076
-  timestamp: 1757021699745
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
-  sha256: cd9ca750b5605faf4c7a90f44dc6cf8040188234587e258f2c0d02b1b96df451
-  md5: 227ab9f14df261b66e0e420f56501e4a
+  size: 904334
+  timestamp: 1754619845695
+- conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.15.1.6-h2e68323_0.conda
+  sha256: 332f54150917fef88d30024e718206d31acfc71f172c85a8addff883019608ef
+  md5: 4bc6f4d8c70abdcd8732efa04ed0ab34
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 hbc026e6_0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libcufile 1.15.1.6 h2e68323_0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
   - libcufile-static >=1.15.1.6
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 40775
-  timestamp: 1757021671143
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
-  sha256: 80cfea59157864e420b1a7aaa0c12879708389218f17af05c04a3b145be1dabb
-  md5: 5c9cd78953fd68ca33b9747353e90fd4
+  size: 35484
+  timestamp: 1754617150524
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-dev-1.15.1.6-h1c78503_0.conda
+  sha256: f720456e97475182175fbed24f78310bf256fdfd58741032e8ff68bf1ed4ac63
+  md5: 04583457a3d275e328e3ce991023dea5
   depends:
-  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 had8bf56_0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libcufile 1.15.1.6 h1c78503_0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
+  - arm-variant * sbsa
   - libcufile-static >=1.15.1.6
-  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 41023
-  timestamp: 1757021720713
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
-  sha256: 803570e401b3841ba426163f941a89e255d8408efff83fcdfee37214e5f92927
-  md5: 0fbddc6e0a54358e806221f9bd5a4f83
+  size: 35482
+  timestamp: 1754620003037
+- conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.4.0.35-h50d9014_0.conda
+  sha256: a64353f9c194eb98eba4dbe9ff0d7b818cc52351d9adbbd8a4dc7942fe8d7020
+  md5: 605843da8a9ce6ef128804b22127814a
   depends:
-  - __glibc >=2.28,<3.0.a0
+  - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43597395
-  timestamp: 1759327581167
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
-  sha256: 47d62d514bd90dc1e772daecad8bab202cc7eb90a2a4f6aff5a6d3800913c123
-  md5: 7d214813bd19bc72b1cae48662fce35d
+  size: 43535237
+  timestamp: 1751484704044
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-10.4.0.35-h384c9aa_0.conda
+  sha256: 16da24fa8163d8e9d2fc3d67fd8db44118b8dfa02134382e7f6c3b8ab116c78a
+  md5: 522ce77af61858c518c95f5aea3ef932
   depends:
-  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43897229
-  timestamp: 1759327764810
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
-  sha256: 9f8cd71ba7a4a61e3788895ee1f60d10970318e27aa624c90c175954df89cdc1
-  md5: a2e7bd789f12f442fb89878bf9889a7e
+  size: 43809768
+  timestamp: 1751482301093
+- conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.4.0.35-h50d9014_0.conda
+  sha256: acf4342dfa88bba241e92b5db68960157cfce2f4f94c6a643e659ae4e266fd75
+  md5: 6b2cad08be6d337ab4380484bd20ceb3
   depends:
-  - __glibc >=2.28,<3.0.a0
+  - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 h676940d_1
-  - libgcc >=14
-  - libstdcxx >=14
+  - libcurand 10.4.0.35 h50d9014_0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
   - libcurand-static >=10.4.0.35
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 266784
-  timestamp: 1759327649403
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
-  sha256: 8026db45a0607f49670349976628e937c51fc9d8ae4c6ab3e203d638a615d43a
-  md5: b5edc27749d59d16f7da066367435baa
+  size: 254440
+  timestamp: 1751484771575
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-dev-10.4.0.35-h384c9aa_0.conda
+  sha256: eef2549735c1b7f023b23cc2a4bce7af35781db7642a677cd47989e09cc0182e
+  md5: 70ee799194e71256f1adbeb103e31ef1
   depends:
-  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 he38c790_1
-  - libgcc >=14
-  - libstdcxx >=14
+  - libcurand 10.4.0.35 h384c9aa_0
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
-  - libcurand-static >=10.4.0.35
   - arm-variant * sbsa
+  - libcurand-static >=10.4.0.35
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 262323
-  timestamp: 1759327877841
+  size: 246655
+  timestamp: 1751482603422
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
   sha256: 100e29ca864c32af15a5cc354f502d07b2600218740fdf2439fa7d66b50b3529
   md5: 01e149d4a53185622dc2e788281961f2
@@ -1373,106 +1343,98 @@ packages:
   license_family: BSD
   size: 115123
   timestamp: 1702146237623
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
-  md5: 4211416ecba1866fab0c6470986c22d6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+  sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
+  md5: 8b09ae86839581147ef2e5c5e229d164
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - expat 2.7.1.*
+  - expat 2.7.3.*
   license: MIT
   license_family: MIT
-  size: 74811
-  timestamp: 1752719572741
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.1-hfae3067_0.conda
-  sha256: 378cabff44ea83ce4d9f9c59f47faa8d822561d39166608b3e65d1e06c927415
-  md5: f75d19f3755461db2eb69401f5514f4c
+  size: 76643
+  timestamp: 1763549731408
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.3-hfae3067_0.conda
+  sha256: cc2581a78315418cc2e0bb2a273d37363203e79cefe78ba6d282fed546262239
+  md5: b414e36fbb7ca122030276c75fa9c34a
   depends:
   - libgcc >=14
   constrains:
-  - expat 2.7.1.*
+  - expat 2.7.3.*
   license: MIT
   license_family: MIT
-  size: 74309
-  timestamp: 1752719762749
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
-  sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
-  md5: c0374badb3a5d4b1372db28d19462c53
+  size: 76201
+  timestamp: 1763549910086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_15.conda
+  sha256: 37f2edde2f8281672987c63f13c85a57d04d889dc929ce38204426d5eb2059cc
+  md5: a5d86b0496174a412d531eac03af9174
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 15.2.0 h767d61c_7
-  - libgcc-ng ==15.2.0=*_7
+  - libgomp 15.2.0 he0feb66_15
+  - libgcc-ng ==15.2.0=*_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 822552
-  timestamp: 1759968052178
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-he277a41_7.conda
-  sha256: 616f5960930ad45b48c57f49c3adddefd9423674b331887ef0e69437798c214b
-  md5: afa05d91f8d57dd30985827a09c21464
+  size: 1041379
+  timestamp: 1764836112865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_15.conda
+  sha256: ff184dbe54493b663eab2d62fa0b5a689eb84bec6401fcaeb44265c7f31ae4c6
+  md5: cfdf8700e69902a113f2611e3cc09b55
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 15.2.0 he277a41_7
-  - libgcc-ng ==15.2.0=*_7
+  - libgcc-ng ==15.2.0=*_15
+  - libgomp 15.2.0 h8acb6b2_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 510719
-  timestamp: 1759967448307
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-h85bb3a7_107.conda
-  sha256: 57a1e792e9cffb3e641c84d3830eb637a81c85f33bdc3d45ac7b653c701f9d68
-  md5: 84915638a998fae4d495fa038683a73e
+  size: 621200
+  timestamp: 1764836146613
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_115.conda
+  sha256: ef6e085bfde0339853fb5737fb8f24c201c35b6717754cee5b44550b0e24ce76
+  md5: eedcd688f597873e1d16f0529f4d6d10
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2731390
-  timestamp: 1759965626607
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h370b906_107.conda
-  sha256: 5ca6fd355bf101357287293c434c9bbb72bb5450075a76ef659801e66840a0ce
-  md5: 0a192528aa60ff78e8ac834a6fce77ae
+  size: 3089251
+  timestamp: 1764836386115
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_115.conda
+  sha256: 72213376322152a1e3e7745ce95b587876830451d26f196f07a2ac3081791549
+  md5: 3e4c04a124cc3e660223267b8a150395
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2125270
-  timestamp: 1759967447786
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
-  sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
-  md5: 280ea6eee9e2ddefde25ff799c4f0363
+  size: 2343273
+  timestamp: 1764836330285
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_15.conda
+  sha256: 497d8cdba0da8fa154613d1c15f585674cadc194964ed1b4fe7c2809938dc41f
+  md5: 7b742943660c5173bb6a5c823021c9a0
   depends:
-  - libgcc 15.2.0 h767d61c_7
+  - libgcc 15.2.0 he0feb66_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 29313
-  timestamp: 1759968065504
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_7.conda
-  sha256: 7d98979b2b5698330007b0146b8b4b95b3790378de12129ce13c9fc88c1ef45a
-  md5: a5ce1f0a32f02c75c11580c5b2f9258a
+  size: 26834
+  timestamp: 1764836127111
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_15.conda
+  sha256: 80e6135b5b0083ad6f0f00b8368d666fb148923fe2d3ab7d8cdca3eaf575eeff
+  md5: ad92990dc6f608f412a01540a7c9510e
   depends:
-  - libgcc 15.2.0 he277a41_7
+  - libgcc 15.2.0 h8acb6b2_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 29261
-  timestamp: 1759967452303
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
-  sha256: e9fb1c258c8e66ee278397b5822692527c5f5786d372fe7a869b900853f3f5ca
-  md5: f7b4d76975aac7e5d9e6ad13845f92fe
+  size: 26927
+  timestamp: 1764836155568
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_15.conda
+  sha256: b3c4e39be7aba6f5a8695d428362c5c918b96a281ce0a7037f1e889dfc340615
+  md5: a90d6983da0757f4c09bb8fcfaf34e71
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 447919
-  timestamp: 1759967942498
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-he277a41_7.conda
-  sha256: 0a024f1e4796f5d90fb8e8555691dad1b3bdfc6ac3c2cd14d876e30f805fcac7
-  md5: 34cef4753287c36441f907d5fdd78d42
+  size: 602978
+  timestamp: 1764836011147
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_15.conda
+  sha256: d76cbb7e76af310828c74396a78c59a3b305431da25c9337e420bb441d2e8ca0
+  md5: 0719da240fd6086c34c4c30080329806
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 450308
-  timestamp: 1759967379407
+  size: 587301
+  timestamp: 1764836050907
 - conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.10.00-cuda13_0_251008_fb6220c4.conda
   build_number: 0
   sha256: 9cfe542d99632d0879849c55c2f249a5a30ad3c85dc7801869cec61119d6182f
@@ -1561,25 +1523,6 @@ packages:
   license_family: MIT
   size: 728661
   timestamp: 1756835019535
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-  sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
-  md5: db63358239cbe1ff86242406d440e44a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 741323
-  timestamp: 1731846827427
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
-  sha256: 2e603bf640738511faf80de284daa031f0e67de66b77bed7d0da1045ef062abf
-  md5: bb24d3dd7d028b70f0bb5f6d6e1329c0
-  depends:
-  - libgcc >=13
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 768716
-  timestamp: 1731846931826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
   sha256: eb130af5be94c7db5e3448c7f254f8e066e62d1b76cd1c6c7c33f3565a55a685
   md5: 20ab6b90150325f1af7ca96bffafde63
@@ -1645,66 +1588,47 @@ packages:
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
   size: 52087
   timestamp: 1757690097598
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
-  sha256: 3cb21ce5d8dd92024e7ae983964231bf45aefada70509ca0a85e3aab32923f2f
-  md5: dddda2b83f5c5106ba9b02550f6278b2
+- conda: https://conda.anaconda.org/nvidia/linux-64/libnvjitlink-13.0.88-hb0a779f_0.conda
+  sha256: 8978eeb81a53ca43f6f31d31e15e0a29ca3114ca80dd75a09a26a54b86fbaa89
+  md5: 74b569c3f3a8a75e19fcac70a9065648
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 31218311
-  timestamp: 1757021832026
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
-  sha256: 3a8b45998babc28786af0ef37787a81a1a8f05a681836d05cec7de3400705964
-  md5: 69a51843fab75153ebd35a551c5e4b29
+  size: 31241147
+  timestamp: 1755727784409
+- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libnvjitlink-13.0.88-h492901c_0.conda
+  sha256: 73f8aa200dab8617e7adb9f9aca69969d3e7c24647c5569b97434cbd0a0b82f3
+  md5: 3c7c249032be1ad26b69329708032620
   depends:
   - arm-variant * sbsa
   - cuda-version >=13,<13.1.0a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc-ng >=11.2.0
+  - libstdcxx-ng >=11.2.0
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29710724
-  timestamp: 1757021907780
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
-  sha256: 23990b93978cc18a316e31fe71f7a8bf5e1c54d561c73cad36a583aaef510b44
-  md5: 60fe2b4386aa893d66dea5b01326b3a6
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27918
-  timestamp: 1757021661262
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
-  sha256: ab241802ffe60f910804a84eba32404c7bea484debc5bcf672ce658bfbdb1680
-  md5: 415dd15457ce91bb59ce584dcfc641a4
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27986
-  timestamp: 1757021596258
-- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: fa318fe80e61e698db006103e6daaf1b8318db1974f332df8c8e2b698f987cfc
-  md5: d9b0c4f42d730faf187ea126e075fe5f
+  size: 29732324
+  timestamp: 1755728305075
+- conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-64-13.0.88-0.conda
+  sha256: c48ad05fbcfa574935ad1956237b053af50d6fab10b90cde8a5ba91fec2f9542
+  md5: 21bb32ff626d87faafa71415a571aa53
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 15040180
-  timestamp: 1757021509018
-- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 01a61c4933c07293e820d460f128500f34a6038fb4f87805fbedafb7eab63cd6
-  md5: 24bebae254ac9789d1f8dd8e02031cba
+  size: 15068972
+  timestamp: 1755730695984
+- conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+  sha256: 2ae53672921e400daff02cb63dc1ce05f23a59e7a8da1cbcfcdf42c3c79b9599
+  md5: 1e4216d61a1878787f129c3df258bf01
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 14217893
-  timestamp: 1757021478031
+  size: 14219197
+  timestamp: 1755731597201
 - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
   sha256: 9a2275c739256cbecdeacf106ec20b9a2862e4805d4cd736043040509e21ac64
   md5: cbad75f2a79badf75b2af9b323883f46
@@ -1735,27 +1659,25 @@ packages:
   license: Apache-2.0
   size: 1304327
   timestamp: 1759940642160
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-hd08acf3_7.conda
-  sha256: 73eb65f58ed086cf73fb9af3be4a9b288f630e9c2e1caacc75aff5f265d2dda2
-  md5: 716f4c96e07207d74e635c915b8b3f8b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_15.conda
+  sha256: 35965892734289a769266e7ad3c117f8fabe74f0e01d8bdd478e0d59cc49affd
+  md5: 9e82f96224931323c6ed53d88fb3241b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14.3.0
   - libstdcxx >=14.3.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5110341
-  timestamp: 1759965766003
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-h48d3638_7.conda
-  sha256: f096b7c42438c3e6abcbca1c277a4f0977b4d49a5c532c208dbde9a96b5955a0
-  md5: 3bc4b38d25420ccd122396ff6e3574fa
+  size: 7947918
+  timestamp: 1764836564921
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_15.conda
+  sha256: 0491a1217ad365351349291732522c934e485f6efa39128943ba83abe5bef815
+  md5: b283c0151246b072a4a6ce3703d03fda
   depends:
   - libgcc >=14.3.0
   - libstdcxx >=14.3.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5086981
-  timestamp: 1759967549642
+  size: 7197687
+  timestamp: 1764836471948
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -1779,103 +1701,59 @@ packages:
   license_family: BSD
   size: 311396
   timestamp: 1745609845915
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
-  sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
-  md5: 5b767048b1b3ee9a954b06f4084f93dc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_15.conda
+  sha256: 2648485aa2dcd5ca385423841a728f262458aec5d814a79da5ab75098e223e3f
+  md5: fccfb26375ec5e4a2192dee6604b6d02
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 h767d61c_7
+  - libgcc 15.2.0 he0feb66_15
   constrains:
-  - libstdcxx-ng ==15.2.0=*_7
+  - libstdcxx-ng ==15.2.0=*_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3898269
-  timestamp: 1759968103436
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-h3f4de04_7.conda
-  sha256: 4c6d1a2ae58044112233a57103bbf06000bd4c2aad44a0fd3b464b05fa8df514
-  md5: 6a2f0ee17851251a85fbebafbe707d2d
+  size: 5856371
+  timestamp: 1764836166363
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_15.conda
+  sha256: f6347ce1d1a8a9ecfa16fc118594b0a5cab9194a8dcc7e79cd02a7497822d1d2
+  md5: 2873f805cdabcf33b880b19077cf6180
   depends:
-  - libgcc 15.2.0 he277a41_7
+  - libgcc 15.2.0 h8acb6b2_15
   constrains:
-  - libstdcxx-ng ==15.2.0=*_7
+  - libstdcxx-ng ==15.2.0=*_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3831785
-  timestamp: 1759967470295
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h85bb3a7_107.conda
-  sha256: 54ba5632d93faebbec3899d9df84c6e71c4574d70a2f3babfc5aac4247874038
-  md5: eaf0f047b048c4d86a4b8c60c0e95f38
+  size: 5540090
+  timestamp: 1764836183565
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_115.conda
+  sha256: e4912489035a077a8e7c754fea33fd5a96d95bd41042ad6b5d60b881049048be
+  md5: 1ef1a0376c610365eb26e67f5da5e48d
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 13244605
-  timestamp: 1759965656146
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h370b906_107.conda
-  sha256: 5e8405b8b626490694e6ad7eed2dc8571b125883a1695ee2c78f61cd611f8ac5
-  md5: dcfd023b6ccaea0c3e08de77f0fe43f3
+  size: 19600238
+  timestamp: 1764836425209
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_115.conda
+  sha256: 483ace48a26071a78fdcacf333a6515b88e194beea2b706cfc33a51666a5a281
+  md5: bac3774b052191747439e80a88d4f074
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 12425310
-  timestamp: 1759967470230
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
-  sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
-  md5: f627678cf829bd70bccf141a19c3ad3e
+  size: 17302972
+  timestamp: 1764836355263
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_15.conda
+  sha256: 2ffaec42c561f53dcc025277043aa02e2557dc0db62bc009be4c7559a7f19f09
+  md5: 20a8584ff8677ac9d724345b9d4eb757
   depends:
-  - libstdcxx 15.2.0 h8f9b012_7
+  - libstdcxx 15.2.0 h934c35e_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 29343
-  timestamp: 1759968157195
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hf1166c9_7.conda
-  sha256: 26fc1bdb39042f27302b363785fea6f6b9607f9c2f5eb949c6ae0bdbb8599574
-  md5: 9e5deec886ad32f3c6791b3b75c78681
+  size: 26905
+  timestamp: 1764836222826
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_15.conda
+  sha256: 73d026540bd2ec75186bc82c164fbfa51cbe44c4c27ed64b57bf52b10f6f3d63
+  md5: 7a99de7c14096347968d1fd574b46bb2
   depends:
-  - libstdcxx 15.2.0 h3f4de04_7
+  - libstdcxx 15.2.0 hef695bb_15
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 29341
-  timestamp: 1759967498023
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
-  sha256: b30c06f60f03c2cf101afeb3452f48f12a2553b4cb631c9460c8a8ccf0813ae5
-  md5: b04e0a2163a72588a40cde1afd6f2d18
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 491211
-  timestamp: 1763011323224
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
-  sha256: 22e5bc2b72eb4a104927d34d06954573dbbdef1981fd7f73520f2ca82f0b7101
-  md5: e7a86e3cdea9c37bf12005778d490148
-  depends:
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 517490
-  timestamp: 1763011526609
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
-  sha256: 751cf346f0f56cc9bfa43f7b5c9c30df2fcec8d84d164ac0cd74a27a3af79f30
-  md5: 2f6b30acaa0d6e231d01166549108e2c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 144395
-  timestamp: 1763011330153
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
-  sha256: dd1ec27fef9f74ebdd0211ad875ba037f924931c81be164e7ff756b5d86ffc72
-  md5: 4fc935d5bebd8e6e070a861544a71a34
-  depends:
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 156835
-  timestamp: 1763011535779
+  size: 26977
+  timestamp: 1764836231696
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -1954,27 +1832,27 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 926034
   timestamp: 1738196018799
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.1-h171cf75_0.conda
-  sha256: 1522b6d4a55af3b5a4475db63a608aad4c250af9f05050064298dcebe5957d38
-  md5: 6567fa1d9ca189076d9443a0b125541c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
+  sha256: 6f7d59dbec0a7b00bf5d103a4306e8886678b796ff2151b62452d4582b2a53fb
+  md5: b518e9e92493721281a60fa975bddc65
   depends:
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
   license: Apache-2.0
   license_family: APACHE
-  size: 186326
-  timestamp: 1752218296032
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.1-hdc560ac_0.conda
-  sha256: a3f1ea64658be3faddd30dca61e00a8df1680500a571e9c0159b3c0eaa8b2274
-  md5: eff201e0dd7462df1f2a497cd0f1aa11
+  size: 186323
+  timestamp: 1763688260928
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
+  sha256: 45fbc7c8c44681f5cefba1e5b26ca504a4485b000c5dfaa31cec0b7bc78d0de4
+  md5: 8b5222a41b5d51fb1a5a2c514e770218
   depends:
   - libstdcxx >=14
   - libgcc >=14
   license: Apache-2.0
   license_family: APACHE
-  size: 183057
-  timestamp: 1752218322983
+  size: 182666
+  timestamp: 1763688214250
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
   sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
   md5: 9ee58d5c534af06558933af3c845a780
@@ -2015,33 +1893,6 @@ packages:
   license: Apache-2.0
   size: 223501
   timestamp: 1744213280925
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
-  sha256: 5c09b833b698ecd19da14f5ff903063cf174382d6b32c86166984a93d427d681
-  md5: fe7412835a65cd99eacf3afbb124c7ac
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libnl >=3.11.0,<4.0a0
-  - libstdcxx >=14
-  - libsystemd0 >=257.9
-  - libudev1 >=257.9
-  license: Linux-OpenIB
-  license_family: BSD
-  size: 1244282
-  timestamp: 1761557737114
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
-  sha256: c6ebff176e112940a7a9f269b671a51bc83708e6846fa0d7be451b74e18b9b4b
-  md5: 9e7498e2faf70daf30bd982c50038ffc
-  depends:
-  - libgcc >=14
-  - libnl >=3.11.0,<4.0a0
-  - libstdcxx >=14
-  - libsystemd0 >=257.9
-  - libudev1 >=257.9
-  license: Linux-OpenIB
-  license_family: BSD
-  size: 1313626
-  timestamp: 1761557755128
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
   sha256: d5c73079c1dd2c2a313c3bfd81c73dbd066b7eb08d213778c8bff520091ae894
   md5: c1c9b02933fdb2cfb791d936c20e887e
@@ -2131,26 +1982,20 @@ packages:
   license: LicenseRef-BSD-like
   size: 162036
   timestamp: 1754913052303
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
-  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 567578
-  timestamp: 1742433379869
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
-  sha256: 0812e7b45f087cfdd288690ada718ce5e13e8263312e03b643dd7aa50d08b51b
-  md5: 5be90c5a3e4b43c53e38f50a85e11527
+  size: 601375
+  timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+  sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+  md5: c3655f82dcea2aa179b291e7099c1fcc
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 551176
-  timestamp: 1742433378347
+  size: 614429
+  timestamp: 1764777145593

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,12 +3,13 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/rapidsai/
-    - url: https://conda.anaconda.org/nvidia/
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/nvidia/
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
@@ -18,27 +19,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.3-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_15.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl_linux-64-13.0.85-1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-64-13.0.88-0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-crt-tools-13.0.88-0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-13.0.96-ha533d76_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-13.0.96-h3b4bcfc_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-64-13.0.96-hbe36340_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-static-13.0.96-h3b4bcfc_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-64-13.0.96-hbe36340_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-13.0.96-h73695a4_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-64-13.0.96-hbe36340_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-13.0.88-hb25713b_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-64-13.0.88-0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-impl-13.0.88-hbe36340_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-tools-13.0.88-h3b4bcfc_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc_linux-64-13.0.88-he6262bf_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-13.0.87-ha2c4e13_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-13.0.88-hb0a779f_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-64-13.0.88-0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-impl-13.0.88-h3b4bcfc_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-tools-13.0.88-h3b4bcfc_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dlpack-0.8-h59595ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_15.conda
@@ -51,11 +52,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.15.1.6-h2e68323_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.15.1.6-h2e68323_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.4.0.35-h50d9014_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.4.0.35-h50d9014_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
@@ -67,17 +69,21 @@ environments:
       - conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.10.00-cuda13_0_251008_fb6220c4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-h7bcfba5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-h7bcfba5_3.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjitlink-13.0.88-hb0a779f_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-64-13.0.88-0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_15.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_115.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
@@ -85,6 +91,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-64/rapids-logger-0.1.1-h98325ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.12.0-he64ecbb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
@@ -93,7 +100,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/noarch/arm-variant-1.2.0-sbsa.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_104.conda
@@ -103,27 +111,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.3-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_15.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cccl_linux-aarch64-13.0.85-h119d96e_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-crt-tools-13.0.88-h119d96e_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-13.0.96-h7bee0a1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-dev-13.0.96-h48dd3d1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-static-13.0.96-h48dd3d1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h48dd3d1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-aarch64-13.0.96-h7bee0a1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-13.0.88-h331fd37_100.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-impl-13.0.88-h48dd3d1_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-tools-13.0.88-h48dd3d1_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h7533faf_100.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvml-dev-13.0.87-h691c0af_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvrtc-13.0.88-h492901c_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-impl-13.0.88-h48dd3d1_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-tools-13.0.88-h48dd3d1_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.0.87-h40ab4d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.11.0-h7b35c40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dlpack-0.8-h2f0025b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_15.conda
@@ -136,11 +144,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-1.15.1.6-h1c78503_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-dev-1.15.1.6-h1c78503_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-10.4.0.35-h384c9aa_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-dev-10.4.0.35-h384c9aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.17.0-h7bfdcfb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
@@ -152,17 +161,21 @@ environments:
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.10.00-cuda13_0_251008_fb6220c4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.67.0-ha888d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnuma-2.0.18-h86ecc28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-he387df4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-he387df4_3.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-aarch64/libnvjitlink-13.0.88-h492901c_0.conda
-      - conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h119d96e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_15.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_115.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
@@ -170,6 +183,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.0-h8e36d6e_0.conda
       - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/rapids-logger-0.1.1-h4f43097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.12.0-hb434046_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_8.conda
@@ -208,13 +222,32 @@ packages:
   license_family: BSD
   size: 23712
   timestamp: 1650670790230
-- conda: https://conda.anaconda.org/nvidia/noarch/arm-variant-1.2.0-sbsa.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
   sha256: 0658cac65071ace5beded633851681e6f0b381040c8ce313bbe2a0ab410c5072
   md5: b7d6244b9c7a660f10336645e73c2cd2
   license: BSD-3-Clause
   license_family: BSD
   size: 7126
   timestamp: 1742928603302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+  sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
+  md5: 791365c5f65975051e4e017b5da3abf5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 68072
+  timestamp: 1756738968573
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+  sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
+  md5: 1ef6c06fec1b6f5ee99ffe2152e53568
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 74992
+  timestamp: 1660065534958
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
   sha256: 1625ea421e0f44dbdde01e3e7d2c4958bea6c55731e6ac6954ba912d339982c2
   md5: d351e4894d6c4d9d8775bf169a97089d
@@ -396,331 +429,322 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 30750
   timestamp: 1764836639741
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl_linux-64-13.0.85-1.conda
-  sha256: 693bee3487a484e1d6cb3f7f994d5433df7a698e94116272dc04da25cc542a26
-  md5: fa3fb6896ca529d1863301b831ccf985
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
+  sha256: a6e372858d440e3adcea6902a013f9e5df5794ac414532bf21340919565406fc
+  md5: 9cdd4053158422e3ef9d7a3feb31e40d
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1151590
-  timestamp: 1755226921988
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cccl_linux-aarch64-13.0.85-h119d96e_1.conda
-  sha256: ae0d6ee9a719c8d54e5c35f7e8c9562431be87adc85f21ef15b62921e1ad94b8
-  md5: 5482d83595b1c801a1f5479f44de2ff6
-  depends:
-  - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  constrains:
-  - arm-variant * sbsa
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1147814
-  timestamp: 1755227272989
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-64-13.0.88-0.conda
-  sha256: 83fc861daf59475c31e69ffd7ee58f9c4049099a01cdd6bde59bd9edc992a97e
-  md5: 593db12a0b0152b3017184863c8388f7
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 86152
-  timestamp: 1755730598660
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-  sha256: 02fb970d0a8238700fd0fa7ab9a6daf94909a33854b9bc5253da1da48aee5fc4
-  md5: eddca933593f2d106860f7f7a562e516
+  size: 1143068
+  timestamp: 1757017456077
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
+  sha256: 89d1251bfb27d9d861764cd1daae2b835588045ba920debab66a79e208484032
+  md5: 6739a8321047a32fe33edc982b570c9c
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 86211
-  timestamp: 1755731173145
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-crt-tools-13.0.88-0.conda
-  sha256: 4cc402d170d9519470df95a5a593cdce4eea82f55586a90ee521ad5b752a2300
-  md5: c12257073b2cab320ac2070f04725c51
+  size: 1141138
+  timestamp: 1757017459617
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
+  sha256: dff9f97d3c8f47e1e4b6d486401d11a2d8aa9474a07adbd177b042a8cb640e1f
+  md5: 99dddaab1ca61632434f37079fce52e9
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20243
-  timestamp: 1755730602108
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-crt-tools-13.0.88-h119d96e_0.conda
-  sha256: c7c5c73727370965724817412fef6493f496fe3374e6a02fb1614dc563787060
-  md5: 9b7eb28a43190a5587da9d7ae40048ab
+  size: 95746
+  timestamp: 1757021345670
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+  sha256: 5ffbb6e143bd16951c1bc71d32f8137f9ed890df9420e1c9d5d30c12823b951e
+  md5: 766775e40dac3236cd90077f460552db
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20317
-  timestamp: 1755731197964
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-13.0.96-ha533d76_1.conda
-  sha256: 139c939d14fa7db1c84b88e199f2ea4be1e3cac2ff1aaa786e8c8e575848a750
-  md5: 9767138ad770a6ac7da2b54a5c86c3ba
+  size: 95711
+  timestamp: 1757021337458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
+  sha256: c7fc9f3c3f0c51678dc92b1caa46dbce35a1dc6e6176771f0a87272a22a35256
+  md5: d72c22960bc7ec9144bedaeb6138a261
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 29931
+  timestamp: 1757021356880
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
+  sha256: 564b166a587e62c92c6e0b4044955cedab42168ae2730f74694fe89ef61b9fd3
+  md5: 75359c125cfd48ee457a6659b561a764
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 30038
+  timestamp: 1757021339160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
+  sha256: 22f6466441812649da65ef47792854e9552e566d7ac6c3682d81dbb480de529c
+  md5: b585052893126ed45c015bcab43ff12a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart_linux-64 13.0.96 h73695a4_1
+  - cuda-cudart_linux-64 13.0.96 h376f20c_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18865
-  timestamp: 1758935647523
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-13.0.96-h7bee0a1_1.conda
-  sha256: 9b5a3ba4facf556967d8b6bdc435a5ae267218d988e88c6e9e13b3a7e11ce485
-  md5: f9267770e2868d14e4212fc162b69e18
+  size: 24027
+  timestamp: 1760034148822
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
+  sha256: 0387b104ebf74f83ed911cd90aebb064ed1d2ffb147c36cb6c268415302431a8
+  md5: fd19003beb0686dd8e47466bbab1b11f
   depends:
   - arm-variant * sbsa
-  - cuda-cudart_linux-aarch64 13.0.96 h7bee0a1_1
+  - cuda-cudart_linux-aarch64 13.0.96 h8f3c8d4_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  constrains:
-  - arm-variant * sbsa
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18900
-  timestamp: 1758936422603
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-13.0.96-h3b4bcfc_1.conda
-  sha256: cfa6a91e5ec9a761e440dad558c70762fe157375455ed4c9f261b87876b55c91
-  md5: 1c9383655b782f7803e5a22189caf572
+  size: 24195
+  timestamp: 1760034124717
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
+  sha256: 5af0357651051bc0a308eb007955d928dd6d6a5aafdc96e2868526fc2c87bda8
+  md5: 5e325914e6b2ed97a412e54755268217
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart 13.0.96 ha533d76_1
-  - cuda-cudart-dev_linux-64 13.0.96 hbe36340_1
-  - cuda-cudart-static 13.0.96 h3b4bcfc_1
+  - cuda-cudart 13.0.96 hecca717_0
+  - cuda-cudart-dev_linux-64 13.0.96 h376f20c_0
+  - cuda-cudart-static 13.0.96 hecca717_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18838
-  timestamp: 1758935673163
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-dev-13.0.96-h48dd3d1_1.conda
-  sha256: 2c028ace621ddfd80a3c71302a1db291a81bae792ca5f861d6de2be38e2d4bea
-  md5: be56a3a17519f444254143cbbd7ae57d
+  size: 24515
+  timestamp: 1760034188804
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
+  sha256: 2965f65bc5031da466cd26b7a9e056e67cae206ff04483958617a591928f610f
+  md5: 647578ce75f6ac021ad50daf7dd6c5ef
   depends:
   - arm-variant * sbsa
-  - cuda-cudart 13.0.96 h7bee0a1_1
-  - cuda-cudart-dev_linux-aarch64 13.0.96 h48dd3d1_1
-  - cuda-cudart-static 13.0.96 h48dd3d1_1
+  - cuda-cudart 13.0.96 h8f3c8d4_0
+  - cuda-cudart-dev_linux-aarch64 13.0.96 h8f3c8d4_0
+  - cuda-cudart-static 13.0.96 h8f3c8d4_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  constrains:
-  - arm-variant * sbsa
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18862
-  timestamp: 1758936655607
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-64-13.0.96-hbe36340_1.conda
-  sha256: 1d55c7decfec0b60b1c7121f13c7bef7973bd62af7c0e6d16e492e9c5986dc84
-  md5: cd857146e298eb03a259d4168db5f43b
+  size: 24661
+  timestamp: 1760034143509
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
+  sha256: 9730992d8a9696cb740420a40340e8ae142e26ec42e0cb3a74c6bfb9f3d43d75
+  md5: 452f0e77df30da17b08e3295ef279df2
   depends:
   - cuda-cccl_linux-64
   - cuda-cudart-static_linux-64
   - cuda-cudart_linux-64
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 379132
-  timestamp: 1758935653518
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
-  sha256: b1f23f26f99dc08059051a805d66de127e0d693fb3acc4d9385fe3e0964235c5
-  md5: b2419e4945d11525819e5b2881f8fa96
+  size: 385615
+  timestamp: 1760034157020
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+  sha256: a56da2191e818e0e54be0c9956fec02e26940b0ac6ca1747c1badae2804cae40
+  md5: c9fa4020ff1370f7b5216c24f222d584
   depends:
+  - arm-variant * sbsa
   - cuda-cccl_linux-aarch64
   - cuda-cudart-static_linux-aarch64
   - cuda-cudart_linux-aarch64
   - cuda-version >=13.0,<13.1.0a0
-  constrains:
-  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 378348
-  timestamp: 1758936475543
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-static-13.0.96-h3b4bcfc_1.conda
-  sha256: 18feb9e3bd54fe8ac55b829b8f13e21c8e4c1c9b9961bb0d1f5e9b3df4c6f529
-  md5: 0dad74d4f50ebdfad8569d54c15da3f1
+  size: 385612
+  timestamp: 1760034129929
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
+  sha256: c158fb5fdb660181e480d50dcc9df40febeb313a9bbed71954093305373994ba
+  md5: 36d04d463e960a0273fdb788c11b87e4
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart-static_linux-64 13.0.96 hbe36340_1
+  - cuda-cudart-static_linux-64 13.0.96 h376f20c_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18366
-  timestamp: 1758935661834
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-cudart-static-13.0.96-h48dd3d1_1.conda
-  sha256: de764d3e6db5522741c6d24435610d4b60efe3410464a362d4f75ec2a8ac1efd
-  md5: 7677f80dfc3b54c652cf58a683932650
+  size: 24031
+  timestamp: 1760034170778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
+  sha256: 5e5c99dfb2dc675e84d46ebcb560eeefcf20f30c7447af8d6bd1257e2b91540c
+  md5: 51205a311969eaea7b25773345b03395
   depends:
   - arm-variant * sbsa
-  - cuda-cudart-static_linux-aarch64 13.0.96 h48dd3d1_1
+  - cuda-cudart-static_linux-aarch64 13.0.96 h8f3c8d4_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
-  constrains:
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 24201
+  timestamp: 1760034133545
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
+  sha256: b1b626540ff0e19f15036433f9c64aad5cc37b503e0cc7cbd4abeef678db63ab
+  md5: 3317a47036e9e0c31462454635c50457
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 1077227
+  timestamp: 1760034117715
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+  sha256: 773eed1956cafeadb6460699fe98db274b1732c164ce82b02a2d10810994d3d2
+  md5: 038c4cf5847929f1269dd01aedc32a4f
+  depends:
   - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18389
-  timestamp: 1758936542956
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-64-13.0.96-hbe36340_1.conda
-  sha256: a799d615b382262ca42742d181742b5116ba4bb4fd449a855a4ba37ae83c0bcb
-  md5: 3d616429d24cefcf7091fc583035578f
+  size: 1080940
+  timestamp: 1760034110333
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
+  sha256: a24fc5d9d229328c4165c1e08a53717a804b70832ef5365ed3071c7e8ef2d72f
+  md5: c4bbc81db4cf35b6766436f2d774ead5
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1070826
-  timestamp: 1758935626303
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h48dd3d1_1.conda
-  sha256: 03bae57c2c4c851218f19d38db52849b71c24fc7ea2b8f64d275750c53e459f3
-  md5: 4c4650cc9d29182be88f661dca64f11c
+  size: 185278
+  timestamp: 1760034128147
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+  sha256: c1be1727a13bcaf6ef9a76e1d1d00845e37556a40530d559406939fbc618fdb2
+  md5: ae0425af7774272e8926e6d3b4ca4f50
   depends:
-  - cuda-version >=13.0,<13.1.0a0
-  constrains:
   - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1075561
-  timestamp: 1758936253135
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-64-13.0.96-h73695a4_1.conda
-  sha256: 6b92589cd90f08956df56e8a14237412e59e05368e31770f4aacb2df5f8d5d3f
-  md5: 194257b0bc6106412711820cb13f9648
+  size: 199749
+  timestamp: 1760034117080
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
+  sha256: 00baf846f6e109df717f8b1602118ad1c46e3ba9b1864d676e420e3544d416ac
+  md5: f44904debd095f95ad8e523f7d26eff9
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 179667
-  timestamp: 1758935634601
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-cudart_linux-aarch64-13.0.96-h7bee0a1_1.conda
-  sha256: 76c0c3323d0c4bbec2f438513ac33853d1bca4c03227245144594f5205da3b98
-  md5: 16c24c0f22ffda329ca59e9b65d20f78
+  size: 38400
+  timestamp: 1760034138622
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
+  sha256: 56b88567441810285d448e7332b00ee9253a3713e620c84594d11bc5e7b0a1bd
+  md5: ebeb2cae11008509872411f0301a603c
   depends:
-  - cuda-version >=13.0,<13.1.0a0
-  constrains:
   - arm-variant * sbsa
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 195306
-  timestamp: 1758936312952
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-64-13.0.96-hbe36340_1.conda
-  sha256: 63fde5fa64a218f92e57d88aecc80069f4f6b3a5a7e438a4ab64be466ba5cd21
-  md5: cde8561315b098ff88da28b601b53148
-  depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 33221
-  timestamp: 1758935640846
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h48dd3d1_1.conda
-  sha256: 08ba6bb0b4b402259c46897c49f7e1ae5ad85926adba12c3b019b36bfbc7fdc1
-  md5: 8306d9777b02d93c56105e481cfabd0c
-  depends:
-  - cuda-version >=13.0,<13.1.0a0
-  constrains:
-  - arm-variant * sbsa
-  license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 34839
-  timestamp: 1758936366549
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-13.0.88-hb25713b_0.conda
-  sha256: 75c1aa395b1dded1bf4728b860dde396a0db550463773132cd4ab4f00ff04f69
-  md5: 804a71652dce48990f158cf236de5a22
+  size: 40113
+  timestamp: 1760034119535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
+  sha256: a616d6b91f7bc58f0a2bca5871e1d94abe120c1baab090826762a7df36bb42a3
+  md5: a41247f1d8976ca80c81d457bafee5db
   depends:
   - cuda-nvcc_linux-64 13.0.88.*
   - gcc_linux-64
   - gxx_linux-64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 17032
-  timestamp: 1755730844448
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-13.0.88-h331fd37_100.conda
-  sha256: 1a713efbc240717ad1e73ccd7e35c61b2ea38b1de87f2591fe6e88ff84dfae43
-  md5: 48717a752b38617e77025a4fefa6e687
+  size: 24902
+  timestamp: 1762289415743
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
+  sha256: d18550073d02ba6fa43be7ba49829f3b9ddfe3a98e4bb9854541a0f5f8c470e3
+  md5: f21892aa190d6862ec3c381ad6ae1e80
   depends:
   - cuda-nvcc_linux-aarch64 13.0.88.*
   - gcc_linux-aarch64
   - gxx_linux-aarch64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 17060
-  timestamp: 1755733629542
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-64-13.0.88-0.conda
-  sha256: b040b6bd5060a4a4b4fb47f60a16838ba55bceb50efb0193ffd92e95581048ac
-  md5: cb0453a6630efd252b8712bde30d65ef
+  size: 24944
+  timestamp: 1762289394229
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
+  sha256: 9da527d5f0f4aa801d087def466deecec166fe89713aaccb94ef6dc392fcb912
+  md5: 592146b39bcd34626389655523d8d39f
   depends:
-  - cuda-crt-dev_linux-64 13.0.88 0
-  - cuda-nvvm-dev_linux-64 13.0.88 0
+  - cuda-crt-dev_linux-64 13.0.88 ha770c72_0
+  - cuda-nvvm-dev_linux-64 13.0.88 ha770c72_0
   - cuda-version >=13.0,<13.1.0a0
   - libgcc >=6
-  - libnvptxcompiler-dev_linux-64 13.0.88 0
+  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
   constrains:
-  - gcc_impl_linux-64 >=6,<15.0a0
+  - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 19197
-  timestamp: 1755730784704
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-  sha256: 82f644f2ba4a9a9640f682b301c30db0f02ef1c885091575ba49f4ccde803382
-  md5: dcd6b610517829cf98f8b25cadac60a9
+  size: 28946
+  timestamp: 1757021683159
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
+  sha256: c44ddb96258a53762ef6a28ad1023f0096d04233397f496c27f4b113186bfca0
+  md5: 2dbf71edc5f9ea2dd38d52814bedffe3
   depends:
   - arm-variant * sbsa
-  - cuda-crt-dev_linux-aarch64 13.0.88 h119d96e_0
-  - cuda-nvvm-dev_linux-aarch64 13.0.88 h119d96e_0
+  - cuda-crt-dev_linux-aarch64 13.0.88 h579c4fd_0
+  - cuda-nvvm-dev_linux-aarch64 13.0.88 h579c4fd_0
   - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h119d96e_0
+  - libgcc >=6
+  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<15.0a0
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 19292
-  timestamp: 1755732024042
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-impl-13.0.88-hbe36340_0.conda
-  sha256: 1f8e8d3fc4ce98a6d882cedcb2345e4e9abcf96988ff6d0822d622baa7334fa0
-  md5: 477bbfe005c23b88ff225b2ef4df06b7
+  size: 29072
+  timestamp: 1757021613549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
+  sha256: 259e1ae6a7729ef77b515e9a491f9f820ef0db1837b43f7156c58161fdb451ed
+  md5: 5eafe62a4236322ca351653d3dadab20
   depends:
-  - cuda-cudart >=13.0.48,<14.0a0
+  - cuda-cudart >=13.0.88,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-64 13.0.88 0
-  - cuda-nvcc-tools 13.0.88 h3b4bcfc_0
-  - cuda-nvvm-impl 13.0.88 h3b4bcfc_0
+  - cuda-nvcc-dev_linux-64 13.0.88 he91c749_0
+  - cuda-nvcc-tools 13.0.88 he02047a_0
+  - cuda-nvvm-impl 13.0.88 h4bc722e_0
   - cuda-version >=13.0,<13.1.0a0
+  - libnvptxcompiler-dev 13.0.88 ha770c72_0
   constrains:
-  - gcc_impl_linux-64 >=6,<15.0a0
+  - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 19650
-  timestamp: 1755730789182
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-impl-13.0.88-h48dd3d1_0.conda
-  sha256: 9345eaea54d81e2527278b93e51ad132a6f1f99196d5adcb6f8f95ac11813744
-  md5: 425b87c0a6ea1c5f57c749379995de68
+  size: 28077
+  timestamp: 1757021695541
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
+  sha256: 81b16bd2edf9a581be49e03f8bf0d8ff048d47aff4278bfe38f49ee4a379a10c
+  md5: 58b623409f1b5bdea63bc46849ff1852
   depends:
   - arm-variant * sbsa
-  - cuda-cudart >=13.0.48,<14.0a0
+  - cuda-cudart >=13.0.88,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-aarch64 13.0.88 h119d96e_0
-  - cuda-nvcc-tools 13.0.88 h48dd3d1_0
-  - cuda-nvvm-impl 13.0.88 h48dd3d1_0
+  - cuda-nvcc-dev_linux-aarch64 13.0.88 h4310d6a_0
+  - cuda-nvcc-tools 13.0.88 h614329b_0
+  - cuda-nvvm-impl 13.0.88 h7b14b0b_0
   - cuda-version >=13.0,<13.1.0a0
+  - libnvptxcompiler-dev 13.0.88 h579c4fd_0
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<15.0a0
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 19679
-  timestamp: 1755732061531
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-tools-13.0.88-h3b4bcfc_0.conda
-  sha256: 627dd65f6699336acb3bfdc9ff44dfb0d2e43ed7f2601a00da23fdd495998f91
-  md5: 14deb60892cb99fcc8e4be9ca006ecda
+  size: 28154
+  timestamp: 1757021621068
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
+  sha256: b9cd738b3bb8eeba112c423acc3a922a6526ed6b7c72d1857cf3ade55073dc76
+  md5: 994f869d05c03cc1b5a9fc9911183a62
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-crt-tools 13.0.88 0
-  - cuda-nvvm-tools 13.0.88 h3b4bcfc_0
+  - cuda-crt-tools 13.0.88 ha770c72_0
+  - cuda-nvvm-tools 13.0.88 h4bc722e_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
+  - libstdcxx >=12
   constrains:
-  - gcc_impl_linux-64 >=6,<15.0a0
+  - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29054509
-  timestamp: 1755730735142
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc-tools-13.0.88-h48dd3d1_0.conda
-  sha256: 5651e7238e1564012be1b122fef367cefa32279aa7cd2535d8daf57818a07d46
-  md5: c57cc1d9634e1f44bd02aead09e5c6d6
+  size: 28824961
+  timestamp: 1757021588514
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
+  sha256: e425fc791c68c4cb4d849cff2487bf3d7021405dc94fcbc5e00eb975bec33a1f
+  md5: b1e9a6c10d9cfb3e5ab63e8e4a3c1a47
   depends:
   - arm-variant * sbsa
-  - cuda-crt-tools 13.0.88 h119d96e_0
-  - cuda-nvvm-tools 13.0.88 h48dd3d1_0
+  - cuda-crt-tools 13.0.88 h579c4fd_0
+  - cuda-nvvm-tools 13.0.88 h7b14b0b_0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
+  - libstdcxx >=12
   constrains:
-  - gcc_impl_linux-aarch64 >=6,<15.0a0
+  - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 25295549
-  timestamp: 1755731805173
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc_linux-64-13.0.88-he6262bf_0.conda
-  sha256: 62ac58810ae67641fb54b0d4f40f7957470cede4b846181657a39aab9bea7364
-  md5: 670b3e9dcbab5a9a68a96f932cdf0252
+  size: 25207775
+  timestamp: 1757021545690
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
+  sha256: 99e27429c56f1b0120d32cef1996c5124f96f439291ce379dc00ee10b1e576c6
+  md5: 5ae59e3f3be0a3ba8ae96acd435a1d48
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-cudart-dev_linux-64 13.0.*
@@ -730,11 +754,11 @@ packages:
   - cuda-nvcc-tools 13.0.88.*
   - sysroot_linux-64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20437
-  timestamp: 1755730840514
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h7533faf_100.conda
-  sha256: b6be55f7f2bfe130fd9e440cece1382aa2ab51c165e890a372978b7b9d07b814
-  md5: 5529f5098152ca49349ebc9aa0c3957b
+  size: 26850
+  timestamp: 1762289415201
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
+  sha256: 80754283b3ebeaa21fc797cd800e1849a6b3f280acb8ff9778f4160d4b2c5530
+  md5: 2cecef0f16fdc6892f39ef44132de812
   depends:
   - arm-variant * sbsa
   - cuda-cudart-dev_linux-aarch64 13.0.*
@@ -742,126 +766,122 @@ packages:
   - cuda-nvcc-dev_linux-aarch64 13.0.88.*
   - cuda-nvcc-impl 13.0.88.*
   - cuda-nvcc-tools 13.0.88.*
-  - sysroot_linux-aarch64 >=2.26,<3.0a0
+  - sysroot_linux-aarch64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20448
-  timestamp: 1755733596514
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-13.0.87-ha2c4e13_0.conda
-  sha256: 069cf822fa1c07bd2de7bc75a4235b1d607ca8f33ef10e6bd7ea8b86c35d4289
-  md5: ac896c03c13c91b4215ecdda312fd9c3
+  size: 26954
+  timestamp: 1762289393657
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
+  sha256: 7f5d6a04fcdc6e5afb626e26e551456fe7c0eb7c98e5cf1c331f49f2cab612c5
+  md5: b2ed25d01b04defac0a8fafe87c9d00c
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 144432
-  timestamp: 1755643102140
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvml-dev-13.0.87-h691c0af_0.conda
-  sha256: 1f79a2d0a4522db3912d773631daaaa5fd7105f96367b5e3eaef7b82dfcbd41a
-  md5: a66df1d62716b69f48380ec6cab63005
+  size: 147542
+  timestamp: 1757018416900
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.0.87-h40ab4d6_0.conda
+  sha256: f9a7b189dbb3ed1be36a766519cb5dc46a2fe49de68872755f60dc3d9dca1e57
+  md5: 8acec65bd2edb2406cbadc1f429d0a66
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 149047
-  timestamp: 1755643584727
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-13.0.88-hb0a779f_0.conda
-  sha256: 848321bbf579b833c6daa02f873631e9862b8ca03c6dd1b5132612d548913cb2
-  md5: 5c609a74ab01d6cdb4da1d6660180ad8
+  size: 154141
+  timestamp: 1757018436399
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
+  sha256: e84b749251df8111359420c313b800fa896d18d44c07c7c3eec1abd155bb6b69
+  md5: dd4b7cf241cc912e4ade183911c24b7f
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 68552113
-  timestamp: 1755727144335
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvrtc-13.0.88-h492901c_0.conda
-  sha256: f45066022b48b28ce2f13c5fc076883f531f33cffc22a08c457d1ec02d99e397
-  md5: d5e5b82b0d4e996c3ea73b1c1ced47cd
+  size: 68354405
+  timestamp: 1757018387981
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
+  sha256: 723785ec1502d3f10c23e647358f9dcdfa9affc2b0542e6cdbe0770533f5e372
+  md5: f368bf1ceda5c36745b408b88fdd71a8
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 32661539
-  timestamp: 1755727509774
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-64-13.0.88-0.conda
-  sha256: 12e60b492da45abed7bbef783d9c35153eb92b71045e8cb479598af95ad2022e
-  md5: ca70a9683c049e61afc731f1d23c28f0
+  size: 32555050
+  timestamp: 1757018424779
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
+  sha256: 65b4851cf4ad2fc906875d70ce85faf612d26fc0bb7dfe4266e5cc84994eab23
+  md5: 155fa228684274e8fe1227186a04d7f2
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18285
-  timestamp: 1755730605214
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-  sha256: 96f2f185f317d3559599eda495945a2c3d821baa76770c47c13276b119572b32
-  md5: e9ba081fc9cb7327f879bedd943dd2d7
+  size: 27954
+  timestamp: 1757021367553
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+  sha256: 37201c22627900dfd0591ec6d8325814df64f7713c8ac87af96c1ae042067aa2
+  md5: dfe7a4d9546dd7cd3face2640e321897
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18368
-  timestamp: 1755731221222
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-impl-13.0.88-h3b4bcfc_0.conda
-  sha256: 18a68b641e3dcc21383348f813e3bd518d9bbdea8e465cfef4529f6090131e4e
-  md5: 2f0b8594f3d0906111e08b2bc2a02ee8
+  size: 28061
+  timestamp: 1757021345227
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
+  sha256: 1972fd15941a0f33c59e1f6b93045945cb1678b6efa0f8101c1cb24112093af5
+  md5: bd78fee8953411bfe1e70b184756fa42
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 21666629
-  timestamp: 1755730614089
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-impl-13.0.88-h48dd3d1_0.conda
-  sha256: 73bbf2cf836c4e2ecd178578fabc3289fbac531c2d8227d93ee2919de089b6a1
-  md5: 10d5ae8213734f2b43b2496a41a91b6b
+  size: 21662718
+  timestamp: 1757021391692
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
+  sha256: 1d5c24588585639fd4b340b42dc2180dae7eae045f14ede1ccc7f5038cc124a0
+  md5: f615684b985e74817ee584446d6c23dd
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20805725
-  timestamp: 1755731294887
-- conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvm-tools-13.0.88-h3b4bcfc_0.conda
-  sha256: 01c29b779afb01bb1fef6d679ddd9e978a48bd91fbe8b467ab0a4eb7a1449dfd
-  md5: 034e42270ccb1c39768e8ed21a4dcc5d
+  size: 20784164
+  timestamp: 1757021384178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
+  sha256: 248e9c7df5fe8aebe403dadc3ae79ae710d518d760ea9c0e9714c3b5e21800a5
+  md5: 07a6762db5ed5ff0887a24ad1675375b
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24556461
-  timestamp: 1755730652805
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/cuda-nvvm-tools-13.0.88-h48dd3d1_0.conda
-  sha256: 172a201b66dc34a7a9c77427452c8bfcf2912bf926fffa0c570d9b395f1befae
-  md5: a289a9ba063f3416a42ed1b034bf5df3
+  size: 24519392
+  timestamp: 1757021447444
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
+  sha256: ab31f55fd176e886d2ce3ee730f0a775dd9c4bb7374e6692a44045170834d322
+  md5: 302f4b10ac0b239c5d74fc1ca46966a7
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 23578354
-  timestamp: 1755731446917
-- conda: https://conda.anaconda.org/nvidia/noarch/cuda-version-13.0-3.conda
-  sha256: 1bd1132ecf4664f557abeb874ebc4f3cbb95b7c06bffb74360839bdac88b18fb
-  md5: 229ffe48651b3c76d1a646d9669f63ca
+  size: 23566779
+  timestamp: 1757021431631
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+  sha256: b0511bf95bf784096866c8add22afe365ff534c5d87f033119653d6d3c57d4bc
+  md5: 2f875735837c072c78894980f96c50df
   constrains:
-  - cudatoolkit 13.0|13.0.*
   - __cuda >=13
+  - cudatoolkit 13.0|13.0.*
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 17370
-  timestamp: 1759480541986
+  size: 21542
+  timestamp: 1754337583956
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
   sha256: 3fcc97ae3e89c150401a50a4de58794ffc67b1ed0e1851468fcc376980201e25
   md5: 5da8c935dca9186673987f79cef0b2a5
@@ -1122,6 +1142,27 @@ packages:
   license_family: GPL
   size: 875534
   timestamp: 1764007911054
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+  sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
+  md5: 09c264d40c67b82b49a3f3b89037bd2e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - attr >=2.5.2,<2.6.0a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 121429
+  timestamp: 1762349484074
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
+  sha256: 154eefd8f94010d89ba76a057949b9b1f75c7379bd0d19d4657c952bedcf5904
+  md5: 10fe36ec0a9f7b1caae0331c9ba50f61
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108542
+  timestamp: 1762350753349
 - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.10.00-cuda13_251008_f4e35ca0.conda
   sha256: 5a0f46e495db551df41dc77d7f21db9a46379234ff1fe27da4b2d97aff2d3c29
   md5: 1f5770d57804ddc301616ad3b8ca5330
@@ -1165,112 +1206,118 @@ packages:
   license: Apache-2.0
   size: 245606959
   timestamp: 1759942682160
-- conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.15.1.6-h2e68323_0.conda
-  sha256: 819393a7cdbf7e542a8ac5057e2fb686de51d14c2caa32bd54bfea2472ded288
-  md5: ed84caa5bae55c6589e1aa88f05da6eb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
+  sha256: 2cddb2fc468c8469b0dc932cb9792940187f64caacf2a59367a4db86dccbe27e
+  md5: bdd53a936c0bba2ff2a28268dde33b6c
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=59.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 979863
-  timestamp: 1754617120479
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-1.15.1.6-h1c78503_0.conda
-  sha256: 8d1d2255b03ee60622e050579ae0d1ac95a669b96c6351e8b21d58544cb3eb72
-  md5: 14195c61e97a83e9c70b6b1aa026d852
+  size: 977986
+  timestamp: 1757021650640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
+  sha256: 21b70a25a0cdc0ef64411af25ab19b6229a4f15543b20ffc84fe60b043f50f5d
+  md5: 078227cbdf7463d09dc2e560f042e055
   depends:
+  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=59.0
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 904334
-  timestamp: 1754619845695
-- conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.15.1.6-h2e68323_0.conda
-  sha256: 332f54150917fef88d30024e718206d31acfc71f172c85a8addff883019608ef
-  md5: 4bc6f4d8c70abdcd8732efa04ed0ab34
+  size: 908076
+  timestamp: 1757021699745
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
+  sha256: cd9ca750b5605faf4c7a90f44dc6cf8040188234587e258f2c0d02b1b96df451
+  md5: 227ab9f14df261b66e0e420f56501e4a
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 h2e68323_0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libcufile 1.15.1.6 hbc026e6_0
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
   - libcufile-static >=1.15.1.6
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 35484
-  timestamp: 1754617150524
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcufile-dev-1.15.1.6-h1c78503_0.conda
-  sha256: f720456e97475182175fbed24f78310bf256fdfd58741032e8ff68bf1ed4ac63
-  md5: 04583457a3d275e328e3ce991023dea5
+  size: 40775
+  timestamp: 1757021671143
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
+  sha256: 80cfea59157864e420b1a7aaa0c12879708389218f17af05c04a3b145be1dabb
+  md5: 5c9cd78953fd68ca33b9747353e90fd4
   depends:
+  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 h1c78503_0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libcufile 1.15.1.6 had8bf56_0
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
-  - arm-variant * sbsa
   - libcufile-static >=1.15.1.6
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 35482
-  timestamp: 1754620003037
-- conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.4.0.35-h50d9014_0.conda
-  sha256: a64353f9c194eb98eba4dbe9ff0d7b818cc52351d9adbbd8a4dc7942fe8d7020
-  md5: 605843da8a9ce6ef128804b22127814a
+  size: 41023
+  timestamp: 1757021720713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
+  sha256: 803570e401b3841ba426163f941a89e255d8408efff83fcdfee37214e5f92927
+  md5: 0fbddc6e0a54358e806221f9bd5a4f83
   depends:
-  - __glibc >=2.17,<3.0.a0
+  - __glibc >=2.28,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43535237
-  timestamp: 1751484704044
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-10.4.0.35-h384c9aa_0.conda
-  sha256: 16da24fa8163d8e9d2fc3d67fd8db44118b8dfa02134382e7f6c3b8ab116c78a
-  md5: 522ce77af61858c518c95f5aea3ef932
+  size: 43597395
+  timestamp: 1759327581167
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
+  sha256: 47d62d514bd90dc1e772daecad8bab202cc7eb90a2a4f6aff5a6d3800913c123
+  md5: 7d214813bd19bc72b1cae48662fce35d
   depends:
+  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43809768
-  timestamp: 1751482301093
-- conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.4.0.35-h50d9014_0.conda
-  sha256: acf4342dfa88bba241e92b5db68960157cfce2f4f94c6a643e659ae4e266fd75
-  md5: 6b2cad08be6d337ab4380484bd20ceb3
+  size: 43897229
+  timestamp: 1759327764810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
+  sha256: 9f8cd71ba7a4a61e3788895ee1f60d10970318e27aa624c90c175954df89cdc1
+  md5: a2e7bd789f12f442fb89878bf9889a7e
   depends:
-  - __glibc >=2.17,<3.0.a0
+  - __glibc >=2.28,<3.0.a0
   - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 h50d9014_0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libcurand 10.4.0.35 h676940d_1
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
   - libcurand-static >=10.4.0.35
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 254440
-  timestamp: 1751484771575
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libcurand-dev-10.4.0.35-h384c9aa_0.conda
-  sha256: eef2549735c1b7f023b23cc2a4bce7af35781db7642a677cd47989e09cc0182e
-  md5: 70ee799194e71256f1adbeb103e31ef1
+  size: 266784
+  timestamp: 1759327649403
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
+  sha256: 8026db45a0607f49670349976628e937c51fc9d8ae4c6ab3e203d638a615d43a
+  md5: b5edc27749d59d16f7da066367435baa
   depends:
+  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 h384c9aa_0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libcurand 10.4.0.35 he38c790_1
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
-  - arm-variant * sbsa
   - libcurand-static >=10.4.0.35
+  - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 246655
-  timestamp: 1751482603422
+  size: 262323
+  timestamp: 1759327877841
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
   sha256: 100e29ca864c32af15a5cc354f502d07b2600218740fdf2439fa7d66b50b3529
   md5: 01e149d4a53185622dc2e788281961f2
@@ -1523,6 +1570,25 @@ packages:
   license_family: MIT
   size: 728661
   timestamp: 1756835019535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+  sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
+  md5: db63358239cbe1ff86242406d440e44a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 741323
+  timestamp: 1731846827427
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
+  sha256: 2e603bf640738511faf80de284daa031f0e67de66b77bed7d0da1045ef062abf
+  md5: bb24d3dd7d028b70f0bb5f6d6e1329c0
+  depends:
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 768716
+  timestamp: 1731846931826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
   sha256: eb130af5be94c7db5e3448c7f254f8e066e62d1b76cd1c6c7c33f3565a55a685
   md5: 20ab6b90150325f1af7ca96bffafde63
@@ -1588,47 +1654,66 @@ packages:
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
   size: 52087
   timestamp: 1757690097598
-- conda: https://conda.anaconda.org/nvidia/linux-64/libnvjitlink-13.0.88-hb0a779f_0.conda
-  sha256: 8978eeb81a53ca43f6f31d31e15e0a29ca3114ca80dd75a09a26a54b86fbaa89
-  md5: 74b569c3f3a8a75e19fcac70a9065648
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
+  sha256: 3cb21ce5d8dd92024e7ae983964231bf45aefada70509ca0a85e3aab32923f2f
+  md5: dddda2b83f5c5106ba9b02550f6278b2
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=13,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 31241147
-  timestamp: 1755727784409
-- conda: https://conda.anaconda.org/nvidia/linux-aarch64/libnvjitlink-13.0.88-h492901c_0.conda
-  sha256: 73f8aa200dab8617e7adb9f9aca69969d3e7c24647c5569b97434cbd0a0b82f3
-  md5: 3c7c249032be1ad26b69329708032620
+  size: 31218311
+  timestamp: 1757021832026
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
+  sha256: 3a8b45998babc28786af0ef37787a81a1a8f05a681836d05cec7de3400705964
+  md5: 69a51843fab75153ebd35a551c5e4b29
   depends:
   - arm-variant * sbsa
   - cuda-version >=13,<13.1.0a0
-  - libgcc-ng >=11.2.0
-  - libstdcxx-ng >=11.2.0
+  - libgcc >=14
+  - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29732324
-  timestamp: 1755728305075
-- conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-64-13.0.88-0.conda
-  sha256: c48ad05fbcfa574935ad1956237b053af50d6fab10b90cde8a5ba91fec2f9542
-  md5: 21bb32ff626d87faafa71415a571aa53
+  size: 29710724
+  timestamp: 1757021907780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
+  sha256: 23990b93978cc18a316e31fe71f7a8bf5e1c54d561c73cad36a583aaef510b44
+  md5: 60fe2b4386aa893d66dea5b01326b3a6
+  depends:
+  - cuda-version >=13.0,<13.1.0a0
+  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 27918
+  timestamp: 1757021661262
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
+  sha256: ab241802ffe60f910804a84eba32404c7bea484debc5bcf672ce658bfbdb1680
+  md5: 415dd15457ce91bb59ce584dcfc641a4
+  depends:
+  - arm-variant * sbsa
+  - cuda-version >=13.0,<13.1.0a0
+  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  size: 27986
+  timestamp: 1757021596258
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
+  sha256: fa318fe80e61e698db006103e6daaf1b8318db1974f332df8c8e2b698f987cfc
+  md5: d9b0c4f42d730faf187ea126e075fe5f
   depends:
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 15068972
-  timestamp: 1755730695984
-- conda: https://conda.anaconda.org/nvidia/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h119d96e_0.conda
-  sha256: 2ae53672921e400daff02cb63dc1ce05f23a59e7a8da1cbcfcdf42c3c79b9599
-  md5: 1e4216d61a1878787f129c3df258bf01
+  size: 15040180
+  timestamp: 1757021509018
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
+  sha256: 01a61c4933c07293e820d460f128500f34a6038fb4f87805fbedafb7eab63cd6
+  md5: 24bebae254ac9789d1f8dd8e02031cba
   depends:
   - arm-variant * sbsa
   - cuda-version >=13.0,<13.1.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 14219197
-  timestamp: 1755731597201
+  size: 14217893
+  timestamp: 1757021478031
 - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.10.00-cuda13_251008_7aaad1de.conda
   sha256: 9a2275c739256cbecdeacf106ec20b9a2862e4805d4cd736043040509e21ac64
   md5: cbad75f2a79badf75b2af9b323883f46
@@ -1754,6 +1839,44 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   size: 26977
   timestamp: 1764836231696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
+  sha256: b30c06f60f03c2cf101afeb3452f48f12a2553b4cb631c9460c8a8ccf0813ae5
+  md5: b04e0a2163a72588a40cde1afd6f2d18
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 491211
+  timestamp: 1763011323224
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
+  sha256: 22e5bc2b72eb4a104927d34d06954573dbbdef1981fd7f73520f2ca82f0b7101
+  md5: e7a86e3cdea9c37bf12005778d490148
+  depends:
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 517490
+  timestamp: 1763011526609
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
+  sha256: 751cf346f0f56cc9bfa43f7b5c9c30df2fcec8d84d164ac0cd74a27a3af79f30
+  md5: 2f6b30acaa0d6e231d01166549108e2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 144395
+  timestamp: 1763011330153
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
+  sha256: dd1ec27fef9f74ebdd0211ad875ba037f924931c81be164e7ff756b5d86ffc72
+  md5: 4fc935d5bebd8e6e070a861544a71a34
+  depends:
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 156835
+  timestamp: 1763011535779
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -1893,6 +2016,33 @@ packages:
   license: Apache-2.0
   size: 223501
   timestamp: 1744213280925
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
+  sha256: 5c09b833b698ecd19da14f5ff903063cf174382d6b32c86166984a93d427d681
+  md5: fe7412835a65cd99eacf3afbb124c7ac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libnl >=3.11.0,<4.0a0
+  - libstdcxx >=14
+  - libsystemd0 >=257.9
+  - libudev1 >=257.9
+  license: Linux-OpenIB
+  license_family: BSD
+  size: 1244282
+  timestamp: 1761557737114
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
+  sha256: c6ebff176e112940a7a9f269b671a51bc83708e6846fa0d7be451b74e18b9b4b
+  md5: 9e7498e2faf70daf30bd982c50038ffc
+  depends:
+  - libgcc >=14
+  - libnl >=3.11.0,<4.0a0
+  - libstdcxx >=14
+  - libsystemd0 >=257.9
+  - libudev1 >=257.9
+  license: Linux-OpenIB
+  license_family: BSD
+  size: 1313626
+  timestamp: 1761557755128
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
   sha256: d5c73079c1dd2c2a313c3bfd81c73dbd066b7eb08d213778c8bff520091ae894
   md5: c1c9b02933fdb2cfb791d936c20e887e

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [workspace]
-channels = ["rapidsai", "conda-forge"]
+channels = ["rapidsai", "conda-forge", "nvidia" ]
 name = "sirius"
 platforms = ["linux-64", "linux-aarch64"]
 requires-pixi = "0.59.*"
@@ -18,6 +18,7 @@ CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real;120a-real;120"
 [dependencies]
 cmake = "4.1.*"
 cuda-nvcc = "*"
+cuda-nvml-dev = "*"
 cuda-version = "13.*"
 cxx-compiler = "*"
 make = "*"

--- a/src/include/memory/topology_discovery.hpp
+++ b/src/include/memory/topology_discovery.hpp
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sirius::memory
+{
+
+/**
+ * @brief GPU information.
+ */
+struct GpuTopologyInfo
+{
+  unsigned int id;                          ///< GPU device ID.
+  std::string name;                         ///< GPU device name.
+  std::string pci_bus_id;                   ///< PCI bus ID.
+  std::string uuid;                         ///< GPU UUID.
+  int numa_node;                            ///< NUMA node ID (-1 if unknown).
+  std::string cpu_affinity_list;            ///< CPU affinity list.
+  std::vector<int> cpu_cores;               ///< List of CPU core IDs.
+  std::vector<int> memory_binding;          ///< NUMA nodes for memory binding.
+  std::vector<std::string> network_devices; ///< Network devices (NICs) optimal for this GPU.
+};
+
+/**
+ * @brief Network device information.
+ */
+struct NetworkDeviceInfo
+{
+  std::string name;       ///< Device name (e.g., "mlx5_0").
+  int numa_node;          ///< NUMA node ID (-1 if unknown).
+  std::string pci_bus_id; ///< PCI bus ID.
+};
+
+/**
+ * @brief System topology information.
+ */
+struct SystemTopologyInfo
+{
+  std::string hostname;                           ///< System hostname.
+  unsigned int num_gpus;                          ///< Total number of GPUs.
+  int num_numa_nodes;                             ///< Total number of NUMA nodes.
+  int num_network_devices;                        ///< Total number of network devices.
+  std::vector<GpuTopologyInfo> gpus;              ///< GPU topology information.
+  std::vector<NetworkDeviceInfo> network_devices; ///< Network device information.
+};
+
+/**
+ * @brief PCIe topology path types.
+ */
+enum class PciePathType
+{
+  PIX  = 0, ///< Connection traversing at most a single PCIe bridge (best).
+  PXB  = 1, ///< Connection traversing multiple PCIe bridges.
+  PHB  = 2, ///< Connection traversing PCIe Host Bridge.
+  NODE = 3, ///< Connection traversing PCIe and interconnect within NUMA node.
+  SYS  = 4  ///< Connection traversing NUMA interconnect (worst).
+};
+
+/**
+ * @brief Discover system topology including GPUs, NUMA nodes, and network devices.
+ *
+ * This class provides methods to discover system topology information using NVML
+ * and /sys filesystem queries. It dynamically identifies GPU-to-NUMA-to-NIC mappings
+ * based on PCIe topology.
+ *
+ * Example usage:
+ * @code
+ * rapidsmpf::TopologyDiscovery discovery;
+ * if (discovery.discover()) {
+ *     auto topology = discovery.get_topology();
+ * }
+ * @endcode
+ */
+class TopologyDiscovery
+{
+public:
+  /**
+   * @brief Discover system topology.
+   *
+   * This method performs the actual discovery of GPUs, NUMA nodes, CPU affinity,
+   * and network devices. It must be called before `get_topology()`.
+   *
+   * @return true if discovery was successful, false otherwise.
+   */
+  [[nodiscard]] bool discover();
+
+  /**
+   * @brief Get the discovered topology information.
+   *
+   * @return SystemTopologyInfo structure containing all topology data.
+   * @note `discover()` must be called first.
+   */
+  [[nodiscard]] SystemTopologyInfo const& get_topology() const
+  {
+    return topology_.value();
+  }
+
+  /**
+   * @brief Check if topology has been discovered.
+   *
+   * @return true if `discover()` has been called successfully.
+   */
+  [[nodiscard]] bool is_discovered() const
+  {
+    return topology_.has_value();
+  }
+
+private:
+  std::optional<SystemTopologyInfo> topology_; ///< Discovered topology information.
+};
+
+} // namespace sirius::memory

--- a/src/memory/topology_discovery.cpp
+++ b/src/memory/topology_discovery.cpp
@@ -1,0 +1,738 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#include <dlfcn.h>
+#include <nvml.h>
+#include <unistd.h>
+
+#include "memory/topology_discovery.hpp"
+
+namespace fs = std::filesystem;
+
+namespace sirius::memory
+{
+
+namespace
+{
+
+// Runtime NVML loader to avoid link-time dependency on CUDA::nvml
+struct NvmlLoader
+{
+  void* handle = nullptr;
+
+  // Function pointers
+  nvmlReturn_t (*p_nvmlInit_v2)()                                              = nullptr;
+  nvmlReturn_t (*p_nvmlShutdown)()                                             = nullptr;
+  nvmlReturn_t (*p_nvmlDeviceGetCount_v2)(unsigned int*)                       = nullptr;
+  nvmlReturn_t (*p_nvmlDeviceGetHandleByIndex_v2)(unsigned int, nvmlDevice_t*) = nullptr;
+  nvmlReturn_t (*p_nvmlDeviceGetName)(nvmlDevice_t, char*, unsigned int)       = nullptr;
+  nvmlReturn_t (*p_nvmlDeviceGetPciInfo_v3)(nvmlDevice_t, nvmlPciInfo_t*)      = nullptr;
+  nvmlReturn_t (*p_nvmlDeviceGetUUID)(nvmlDevice_t, char*, unsigned int)       = nullptr;
+  const char* (*p_nvmlErrorString)(nvmlReturn_t)                               = nullptr;
+
+  NvmlLoader()
+  {
+    load();
+  }
+
+  ~NvmlLoader()
+  {
+    if (handle)
+    {
+      dlclose(handle);
+    }
+  }
+
+  void load()
+  {
+    // Try the SONAME first, then the unversioned name as a fallback
+    handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY | RTLD_LOCAL);
+    if (!handle)
+    {
+      handle = dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_LOCAL);
+    }
+    if (!handle)
+    {
+      return;
+    }
+
+    p_nvmlInit_v2  = reinterpret_cast<nvmlReturn_t (*)()>(dlsym(handle, "nvmlInit_v2"));
+    p_nvmlShutdown = reinterpret_cast<nvmlReturn_t (*)()>(dlsym(handle, "nvmlShutdown"));
+    p_nvmlDeviceGetCount_v2 =
+      reinterpret_cast<nvmlReturn_t (*)(unsigned int*)>(dlsym(handle, "nvmlDeviceGetCount_v2"));
+    p_nvmlDeviceGetHandleByIndex_v2 =
+      reinterpret_cast<nvmlReturn_t (*)(unsigned int, nvmlDevice_t*)>(
+        dlsym(handle, "nvmlDeviceGetHandleByIndex_v2"));
+    p_nvmlDeviceGetName = reinterpret_cast<nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int)>(
+      dlsym(handle, "nvmlDeviceGetName"));
+    p_nvmlDeviceGetPciInfo_v3 = reinterpret_cast<nvmlReturn_t (*)(nvmlDevice_t, nvmlPciInfo_t*)>(
+      dlsym(handle, "nvmlDeviceGetPciInfo_v3"));
+    p_nvmlDeviceGetUUID = reinterpret_cast<nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int)>(
+      dlsym(handle, "nvmlDeviceGetUUID"));
+    p_nvmlErrorString =
+      reinterpret_cast<const char* (*)(nvmlReturn_t)>(dlsym(handle, "nvmlErrorString"));
+    // If any required symbol is missing, treat NVML as unavailable
+    if (!p_nvmlInit_v2 || !p_nvmlShutdown || !p_nvmlDeviceGetCount_v2 ||
+        !p_nvmlDeviceGetHandleByIndex_v2 || !p_nvmlDeviceGetName || !p_nvmlDeviceGetPciInfo_v3 ||
+        !p_nvmlDeviceGetUUID || !p_nvmlErrorString)
+    {
+      dlclose(handle);
+      handle                          = nullptr;
+      p_nvmlInit_v2                   = nullptr;
+      p_nvmlShutdown                  = nullptr;
+      p_nvmlDeviceGetCount_v2         = nullptr;
+      p_nvmlDeviceGetHandleByIndex_v2 = nullptr;
+      p_nvmlDeviceGetName             = nullptr;
+      p_nvmlDeviceGetPciInfo_v3       = nullptr;
+      p_nvmlDeviceGetUUID             = nullptr;
+      p_nvmlErrorString               = nullptr;
+    }
+  }
+
+  [[nodiscard]] bool available() const
+  {
+    return handle && p_nvmlInit_v2 && p_nvmlShutdown && p_nvmlDeviceGetCount_v2 &&
+           p_nvmlDeviceGetHandleByIndex_v2 && p_nvmlDeviceGetName && p_nvmlDeviceGetPciInfo_v3 &&
+           p_nvmlDeviceGetUUID && p_nvmlErrorString;
+  }
+};
+
+NvmlLoader& get_nvml_loader()
+{
+  static NvmlLoader loader;
+  return loader;
+}
+
+/**
+ * @brief Network device with topology information.
+ */
+struct NetworkDeviceWithTopology
+{
+  std::string name;
+  int numa_node;
+  std::string pci_bus_id;
+};
+
+/**
+ * @brief Read a file and return its content.
+ *
+ * Attempts to open and read the file at @p path. If the file cannot be opened or
+ * read, returns an empty string. On success, returns the full contents with a
+ * single trailing '\n' removed if present.
+ *
+ * @param path File to read.
+ * @return File content on success; empty string on failure.
+ */
+std::string read_file_content(std::string const& path)
+{
+  std::ifstream file(path);
+  if (!file.is_open())
+  {
+    return "";
+  }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  std::string content = buffer.str();
+  // Trim trailing newline
+  if (!content.empty() && content.back() == '\n')
+  {
+    content.pop_back();
+  }
+  return content;
+}
+
+/**
+ * @brief Parse a CPU list string into a vector of core ids.
+ *
+ * Accepts formats like "0-31,128-159" or comma-separated single cores. If @p cpulist
+ * is empty, returns an empty vector.
+ *
+ * @param cpulist CPU list string (e.g., "0-31,128-159").
+ * @return Vector of CPU core ids; empty if @p cpulist is empty.
+ * @throw std::invalid_argument or std::out_of_range if tokens are malformed and cannot be
+ * parsed with std::stoi.
+ */
+std::vector<int> parse_cpu_list(std::string const& cpulist)
+{
+  std::vector<int> cores;
+  if (cpulist.empty())
+  {
+    return cores;
+  }
+
+  std::istringstream iss(cpulist);
+  std::string token;
+  while (std::getline(iss, token, ','))
+  {
+    size_t dash_pos = token.find('-');
+    if (dash_pos != std::string::npos)
+    {
+      // Range, e.g., "0-31"
+      int start = std::stoi(token.substr(0, dash_pos));
+      int end   = std::stoi(token.substr(dash_pos + 1));
+      for (int i = start; i <= end; ++i)
+      {
+        cores.push_back(i);
+      }
+    }
+    else
+    {
+      // Single core, e.g., "5"
+      cores.push_back(std::stoi(token));
+    }
+  }
+  return cores;
+}
+
+/**
+ * @brief Normalize PCI bus ID to standard format.
+ *
+ * Converts the domain to 4 hex digits and lowercases the entire string. If the input
+ * does not contain a colon (unexpected format), the input is returned unchanged.
+ *
+ * @param pci_bus_id PCI bus ID to normalize.
+ * @return Normalized PCI bus ID in format (0000:06:00.0); unchanged on unrecognized
+ * input.
+ */
+std::string normalize_pci_bus_id(std::string const& pci_bus_id)
+{
+  // NVML may return format like "00000000:0A:00.0" but /sys uses "0000:0a:00.0"
+  // Find the first colon and take the last 4 hex digits before it as domain
+  size_t colon_pos = pci_bus_id.find(':');
+  if (colon_pos == std::string::npos)
+  {
+    return pci_bus_id;
+  }
+  std::string domain = pci_bus_id.substr(0, colon_pos);
+  if (domain.length() > 4)
+  {
+    domain = domain.substr(domain.length() - 4);
+  }
+
+  // Convert to lowercase
+  std::string normalized_id = domain + pci_bus_id.substr(colon_pos);
+  std::ranges::transform(normalized_id, normalized_id.begin(), ::tolower);
+
+  return normalized_id;
+}
+
+/**
+ * @brief Get NUMA node from /sys for a PCI device.
+ *
+ * Reads /sys/bus/pci/devices/<pci>/numa_node. If the file is missing, empty, or
+ * cannot be parsed as an integer, returns -1.
+ *
+ * @param pci_bus_id PCI bus ID of the device.
+ * @return NUMA node number on success; -1 if unavailable.
+ */
+int get_numa_node_from_sys(std::string const& pci_bus_id)
+{
+  std::string normalized_id = normalize_pci_bus_id(pci_bus_id);
+  std::string path          = "/sys/bus/pci/devices/" + normalized_id + "/numa_node";
+  std::string content       = read_file_content(path);
+  if (content.empty())
+  {
+    return -1;
+  }
+  try
+  {
+    return std::stoi(content);
+  }
+  catch (...)
+  {
+    return -1;
+  }
+}
+
+/**
+ * @brief Get CPU affinity list from /sys for a PCI device.
+ *
+ * Reads /sys/bus/pci/devices/<pci>/local_cpulist and returns the file content as-is
+ * (with any trailing newline trimmed). If the file is missing or unreadable, returns
+ * an empty string.
+ *
+ * @param pci_bus_id PCI bus ID of the device.
+ * @return CPU affinity list string; empty on failure.
+ */
+std::string get_cpu_affinity_from_sys(std::string const& pci_bus_id)
+{
+  std::string normalized_id = normalize_pci_bus_id(pci_bus_id);
+  std::string path          = "/sys/bus/pci/devices/" + normalized_id + "/local_cpulist";
+  return read_file_content(path);
+}
+
+/**
+ * @brief Get PCI bus ID from a device directory in /sys.
+ *
+ * Resolves <device_path>/device symlink and returns its basename (e.g., "0000:06:00.0").
+ * Returns an empty string if the symlink does not exist or cannot be resolved.
+ *
+ * @param device_path Path to the device in /sys.
+ * @return PCI bus ID of the device; empty string if not available.
+ */
+std::string get_pci_bus_id_from_device(std::string const& device_path)
+{
+  fs::path device_link = fs::path(device_path) / "device";
+  if (!fs::exists(device_link))
+  {
+    return "";
+  }
+
+  try
+  {
+    fs::path real_path = fs::canonical(device_link);
+    return real_path.filename().string();
+  }
+  catch (...)
+  {
+    return "";
+  }
+}
+
+/**
+ * @brief Parse PCI bus number from a PCI ID string.
+ *
+ * Expects format domain:bus:device.function (e.g., "0000:06:00.0"). If parsing fails
+ * or the expected separators are missing, returns -1.
+ *
+ * @param pci_id PCI ID string.
+ * @return PCI bus number (integer) on success; -1 on failure.
+ */
+int get_pci_bus_number(std::string const& pci_id)
+{
+  size_t first_colon = pci_id.find(':');
+  if (first_colon == std::string::npos)
+  {
+    return -1;
+  }
+
+  size_t second_colon = pci_id.find(':', first_colon + 1);
+  if (second_colon == std::string::npos)
+  {
+    return -1;
+  }
+
+  std::string bus_str = pci_id.substr(first_colon + 1, second_colon - first_colon - 1);
+  try
+  {
+    return std::stoi(bus_str, nullptr, 16);
+  }
+  catch (...)
+  {
+    return -1;
+  }
+}
+
+/**
+ * @brief Get PCIe path type between two devices by analyzing /sys topology.
+ *
+ * Uses NUMA node comparison and PCI bus number proximity as a heuristic. If either
+ * device's bus cannot be parsed, falls back to PHB. If NUMA nodes differ (and are
+ * known), returns SYS.
+ *
+ * @param gpu_pci_id PCI bus ID of the GPU device.
+ * @param nic_pci_id PCI bus ID of the NIC device.
+ * @return Path type (PIX, PXB, PHB, NODE, or SYS); PHB when indeterminate.
+ */
+PciePathType get_pcie_path_type(std::string const& gpu_pci_id, std::string const& nic_pci_id)
+{
+  std::string gpu_norm = normalize_pci_bus_id(gpu_pci_id);
+  std::string nic_norm = normalize_pci_bus_id(nic_pci_id);
+
+  // Read NUMA nodes
+  int gpu_numa = -1, nic_numa = -1;
+  std::string gpu_numa_str = read_file_content("/sys/bus/pci/devices/" + gpu_norm + "/numa_node");
+  std::string nic_numa_str = read_file_content("/sys/bus/pci/devices/" + nic_norm + "/numa_node");
+
+  if (!gpu_numa_str.empty())
+  {
+    gpu_numa = std::stoi(gpu_numa_str);
+  }
+  if (!nic_numa_str.empty())
+  {
+    nic_numa = std::stoi(nic_numa_str);
+  }
+
+  // If different NUMA nodes, it's a SYS connection
+  if (gpu_numa != nic_numa && gpu_numa >= 0 && nic_numa >= 0)
+  {
+    return PciePathType::SYS;
+  }
+
+  // Use PCI bus number proximity as a heuristic for connection quality
+  // Devices on nearby PCI buses are typically on the same PCIe root complex
+  int gpu_bus = get_pci_bus_number(gpu_pci_id);
+  int nic_bus = get_pci_bus_number(nic_pci_id);
+
+  if (gpu_bus < 0 || nic_bus < 0)
+  {
+    // Can't determine, assume PHB
+    return PciePathType::PHB;
+  }
+
+  int bus_distance = std::abs(gpu_bus - nic_bus);
+
+  // Heuristic based on PCI bus proximity:
+  // - Very close buses (distance <= 2): likely PIX (single bridge)
+  // - Moderate distance (3-10): likely PHB (host bridge)
+  // - Large distance (>10): likely NODE or worse
+
+  if (bus_distance <= 2)
+  {
+    return PciePathType::PIX;
+  }
+  else if (bus_distance <= 10)
+  {
+    return PciePathType::PHB;
+  }
+  else
+  {
+    return PciePathType::NODE;
+  }
+}
+
+/**
+ * @brief Discover network devices (InfiniBand/RoCE).
+ *
+ * Scans /sys/class/infiniband and collects device name, NUMA node, and PCI bus ID.
+ * If the directory does not exist or an error occurs during iteration, returns an
+ * empty vector (a warning is logged for iteration errors).
+ *
+ * @return Vector of discovered network devices; empty if none or on failure.
+ */
+std::vector<NetworkDeviceWithTopology> discover_network_devices_with_topology()
+{
+  std::vector<NetworkDeviceWithTopology> devices;
+  std::string ib_path = "/sys/class/infiniband";
+
+  if (!fs::exists(ib_path))
+  {
+    return devices;
+  }
+
+  try
+  {
+    for (auto const& entry : fs::directory_iterator(ib_path))
+    {
+      if (!entry.is_directory())
+      {
+        continue;
+      }
+
+      NetworkDeviceWithTopology dev;
+      dev.name = entry.path().filename().string();
+
+      // Get device's NUMA node and PCI bus ID
+      std::string numa_path = entry.path().string() + "/device/numa_node";
+      std::string numa_str  = read_file_content(numa_path);
+      dev.numa_node         = numa_str.empty() ? -1 : std::stoi(numa_str);
+      dev.pci_bus_id        = get_pci_bus_id_from_device(entry.path().string());
+
+      devices.push_back(dev);
+    }
+  }
+  catch (std::exception const& e)
+  {
+    std::cerr << "Warning: Error discovering network devices: " << e.what() << std::endl;
+  }
+
+  return devices;
+}
+
+/**
+ * @brief Map network devices to a GPU based on PCIe topology and NUMA proximity.
+ *
+ * Prefers NICs with the best (lowest) PCIe path type to the GPU. If no PCI topology
+ * information is available, falls back to matching by NUMA node. If still ambiguous,
+ * returns all devices. May return an empty vector when @p network_devices is empty
+ * or none have PCI info.
+ *
+ * @param gpu_numa_node NUMA node to query.
+ * @param network_devices Network devices on the system.
+ * @return Vector of device names selected for the GPU; possibly empty.
+ */
+std::vector<std::string>
+map_network_devices_to_gpu(std::string const& gpu_pci_id,
+                           int gpu_numa_node,
+                           std::vector<NetworkDeviceInfo> const& network_devices)
+{
+  std::vector<std::string> mapped_devices;
+
+  // Structure to hold NIC with its topology path type
+  struct NicWithPath
+  {
+    std::string name;
+    PciePathType path_type;
+  };
+
+  std::vector<NicWithPath> nics_with_paths;
+
+  // Query topology distance for each NIC
+  for (auto const& dev : network_devices)
+  {
+    if (dev.pci_bus_id.empty())
+    {
+      continue; // Skip devices without PCI info
+    }
+
+    NicWithPath nic;
+    nic.name      = dev.name;
+    nic.path_type = get_pcie_path_type(gpu_pci_id, dev.pci_bus_id);
+
+    nics_with_paths.push_back(nic);
+  }
+
+  // Find the best (lowest) path type
+  if (nics_with_paths.empty())
+  {
+    return mapped_devices;
+  }
+
+  PciePathType best_path_type = PciePathType::SYS;
+  for (auto const& nic : nics_with_paths)
+  {
+    if (nic.path_type < best_path_type)
+    {
+      best_path_type = nic.path_type;
+    }
+  }
+
+  // Return all NICs with the best path type
+  for (auto const& nic : nics_with_paths)
+  {
+    if (nic.path_type == best_path_type)
+    {
+      mapped_devices.push_back(nic.name);
+    }
+  }
+
+  // If no devices found, fall back to NUMA-based mapping
+  if (mapped_devices.empty())
+  {
+    for (auto const& dev : network_devices)
+    {
+      if (dev.numa_node == gpu_numa_node)
+      {
+        mapped_devices.push_back(dev.name);
+      }
+    }
+  }
+
+  // Last resort: return all devices
+  if (mapped_devices.empty() && !network_devices.empty())
+  {
+    for (auto const& dev : network_devices)
+    {
+      mapped_devices.push_back(dev.name);
+    }
+  }
+
+  return mapped_devices;
+}
+
+/**
+ * @brief Get system hostname.
+ *
+ * Returns the system hostname on success; returns an empty string if the
+ * hostname cannot be determined.
+ *
+ * @return Hostname string, or an empty string if unavailable.
+ */
+std::string get_hostname()
+{
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) == 0)
+  {
+    return std::string(hostname.data());
+  }
+  return "";
+}
+
+/**
+ * @brief Count NUMA nodes on the system.
+ *
+ * Counts subdirectories named "node*" under /sys/devices/system/node. Returns 0 if
+ * the directory does not exist or cannot be iterated.
+ *
+ * @return Number of NUMA nodes; 0 if unavailable.
+ */
+int count_numa_nodes()
+{
+  std::string numa_path = "/sys/devices/system/node";
+  int count             = 0;
+
+  if (!fs::exists(numa_path))
+  {
+    return 0;
+  }
+
+  try
+  {
+    for (auto const& entry : fs::directory_iterator(numa_path))
+    {
+      std::string name = entry.path().filename().string();
+      if (name.starts_with("node"))
+      { // starts with "node"
+        count++;
+      }
+    }
+  }
+  catch (...)
+  {
+    return 0;
+  }
+
+  return count;
+}
+
+} // namespace
+
+bool TopologyDiscovery::discover()
+{
+  SystemTopologyInfo topology;
+  NvmlLoader& nvml    = get_nvml_loader();
+  nvmlReturn_t result = NVML_SUCCESS;
+  if (!nvml.available())
+  {
+    std::cerr << "NVML not available: failed to load libnvidia-ml.so.1" << std::endl;
+    // Continue anyway to report system info even without GPUs
+  }
+  else
+  {
+    result = nvml.p_nvmlInit_v2();
+    if (result != NVML_SUCCESS)
+    {
+      std::cerr << "Failed to initialize NVML: " << nvml.p_nvmlErrorString(result) << std::endl;
+      // Continue anyway to report system info even without GPUs
+    }
+  }
+
+  // Get GPU count
+  unsigned int device_count = 0;
+  bool nvml_available       = false;
+  if (nvml.available() && result == NVML_SUCCESS)
+  {
+    result = nvml.p_nvmlDeviceGetCount_v2(&device_count);
+    if (result != NVML_SUCCESS)
+    {
+      std::cerr << "Warning: Failed to get device count: " << nvml.p_nvmlErrorString(result)
+                << std::endl;
+      device_count = 0;
+    }
+    else
+    {
+      nvml_available = true;
+    }
+  }
+
+  // Discover network devices
+  std::vector<NetworkDeviceWithTopology> network_devices_with_topology =
+    discover_network_devices_with_topology();
+
+  // Get system information
+  topology.hostname            = get_hostname();
+  topology.num_numa_nodes      = count_numa_nodes();
+  topology.num_gpus            = device_count;
+  topology.num_network_devices = static_cast<int>(network_devices_with_topology.size());
+
+  // Convert network devices to public format
+  topology.network_devices.clear();
+  for (auto const& dev : network_devices_with_topology)
+  {
+    NetworkDeviceInfo info;
+    info.name       = dev.name;
+    info.numa_node  = dev.numa_node;
+    info.pci_bus_id = dev.pci_bus_id;
+    topology.network_devices.push_back(info);
+  }
+
+  // Collect GPU information
+  topology.gpus.clear();
+
+  for (unsigned int i = 0; i < device_count; ++i)
+  {
+    nvmlDevice_t device;
+    result = nvml.p_nvmlDeviceGetHandleByIndex_v2(i, &device);
+    if (result != NVML_SUCCESS)
+    {
+      std::cerr << "Warning: Failed to get handle for GPU " << i << ": "
+                << nvml.p_nvmlErrorString(result) << std::endl;
+      continue;
+    }
+
+    GpuTopologyInfo gpu;
+    gpu.id = i;
+
+    // Get device name, PCI bus ID and UUID
+    std::array<char, NVML_DEVICE_NAME_BUFFER_SIZE> name{};
+    result = nvml.p_nvmlDeviceGetName(device, name.data(), NVML_DEVICE_NAME_BUFFER_SIZE);
+    if (result == NVML_SUCCESS)
+    {
+      gpu.name = std::string(name.data());
+    }
+    else
+    {
+      gpu.name = "Unknown";
+    }
+
+    nvmlPciInfo_t pci_info;
+    result = nvml.p_nvmlDeviceGetPciInfo_v3(device, &pci_info);
+    if (result == NVML_SUCCESS)
+    {
+      gpu.pci_bus_id = std::string(pci_info.busId);
+    }
+    else
+    {
+      std::cerr << "Warning: Failed to get PCI info for GPU " << i << std::endl;
+      continue;
+    }
+
+    std::array<char, NVML_DEVICE_UUID_BUFFER_SIZE> uuid{};
+    result = nvml.p_nvmlDeviceGetUUID(device, uuid.data(), NVML_DEVICE_UUID_BUFFER_SIZE);
+    if (result == NVML_SUCCESS)
+    {
+      gpu.uuid = std::string(uuid.data());
+    }
+    else
+    {
+      gpu.uuid = "Unknown";
+    }
+
+    // Get NUMA node and CPU affinity from /sys
+    gpu.numa_node         = get_numa_node_from_sys(gpu.pci_bus_id);
+    gpu.cpu_affinity_list = get_cpu_affinity_from_sys(gpu.pci_bus_id);
+    gpu.cpu_cores         = parse_cpu_list(gpu.cpu_affinity_list);
+
+    // Memory binding is typically the same as NUMA node
+    if (gpu.numa_node >= 0)
+    {
+      gpu.memory_binding.push_back(gpu.numa_node);
+    }
+
+    // Map network devices to this GPU using PCIe topology
+    gpu.network_devices =
+      map_network_devices_to_gpu(gpu.pci_bus_id, gpu.numa_node, topology.network_devices);
+
+    topology.gpus.push_back(gpu);
+  }
+
+  if (nvml_available)
+  {
+    nvml.p_nvmlShutdown();
+  }
+
+  topology_ = std::move(topology);
+  return true;
+}
+
+} // namespace sirius::memory

--- a/test/cpp/memory_management/CMakeLists.txt
+++ b/test/cpp/memory_management/CMakeLists.txt
@@ -17,5 +17,6 @@ set(TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_cache.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_memory_reservation_manager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_memory_space.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_topology_discovery.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_kernels.cu
   PARENT_SCOPE)

--- a/test/cpp/memory_management/test_topology_discovery.cpp
+++ b/test/cpp/memory_management/test_topology_discovery.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test Tags:
+ * [memory_space] - Basic memory space functionality tests
+ * [threading] - Multi-threaded tests
+ * [gpu] - GPU-specific tests requiring CUDA
+ * [.multi-device] - Tests requiring multiple GPU devices (hidden by default)
+ *
+ * Running tests:
+ * - Default (includes single GPU): ./test_executable
+ * - Include multi-device tests: ./test_executable "[.multi-device]"
+ * - Exclude multi-device tests: ./test_executable "~[.multi-device]"
+ * - Run all tests: ./test_executable "[memory_space]"
+ */
+
+#include "catch.hpp"
+#include "memory/topology_discovery.hpp"
+
+#include <cstdlib>
+#include <vector>
+
+using namespace sirius::memory;
+
+// Test topology discovery
+TEST_CASE("Topology Discovery", "[memory_space]")
+{
+  TopologyDiscovery discovery;
+
+  // Call discover() method
+  bool success = discovery.discover();
+
+  // Verify discovery was successful
+  REQUIRE(success == true);
+  REQUIRE(discovery.is_discovered() == true);
+
+  // Get the topology information
+  const auto& topology = discovery.get_topology();
+
+  // Verify basic topology information
+  REQUIRE(!topology.hostname.empty());
+  REQUIRE(topology.num_gpus >= 0);
+  REQUIRE(topology.num_numa_nodes >= 0);
+  REQUIRE(topology.num_network_devices >= 0);
+
+  // Verify GPU information consistency
+  REQUIRE(topology.gpus.size() == topology.num_gpus);
+
+  // If GPUs are present, verify their information
+  if (topology.num_gpus > 0)
+  {
+    for (const auto& gpu : topology.gpus)
+    {
+      REQUIRE(!gpu.name.empty());
+      REQUIRE(!gpu.pci_bus_id.empty());
+      REQUIRE(!gpu.uuid.empty());
+      // NUMA node may be -1 if unknown
+      REQUIRE(gpu.numa_node >= -1);
+    }
+  }
+
+  // Verify network device information consistency
+  REQUIRE(topology.network_devices.size() == static_cast<size_t>(topology.num_network_devices));
+
+  // If network devices are present, verify their information
+  for (const auto& net_dev : topology.network_devices)
+  {
+    REQUIRE(!net_dev.name.empty());
+    // NUMA node may be -1 if unknown
+    REQUIRE(net_dev.numa_node >= -1);
+  }
+}


### PR DESCRIPTION
This PR adds topology-aware memory manager initialization based on the [rapidsmpf-topology discovery](https://github.com/rapidsai/rapidsmpf/blob/main/cpp/include/rapidsmpf/topology_discovery.hpp) 

- Topology discovery source files have been copied to sirius-db (at least for the moment) 
- There are several questions, 
    - how to handle `CUDA_VISIBLE_DEVICES` env var?
    - Memory spaces currently only hold rmm device allocators. This would be problematic for host allocators. So, this PR only adds GPU memory spaces 
    - what is the GPU allocation policy? Single process managing many devices? One-device-per-process?

PR is targeted to https://github.com/sirius-db/sirius/pull/97 branch

The PR might be touching many lines due to a clang-format run on the files. Maybe this needs to happen prior to this PR. 