### PR TITLE
Enable string scalar materialization for GPU aggregates

### DIFF
--- a/src/cuda/operator/materialize.cu
+++ b/src/cuda/operator/materialize.cu
@@ -501,7 +501,13 @@ __global__ void create_cpu_strings(duckdb_string_type* gpu_strings,
     if (str_length <= inline_threshold) {
       curr_string.value.inlined.length = str_length;
       char* gpu_data_ptr               = gpu_chars + str_offset;
-      memcpy(curr_string.value.inlined.inlined, gpu_data_ptr, str_length);
+      // memcpy(curr_string.value.inlined.inlined, gpu_data_ptr, str_length);
+            // copy byte by byte to avoid unaligned access
+            #pragma unroll
+            for (size_t i = 0; i < str_length; i++) {
+                curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
+            }
+
     } else {
       curr_string.value.pointer.length = str_length;
       curr_string.value.pointer.ptr    = cpu_chars_buffer + str_offset;

--- a/src/cuda/operator/materialize.cu
+++ b/src/cuda/operator/materialize.cu
@@ -501,12 +501,10 @@ __global__ void create_cpu_strings(duckdb_string_type* gpu_strings,
     if (str_length <= inline_threshold) {
       curr_string.value.inlined.length = str_length;
       char* gpu_data_ptr               = gpu_chars + str_offset;
-      // memcpy(curr_string.value.inlined.inlined, gpu_data_ptr, str_length);
-            // copy byte by byte to avoid unaligned access
-            #pragma unroll 1
-            for (size_t i = 0; i < str_length; i++) {
-                curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
-            }
+      // copy byte by byte to avoid unaligned access
+      for (size_t i = 0; i < str_length; i++) {
+          curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
+      }
 
     } else {
       curr_string.value.pointer.length = str_length;

--- a/src/cuda/operator/materialize.cu
+++ b/src/cuda/operator/materialize.cu
@@ -503,7 +503,7 @@ __global__ void create_cpu_strings(duckdb_string_type* gpu_strings,
       char* gpu_data_ptr               = gpu_chars + str_offset;
       // copy byte by byte to avoid unaligned access
       for (size_t i = 0; i < str_length; i++) {
-          curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
+        curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
       }
 
     } else {

--- a/src/cuda/operator/materialize.cu
+++ b/src/cuda/operator/materialize.cu
@@ -503,7 +503,7 @@ __global__ void create_cpu_strings(duckdb_string_type* gpu_strings,
       char* gpu_data_ptr               = gpu_chars + str_offset;
       // memcpy(curr_string.value.inlined.inlined, gpu_data_ptr, str_length);
             // copy byte by byte to avoid unaligned access
-            #pragma unroll
+            #pragma unroll 1
             for (size_t i = 0; i < str_length; i++) {
                 curr_string.value.inlined.inlined[i] = gpu_data_ptr[i];
             }

--- a/src/gpu_columns.cpp
+++ b/src/gpu_columns.cpp
@@ -538,8 +538,12 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
     } else if (scalar_type.id() == cudf::type_id::STRING ){
         auto& typed_scalar = static_cast<cudf::string_scalar&>(cudf_scalar); 
         size_t string_size = typed_scalar.size();
-        data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(string_size, 0, 0);
-        callCudaMemcpyDeviceToDevice<uint8_t>(data_wrapper.data, const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(typed_scalar.data())), string_size, 0);
+        if (string_size > 0) {
+            data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(string_size, 0, 0);
+            callCudaMemcpyDeviceToDevice<uint8_t>(data_wrapper.data, const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(typed_scalar.data())), string_size, 0);
+        } else {
+            data_wrapper.data = nullptr;
+        }
         data_wrapper.type = GPUColumnType(GPUColumnTypeId::VARCHAR);
         data_wrapper.num_bytes = string_size;
         data_wrapper.offset = gpuBufferManager->customCudaMalloc<uint64_t>(2, 0, 0);

--- a/src/gpu_columns.cpp
+++ b/src/gpu_columns.cpp
@@ -535,21 +535,25 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
       data_wrapper.data, reinterpret_cast<uint8_t*>(typed_scalar.data()), sizeof(int32_t), 0);
     data_wrapper.type      = GPUColumnType(GPUColumnTypeId::DATE);
     data_wrapper.num_bytes = sizeof(int32_t);
-    } else if (scalar_type.id() == cudf::type_id::STRING ){
-        auto& typed_scalar = static_cast<cudf::string_scalar&>(cudf_scalar); 
-        size_t string_size = typed_scalar.size();
-        if (string_size > 0) {
-            data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(string_size, 0, 0);
-            callCudaMemcpyDeviceToDevice<uint8_t>(data_wrapper.data, const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(typed_scalar.data())), string_size, 0);
-        } else {
-            data_wrapper.data = nullptr;
-        }
-        data_wrapper.type = GPUColumnType(GPUColumnTypeId::VARCHAR);
-        data_wrapper.num_bytes = string_size;
-        data_wrapper.offset = gpuBufferManager->customCudaMalloc<uint64_t>(2, 0, 0);
-        uint64_t offsets[] = {0, string_size};
-        callCudaMemcpyHostToDevice<uint64_t>(data_wrapper.offset, offsets, 2, 0);
-        data_wrapper.is_string_data = true;
+  } else if (scalar_type.id() == cudf::type_id::STRING) {
+    auto& typed_scalar = static_cast<cudf::string_scalar&>(cudf_scalar);
+    size_t string_size = typed_scalar.size();
+    if (string_size > 0) {
+      data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(string_size, 0, 0);
+      callCudaMemcpyDeviceToDevice<uint8_t>(
+        data_wrapper.data,
+        const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(typed_scalar.data())),
+        string_size,
+        0);
+    } else {
+      data_wrapper.data = nullptr;
+    }
+    data_wrapper.type      = GPUColumnType(GPUColumnTypeId::VARCHAR);
+    data_wrapper.num_bytes = string_size;
+    data_wrapper.offset    = gpuBufferManager->customCudaMalloc<uint64_t>(2, 0, 0);
+    uint64_t offsets[]     = {0, string_size};
+    callCudaMemcpyHostToDevice<uint64_t>(data_wrapper.offset, offsets, 2, 0);
+    data_wrapper.is_string_data = true;
   } else {
     throw NotImplementedException("Unsupported cudf data type in `setFromCudfScalar`: %d",
                                   static_cast<int>(scalar_type.id()));
@@ -563,14 +567,14 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
   } else {
     data_wrapper.validity_mask = createNullMask(1, cudf::mask_state::ALL_NULL);
   }
-  data_wrapper.mask_bytes     = getMaskBytesSize(data_wrapper.size);
-  column_length               = 1;
-    if (scalar_type.id() != cudf::type_id::STRING) {
-      data_wrapper.offset         = nullptr;
-      data_wrapper.is_string_data = false;
-    }
-  row_ids                     = nullptr;
-  row_id_count                = 0;
+  data_wrapper.mask_bytes = getMaskBytesSize(data_wrapper.size);
+  column_length           = 1;
+  if (scalar_type.id() != cudf::type_id::STRING) {
+    data_wrapper.offset         = nullptr;
+    data_wrapper.is_string_data = false;
+  }
+  row_ids      = nullptr;
+  row_id_count = 0;
 }
 
 int32_t* GPUColumn::convertSiriusOffsetToCudfOffset()

--- a/src/gpu_columns.cpp
+++ b/src/gpu_columns.cpp
@@ -535,6 +535,17 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
       data_wrapper.data, reinterpret_cast<uint8_t*>(typed_scalar.data()), sizeof(int32_t), 0);
     data_wrapper.type      = GPUColumnType(GPUColumnTypeId::DATE);
     data_wrapper.num_bytes = sizeof(int32_t);
+    } else if (scalar_type.id() == cudf::type_id::STRING ){
+        auto& typed_scalar = static_cast<cudf::string_scalar&>(cudf_scalar); 
+        size_t string_size = typed_scalar.size();
+        data_wrapper.data = gpuBufferManager->customCudaMalloc<uint8_t>(string_size, 0, 0);
+        callCudaMemcpyDeviceToDevice<uint8_t>(data_wrapper.data, const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(typed_scalar.data())), string_size, 0);
+        data_wrapper.type = GPUColumnType(GPUColumnTypeId::VARCHAR);
+        data_wrapper.num_bytes = string_size;
+        data_wrapper.offset = gpuBufferManager->customCudaMalloc<uint64_t>(2, 0, 0);
+        uint64_t offsets[] = {0, string_size};
+        callCudaMemcpyHostToDevice<uint64_t>(data_wrapper.offset, offsets, 2, 0);
+        data_wrapper.is_string_data = true;
   } else {
     throw NotImplementedException("Unsupported cudf data type in `setFromCudfScalar`: %d",
                                   static_cast<int>(scalar_type.id()));
@@ -550,8 +561,10 @@ void GPUColumn::setFromCudfScalar(cudf::scalar& cudf_scalar, GPUBufferManager* g
   }
   data_wrapper.mask_bytes     = getMaskBytesSize(data_wrapper.size);
   column_length               = 1;
-  data_wrapper.offset         = nullptr;
-  data_wrapper.is_string_data = false;
+    if (scalar_type.id() != cudf::type_id::STRING) {
+      data_wrapper.offset         = nullptr;
+      data_wrapper.is_string_data = false;
+    }
   row_ids                     = nullptr;
   row_id_count                = 0;
 }

--- a/src/operator/gpu_physical_ungrouped_aggregate.cpp
+++ b/src/operator/gpu_physical_ungrouped_aggregate.cpp
@@ -70,13 +70,16 @@ void HandleAggregateExpressionCuDF(vector<shared_ptr<GPUColumn>>& aggregate_keys
             aggregate_keys[agg_idx]->data_wrapper.num_bytes * 2;
         }
       } else if (expr.function.name.compare("avg") == 0 &&
-                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr ||
+                  aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::AVERAGE;
       } else if (expr.function.name.compare("max") == 0 &&
-                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr ||
+                  aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::MAX;
       } else if (expr.function.name.compare("min") == 0 &&
-                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr ||
+                  aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::MIN;
       } else if (expr.function.name.compare("count_star") == 0 &&
                  aggregate_keys[agg_idx]->data_wrapper.data == nullptr) {

--- a/src/operator/gpu_physical_ungrouped_aggregate.cpp
+++ b/src/operator/gpu_physical_ungrouped_aggregate.cpp
@@ -70,13 +70,13 @@ void HandleAggregateExpressionCuDF(vector<shared_ptr<GPUColumn>>& aggregate_keys
             aggregate_keys[agg_idx]->data_wrapper.num_bytes * 2;
         }
       } else if (expr.function.name.compare("avg") == 0 &&
-                 aggregate_keys[agg_idx]->data_wrapper.data != nullptr) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::AVERAGE;
       } else if (expr.function.name.compare("max") == 0 &&
-                 aggregate_keys[agg_idx]->data_wrapper.data != nullptr) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::MAX;
       } else if (expr.function.name.compare("min") == 0 &&
-                 aggregate_keys[agg_idx]->data_wrapper.data != nullptr) {
+                 (aggregate_keys[agg_idx]->data_wrapper.data != nullptr || aggregate_keys[agg_idx]->column_length == 0)) {
         agg_mode[agg_idx] = AggregationType::MIN;
       } else if (expr.function.name.compare("count_star") == 0 &&
                  aggregate_keys[agg_idx]->data_wrapper.data == nullptr) {


### PR DESCRIPTION
This pull request includes adding support for string scalars in GPU columns. This support for string aggregation is already provided by cuDF but was not being utilized.

* Added support for handling `STRING` type scalars in `GPUColumn::setFromCudfScalar`, including allocation and copying of string data and offsets, and setting string-specific metadata.
* Replaced `memcpy` with a byte-by-byte copy for inlined strings in the CUDA materialization kernel to avoid unaligned memory access issues on the GPU.
* Modified aggregation checks in `HandleAggregateExpressionCuDF` to allow `avg`, `min`, and `max` to run on empty inputs instead of being rejected, returning 0 rows downstream.

This PR was tested on the entire JOB benchmark which was not proceeding earlier due to unsupported string aggregation. Results were also compared with DuckDB. `make test` was also verified.

Previously:

<img width="506" height="438" alt="image" src="https://github.com/user-attachments/assets/18fd5fea-e49c-4ffe-8964-32863e5b6db3" />

Now:
<img width="2700" height="4200" alt="job_sirius_vs_duckdb_run5" src="https://github.com/user-attachments/assets/4f1d753f-fcf7-4c15-9103-27bdbbb90d6e" />
