### PR TITLE
Fix sign extension in integer to int128 conversions

### DIFF
--- a/src/cuda/utils.cu
+++ b/src/cuda/utils.cu
@@ -52,15 +52,13 @@ __global__ void convert_int64_to_int128(uint8_t* input, uint8_t* output, size_t 
 {
   size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
-    // Store the converted value as 16 bytes in output
-    uint64_t* input_ptr  = reinterpret_cast<uint64_t*>(input + idx * 8);
-    uint64_t* output_ptr = reinterpret_cast<uint64_t*>(output + idx * 16);
-    // for (int i = 0; i < 8; ++i) {
-    // output[idx * 16 + i] = input[idx * 8 + i];
-    // output[idx * 16 + i + 8] = 0;
-    output_ptr[0] = input_ptr[0];
-    output_ptr[1] = 0;  // Set the upper 64 bits to zero
-    // }
+    // Store the converted value as 16 bytes in output with proper sign extension
+    int64_t* input_ptr  = reinterpret_cast<int64_t*>(input + idx * 8);
+    int64_t* output_ptr = reinterpret_cast<int64_t*>(output + idx * 16);
+    int64_t value       = input_ptr[0];
+    output_ptr[0]       = value;
+    // Sign extend: if negative, upper bits should be all 1s (-1), else all 0s
+    output_ptr[1] = (value < 0) ? -1 : 0;
   }
 }
 
@@ -68,15 +66,14 @@ __global__ void convert_int32_to_int128(uint8_t* input, uint8_t* output, size_t 
 {
   size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
-    // Store the converted value as 16 bytes in output
+    // Store the converted value as 16 bytes in output with proper sign extension
     int32_t* input_ptr  = reinterpret_cast<int32_t*>(input + idx * 4);
-    int32_t* output_ptr = reinterpret_cast<int32_t*>(output + idx * 16);
-    // for (int i = 0; i < 8; ++i) {
-    output_ptr[0] = input_ptr[0];
-    output_ptr[1] = 0;  // Set the upper 64 bits to zero
-    output_ptr[2] = 0;  // Set the upper 64 bits to zero
-    output_ptr[3] = 0;  // Set the upper 64 bits to zero
-    // }
+    int64_t* output_ptr = reinterpret_cast<int64_t*>(output + idx * 16);
+    int32_t value       = input_ptr[0];
+    // Sign extend to 64 bits first, then to 128 bits
+    int64_t extended = static_cast<int64_t>(value);
+    output_ptr[0]    = extended;
+    output_ptr[1]    = (value < 0) ? -1 : 0;
   }
 }
 
@@ -84,19 +81,14 @@ __global__ void convert_int16_to_int128(uint8_t* input, uint8_t* output, size_t 
 {
   size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
-    // Store the converted value as 16 bytes in output
+    // Store the converted value as 16 bytes in output with proper sign extension
     int16_t* input_ptr  = reinterpret_cast<int16_t*>(input + idx * 2);
-    int16_t* output_ptr = reinterpret_cast<int16_t*>(output + idx * 16);
-    // for (int i = 0; i < 8; ++i) {
-    output_ptr[0] = input_ptr[0];
-    output_ptr[1] = 0;  // Set the upper 64 bits to zero
-    output_ptr[2] = 0;  // Set the upper 64 bits to zero
-    output_ptr[3] = 0;  // Set the upper 64 bits to zero
-    output_ptr[4] = 0;  // Set the upper 64 bits to zero
-    output_ptr[5] = 0;  // Set the upper 64 bits to zero
-    output_ptr[6] = 0;  // Set the upper 64 bits to zero
-    output_ptr[7] = 0;  // Set the upper 64 bits to zero
-    // }
+    int64_t* output_ptr = reinterpret_cast<int64_t*>(output + idx * 16);
+    int16_t value       = input_ptr[0];
+    // Sign extend to 64 bits first, then to 128 bits
+    int64_t extended = static_cast<int64_t>(value);
+    output_ptr[0]    = extended;
+    output_ptr[1]    = (value < 0) ? -1 : 0;
   }
 }
 

--- a/src/gpu_columns.cpp
+++ b/src/gpu_columns.cpp
@@ -470,7 +470,7 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
   SIRIUS_LOG_DEBUG("Set a GPUColumn from cudf::scalar");
   cudf::data_type scalar_type = cudf_scalar.type();
   if (scalar_type == cudf::data_type(cudf::type_id::INT64)) {
-    auto& typed_scalar = static_cast<cudf::numeric_scalar<uint64_t>&>(cudf_scalar);
+    auto& typed_scalar = static_cast<cudf::numeric_scalar<int64_t>&>(cudf_scalar);
     data_wrapper.data  = gpuBufferManager->customCudaMalloc<uint8_t>(sizeof(uint64_t), 0, 0);
     callCudaMemcpyDeviceToDevice<uint8_t>(
       data_wrapper.data, reinterpret_cast<uint8_t*>(typed_scalar.data()), sizeof(uint64_t), 0);


### PR DESCRIPTION
## Problem
Converting INT64/INT32/INT16 to INT128 corrupted negative values. For example:
- Input: `-155262`
- GPU output: `18446744073709396354` (which is 2^64 - 155262)

## Root Cause
The `convert_intXX_to_int128` CUDA kernels always set upper 64 bits to zero:
```cpp
output_ptr[1] = 0;  // Wrong for negative numbers!
```

For proper two's complement sign extension:
- Negative values need upper bits = `0xFFFFFFFFFFFFFFFF` (all 1s)
- Positive values need upper bits = `0x0000000000000000` (all 0s)

## Solution
Fixed all three conversion kernels to properly sign-extend:
```cpp
output_ptr[1] = (value < 0) ? -1 : 0;
```

Also fixed `gpu_columns.cpp` to use `int64_t` instead of `uint64_t` for INT64 scalar casting.

## Testing
```sql
SELECT SUM(ss_quantity - 100) FROM store_sales WHERE ss_sold_date_sk = 2452260;
```
| | Before | After | CPU |
|--|--------|-------|-----|
| Result | 18446744073709396354 ❌ | -155262 ✅ | -155262 |

Positive values regression test passed.

Tested on Tesla V100-SXM2-32GB