### PR TITLE
Support all DECIMAL sizes for AVG aggregation in GROUP BY

### DIFF
--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -157,10 +157,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys, vector<shared_ptr<GPUColu
       auto aggregate = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
       requests[agg].aggregations.push_back(std::move(aggregate));
       // If aggregate input column is decimal, need to convert to double following duckdb
+      // Support all DECIMAL sizes (DECIMAL32, DECIMAL64, DECIMAL128)
       if (aggregate_keys[agg]->data_wrapper.type.id() == GPUColumnTypeId::DECIMAL) {
-        if (aggregate_keys[agg]->data_wrapper.getColumnTypeSize() != sizeof(int64_t)) {
-          throw NotImplementedException("Only support decimal64 for decimal AVG group-by");
-        }
         auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
         auto to_cudf_type = cudf::data_type(cudf::type_id::FLOAT64);
         auto to_cudf_column = cudf::cast(


### PR DESCRIPTION
Problem:
AVG() aggregation on DECIMAL columns only supported DECIMAL64, throwing 'Only support decimal64 for decimal AVG group-by' for other sizes like DECIMAL32.

Root cause:
Unnecessary size check restricted AVG to only int64_t-sized decimals, even though cudf::cast can handle all DECIMAL types.

Solution:
Remove the size restriction, allowing DECIMAL32, DECIMAL64, and DECIMAL128 columns to be cast to FLOAT64 for AVG computation.

Testing:
- TPC-DS SF1 query: AVG(ss_ext_sales_price) GROUP BY d_year
- Before fix: Falls back to CPU with error
- After fix: Runs on GPU, result matches CPU (1912.146...)

Tested on:
- Tesla V100-SXM2-32GB (Compute 7.0)