### PR TITLE
Fix DECIMAL overflow in SUM aggregations

### DIFF
--- a/src/cuda/cudf/cudf_aggregate.cu
+++ b/src/cuda/cudf/cudf_aggregate.cu
@@ -126,6 +126,12 @@ void cudf_aggregate(vector<shared_ptr<GPUColumn>>& column,
         } else if (num_rows > 1) {
           to_cudf_type = cudf::data_type(cudf::type_id::INT32);
         }
+      } else if (to_cudf_type.id() == cudf::type_id::DECIMAL32) {
+        int32_t scale = to_cudf_type.scale();
+        to_cudf_type  = cudf::data_type(cudf::type_id::DECIMAL64, scale);
+      } else if (to_cudf_type.id() == cudf::type_id::DECIMAL64) {
+        int32_t scale = to_cudf_type.scale();
+        to_cudf_type  = cudf::data_type(cudf::type_id::DECIMAL128, scale);
       }
 
       // CuDF reduce will return an invalid scalar if all values are NULL


### PR DESCRIPTION
Problem:
SUM aggregations on DECIMAL32/DECIMAL64 columns could overflow, producing incorrect results. For example, summing ~$1B in sales would return -$10M due to integer overflow.

Root cause:
Unlike INT32/INT16 which had overflow protection (upgrading to larger types), DECIMAL types were not being widened before aggregation.

Solution:
- In cudf_aggregate.cu: Upgrade DECIMAL32->DECIMAL64 and DECIMAL64->DECIMAL128 for ungrouped SUM operations
- In cudf_groupby.cu: Same upgrade for grouped SUM operations

Testing:
- TPC-DS SF1 query: SUM(ss_ext_sales_price) GROUP BY d_year
- Before fix: -10,838,124.72 (wrong)
- After fix:  1,019,954,026.32 (matches CPU baseline)

Tested on:
- Tesla V100-SXM2-32GB (Compute 7.0)
- Quadro RTX 6000 (Compute 7.5)