### PR TITLE
Avoid invalid CUDA launches when converting empty row-ids

### DIFF
--- a/src/cuda/cudf/cudf_utils.cu
+++ b/src/cuda/cudf/cudf_utils.cu
@@ -62,6 +62,9 @@ __global__ void convert_int32_to_uint64(int32_t* data, uint64_t* output, size_t 
 }
 
 int32_t* convertUInt64ToInt32(uint64_t* data, size_t N) {
+    if (N == 0) {
+        return nullptr;
+    }
     int tile_items = BLOCK_THREADS * ITEMS_PER_THREAD;
     GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
     int32_t* output_dev = gpuBufferManager->customCudaMalloc<int32_t>(N, 0, 0);
@@ -71,6 +74,9 @@ int32_t* convertUInt64ToInt32(uint64_t* data, size_t N) {
 }
 
 uint64_t* convertInt32ToUInt64(int32_t* data, size_t N) {
+    if (N == 0) {
+        return nullptr;
+    }
     int tile_items = BLOCK_THREADS * ITEMS_PER_THREAD;
     GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
     uint64_t* output_dev = gpuBufferManager->customCudaMalloc<uint64_t>(N, 0, 0);


### PR DESCRIPTION
### Summary

Added explicit `N == 0` guards to `convertUInt64ToInt32` and `convertInt32ToUInt64` (the helpers used when translating Sirius row-id/offset buffers to cuDF-compatible ones). When the input length is zero, the functions now immediately return `nullptr` instead of launching `<<<0, BLOCK_THREADS>>>`, which CUDA treats as an invalid configuration.
This prevents the crash encountered when GPU pipelines produce empty result sets but still run through the row-id conversion path (e.g., joins that ultimately yield zero rows). 

Closes: #114 

<img width="1099" height="887" alt="fixed" src="https://github.com/user-attachments/assets/882d5bbc-b3aa-4395-b568-eef12c1e9669" />


