### PR TITLE
DuckDB Data Representation

### DIFF
--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -15,7 +15,9 @@
 set(EXTENSION_SOURCES
         ${EXTENSION_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/cpu_data_representation.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/duckdb_data_representation.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/gpu_data_representation.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/data_representation_converter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/data_batch.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/data_batch_view.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/data_repository.cpp

--- a/src/data/data_representation_converter.cpp
+++ b/src/data/data_representation_converter.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "data/data_representation_converter.hpp"
+#include "memory/result_table.hpp"
+#include "memory/fixed_size_host_memory_resource.hpp"
+
+#include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/types.hpp"
+
+#include <cuda_runtime.h>
+#include <cudf/column/column_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/bit.hpp>
+
+#include <cmath>
+#include <unordered_map>
+
+namespace sirius {
+
+using sirius::memory::fixed_size_host_memory_resource;
+
+constexpr size_t BYTE_TO_BITS = 8;
+
+// Helper map to map CUDF types to DuckDB types. TODO(Devesh): Make sure that all of the mapping make sense because not all of them are 1:1 mappings
+const std::unordered_map<cudf::type_id, duckdb::LogicalTypeId> CUDF_TO_DUCKDB_TYPES_MAP = {
+    // Signed Integers
+    {cudf::type_id::INT8,    duckdb::LogicalTypeId::TINYINT},
+    {cudf::type_id::INT16,   duckdb::LogicalTypeId::SMALLINT},
+    {cudf::type_id::INT32,   duckdb::LogicalTypeId::INTEGER},
+    {cudf::type_id::INT64,   duckdb::LogicalTypeId::BIGINT},
+
+    // Unsigned Integers
+    {cudf::type_id::UINT8,   duckdb::LogicalTypeId::UTINYINT},
+    {cudf::type_id::UINT16,  duckdb::LogicalTypeId::USMALLINT},
+    {cudf::type_id::UINT32,  duckdb::LogicalTypeId::UINTEGER},
+    {cudf::type_id::UINT64,  duckdb::LogicalTypeId::UBIGINT},
+
+    // Floating Point
+    {cudf::type_id::FLOAT32, duckdb::LogicalTypeId::FLOAT},
+    {cudf::type_id::FLOAT64, duckdb::LogicalTypeId::DOUBLE},
+
+    // Boolean & String
+    {cudf::type_id::BOOL8,   duckdb::LogicalTypeId::BOOLEAN},
+    {cudf::type_id::STRING,  duckdb::LogicalTypeId::VARCHAR},
+
+    // Timestamps
+    // cudf::TIMESTAMP_DAYS -> DuckDB DATE (days since epoch)
+    {cudf::type_id::TIMESTAMP_DAYS,         duckdb::LogicalTypeId::DATE},
+    {cudf::type_id::TIMESTAMP_SECONDS,      duckdb::LogicalTypeId::TIMESTAMP_SEC},
+    {cudf::type_id::TIMESTAMP_MILLISECONDS, duckdb::LogicalTypeId::TIMESTAMP_MS},
+    {cudf::type_id::TIMESTAMP_MICROSECONDS, duckdb::LogicalTypeId::TIMESTAMP}, // Default TIMESTAMP is us
+    {cudf::type_id::TIMESTAMP_NANOSECONDS,  duckdb::LogicalTypeId::TIMESTAMP_NS},
+};
+
+inline duckdb::LogicalTypeId cudf_type_to_duckdb_type(cudf::type_id id) {
+    auto it = CUDF_TO_DUCKDB_TYPES_MAP.find(id);
+    if (it != CUDF_TO_DUCKDB_TYPES_MAP.end()) {
+        return it->second;
+    }
+
+    return duckdb::LogicalTypeId::INVALID;
+}
+
+// Helper function used to determine the number of bytes needed to store a particular column
+size_t determine_column_bytes_needed(cudf::column_view& column_view, rmm::cuda_stream_view& stream) { 
+    size_t num_rows = column_view.size();
+
+    // First determine the bytes needed to hold the null mask
+    size_t null_mask_bytes = cudf::bitmask_allocation_size_bytes(num_rows); // By default aligns to 64 byte boundary
+
+    // Now determine the bytes needed to hold the actual data
+    size_t data_bytes = 0;
+    cudf::data_type col_type = column_view.type();
+    if(col_type.id() == cudf::type_id::STRING) { 
+        // For string get the number bytes for the offset and chars column
+        cudf::strings_column_view strings_view(column_view);
+        size_t offset_bytes = num_rows * cudf::size_of(strings_view.offsets().type());
+        size_t chars_bytes = strings_view.chars_size(stream);
+        size_t duckdb_string_bytes = num_rows * sizeof(duckdb::string_t);
+        data_bytes = offset_bytes + chars_bytes;
+    } else {
+        int32_t width = cudf::size_of(col_type);
+        data_bytes = width * num_rows;
+    }
+
+    return null_mask_bytes + data_bytes;
+}
+
+// Ensures that the location is aligned to the specificed size within the block
+inline void align_location(sirius::memory::result_table_location& location, size_t target_alignment, fixed_size_host_memory_resource::multiple_blocks_allocation& allocated_blocks) { 
+    if(location.block_offset % target_alignment != 0) { 
+        location.block_offset += target_alignment - (location.block_offset % target_alignment);
+        
+        // Deal with this shift overflowing into the next block
+        if(location.block_offset >= allocated_blocks.block_size) { 
+            location.allocation_index += 1;
+            location.block_offset = 0;
+            allocated_blocks.ensure_capacity(location.allocation_index + 1);
+        }
+    }
+} 
+
+// Helper function to copy data from GPU to CPU in a way that ensures that records are aligned to their size and no record
+// is spread across pages
+inline void copy_buffer_to_cpu(
+    const char* gpu_data_buffer, size_t num_records, size_t record_size, 
+    fixed_size_host_memory_resource::multiple_blocks_allocation& allocated_blocks,
+    sirius::memory::result_table_location& write_location,
+    rmm::cuda_stream_view& stream) { 
+    
+    size_t records_left = num_records;
+    while(records_left > 0) {
+        size_t curr_write_offset = write_location.block_offset;
+        char* block_copy_ptr = (char*) allocated_blocks[write_location.allocation_index] + curr_write_offset;
+
+        // Determine the number of records we can copy into this block while maintaing alignment
+        size_t max_possible_copyable_record = (allocated_blocks.block_size - curr_write_offset)/record_size;
+        size_t records_to_copy = std::min(records_left, max_possible_copyable_record); 
+        size_t bytes_to_copy = records_to_copy * record_size;
+
+        // Perform the copy
+        cudaMemcpyAsync(block_copy_ptr, gpu_data_buffer, bytes_to_copy, cudaMemcpyDeviceToHost, stream.value());
+        gpu_data_buffer += bytes_to_copy;
+        write_location.block_offset = curr_write_offset + records_to_copy * record_size;
+        records_left -= records_to_copy;
+
+        // If we still have records to copy then move to the next block
+        if(records_left > 0) { 
+            write_location.allocation_index += 1;
+            write_location.block_offset = 0;
+            allocated_blocks.ensure_capacity(write_location.allocation_index + 1);
+        }
+    }
+}
+
+sirius::unique_ptr<sirius::duckdb_table_representation> data_representation_converter::convert_gpu_table_to_result_format(
+    cudf::table_view src_table, 
+    sirius::memory::memory_space& host_memory_space,
+    rmm::cuda_stream_view stream
+) {
+    // Get the allocator from the host memory space
+    auto host_memory_resource = host_memory_space.get_default_allocator_as<sirius::memory::fixed_size_host_memory_resource>();
+    if(host_memory_resource == nullptr) { 
+        throw std::runtime_error("Can't cast allocator of host memory resource to fixed sized allocator");
+    }
+
+    // Request an initial allocation from the allocator based on the column sizes 
+    std::vector<cudf::column_view> table_columns(src_table.begin(), src_table.end());
+    size_t num_columns = table_columns.size();
+    size_t min_bytes_needed = 0;
+    for (int i = 0; i < num_columns; i++) {
+        min_bytes_needed += determine_column_bytes_needed(table_columns[i], stream);
+    }
+    fixed_size_host_memory_resource::multiple_blocks_allocation allocated_blocks = host_memory_resource->allocate_multiple_blocks(min_bytes_needed);
+
+    // Now start copying the table data to CPU a column at a time using the stream
+    duckdb::vector<duckdb::LogicalType> duckdb_col_types;
+
+    size_t num_rows = table_columns[0].size();
+    std::vector<sirius::memory::result_table_column> result_columns;
+    sirius::memory::result_table_location allocation_write_location; 
+    for (int i = 0; i < num_columns; i++) {
+        // Initialize the result column
+        cudf::column_view& cudf_column = table_columns[i];
+        sirius::memory::result_table_column result_column;
+        cudf::data_type col_type = cudf_column.type();
+        result_column.column_type = col_type.id();
+
+        // Copy over its null bitmask
+        rmm::device_buffer mask_buffer;
+        if (cudf_column.null_mask() != nullptr) {
+            mask_buffer = cudf::copy_bitmask(cudf_column); // We perform a copy here because the bitmask may not be aligned by default
+        } else { 
+            mask_buffer = cudf::create_null_mask(cudf_column.size(), cudf::mask_state::ALL_VALID);
+        }
+
+        size_t mask_size = mask_buffer.size();
+        result_column.valid_mask_loc = allocation_write_location;
+        copy_buffer_to_cpu(static_cast<const char*>(mask_buffer.data()), mask_size, 1, allocated_blocks, allocation_write_location, stream);
+        result_column.valid_mask_bytes = mask_size;
+
+        // Copy over the actual column contents
+        result_column.num_rows = num_rows;
+        duckdb::LogicalTypeId duckdb_col_type = cudf_type_to_duckdb_type(result_column.column_type);
+        duckdb_col_types.push_back(duckdb::LogicalType(duckdb_col_type));
+        if(col_type.id() == cudf::type_id::STRING) { 
+            // First copy the offsets
+            cudf::strings_column_view strings_col(cudf_column);
+            cudf::column_view strings_col_offsets = strings_col.offsets();
+            size_t offsets_width = cudf::size_of(strings_col_offsets.type()); 
+            const char* offsets_ptr = reinterpret_cast<const char*>(strings_col_offsets.head()) + offsets_width * strings_col_offsets.offset();
+            
+            align_location(allocation_write_location, offsets_width, allocated_blocks);
+            result_column.data_loc = allocation_write_location;
+            copy_buffer_to_cpu(offsets_ptr, num_rows, offsets_width, allocated_blocks, allocation_write_location, stream);
+
+            // Then copy the chars
+            size_t chars_bytes = strings_col.chars_size(stream);
+            const char* actual_chars_ptr = reinterpret_cast<const char*>(strings_col.chars_begin(stream));
+            copy_buffer_to_cpu(actual_chars_ptr, chars_bytes, 1, allocated_blocks, allocation_write_location, stream);
+            
+            result_column.column_data_bytes = chars_bytes + offsets_width * num_rows;
+
+            // TODO(Devesh): Handle creating of the German style strings needed by DuckDB
+        } else { 
+            size_t record_width = cudf::size_of(col_type); 
+            const char* records_ptr = reinterpret_cast<const char*>(cudf_column.head()) + record_width * cudf_column.offset();
+
+            align_location(allocation_write_location, record_width, allocated_blocks);
+            result_column.data_loc = allocation_write_location;
+            copy_buffer_to_cpu(records_ptr, num_rows, record_width, allocated_blocks, allocation_write_location, stream);
+
+            result_column.column_data_bytes = record_width * num_rows;
+        }
+        result_columns.push_back(result_column);
+    }
+
+    stream.synchronize();
+
+    // Now also create Data Chunks in a format that we can pass to DuckDB - For now this assumes that we only have integer columns
+    std::vector<sirius::memory::result_table_location> column_valid_mask_location;
+    std::vector<sirius::memory::result_table_location> column_data_location;
+    for(int i = 0; i < num_columns; i++) { 
+        column_valid_mask_location.push_back(result_columns[i].valid_mask_loc);
+        column_data_location.push_back(result_columns[i].data_loc);
+    }
+    
+    size_t block_size = allocated_blocks.block_size;
+    size_t records_left = num_rows;
+    std::vector<sirius::unique_ptr<duckdb::DataChunk>> result_chunks;
+    while(records_left > 0) { 
+        // Determine the number of records we can include without crossing a block boundary
+        size_t records_in_chunk = std::min(records_left, static_cast<size_t>(STANDARD_VECTOR_SIZE));
+
+        for(int i = 0; i < num_columns; i++) { 
+            cudf::type_id col_type = result_columns[i].column_type;
+            // Determine maximum records from null mask
+            size_t max_mask_records = (block_size - column_valid_mask_location[i].block_offset) * BYTE_TO_BITS;
+            records_in_chunk = std::min(records_in_chunk, max_mask_records);
+
+            if(col_type == cudf::type_id::STRING) { 
+                // TODO(Devesh): Extend this implementation to account for string columns
+            } else { 
+                // Determine maximum amount of data points
+                size_t record_width = cudf::size_of(cudf::data_type(col_type));
+                size_t curr_record_offset = column_data_location[i].block_offset;
+                size_t max_records_from_col = (block_size - curr_record_offset)/record_width; 
+                max_records_from_col = max_records_from_col - (max_records_from_col % BYTE_TO_BITS); // We want to ensure that the number of records is a multiple of 8 so that we don't have to splice the null mask 
+
+                records_in_chunk = std::min(records_in_chunk, max_records_from_col); 
+            }
+        }
+
+        // Create the Data Chunk
+        sirius::unique_ptr<duckdb::DataChunk> chunk = sirius::make_unique<duckdb::DataChunk>();
+		chunk->InitializeEmpty(duckdb_col_types);
+        for(int i = 0; i < num_columns; i++) { 
+            cudf::type_id col_type = result_columns[i].column_type;
+            if(col_type == cudf::type_id::STRING) { 
+                // TODO(Devesh): Extend this implementation to account for string columns
+            } else { 
+                // Create the vector
+                size_t data_block_to_load = column_data_location[i].allocation_index;
+                uint8_t* col_records_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[data_block_to_load]) + column_data_location[i].block_offset;
+                duckdb::Vector col_vector(duckdb_col_types[i], col_records_ptr);
+                
+                // Set the null mask
+                size_t mask_block_to_load = column_valid_mask_location[i].allocation_index;
+                uint8_t* mask_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[mask_block_to_load]) + column_valid_mask_location[i].block_offset;
+                duckdb::ValidityMask validity_mask(reinterpret_cast<duckdb::validity_t*>(mask_ptr), records_in_chunk);
+                duckdb::FlatVector::SetValidity(col_vector, validity_mask);
+
+                // Add the vector to the chunk
+                chunk->data[i].Reference(col_vector);
+            }
+        }
+        chunk->SetCardinality(records_in_chunk);
+        records_left -= records_in_chunk;
+        result_chunks.push_back(std::move(chunk));
+
+        // Increment the read offsets
+        for(int i = 0; i < num_columns; i++) { 
+            cudf::type_id col_type = result_columns[i].column_type;
+            if(col_type == cudf::type_id::STRING) { 
+
+            } else { 
+                size_t record_width = cudf::size_of(cudf::data_type(col_type));
+
+                // Increment the data record location
+                column_data_location[i].block_offset += record_width * records_in_chunk;
+                if(column_data_location[i].block_offset + record_width >= block_size) { // See if we the remaining records are in the next block
+                    column_data_location[i].allocation_index += 1;
+                    column_data_location[i].block_offset = 0;
+                }
+
+                // Increment the mask ptr
+                size_t mask_increment = std::ceil(records_in_chunk/BYTE_TO_BITS);
+                column_valid_mask_location[i].block_offset += mask_increment;
+                column_valid_mask_location[i].allocation_index += column_valid_mask_location[i].block_offset/block_size;
+                column_valid_mask_location[i].block_offset = column_valid_mask_location[i].block_offset % block_size;
+            }
+        }
+    }
+
+    // Create the result
+    sirius::unique_ptr<sirius::memory::result_table_allocation> result_table_allocation = sirius::make_unique<sirius::memory::result_table_allocation>(
+        std::move(allocated_blocks), std::move(result_columns)
+    );
+    return sirius::make_unique<sirius::duckdb_table_representation>(std::move(result_table_allocation), std::move(result_chunks), host_memory_space);
+}
+
+}

--- a/src/data/data_representation_converter.cpp
+++ b/src/data/data_representation_converter.cpp
@@ -88,12 +88,13 @@ size_t determine_column_bytes_needed(cudf::column_view& column_view, rmm::cuda_s
     size_t data_bytes = 0;
     cudf::data_type col_type = column_view.type();
     if(col_type.id() == cudf::type_id::STRING) { 
-        // For string get the number bytes for the offset and chars column
+        // For string get the number bytes for the offset and chars column. Also account for the space needed for the duckdb
+        // representation
         cudf::strings_column_view strings_view(column_view);
         size_t offset_bytes = num_rows * cudf::size_of(strings_view.offsets().type());
         size_t chars_bytes = strings_view.chars_size(stream);
         size_t duckdb_string_bytes = num_rows * sizeof(duckdb::string_t);
-        data_bytes = offset_bytes + chars_bytes;
+        data_bytes = offset_bytes + chars_bytes + duckdb_string_bytes;
     } else {
         int32_t width = cudf::size_of(col_type);
         data_bytes = width * num_rows;
@@ -108,7 +109,7 @@ inline void align_location(sirius::memory::result_table_location& location, size
         location.block_offset += target_alignment - (location.block_offset % target_alignment);
         
         // Deal with this shift overflowing into the next block
-        if(location.block_offset >= allocated_blocks.block_size) { 
+        if(location.block_offset >= allocated_blocks.block_size || location.block_offset >= allocated_blocks.block_size) { 
             location.allocation_index += 1;
             location.block_offset = 0;
             allocated_blocks.ensure_capacity(location.allocation_index + 1);
@@ -118,7 +119,7 @@ inline void align_location(sirius::memory::result_table_location& location, size
 
 // Helper function to copy data from GPU to CPU in a way that ensures that records are aligned to their size and no record
 // is spread across pages
-inline void copy_buffer_to_cpu(
+void copy_buffer_to_cpu(
     const char* gpu_data_buffer, size_t num_records, size_t record_size, 
     fixed_size_host_memory_resource::multiple_blocks_allocation& allocated_blocks,
     sirius::memory::result_table_location& write_location,
@@ -127,7 +128,7 @@ inline void copy_buffer_to_cpu(
     size_t records_left = num_records;
     while(records_left > 0) {
         size_t curr_write_offset = write_location.block_offset;
-        char* block_copy_ptr = (char*) allocated_blocks[write_location.allocation_index] + curr_write_offset;
+        char* block_copy_ptr = reinterpret_cast<char*>(allocated_blocks[write_location.allocation_index]) + curr_write_offset;
 
         // Determine the number of records we can copy into this block while maintaing alignment
         size_t max_possible_copyable_record = (allocated_blocks.block_size - curr_write_offset)/record_size;
@@ -141,11 +142,103 @@ inline void copy_buffer_to_cpu(
         records_left -= records_to_copy;
 
         // If we still have records to copy then move to the next block
-        if(records_left > 0) { 
+        if(records_left > 0 || write_location.block_offset >= allocated_blocks.block_size) { 
             write_location.allocation_index += 1;
             write_location.block_offset = 0;
             allocated_blocks.ensure_capacity(write_location.allocation_index + 1);
         }
+    }
+}
+
+
+inline void increment_location(sirius::memory::result_table_location& curr_location, fixed_size_host_memory_resource::multiple_blocks_allocation& allocated_blocks, size_t num_strides, size_t stride_length) { 
+    size_t records_left = num_strides;
+    while(records_left > 0) { 
+        // Increement the location within the block
+        size_t max_possible_records = (allocated_blocks.block_size - curr_location.block_offset)/stride_length;
+        size_t num_increment_records = std::min(records_left, max_possible_records);
+        curr_location.block_offset += num_increment_records * stride_length;
+        records_left -= num_increment_records;
+
+        // See if we need to switch to the next block
+        if(records_left > 0 || curr_location.block_offset >= allocated_blocks.block_size) { 
+            curr_location.allocation_index += 1;
+            curr_location.block_offset = 0;
+            allocated_blocks.ensure_capacity(curr_location.allocation_index + 1);
+        }
+    }
+}
+
+// Helper method to convert arrow style string into German style string
+void create_duckdb_strings(sirius::memory::result_table_column& results_column, fixed_size_host_memory_resource::multiple_blocks_allocation& allocated_blocks,
+    sirius::memory::result_table_location& write_location, cudf::data_type offset_type) { 
+    
+    // First allocate space for all of the duckdb strings
+    size_t num_rows = results_column.num_rows;
+    sirius::memory::result_table_location curr_string_location = write_location;
+    increment_location(write_location, allocated_blocks, num_rows, sizeof(duckdb::string_t));
+    
+    // Get the ptrs to the offsets and the actual characters
+    sirius::memory::result_table_location curr_offset_location = results_column.data_loc;
+    sirius::memory::result_table_location curr_char_location = curr_offset_location;
+    size_t offsets_width = cudf::size_of(offset_type);
+    increment_location(curr_char_location, allocated_blocks, num_rows + 1, offsets_width);
+
+    // Now go through creating German style strings
+    for(size_t curr_record = 0; curr_record < num_rows; curr_record++) { 
+        // Get the length of the current string
+        size_t curr_string_length; 
+        uint8_t* string_offsets_raw_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[curr_offset_location.allocation_index]) + curr_offset_location.block_offset;
+        if(offset_type.id() == cudf::type_id::INT32) { 
+            int32_t* offsets_values_ptr = reinterpret_cast<int32_t*>(string_offsets_raw_ptr);
+            curr_string_length = offsets_values_ptr[1] - offsets_values_ptr[0];
+        } else { 
+            throw std::runtime_error("create_duckdb_strings encountered unexpected string offset type");
+        }
+
+        if(curr_string_length >= allocated_blocks.block_size) {  // Validate assumption that the string fits within a block
+            std::string err_msg = std::string("create_duckdb_strings encountered string of length ") + std::to_string(curr_string_length) + std::string(" with block size of ") + std::to_string(allocated_blocks.block_size);
+            throw std::runtime_error(err_msg);
+        }
+        increment_location(curr_offset_location, allocated_blocks, 1, offsets_width);
+
+        // Now actually create the german style string
+        uint8_t* curr_string_raw_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[curr_string_location.allocation_index]) + curr_string_location.block_offset;
+        duckdb::string_t* curr_string_ptr = reinterpret_cast<duckdb::string_t*>(curr_string_raw_ptr); 
+
+        char* curr_string_chars_ptr = reinterpret_cast<char*>(allocated_blocks[curr_char_location.allocation_index]) + curr_char_location.block_offset;
+        if(curr_char_location.block_offset + curr_string_length <= allocated_blocks.block_size) { 
+            // The string is within a block boundary so we can directly create the german style string
+            curr_string_ptr[0] = duckdb::string_t(curr_string_chars_ptr, curr_string_length);
+
+            // Increment the locations to the next record
+            increment_location(curr_string_location, allocated_blocks, 1, sizeof(duckdb::string_t));
+            increment_location(curr_char_location, allocated_blocks, curr_string_length, 1);
+            continue;
+        }
+        
+        // If not we first need to copy the string to be contingous
+        size_t num_overflow_bytes = (curr_char_location.block_offset + curr_string_length) - allocated_blocks.block_size;
+        size_t num_curr_block_bytes = curr_string_length - num_overflow_bytes;
+        sirius::memory::result_table_location str_write_location = write_location;
+        if(str_write_location.block_offset + curr_string_length >= allocated_blocks.block_size) { 
+            str_write_location.allocation_index += 1;
+            str_write_location.block_offset = 0;
+            allocated_blocks.ensure_capacity(str_write_location.allocation_index + 1);
+        }
+        char* contingous_str_ptr = reinterpret_cast<char*>(allocated_blocks[str_write_location.allocation_index]) + str_write_location.block_offset;
+        std::memcpy(contingous_str_ptr, curr_string_chars_ptr, num_curr_block_bytes);
+        char* curr_string_overflow_ptr = reinterpret_cast<char*>(allocated_blocks[curr_char_location.allocation_index + 1]);
+        std::memcpy(contingous_str_ptr + num_curr_block_bytes, curr_string_overflow_ptr, num_overflow_bytes);
+
+        // Now create the german style string
+        curr_string_ptr[0] = duckdb::string_t(contingous_str_ptr, curr_string_length);
+
+        // Increment the locations to the next record
+        write_location = str_write_location;
+        increment_location(write_location, allocated_blocks, curr_string_length, 1);
+        increment_location(curr_string_location, allocated_blocks, 1, sizeof(duckdb::string_t));
+        increment_location(curr_char_location, allocated_blocks, curr_string_length, 1);
     }
 }
 
@@ -179,6 +272,7 @@ sirius::unique_ptr<sirius::duckdb_table_representation> data_representation_conv
         // Initialize the result column
         cudf::column_view& cudf_column = table_columns[i];
         sirius::memory::result_table_column result_column;
+        result_column.num_rows = num_rows;
         cudf::data_type col_type = cudf_column.type();
         result_column.column_type = col_type.id();
 
@@ -196,7 +290,6 @@ sirius::unique_ptr<sirius::duckdb_table_representation> data_representation_conv
         result_column.valid_mask_bytes = mask_size;
 
         // Copy over the actual column contents
-        result_column.num_rows = num_rows;
         duckdb::LogicalTypeId duckdb_col_type = cudf_type_to_duckdb_type(result_column.column_type);
         duckdb_col_types.push_back(duckdb::LogicalType(duckdb_col_type));
         if(col_type.id() == cudf::type_id::STRING) { 
@@ -206,18 +299,22 @@ sirius::unique_ptr<sirius::duckdb_table_representation> data_representation_conv
             size_t offsets_width = cudf::size_of(strings_col_offsets.type()); 
             const char* offsets_ptr = reinterpret_cast<const char*>(strings_col_offsets.head()) + offsets_width * strings_col_offsets.offset();
             
+            // Get the offsets
             align_location(allocation_write_location, offsets_width, allocated_blocks);
             result_column.data_loc = allocation_write_location;
-            copy_buffer_to_cpu(offsets_ptr, num_rows, offsets_width, allocated_blocks, allocation_write_location, stream);
+            copy_buffer_to_cpu(offsets_ptr, num_rows + 1, offsets_width, allocated_blocks, allocation_write_location, stream);
 
             // Then copy the chars
             size_t chars_bytes = strings_col.chars_size(stream);
             const char* actual_chars_ptr = reinterpret_cast<const char*>(strings_col.chars_begin(stream));
             copy_buffer_to_cpu(actual_chars_ptr, chars_bytes, 1, allocated_blocks, allocation_write_location, stream);
-            
             result_column.column_data_bytes = chars_bytes + offsets_width * num_rows;
 
-            // TODO(Devesh): Handle creating of the German style strings needed by DuckDB
+            // Also create the DuckDB strings
+            align_location(allocation_write_location, sizeof(duckdb::string_t), allocated_blocks);
+            result_column.duckdb_strings_loc = allocation_write_location;
+            stream.synchronize(); // Synchronize to ensure that the characters and offsets are materialized onto the CPU
+            create_duckdb_strings(result_column, allocated_blocks, allocation_write_location, strings_col_offsets.type());
         } else { 
             size_t record_width = cudf::size_of(col_type); 
             const char* records_ptr = reinterpret_cast<const char*>(cudf_column.head()) + record_width * cudf_column.offset();
@@ -238,83 +335,94 @@ sirius::unique_ptr<sirius::duckdb_table_representation> data_representation_conv
     std::vector<sirius::memory::result_table_location> column_data_location;
     for(int i = 0; i < num_columns; i++) { 
         column_valid_mask_location.push_back(result_columns[i].valid_mask_loc);
-        column_data_location.push_back(result_columns[i].data_loc);
+        if(result_columns[i].column_type == cudf::type_id::STRING) { 
+            column_data_location.push_back(result_columns[i].duckdb_strings_loc);
+        } else { 
+            column_data_location.push_back(result_columns[i].data_loc);
+        }
     }
     
+    size_t num_processed_records = 0;
     size_t block_size = allocated_blocks.block_size;
-    size_t records_left = num_rows;
     std::vector<sirius::unique_ptr<duckdb::DataChunk>> result_chunks;
-    while(records_left > 0) { 
+    while(num_processed_records < num_rows) { 
         // Determine the number of records we can include without crossing a block boundary
-        size_t records_in_chunk = std::min(records_left, static_cast<size_t>(STANDARD_VECTOR_SIZE));
+        size_t records_in_chunk = std::min(num_rows - num_processed_records, static_cast<size_t>(STANDARD_VECTOR_SIZE));
 
         for(int i = 0; i < num_columns; i++) { 
             cudf::type_id col_type = result_columns[i].column_type;
             // Determine maximum records from null mask
-            size_t max_mask_records = (block_size - column_valid_mask_location[i].block_offset) * BYTE_TO_BITS;
+            sirius::memory::result_table_location record_validity_mask_loc = column_valid_mask_location[i];
+            increment_location(record_validity_mask_loc, allocated_blocks, num_processed_records/BYTE_TO_BITS, 1);
+            size_t max_mask_records = (block_size - record_validity_mask_loc.block_offset) * BYTE_TO_BITS;
             records_in_chunk = std::min(records_in_chunk, max_mask_records);
 
+            // Determine maximum records from data points
+            size_t record_width; 
             if(col_type == cudf::type_id::STRING) { 
-                // TODO(Devesh): Extend this implementation to account for string columns
+                record_width = sizeof(duckdb::string_t);
             } else { 
-                // Determine maximum amount of data points
-                size_t record_width = cudf::size_of(cudf::data_type(col_type));
-                size_t curr_record_offset = column_data_location[i].block_offset;
-                size_t max_records_from_col = (block_size - curr_record_offset)/record_width; 
-                max_records_from_col = max_records_from_col - (max_records_from_col % BYTE_TO_BITS); // We want to ensure that the number of records is a multiple of 8 so that we don't have to splice the null mask 
-
-                records_in_chunk = std::min(records_in_chunk, max_records_from_col); 
+                record_width = cudf::size_of(cudf::data_type(col_type));
             }
+
+            size_t curr_record_offset = column_data_location[i].block_offset;
+            size_t max_records_from_col = (block_size - curr_record_offset)/record_width; 
+            if(max_records_from_col > BYTE_TO_BITS) { // If the possible round down to a multiple of 8 
+                max_records_from_col = max_records_from_col - (max_records_from_col % BYTE_TO_BITS);
+            }
+            records_in_chunk = std::min(records_in_chunk, max_records_from_col); 
         }
 
         // Create the Data Chunk
         sirius::unique_ptr<duckdb::DataChunk> chunk = sirius::make_unique<duckdb::DataChunk>();
 		chunk->InitializeEmpty(duckdb_col_types);
         for(int i = 0; i < num_columns; i++) { 
-            cudf::type_id col_type = result_columns[i].column_type;
-            if(col_type == cudf::type_id::STRING) { 
-                // TODO(Devesh): Extend this implementation to account for string columns
+            // Create the vector
+            sirius::memory::result_table_location& col_data_location = column_data_location[i];
+            uint8_t* col_records_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[col_data_location.allocation_index]) + col_data_location.block_offset;
+            duckdb::Vector col_vector(duckdb_col_types[i], col_records_ptr);
+
+            // Set the validity mask based on the starting location of the record
+            size_t validity_mask_starting_byte = num_processed_records/BYTE_TO_BITS;
+            size_t validity_mask_starting_bit = num_processed_records - validity_mask_starting_byte * BYTE_TO_BITS;
+            sirius::memory::result_table_location record_validity_mask_loc = column_valid_mask_location[i];
+            increment_location(record_validity_mask_loc, allocated_blocks, validity_mask_starting_byte, 1);
+
+            size_t mask_block_to_load = record_validity_mask_loc.allocation_index;
+            uint8_t* mask_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[mask_block_to_load]) + record_validity_mask_loc.block_offset;
+            if(validity_mask_starting_bit > 0) { // Account for the fact that the validity mask may not start at a byte boundary
+                size_t records_in_view = std::ceil((1.0 * records_in_chunk)/BYTE_TO_BITS);
+                duckdb::ValidityMask validity_mask_view(reinterpret_cast<duckdb::validity_t*>(mask_ptr), records_in_view);
+
+                duckdb::ValidityMask sliced_mask(records_in_chunk); // Slice the view to include the relevant records
+                sliced_mask.Slice(validity_mask_view, validity_mask_starting_bit, num_rows);
+                duckdb::FlatVector::SetValidity(col_vector, sliced_mask);
             } else { 
-                // Create the vector
-                size_t data_block_to_load = column_data_location[i].allocation_index;
-                uint8_t* col_records_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[data_block_to_load]) + column_data_location[i].block_offset;
-                duckdb::Vector col_vector(duckdb_col_types[i], col_records_ptr);
-                
-                // Set the null mask
-                size_t mask_block_to_load = column_valid_mask_location[i].allocation_index;
-                uint8_t* mask_ptr = reinterpret_cast<uint8_t*>(allocated_blocks[mask_block_to_load]) + column_valid_mask_location[i].block_offset;
                 duckdb::ValidityMask validity_mask(reinterpret_cast<duckdb::validity_t*>(mask_ptr), records_in_chunk);
                 duckdb::FlatVector::SetValidity(col_vector, validity_mask);
-
-                // Add the vector to the chunk
-                chunk->data[i].Reference(col_vector);
             }
+
+            // Add the vector to the chunk
+            chunk->data[i].Reference(col_vector);
         }
+
         chunk->SetCardinality(records_in_chunk);
-        records_left -= records_in_chunk;
         result_chunks.push_back(std::move(chunk));
+        num_processed_records += records_in_chunk;
 
         // Increment the read offsets
         for(int i = 0; i < num_columns; i++) { 
+            // Determine the record width
+            size_t record_width;
             cudf::type_id col_type = result_columns[i].column_type;
             if(col_type == cudf::type_id::STRING) { 
-
+                record_width = sizeof(duckdb::string_t);
             } else { 
-                size_t record_width = cudf::size_of(cudf::data_type(col_type));
-
-                // Increment the data record location
-                column_data_location[i].block_offset += record_width * records_in_chunk;
-                if(column_data_location[i].block_offset + record_width >= block_size) { // See if we the remaining records are in the next block
-                    column_data_location[i].allocation_index += 1;
-                    column_data_location[i].block_offset = 0;
-                }
-
-                // Increment the mask ptr
-                size_t mask_increment = std::ceil(records_in_chunk/BYTE_TO_BITS);
-                column_valid_mask_location[i].block_offset += mask_increment;
-                column_valid_mask_location[i].allocation_index += column_valid_mask_location[i].block_offset/block_size;
-                column_valid_mask_location[i].block_offset = column_valid_mask_location[i].block_offset % block_size;
+                record_width = cudf::size_of(cudf::data_type(col_type));
             }
+
+            // Increment the data record location only - No need to increment the validity mask as we recalculate it every time
+            increment_location(column_data_location[i], allocated_blocks, records_in_chunk, record_width);
         }
     }
 

--- a/src/data/duckdb_data_representation.cpp
+++ b/src/data/duckdb_data_representation.cpp
@@ -36,7 +36,7 @@ duckdb_table_representation::duckdb_table_representation(sirius::unique_ptr<siri
 }
 
 std::size_t duckdb_table_representation::get_size_in_bytes() const {
-    return 0;
+    return _result_table->allocation.size() * _result_table->allocation.block_size;
 }
 
 sirius::unique_ptr<idata_representation> duckdb_table_representation::convert_to_memory_space(sirius::memory::memory_space& target_memory_space, rmm::cuda_stream_view stream) {

--- a/src/data/duckdb_data_representation.cpp
+++ b/src/data/duckdb_data_representation.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "data/duckdb_data_representation.hpp"
+
+namespace sirius {
+
+duckdb_table_representation::duckdb_table_representation(sirius::unique_ptr<sirius::memory::result_table_allocation> result_table, std::vector<sirius::unique_ptr<duckdb::DataChunk>> output_vectors, sirius::memory::memory_space& memory_space)
+    : idata_representation(memory_space), _result_table(std::move(result_table)) {
+
+    // Create the output chunks to reference the data in the result table but using duckdb types
+    for(int i = 0; i < output_vectors.size(); i++) { 
+        sirius::unique_ptr<duckdb::DataChunk>& result_data_chunk = output_vectors[i];
+        duckdb::unique_ptr<duckdb::DataChunk> duckdb_data_chunk = duckdb::make_uniq<duckdb::DataChunk>();
+
+        duckdb_data_chunk->InitializeEmpty(result_data_chunk->GetTypes());
+        duckdb_data_chunk->SetCardinality(result_data_chunk->size());
+        for(int col = 0; col < result_data_chunk->ColumnCount(); col++) {
+            duckdb_data_chunk->data[col].Reference(result_data_chunk->data[col]);
+        }
+        _output_chunks.push_back(std::move(duckdb_data_chunk));
+    }
+}
+
+std::size_t duckdb_table_representation::get_size_in_bytes() const {
+    return 0;
+}
+
+sirius::unique_ptr<idata_representation> duckdb_table_representation::convert_to_memory_space(sirius::memory::memory_space& target_memory_space, rmm::cuda_stream_view stream) {
+    throw std::runtime_error("DuckDB table representation currently doesn't support being converted to another memory spaces");
+}
+
+} // namespace sirius

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -17,6 +17,8 @@
 #include "data/gpu_data_representation.hpp"
 #include <cudf/utilities/traits.hpp>
 
+#include "data/data_representation_converter.hpp"
+
 namespace sirius {
 
 gpu_table_representation::gpu_table_representation(cudf::table table, sirius::memory::memory_space& memory_space)
@@ -42,6 +44,10 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
     // TODO: Implement conversion to GPU representation
     // This should use data_representation_converter::convert_to_gpu_representation
     throw std::runtime_error("gpu_table_representation::convert_to_memory_space not yet implemented");
+}
+
+sirius::unique_ptr<duckdb_table_representation> gpu_table_representation::convert_to_result_format(sirius::memory::memory_space& host_memory_space, rmm::cuda_stream_view stream) { 
+    return data_representation_converter::convert_gpu_table_to_result_format(_table.view(), host_memory_space, stream);
 }
 
 } // namespace sirius

--- a/src/include/data/data_representation_converter.hpp
+++ b/src/include/data/data_representation_converter.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "data/gpu_data_representation.hpp"
+#include "data/duckdb_data_representation.hpp"
+#include "memory/memory_space.hpp"
+
+#include "cudf/cudf_utils.hpp"
+
+namespace sirius {
+
+/**
+ * @brief Utility class for converting between data representations
+ */
+class data_representation_converter {
+public: 
+
+    static sirius::unique_ptr<sirius::duckdb_table_representation> convert_gpu_table_to_result_format(
+        cudf::table_view src_table,
+        sirius::memory::memory_space& host_memory_space,
+        rmm::cuda_stream_view stream
+    );
+};
+
+}

--- a/src/include/data/duckdb_data_representation.hpp
+++ b/src/include/data/duckdb_data_representation.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "data/common.hpp"
+#include "memory/fixed_size_host_memory_resource.hpp"
+#include "memory/memory_space.hpp"
+#include "memory/result_table.hpp"
+#include "helper/helper.hpp"
+
+#include "duckdb/common/types/data_chunk.hpp"
+
+namespace sirius {
+
+/**
+ * @brief Data representation for the result that get returned to duckdb
+ * 
+ * This represents a Data Batch that is an output of an query. The reason that this is different from
+ * host_table_representation as that represents 
+ */
+class duckdb_table_representation : public idata_representation { 
+public:  
+
+    /**
+     * @brief Construct a new duckdb_table_repersentation object
+     * 
+     * @param result_table Internal representation storing the cudf table in an output friendly format
+     * @param data_chunks The Data Chunks representing the table results that can be passed directly to DuckDB
+     * @param memory_space The memory space that this table resides in
+     */
+    duckdb_table_representation(sirius::unique_ptr<sirius::memory::result_table_allocation> result_table, std::vector<sirius::unique_ptr<duckdb::DataChunk>> output_vectors, sirius::memory::memory_space& memory_space);
+
+    /**
+     * @brief Get the size of the data representation in bytes
+     * 
+     * @return std::size_t The number of bytes used to store this representation
+     */
+    std::size_t get_size_in_bytes() const override;
+
+    /**
+     * @brief Returns a reference to the result data chunks
+     */
+    std::vector<duckdb::unique_ptr<duckdb::DataChunk>>& get_output_chunks() { 
+        return _output_chunks;
+    }
+
+    /**
+     * @brief Convert this CPU table representation to a different memory tier
+     * 
+     * @param target_memory_space The target memory space to convert to
+     * @param stream CUDA stream to use for memory operations
+     * @return sirius::unique_ptr<idata_representation> A new data representation in the target tier
+     */
+    sirius::unique_ptr<idata_representation> convert_to_memory_space(sirius::memory::memory_space& target_memory_space, rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
+
+private: 
+    sirius::unique_ptr<sirius::memory::result_table_allocation> _result_table;
+    std::vector<duckdb::unique_ptr<duckdb::DataChunk>> _output_chunks; 
+};
+
+}

--- a/src/include/data/gpu_data_representation.hpp
+++ b/src/include/data/gpu_data_representation.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "data/common.hpp"
+#include "data/duckdb_data_representation.hpp"
 #include "memory/memory_space.hpp"
 #include "cudf/cudf_utils.hpp"
 #include "helper/helper.hpp"
@@ -66,6 +67,13 @@ public:
      */
     sirius::unique_ptr<idata_representation> convert_to_memory_space(sirius::memory::memory_space& target_memory_space, rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
 
+    /**
+     * @brief Convert this GPU table representation to a duckdb representation
+     * 
+     * @param host_memory_space Memory space we want to store the results
+     * @param stream CUDA stream to use for the memory operations
+     */
+    sirius::unique_ptr<duckdb_table_representation> convert_to_result_format(sirius::memory::memory_space& host_memory_space, rmm::cuda_stream_view stream = rmm::cuda_stream_default);  
 private:
     cudf::table _table; ///< The actual cuDF table with the data
 };

--- a/src/include/memory/fixed_size_host_memory_resource.hpp
+++ b/src/include/memory/fixed_size_host_memory_resource.hpp
@@ -131,7 +131,7 @@ public:
 
         ~multiple_blocks_allocation() {
             for (void* ptr : blocks) {
-                mr->deallocate(ptr, block_size);
+                if(ptr != nullptr) mr->deallocate(ptr, block_size);
             }
         }
 
@@ -156,6 +156,26 @@ public:
                 other.blocks.clear();
             }
             return *this;
+        }
+
+        /**
+         * @brief Ensures that the allocation has at least the specified number of blocks
+         * 
+         * Checks if the allocation has at least the specified number of blocks and if not requests more blocks
+         */
+        void ensure_capacity(size_t num_blocks) { 
+            if(num_blocks <= blocks.size()) { // We already have the requested number of blocks
+                return;
+            }
+
+            int num_additional_blocks = num_blocks - blocks.size();
+            multiple_blocks_allocation additional_allocation = mr->allocate_multiple_blocks(num_additional_blocks * block_size);
+            
+            // Copy over the block pointers from that allocation to this allocation
+            for(int i = 0; i < additional_allocation.blocks.size(); i++) { 
+                blocks.push_back(additional_allocation.blocks[i]);
+                additional_allocation.blocks[i] = nullptr; // This ensures that they don't get deallocated when additional_allocation goes out of scope 
+            }
         }
 
         std::size_t size() const noexcept { return blocks.size(); }

--- a/src/include/memory/memory_space.hpp
+++ b/src/include/memory/memory_space.hpp
@@ -95,6 +95,19 @@ public:
     bool can_reserve(size_t size) const;
     std::string to_string() const;
 
+    /**
+     * @brief Attempt to retrieve the default allocator as a concrete type.
+     *
+     * Returns nullptr if the default allocator is not of the requested type.
+     */
+    template <typename T>
+    T* get_default_allocator_as() const {
+        if (_allocators.empty()) {
+            return nullptr;
+        }
+        return dynamic_cast<T*>(_allocators[0].get());
+    }
+
 private:
     const Tier _tier;
     const size_t _device_id;

--- a/src/include/memory/result_table.hpp
+++ b/src/include/memory/result_table.hpp
@@ -39,7 +39,8 @@ struct result_table_location {
  * metadata in order to reconstruct all of the details and this column stores those details. Note
  * that all columns first store the validity bitmask and the actual data (not necessarily contigously). 
  *   - For fixed data it is just storing the underlying columnar data
- *   - For variable size strings we first store the offset and then the actual characters
+ *   - For variable size strings we first store the offset and then the actual characters. Additionally, we also
+ *   - store the duckdb style string alongside the raw characters that we copied over from the GPU
  */
 struct result_table_column { 
     cudf::type_id column_type; // The type of the column
@@ -48,6 +49,7 @@ struct result_table_column {
     size_t valid_mask_bytes; // The number of bytes occupied by the validity mask
     size_t num_rows; // The number of rows in the column
     size_t column_data_bytes; // The number of bytes needed to store the column's data
+    result_table_location duckdb_strings_loc; 
 };
 
 /**

--- a/src/include/memory/result_table.hpp
+++ b/src/include/memory/result_table.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include "fixed_size_host_memory_resource.hpp"
+#include "helper/helper.hpp"
+
+namespace sirius {
+namespace memory {
+
+/**
+ * @brief Structure used to represent the location in a multi block allocation
+ */
+struct result_table_location { 
+    size_t allocation_index = 0; // Index of the block in the allocation
+    size_t block_offset = 0; // The offset within the block
+};
+
+/**
+ * @brief Structure storing metatadata related to a specific column in the result table
+ * 
+ * Since we are spreading out the contents of a column across multiple blocks, we need to maintain
+ * metadata in order to reconstruct all of the details and this column stores those details. Note
+ * that all columns first store the validity bitmask and the actual data (not necessarily contigously). 
+ *   - For fixed data it is just storing the underlying columnar data
+ *   - For variable size strings we first store the offset and then the actual characters
+ */
+struct result_table_column { 
+    cudf::type_id column_type; // The type of the column
+    result_table_location valid_mask_loc; // The location where the validity mask of the column is
+    result_table_location data_loc; // The location where the data of the column actually is
+    size_t valid_mask_bytes; // The number of bytes occupied by the validity mask
+    size_t num_rows; // The number of rows in the column
+    size_t column_data_bytes; // The number of bytes needed to store the column's data
+};
+
+/**
+ * @brief Structure containing both the host memory allocation and additional metadata for create results
+ * 
+ * Currently, both cudf and duckdb store and expect data to be in an arrow style format (i.e. contingous buffer)
+ * but we use fixed sized blocks for our host memory allocation. Thus, we need to store the result table in host memory
+ * in a way that they are spread across the allocated blocks but we can pass to DuckDB as if they were contigious and this
+ * representation is used to effectivelly perform that mapping/abstraction.
+ */
+ struct result_table_allocation {
+    fixed_size_host_memory_resource::multiple_blocks_allocation allocation;
+    std::vector<result_table_column> columns;
+    
+    result_table_allocation(fixed_size_host_memory_resource::multiple_blocks_allocation alloc, std::vector<result_table_column> columns) 
+        : allocation(std::move(alloc)), columns(std::move(columns)) {}
+};
+
+} // namespace memory
+} // namespace sirius

--- a/test/cpp/data/CMakeLists.txt
+++ b/test/cpp/data/CMakeLists.txt
@@ -19,5 +19,6 @@ set(TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/test_data_repository.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_data_repository_manager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_data_representation.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_duckdb_data_representation.cpp
   PARENT_SCOPE)
 

--- a/test/cpp/data/test_duckdb_data_representation.cpp
+++ b/test/cpp/data/test_duckdb_data_representation.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include <memory>
+#include <vector>
+
+#include "duckdb/common/typedefs.hpp"
+
+#include "data/cpu_data_representation.hpp"
+#include "data/gpu_data_representation.hpp"
+#include "data/duckdb_data_representation.hpp"
+#include "data/common.hpp"
+#include "memory/null_device_memory_resource.hpp"
+#include "memory/result_table.hpp"
+#include "memory/fixed_size_host_memory_resource.hpp"
+
+using namespace sirius;
+
+// Mock memory_space for testing - provides a simple memory_space without real allocators
+class mock_memory_space : public memory::memory_space {
+public:
+    mock_memory_space(memory::Tier tier, std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> allocators, size_t device_id = 0)
+        : memory::memory_space(tier, device_id, 1024 * 1024 * 1024, allocators.size() > 0 ? std::move(allocators) : create_null_allocators()) {
+        
+    }
+    
+private:
+    static std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> create_null_allocators() {
+        std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> allocators;
+        allocators.push_back(std::make_unique<memory::null_device_memory_resource>());
+        return allocators;
+    }
+};
+
+// Helper function creates a small fixed sized buffer pool 
+constexpr std::size_t DEFAULT_BLOCK_SIZE = 2 << 10;
+std::unique_ptr<rmm::mr::device_memory_resource> create_host_memory_resource(int num_blocks = 1) { 
+    constexpr std::size_t blocks_in_pool = 1;
+    return std::make_unique<memory::fixed_size_host_memory_resource>(DEFAULT_BLOCK_SIZE, blocks_in_pool, num_blocks);
+}
+
+// Helper method to create test tables
+std::unique_ptr<cudf::column> create_fixed_size_column(cudf::type_id col_type_id, int num_rows, bool has_null_mask) { 
+    return cudf::make_numeric_column(
+        cudf::data_type{col_type_id},
+        num_rows,
+        has_null_mask ? cudf::mask_state::UNINITIALIZED : cudf::mask_state::UNALLOCATED 
+    ); // Note that cudf::mask_state::UNINITIALIZED populates with random data so switch to cudf::mask_state::ALL_VALID/cudf::mask_state::ALL_NULL for determinstic behaviour
+}
+
+std::unique_ptr<cudf::column> create_string_column(int num_rows, bool has_null_mask) { 
+    cudf::string_scalar row_value("hello_world", true);
+    auto col = cudf::make_column_from_scalar(row_value, num_rows);
+    if (!has_null_mask) {
+        col->set_null_mask(rmm::device_buffer{}, 0);
+    }
+    return col;
+}
+
+sirius::unique_ptr<gpu_table_representation> create_gpu_representation(sirius::memory::memory_space& memory_space, std::vector<cudf::type_id> col_types, std::vector<bool> is_nullable_col, int num_rows) { 
+    std::vector<std::unique_ptr<cudf::column>> columns;
+    for(int i = 0; i < col_types.size(); i++) { 
+        std::unique_ptr<cudf::column> curr_col; 
+        if(col_types[i] == cudf::type_id::STRING) { 
+            curr_col = create_string_column(num_rows, is_nullable_col[i]);
+        } else { 
+            curr_col = create_fixed_size_column(col_types[i], num_rows, is_nullable_col[i]);
+        }
+
+        columns.push_back(std::move(curr_col));
+    }
+
+    cudf::table underlying_table = cudf::table(std::move(columns));
+    return sirius::make_unique<gpu_table_representation>(std::move(underlying_table), memory_space);
+}
+
+// Helper function to verify that the DataChunks repreents the specified cudf columns
+void verify_validity_mask(cudf::column_view cudf_col_view, size_t col, size_t num_records, std::vector<duckdb::unique_ptr<duckdb::DataChunk>>& output_chunks) { 
+    // Copy the cudf mask to host if there is one
+    std::vector<uint8_t> h_cudf_mask;
+    bool cudf_has_mask = cudf_col_view.null_mask() != nullptr;
+    if (cudf_has_mask) {
+        // Calculate size in 32-bit words needed for bitmask
+        rmm::device_buffer mask_buffer = cudf::copy_bitmask(cudf_col_view);
+        h_cudf_mask.resize(mask_buffer.size());
+        
+        // Copy mask from GPU to CPU
+        cudaMemcpy(
+            h_cudf_mask.data(), 
+            mask_buffer.data(), 
+            mask_buffer.size(), 
+            cudaMemcpyDeviceToHost
+        );
+    }
+
+    // Iterate through chunk by chunk
+    size_t global_record_offset = 0;
+    for (int chunk_idx = 0; chunk_idx < output_chunks.size(); chunk_idx++) {
+        // Get the specific vector for this column
+        duckdb::unique_ptr<duckdb::DataChunk>& result_chunk = output_chunks[chunk_idx];
+        size_t chunk_size = static_cast<size_t>(result_chunk->size());
+        auto& column_vector = result_chunk->data[col];
+
+        for (size_t chunk_offset = 0; chunk_offset < chunk_size; chunk_offset++) {
+            size_t curr_record_offset = global_record_offset + chunk_offset;
+
+            // Get the cudf validity value for this record
+            bool cudf_is_valid = true;
+            if(cudf_has_mask) { 
+                size_t element_index = curr_record_offset / 8;
+                size_t bit_index = curr_record_offset % 8;
+                cudf_is_valid = static_cast<bool>((h_cudf_mask[element_index] >> bit_index) & 1);
+            }
+
+            // Compare this againse the duckdb value
+            bool duckdb_is_valid = !column_vector.GetValue(chunk_offset).IsNull();
+            if(cudf_is_valid != duckdb_is_valid) { 
+                std::cout << "Null Mismatch Detail - Chunk: " << chunk_idx << ", Chunk Offset: " << chunk_offset << ", Global Offset: " << curr_record_offset << ", Cudf Value - " << cudf_is_valid << ", Duckdb Value - " << duckdb_is_valid << std::endl;
+            }
+            REQUIRE(cudf_is_valid == duckdb_is_valid);
+        }
+
+        global_record_offset += chunk_size;
+    }
+}
+
+void verify_fixed_size_representation(cudf::column_view cudf_col_view, size_t col, size_t num_records, std::vector<duckdb::unique_ptr<duckdb::DataChunk>>& output_chunks) { 
+    // Copy the records into a flat buffer on the CPU
+    size_t record_width = cudf::size_of(cudf_col_view.type());
+    const char* d_records_ptr = reinterpret_cast<const char*>(cudf_col_view.head()) + record_width * cudf_col_view.offset();
+    size_t buffer_size_bytes = num_records * record_width;
+    std::vector<duckdb::data_t> h_records;
+    h_records.resize(buffer_size_bytes/sizeof(duckdb::data_t));
+
+    cudaMemcpy(
+        h_records.data(), 
+        d_records_ptr, 
+        buffer_size_bytes, 
+        cudaMemcpyDeviceToHost
+    );
+
+    // Compare the data with the column's data
+    size_t global_record_offset = 0;
+    for (int chunk_idx = 0; chunk_idx < output_chunks.size(); chunk_idx++) {
+        // Get the specific vector for this column
+        duckdb::unique_ptr<duckdb::DataChunk>& result_chunk = output_chunks[chunk_idx];
+        size_t chunk_size = static_cast<size_t>(result_chunk->size());
+        auto& column_vector = result_chunk->data[col];
+
+        for (size_t chunk_offset = 0; chunk_offset < chunk_size; chunk_offset++) {
+            // Get the ptrs to the data in cudf and duckdb
+            size_t curr_record_offset = global_record_offset + chunk_offset;
+            duckdb::data_t* cudf_record_ptr = h_records.data() + curr_record_offset * record_width;
+            duckdb::data_t* duckdb_record_ptr = column_vector.GetData() + chunk_offset * record_width;
+
+            // Compare the duckdb data with the cudf data based on the record width
+            if(record_width == 4) { 
+                REQUIRE(reinterpret_cast<uint32_t*>(cudf_record_ptr)[0] == reinterpret_cast<uint32_t*>(duckdb_record_ptr)[0]);
+            } else { // Fallback to character at a time comparsion
+                size_t num_vals_to_check = record_width/sizeof(duckdb::data_t);
+                for(size_t i = 0; i < num_vals_to_check; i++) { 
+                    REQUIRE(cudf_record_ptr[i] == duckdb_record_ptr[i]);
+                }
+            }
+        }
+    }
+}
+
+void verify_representation_conversion(sirius::unique_ptr<duckdb_table_representation> duckdb_representation, sirius::unique_ptr<gpu_table_representation> gpu_representation) { 
+    const cudf::table& gpu_table = gpu_representation->get_table();
+    std::vector<duckdb::unique_ptr<duckdb::DataChunk>>& output_chunks = duckdb_representation->get_output_chunks();
+
+    // First verify that the row count is correct
+    size_t expected_columns = gpu_table.num_columns();
+    size_t expected_rows = gpu_table.num_rows();
+    size_t data_chunk_records = 0;
+    for (const auto& data_chunk : output_chunks) {
+        REQUIRE(data_chunk->ColumnCount() == expected_columns);
+        data_chunk_records += data_chunk->size();
+    }
+    REQUIRE(data_chunk_records == expected_rows);
+
+    // Now verify that each column's count is correct
+    for(size_t i = 0; i < expected_columns; i++) { 
+        // First check that it has the expected bitmask 
+        cudf::column_view cudf_col_view = gpu_table.get_column(i).view();
+        verify_validity_mask(cudf_col_view, i, expected_rows, output_chunks);
+
+        // Then verify the actual data
+        if(cudf_col_view.type().id() == cudf::type_id::STRING) { 
+
+        } else { 
+            verify_fixed_size_representation(cudf_col_view, i, expected_rows, output_chunks);
+        }
+    }
+}
+
+TEST_CASE("result_convertor_single_non_nullable_int_conversion", "[duckdb_data_representation][non_null_int_conversion]") {
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    int num_test_rows = 400;
+    std::vector<cudf::type_id> col_types = {cudf::type_id::INT32};
+    std::vector<bool> is_null_column = {false};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+
+TEST_CASE("result_convertor_single_nullable_int_conversion", "[duckdb_data_representation][nullable_int_conversion]") {
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    int num_test_rows = 400;
+    std::vector<cudf::type_id> col_types = {cudf::type_id::INT32};
+    std::vector<bool> is_null_column = {true};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+TEST_CASE("result_convertor_single_nullable_int_multiple_block_conversion", "[duckdb_data_representation][nullable_int_conversion]") {
+    // Create the gpu and host memory spaces
+    int num_test_rows = 2500;
+    int total_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8);
+    int blocks_needed = std::ceil((1.0 * total_bytes_needed)/DEFAULT_BLOCK_SIZE);
+
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource(blocks_needed));
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    std::vector<cudf::type_id> col_types = {cudf::type_id::INT32};
+    std::vector<bool> is_null_column = {true};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}

--- a/test/cpp/data/test_duckdb_data_representation.cpp
+++ b/test/cpp/data/test_duckdb_data_representation.cpp
@@ -15,11 +15,8 @@
  */
 
 #include "catch.hpp"
-#include <memory>
-#include <vector>
 
 #include "duckdb/common/typedefs.hpp"
-
 #include "data/cpu_data_representation.hpp"
 #include "data/gpu_data_representation.hpp"
 #include "data/duckdb_data_representation.hpp"
@@ -27,6 +24,13 @@
 #include "memory/null_device_memory_resource.hpp"
 #include "memory/result_table.hpp"
 #include "memory/fixed_size_host_memory_resource.hpp"
+
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <random>
+#include <cudf/utilities/bit.hpp>
+#include <rmm/device_buffer.hpp>
 
 using namespace sirius;
 
@@ -62,12 +66,27 @@ std::unique_ptr<cudf::column> create_fixed_size_column(cudf::type_id col_type_id
     ); // Note that cudf::mask_state::UNINITIALIZED populates with random data so switch to cudf::mask_state::ALL_VALID/cudf::mask_state::ALL_NULL for determinstic behaviour
 }
 
+static const std::string TEST_STRING_VALUE = "super_simple_string"; 
 std::unique_ptr<cudf::column> create_string_column(int num_rows, bool has_null_mask) { 
-    cudf::string_scalar row_value("hello_world", true);
+    cudf::string_scalar row_value(TEST_STRING_VALUE.c_str(), true);
     auto col = cudf::make_column_from_scalar(row_value, num_rows);
     if (!has_null_mask) {
         col->set_null_mask(rmm::device_buffer{}, 0);
+    } else { 
+        // Create a randomly generate bitmask
+        std::size_t mask_size = cudf::bitmask_allocation_size_bytes(num_rows);
+        std::vector<uint8_t> host_random_mask(mask_size);
+        std::generate(host_random_mask.begin(), host_random_mask.end(), std::rand);
+        cudf::size_type null_count = 0;
+        for(int i = 0; i < num_rows; i++) {
+            null_count += (host_random_mask[i/8] >> (i % 8)) & 1;
+        }
+
+        // Copy to GPU and pass to cudf
+        rmm::device_buffer gpu_mask(host_random_mask.data(), mask_size, rmm::cuda_stream_default);
+        col->set_null_mask(std::move(gpu_mask), null_count);
     }
+
     return col;
 }
 
@@ -128,9 +147,6 @@ void verify_validity_mask(cudf::column_view cudf_col_view, size_t col, size_t nu
 
             // Compare this againse the duckdb value
             bool duckdb_is_valid = !column_vector.GetValue(chunk_offset).IsNull();
-            if(cudf_is_valid != duckdb_is_valid) { 
-                std::cout << "Null Mismatch Detail - Chunk: " << chunk_idx << ", Chunk Offset: " << chunk_offset << ", Global Offset: " << curr_record_offset << ", Cudf Value - " << cudf_is_valid << ", Duckdb Value - " << duckdb_is_valid << std::endl;
-            }
             REQUIRE(cudf_is_valid == duckdb_is_valid);
         }
 
@@ -169,12 +185,35 @@ void verify_fixed_size_representation(cudf::column_view cudf_col_view, size_t co
 
             // Compare the duckdb data with the cudf data based on the record width
             if(record_width == 4) { 
-                REQUIRE(reinterpret_cast<uint32_t*>(cudf_record_ptr)[0] == reinterpret_cast<uint32_t*>(duckdb_record_ptr)[0]);
+                int32_t cudf_record_value = reinterpret_cast<int32_t*>(cudf_record_ptr)[0];
+                int32_t duckdb_record_value = reinterpret_cast<int32_t*>(duckdb_record_ptr)[0];
+                REQUIRE(cudf_record_value == duckdb_record_value);
             } else { // Fallback to character at a time comparsion
                 size_t num_vals_to_check = record_width/sizeof(duckdb::data_t);
                 for(size_t i = 0; i < num_vals_to_check; i++) { 
                     REQUIRE(cudf_record_ptr[i] == duckdb_record_ptr[i]);
                 }
+            }
+        }
+
+        global_record_offset += chunk_size;
+    }
+}
+
+// Note that since we create the string column in create_string_column with a fixed scalar this method just needs to verify
+// that the duckdb string representation has that scalar value
+void verify_string_representation(std::vector<duckdb::unique_ptr<duckdb::DataChunk>>& output_chunks, size_t col, size_t num_records) { 
+    for (int chunk_idx = 0; chunk_idx < output_chunks.size(); chunk_idx++) {
+        // Get the specific vector for this column and convert it into a string column
+        duckdb::unique_ptr<duckdb::DataChunk>& result_chunk = output_chunks[chunk_idx];
+        size_t chunk_size = static_cast<size_t>(result_chunk->size());
+        auto& column_vector = result_chunk->data[col];
+        REQUIRE(column_vector.GetVectorType() == duckdb::VectorType::FLAT_VECTOR);
+
+        for (size_t chunk_offset = 0; chunk_offset < chunk_size; chunk_offset++) {
+            if(!duckdb::FlatVector::IsNull(column_vector, chunk_offset)) { // Only check the non null records
+                duckdb::string_t curr_string = duckdb::FlatVector::GetValue<duckdb::string_t>(column_vector, chunk_offset);
+                REQUIRE(curr_string.GetString() == TEST_STRING_VALUE);
             }
         }
     }
@@ -202,7 +241,7 @@ void verify_representation_conversion(sirius::unique_ptr<duckdb_table_representa
 
         // Then verify the actual data
         if(cudf_col_view.type().id() == cudf::type_id::STRING) { 
-
+            verify_string_representation(output_chunks, i, expected_rows);
         } else { 
             verify_fixed_size_representation(cudf_col_view, i, expected_rows, output_chunks);
         }
@@ -227,7 +266,6 @@ TEST_CASE("result_convertor_single_non_nullable_int_conversion", "[duckdb_data_r
     verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
 }
 
-
 TEST_CASE("result_convertor_single_nullable_int_conversion", "[duckdb_data_representation][nullable_int_conversion]") {
     // Create the gpu and host memory spaces
     mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
@@ -247,10 +285,10 @@ TEST_CASE("result_convertor_single_nullable_int_conversion", "[duckdb_data_repre
 }
 
 TEST_CASE("result_convertor_single_nullable_int_multiple_block_conversion", "[duckdb_data_representation][nullable_int_conversion]") {
-    // Create the gpu and host memory spaces
-    int num_test_rows = 2500;
-    int total_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8);
-    int blocks_needed = std::ceil((1.0 * total_bytes_needed)/DEFAULT_BLOCK_SIZE);
+    // Determine the blocks needed
+    size_t num_test_rows = 2500;
+    size_t total_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8);
+    size_t blocks_needed = std::ceil((1.0 * total_bytes_needed)/DEFAULT_BLOCK_SIZE);
 
     mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
     std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
@@ -260,6 +298,89 @@ TEST_CASE("result_convertor_single_nullable_int_multiple_block_conversion", "[du
     // Create the test gpu representation
     std::vector<cudf::type_id> col_types = {cudf::type_id::INT32};
     std::vector<bool> is_null_column = {true};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+TEST_CASE("result_convertor_single_non_nullable_string_conversion", "[duckdb_data_representation][non_null_string_conversion]") {
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    int num_test_rows = 45;
+    std::vector<cudf::type_id> col_types = {cudf::type_id::STRING};
+    std::vector<bool> is_null_column = {false};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+TEST_CASE("result_convertor_single_nullable_string_conversion", "[duckdb_data_representation][null_string_conversion]") {
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    int num_test_rows = 45;
+    std::vector<cudf::type_id> col_types = {cudf::type_id::STRING};
+    std::vector<bool> is_null_column = {true};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+TEST_CASE("result_convertor_single_nullable_string_multi_block_conversion", "[duckdb_data_representation][null_string_conversion]") {
+    // Determine the blocks needed
+    size_t num_test_rows = 250;
+    size_t total_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8) + num_test_rows * (TEST_STRING_VALUE.size() + sizeof(duckdb::string_t));
+    size_t blocks_needed = std::ceil((1.0 * total_bytes_needed)/DEFAULT_BLOCK_SIZE);
+    
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    std::vector<cudf::type_id> col_types = {cudf::type_id::STRING};
+    std::vector<bool> is_null_column = {true};
+    sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
+
+    // Perform the conversion and verify
+    sirius::unique_ptr<duckdb_table_representation> duckdb_representation = gpu_table_representation->convert_to_result_format(host_memory_space);
+    verify_representation_conversion(std::move(duckdb_representation), std::move(gpu_table_representation));
+}
+
+
+TEST_CASE("result_convertor_multi_type_conversion", "[duckdb_data_representation][multi_type_conversion]") {
+    // Determine the blocks needed
+    size_t num_test_rows = 100;
+    size_t string_col_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8) + num_test_rows * (TEST_STRING_VALUE.size() + sizeof(duckdb::string_t));
+    size_t int_col_bytes_needed = num_test_rows * sizeof(int) + std::ceil((1.0 * num_test_rows)/8);
+    size_t total_bytes_needed = 2 * string_col_bytes_needed + 2 * int_col_bytes_needed;
+    size_t blocks_needed = std::ceil((1.0 * total_bytes_needed)/DEFAULT_BLOCK_SIZE);
+
+    // Create the gpu and host memory spaces
+    mock_memory_space gpu_memory_space(memory::Tier::GPU, {});
+    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> host_allocators;
+    host_allocators.push_back(create_host_memory_resource());
+    mock_memory_space host_memory_space(memory::Tier::GPU, std::move(host_allocators));
+
+    // Create the test gpu representation
+    std::vector<cudf::type_id> col_types = {cudf::type_id::INT32,cudf::type_id::STRING,cudf::type_id::INT32,cudf::type_id::STRING};
+    std::vector<bool> is_null_column = {false, true, true, false};
     sirius::unique_ptr<gpu_table_representation> gpu_table_representation = create_gpu_representation(gpu_memory_space, col_types, is_null_column, num_test_rows);
 
     // Perform the conversion and verify


### PR DESCRIPTION
This PR introduces some of the changes needed to make to the result collector to work with new architecture: 
- Introduces a `duckdb_table_representation` to represent a table as a collection of `duckdb::DataChunk`
- Introduces a `result_table_allocation` which actually stores the raw data referenced by the `duckdb::DataChunk` spread across multiple blocks of a `fixed_size_host_memory_resource::multiple_blocks_allocation`
- Introduces a static `data_representation_converter::convert_gpu_table_to_result_format` to perform the conversion from cudf's representation to Duckdb's representation

Future work for a followup PRs:
- - Extend the Downgrade Executor to introduce a downgrade task that downgrades to the `duckdb_table_representation`. This is currently blocked on #97
- Update the task creator to create downgrade tasks for Data Batches in the query output Data Repository. This is currently blocked on #98
- Update our extension interface to pass the Data Chunks to DuckDB by reading from the Data Repository
- Extend support to other types than string/integer + support type casting