### PR TITLE
Refactor/cucascade namespace

### DIFF
--- a/src/creator/downgrade_task_creator.cpp
+++ b/src/creator/downgrade_task_creator.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "downgrade/downgrade_task_creator.hpp"
+#include "creator/downgrade_task_creator.hpp"
 
 namespace sirius {
 

--- a/src/creator/downgrade_task_creator.cpp
+++ b/src/creator/downgrade_task_creator.cpp
@@ -18,7 +18,7 @@
 
 namespace sirius {
 
-void downgrade_task_creator::schedule(sirius::unique_ptr<parallel::downgrade_task> downgrade_task)
+void downgrade_task_creator::schedule(std::unique_ptr<parallel::downgrade_task> downgrade_task)
 {
   // Downgrade-specific scheduling logic
   // Schedule the downgrade task using the downgrade_task_queue

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -23,8 +23,8 @@ void itask_creator::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  _thread = sirius::make_unique<parallel::task_executor_thread>(
-    sirius::make_unique<sirius::thread>(&itask_creator::worker_loop, this));
+  _thread = std::make_unique<parallel::task_executor_thread>(
+    std::make_unique<std::thread>(&itask_creator::worker_loop, this));
 }
 
 void itask_creator::stop()

--- a/src/data/cpu_data_representation.cpp
+++ b/src/data/cpu_data_representation.cpp
@@ -29,7 +29,7 @@
 namespace cucascade {
 
 host_table_representation::host_table_representation(
-  sirius::unique_ptr<cucascade::memory::host_table_allocation> host_table,
+  std::unique_ptr<cucascade::memory::host_table_allocation> host_table,
   cucascade::memory::memory_space* memory_space)
   : idata_representation(*memory_space), _host_table(std::move(host_table))
 {
@@ -37,13 +37,13 @@ host_table_representation::host_table_representation(
 
 std::size_t host_table_representation::get_size_in_bytes() const { return _host_table->data_size; }
 
-const sirius::unique_ptr<cucascade::memory::host_table_allocation>&
+const std::unique_ptr<cucascade::memory::host_table_allocation>&
 host_table_representation::get_host_table() const
 {
   return _host_table;
 }
 
-sirius::unique_ptr<idata_representation> host_table_representation::convert_to_memory_space(
+std::unique_ptr<idata_representation> host_table_representation::convert_to_memory_space(
   const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
 {
   auto const data_size = _host_table->data_size;
@@ -77,15 +77,15 @@ sirius::unique_ptr<idata_representation> host_table_representation::convert_to_m
       }
     }
 
-    auto new_metadata = sirius::make_unique<sirius::vector<uint8_t>>(*_host_table->metadata);
-    auto new_gpu_data = sirius::make_unique<rmm::device_buffer>(std::move(dst_buffer));
+    auto new_metadata = std::make_unique<std::vector<uint8_t>>(*_host_table->metadata);
+    auto new_gpu_data = std::make_unique<rmm::device_buffer>(std::move(dst_buffer));
     auto new_table_view =
       cudf::unpack(new_metadata->data(), static_cast<uint8_t const*>(new_gpu_data->data()));
     auto new_table = cudf::table(new_table_view, stream, mr);
     stream.synchronize();
 
     cudaSetDevice(previous_device);
-    return sirius::make_unique<gpu_table_representation>(
+    return std::make_unique<gpu_table_representation>(
       std::move(new_table), *const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::HOST) {
     assert(this->get_device_id() != target_memory_space->get_device_id());
@@ -123,10 +123,10 @@ sirius::unique_ptr<idata_representation> host_table_representation::convert_to_m
         dst_block_offset = 0;
       }
     }
-    auto metadata_copy = sirius::make_unique<sirius::vector<uint8_t>>(*_host_table->metadata);
-    auto host_table_allocation = sirius::make_unique<cucascade::memory::host_table_allocation>(
+    auto metadata_copy = std::make_unique<std::vector<uint8_t>>(*_host_table->metadata);
+    auto host_table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
       std::move(dst_allocation), std::move(metadata_copy), data_size);
-    return sirius::make_unique<host_table_representation>(
+    return std::make_unique<host_table_representation>(
       std::move(host_table_allocation),
       const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::DISK) {

--- a/src/data/cpu_data_representation.cpp
+++ b/src/data/cpu_data_representation.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<idata_representation> host_table_representation::convert_to_memo
         dst_block_offset = 0;
       }
     }
-    auto metadata_copy = std::make_unique<std::vector<uint8_t>>(*_host_table->metadata);
+    auto metadata_copy         = std::make_unique<std::vector<uint8_t>>(*_host_table->metadata);
     auto host_table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
       std::move(dst_allocation), std::move(metadata_copy), data_size);
     return std::make_unique<host_table_representation>(

--- a/src/data/cpu_data_representation.cpp
+++ b/src/data/cpu_data_representation.cpp
@@ -26,25 +26,25 @@
 #include <algorithm>
 #include <cstring>
 
-namespace sirius {
+namespace cucascade {
 
 host_table_representation::host_table_representation(
-  sirius::unique_ptr<sirius::memory::host_table_allocation> host_table,
-  sirius::memory::memory_space* memory_space)
+  sirius::unique_ptr<cucascade::memory::host_table_allocation> host_table,
+  cucascade::memory::memory_space* memory_space)
   : idata_representation(*memory_space), _host_table(std::move(host_table))
 {
 }
 
 std::size_t host_table_representation::get_size_in_bytes() const { return _host_table->data_size; }
 
-const sirius::unique_ptr<sirius::memory::host_table_allocation>&
+const sirius::unique_ptr<cucascade::memory::host_table_allocation>&
 host_table_representation::get_host_table() const
 {
   return _host_table;
 }
 
 sirius::unique_ptr<idata_representation> host_table_representation::convert_to_memory_space(
-  const sirius::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
+  const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
 {
   auto const data_size = _host_table->data_size;
 
@@ -86,11 +86,11 @@ sirius::unique_ptr<idata_representation> host_table_representation::convert_to_m
 
     cudaSetDevice(previous_device);
     return sirius::make_unique<gpu_table_representation>(
-      std::move(new_table), *const_cast<sirius::memory::memory_space*>(target_memory_space));
+      std::move(new_table), *const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::HOST) {
     assert(this->get_device_id() != target_memory_space->get_device_id());
     auto mr = target_memory_space
-                ->get_memory_resource_as<sirius::memory::fixed_size_host_memory_resource>();
+                ->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
     if (mr == nullptr) {
       throw std::runtime_error(
         "Target HOST memory_space does not have a fixed_size_host_memory_resource");
@@ -124,11 +124,11 @@ sirius::unique_ptr<idata_representation> host_table_representation::convert_to_m
       }
     }
     auto metadata_copy = sirius::make_unique<sirius::vector<uint8_t>>(*_host_table->metadata);
-    auto host_table_allocation = sirius::make_unique<sirius::memory::host_table_allocation>(
+    auto host_table_allocation = sirius::make_unique<cucascade::memory::host_table_allocation>(
       std::move(dst_allocation), std::move(metadata_copy), data_size);
     return sirius::make_unique<host_table_representation>(
       std::move(host_table_allocation),
-      const_cast<sirius::memory::memory_space*>(target_memory_space));
+      const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::DISK) {
     throw std::runtime_error(
       "Conversion to DISK tier not implemented for host_table_representation");
@@ -138,4 +138,4 @@ sirius::unique_ptr<idata_representation> host_table_representation::convert_to_m
   }
 }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -20,12 +20,12 @@
 #include "data/gpu_data_representation.hpp"
 #include "memory/memory_reservation_manager.hpp"
 
-namespace sirius {
+namespace cucascade {
 
 data_batch::data_batch(uint64_t batch_id,
                        data_repository_manager& data_repo_mgr,
                        sirius::unique_ptr<idata_representation> data,
-                       sirius::memory::memory_space& memory_space)
+                       cucascade::memory::memory_space& memory_space)
   : _batch_id(batch_id),
     _data(std::move(data)),
     _data_repo_mgr(&data_repo_mgr),
@@ -152,13 +152,13 @@ size_t data_batch::get_pin_count() const
 
 data_repository_manager* data_batch::get_data_repository_manager() const { return _data_repo_mgr; }
 
-sirius::memory::memory_space* data_batch::get_memory_space() const
+cucascade::memory::memory_space* data_batch::get_memory_space() const
 {
   if (_memory_space != nullptr) { return _memory_space; }
   if (_data == nullptr) { return nullptr; }
-  auto& manager = sirius::memory::memory_reservation_manager::get_instance();
+  auto& manager = cucascade::memory::memory_reservation_manager::get_instance();
   auto* space   = manager.get_memory_space(_data->get_current_tier(), _data->get_device_id());
-  return const_cast<sirius::memory::memory_space*>(space);
+  return const_cast<cucascade::memory::memory_space*>(space);
 }
 
 void data_batch::set_data(sirius::unique_ptr<idata_representation> data)
@@ -171,15 +171,15 @@ void data_batch::set_data(sirius::unique_ptr<idata_representation> data)
   }
   _data = std::move(data);
   if (_data) {
-    auto& manager = sirius::memory::memory_reservation_manager::get_instance();
+    auto& manager = cucascade::memory::memory_reservation_manager::get_instance();
     auto* space   = manager.get_memory_space(_data->get_current_tier(), _data->get_device_id());
-    _memory_space = const_cast<sirius::memory::memory_space*>(space);
+    _memory_space = const_cast<cucascade::memory::memory_space*>(space);
   } else {
     _memory_space = nullptr;
   }
 }
 
-void data_batch::convert_to_memory_space(const sirius::memory::memory_space* target_memory_space,
+void data_batch::convert_to_memory_space(const cucascade::memory::memory_space* target_memory_space,
                                          rmm::cuda_stream_view stream)
 {
   std::lock_guard<sirius::mutex> lock(_mutex);
@@ -189,7 +189,7 @@ void data_batch::convert_to_memory_space(const sirius::memory::memory_space* tar
   }
   auto new_representation = _data->convert_to_memory_space(target_memory_space, stream);
   _data                   = std::move(new_representation);
-  _memory_space           = const_cast<sirius::memory::memory_space*>(target_memory_space);
+  _memory_space           = const_cast<cucascade::memory::memory_space*>(target_memory_space);
 }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -24,7 +24,7 @@ namespace cucascade {
 
 data_batch::data_batch(uint64_t batch_id,
                        data_repository_manager& data_repo_mgr,
-                       sirius::unique_ptr<idata_representation> data,
+                       std::unique_ptr<idata_representation> data,
                        cucascade::memory::memory_space& memory_space)
   : _batch_id(batch_id),
     _data(std::move(data)),
@@ -35,7 +35,7 @@ data_batch::data_batch(uint64_t batch_id,
 
 data_batch::data_batch(uint64_t batch_id,
                        data_repository_manager& data_repo_mgr,
-                       sirius::unique_ptr<idata_representation> data)
+                       std::unique_ptr<idata_representation> data)
   : _batch_id(batch_id),
     _data(std::move(data)),
     _data_repo_mgr(&data_repo_mgr),
@@ -49,7 +49,7 @@ data_batch::data_batch(data_batch&& other)
     _data_repo_mgr(other._data_repo_mgr),
     _memory_space(other._memory_space)
 {
-  std::lock_guard<sirius::mutex> lock(other._mutex);
+  std::lock_guard<std::mutex> lock(other._mutex);
   size_t other_view_count = other._view_count;
   size_t other_pin_count  = other._pin_count;
   if (other_view_count != 0) {
@@ -66,7 +66,7 @@ data_batch::data_batch(data_batch&& other)
 data_batch& data_batch::operator=(data_batch&& other)
 {
   if (this != &other) {
-    std::lock_guard<sirius::mutex> lock(other._mutex);
+    std::lock_guard<std::mutex> lock(other._mutex);
     size_t other_view_count = other._view_count;
     size_t other_pin_count  = other._pin_count;
     if (other_view_count != 0) {
@@ -96,13 +96,13 @@ uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
 void data_batch::increment_view_ref_count()
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   _view_count += 1;
 }
 
 size_t data_batch::decrement_view_ref_count()
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   size_t old_count = _view_count;
   _view_count -= 1;
   return old_count;
@@ -110,7 +110,7 @@ size_t data_batch::decrement_view_ref_count()
 
 void data_batch::decrement_pin_ref_count()
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   const auto tier =
     (_memory_space != nullptr) ? _memory_space->get_tier() : _data->get_current_tier();
   if (tier != memory::Tier::GPU) {
@@ -121,7 +121,7 @@ void data_batch::decrement_pin_ref_count()
 
 void data_batch::increment_pin_ref_count()
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   const auto tier =
     (_memory_space != nullptr) ? _memory_space->get_tier() : _data->get_current_tier();
   if (tier != memory::Tier::GPU) {
@@ -133,20 +133,20 @@ void data_batch::increment_pin_ref_count()
 
 idata_representation* data_batch::get_data() const { return _data.get(); }
 
-sirius::unique_ptr<data_batch_view> data_batch::create_view()
+std::unique_ptr<data_batch_view> data_batch::create_view()
 {
-  return sirius::make_unique<data_batch_view>(this);
+  return std::make_unique<data_batch_view>(this);
 }
 
 size_t data_batch::get_view_count() const
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   return _view_count;
 }
 
 size_t data_batch::get_pin_count() const
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   return _pin_count;
 }
 
@@ -161,9 +161,9 @@ cucascade::memory::memory_space* data_batch::get_memory_space() const
   return const_cast<cucascade::memory::memory_space*>(space);
 }
 
-void data_batch::set_data(sirius::unique_ptr<idata_representation> data)
+void data_batch::set_data(std::unique_ptr<idata_representation> data)
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   size_t views = _view_count;
   size_t pins  = _pin_count;
   if (views != 0 || pins != 0) {
@@ -182,7 +182,7 @@ void data_batch::set_data(sirius::unique_ptr<idata_representation> data)
 void data_batch::convert_to_memory_space(const cucascade::memory::memory_space* target_memory_space,
                                          rmm::cuda_stream_view stream)
 {
-  std::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
 
   if (_pin_count != 0) {
     throw std::runtime_error("Cannot convert memory space while there are active pins");

--- a/src/data/data_batch_view.cpp
+++ b/src/data/data_batch_view.cpp
@@ -19,7 +19,7 @@
 #include "data/data_repository_manager.hpp"
 #include "data/gpu_data_representation.hpp"
 
-namespace sirius {
+namespace cucascade {
 
 data_batch_view::data_batch_view(data_batch* batch) : _batch(batch)
 {
@@ -79,4 +79,4 @@ data_batch_view::~data_batch_view()
   }
 }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/data_repository.cpp
+++ b/src/data/data_repository.cpp
@@ -18,7 +18,7 @@
 
 #include "data/data_batch_view.hpp"
 
-namespace sirius {
+namespace cucascade {
 
 void idata_repository::add_new_data_batch_view(sirius::unique_ptr<data_batch_view> batch_view)
 {
@@ -35,4 +35,4 @@ sirius::unique_ptr<data_batch_view> idata_repository::pull_data_batch_view()
   return batch;
 }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/data_repository.cpp
+++ b/src/data/data_repository.cpp
@@ -20,13 +20,13 @@
 
 namespace cucascade {
 
-void idata_repository::add_new_data_batch_view(sirius::unique_ptr<data_batch_view> batch_view)
+void idata_repository::add_new_data_batch_view(std::unique_ptr<data_batch_view> batch_view)
 {
   std::lock_guard<std::mutex> lock(_mutex);
   _data_batches.push_back(std::move(batch_view));
 }
 
-sirius::unique_ptr<data_batch_view> idata_repository::pull_data_batch_view()
+std::unique_ptr<data_batch_view> idata_repository::pull_data_batch_view()
 {
   std::lock_guard<std::mutex> lock(_mutex);
   if (_data_batches.empty()) { return nullptr; }

--- a/src/data/data_repository_manager.cpp
+++ b/src/data/data_repository_manager.cpp
@@ -56,7 +56,7 @@ void data_repository_manager::delete_data_batch(size_t batch_id)
 }
 
 std::unique_ptr<idata_repository>& data_repository_manager::get_repository(size_t operator_id,
-                                                                          std::string_view port_id)
+                                                                           std::string_view port_id)
 {
   return _repositories.at({operator_id, std::string(port_id)});
 }

--- a/src/data/data_repository_manager.cpp
+++ b/src/data/data_repository_manager.cpp
@@ -21,7 +21,7 @@
 
 namespace cucascade {
 
-void data_repository_manager::add_new_repository(::duckdb::GPUPhysicalOperator* op,
+void data_repository_manager::add_new_repository(size_t operator_id,
                                                  std::string_view port_id,
                                                  std::unique_ptr<idata_repository> repository)
 {
@@ -29,17 +29,16 @@ void data_repository_manager::add_new_repository(::duckdb::GPUPhysicalOperator* 
   {
     std::lock_guard<std::mutex> lock(_mutex);
     // Move out the old repository before replacing to avoid holding the lock during destruction
-    auto it = _repositories.find({op, std::string(port_id)});
+    auto it = _repositories.find({operator_id, std::string(port_id)});
     if (it != _repositories.end()) { old_repository = std::move(it->second); }
-    _repositories[{op, std::string(port_id)}] = std::move(repository);
+    _repositories[{operator_id, std::string(port_id)}] = std::move(repository);
   }
   // old_repository is destroyed here, outside the locked section
   // This prevents deadlock when data_batch_view destructors call delete_data_batch()
 }
 
 void data_repository_manager::add_new_data_batch(
-  std::unique_ptr<data_batch> batch,
-  std::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops)
+  std::unique_ptr<data_batch> batch, std::vector<std::pair<size_t, std::string_view>> ops)
 {
   for (auto op : ops) {
     auto batch_view = batch->create_view();
@@ -56,10 +55,10 @@ void data_repository_manager::delete_data_batch(size_t batch_id)
   _data_batches.erase(batch_id);
 }
 
-std::unique_ptr<idata_repository>& data_repository_manager::get_repository(
-  ::duckdb::GPUPhysicalOperator* op, std::string_view port_id)
+std::unique_ptr<idata_repository>& data_repository_manager::get_repository(size_t operator_id,
+                                                                          std::string_view port_id)
 {
-  return _repositories.at({op, std::string(port_id)});
+  return _repositories.at({operator_id, std::string(port_id)});
 }
 
 std::vector<std::unique_ptr<data_batch>> data_repository_manager::get_data_batches_for_downgrade(

--- a/src/data/data_repository_manager.cpp
+++ b/src/data/data_repository_manager.cpp
@@ -23,11 +23,11 @@ namespace cucascade {
 
 void data_repository_manager::add_new_repository(::duckdb::GPUPhysicalOperator* op,
                                                  std::string_view port_id,
-                                                 sirius::unique_ptr<idata_repository> repository)
+                                                 std::unique_ptr<idata_repository> repository)
 {
-  sirius::unique_ptr<idata_repository> old_repository;
+  std::unique_ptr<idata_repository> old_repository;
   {
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     // Move out the old repository before replacing to avoid holding the lock during destruction
     auto it = _repositories.find({op, std::string(port_id)});
     if (it != _repositories.end()) { old_repository = std::move(it->second); }
@@ -38,25 +38,25 @@ void data_repository_manager::add_new_repository(::duckdb::GPUPhysicalOperator* 
 }
 
 void data_repository_manager::add_new_data_batch(
-  sirius::unique_ptr<data_batch> batch,
-  sirius::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops)
+  std::unique_ptr<data_batch> batch,
+  std::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops)
 {
   for (auto op : ops) {
     auto batch_view = batch->create_view();
     _repositories[{op.first, std::string(op.second)}]->add_new_data_batch_view(
       std::move(batch_view));
   }
-  sirius::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   _data_batches.insert({batch->get_batch_id(), std::move(batch)});
 }
 
 void data_repository_manager::delete_data_batch(size_t batch_id)
 {
-  sirius::lock_guard<sirius::mutex> lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   _data_batches.erase(batch_id);
 }
 
-sirius::unique_ptr<idata_repository>& data_repository_manager::get_repository(
+std::unique_ptr<idata_repository>& data_repository_manager::get_repository(
   ::duckdb::GPUPhysicalOperator* op, std::string_view port_id)
 {
   return _repositories.at({op, std::string(port_id)});

--- a/src/data/data_repository_manager.cpp
+++ b/src/data/data_repository_manager.cpp
@@ -19,7 +19,7 @@
 #include "data/data_batch.hpp"
 #include "data/data_batch_view.hpp"
 
-namespace sirius {
+namespace cucascade {
 
 void data_repository_manager::add_new_repository(::duckdb::GPUPhysicalOperator* op,
                                                  std::string_view port_id,
@@ -63,7 +63,7 @@ sirius::unique_ptr<idata_repository>& data_repository_manager::get_repository(
 }
 
 std::vector<std::unique_ptr<data_batch>> data_repository_manager::get_data_batches_for_downgrade(
-  sirius::memory::memory_space_id memory_space_id, size_t amount_to_downgrade)
+  cucascade::memory::memory_space_id memory_space_id, size_t amount_to_downgrade)
 {
   std::vector<std::unique_ptr<data_batch>> data_batches;
   size_t downgrade_amount = 0;
@@ -79,4 +79,4 @@ std::vector<std::unique_ptr<data_batch>> data_repository_manager::get_data_batch
 
 uint64_t data_repository_manager::get_next_data_batch_id() { return _next_data_batch_id++; }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -27,10 +27,10 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda_runtime_api.h>
-namespace sirius {
+namespace cucascade {
 
 gpu_table_representation::gpu_table_representation(cudf::table table,
-                                                   sirius::memory::memory_space& memory_space)
+                                                   cucascade::memory::memory_space& memory_space)
   : idata_representation(memory_space), _table(std::move(table))
 {
 }
@@ -51,7 +51,7 @@ std::size_t gpu_table_representation::get_size_in_bytes() const
 const cudf::table& gpu_table_representation::get_table() const { return _table; }
 
 sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_memory_space(
-  const sirius::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
+  const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
 {
   auto packed_data = cudf::pack(_table, stream);
   if (target_memory_space->get_tier() == memory::Tier::GPU) {
@@ -92,10 +92,10 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
     cudaSetDevice(source_device_id);
 
     return sirius::make_unique<gpu_table_representation>(
-      std::move(new_table), *const_cast<sirius::memory::memory_space*>(target_memory_space));
+      std::move(new_table), *const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::HOST) {
     auto mr = target_memory_space
-                ->get_memory_resource_as<sirius::memory::fixed_size_host_memory_resource>();
+                ->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
     auto allocation = mr->allocate_multiple_blocks(packed_data.gpu_data->size());
 
     size_t block_index      = 0;
@@ -119,11 +119,11 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
       }
     }
     stream.synchronize();
-    auto host_table_allocation = sirius::make_unique<sirius::memory::host_table_allocation>(
+    auto host_table_allocation = sirius::make_unique<cucascade::memory::host_table_allocation>(
       std::move(allocation), std::move(packed_data.metadata), packed_data.gpu_data->size());
     return sirius::make_unique<host_table_representation>(
       std::move(host_table_allocation),
-      const_cast<sirius::memory::memory_space*>(target_memory_space));
+      const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else {
     throw std::runtime_error(
       "Invalid target memory space for "
@@ -131,4 +131,4 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
   }
 }
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -50,7 +50,7 @@ std::size_t gpu_table_representation::get_size_in_bytes() const
 
 const cudf::table& gpu_table_representation::get_table() const { return _table; }
 
-sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_memory_space(
+std::unique_ptr<idata_representation> gpu_table_representation::convert_to_memory_space(
   const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
 {
   auto packed_data = cudf::pack(_table, stream);
@@ -83,7 +83,7 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
     rmm::device_buffer dst_buffer = std::move(dst_uvector).release();
     // Unpack using pointer-based API and construct an owning cudf::table
     auto new_metadata = std::move(packed_data.metadata);
-    auto new_gpu_data = sirius::make_unique<rmm::device_buffer>(std::move(dst_buffer));
+    auto new_gpu_data = std::make_unique<rmm::device_buffer>(std::move(dst_buffer));
     auto new_table_view =
       cudf::unpack(new_metadata->data(), static_cast<uint8_t const*>(new_gpu_data->data()));
     auto new_table = cudf::table(new_table_view, target_stream, mr);
@@ -91,7 +91,7 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
     target_stream.synchronize();
     cudaSetDevice(source_device_id);
 
-    return sirius::make_unique<gpu_table_representation>(
+    return std::make_unique<gpu_table_representation>(
       std::move(new_table), *const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else if (target_memory_space->get_tier() == memory::Tier::HOST) {
     auto mr = target_memory_space
@@ -119,9 +119,9 @@ sirius::unique_ptr<idata_representation> gpu_table_representation::convert_to_me
       }
     }
     stream.synchronize();
-    auto host_table_allocation = sirius::make_unique<cucascade::memory::host_table_allocation>(
+    auto host_table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
       std::move(allocation), std::move(packed_data.metadata), packed_data.gpu_data->size());
-    return sirius::make_unique<host_table_representation>(
+    return std::make_unique<host_table_representation>(
       std::move(host_table_allocation),
       const_cast<cucascade::memory::memory_space*>(target_memory_space));
   } else {

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -19,7 +19,7 @@
 namespace cucascade {
 namespace parallel {
 
-void downgrade_executor::schedule(sirius::unique_ptr<itask> task)
+void downgrade_executor::schedule(std::unique_ptr<itask> task)
 {
   // Downgrade-specific scheduling logic
   auto downgrade_task = cast_to_downgrade_task(task.get());
@@ -46,8 +46,8 @@ void downgrade_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(sirius::make_unique<task_executor_thread>(
-      sirius::make_unique<sirius::thread>(&downgrade_executor::worker_loop, this, i)));
+    _threads.push_back(std::make_unique<task_executor_thread>(
+      std::make_unique<std::thread>(&downgrade_executor::worker_loop, this, i)));
   }
 }
 

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -16,7 +16,7 @@
 
 #include "downgrade/downgrade_executor.hpp"
 
-namespace cucascade {
+namespace sirius {
 namespace parallel {
 
 void downgrade_executor::schedule(std::unique_ptr<itask> task)
@@ -83,4 +83,4 @@ void downgrade_executor::worker_loop(int worker_id)
 }
 
 }  // namespace parallel
-}  // namespace cucascade
+}  // namespace sirius

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -16,7 +16,7 @@
 
 #include "downgrade/downgrade_executor.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace parallel {
 
 void downgrade_executor::schedule(sirius::unique_ptr<itask> task)
@@ -83,4 +83,4 @@ void downgrade_executor::worker_loop(int worker_id)
 }
 
 }  // namespace parallel
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -25,7 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-namespace cucascade {
+namespace sirius {
 namespace parallel {
 
 void downgrade_task::execute()
@@ -34,7 +34,7 @@ void downgrade_task::execute()
   rmm::cuda_stream_view stream = rmm::cuda_stream_default;
   // get the memory_space and check that its gpu
   auto memory_space = _local_state->cast<downgrade_task_local_state>()._batch->get_memory_space();
-  if (memory_space->get_tier() != memory::Tier::GPU) {
+  if (memory_space->get_tier() != cucascade::memory::Tier::GPU) {
     mark_task_completion();
     return;
   } else {
@@ -53,7 +53,7 @@ void downgrade_task::execute()
       if (!mem_space) {
         throw std::runtime_error("Invalid reservation memory_space for HOST tier");
       }
-      auto* fixed_mr = reservation->get_memory_resource_of<memory::Tier::HOST>();
+      auto* fixed_mr = reservation->get_memory_resource_of<cucascade::memory::Tier::HOST>();
 
       batch->convert_to_memory_space(mem_space, stream);
 
@@ -112,4 +112,4 @@ uint64_t downgrade_task::get_task_id() const
 }
 
 }  // namespace parallel
-}  // namespace cucascade
+}  // namespace sirius

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -98,7 +98,7 @@ void downgrade_task::mark_task_completion()
   // notify task_creator about task completion
   uint64_t task_id     = _local_state->cast<downgrade_task_local_state>()._task_id;
   uint64_t pipeline_id = _local_state->cast<downgrade_task_local_state>()._pipeline_id;
-  auto message         = sirius::make_unique<sirius::task_completion_message>();
+  auto message         = std::make_unique<sirius::task_completion_message>();
   message->task_id     = task_id;
   message->pipeline_id = pipeline_id;
   message->source      = sirius::Source::PIPELINE;

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -25,7 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-namespace sirius {
+namespace cucascade {
 namespace parallel {
 
 void downgrade_task::execute()
@@ -42,9 +42,9 @@ void downgrade_task::execute()
     auto data_size = batch->get_data()->get_size_in_bytes();
 
     try {
-      auto& mr_manager = sirius::memory::memory_reservation_manager::get_instance();
+      auto& mr_manager = cucascade::memory::memory_reservation_manager::get_instance();
       auto reservation = mr_manager.request_reservation(
-        sirius::memory::any_memory_space_in_tier{sirius::memory::Tier::HOST}, data_size);
+        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST}, data_size);
       if (!reservation) {
         throw rmm::out_of_memory("Failed to allocate host memory for downgrade task.");
       }
@@ -65,15 +65,15 @@ void downgrade_task::execute()
     }
 
     // Obtain HOST-tier memory resource from the memory manager
-    // auto& mr_manager = sirius::memory::memory_reservation_manager::get_instance();
-    // auto host_spaces = mr_manager.get_memory_spaces_for_tier(sirius::memory::Tier::HOST);
+    // auto& mr_manager = cucascade::memory::memory_reservation_manager::get_instance();
+    // auto host_spaces = mr_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
     // if (host_spaces.empty()) {
     //     mark_task_completion();
     //     return;
     // }
     // auto host_allocator_ref = host_spaces[0]->get_default_allocator();
     // auto* host_fixed_mr =
-    // dynamic_cast<sirius::memory::fixed_size_host_memory_resource*>(&host_allocator_ref.get());
+    // dynamic_cast<cucascade::memory::fixed_size_host_memory_resource*>(&host_allocator_ref.get());
 
     // // Fallback: if cast fails, complete task without conversion
     // if (host_fixed_mr == nullptr) {
@@ -112,4 +112,4 @@ uint64_t downgrade_task::get_task_id() const
 }
 
 }  // namespace parallel
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -55,9 +55,21 @@ void GPUExecutor::Reset()
   pipelines.clear();
   new_pipeline_breakers.clear();
   concat_ops.clear();
+  operator_to_id.clear();
+  next_operator_id.store(0);
   // events.clear();
   // to_be_rescheduled_tasks.clear();
   // execution_result = PendingExecutionResult::RESULT_NOT_READY;
+}
+
+size_t GPUExecutor::get_operator_id(const GPUPhysicalOperator* op)
+{
+  std::lock_guard<std::mutex> lock(operator_id_mutex);
+  auto it = operator_to_id.find(op);
+  if (it != operator_to_id.end()) { return it->second; }
+  size_t id          = next_operator_id++;
+  operator_to_id[op] = id;
+  return id;
 }
 
 void GPUExecutor::Initialize(unique_ptr<GPUPhysicalOperator> plan)
@@ -585,25 +597,26 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
             ::std::make_unique<::cucascade::idata_repository>();
           std::string_view port_id = next_port.second;
           auto next_op             = next_port.first;
-          data_repo_manager->add_new_repository(next_op, port_id, std::move(repo));
+          size_t op_id             = get_operator_id(next_op);
+          data_repo_manager->add_new_repository(op_id, port_id, std::move(repo));
           next_op->add_port(port_id,
                             std::make_unique<GPUPhysicalOperator::port>(
                               MemoryBarrierType::FULL,
-                              data_repo_manager->get_repository(next_op, port_id).get(),
+                              data_repo_manager->get_repository(op_id, port_id).get(),
                               new_scheduled[i]));
         }
 
         if (new_scheduled[i]->source->type == PhysicalOperatorType::TABLE_SCAN) {
           ::std::unique_ptr<::cucascade::idata_repository> repo =
             ::std::make_unique<::cucascade::idata_repository>();
-          std::string port_id = "scan";
-          data_repo_manager->add_new_repository(
-            new_scheduled[i]->source.get(), port_id, std::move(repo));
+          std::string port_id  = "scan";
+          size_t source_op_id  = get_operator_id(new_scheduled[i]->source.get());
+          data_repo_manager->add_new_repository(source_op_id, port_id, std::move(repo));
           new_scheduled[i]->source->add_port(
             port_id,
             std::make_unique<GPUPhysicalOperator::port>(
               MemoryBarrierType::PIPELINE,
-              data_repo_manager->get_repository(new_scheduled[i]->source.get(), port_id).get(),
+              data_repo_manager->get_repository(source_op_id, port_id).get(),
               new_scheduled[i]));
         }
 
@@ -611,13 +624,13 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
           ::std::unique_ptr<::cucascade::idata_repository> repo =
             ::std::make_unique<::cucascade::idata_repository>();
           std::string port_id = "final";
-          data_repo_manager->add_new_repository(
-            new_scheduled[i]->sink.get(), port_id, std::move(repo));
+          size_t sink_op_id   = get_operator_id(new_scheduled[i]->sink.get());
+          data_repo_manager->add_new_repository(sink_op_id, port_id, std::move(repo));
           new_scheduled[i]->sink->add_port(
             port_id,
             std::make_unique<GPUPhysicalOperator::port>(
               MemoryBarrierType::FULL,
-              data_repo_manager->get_repository(new_scheduled[i]->sink.get(), port_id).get(),
+              data_repo_manager->get_repository(sink_op_id, port_id).get(),
               new_scheduled[i]));
         }
       }

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -309,7 +309,7 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         SIRIUS_LOG_DEBUG("");  // Blank line for separation
       }
 
-      auto data_repo_manager = ::sirius::make_unique<::cucascade::data_repository_manager>();
+      auto data_repo_manager = ::std::make_unique<::cucascade::data_repository_manager>();
       unordered_map<const GPUPhysicalOperator*, vector<shared_ptr<GPUPipeline>>>
         source_to_pipelines;
 
@@ -581,8 +581,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         for (auto next_port : new_scheduled[i]->sink->get_next_port_after_sink()) {
-          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
-            ::sirius::make_unique<::cucascade::idata_repository>();
+          ::std::unique_ptr<::cucascade::idata_repository> repo =
+            ::std::make_unique<::cucascade::idata_repository>();
           std::string_view port_id = next_port.second;
           auto next_op             = next_port.first;
           data_repo_manager->add_new_repository(next_op, port_id, std::move(repo));
@@ -594,8 +594,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         if (new_scheduled[i]->source->type == PhysicalOperatorType::TABLE_SCAN) {
-          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
-            ::sirius::make_unique<::cucascade::idata_repository>();
+          ::std::unique_ptr<::cucascade::idata_repository> repo =
+            ::std::make_unique<::cucascade::idata_repository>();
           std::string port_id = "scan";
           data_repo_manager->add_new_repository(
             new_scheduled[i]->source.get(), port_id, std::move(repo));
@@ -608,8 +608,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         if (new_scheduled[i]->sink->type == PhysicalOperatorType::RESULT_COLLECTOR) {
-          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
-            ::sirius::make_unique<::cucascade::idata_repository>();
+          ::std::unique_ptr<::cucascade::idata_repository> repo =
+            ::std::make_unique<::cucascade::idata_repository>();
           std::string port_id = "final";
           data_repo_manager->add_new_repository(
             new_scheduled[i]->sink.get(), port_id, std::move(repo));

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -609,8 +609,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         if (new_scheduled[i]->source->type == PhysicalOperatorType::TABLE_SCAN) {
           ::std::unique_ptr<::cucascade::idata_repository> repo =
             ::std::make_unique<::cucascade::idata_repository>();
-          std::string port_id  = "scan";
-          size_t source_op_id  = get_operator_id(new_scheduled[i]->source.get());
+          std::string port_id = "scan";
+          size_t source_op_id = get_operator_id(new_scheduled[i]->source.get());
           data_repo_manager->add_new_repository(source_op_id, port_id, std::move(repo));
           new_scheduled[i]->source->add_port(
             port_id,

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -309,7 +309,7 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         SIRIUS_LOG_DEBUG("");  // Blank line for separation
       }
 
-      auto data_repo_manager = ::sirius::make_unique<::sirius::data_repository_manager>();
+      auto data_repo_manager = ::sirius::make_unique<::cucascade::data_repository_manager>();
       unordered_map<const GPUPhysicalOperator*, vector<shared_ptr<GPUPipeline>>>
         source_to_pipelines;
 
@@ -581,8 +581,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         for (auto next_port : new_scheduled[i]->sink->get_next_port_after_sink()) {
-          ::sirius::unique_ptr<::sirius::idata_repository> repo =
-            ::sirius::make_unique<::sirius::idata_repository>();
+          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
+            ::sirius::make_unique<::cucascade::idata_repository>();
           std::string_view port_id = next_port.second;
           auto next_op             = next_port.first;
           data_repo_manager->add_new_repository(next_op, port_id, std::move(repo));
@@ -594,8 +594,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         if (new_scheduled[i]->source->type == PhysicalOperatorType::TABLE_SCAN) {
-          ::sirius::unique_ptr<::sirius::idata_repository> repo =
-            ::sirius::make_unique<::sirius::idata_repository>();
+          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
+            ::sirius::make_unique<::cucascade::idata_repository>();
           std::string port_id = "scan";
           data_repo_manager->add_new_repository(
             new_scheduled[i]->source.get(), port_id, std::move(repo));
@@ -608,8 +608,8 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
         }
 
         if (new_scheduled[i]->sink->type == PhysicalOperatorType::RESULT_COLLECTOR) {
-          ::sirius::unique_ptr<::sirius::idata_repository> repo =
-            ::sirius::make_unique<::sirius::idata_repository>();
+          ::sirius::unique_ptr<::cucascade::idata_repository> repo =
+            ::sirius::make_unique<::cucascade::idata_repository>();
           std::string port_id = "final";
           data_repo_manager->add_new_repository(
             new_scheduled[i]->sink.get(), port_id, std::move(repo));

--- a/src/gpu_physical_operator.cpp
+++ b/src/gpu_physical_operator.cpp
@@ -54,7 +54,7 @@ OperatorResultType GPUPhysicalOperator::Execute(GPUIntermediateRelation& input_r
   throw InternalException("Calling Execute on a node that is not an operator!");
 }
 
-// TODO: Implement Execute for sirius::vector<sirius::unique_ptr<sirius::data_batch_view>>
+// TODO: Implement Execute for sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>
 // input_batch if needed.
 
 //===--------------------------------------------------------------------===//
@@ -181,11 +181,11 @@ GPUPhysicalOperator::port* GPUPhysicalOperator::get_port(std::string_view port_i
   return it->second.get();
 }
 
-::sirius::vector<::sirius::unique_ptr<::sirius::data_batch>> GPUPhysicalOperator::execute(
-  ::sirius::vector<::sirius::unique_ptr<::sirius::data_batch_view>> input_batch)
+::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>> GPUPhysicalOperator::execute(
+  ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch_view>> input_batch)
 {
   // not doing anything for now
-  return ::sirius::vector<::sirius::unique_ptr<::sirius::data_batch>>{};
+  return ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>>{};
 }
 
 void GPUPhysicalOperator::add_next_port_after_sink(

--- a/src/gpu_physical_operator.cpp
+++ b/src/gpu_physical_operator.cpp
@@ -54,7 +54,7 @@ OperatorResultType GPUPhysicalOperator::Execute(GPUIntermediateRelation& input_r
   throw InternalException("Calling Execute on a node that is not an operator!");
 }
 
-// TODO: Implement Execute for sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>
+// TODO: Implement Execute for std::vector<std::unique_ptr<cucascade::data_batch_view>>
 // input_batch if needed.
 
 //===--------------------------------------------------------------------===//
@@ -181,11 +181,11 @@ GPUPhysicalOperator::port* GPUPhysicalOperator::get_port(std::string_view port_i
   return it->second.get();
 }
 
-::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>> GPUPhysicalOperator::execute(
-  ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch_view>> input_batch)
+::std::vector<::std::unique_ptr<::cucascade::data_batch>> GPUPhysicalOperator::execute(
+  ::std::vector<::std::unique_ptr<::cucascade::data_batch_view>> input_batch)
 {
   // not doing anything for now
-  return ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>>{};
+  return ::std::vector<::std::unique_ptr<::cucascade::data_batch>>{};
 }
 
 void GPUPhysicalOperator::add_next_port_after_sink(

--- a/src/include/creator/downgrade_task_creator.hpp
+++ b/src/include/creator/downgrade_task_creator.hpp
@@ -70,7 +70,8 @@ class downgrade_task_creator : public itask_creator {
   void schedule(sirius::unique_ptr<parallel::downgrade_task> downgrade_task);
 
  private:
-  cucascade::data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository for data access
+  cucascade::data_repository_manager&
+    _data_repo_mgr;  ///< Reference to the data repository for data access
   parallel::downgrade_executor&
     _downgrade_exec;  ///< Reference to the downgrade executor for task execution
 };

--- a/src/include/creator/downgrade_task_creator.hpp
+++ b/src/include/creator/downgrade_task_creator.hpp
@@ -37,7 +37,7 @@ class downgrade_task_creator : public itask_creator {
    * batches
    * @param downgrade_exec Reference to the downgrade executor for task execution
    */
-  downgrade_task_creator(data_repository_manager& data_repo_mgr,
+  downgrade_task_creator(cucascade::data_repository_manager& data_repo_mgr,
                          parallel::downgrade_executor& downgrade_exec)
     : itask_creator(), _data_repo_mgr(data_repo_mgr), _downgrade_exec(downgrade_exec)
   {
@@ -70,7 +70,7 @@ class downgrade_task_creator : public itask_creator {
   void schedule(sirius::unique_ptr<parallel::downgrade_task> downgrade_task);
 
  private:
-  data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository for data access
+  cucascade::data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository for data access
   parallel::downgrade_executor&
     _downgrade_exec;  ///< Reference to the downgrade executor for task execution
 };

--- a/src/include/creator/downgrade_task_creator.hpp
+++ b/src/include/creator/downgrade_task_creator.hpp
@@ -67,7 +67,7 @@ class downgrade_task_creator : public itask_creator {
    *
    * @param downgrade_task The downgrade task to schedule for execution
    */
-  void schedule(sirius::unique_ptr<parallel::downgrade_task> downgrade_task);
+  void schedule(std::unique_ptr<parallel::downgrade_task> downgrade_task);
 
  private:
   cucascade::data_repository_manager&

--- a/src/include/creator/task_completion.hpp
+++ b/src/include/creator/task_completion.hpp
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 #pragma once
-#include "helper/helper.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <semaphore>
 
 namespace sirius {
 
@@ -65,9 +70,9 @@ class task_completion_message_queue {
    *
    * @param message The completion message to enqueue (ownership is transferred)
    */
-  void enqueue_message(sirius::unique_ptr<task_completion_message> message)
+  void enqueue_message(std::unique_ptr<task_completion_message> message)
   {
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     _message_queue.push(std::move(message));
     _sem.release();  // signal that one item is available
   }
@@ -78,13 +83,13 @@ class task_completion_message_queue {
    * This method blocks until a message becomes available, then safely dequeues
    * and returns it to the caller.
    *
-   * @return sirius::unique_ptr<task_completion_message> The dequeued message, or nullptr if queue
+   * @return std::unique_ptr<task_completion_message> The dequeued message, or nullptr if queue
    * is empty
    */
-  sirius::unique_ptr<task_completion_message> dequeue_message()
+  std::unique_ptr<task_completion_message> dequeue_message()
   {
     _sem.acquire();  // wait until there's something
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     if (_message_queue.empty()) { return nullptr; }
     auto message = std::move(_message_queue.front());
     _message_queue.pop();
@@ -94,13 +99,13 @@ class task_completion_message_queue {
   /**
    * @brief Alias for dequeue_message for consistent interface
    *
-   * @return sirius::unique_ptr<task_completion_message> The dequeued message
+   * @return std::unique_ptr<task_completion_message> The dequeued message
    */
-  sirius::unique_ptr<task_completion_message> pull_message() { return dequeue_message(); }
+  std::unique_ptr<task_completion_message> pull_message() { return dequeue_message(); }
 
  private:
-  sirius::mutex _mutex;  ///< Mutex for thread-safe queue access
-  sirius::queue<sirius::unique_ptr<task_completion_message>>
+  std::mutex _mutex;  ///< Mutex for thread-safe queue access
+  std::queue<std::unique_ptr<task_completion_message>>
     _message_queue;                   ///< Underlying message queue
   std::counting_semaphore<> _sem{0};  ///< Semaphore for blocking/signaling (starts with 0 permits)
 };

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -16,10 +16,13 @@
 
 #pragma once
 
-#include "helper/helper.hpp"
 #include "task_executor.hpp"
 
+#include <atomic>
 #include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 namespace sirius {
 
@@ -55,10 +58,10 @@ class itask_creator {
   virtual uint64_t get_next_task_id();
 
  protected:
-  sirius::atomic<bool> _running;
-  sirius::unique_ptr<parallel::task_executor_thread> _thread;
-  sirius::atomic<uint64_t> _next_task_id = 0;  ///< Atomic counter for generating unique task IDs
-  sirius::mutex _mtx;                          ///< Mutex for synchronization
+  std::atomic<bool> _running;
+  std::unique_ptr<parallel::task_executor_thread> _thread;
+  std::atomic<uint64_t> _next_task_id = 0;  ///< Atomic counter for generating unique task IDs
+  std::mutex _mtx;                          ///< Mutex for synchronization
   std::condition_variable _cv;                 ///< Condition variable for thread coordination
   bool _ready = false;                         ///< Flag indicating readiness state
 };

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -62,8 +62,8 @@ class itask_creator {
   std::unique_ptr<parallel::task_executor_thread> _thread;
   std::atomic<uint64_t> _next_task_id = 0;  ///< Atomic counter for generating unique task IDs
   std::mutex _mtx;                          ///< Mutex for synchronization
-  std::condition_variable _cv;                 ///< Condition variable for thread coordination
-  bool _ready = false;                         ///< Flag indicating readiness state
+  std::condition_variable _cv;              ///< Condition variable for thread coordination
+  bool _ready = false;                      ///< Flag indicating readiness state
 };
 
 }  // namespace sirius

--- a/src/include/data/common.hpp
+++ b/src/include/data/common.hpp
@@ -22,7 +22,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief Interface representing a data representation residing in a specific memory tier.
@@ -41,7 +41,7 @@ class idata_representation {
    *
    * @param memory_space The memory space where the data resides
    */
-  idata_representation(sirius::memory::memory_space& memory_space) : _memory_space(memory_space) {}
+  idata_representation(cucascade::memory::memory_space& memory_space) : _memory_space(memory_space) {}
 
   /**
    * @brief Virtual destructor to ensure proper cleanup of derived classes
@@ -78,7 +78,7 @@ class idata_representation {
    * space
    */
   virtual sirius::unique_ptr<idata_representation> convert_to_memory_space(
-    const sirius::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream) = 0;
+    const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream) = 0;
 
   /**
    * @brief Safely casts this interface to a specific derived type
@@ -105,7 +105,7 @@ class idata_representation {
   }
 
  private:
-  sirius::memory::memory_space& _memory_space;  ///< The memory space where the data resides
+  cucascade::memory::memory_space& _memory_space;  ///< The memory space where the data resides
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/common.hpp
+++ b/src/include/data/common.hpp
@@ -16,11 +16,13 @@
 
 #pragma once
 
-#include "helper/helper.hpp"
 #include "memory/memory_space.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <cstddef>
+#include <memory>
 
 namespace cucascade {
 
@@ -76,10 +78,10 @@ class idata_representation {
    *
    * @param target_memory_space The target memory space to convert to
    * @param stream CUDA stream to use for memory operations
-   * @return sirius::unique_ptr<idata_representation> A new data representation in the target memory
+   * @return std::unique_ptr<idata_representation> A new data representation in the target memory
    * space
    */
-  virtual sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  virtual std::unique_ptr<idata_representation> convert_to_memory_space(
     const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream) = 0;
 
   /**

--- a/src/include/data/common.hpp
+++ b/src/include/data/common.hpp
@@ -41,7 +41,9 @@ class idata_representation {
    *
    * @param memory_space The memory space where the data resides
    */
-  idata_representation(cucascade::memory::memory_space& memory_space) : _memory_space(memory_space) {}
+  idata_representation(cucascade::memory::memory_space& memory_space) : _memory_space(memory_space)
+  {
+  }
 
   /**
    * @brief Virtual destructor to ensure proper cleanup of derived classes

--- a/src/include/data/cpu_data_representation.hpp
+++ b/src/include/data/cpu_data_representation.hpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief Data representation for a table being stored in host memory.
@@ -42,8 +42,8 @@ class host_table_representation : public idata_representation {
    * @param meta Metadata required to reconstruct the cuDF columns (using cudf::unpack())
    * @param size The size of the actual data in bytes
    */
-  host_table_representation(sirius::unique_ptr<sirius::memory::host_table_allocation> host_table,
-                            sirius::memory::memory_space* memory_space);
+  host_table_representation(sirius::unique_ptr<cucascade::memory::host_table_allocation> host_table,
+                            cucascade::memory::memory_space* memory_space);
 
   /**
    * @brief Get the size of the data representation in bytes
@@ -55,10 +55,10 @@ class host_table_representation : public idata_representation {
   /**
    * @brief Get the underlying host table allocation
    *
-   * @return sirius::unique_ptr<sirius::memory::table_allocation> The underlying host table
+   * @return sirius::unique_ptr<cucascade::memory::table_allocation> The underlying host table
    * allocation
    */
-  const sirius::unique_ptr<sirius::memory::host_table_allocation>& get_host_table() const;
+  const sirius::unique_ptr<cucascade::memory::host_table_allocation>& get_host_table() const;
 
   /**
    * @brief Convert this CPU table representation to a different memory tier
@@ -68,12 +68,12 @@ class host_table_representation : public idata_representation {
    * @return sirius::unique_ptr<idata_representation> A new data representation in the target tier
    */
   sirius::unique_ptr<idata_representation> convert_to_memory_space(
-    const sirius::memory::memory_space* target_memory_space,
+    const cucascade::memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
 
  private:
-  sirius::unique_ptr<sirius::memory::host_table_allocation>
+  sirius::unique_ptr<cucascade::memory::host_table_allocation>
     _host_table;  ///< The allocation where the actual data resides
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/cpu_data_representation.hpp
+++ b/src/include/data/cpu_data_representation.hpp
@@ -17,11 +17,11 @@
 #pragma once
 
 #include "data/common.hpp"
-#include "helper/helper.hpp"
 #include "memory/fixed_size_host_memory_resource.hpp"
 #include "memory/host_table.hpp"
 #include "memory/memory_space.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace cucascade {
@@ -42,7 +42,7 @@ class host_table_representation : public idata_representation {
    * @param meta Metadata required to reconstruct the cuDF columns (using cudf::unpack())
    * @param size The size of the actual data in bytes
    */
-  host_table_representation(sirius::unique_ptr<cucascade::memory::host_table_allocation> host_table,
+  host_table_representation(std::unique_ptr<cucascade::memory::host_table_allocation> host_table,
                             cucascade::memory::memory_space* memory_space);
 
   /**
@@ -55,24 +55,24 @@ class host_table_representation : public idata_representation {
   /**
    * @brief Get the underlying host table allocation
    *
-   * @return sirius::unique_ptr<cucascade::memory::table_allocation> The underlying host table
+   * @return std::unique_ptr<cucascade::memory::table_allocation> The underlying host table
    * allocation
    */
-  const sirius::unique_ptr<cucascade::memory::host_table_allocation>& get_host_table() const;
+  const std::unique_ptr<cucascade::memory::host_table_allocation>& get_host_table() const;
 
   /**
    * @brief Convert this CPU table representation to a different memory tier
    *
    * @param target_memory_space The target memory space to convert to
    * @param stream CUDA stream to use for memory operations
-   * @return sirius::unique_ptr<idata_representation> A new data representation in the target tier
+   * @return std::unique_ptr<idata_representation> A new data representation in the target tier
    */
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const cucascade::memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
 
  private:
-  sirius::unique_ptr<cucascade::memory::host_table_allocation>
+  std::unique_ptr<cucascade::memory::host_table_allocation>
     _host_table;  ///< The allocation where the actual data resides
 };
 

--- a/src/include/data/data_batch.hpp
+++ b/src/include/data/data_batch.hpp
@@ -15,12 +15,15 @@
  */
 
 #pragma once
+
 #include "data/common.hpp"
-#include "helper/helper.hpp"
 
 #include <cudf/table/table.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <variant>
 
@@ -63,10 +66,10 @@ class data_batch {
    */
   data_batch(uint64_t batch_id,
              data_repository_manager& data_repo_mgr,
-             sirius::unique_ptr<idata_representation> data);
+             std::unique_ptr<idata_representation> data);
   data_batch(uint64_t batch_id,
              data_repository_manager& data_repo_mgr,
-             sirius::unique_ptr<idata_representation> data,
+             std::unique_ptr<idata_representation> data,
              cucascade::memory::memory_space& memory_space);
 
   /**
@@ -151,10 +154,10 @@ class data_batch {
    * a data_batch_view from its CUDF table view. The data_batch_view constructor will
    * handle incrementing the reference count.
    *
-   * @return sirius::unique_ptr<data_batch_view> A unique pointer to the new data_batch_view
+   * @return std::unique_ptr<data_batch_view> A unique pointer to the new data_batch_view
    * @note Assumes data is already in GPU tier as gpu_table_representation
    */
-  sirius::unique_ptr<data_batch_view> create_view();
+  std::unique_ptr<data_batch_view> create_view();
 
   /**
    * @brief Get the current view reference count (mutex-protected).
@@ -194,7 +197,7 @@ class data_batch {
    * @brief Replace the underlying data representation.
    *        Requires no active views or pins.
    */
-  void set_data(sirius::unique_ptr<idata_representation> data);
+  void set_data(std::unique_ptr<idata_representation> data);
 
   /**
    * @brief Convert the underlying representation to the target memory_space.
@@ -205,7 +208,7 @@ class data_batch {
 
   bool try_to_lock_for_downgrade()
   {
-    std::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     if (_pin_count == 0 && !_downgrade_locked) {
       _downgrade_locked = true;
       return true;
@@ -214,10 +217,10 @@ class data_batch {
   }
 
  private:
-  mutable sirius::mutex
+  mutable std::mutex
     _mutex;            ///< Mutex for thread-safe access to tier checking and reference counting
   uint64_t _batch_id;  ///< Unique identifier for this data batch
-  sirius::unique_ptr<idata_representation> _data;  ///< Pointer to the actual data representation
+  std::unique_ptr<idata_representation> _data;  ///< Pointer to the actual data representation
   size_t _view_count = 0;                          ///< Reference count for tracking views
   size_t _pin_count  = 0;  ///< Reference count for tracking pins to prevent eviction
   data_repository_manager* _data_repo_mgr;         ///< Pointer to the data repository manager

--- a/src/include/data/data_batch.hpp
+++ b/src/include/data/data_batch.hpp
@@ -24,13 +24,13 @@
 #include <stdexcept>
 #include <variant>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 class memory_space;
 }
-}  // namespace sirius
+}  // namespace cucascade
 
-namespace sirius {
+namespace cucascade {
 
 class data_batch_view;          // Forward declarationc
 class data_repository_manager;  // Forward declaration
@@ -67,7 +67,7 @@ class data_batch {
   data_batch(uint64_t batch_id,
              data_repository_manager& data_repo_mgr,
              sirius::unique_ptr<idata_representation> data,
-             sirius::memory::memory_space& memory_space);
+             cucascade::memory::memory_space& memory_space);
 
   /**
    * @brief Move constructor - transfers ownership of the batch and its data.
@@ -188,7 +188,7 @@ class data_batch {
   /**
    * @brief Get the memory_space where this batch currently resides.
    */
-  sirius::memory::memory_space* get_memory_space() const;
+  cucascade::memory::memory_space* get_memory_space() const;
 
   /**
    * @brief Replace the underlying data representation.
@@ -200,7 +200,7 @@ class data_batch {
    * @brief Convert the underlying representation to the target memory_space.
    *        Requires no active views or pins.
    */
-  void convert_to_memory_space(const sirius::memory::memory_space* target_memory_space,
+  void convert_to_memory_space(const cucascade::memory::memory_space* target_memory_space,
                                rmm::cuda_stream_view stream);
 
   bool try_to_lock_for_downgrade()
@@ -221,8 +221,8 @@ class data_batch {
   size_t _view_count = 0;                          ///< Reference count for tracking views
   size_t _pin_count  = 0;  ///< Reference count for tracking pins to prevent eviction
   data_repository_manager* _data_repo_mgr;      ///< Pointer to the data repository manager
-  sirius::memory::memory_space* _memory_space;  ///< Memory space where the data resides
+  cucascade::memory::memory_space* _memory_space;  ///< Memory space where the data resides
   bool _downgrade_locked = false;               ///< Whether the batch is locked for downgrade
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/data_batch.hpp
+++ b/src/include/data/data_batch.hpp
@@ -221,7 +221,7 @@ class data_batch {
     _mutex;            ///< Mutex for thread-safe access to tier checking and reference counting
   uint64_t _batch_id;  ///< Unique identifier for this data batch
   std::unique_ptr<idata_representation> _data;  ///< Pointer to the actual data representation
-  size_t _view_count = 0;                          ///< Reference count for tracking views
+  size_t _view_count = 0;                       ///< Reference count for tracking views
   size_t _pin_count  = 0;  ///< Reference count for tracking pins to prevent eviction
   data_repository_manager* _data_repo_mgr;         ///< Pointer to the data repository manager
   cucascade::memory::memory_space* _memory_space;  ///< Memory space where the data resides

--- a/src/include/data/data_batch.hpp
+++ b/src/include/data/data_batch.hpp
@@ -220,9 +220,9 @@ class data_batch {
   sirius::unique_ptr<idata_representation> _data;  ///< Pointer to the actual data representation
   size_t _view_count = 0;                          ///< Reference count for tracking views
   size_t _pin_count  = 0;  ///< Reference count for tracking pins to prevent eviction
-  data_repository_manager* _data_repo_mgr;      ///< Pointer to the data repository manager
+  data_repository_manager* _data_repo_mgr;         ///< Pointer to the data repository manager
   cucascade::memory::memory_space* _memory_space;  ///< Memory space where the data resides
-  bool _downgrade_locked = false;               ///< Whether the batch is locked for downgrade
+  bool _downgrade_locked = false;                  ///< Whether the batch is locked for downgrade
 };
 
 }  // namespace cucascade

--- a/src/include/data/data_batch_view.hpp
+++ b/src/include/data/data_batch_view.hpp
@@ -25,7 +25,7 @@
 #include <stdexcept>
 #include <variant>
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief A view into a data_batch that manages reference counting and provides CUDF table access.
@@ -139,4 +139,4 @@ class data_batch_view {
   bool _pinned = false;  ///< Whether the batch is pinned
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/data_batch_view.hpp
+++ b/src/include/data/data_batch_view.hpp
@@ -15,9 +15,9 @@
  */
 
 #pragma once
+
 #include "data/common.hpp"
 #include "data/data_batch.hpp"
-#include "helper/helper.hpp"
 
 #include <cudf/table/table.hpp>
 

--- a/src/include/data/data_repository.hpp
+++ b/src/include/data/data_repository.hpp
@@ -15,8 +15,12 @@
  */
 
 #pragma once
+
 #include "data_batch.hpp"
-#include "helper/helper.hpp"
+
+#include <memory>
+#include <mutex>
+#include <vector>
 
 namespace cucascade {
 
@@ -56,7 +60,7 @@ class idata_repository {
    *
    * @note Thread-safe operation protected by internal mutex
    */
-  virtual void add_new_data_batch_view(sirius::unique_ptr<data_batch_view> batch_view);
+  virtual void add_new_data_batch_view(std::unique_ptr<data_batch_view> batch_view);
 
   /**
    * @brief Remove and return a data batch from this repository according to eviction policy.
@@ -66,15 +70,15 @@ class idata_repository {
    * - LRU: Returns the least recently used batch
    * - Priority: Returns the lowest priority batch
    *
-   * @return sirius::unique_ptr<data_batch_view> The evicted data batch, or nullptr if empty
+   * @return std::unique_ptr<data_batch_view> The evicted data batch, or nullptr if empty
    *
    * @note Thread-safe operation protected by internal mutex
    */
-  virtual sirius::unique_ptr<data_batch_view> pull_data_batch_view();
+  virtual std::unique_ptr<data_batch_view> pull_data_batch_view();
 
  protected:
-  sirius::mutex _mutex;  ///< Mutex for thread-safe access to repository operations
-  sirius::vector<sirius::unique_ptr<data_batch_view>>
+  std::mutex _mutex;  ///< Mutex for thread-safe access to repository operations
+  std::vector<std::unique_ptr<data_batch_view>>
     _data_batches;  ///< Map of pipeline source to data_batch_view
 };
 

--- a/src/include/data/data_repository.hpp
+++ b/src/include/data/data_repository.hpp
@@ -18,7 +18,7 @@
 #include "data_batch.hpp"
 #include "helper/helper.hpp"
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief Abstract interface for managing collections of data_batch_view objects within a pipeline.
@@ -78,4 +78,4 @@ class idata_repository {
     _data_batches;  ///< Map of pipeline source to data_batch_view
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/data_repository_manager.hpp
+++ b/src/include/data/data_repository_manager.hpp
@@ -18,7 +18,6 @@
 
 #include "data/data_repository.hpp"
 #include "data_batch.hpp"
-#include "gpu_physical_operator.hpp"
 
 #include <atomic>
 #include <map>
@@ -33,21 +32,21 @@ namespace cucascade {
 /**
  * @brief Key type for identifying a unique operator-port combination.
  *
- * Uses std::string instead of string_view to ensure the key owns its data,
- * avoiding lifetime issues and allowing use with standard comparison.
+ * Uses size_t operator_id to identify operators. The caller is responsible for mapping
+ * operators to IDs.
  */
 struct operator_port_key {
-  ::duckdb::GPUPhysicalOperator* op;
+  size_t operator_id;
   std::string port_id;
 
   bool operator==(const operator_port_key& other) const
   {
-    return op == other.op && port_id == other.port_id;
+    return operator_id == other.operator_id && port_id == other.port_id;
   }
 
   bool operator<(const operator_port_key& other) const
   {
-    if (op != other.op) return op < other.op;
+    if (operator_id != other.operator_id) return operator_id < other.operator_id;
     return port_id < other.port_id;
   }
 };
@@ -89,18 +88,27 @@ class data_repository_manager {
   data_repository_manager() = default;
 
   /**
-   * @brief Register a new data repository for the specified pipeline.
+   * @brief Destructor - ensures repositories are cleared before data batches.
    *
-   * Associates a data repository implementation with a pipeline ID. Each pipeline
-   * can have exactly one repository, and attempting to add a repository for an
-   * existing pipeline will replace the previous one.
+   * Repositories contain data_batch_view objects that reference data_batch objects.
+   * We must destroy all views before destroying the batches they reference.
+   */
+  ~data_repository_manager() { _repositories.clear(); }
+
+  /**
+   * @brief Register a new data repository for the specified operator ID.
    *
-   * @param op The GPUPhysicalOperator associated with the repository
+   * Associates a data repository implementation with an operator ID and port. Each
+   * operator-port combination can have exactly one repository, and attempting to add
+   * a repository for an existing combination will replace the previous one.
+   *
+   * @param operator_id The unique ID of the operator associated with the repository
+   * @param port_id The port identifier for this repository
    * @param repository Unique pointer to the repository implementation (ownership transferred)
    *
    * @note Thread-safe operation
    */
-  void add_new_repository(::duckdb::GPUPhysicalOperator* op,
+  void add_new_repository(size_t operator_id,
                           std::string_view port_id,
                           std::unique_ptr<idata_repository> repository);
 
@@ -111,29 +119,28 @@ class data_repository_manager {
    * data_batch_views reference these batches.
    *
    * @param batch The data_batch to add (ownership transferred)
-   * @param ops The GPUPhysicalOperators whose repositories will receive views of this batch
+   * @param ops The operator IDs and ports whose repositories will receive views of this batch
    *
    * @note Thread-safe operation
    */
-  void add_new_data_batch(
-    std::unique_ptr<data_batch> batch,
-    std::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops);
+  void add_new_data_batch(std::unique_ptr<data_batch> batch,
+                          std::vector<std::pair<size_t, std::string_view>> ops);
 
   /**
-   * @brief Get direct access to a pipeline's repository for advanced operations.
+   * @brief Get direct access to a repository for advanced operations.
    *
    * Provides direct access to the underlying repository implementation, allowing
    * for repository-specific operations that aren't covered by the common interface.
    *
-   * @param op the GPUPhysicalOperator whose repository is requested
+   * @param operator_id The unique ID of the operator whose repository is requested
+   * @param port_id The port identifier for the repository
    * @return std::unique_ptr<idata_repository>& Reference to the repository
    *
-   * @throws std::out_of_range If no repository exists for the specified pipeline
+   * @throws std::out_of_range If no repository exists for the specified operator/port
    * @note Thread-safe for read access, but modifications should use the repository's own thread
    * safety
    */
-  std::unique_ptr<idata_repository>& get_repository(::duckdb::GPUPhysicalOperator* op,
-                                                    std::string_view port_id);
+  std::unique_ptr<idata_repository>& get_repository(size_t operator_id, std::string_view port_id);
 
   /**
    * @brief Generate a globally unique data batch identifier.
@@ -180,7 +187,7 @@ class data_repository_manager {
   std::atomic<uint64_t> _next_data_batch_id =
     0;  ///< Atomic counter for generating unique data batch identifiers
   std::map<operator_port_key, std::unique_ptr<idata_repository>>
-    _repositories;  ///< Map of pipeline ID to idata_repository (uses std::map for O(log n) lookups
+    _repositories;  ///< Map of operator ID to idata_repository (uses std::map for O(log n) lookups
                     ///< without needing a hash function)
   std::unordered_map<size_t, std::unique_ptr<data_batch>> _data_batches;
 };

--- a/src/include/data/data_repository_manager.hpp
+++ b/src/include/data/data_repository_manager.hpp
@@ -24,7 +24,7 @@
 #include <map>
 #include <string>
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief Key type for identifying a unique operator-port combination.
@@ -155,7 +155,7 @@ class data_repository_manager {
    * downgraded
    */
   std::vector<std::unique_ptr<data_batch>> get_data_batches_for_downgrade(
-    sirius::memory::memory_space_id memory_space_id, size_t amount_to_downgrade);
+    cucascade::memory::memory_space_id memory_space_id, size_t amount_to_downgrade);
 
  private:
   /**
@@ -181,4 +181,4 @@ class data_repository_manager {
   unordered_map<size_t, sirius::unique_ptr<data_batch>> _data_batches;
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/data_repository_manager.hpp
+++ b/src/include/data/data_repository_manager.hpp
@@ -19,10 +19,14 @@
 #include "data/data_repository.hpp"
 #include "data_batch.hpp"
 #include "gpu_physical_operator.hpp"
-#include "helper/helper.hpp"
 
+#include <atomic>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace cucascade {
 
@@ -98,7 +102,7 @@ class data_repository_manager {
    */
   void add_new_repository(::duckdb::GPUPhysicalOperator* op,
                           std::string_view port_id,
-                          sirius::unique_ptr<idata_repository> repository);
+                          std::unique_ptr<idata_repository> repository);
 
   /**
    * @brief Add a new data_batch to the holder.
@@ -112,8 +116,8 @@ class data_repository_manager {
    * @note Thread-safe operation
    */
   void add_new_data_batch(
-    sirius::unique_ptr<data_batch> batch,
-    sirius::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops);
+    std::unique_ptr<data_batch> batch,
+    std::vector<std::pair<::duckdb::GPUPhysicalOperator*, std::string_view>> ops);
 
   /**
    * @brief Get direct access to a pipeline's repository for advanced operations.
@@ -122,13 +126,13 @@ class data_repository_manager {
    * for repository-specific operations that aren't covered by the common interface.
    *
    * @param op the GPUPhysicalOperator whose repository is requested
-   * @return sirius::unique_ptr<idata_repository>& Reference to the repository
+   * @return std::unique_ptr<idata_repository>& Reference to the repository
    *
    * @throws std::out_of_range If no repository exists for the specified pipeline
    * @note Thread-safe for read access, but modifications should use the repository's own thread
    * safety
    */
-  sirius::unique_ptr<idata_repository>& get_repository(::duckdb::GPUPhysicalOperator* op,
+  std::unique_ptr<idata_repository>& get_repository(::duckdb::GPUPhysicalOperator* op,
                                                        std::string_view port_id);
 
   /**
@@ -172,13 +176,13 @@ class data_repository_manager {
    */
   void delete_data_batch(size_t batch_id);
 
-  mutex _mutex;  ///< Mutex for thread-safe access to holder
-  sirius::atomic<uint64_t> _next_data_batch_id =
+  std::mutex _mutex;  ///< Mutex for thread-safe access to holder
+  std::atomic<uint64_t> _next_data_batch_id =
     0;  ///< Atomic counter for generating unique data batch identifiers
-  std::map<operator_port_key, sirius::unique_ptr<idata_repository>>
+  std::map<operator_port_key, std::unique_ptr<idata_repository>>
     _repositories;  ///< Map of pipeline ID to idata_repository (uses std::map for O(log n) lookups
                     ///< without needing a hash function)
-  unordered_map<size_t, sirius::unique_ptr<data_batch>> _data_batches;
+  std::unordered_map<size_t, std::unique_ptr<data_batch>> _data_batches;
 };
 
 }  // namespace cucascade

--- a/src/include/data/data_repository_manager.hpp
+++ b/src/include/data/data_repository_manager.hpp
@@ -133,7 +133,7 @@ class data_repository_manager {
    * safety
    */
   std::unique_ptr<idata_repository>& get_repository(::duckdb::GPUPhysicalOperator* op,
-                                                       std::string_view port_id);
+                                                    std::string_view port_id);
 
   /**
    * @brief Generate a globally unique data batch identifier.

--- a/src/include/data/gpu_data_representation.hpp
+++ b/src/include/data/gpu_data_representation.hpp
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include "cudf/cudf_utils.hpp"
 #include "data/common.hpp"
 #include "memory/memory_space.hpp"
 
+#include <cudf/table/table.hpp>
 #include <memory>
 #include <vector>
 

--- a/src/include/data/gpu_data_representation.hpp
+++ b/src/include/data/gpu_data_representation.hpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-namespace sirius {
+namespace cucascade {
 
 /**
  * @brief Data representation for a table being stored in GPU memory.
@@ -43,7 +43,7 @@ class gpu_table_representation : public idata_representation {
    *
    * @param table The actual cuDF table with the data
    */
-  gpu_table_representation(cudf::table table, sirius::memory::memory_space& memory_space);
+  gpu_table_representation(cudf::table table, cucascade::memory::memory_space& memory_space);
 
   /**
    * @brief Get the size of the data representation in bytes
@@ -67,11 +67,11 @@ class gpu_table_representation : public idata_representation {
    * space
    */
   sirius::unique_ptr<idata_representation> convert_to_memory_space(
-    const sirius::memory::memory_space* target_memory_space,
+    const cucascade::memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
 
  private:
   cudf::table _table;  ///< The actual cuDF table with the data
 };
 
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/data/gpu_data_representation.hpp
+++ b/src/include/data/gpu_data_representation.hpp
@@ -18,9 +18,9 @@
 
 #include "cudf/cudf_utils.hpp"
 #include "data/common.hpp"
-#include "helper/helper.hpp"
 #include "memory/memory_space.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace cucascade {
@@ -63,10 +63,10 @@ class gpu_table_representation : public idata_representation {
    * @brief Convert this GPU table representation to a different memory tier
    *
    * @param stream CUDA stream to use for memory operations
-   * @return sirius::unique_ptr<idata_representation> A new data representation in the target memory
+   * @return std::unique_ptr<idata_representation> A new data representation in the target memory
    * space
    */
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const cucascade::memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override;
 

--- a/src/include/data/gpu_data_representation.hpp
+++ b/src/include/data/gpu_data_representation.hpp
@@ -20,6 +20,7 @@
 #include "memory/memory_space.hpp"
 
 #include <cudf/table/table.hpp>
+
 #include <memory>
 #include <vector>
 

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -122,8 +122,9 @@ class downgrade_executor : public itask_executor {
   downgrade_task* cast_to_downgrade_task(itask* task);
 
  private:
-  cucascade::data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository manager
-                                                       ///< for accessing data during downgrade operations
+  cucascade::data_repository_manager&
+    _data_repo_mgr;  ///< Reference to the data repository manager
+                     ///< for accessing data during downgrade operations
 };
 
 }  // namespace parallel

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -42,7 +42,7 @@ class downgrade_executor : public itask_executor {
    * @param data_repo_mgr Reference to the data repository for accessing and storing data batches
    */
   explicit downgrade_executor(task_executor_config config, data_repository_manager& data_repo_mgr)
-    : itask_executor(sirius::make_unique<downgrade_task_queue>(), config),
+    : itask_executor(std::make_unique<downgrade_task_queue>(), config),
       _data_repo_mgr(data_repo_mgr)
   {
   }
@@ -66,7 +66,7 @@ class downgrade_executor : public itask_executor {
    *
    * @param downgrade_task The downgrade task to schedule for execution
    */
-  void schedule_downgrade_task(sirius::unique_ptr<downgrade_task> downgrade_task)
+  void schedule_downgrade_task(std::unique_ptr<downgrade_task> downgrade_task)
   {
     // Convert to itask and use parent's schedule method
     schedule(std::move(downgrade_task));
@@ -81,7 +81,7 @@ class downgrade_executor : public itask_executor {
    *
    * @param task The task to schedule (must be a downgrade_task)
    */
-  void schedule(sirius::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<itask> task) override;
 
   /**
    * @brief Main worker loop for executing downgrade tasks

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -20,7 +20,7 @@
 #include "memory/memory_reservation.hpp"
 #include "parallel/task_executor.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace parallel {
 
 /**
@@ -125,4 +125,4 @@ class downgrade_executor : public itask_executor {
 };
 
 }  // namespace parallel
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -16,11 +16,12 @@
 
 #pragma once
 #include "data/data_repository.hpp"
+#include "downgrade/downgrade_queue.hpp"
 #include "downgrade/downgrade_task.hpp"
 #include "memory/memory_reservation.hpp"
 #include "parallel/task_executor.hpp"
 
-namespace cucascade {
+namespace sirius {
 namespace parallel {
 
 /**
@@ -41,7 +42,8 @@ class downgrade_executor : public itask_executor {
    * @param config Configuration for the task executor (thread count, retry policy, etc.)
    * @param data_repo_mgr Reference to the data repository for accessing and storing data batches
    */
-  explicit downgrade_executor(task_executor_config config, data_repository_manager& data_repo_mgr)
+  explicit downgrade_executor(task_executor_config config,
+                              cucascade::data_repository_manager& data_repo_mgr)
     : itask_executor(std::make_unique<downgrade_task_queue>(), config),
       _data_repo_mgr(data_repo_mgr)
   {
@@ -120,9 +122,9 @@ class downgrade_executor : public itask_executor {
   downgrade_task* cast_to_downgrade_task(itask* task);
 
  private:
-  data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository manager for
-                                            ///< accessing data during downgrade operations
+  cucascade::data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository manager
+                                                       ///< for accessing data during downgrade operations
 };
 
 }  // namespace parallel
-}  // namespace cucascade
+}  // namespace sirius

--- a/src/include/downgrade/downgrade_queue.hpp
+++ b/src/include/downgrade/downgrade_queue.hpp
@@ -15,11 +15,16 @@
  */
 
 #pragma once
+
 #include "config.hpp"
 #include "data/data_repository.hpp"
-#include "helper/helper.hpp"
 #include "parallel/task_executor.hpp"
 #include "task_completion.hpp"
+
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <semaphore>
 
 namespace cucascade {
 namespace parallel {
@@ -29,7 +34,7 @@ namespace parallel {
  *
  * This class provides a thread-safe queue implementation for scheduling and retrieving
  * downgrade tasks. It uses mutexes and semaphores to ensure safe concurrent access.
- * Currently, it uses a simple FIFO queue (sirius::queue), but future versions may
+ * Currently, it uses a simple FIFO queue (std::queue), but future versions may
  * implement more sophisticated scheduling algorithms such as priority scheduling,
  * task stealing, or work balancing.
  */
@@ -50,7 +55,7 @@ class downgrade_task_queue : public itask_queue {
    */
   void open() override
   {
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     _is_open = true;
   }
 
@@ -67,7 +72,7 @@ class downgrade_task_queue : public itask_queue {
     for (int i = 0; i < Config::NUM_DOWNGRADE_EXECUTOR_THREADS; ++i) {
       _sem.release();
     }
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     _is_open = false;
   }
 
@@ -77,11 +82,11 @@ class downgrade_task_queue : public itask_queue {
    * @param task The task to be scheduled (must be a downgrade_task)
    * @throws std::runtime_error If the queue is not currently open for accepting tasks
    */
-  void push(sirius::unique_ptr<itask> task) override
+  void push(std::unique_ptr<itask> task) override
   {
     // Convert itask to downgrade_task - since we know it's a downgrade_task
     auto downgrade_task =
-      sirius::unique_ptr<downgrade_task>(static_cast<downgrade_task*>(task.release()));
+      std::unique_ptr<downgrade_task>(static_cast<downgrade_task*>(task.release()));
     push(std::move(downgrade_task));
   }
 
@@ -91,7 +96,7 @@ class downgrade_task_queue : public itask_queue {
    * @param downgrade_task The downgrade task to be scheduled
    * @throws std::runtime_error If the queue is not currently open for accepting tasks
    */
-  void push(sirius::unique_ptr<downgrade_task> downgrade_task)
+  void push(std::unique_ptr<downgrade_task> downgrade_task)
   {
     enqueue_task(std::move(downgrade_task));
   }
@@ -105,7 +110,7 @@ class downgrade_task_queue : public itask_queue {
    * @return A unique pointer to the task to execute, or nullptr if none available
    * @throws std::runtime_error If the queue is closed and not returning tasks
    */
-  sirius::unique_ptr<itask> pull() override
+  std::unique_ptr<itask> pull() override
   {
     // Delegate to downgrade-specific version and return as base type
     auto downgrade_task = pull_downgrade_task();
@@ -121,7 +126,7 @@ class downgrade_task_queue : public itask_queue {
    * @return A unique pointer to the downgrade task to execute, or nullptr if none available
    * @throws std::runtime_error If the queue is closed and not returning tasks
    */
-  sirius::unique_ptr<downgrade_task> pull_downgrade_task() { return dequeue_task(); }
+  std::unique_ptr<downgrade_task> pull_downgrade_task() { return dequeue_task(); }
 
   /**
    * @brief Enqueues a downgrade task into the queue
@@ -131,9 +136,9 @@ class downgrade_task_queue : public itask_queue {
    *
    * @param downgrade_task The downgrade task to enqueue
    */
-  void enqueue_task(sirius::unique_ptr<downgrade_task> downgrade_task)
+  void enqueue_task(std::unique_ptr<downgrade_task> downgrade_task)
   {
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     if (downgrade_task && _is_open) { _task_queue.push(std::move(downgrade_task)); }
     _sem.release();  // signal that one item is available
   }
@@ -147,10 +152,10 @@ class downgrade_task_queue : public itask_queue {
    * @return A unique pointer to the dequeued downgrade task, or nullptr if queue is empty and
    * closed
    */
-  sirius::unique_ptr<downgrade_task> dequeue_task()
+  std::unique_ptr<downgrade_task> dequeue_task()
   {
     _sem.acquire();  // wait until there's something
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     // If the queue is closed and empty, return nullptr to signal shutdown
     if (!_is_open && _task_queue.empty()) { return nullptr; }
 
@@ -172,15 +177,15 @@ class downgrade_task_queue : public itask_queue {
    */
   bool is_empty() const
   {
-    sirius::lock_guard<sirius::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     return _task_queue.empty();
   }
 
  private:
-  sirius::queue<sirius::unique_ptr<downgrade_task>>
+  std::queue<std::unique_ptr<downgrade_task>>
     _task_queue;                      ///< FIFO queue storing the downgrade tasks
   bool _is_open = false;              ///< Whether the queue is open for operations
-  mutable sirius::mutex _mutex;       ///< Mutex for thread-safe access (mutable for const methods)
+  mutable std::mutex _mutex;       ///< Mutex for thread-safe access (mutable for const methods)
   std::counting_semaphore<> _sem{0};  ///< Semaphore for blocking/signaling (starts with 0 permits)
 };
 

--- a/src/include/downgrade/downgrade_queue.hpp
+++ b/src/include/downgrade/downgrade_queue.hpp
@@ -185,7 +185,7 @@ class downgrade_task_queue : public itask_queue {
   std::queue<std::unique_ptr<downgrade_task>>
     _task_queue;                      ///< FIFO queue storing the downgrade tasks
   bool _is_open = false;              ///< Whether the queue is open for operations
-  mutable std::mutex _mutex;       ///< Mutex for thread-safe access (mutable for const methods)
+  mutable std::mutex _mutex;          ///< Mutex for thread-safe access (mutable for const methods)
   std::counting_semaphore<> _sem{0};  ///< Semaphore for blocking/signaling (starts with 0 permits)
 };
 

--- a/src/include/downgrade/downgrade_queue.hpp
+++ b/src/include/downgrade/downgrade_queue.hpp
@@ -21,7 +21,7 @@
 #include "parallel/task_executor.hpp"
 #include "task_completion.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace parallel {
 
 /**
@@ -185,4 +185,4 @@ class downgrade_task_queue : public itask_queue {
 };
 
 }  // namespace parallel
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/downgrade/downgrade_queue.hpp
+++ b/src/include/downgrade/downgrade_queue.hpp
@@ -17,16 +17,15 @@
 #pragma once
 
 #include "config.hpp"
-#include "data/data_repository.hpp"
+#include "downgrade/downgrade_task.hpp"
 #include "parallel/task_executor.hpp"
-#include "task_completion.hpp"
 
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <semaphore>
 
-namespace cucascade {
+namespace sirius {
 namespace parallel {
 
 /**
@@ -190,4 +189,4 @@ class downgrade_task_queue : public itask_queue {
 };
 
 }  // namespace parallel
-}  // namespace cucascade
+}  // namespace sirius

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -15,12 +15,15 @@
  */
 
 #pragma once
+
 #include "config.hpp"
 #include "data/data_repository.hpp"
-#include "helper/helper.hpp"
 #include "memory/common.hpp"
 #include "parallel/task_executor.hpp"
 #include "task_completion.hpp"
+
+#include <cstdint>
+#include <memory>
 
 namespace cucascade {
 namespace parallel {
@@ -61,13 +64,13 @@ class downgrade_task_local_state : public sirius::parallel::itask_local_state {
  public:
   explicit downgrade_task_local_state(uint64_t task_id,
                                       uint64_t pipeline_id,
-                                      sirius::unique_ptr<data_batch> batch)
+                                      std::unique_ptr<data_batch> batch)
     : _task_id(task_id), _pipeline_id(pipeline_id), _batch(std::move(batch))
   {
   }
   uint64_t _task_id;
   uint64_t _pipeline_id;
-  sirius::unique_ptr<data_batch> _batch;
+  std::unique_ptr<data_batch> _batch;
 };
 
 /**
@@ -85,8 +88,8 @@ class downgrade_task : public sirius::parallel::itask {
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  downgrade_task(sirius::unique_ptr<sirius::parallel::itask_local_state> local_state,
-                 sirius::shared_ptr<sirius::parallel::itask_global_state> global_state)
+  downgrade_task(std::unique_ptr<sirius::parallel::itask_local_state> local_state,
+                 std::shared_ptr<sirius::parallel::itask_global_state> global_state)
     : sirius::parallel::itask(std::move(local_state), std::move(global_state))
   {
   }

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace cucascade {
+namespace sirius {
 namespace parallel {
 
 /**
@@ -35,7 +35,7 @@ namespace parallel {
  * an operation need access to, including the data repository for storing results
  * and the message queue for task completion notifications.
  */
-class downgrade_task_global_state : public sirius::parallel::itask_global_state {
+class downgrade_task_global_state : public itask_global_state {
  public:
   /**
    * @brief Construct a new downgrade_task_global_state object
@@ -43,14 +43,14 @@ class downgrade_task_global_state : public sirius::parallel::itask_global_state 
    * @param data_repo_mgr Reference to the data repository manager for storing task outputs
    * @param message_queue Reference to the message queue for task completion notifications
    */
-  explicit downgrade_task_global_state(data_repository_manager& data_repo_mgr,
-                                       sirius::task_completion_message_queue& message_queue)
+  explicit downgrade_task_global_state(cucascade::data_repository_manager& data_repo_mgr,
+                                       task_completion_message_queue& message_queue)
     : _data_repo_mgr(data_repo_mgr), _message_queue(message_queue)
   {
   }
 
-  data_repository_manager& _data_repo_mgr;  ///< Repository for storing and retrieving data batches
-  sirius::task_completion_message_queue&
+  cucascade::data_repository_manager& _data_repo_mgr;  ///< Repository for storing and retrieving data batches
+  task_completion_message_queue&
     _message_queue;  ///< Message queue to notify task_creator about task completion
 };
 
@@ -60,17 +60,17 @@ class downgrade_task_global_state : public sirius::parallel::itask_global_state 
  * This class holds the local state for a downgrade task, including the task ID,
  * the pipeline ID, and the data batch view.
  */
-class downgrade_task_local_state : public sirius::parallel::itask_local_state {
+class downgrade_task_local_state : public itask_local_state {
  public:
   explicit downgrade_task_local_state(uint64_t task_id,
                                       uint64_t pipeline_id,
-                                      std::unique_ptr<data_batch> batch)
+                                      std::unique_ptr<cucascade::data_batch> batch)
     : _task_id(task_id), _pipeline_id(pipeline_id), _batch(std::move(batch))
   {
   }
   uint64_t _task_id;
   uint64_t _pipeline_id;
-  std::unique_ptr<data_batch> _batch;
+  std::unique_ptr<cucascade::data_batch> _batch;
 };
 
 /**
@@ -80,7 +80,7 @@ class downgrade_task_local_state : public sirius::parallel::itask_local_state {
  * downgrade operation. Memory downgrading involves moving data from higher-tier (faster)
  * memory to lower-tier (slower) memory to free up space.
  */
-class downgrade_task : public sirius::parallel::itask {
+class downgrade_task : public itask {
  public:
   /**
    * @brief Construct a new downgrade_task object
@@ -88,9 +88,9 @@ class downgrade_task : public sirius::parallel::itask {
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  downgrade_task(std::unique_ptr<sirius::parallel::itask_local_state> local_state,
-                 std::shared_ptr<sirius::parallel::itask_global_state> global_state)
-    : sirius::parallel::itask(std::move(local_state), std::move(global_state))
+  downgrade_task(std::unique_ptr<itask_local_state> local_state,
+                 std::shared_ptr<itask_global_state> global_state)
+    : itask(std::move(local_state), std::move(global_state))
   {
   }
 
@@ -121,4 +121,4 @@ class downgrade_task : public sirius::parallel::itask {
 };
 
 }  // namespace parallel
-}  // namespace cucascade
+}  // namespace sirius

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -49,7 +49,8 @@ class downgrade_task_global_state : public itask_global_state {
   {
   }
 
-  cucascade::data_repository_manager& _data_repo_mgr;  ///< Repository for storing and retrieving data batches
+  cucascade::data_repository_manager&
+    _data_repo_mgr;  ///< Repository for storing and retrieving data batches
   task_completion_message_queue&
     _message_queue;  ///< Message queue to notify task_creator about task completion
 };

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -22,7 +22,7 @@
 #include "parallel/task_executor.hpp"
 #include "task_completion.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace parallel {
 
 /**
@@ -32,7 +32,7 @@ namespace parallel {
  * an operation need access to, including the data repository for storing results
  * and the message queue for task completion notifications.
  */
-class downgrade_task_global_state : public itask_global_state {
+class downgrade_task_global_state : public sirius::parallel::itask_global_state {
  public:
   /**
    * @brief Construct a new downgrade_task_global_state object
@@ -41,13 +41,13 @@ class downgrade_task_global_state : public itask_global_state {
    * @param message_queue Reference to the message queue for task completion notifications
    */
   explicit downgrade_task_global_state(data_repository_manager& data_repo_mgr,
-                                       task_completion_message_queue& message_queue)
+                                       sirius::task_completion_message_queue& message_queue)
     : _data_repo_mgr(data_repo_mgr), _message_queue(message_queue)
   {
   }
 
   data_repository_manager& _data_repo_mgr;  ///< Repository for storing and retrieving data batches
-  task_completion_message_queue&
+  sirius::task_completion_message_queue&
     _message_queue;  ///< Message queue to notify task_creator about task completion
 };
 
@@ -57,7 +57,7 @@ class downgrade_task_global_state : public itask_global_state {
  * This class holds the local state for a downgrade task, including the task ID,
  * the pipeline ID, and the data batch view.
  */
-class downgrade_task_local_state : public itask_local_state {
+class downgrade_task_local_state : public sirius::parallel::itask_local_state {
  public:
   explicit downgrade_task_local_state(uint64_t task_id,
                                       uint64_t pipeline_id,
@@ -77,7 +77,7 @@ class downgrade_task_local_state : public itask_local_state {
  * downgrade operation. Memory downgrading involves moving data from higher-tier (faster)
  * memory to lower-tier (slower) memory to free up space.
  */
-class downgrade_task : public itask {
+class downgrade_task : public sirius::parallel::itask {
  public:
   /**
    * @brief Construct a new downgrade_task object
@@ -85,9 +85,9 @@ class downgrade_task : public itask {
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  downgrade_task(sirius::unique_ptr<itask_local_state> local_state,
-                 sirius::shared_ptr<itask_global_state> global_state)
-    : itask(std::move(local_state), std::move(global_state))
+  downgrade_task(sirius::unique_ptr<sirius::parallel::itask_local_state> local_state,
+                 sirius::shared_ptr<sirius::parallel::itask_global_state> global_state)
+    : sirius::parallel::itask(std::move(local_state), std::move(global_state))
   {
   }
 
@@ -118,4 +118,4 @@ class downgrade_task : public itask {
 };
 
 }  // namespace parallel
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/gpu_executor.hpp
+++ b/src/include/gpu_executor.hpp
@@ -60,6 +60,14 @@ class GPUExecutor {
   //! Storage for pipeline breaker created during pipeline splitting
   vector<unique_ptr<GPUPhysicalOperator>> new_pipeline_breakers;
   vector<unique_ptr<GPUPhysicalOperator>> concat_ops;
+  //! Map from operator pointer to unique ID for data_repository_manager
+  std::unordered_map<const GPUPhysicalOperator*, size_t> operator_to_id;
+  //! Mutex for thread-safe access to operator_to_id map
+  std::mutex operator_id_mutex;
+  //! Counter for generating unique operator IDs
+  std::atomic<size_t> next_operator_id{0};
+  //! Get or create a unique ID for an operator
+  size_t get_operator_id(const GPUPhysicalOperator* op);
   //! The current root pipeline index
   idx_t root_pipeline_idx;
   //! The amount of completed pipelines of the query

--- a/src/include/gpu_physical_operator.hpp
+++ b/src/include/gpu_physical_operator.hpp
@@ -97,8 +97,8 @@ class GPUPhysicalOperator {
 
   virtual OperatorResultType Execute(GPUIntermediateRelation& input_relation,
                                      GPUIntermediateRelation& output_relation) const;
-  virtual ::sirius::vector<::sirius::unique_ptr<::sirius::data_batch>> execute(
-    ::sirius::vector<::sirius::unique_ptr<::sirius::data_batch_view>> input_batch);
+  virtual ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>> execute(
+    ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch_view>> input_batch);
 
   virtual bool ParallelOperator() const { return false; }
 
@@ -178,13 +178,13 @@ class GPUPhysicalOperator {
 
   struct port {
     MemoryBarrierType type;
-    ::sirius::idata_repository* repo;
+    ::cucascade::idata_repository* repo;
     shared_ptr<GPUPipeline> src_pipeline;
     bool src_pipeline_finished{false};
   };
 
   // source pipeline pushed to repo of the ports
-  void push_data_batch_view(std::string_view port_id, ::sirius::data_batch_view batch_view);
+  void push_data_batch_view(std::string_view port_id, ::cucascade::data_batch_view batch_view);
   void add_port(std::string_view port_id, std::unique_ptr<port> p);
   port* get_port(std::string_view port_id);
   void add_next_port_after_sink(std::pair<GPUPhysicalOperator*, std::string_view> port_locator);

--- a/src/include/gpu_physical_operator.hpp
+++ b/src/include/gpu_physical_operator.hpp
@@ -97,8 +97,8 @@ class GPUPhysicalOperator {
 
   virtual OperatorResultType Execute(GPUIntermediateRelation& input_relation,
                                      GPUIntermediateRelation& output_relation) const;
-  virtual ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch>> execute(
-    ::sirius::vector<::sirius::unique_ptr<::cucascade::data_batch_view>> input_batch);
+  virtual ::std::vector<::std::unique_ptr<::cucascade::data_batch>> execute(
+    ::std::vector<::std::unique_ptr<::cucascade::data_batch_view>> input_batch);
 
   virtual bool ParallelOperator() const { return false; }
 

--- a/src/include/helper/helper.hpp
+++ b/src/include/helper/helper.hpp
@@ -18,61 +18,7 @@
 
 #include <nvtx3/nvtx3.hpp>
 
-#include <atomic>
-#include <iostream>
-#include <memory>
-#include <mutex>
-#include <queue>
-#include <thread>
-#include <unordered_map>
-#include <vector>
-
 namespace sirius {
-
-// Smart pointer wrappers
-template <typename T>
-using unique_ptr = std::unique_ptr<T>;
-
-template <typename T>
-using shared_ptr = std::shared_ptr<T>;
-
-// Smart pointer factory functions
-template <typename T, typename... Args>
-constexpr auto make_unique(Args&&... args)
-{
-  return std::make_unique<T>(std::forward<Args>(args)...);
-}
-
-template <typename T, typename... Args>
-auto make_shared(Args&&... args)
-{
-  return std::make_shared<T>(std::forward<Args>(args)...);
-}
-
-// Container wrappers
-template <typename T, typename Allocator = std::allocator<T>>
-using vector = std::vector<T, Allocator>;
-
-template <typename Key,
-          typename T,
-          typename Hash      = std::hash<Key>,
-          typename KeyEqual  = std::equal_to<Key>,
-          typename Allocator = std::allocator<std::pair<const Key, T>>>
-using unordered_map = std::unordered_map<Key, T, Hash, KeyEqual, Allocator>;
-
-template <typename T, typename Container = std::deque<T>>
-using queue = std::queue<T, Container>;
-
-// Threading wrappers
-using mutex = std::mutex;
-
-template <typename Mutex>
-using lock_guard = std::lock_guard<Mutex>;
-
-template <typename T>
-using atomic = std::atomic<T>;
-
-using thread = std::thread;
 
 template <class T, class SRC>
 void DynamicCastCheck(const SRC* source)

--- a/src/include/memory/common.hpp
+++ b/src/include/memory/common.hpp
@@ -85,8 +85,8 @@ inline std::error_code make_error_code(MemoryError e);
 
 struct cucascade_out_of_memory : public rmm::out_of_memory {
   explicit cucascade_out_of_memory(std::string_view message,
-                                std::size_t requested_bytes,
-                                std::size_t global_usage);
+                                   std::size_t requested_bytes,
+                                   std::size_t global_usage);
 
   const std::size_t requested_bytes;
   const std::size_t global_usage;

--- a/src/include/memory/common.hpp
+++ b/src/include/memory/common.hpp
@@ -28,7 +28,7 @@
 #include <system_error>
 #include <utility>
 
-namespace sirius {
+namespace cucascade {
 
 template <class... Ts>
 struct overloaded : Ts... {
@@ -83,8 +83,8 @@ const memory_error_category& memory_category();
 
 inline std::error_code make_error_code(MemoryError e);
 
-struct sirius_out_of_memory : public rmm::out_of_memory {
-  explicit sirius_out_of_memory(std::string_view message,
+struct cucascade_out_of_memory : public rmm::out_of_memory {
+  explicit cucascade_out_of_memory(std::string_view message,
                                 std::size_t requested_bytes,
                                 std::size_t global_usage);
 
@@ -207,16 +207,16 @@ std::unique_ptr<rmm::mr::device_memory_resource> make_default_host_memory_resour
 DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier);
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade
 
 // Specialization for std::hash to enable use of std::pair<Tier, size_t> as key
 namespace std {
 template <>
-struct hash<sirius::memory::memory_space_id> {
-  size_t operator()(const sirius::memory::memory_space_id& p) const;
+struct hash<cucascade::memory::memory_space_id> {
+  size_t operator()(const cucascade::memory::memory_space_id& p) const;
 };
 
 template <>
-struct is_error_code_enum<sirius::memory::MemoryError> : true_type {};
+struct is_error_code_enum<cucascade::memory::MemoryError> : true_type {};
 
 }  // namespace std

--- a/src/include/memory/disk_access_limiter.hpp
+++ b/src/include/memory/disk_access_limiter.hpp
@@ -26,7 +26,7 @@
 #include "memory/memory_reservation.hpp"
 #include "memory/notification_channel.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 class disk_access_limiter {
@@ -166,4 +166,4 @@ class disk_access_limiter {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/fixed_size_host_memory_resource.hpp
+++ b/src/include/memory/fixed_size_host_memory_resource.hpp
@@ -36,7 +36,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // TODO: this doesn't handle multiple numa domains yet. We need to make our own
@@ -377,4 +377,4 @@ using fixed_multiple_blocks_allocation =
   fixed_size_host_memory_resource::fixed_multiple_blocks_allocation;
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/host_table.hpp
+++ b/src/include/memory/host_table.hpp
@@ -19,7 +19,7 @@
 #include "fixed_size_host_memory_resource.hpp"
 #include "helper/helper.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 /**
@@ -43,4 +43,4 @@ struct host_table_allocation {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/host_table.hpp
+++ b/src/include/memory/host_table.hpp
@@ -17,7 +17,10 @@
 #pragma once
 
 #include "fixed_size_host_memory_resource.hpp"
-#include "helper/helper.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace cucascade {
 namespace memory {
@@ -31,11 +34,11 @@ namespace memory {
  */
 struct host_table_allocation {
   memory::fixed_multiple_blocks_allocation allocation;
-  sirius::unique_ptr<sirius::vector<uint8_t>> metadata;
+  std::unique_ptr<std::vector<uint8_t>> metadata;
   std::size_t data_size;
 
   host_table_allocation(memory::fixed_multiple_blocks_allocation alloc,
-                        sirius::unique_ptr<sirius::vector<uint8_t>> meta,
+                        std::unique_ptr<std::vector<uint8_t>> meta,
                         std::size_t data_sz)
     : allocation(std::move(alloc)), metadata(std::move(meta)), data_size(data_sz)
   {

--- a/src/include/memory/memory_reservation.hpp
+++ b/src/include/memory/memory_reservation.hpp
@@ -29,7 +29,7 @@
 #include <string>
 #include <utility>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // Forward declarations
@@ -267,4 +267,4 @@ struct reservation {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/memory_reservation_manager.hpp
+++ b/src/include/memory/memory_reservation_manager.hpp
@@ -38,7 +38,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // Forward declarations
@@ -319,4 +319,4 @@ class memory_reservation_manager {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/memory_space.hpp
+++ b/src/include/memory/memory_space.hpp
@@ -34,7 +34,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // Forward declaration
@@ -155,4 +155,4 @@ struct memory_space_hash {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/notification_channel.hpp
+++ b/src/include/memory/notification_channel.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <utility>
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 struct notification_channel : std::enable_shared_from_this<notification_channel> {
@@ -103,4 +103,4 @@ struct notify_on_exit {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/null_device_memory_resource.hpp
+++ b/src/include/memory/null_device_memory_resource.hpp
@@ -19,7 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 /**
@@ -43,4 +43,4 @@ class null_device_memory_resource : public rmm::mr::device_memory_resource {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/numa_region_pinned_host_allocator.hpp
+++ b/src/include/memory/numa_region_pinned_host_allocator.hpp
@@ -30,7 +30,7 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 class numa_region_pinned_host_memory_resource final : public rmm::mr::device_memory_resource {
@@ -142,4 +142,4 @@ class numa_region_pinned_host_memory_resource final : public rmm::mr::device_mem
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/oom_handling_policy.hpp
+++ b/src/include/memory/oom_handling_policy.hpp
@@ -27,7 +27,7 @@
 
 #include <fmt/core.h>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 struct oom_handling_policy {
@@ -71,4 +71,4 @@ inline std::unique_ptr<oom_handling_policy> make_default_oom_policy()
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/reservation_aware_resource_adaptor.hpp
+++ b/src/include/memory/reservation_aware_resource_adaptor.hpp
@@ -32,7 +32,7 @@
 #include "memory/notification_channel.hpp"
 #include "memory/oom_handling_policy.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 /**
@@ -428,4 +428,4 @@ class reservation_aware_resource_adaptor : public rmm::mr::device_memory_resourc
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/reservation_manager_configurator.hpp
+++ b/src/include/memory/reservation_manager_configurator.hpp
@@ -26,7 +26,7 @@
 #include <variant>
 #include <vector>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 //===----------------------------------------------------------------------===//
@@ -163,4 +163,4 @@ class reservation_manager_configurator {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/stream_pool.hpp
+++ b/src/include/memory/stream_pool.hpp
@@ -24,7 +24,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 class exclusive_stream_pool;
@@ -102,4 +102,4 @@ class exclusive_stream_pool {
 };
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/include/memory/topology_discovery.hpp
+++ b/src/include/memory/topology_discovery.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace sirius::memory {
+namespace cucascade::memory {
 
 /**
  * @brief GPU information.
@@ -82,7 +82,7 @@ enum class PciePathType {
  *
  * Example usage:
  * @code
- * sirius::memory:topology_discovery discovery;
+ * cucascade::memory:topology_discovery discovery;
  * if (discovery.discover()) {
  *     auto topology = discovery.get_topology();
  * }
@@ -119,4 +119,4 @@ class topology_discovery {
   std::optional<system_topology_info> topology_;  ///< Discovered topology information.
 };
 
-}  // namespace sirius::memory
+}  // namespace cucascade::memory

--- a/src/include/operator/aggregate/gpu_aggregate_impl.hpp
+++ b/src/include/operator/aggregate/gpu_aggregate_impl.hpp
@@ -49,10 +49,10 @@ class gpu_aggregate_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> local_ungrouped_aggregate(
+  static std::unique_ptr<cucascade::data_batch> local_ungrouped_aggregate(
     const cucascade::data_batch_view& input,
-    const sirius::vector<cudf::aggregation::Kind>& aggregates,
-    const sirius::vector<int>& aggregate_idx,
+    const std::vector<cudf::aggregation::Kind>& aggregates,
+    const std::vector<int>& aggregate_idx,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -70,11 +70,11 @@ class gpu_aggregate_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> local_grouped_aggregate(
+  static std::unique_ptr<cucascade::data_batch> local_grouped_aggregate(
     const cucascade::data_batch_view& input,
-    const sirius::vector<int>& group_idx,
-    const sirius::vector<cudf::aggregation::Kind>& aggregates,
-    const sirius::vector<int>& aggregate_idx,
+    const std::vector<int>& group_idx,
+    const std::vector<cudf::aggregation::Kind>& aggregates,
+    const std::vector<int>& aggregate_idx,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);

--- a/src/include/operator/aggregate/gpu_aggregate_impl.hpp
+++ b/src/include/operator/aggregate/gpu_aggregate_impl.hpp
@@ -49,13 +49,13 @@ class gpu_aggregate_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> local_ungrouped_aggregate(
-    const data_batch_view& input,
+  static sirius::unique_ptr<cucascade::data_batch> local_ungrouped_aggregate(
+    const cucascade::data_batch_view& input,
     const sirius::vector<cudf::aggregation::Kind>& aggregates,
     const sirius::vector<int>& aggregate_idx,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform local grouped aggregate on the input data batch.
@@ -70,14 +70,14 @@ class gpu_aggregate_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> local_grouped_aggregate(
-    const data_batch_view& input,
+  static sirius::unique_ptr<cucascade::data_batch> local_grouped_aggregate(
+    const cucascade::data_batch_view& input,
     const sirius::vector<int>& group_idx,
     const sirius::vector<cudf::aggregation::Kind>& aggregates,
     const sirius::vector<int>& aggregate_idx,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 };
 
 }  // namespace op

--- a/src/include/operator/merge/gpu_merge_impl.hpp
+++ b/src/include/operator/merge/gpu_merge_impl.hpp
@@ -49,8 +49,8 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> concat(
-    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+  static std::unique_ptr<cucascade::data_batch> concat(
+    const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -66,9 +66,9 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> merge_ungrouped_aggregate(
-    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
-    const sirius::vector<cudf::aggregation::Kind>& aggregates,
+  static std::unique_ptr<cucascade::data_batch> merge_ungrouped_aggregate(
+    const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
+    const std::vector<cudf::aggregation::Kind>& aggregates,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -88,10 +88,10 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> merge_grouped_aggregate(
-    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+  static std::unique_ptr<cucascade::data_batch> merge_grouped_aggregate(
+    const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
     int num_group_cols,
-    const sirius::vector<cudf::aggregation::Kind>& aggregates,
+    const std::vector<cudf::aggregation::Kind>& aggregates,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -111,11 +111,11 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> merge_order_by(
-    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
-    const sirius::vector<int>& order_key_idx,
-    const sirius::vector<cudf::order>& column_order,
-    const sirius::vector<cudf::null_order>& null_precedence,
+  static std::unique_ptr<cucascade::data_batch> merge_order_by(
+    const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
+    const std::vector<int>& order_key_idx,
+    const std::vector<cudf::order>& column_order,
+    const std::vector<cudf::null_order>& null_precedence,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -137,13 +137,13 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> merge_top_n(
-    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+  static std::unique_ptr<cucascade::data_batch> merge_top_n(
+    const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
     const int limit,
     const int offset,
-    const sirius::vector<int>& order_key_idx,
-    const sirius::vector<cudf::order>& column_order,
-    const sirius::vector<cudf::null_order>& null_precedence,
+    const std::vector<int>& order_key_idx,
+    const std::vector<cudf::order>& column_order,
+    const std::vector<cudf::null_order>& null_precedence,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);

--- a/src/include/operator/merge/gpu_merge_impl.hpp
+++ b/src/include/operator/merge/gpu_merge_impl.hpp
@@ -49,11 +49,11 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> concat(
-    const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+  static sirius::unique_ptr<cucascade::data_batch> concat(
+    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform ungrouped merge aggregate on multiple data batches.
@@ -66,12 +66,12 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> merge_ungrouped_aggregate(
-    const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+  static sirius::unique_ptr<cucascade::data_batch> merge_ungrouped_aggregate(
+    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
     const sirius::vector<cudf::aggregation::Kind>& aggregates,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform grouped merge aggregate on multiple data batches.
@@ -88,13 +88,13 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> merge_grouped_aggregate(
-    const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+  static sirius::unique_ptr<cucascade::data_batch> merge_grouped_aggregate(
+    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
     int num_group_cols,
     const sirius::vector<cudf::aggregation::Kind>& aggregates,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform merge order-by on multiple data batches.
@@ -111,14 +111,14 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> merge_order_by(
-    const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+  static sirius::unique_ptr<cucascade::data_batch> merge_order_by(
+    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
     const sirius::vector<int>& order_key_idx,
     const sirius::vector<cudf::order>& column_order,
     const sirius::vector<cudf::null_order>& null_precedence,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform merge order-by on multiple data batches.
@@ -137,16 +137,16 @@ class gpu_merge_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> merge_top_n(
-    const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+  static sirius::unique_ptr<cucascade::data_batch> merge_top_n(
+    const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
     const int limit,
     const int offset,
     const sirius::vector<int>& order_key_idx,
     const sirius::vector<cudf::order>& column_order,
     const sirius::vector<cudf::null_order>& null_precedence,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 };
 
 }  // namespace op

--- a/src/include/operator/order/gpu_order_impl.hpp
+++ b/src/include/operator/order/gpu_order_impl.hpp
@@ -48,12 +48,12 @@ class gpu_order_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> local_order_by(
+  static std::unique_ptr<cucascade::data_batch> local_order_by(
     const cucascade::data_batch_view& input,
-    const sirius::vector<int>& order_key_idx,
-    const sirius::vector<cudf::order>& column_order,
-    const sirius::vector<cudf::null_order>& null_precedence,
-    const sirius::vector<int>& projections,
+    const std::vector<int>& order_key_idx,
+    const std::vector<cudf::order>& column_order,
+    const std::vector<cudf::null_order>& null_precedence,
+    const std::vector<int>& projections,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);
@@ -75,14 +75,14 @@ class gpu_order_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<cucascade::data_batch> local_top_n(
+  static std::unique_ptr<cucascade::data_batch> local_top_n(
     const cucascade::data_batch_view& input,
     const int limit,
     const int offset,
-    const sirius::vector<int>& order_key_idx,
-    const sirius::vector<cudf::order>& column_order,
-    const sirius::vector<cudf::null_order>& null_precedence,
-    const sirius::vector<int>& projections,
+    const std::vector<int>& order_key_idx,
+    const std::vector<cudf::order>& column_order,
+    const std::vector<cudf::null_order>& null_precedence,
+    const std::vector<int>& projections,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
     cucascade::data_repository_manager& data_repository_mgr);

--- a/src/include/operator/order/gpu_order_impl.hpp
+++ b/src/include/operator/order/gpu_order_impl.hpp
@@ -48,15 +48,15 @@ class gpu_order_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> local_order_by(
-    const data_batch_view& input,
+  static sirius::unique_ptr<cucascade::data_batch> local_order_by(
+    const cucascade::data_batch_view& input,
     const sirius::vector<int>& order_key_idx,
     const sirius::vector<cudf::order>& column_order,
     const sirius::vector<cudf::null_order>& null_precedence,
     const sirius::vector<int>& projections,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform local top-n (with offset) on the input data batch.
@@ -75,8 +75,8 @@ class gpu_order_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::unique_ptr<data_batch> local_top_n(
-    const data_batch_view& input,
+  static sirius::unique_ptr<cucascade::data_batch> local_top_n(
+    const cucascade::data_batch_view& input,
     const int limit,
     const int offset,
     const sirius::vector<int>& order_key_idx,
@@ -84,8 +84,8 @@ class gpu_order_impl {
     const sirius::vector<cudf::null_order>& null_precedence,
     const sirius::vector<int>& projections,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 };
 
 }  // namespace op

--- a/src/include/operator/partition/gpu_partition_impl.hpp
+++ b/src/include/operator/partition/gpu_partition_impl.hpp
@@ -49,9 +49,9 @@ class gpu_partition_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::vector<sirius::unique_ptr<cucascade::data_batch>> hash_partition(
+  static std::vector<std::unique_ptr<cucascade::data_batch>> hash_partition(
     const cucascade::data_batch_view& input,
-    const sirius::vector<int>& partition_key_idx,
+    const std::vector<int>& partition_key_idx,
     int num_partitions,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space,
@@ -68,7 +68,7 @@ class gpu_partition_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::vector<sirius::unique_ptr<cucascade::data_batch>> evenly_partition(
+  static std::vector<std::unique_ptr<cucascade::data_batch>> evenly_partition(
     const cucascade::data_batch_view& input,
     int num_partitions,
     rmm::cuda_stream_view stream,

--- a/src/include/operator/partition/gpu_partition_impl.hpp
+++ b/src/include/operator/partition/gpu_partition_impl.hpp
@@ -49,13 +49,13 @@ class gpu_partition_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::vector<sirius::unique_ptr<data_batch>> hash_partition(
-    const data_batch_view& input,
+  static sirius::vector<sirius::unique_ptr<cucascade::data_batch>> hash_partition(
+    const cucascade::data_batch_view& input,
     const sirius::vector<int>& partition_key_idx,
     int num_partitions,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 
   /**
    * @brief Perform evenly partitioning on the input data batch.
@@ -68,12 +68,12 @@ class gpu_partition_impl {
    *
    * @return The output data batch with ownership.
    */
-  static sirius::vector<sirius::unique_ptr<data_batch>> evenly_partition(
-    const data_batch_view& input,
+  static sirius::vector<sirius::unique_ptr<cucascade::data_batch>> evenly_partition(
+    const cucascade::data_batch_view& input,
     int num_partitions,
     rmm::cuda_stream_view stream,
-    memory::memory_space& memory_space,
-    data_repository_manager& data_repository_mgr);
+    cucascade::memory::memory_space& memory_space,
+    cucascade::data_repository_manager& data_repository_mgr);
 };
 
 }  // namespace op

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -19,6 +19,8 @@
 #include "helper/helper.hpp"
 #include "memory/memory_reservation.hpp"
 
+#include <memory>
+
 namespace sirius {
 namespace parallel {
 
@@ -71,8 +73,8 @@ class itask_global_state {
  */
 class itask {
  public:
-  itask(sirius::unique_ptr<itask_local_state> local_state,
-        sirius::shared_ptr<itask_global_state> global_state)
+  itask(std::unique_ptr<itask_local_state> local_state,
+        std::shared_ptr<itask_global_state> global_state)
     : _local_state(std::move(local_state)), _global_state(global_state)
   {
   }
@@ -89,8 +91,8 @@ class itask {
   virtual void execute() = 0;
 
  protected:
-  sirius::unique_ptr<itask_local_state> _local_state;
-  sirius::shared_ptr<itask_global_state> _global_state;
+  std::unique_ptr<itask_local_state> _local_state;
+  std::shared_ptr<itask_global_state> _global_state;
 };
 
 }  // namespace parallel

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -16,21 +16,24 @@
 
 #pragma once
 
-#include "helper/helper.hpp"
 #include "task_queue.hpp"
 
+#include <atomic>
 #include <condition_variable>
+#include <memory>
+#include <thread>
+#include <vector>
 
 namespace sirius {
 namespace parallel {
 
 struct task_executor_thread {
-  explicit task_executor_thread(sirius::unique_ptr<std::thread> thread)
+  explicit task_executor_thread(std::unique_ptr<std::thread> thread)
     : _internal_thread(std::move(thread))
   {
   }
 
-  sirius::unique_ptr<std::thread> _internal_thread;
+  std::unique_ptr<std::thread> _internal_thread;
 };
 
 struct task_executor_config {
@@ -44,7 +47,7 @@ struct task_executor_config {
  */
 class itask_executor {
  public:
-  itask_executor(sirius::unique_ptr<itask_queue> task_queue, task_executor_config config)
+  itask_executor(std::unique_ptr<itask_queue> task_queue, task_executor_config config)
     : _task_queue(std::move(task_queue)), _config(config), _running(false)
   {
   }
@@ -64,24 +67,24 @@ class itask_executor {
   virtual void stop();
 
   // Schedule a task.
-  virtual void schedule(sirius::unique_ptr<itask> task);
+  virtual void schedule(std::unique_ptr<itask> task);
 
  protected:
   // Helper functions.
   virtual void on_start();
   virtual void on_stop();
   virtual void on_task_error(int worker_id,
-                             sirius::unique_ptr<itask> task,
+                             std::unique_ptr<itask> task,
                              const std::exception& e);
 
   // Main thread loop.
   virtual void worker_loop(int worker_id);
 
  protected:
-  sirius::unique_ptr<itask_queue> _task_queue;
+  std::unique_ptr<itask_queue> _task_queue;
   task_executor_config _config;
-  sirius::atomic<bool> _running;
-  sirius::vector<sirius::unique_ptr<task_executor_thread>> _threads;
+  std::atomic<bool> _running;
+  std::vector<std::unique_ptr<task_executor_thread>> _threads;
 };
 
 }  // namespace parallel

--- a/src/include/parallel/task_executor.hpp
+++ b/src/include/parallel/task_executor.hpp
@@ -73,9 +73,7 @@ class itask_executor {
   // Helper functions.
   virtual void on_start();
   virtual void on_stop();
-  virtual void on_task_error(int worker_id,
-                             std::unique_ptr<itask> task,
-                             const std::exception& e);
+  virtual void on_task_error(int worker_id, std::unique_ptr<itask> task, const std::exception& e);
 
   // Main thread loop.
   virtual void worker_loop(int worker_id);

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -32,15 +32,15 @@ class pipeline_executor;
 class local_task_buffer {
  public:
   local_task_buffer() = default;
-  void produce(sirius::unique_ptr<itask> task);
-  sirius::unique_ptr<itask> consume();
+  void produce(std::unique_ptr<itask> task);
+  std::unique_ptr<itask> consume();
   void open();
   void close();
 
  private:
   mutable std::mutex _mtx;
   std::condition_variable _cv;
-  std::queue<sirius::unique_ptr<itask>> _queue;
+  std::queue<std::unique_ptr<itask>> _queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 
@@ -82,7 +82,7 @@ class gpu_pipeline_executor : public itask_executor {
    *
    * @param task The task to schedule (must be a gpu_pipeline_task)
    */
-  void schedule(sirius::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<itask> task) override;
 
   /**
    * @brief Main worker loop for executing GPU pipeline tasks
@@ -128,7 +128,7 @@ class gpu_pipeline_executor : public itask_executor {
   /**
    * @brief Submit a task request to task_request_queue
    */
-  void submit_task_request(sirius::unique_ptr<task_request> request);
+  void submit_task_request(std::unique_ptr<task_request> request);
 
  private:
   /**
@@ -140,8 +140,8 @@ class gpu_pipeline_executor : public itask_executor {
    */
   gpu_pipeline_task* cast_to_gpu_pipeline_task(itask* task);
 
-  sirius::unique_ptr<std::thread> _gpu_pipeline_executor_manager_thread;
-  sirius::unique_ptr<local_task_buffer> _local_task_buffer;
+  std::unique_ptr<std::thread> _gpu_pipeline_executor_manager_thread;
+  std::unique_ptr<local_task_buffer> _local_task_buffer;
   pipeline_executor* _pipeline_exec;
   const cucascade::memory::memory_space*
     _memory_space_view;  // this is supposed to be the memory space

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -143,8 +143,9 @@ class gpu_pipeline_executor : public itask_executor {
   sirius::unique_ptr<std::thread> _gpu_pipeline_executor_manager_thread;
   sirius::unique_ptr<local_task_buffer> _local_task_buffer;
   pipeline_executor* _pipeline_exec;
-  const cucascade::memory::memory_space* _memory_space_view;  // this is supposed to be the memory space
-                                                   // associated with this pipeline executor
+  const cucascade::memory::memory_space*
+    _memory_space_view;  // this is supposed to be the memory space
+                         // associated with this pipeline executor
 };
 
 }  // namespace parallel

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -59,7 +59,7 @@ class gpu_pipeline_executor : public itask_executor {
    * @param config Configuration for the task executor (thread count, retry policy, etc.)
    */
   explicit gpu_pipeline_executor(task_executor_config config,
-                                 const memory::memory_space* mem_space,
+                                 const cucascade::memory::memory_space* mem_space,
                                  pipeline_executor* pipeline_exec);
 
   /**
@@ -116,9 +116,9 @@ class gpu_pipeline_executor : public itask_executor {
   /**
    * @brief Get the memory space view associated with this executor
    *
-   * @return memory::memory_space* Pointer to the memory space
+   * @return cucascade::memory::memory_space* Pointer to the memory space
    */
-  memory::memory_space* get_memory_space_view();
+  cucascade::memory::memory_space* get_memory_space_view();
 
   /**
    * @brief Manager loop to consume task from local buffer and dispatch to the thread pool
@@ -143,7 +143,7 @@ class gpu_pipeline_executor : public itask_executor {
   sirius::unique_ptr<std::thread> _gpu_pipeline_executor_manager_thread;
   sirius::unique_ptr<local_task_buffer> _local_task_buffer;
   pipeline_executor* _pipeline_exec;
-  const memory::memory_space* _memory_space_view;  // this is supposed to be the memory space
+  const cucascade::memory::memory_space* _memory_space_view;  // this is supposed to be the memory space
                                                    // associated with this pipeline executor
 };
 

--- a/src/include/pipeline/gpu_pipeline_queue.hpp
+++ b/src/include/pipeline/gpu_pipeline_queue.hpp
@@ -15,14 +15,17 @@
  */
 
 #pragma once
+
 #include "config.hpp"
 #include "data/data_repository.hpp"
 #include "gpu_pipeline.hpp"
-#include "helper/helper.hpp"
 #include "parallel/task_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include <blockingconcurrentqueue.h>
+
+#include <atomic>
+#include <memory>
 
 namespace sirius {
 namespace parallel {
@@ -31,7 +34,7 @@ namespace parallel {
  * @brief A task queue specifically for managing gpu_pipeline_task instances.
  *
  * This class provides a thread-safe queue implementation for scheduling and retrieving GPU pipeline
- * tasks. Currently it just uses the sirius::queue, but in the future we might want to implement a
+ * tasks. Currently it just uses the std::queue, but in the future we might want to implement a
  * more sophisticated queue that supports priority scheduling, task stealing, etc..
  */
 class gpu_pipeline_queue : public itask_queue {
@@ -57,7 +60,7 @@ class gpu_pipeline_queue : public itask_queue {
    * @param task The task to be scheduled
    * @throws sirius::runtime_error If the scheduler is not currently accepting requests
    */
-  void push(sirius::unique_ptr<itask> task) override;
+  void push(std::unique_ptr<itask> task) override;
 
   /**
    * @brief Pull a task to execute.
@@ -69,11 +72,11 @@ class gpu_pipeline_queue : public itask_queue {
    * @throws sirius::runtime_error If the scheduler is not currently stopped and thus not returning
    * tasks
    */
-  sirius::unique_ptr<itask> pull() override;
+  std::unique_ptr<itask> pull() override;
 
  private:
   size_t _num_threads;
-  duckdb_moodycamel::BlockingConcurrentQueue<sirius::unique_ptr<itask>> _task_queue;
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<itask>> _task_queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -15,13 +15,17 @@
  */
 
 #pragma once
+
 #include "config.hpp"
 #include "creator/task_completion.hpp"
 #include "data/data_batch_view.hpp"
 #include "data/data_repository.hpp"
 #include "gpu_pipeline.hpp"
-#include "helper/helper.hpp"
 #include "parallel/task_executor.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace sirius {
 namespace parallel {
@@ -80,23 +84,23 @@ class gpu_pipeline_task_local_state : public itask_local_state {
    */
   explicit gpu_pipeline_task_local_state(
     uint64_t task_id,
-    sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>> batch_views,
-    sirius::unique_ptr<cucascade::memory::reservation> res = nullptr)
+    std::vector<std::unique_ptr<cucascade::data_batch_view>> batch_views,
+    std::unique_ptr<cucascade::memory::reservation> res = nullptr)
     : _task_id(task_id), _batch_views(std::move(batch_views)), _reservation(std::move(res))
   {
   }
 
   uint64_t _task_id;  ///< Unique identifier for this task
-  sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>
+  std::vector<std::unique_ptr<cucascade::data_batch_view>>
     _batch_views;  ///< Input data batch views for the pipeline
 
-  void set_reservation(sirius::unique_ptr<cucascade::memory::reservation> res)
+  void set_reservation(std::unique_ptr<cucascade::memory::reservation> res)
   {
     _reservation = std::move(res);
   }
 
  private:
-  sirius::unique_ptr<cucascade::memory::reservation>
+  std::unique_ptr<cucascade::memory::reservation>
     _reservation;  ///< Memory reservation for GPU resources
   // TODO: for now, reservation is passed as a local state, will be null when the task is first
   // created, and will be set when reservation is made
@@ -120,8 +124,8 @@ class gpu_pipeline_task : public itask {
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  gpu_pipeline_task(sirius::unique_ptr<itask_local_state> local_state,
-                    sirius::shared_ptr<itask_global_state> global_state);
+  gpu_pipeline_task(std::unique_ptr<itask_local_state> local_state,
+                    std::shared_ptr<itask_global_state> global_state);
 
   /**
    * @brief Method to actually execute the task
@@ -157,7 +161,7 @@ class gpu_pipeline_task : public itask {
    * @param batch The data batch to push
    * @param pipeline_id The id of the pipeline that produced this data batch
    */
-  void push_data_batch(sirius::unique_ptr<cucascade::data_batch> batch, uint64_t pipeline_id);
+  void push_data_batch(std::unique_ptr<cucascade::data_batch> batch, uint64_t pipeline_id);
 };
 
 }  // namespace parallel

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -46,7 +46,7 @@ class gpu_pipeline_task_global_state : public itask_global_state {
    */
   explicit gpu_pipeline_task_global_state(uint64_t pipeline_id,
                                           duckdb::shared_ptr<duckdb::GPUPipeline> pipeline,
-                                          data_repository_manager& data_repo_mgr,
+                                          cucascade::data_repository_manager& data_repo_mgr,
                                           task_completion_message_queue& message_queue)
     : _pipeline_id(pipeline_id),
       _pipeline(std::move(pipeline)),
@@ -55,7 +55,7 @@ class gpu_pipeline_task_global_state : public itask_global_state {
   {
   }
 
-  data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository manager
+  cucascade::data_repository_manager& _data_repo_mgr;  ///< Reference to the data repository manager
   task_completion_message_queue&
     _message_queue;  ///< Message queue to notify TaskCreator about task completion
   duckdb::shared_ptr<duckdb::GPUPipeline>
@@ -80,23 +80,23 @@ class gpu_pipeline_task_local_state : public itask_local_state {
    */
   explicit gpu_pipeline_task_local_state(
     uint64_t task_id,
-    sirius::vector<sirius::unique_ptr<data_batch_view>> batch_views,
-    sirius::unique_ptr<sirius::memory::reservation> res = nullptr)
+    sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>> batch_views,
+    sirius::unique_ptr<cucascade::memory::reservation> res = nullptr)
     : _task_id(task_id), _batch_views(std::move(batch_views)), _reservation(std::move(res))
   {
   }
 
   uint64_t _task_id;  ///< Unique identifier for this task
-  sirius::vector<sirius::unique_ptr<data_batch_view>>
+  sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>
     _batch_views;  ///< Input data batch views for the pipeline
 
-  void set_reservation(sirius::unique_ptr<sirius::memory::reservation> res)
+  void set_reservation(sirius::unique_ptr<cucascade::memory::reservation> res)
   {
     _reservation = std::move(res);
   }
 
  private:
-  sirius::unique_ptr<sirius::memory::reservation>
+  sirius::unique_ptr<cucascade::memory::reservation>
     _reservation;  ///< Memory reservation for GPU resources
   // TODO: for now, reservation is passed as a local state, will be null when the task is first
   // created, and will be set when reservation is made
@@ -157,7 +157,7 @@ class gpu_pipeline_task : public itask {
    * @param batch The data batch to push
    * @param pipeline_id The id of the pipeline that produced this data batch
    */
-  void push_data_batch(sirius::unique_ptr<data_batch> batch, uint64_t pipeline_id);
+  void push_data_batch(sirius::unique_ptr<cucascade::data_batch> batch, uint64_t pipeline_id);
 };
 
 }  // namespace parallel

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -63,7 +63,7 @@ class pipeline_executor : public itask_executor {
    *
    * @param task The task to schedule (must be a gpu_pipeline_task)
    */
-  void schedule(sirius::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<itask> task) override;
 
   /**
    * @brief Main worker loop for executing GPU pipeline tasks
@@ -100,17 +100,17 @@ class pipeline_executor : public itask_executor {
    * @param task The task to schedule
    * @param gpu_id The GPU ID to which the task should be scheduled
    */
-  void dispatch_to_gpu_executor(sirius::unique_ptr<itask> task, int gpu_id);
+  void dispatch_to_gpu_executor(std::unique_ptr<itask> task, int gpu_id);
 
   /**
    * @brief Submit a task request to task_request_queue
    */
-  void submit_task_request(sirius::unique_ptr<task_request> request);
+  void submit_task_request(std::unique_ptr<task_request> request);
 
  private:
-  sirius::vector<sirius::unique_ptr<gpu_pipeline_executor>>
+  std::vector<std::unique_ptr<gpu_pipeline_executor>>
     _gpu_executors;  ///< Vector of GPU executors
-  sirius::unique_ptr<task_request_queue> _task_request_queue;
+  std::unique_ptr<task_request_queue> _task_request_queue;
 };
 
 }  // namespace parallel

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -108,8 +108,7 @@ class pipeline_executor : public itask_executor {
   void submit_task_request(std::unique_ptr<task_request> request);
 
  private:
-  std::vector<std::unique_ptr<gpu_pipeline_executor>>
-    _gpu_executors;  ///< Vector of GPU executors
+  std::vector<std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;  ///< Vector of GPU executors
   std::unique_ptr<task_request_queue> _task_request_queue;
 };
 

--- a/src/include/pipeline/pipeline_queue.hpp
+++ b/src/include/pipeline/pipeline_queue.hpp
@@ -15,15 +15,17 @@
  */
 
 #pragma once
+
 #include "config.hpp"
 #include "data/data_repository.hpp"
 #include "gpu_pipeline.hpp"
-#include "helper/helper.hpp"
 #include "parallel/task_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include <blockingconcurrentqueue.h>
 
+#include <atomic>
+#include <memory>
 #include <semaphore>
 
 namespace sirius {
@@ -33,7 +35,7 @@ namespace parallel {
  * @brief A task queue specifically for managing gpu_pipeline_task instances.
  *
  * This class provides a thread-safe queue implementation for scheduling and retrieving GPU pipeline
- * tasks. Currently it just uses the sirius::queue, but in the future we might want to implement a
+ * tasks. Currently it just uses the std::queue, but in the future we might want to implement a
  * more sophisticated queue that supports priority scheduling, task stealing, etc..
  */
 class pipeline_queue : public itask_queue {
@@ -59,7 +61,7 @@ class pipeline_queue : public itask_queue {
    * @param task The task to be scheduled
    * @throws sirius::runtime_error If the scheduler is not currently accepting requests
    */
-  void push(sirius::unique_ptr<itask> task) override;
+  void push(std::unique_ptr<itask> task) override;
 
   /**
    * @brief Pull a task to execute.
@@ -71,7 +73,7 @@ class pipeline_queue : public itask_queue {
    * @throws sirius::runtime_error If the scheduler is not currently stopped and thus not returning
    * tasks
    */
-  sirius::unique_ptr<itask> pull() override;
+  std::unique_ptr<itask> pull() override;
 
   /**
    * @brief Check if the task queue is empty
@@ -82,7 +84,7 @@ class pipeline_queue : public itask_queue {
 
  private:
   size_t _num_threads;
-  duckdb_moodycamel::BlockingConcurrentQueue<sirius::unique_ptr<itask>> _task_queue;
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<itask>> _task_queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 

--- a/src/include/pipeline/task_request.hpp
+++ b/src/include/pipeline/task_request.hpp
@@ -35,12 +35,12 @@ class task_request_queue {
   task_request_queue(size_t num_threads) : _num_threads(num_threads) {};
   void open();
   void close();
-  void push(sirius::unique_ptr<task_request> request);
+  void push(std::unique_ptr<task_request> request);
   unique_ptr<task_request> pull();
 
  private:
   size_t _num_threads;
-  duckdb_moodycamel::BlockingConcurrentQueue<sirius::unique_ptr<task_request>> _request_queue;
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<task_request>> _request_queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 

--- a/src/include/task_completion.hpp
+++ b/src/include/task_completion.hpp
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 #pragma once
-#include "helper/helper.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <semaphore>
 
 namespace sirius {
 
@@ -65,9 +70,9 @@ class task_completion_message_queue {
    *
    * @param message The completion message to enqueue (ownership is transferred)
    */
-  void EnqueueMessage(sirius::unique_ptr<task_completion_message> message)
+  void EnqueueMessage(std::unique_ptr<task_completion_message> message)
   {
-    sirius::lock_guard<sirius::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     message_queue_.push(std::move(message));
     sem_.release();  // signal that one item is available
   }
@@ -78,13 +83,13 @@ class task_completion_message_queue {
    * This method blocks until a message becomes available, then safely dequeues
    * and returns it to the caller.
    *
-   * @return sirius::unique_ptr<task_completion_message> The dequeued message, or nullptr if queue
+   * @return std::unique_ptr<task_completion_message> The dequeued message, or nullptr if queue
    * is empty
    */
-  sirius::unique_ptr<task_completion_message> DequeueMessage()
+  std::unique_ptr<task_completion_message> DequeueMessage()
   {
     sem_.acquire();  // wait until there's something
-    sirius::lock_guard<sirius::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (message_queue_.empty()) { return nullptr; }
     auto message = std::move(message_queue_.front());
     message_queue_.pop();
@@ -94,13 +99,13 @@ class task_completion_message_queue {
   /**
    * @brief Alias for DequeueMessage for consistent interface
    *
-   * @return sirius::unique_ptr<task_completion_message> The dequeued message
+   * @return std::unique_ptr<task_completion_message> The dequeued message
    */
-  sirius::unique_ptr<task_completion_message> PullMessage() { return DequeueMessage(); }
+  std::unique_ptr<task_completion_message> PullMessage() { return DequeueMessage(); }
 
  private:
-  mutex mutex_;  ///< Mutex for thread-safe queue access
-  sirius::queue<sirius::unique_ptr<task_completion_message>>
+  std::mutex mutex_;  ///< Mutex for thread-safe queue access
+  std::queue<std::unique_ptr<task_completion_message>>
     message_queue_;                   ///< Underlying message queue
   std::counting_semaphore<> sem_{0};  ///< Semaphore for blocking/signaling (starts with 0 permits)
 };

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -22,7 +22,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/device/cuda_async_memory_resource.hpp>
 
-namespace sirius {
+namespace cucascade {
 
 namespace memory {
 
@@ -50,7 +50,7 @@ std::error_code make_error_code(MemoryError e)
   return std::error_code(static_cast<int>(e), memory_category());
 }
 
-sirius_out_of_memory::sirius_out_of_memory(std::string_view message,
+cucascade_out_of_memory::cucascade_out_of_memory(std::string_view message,
                                            std::size_t requested_bytes,
                                            std::size_t global_usage)
   : rmm::out_of_memory(message.data()), requested_bytes(requested_bytes), global_usage(global_usage)
@@ -69,7 +69,7 @@ std::unique_ptr<rmm::mr::device_memory_resource> make_default_host_memory_resour
                                                                                    size_t limit,
                                                                                    size_t capacity)
 {
-  return std::make_unique<sirius::memory::numa_region_pinned_host_memory_resource>(numa_node_id);
+  return std::make_unique<cucascade::memory::numa_region_pinned_host_memory_resource>(numa_node_id);
 }
 
 DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier)
@@ -84,11 +84,11 @@ DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier)
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade
 
 namespace std {
-size_t hash<sirius::memory::memory_space_id>::operator()(
-  const sirius::memory::memory_space_id& p) const
+size_t hash<cucascade::memory::memory_space_id>::operator()(
+  const cucascade::memory::memory_space_id& p) const
 {
   return p.uuid();
 }

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -51,8 +51,8 @@ std::error_code make_error_code(MemoryError e)
 }
 
 cucascade_out_of_memory::cucascade_out_of_memory(std::string_view message,
-                                           std::size_t requested_bytes,
-                                           std::size_t global_usage)
+                                                 std::size_t requested_bytes,
+                                                 std::size_t global_usage)
   : rmm::out_of_memory(message.data()), requested_bytes(requested_bytes), global_usage(global_usage)
 {
 }

--- a/src/memory/disk_access_limiter.cpp
+++ b/src/memory/disk_access_limiter.cpp
@@ -16,7 +16,7 @@
 
 #include "memory/disk_access_limiter.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 disk_access_limiter::disk_access_limiter(memory_space_id space_id, std::size_t capacity)
@@ -143,4 +143,4 @@ void disk_access_limiter::update_peak_allocated_bytes() noexcept
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/fixed_size_host_memory_resource.cpp
+++ b/src/memory/fixed_size_host_memory_resource.cpp
@@ -28,7 +28,7 @@
 #include <mutex>
 #include <stdexcept>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 namespace {
@@ -340,4 +340,4 @@ std::size_t fixed_size_host_memory_resource::do_reserve_upto(std::size_t bytes,
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/memory_reservation.cpp
+++ b/src/memory/memory_reservation.cpp
@@ -22,7 +22,7 @@
 
 #include <rmm/cuda_device.hpp>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // Provide out-of-line definition for the virtual destructor to satisfy linker
@@ -143,4 +143,4 @@ std::unique_ptr<reservation_limit_policy> make_default_reservation_limit_policy(
 //===----------------------------------------------------------------------===//
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/memory_reservation_manager.cpp
+++ b/src/memory/memory_reservation_manager.cpp
@@ -29,7 +29,7 @@
 #include <mutex>
 #include <stdexcept>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 //===----------------------------------------------------------------------===//
@@ -396,4 +396,4 @@ void memory_reservation_manager::shutdown()
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -86,17 +86,17 @@ int memory_space::get_device_id() const noexcept { return _id.device_id; }
 
 std::unique_ptr<reservation> memory_space::make_reservation_or_null(size_t size)
 {
-  std::unique_ptr<reserved_arena> arena =
-    std::visit(cucascade::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
-                                    return mr->reserve(size, notification_channel_->get_notifier());
-                                  },
-                                  [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
-                                    return mr->reserve(size, notification_channel_->get_notifier());
-                                  },
-                                  [&](std::unique_ptr<fixed_size_host_memory_resource>& mr) {
-                                    return mr->reserve(size, notification_channel_->get_notifier());
-                                  }},
-               _reservation_allocator);
+  std::unique_ptr<reserved_arena> arena = std::visit(
+    cucascade::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
+                            return mr->reserve(size, notification_channel_->get_notifier());
+                          },
+                          [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
+                            return mr->reserve(size, notification_channel_->get_notifier());
+                          },
+                          [&](std::unique_ptr<fixed_size_host_memory_resource>& mr) {
+                            return mr->reserve(size, notification_channel_->get_notifier());
+                          }},
+    _reservation_allocator);
   return reservation::create(*this, std::move(arena));
 }
 
@@ -104,14 +104,14 @@ std::unique_ptr<reservation> memory_space::make_reservation_upto(size_t size)
 {
   std::unique_ptr<reserved_arena> arena = std::visit(
     cucascade::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
-                         return mr->reserve_upto(size, notification_channel_->get_notifier());
-                       },
-                       [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
-                         return mr->reserve_upto(size, notification_channel_->get_notifier());
-                       },
-                       [&](std::unique_ptr<fixed_size_host_memory_resource>& mr) {
-                         return mr->reserve_upto(size, notification_channel_->get_notifier());
-                       }},
+                            return mr->reserve_upto(size, notification_channel_->get_notifier());
+                          },
+                          [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
+                            return mr->reserve_upto(size, notification_channel_->get_notifier());
+                          },
+                          [&](std::unique_ptr<fixed_size_host_memory_resource>& mr) {
+                            return mr->reserve_upto(size, notification_channel_->get_notifier());
+                          }},
     _reservation_allocator);
   return reservation::create(*this, std::move(arena));
 }
@@ -140,14 +140,14 @@ std::size_t memory_space::get_active_reservation_count() const
 {
   return std::visit(
     cucascade::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
-                         return mr->get_active_reservation_count();
-                       },
-                       [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
-                         return mr->get_active_reservation_count();
-                       },
-                       [&](const std::unique_ptr<fixed_size_host_memory_resource>& mr) {
-                         return mr->get_active_reservation_count();
-                       }},
+                            return mr->get_active_reservation_count();
+                          },
+                          [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
+                            return mr->get_active_reservation_count();
+                          },
+                          [&](const std::unique_ptr<fixed_size_host_memory_resource>& mr) {
+                            return mr->get_active_reservation_count();
+                          }},
     _reservation_allocator);
 }
 
@@ -200,14 +200,14 @@ size_t memory_space::get_total_reserved_memory() const
 {
   return std::visit(
     cucascade::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
-                         return mr->get_total_reserved_bytes();
-                       },
-                       [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
-                         return mr->get_total_reserved_bytes();
-                       },
-                       [](const std::unique_ptr<fixed_size_host_memory_resource>& mr) {
-                         return mr->get_total_reserved_bytes();
-                       }},
+                            return mr->get_total_reserved_bytes();
+                          },
+                          [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
+                            return mr->get_total_reserved_bytes();
+                          },
+                          [](const std::unique_ptr<fixed_size_host_memory_resource>& mr) {
+                            return mr->get_total_reserved_bytes();
+                          }},
     _reservation_allocator);
 }
 
@@ -217,11 +217,11 @@ rmm::mr::device_memory_resource* memory_space::get_default_allocator() const noe
 {
   return std::visit(
     cucascade::overloaded{[this](const std::unique_ptr<disk_access_limiter>& other)
-                         -> rmm::mr::device_memory_resource* { return _allocator.get(); },
-                       [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr)
-                         -> rmm::mr::device_memory_resource* { return mr.get(); },
-                       [](const std::unique_ptr<fixed_size_host_memory_resource>& mr)
-                         -> rmm::mr::device_memory_resource* { return mr.get(); }},
+                            -> rmm::mr::device_memory_resource* { return _allocator.get(); },
+                          [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr)
+                            -> rmm::mr::device_memory_resource* { return mr.get(); },
+                          [](const std::unique_ptr<fixed_size_host_memory_resource>& mr)
+                            -> rmm::mr::device_memory_resource* { return mr.get(); }},
     _reservation_allocator);
 }
 

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -32,7 +32,7 @@
 #include <stdexcept>
 #include <variant>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 //===----------------------------------------------------------------------===//
@@ -87,7 +87,7 @@ int memory_space::get_device_id() const noexcept { return _id.device_id; }
 std::unique_ptr<reservation> memory_space::make_reservation_or_null(size_t size)
 {
   std::unique_ptr<reserved_arena> arena =
-    std::visit(sirius::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
+    std::visit(cucascade::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
                                     return mr->reserve(size, notification_channel_->get_notifier());
                                   },
                                   [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
@@ -103,7 +103,7 @@ std::unique_ptr<reservation> memory_space::make_reservation_or_null(size_t size)
 std::unique_ptr<reservation> memory_space::make_reservation_upto(size_t size)
 {
   std::unique_ptr<reserved_arena> arena = std::visit(
-    sirius::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
+    cucascade::overloaded{[&](std::unique_ptr<disk_access_limiter>& mr) {
                          return mr->reserve_upto(size, notification_channel_->get_notifier());
                        },
                        [&](std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
@@ -139,7 +139,7 @@ rmm::cuda_stream_view memory_space::acquire_stream() const
 std::size_t memory_space::get_active_reservation_count() const
 {
   return std::visit(
-    sirius::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
+    cucascade::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
                          return mr->get_active_reservation_count();
                        },
                        [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
@@ -171,7 +171,7 @@ size_t memory_space::get_amount_to_downgrade() const
 size_t memory_space::get_available_memory(rmm::cuda_stream_view stream) const
 {
   return std::visit(
-    sirius::overloaded{
+    cucascade::overloaded{
       [&](const std::unique_ptr<disk_access_limiter>& mr) { return mr->get_available_memory(); },
       [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
         return mr->get_available_memory(stream);
@@ -185,7 +185,7 @@ size_t memory_space::get_available_memory(rmm::cuda_stream_view stream) const
 size_t memory_space::get_available_memory() const
 {
   return std::visit(
-    sirius::overloaded{
+    cucascade::overloaded{
       [&](const std::unique_ptr<disk_access_limiter>& mr) { return mr->get_available_memory(); },
       [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
         return mr->get_available_memory();
@@ -199,7 +199,7 @@ size_t memory_space::get_available_memory() const
 size_t memory_space::get_total_reserved_memory() const
 {
   return std::visit(
-    sirius::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
+    cucascade::overloaded{[&](const std::unique_ptr<disk_access_limiter>& mr) {
                          return mr->get_total_reserved_bytes();
                        },
                        [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
@@ -216,7 +216,7 @@ size_t memory_space::get_max_memory() const noexcept { return _memory_limit; }
 rmm::mr::device_memory_resource* memory_space::get_default_allocator() const noexcept
 {
   return std::visit(
-    sirius::overloaded{[this](const std::unique_ptr<disk_access_limiter>& other)
+    cucascade::overloaded{[this](const std::unique_ptr<disk_access_limiter>& other)
                          -> rmm::mr::device_memory_resource* { return _allocator.get(); },
                        [](const std::unique_ptr<reservation_aware_resource_adaptor>& mr)
                          -> rmm::mr::device_memory_resource* { return mr.get(); },
@@ -255,4 +255,4 @@ size_t memory_space_hash::operator()(const memory_space& ms) const
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/null_device_memory_resource.cpp
+++ b/src/memory/null_device_memory_resource.cpp
@@ -16,10 +16,10 @@
 
 #include "memory/null_device_memory_resource.hpp"
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 // All methods are defined inline in the header; this TU ensures linkage.
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/reservation_aware_resource_adaptor.cpp
+++ b/src/memory/reservation_aware_resource_adaptor.cpp
@@ -31,7 +31,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 using stream_ordered_tracker_state =
@@ -428,10 +428,10 @@ void* reservation_aware_resource_adaptor::do_allocate_unmanaged(std::size_t allo
       return _upstream.allocate_async(allocation_bytes, stream);
     } catch (std::exception& e) {
       _total_allocated_bytes.sub(tracking_bytes);
-      throw sirius_out_of_memory(e.what(), allocation_bytes, post_allocation_size);
+      throw cucascade_out_of_memory(e.what(), allocation_bytes, post_allocation_size);
     }
   } else {
-    throw sirius_out_of_memory(
+    throw cucascade_out_of_memory(
       "not enough capacity to allocate memory", allocation_bytes, post_allocation_size);
   }
 }
@@ -509,4 +509,4 @@ void reservation_aware_resource_adaptor::do_release_reservation(
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/reservation_manager_configurator.cpp
+++ b/src/memory/reservation_manager_configurator.cpp
@@ -30,7 +30,7 @@
 #include <set>
 #include <variant>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 using builder_reference   = reservation_manager_configurator::builder_reference;
@@ -285,4 +285,4 @@ std::vector<int> reservation_manager_configurator::extract_host_ids(
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/stream_pool.cpp
+++ b/src/memory/stream_pool.cpp
@@ -22,7 +22,7 @@
 #include <mutex>
 #include <utility>
 
-namespace sirius {
+namespace cucascade {
 namespace memory {
 
 borrowed_stream::borrowed_stream(rmm::cuda_stream s,
@@ -105,4 +105,4 @@ void exclusive_stream_pool::release_stream(rmm::cuda_stream&& s) noexcept
 }
 
 }  // namespace memory
-}  // namespace sirius
+}  // namespace cucascade

--- a/src/memory/topology_discovery.cpp
+++ b/src/memory/topology_discovery.cpp
@@ -19,7 +19,7 @@
 
 namespace fs = std::filesystem;
 
-namespace sirius::memory {
+namespace cucascade::memory {
 
 namespace {
 
@@ -626,4 +626,4 @@ bool topology_discovery::discover()
   return true;
 }
 
-}  // namespace sirius::memory
+}  // namespace cucascade::memory

--- a/src/operator/aggregate/gpu_aggregate_impl.cpp
+++ b/src/operator/aggregate/gpu_aggregate_impl.cpp
@@ -91,8 +91,8 @@ std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggre
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
@@ -123,8 +123,7 @@ std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   // Here we don't need to explicitly cast input/output for count or sum of integers,
   // because cudf groupby produces INT32 for count, and promotes to INT64 for sum of integers
   // (both signed and unsigned), so types of local aggregation results are consistent.
-  std::unordered_map<int, std::vector<std::unique_ptr<cudf::groupby_aggregation>>>
-    input_col_to_agg;
+  std::unordered_map<int, std::vector<std::unique_ptr<cudf::groupby_aggregation>>> input_col_to_agg;
   std::unordered_map<int, std::vector<int>> input_col_to_output_idx;
   std::vector<int> input_col_order;
   for (int i = 0; i < aggregates.size(); ++i) {
@@ -165,8 +164,8 @@ std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/aggregate/gpu_aggregate_impl.cpp
+++ b/src/operator/aggregate/gpu_aggregate_impl.cpp
@@ -38,13 +38,13 @@ sirius::unique_ptr<Base> get_local_aggregation(cudf::aggregation::Kind kind)
   }
 }
 
-sirius::unique_ptr<data_batch> gpu_aggregate_impl::local_ungrouped_aggregate(
-  const data_batch_view& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggregate(
+  const cucascade::data_batch_view& input,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
   const sirius::vector<int>& aggregate_idx,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   if (aggregates.size() != aggregate_idx.size()) {
     throw std::runtime_error(
@@ -89,20 +89,20 @@ sirius::unique_ptr<data_batch> gpu_aggregate_impl::local_ungrouped_aggregate(
   auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
 
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_aggregate_impl::local_grouped_aggregate(
-  const data_batch_view& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
+  const cucascade::data_batch_view& input,
   const sirius::vector<int>& group_idx,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
   const sirius::vector<int>& aggregate_idx,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check
   if (aggregates.size() != aggregate_idx.size()) {
@@ -163,8 +163,8 @@ sirius::unique_ptr<data_batch> gpu_aggregate_impl::local_grouped_aggregate(
   // Create the output data batch
   auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }

--- a/src/operator/aggregate/gpu_aggregate_impl.cpp
+++ b/src/operator/aggregate/gpu_aggregate_impl.cpp
@@ -22,7 +22,7 @@ namespace sirius {
 namespace op {
 
 template <typename Base = cudf::aggregation>
-sirius::unique_ptr<Base> get_local_aggregation(cudf::aggregation::Kind kind)
+std::unique_ptr<Base> get_local_aggregation(cudf::aggregation::Kind kind)
 {
   switch (kind) {
     case cudf::aggregation::Kind::MIN: return cudf::make_min_aggregation<Base>();
@@ -38,10 +38,10 @@ sirius::unique_ptr<Base> get_local_aggregation(cudf::aggregation::Kind kind)
   }
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggregate(
+std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggregate(
   const cucascade::data_batch_view& input,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
-  const sirius::vector<int>& aggregate_idx,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
+  const std::vector<int>& aggregate_idx,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -51,7 +51,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_ag
       "mismatch between the size of `aggregates` and `aggregate_idx` in "
       "`local_ungrouped_aggregate()`");
   }
-  sirius::vector<sirius::unique_ptr<cudf::column>> output_cols;
+  std::vector<std::unique_ptr<cudf::column>> output_cols;
   auto input_table = input.get_cudf_table_view();
   for (int i = 0; i < aggregates.size(); ++i) {
     const auto& input_col       = input_table.column(aggregate_idx[i]);
@@ -86,20 +86,20 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_ag
     output_cols.push_back(cudf::make_column_from_scalar(
       *output_scalar, 1, cudf::get_default_stream(), memory_space.get_default_allocator()));
   }
-  auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
 
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
+std::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
   const cucascade::data_batch_view& input,
-  const sirius::vector<int>& group_idx,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
-  const sirius::vector<int>& aggregate_idx,
+  const std::vector<int>& group_idx,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
+  const std::vector<int>& aggregate_idx,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -113,7 +113,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggr
 
   // Create cudf groupby
   auto input_table = input.get_cudf_table_view();
-  sirius::vector<cudf::column_view> group_cols;
+  std::vector<cudf::column_view> group_cols;
   for (int idx : group_idx) {
     group_cols.push_back(input_table.column(idx));
   }
@@ -123,10 +123,10 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggr
   // Here we don't need to explicitly cast input/output for count or sum of integers,
   // because cudf groupby produces INT32 for count, and promotes to INT64 for sum of integers
   // (both signed and unsigned), so types of local aggregation results are consistent.
-  sirius::unordered_map<int, sirius::vector<sirius::unique_ptr<cudf::groupby_aggregation>>>
+  std::unordered_map<int, std::vector<std::unique_ptr<cudf::groupby_aggregation>>>
     input_col_to_agg;
-  sirius::unordered_map<int, sirius::vector<int>> input_col_to_output_idx;
-  sirius::vector<int> input_col_order;
+  std::unordered_map<int, std::vector<int>> input_col_to_output_idx;
+  std::vector<int> input_col_order;
   for (int i = 0; i < aggregates.size(); ++i) {
     const auto& aggregate_kind = aggregates[i];
     int aggregate_col_id       = aggregate_idx[i];
@@ -138,7 +138,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggr
     input_col_to_output_idx[aggregate_col_id].push_back(i);
   }
 
-  sirius::vector<cudf::groupby::aggregation_request> requests;
+  std::vector<cudf::groupby::aggregation_request> requests;
   for (int aggregate_col_id : input_col_order) {
     cudf::groupby::aggregation_request request;
     request.values       = input_table.column(aggregate_col_id);
@@ -161,10 +161,10 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggr
   }
 
   // Create the output data batch
-  auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }

--- a/src/operator/aggregate/gpu_aggregate_impl.cpp
+++ b/src/operator/aggregate/gpu_aggregate_impl.cpp
@@ -91,8 +91,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_ag
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggregate(
@@ -165,8 +165,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggr
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/merge/gpu_merge_impl.cpp
+++ b/src/operator/merge/gpu_merge_impl.cpp
@@ -48,8 +48,8 @@ std::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
@@ -135,8 +135,8 @@ std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
@@ -211,8 +211,8 @@ std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
@@ -253,8 +253,8 @@ std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
@@ -315,8 +315,8 @@ std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/merge/gpu_merge_impl.cpp
+++ b/src/operator/merge/gpu_merge_impl.cpp
@@ -24,11 +24,11 @@
 namespace sirius {
 namespace op {
 
-sirius::unique_ptr<data_batch> gpu_merge_impl::concat(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
+  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (input.size() < 2) {
@@ -46,18 +46,18 @@ sirius::unique_ptr<data_batch> gpu_merge_impl::concat(
 
   // Create output data batch.
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_cudf_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
+  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (input.size() < 2) {
@@ -133,19 +133,19 @@ sirius::unique_ptr<data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
 
   // Create output data batch.
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_cudf_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_merge_impl::merge_grouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
+  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
   int num_group_cols,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (input.size() < 2) {
@@ -209,20 +209,20 @@ sirius::unique_ptr<data_batch> gpu_merge_impl::merge_grouped_aggregate(
   // Create the output data batch
   auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_merge_impl::merge_order_by(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
+  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
   const sirius::vector<int>& order_key_idx,
   const sirius::vector<cudf::order>& column_order,
   const sirius::vector<cudf::null_order>& null_precedence,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (input.size() < 2) {
@@ -251,22 +251,22 @@ sirius::unique_ptr<data_batch> gpu_merge_impl::merge_order_by(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_merge_impl::merge_top_n(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
+  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
   const int limit,
   const int offset,
   const sirius::vector<int>& order_key_idx,
   const sirius::vector<cudf::order>& column_order,
   const sirius::vector<cudf::null_order>& null_precedence,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (input.size() < 2) {
@@ -313,8 +313,8 @@ sirius::unique_ptr<data_batch> gpu_merge_impl::merge_top_n(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }

--- a/src/operator/merge/gpu_merge_impl.cpp
+++ b/src/operator/merge/gpu_merge_impl.cpp
@@ -48,8 +48,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
@@ -135,8 +135,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggreg
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
@@ -211,8 +211,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregat
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
@@ -253,8 +253,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
@@ -315,8 +315,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/merge/gpu_merge_impl.cpp
+++ b/src/operator/merge/gpu_merge_impl.cpp
@@ -24,8 +24,8 @@
 namespace sirius {
 namespace op {
 
-sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
-  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+std::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
+  const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -36,7 +36,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
   }
 
   // Pull input cudf tables and merge.
-  sirius::vector<cudf::table_view> input_cudf_table_views;
+  std::vector<cudf::table_view> input_cudf_table_views;
   input_cudf_table_views.resize(input.size());
   for (int i = 0; i < input.size(); ++i) {
     input_cudf_table_views[i] = input[i]->get_cudf_table_view();
@@ -46,15 +46,15 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::concat(
 
   // Create output data batch.
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
+std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggregate(
+  const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -66,7 +66,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggreg
   }
 
   // Pull input cudf tables and concatenate.
-  sirius::vector<cudf::table_view> input_cudf_table_views;
+  std::vector<cudf::table_view> input_cudf_table_views;
   input_cudf_table_views.resize(input.size());
   for (int i = 0; i < input.size(); ++i) {
     input_cudf_table_views[i] = input[i]->get_cudf_table_view();
@@ -79,9 +79,9 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggreg
     cudf::concatenate(input_cudf_table_views, stream, memory_space.get_default_allocator());
 
   // Aggregate on the concatenated table
-  sirius::vector<sirius::unique_ptr<cudf::column>> output_cudf_cols;
+  std::vector<std::unique_ptr<cudf::column>> output_cudf_cols;
   for (int c = 0; c < aggregates.size(); ++c) {
-    sirius::unique_ptr<cudf::reduce_aggregation> reduce_aggregation = nullptr;
+    std::unique_ptr<cudf::reduce_aggregation> reduce_aggregation = nullptr;
     cudf::data_type output_type = concatenated->get_column(c).type();
     switch (aggregates[c]) {
       case cudf::aggregation::Kind::MIN: {
@@ -129,20 +129,20 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_ungrouped_aggreg
     output_cudf_cols.push_back(cudf::make_column_from_scalar(
       *output_scalar, 1, stream, memory_space.get_default_allocator()));
   }
-  auto output_cudf_table = sirius::make_unique<cudf::table>(std::move(output_cudf_cols));
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(output_cudf_cols));
 
   // Create output data batch.
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_cudf_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
+  const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
   int num_group_cols,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -154,7 +154,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregat
   }
 
   // Pull input cudf tables and concatenate.
-  sirius::vector<cudf::table_view> input_cudf_table_views;
+  std::vector<cudf::table_view> input_cudf_table_views;
   input_cudf_table_views.resize(input.size());
   for (int i = 0; i < input.size(); ++i) {
     input_cudf_table_views[i] = input[i]->get_cudf_table_view();
@@ -169,13 +169,13 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregat
   // Create cudf groupby and make aggregation requests.
   // Here we don't need to explicitly cast input/output for count or sum of integers,
   // because cudf groupby produces INT64 for sum of integers (both signed and unsigned).
-  sirius::vector<cudf::column_view> group_cols;
+  std::vector<cudf::column_view> group_cols;
   for (int c = 0; c < num_group_cols; ++c) {
     group_cols.push_back(concatenated->get_column(c).view());
   }
   cudf::groupby::groupby grpby_obj(cudf::table_view(group_cols), cudf::null_policy::INCLUDE);
-  sirius::vector<cudf::groupby::aggregation_request> requests;
-  sirius::vector<sirius::unique_ptr<cudf::column>> cast_columns;
+  std::vector<cudf::groupby::aggregation_request> requests;
+  std::vector<std::unique_ptr<cudf::column>> cast_columns;
   for (int i = 0; i < aggregates.size(); ++i) {
     int aggregate_col_id = num_group_cols + i;
     cudf::groupby::aggregation_request request;
@@ -207,19 +207,19 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregat
   }
 
   // Create the output data batch
-  auto output_table = sirius::make_unique<cudf::table>(std::move(output_cols));
+  auto output_table = std::make_unique<cudf::table>(std::move(output_cols));
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
-  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
-  const sirius::vector<int>& order_key_idx,
-  const sirius::vector<cudf::order>& column_order,
-  const sirius::vector<cudf::null_order>& null_precedence,
+std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
+  const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
+  const std::vector<int>& order_key_idx,
+  const std::vector<cudf::order>& column_order,
+  const std::vector<cudf::null_order>& null_precedence,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -237,7 +237,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
   }
 
   // Pull input cudf tables and merge.
-  sirius::vector<cudf::table_view> input_tables;
+  std::vector<cudf::table_view> input_tables;
   input_tables.resize(input.size());
   for (int i = 0; i < input.size(); ++i) {
     input_tables[i] = input[i]->get_cudf_table_view();
@@ -251,19 +251,19 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
-  const sirius::vector<sirius::unique_ptr<cucascade::data_batch_view>>& input,
+std::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
+  const std::vector<std::unique_ptr<cucascade::data_batch_view>>& input,
   const int limit,
   const int offset,
-  const sirius::vector<int>& order_key_idx,
-  const sirius::vector<cudf::order>& column_order,
-  const sirius::vector<cudf::null_order>& null_precedence,
+  const std::vector<int>& order_key_idx,
+  const std::vector<cudf::order>& column_order,
+  const std::vector<cudf::null_order>& null_precedence,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -280,7 +280,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
   }
 
   // Pull input cudf tables and merge.
-  sirius::vector<cudf::table_view> input_tables;
+  std::vector<cudf::table_view> input_tables;
   input_tables.resize(input.size());
   for (int i = 0; i < input.size(); ++i) {
     input_tables[i] = input[i]->get_cudf_table_view();
@@ -293,17 +293,17 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
                                   memory_space.get_default_allocator());
 
   // Process limit and offset
-  sirius::unique_ptr<cudf::table> output_table = nullptr;
+  std::unique_ptr<cudf::table> output_table = nullptr;
   if (offset >= merged_table->num_rows()) {
-    sirius::vector<sirius::unique_ptr<cudf::column>> empty_cols;
+    std::vector<std::unique_ptr<cudf::column>> empty_cols;
     for (int c = 0; c < merged_table->num_columns(); ++c) {
       empty_cols.push_back(cudf::make_empty_column(merged_table->get_column(c).type()));
     }
-    output_table = sirius::make_unique<cudf::table>(std::move(empty_cols));
+    output_table = std::make_unique<cudf::table>(std::move(empty_cols));
   } else if (offset == 0 && limit >= merged_table->num_rows()) {
     output_table = std::move(merged_table);
   } else {
-    output_table = sirius::make_unique<cudf::table>(
+    output_table = std::make_unique<cudf::table>(
       cudf::slice(merged_table->view(),
                   {offset, std::min(merged_table->num_rows(), offset + limit)},
                   stream)[0],
@@ -313,8 +313,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }

--- a/src/operator/order/gpu_order_impl.cpp
+++ b/src/operator/order/gpu_order_impl.cpp
@@ -21,12 +21,12 @@
 namespace sirius {
 namespace op {
 
-sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
+std::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
   const cucascade::data_batch_view& input,
-  const sirius::vector<int>& order_key_idx,
-  sirius::vector<cudf::order> const& column_order,
-  sirius::vector<cudf::null_order> const& null_precedence,
-  const sirius::vector<int>& projections,
+  const std::vector<int>& order_key_idx,
+  std::vector<cudf::order> const& column_order,
+  std::vector<cudf::null_order> const& null_precedence,
+  const std::vector<int>& projections,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -40,7 +40,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
 
   // Get sorted order
   auto input_table = input.get_cudf_table_view();
-  sirius::vector<cudf::column_view> sort_cols;
+  std::vector<cudf::column_view> sort_cols;
   for (int idx : order_key_idx) {
     sort_cols.push_back(input_table.column(idx));
   }
@@ -48,7 +48,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
     cudf::sorted_order(cudf::table_view(sort_cols), column_order, null_precedence);
 
   // Do projection
-  sirius::vector<cudf::column_view> project_input_cols;
+  std::vector<cudf::column_view> project_input_cols;
   for (int idx : projections) {
     project_input_cols.push_back(input_table.column(idx));
   }
@@ -56,20 +56,20 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
+std::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
   const cucascade::data_batch_view& input,
   const int limit,
   const int offset,
-  const sirius::vector<int>& order_key_idx,
-  const sirius::vector<cudf::order>& column_order,
-  const sirius::vector<cudf::null_order>& null_precedence,
-  const sirius::vector<int>& projections,
+  const std::vector<int>& order_key_idx,
+  const std::vector<cudf::order>& column_order,
+  const std::vector<cudf::null_order>& null_precedence,
+  const std::vector<int>& projections,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
   cucascade::data_repository_manager& data_repository_mgr)
@@ -83,7 +83,7 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
 
   // Get sorted order
   auto input_table = input.get_cudf_table_view();
-  sirius::vector<cudf::column_view> sort_cols;
+  std::vector<cudf::column_view> sort_cols;
   for (int idx : order_key_idx) {
     sort_cols.push_back(input_table.column(idx));
   }
@@ -91,19 +91,19 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
     cudf::sorted_order(cudf::table_view(sort_cols), column_order, null_precedence);
 
   // Get top `limit + offset` rows
-  sirius::unique_ptr<cudf::table> output_table = nullptr;
+  std::unique_ptr<cudf::table> output_table = nullptr;
   if (sorted_order->size() == 0) {
-    sirius::vector<sirius::unique_ptr<cudf::column>> empty_cols;
+    std::vector<std::unique_ptr<cudf::column>> empty_cols;
     for (int idx : projections) {
       empty_cols.push_back(cudf::make_empty_column(input_table.column(idx).type()));
     }
-    output_table = sirius::make_unique<cudf::table>(std::move(empty_cols));
+    output_table = std::make_unique<cudf::table>(std::move(empty_cols));
   } else {
     auto sliced_sorted_order =
       (limit + offset >= sorted_order->size())
         ? sorted_order->view()
         : cudf::slice(sorted_order->view(), {0, limit + offset}, stream)[0];
-    sirius::vector<cudf::column_view> project_input_cols;
+    std::vector<cudf::column_view> project_input_cols;
     for (int idx : projections) {
       project_input_cols.push_back(input_table.column(idx));
     }
@@ -112,8 +112,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                     data_repository_mgr,
                                                     std::move(gpu_table_representation));
 }

--- a/src/operator/order/gpu_order_impl.cpp
+++ b/src/operator/order/gpu_order_impl.cpp
@@ -21,15 +21,15 @@
 namespace sirius {
 namespace op {
 
-sirius::unique_ptr<data_batch> gpu_order_impl::local_order_by(
-  const data_batch_view& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
+  const cucascade::data_batch_view& input,
   const sirius::vector<int>& order_key_idx,
   sirius::vector<cudf::order> const& column_order,
   sirius::vector<cudf::null_order> const& null_precedence,
   const sirius::vector<int>& projections,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   if (order_key_idx.size() != column_order.size() ||
       order_key_idx.size() != null_precedence.size()) {
@@ -56,14 +56,14 @@ sirius::unique_ptr<data_batch> gpu_order_impl::local_order_by(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }
 
-sirius::unique_ptr<data_batch> gpu_order_impl::local_top_n(
-  const data_batch_view& input,
+sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
+  const cucascade::data_batch_view& input,
   const int limit,
   const int offset,
   const sirius::vector<int>& order_key_idx,
@@ -71,8 +71,8 @@ sirius::unique_ptr<data_batch> gpu_order_impl::local_top_n(
   const sirius::vector<cudf::null_order>& null_precedence,
   const sirius::vector<int>& projections,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   if (order_key_idx.size() != column_order.size() ||
       order_key_idx.size() != null_precedence.size()) {
@@ -112,8 +112,8 @@ sirius::unique_ptr<data_batch> gpu_order_impl::local_top_n(
 
   // Create the output data batch
   auto gpu_table_representation =
-    sirius::make_unique<sirius::gpu_table_representation>(*output_table, memory_space);
-  return sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+    sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
+  return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation));
 }

--- a/src/operator/order/gpu_order_impl.cpp
+++ b/src/operator/order/gpu_order_impl.cpp
@@ -58,8 +58,8 @@ std::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 std::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
@@ -114,8 +114,8 @@ std::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
   auto gpu_table_representation =
     std::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                    data_repository_mgr,
-                                                    std::move(gpu_table_representation));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/order/gpu_order_impl.cpp
+++ b/src/operator/order/gpu_order_impl.cpp
@@ -58,8 +58,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
@@ -114,8 +114,8 @@ sirius::unique_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
   auto gpu_table_representation =
     sirius::make_unique<cucascade::gpu_table_representation>(*output_table, memory_space);
   return sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation));
+                                                    data_repository_mgr,
+                                                    std::move(gpu_table_representation));
 }
 
 }  // namespace op

--- a/src/operator/partition/gpu_partition_impl.cpp
+++ b/src/operator/partition/gpu_partition_impl.cpp
@@ -23,13 +23,13 @@
 namespace sirius {
 namespace op {
 
-sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::hash_partition(
-  const data_batch_view& input,
+sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::hash_partition(
+  const cucascade::data_batch_view& input,
   const sirius::vector<int>& partition_key_idx,
   int num_partitions,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (num_partitions < 2) {
@@ -47,7 +47,7 @@ sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::hash_partitio
                                                memory_space.get_default_allocator());
 
   // Slice from the reordered table to create separate table partitions
-  sirius::vector<sirius::unique_ptr<data_batch>> output_batches;
+  sirius::vector<sirius::unique_ptr<cucascade::data_batch>> output_batches;
   sirius::vector<int> slice_indices;
   for (int i = 0; i < num_partitions; ++i) {
     slice_indices.push_back(partition_result.second[i]);
@@ -58,9 +58,9 @@ sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::hash_partitio
   for (int i = 0; i < num_partitions; ++i) {
     auto output_partition = sirius::make_unique<cudf::table>(sliced_partition_views[i]);
     auto gpu_table_representation =
-      sirius::make_unique<sirius::gpu_table_representation>(*output_partition, memory_space);
+      sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
-      sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+      sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                               data_repository_mgr,
                                               std::move(gpu_table_representation)));
   }
@@ -68,12 +68,12 @@ sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::hash_partitio
   return output_batches;
 }
 
-sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::evenly_partition(
-  const data_batch_view& input,
+sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::evenly_partition(
+  const cucascade::data_batch_view& input,
   int num_partitions,
   rmm::cuda_stream_view stream,
-  memory::memory_space& memory_space,
-  data_repository_manager& data_repository_mgr)
+  cucascade::memory::memory_space& memory_space,
+  cucascade::data_repository_manager& data_repository_mgr)
 {
   // Sanity check.
   if (num_partitions < 2) {
@@ -92,14 +92,14 @@ sirius::vector<sirius::unique_ptr<data_batch>> gpu_partition_impl::evenly_partit
   }
 
   // Slice and create separate partitions
-  sirius::vector<sirius::unique_ptr<data_batch>> output_batches;
+  sirius::vector<sirius::unique_ptr<cucascade::data_batch>> output_batches;
   auto sliced_partition_views = cudf::slice(input_table, slice_indices, stream);
   for (int i = 0; i < num_partitions; ++i) {
     auto output_partition = sirius::make_unique<cudf::table>(sliced_partition_views[i]);
     auto gpu_table_representation =
-      sirius::make_unique<sirius::gpu_table_representation>(*output_partition, memory_space);
+      sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
-      sirius::make_unique<sirius::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+      sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                               data_repository_mgr,
                                               std::move(gpu_table_representation)));
   }

--- a/src/operator/partition/gpu_partition_impl.cpp
+++ b/src/operator/partition/gpu_partition_impl.cpp
@@ -61,8 +61,8 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ha
       sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
       sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                              data_repository_mgr,
-                                              std::move(gpu_table_representation)));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation)));
   }
 
   return output_batches;
@@ -100,8 +100,8 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ev
       sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
       sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                              data_repository_mgr,
-                                              std::move(gpu_table_representation)));
+                                                 data_repository_mgr,
+                                                 std::move(gpu_table_representation)));
   }
 
   return output_batches;

--- a/src/operator/partition/gpu_partition_impl.cpp
+++ b/src/operator/partition/gpu_partition_impl.cpp
@@ -23,9 +23,9 @@
 namespace sirius {
 namespace op {
 
-sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::hash_partition(
+std::vector<std::unique_ptr<cucascade::data_batch>> gpu_partition_impl::hash_partition(
   const cucascade::data_batch_view& input,
-  const sirius::vector<int>& partition_key_idx,
+  const std::vector<int>& partition_key_idx,
   int num_partitions,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space,
@@ -47,8 +47,8 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ha
                                                memory_space.get_default_allocator());
 
   // Slice from the reordered table to create separate table partitions
-  sirius::vector<sirius::unique_ptr<cucascade::data_batch>> output_batches;
-  sirius::vector<int> slice_indices;
+  std::vector<std::unique_ptr<cucascade::data_batch>> output_batches;
+  std::vector<int> slice_indices;
   for (int i = 0; i < num_partitions; ++i) {
     slice_indices.push_back(partition_result.second[i]);
     slice_indices.push_back(i == num_partitions - 1 ? input_table.num_rows()
@@ -56,11 +56,11 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ha
   }
   auto sliced_partition_views = cudf::slice(partition_result.first->view(), slice_indices, stream);
   for (int i = 0; i < num_partitions; ++i) {
-    auto output_partition = sirius::make_unique<cudf::table>(sliced_partition_views[i]);
+    auto output_partition = std::make_unique<cudf::table>(sliced_partition_views[i]);
     auto gpu_table_representation =
-      sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
+      std::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
-      sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+      std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation)));
   }
@@ -68,7 +68,7 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ha
   return output_batches;
 }
 
-sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::evenly_partition(
+std::vector<std::unique_ptr<cucascade::data_batch>> gpu_partition_impl::evenly_partition(
   const cucascade::data_batch_view& input,
   int num_partitions,
   rmm::cuda_stream_view stream,
@@ -84,7 +84,7 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ev
   auto input_table            = input.get_cudf_table_view();
   int partition_num_rows_base = input_table.num_rows() / num_partitions;
   int remainder               = input_table.num_rows() % num_partitions;
-  sirius::vector<int> slice_indices;
+  std::vector<int> slice_indices;
   for (int i = 0; i < num_partitions; ++i) {
     int curr_partition_num_rows = partition_num_rows_base + (i < remainder);
     slice_indices.push_back(i == 0 ? 0 : slice_indices.back());
@@ -92,14 +92,14 @@ sirius::vector<sirius::unique_ptr<cucascade::data_batch>> gpu_partition_impl::ev
   }
 
   // Slice and create separate partitions
-  sirius::vector<sirius::unique_ptr<cucascade::data_batch>> output_batches;
+  std::vector<std::unique_ptr<cucascade::data_batch>> output_batches;
   auto sliced_partition_views = cudf::slice(input_table, slice_indices, stream);
   for (int i = 0; i < num_partitions; ++i) {
-    auto output_partition = sirius::make_unique<cudf::table>(sliced_partition_views[i]);
+    auto output_partition = std::make_unique<cudf::table>(sliced_partition_views[i]);
     auto gpu_table_representation =
-      sirius::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
+      std::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
-      sirius::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
+      std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
                                                  data_repository_mgr,
                                                  std::move(gpu_table_representation)));
   }

--- a/src/operator/partition/gpu_partition_impl.cpp
+++ b/src/operator/partition/gpu_partition_impl.cpp
@@ -61,8 +61,8 @@ std::vector<std::unique_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
       std::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
       std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation)));
+                                              data_repository_mgr,
+                                              std::move(gpu_table_representation)));
   }
 
   return output_batches;
@@ -100,8 +100,8 @@ std::vector<std::unique_ptr<cucascade::data_batch>> gpu_partition_impl::evenly_p
       std::make_unique<cucascade::gpu_table_representation>(*output_partition, memory_space);
     output_batches.push_back(
       std::make_unique<cucascade::data_batch>(data_repository_mgr.get_next_data_batch_id(),
-                                                 data_repository_mgr,
-                                                 std::move(gpu_table_representation)));
+                                              data_repository_mgr,
+                                              std::move(gpu_table_representation)));
   }
 
   return output_batches;

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -42,10 +42,7 @@ void itask_executor::stop()
   _threads.clear();
 }
 
-void itask_executor::schedule(std::unique_ptr<itask> task)
-{
-  _task_queue->push(std::move(task));
-}
+void itask_executor::schedule(std::unique_ptr<itask> task) { _task_queue->push(std::move(task)); }
 
 void itask_executor::on_start() { _task_queue->open(); }
 

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -26,8 +26,8 @@ void itask_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(sirius::make_unique<task_executor_thread>(
-      sirius::make_unique<sirius::thread>(&itask_executor::worker_loop, this, i)));
+    _threads.push_back(std::make_unique<task_executor_thread>(
+      std::make_unique<std::thread>(&itask_executor::worker_loop, this, i)));
   }
 }
 
@@ -42,7 +42,7 @@ void itask_executor::stop()
   _threads.clear();
 }
 
-void itask_executor::schedule(sirius::unique_ptr<itask> task)
+void itask_executor::schedule(std::unique_ptr<itask> task)
 {
   _task_queue->push(std::move(task));
 }
@@ -52,7 +52,7 @@ void itask_executor::on_start() { _task_queue->open(); }
 void itask_executor::on_stop() { _task_queue->close(); }
 
 void itask_executor::on_task_error(int worker_id,
-                                   sirius::unique_ptr<itask> task,
+                                   std::unique_ptr<itask> task,
                                    const std::exception& e)
 {
   if (_config.retry_on_error) {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -22,7 +22,7 @@
 namespace sirius {
 namespace parallel {
 
-void local_task_buffer::produce(sirius::unique_ptr<itask> task)
+void local_task_buffer::produce(std::unique_ptr<itask> task)
 {
   {
     std::lock_guard<std::mutex> lock(_mtx);
@@ -31,7 +31,7 @@ void local_task_buffer::produce(sirius::unique_ptr<itask> task)
   _cv.notify_one();  // wake consumer
 }
 
-sirius::unique_ptr<itask> local_task_buffer::consume()
+std::unique_ptr<itask> local_task_buffer::consume()
 {
   std::unique_lock<std::mutex> lock(_mtx);
   _cv.wait(lock, [&] { return (!_queue.empty()) || !_is_open.load(std::memory_order_acquire); });
@@ -51,14 +51,14 @@ void local_task_buffer::close()
 gpu_pipeline_executor::gpu_pipeline_executor(task_executor_config config,
                                              const cucascade::memory::memory_space* mem_space,
                                              pipeline_executor* pipeline_exec)
-  : itask_executor(sirius::make_unique<gpu_pipeline_queue>(config.num_threads), config),
-    _local_task_buffer(sirius::make_unique<local_task_buffer>()),
+  : itask_executor(std::make_unique<gpu_pipeline_queue>(config.num_threads), config),
+    _local_task_buffer(std::make_unique<local_task_buffer>()),
     _memory_space_view(mem_space),
     _pipeline_exec(pipeline_exec)
 {
 }
 
-void gpu_pipeline_executor::schedule(sirius::unique_ptr<itask> task)
+void gpu_pipeline_executor::schedule(std::unique_ptr<itask> task)
 {
   _task_queue->push(std::move(task));
 }
@@ -82,11 +82,11 @@ void gpu_pipeline_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(sirius::make_unique<task_executor_thread>(
-      sirius::make_unique<sirius::thread>(&gpu_pipeline_executor::worker_loop, this, i)));
+    _threads.push_back(std::make_unique<task_executor_thread>(
+      std::make_unique<std::thread>(&gpu_pipeline_executor::worker_loop, this, i)));
   }
   _gpu_pipeline_executor_manager_thread =
-    sirius::make_unique<sirius::thread>(&gpu_pipeline_executor::manager_loop, this);
+    std::make_unique<std::thread>(&gpu_pipeline_executor::manager_loop, this);
 }
 
 void gpu_pipeline_executor::stop()
@@ -128,7 +128,7 @@ void gpu_pipeline_executor::worker_loop(int worker_id)
   }
 }
 
-void gpu_pipeline_executor::submit_task_request(sirius::unique_ptr<task_request> request)
+void gpu_pipeline_executor::submit_task_request(std::unique_ptr<task_request> request)
 {
   _pipeline_exec->submit_task_request(std::move(request));
 }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -49,7 +49,7 @@ void local_task_buffer::close()
 }
 
 gpu_pipeline_executor::gpu_pipeline_executor(task_executor_config config,
-                                             const memory::memory_space* mem_space,
+                                             const cucascade::memory::memory_space* mem_space,
                                              pipeline_executor* pipeline_exec)
   : itask_executor(sirius::make_unique<gpu_pipeline_queue>(config.num_threads), config),
     _local_task_buffer(sirius::make_unique<local_task_buffer>()),

--- a/src/pipeline/gpu_pipeline_queue.cpp
+++ b/src/pipeline/gpu_pipeline_queue.cpp
@@ -32,10 +32,7 @@ void gpu_pipeline_queue::close()
   }
 }
 
-void gpu_pipeline_queue::push(std::unique_ptr<itask> task)
-{
-  _task_queue.enqueue(std::move(task));
-}
+void gpu_pipeline_queue::push(std::unique_ptr<itask> task) { _task_queue.enqueue(std::move(task)); }
 
 std::unique_ptr<itask> gpu_pipeline_queue::pull()
 {

--- a/src/pipeline/gpu_pipeline_queue.cpp
+++ b/src/pipeline/gpu_pipeline_queue.cpp
@@ -32,14 +32,14 @@ void gpu_pipeline_queue::close()
   }
 }
 
-void gpu_pipeline_queue::push(sirius::unique_ptr<itask> task)
+void gpu_pipeline_queue::push(std::unique_ptr<itask> task)
 {
   _task_queue.enqueue(std::move(task));
 }
 
-sirius::unique_ptr<itask> gpu_pipeline_queue::pull()
+std::unique_ptr<itask> gpu_pipeline_queue::pull()
 {
-  sirius::unique_ptr<itask> task;
+  std::unique_ptr<itask> task;
   while (true) {
     if (_task_queue.try_dequeue(task)) { return task; }
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -21,8 +21,8 @@
 namespace sirius {
 namespace parallel {
 
-gpu_pipeline_task::gpu_pipeline_task(sirius::unique_ptr<itask_local_state> local_state,
-                                     sirius::shared_ptr<itask_global_state> global_state)
+gpu_pipeline_task::gpu_pipeline_task(std::unique_ptr<itask_local_state> local_state,
+                                     std::shared_ptr<itask_global_state> global_state)
   : itask(std::move(local_state), std::move(global_state))
 {
 }
@@ -52,7 +52,7 @@ void gpu_pipeline_task::mark_task_completion()
   // notify TaskCreator about task completion
   uint64_t task_id     = _local_state->cast<gpu_pipeline_task_local_state>()._task_id;
   uint64_t pipeline_id = _global_state->cast<gpu_pipeline_task_global_state>()._pipeline_id;
-  auto message         = sirius::make_unique<sirius::task_completion_message>();
+  auto message         = std::make_unique<sirius::task_completion_message>();
   message->task_id     = task_id;
   message->pipeline_id = pipeline_id;
   message->source      = sirius::Source::PIPELINE;

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -25,7 +25,7 @@ namespace sirius {
 namespace parallel {
 
 pipeline_executor::pipeline_executor(task_executor_config config)
-  : itask_executor(sirius::make_unique<pipeline_queue>(config.num_threads), config)
+  : itask_executor(std::make_unique<pipeline_queue>(config.num_threads), config)
 {
   // Initialize GPU pipeline executors for each available GPU
   _gpu_executors.reserve(Config::NUM_GPU);
@@ -35,12 +35,12 @@ pipeline_executor::pipeline_executor(task_executor_config config)
     const cucascade::memory::memory_space* gpu_mem_space =
       mem_res_mgr.get_memory_space(cucascade::memory::Tier::GPU, i);  // Placeholder
     _gpu_executors.push_back(
-      sirius::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
+      std::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
   }
-  _task_request_queue = sirius::make_unique<task_request_queue>(config.num_threads);
+  _task_request_queue = std::make_unique<task_request_queue>(config.num_threads);
 }
 
-void pipeline_executor::schedule(sirius::unique_ptr<itask> task)
+void pipeline_executor::schedule(std::unique_ptr<itask> task)
 {
   _task_queue->push(std::move(task));
 }
@@ -64,8 +64,8 @@ void pipeline_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(sirius::make_unique<task_executor_thread>(
-      sirius::make_unique<sirius::thread>(&pipeline_executor::worker_loop, this, i)));
+    _threads.push_back(std::make_unique<task_executor_thread>(
+      std::make_unique<std::thread>(&pipeline_executor::worker_loop, this, i)));
   }
   // Start all GPU executors
   for (auto& gpu_exec : _gpu_executors) {
@@ -119,12 +119,12 @@ void pipeline_executor::worker_loop(int worker_id)
   }
 }
 
-void pipeline_executor::submit_task_request(sirius::unique_ptr<task_request> request)
+void pipeline_executor::submit_task_request(std::unique_ptr<task_request> request)
 {
   _task_request_queue->push(std::move(request));
 }
 
-void pipeline_executor::dispatch_to_gpu_executor(sirius::unique_ptr<itask> task, int gpu_id)
+void pipeline_executor::dispatch_to_gpu_executor(std::unique_ptr<itask> task, int gpu_id)
 {
   if (gpu_id < 0 || gpu_id >= static_cast<int>(_gpu_executors.size())) {
     throw std::runtime_error("Invalid GPU ID: " + std::to_string(gpu_id));

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -31,9 +31,9 @@ pipeline_executor::pipeline_executor(task_executor_config config)
   _gpu_executors.reserve(Config::NUM_GPU);
   for (int i = 0; i < Config::NUM_GPU; ++i) {
     // TODO: Initialize memory space for each GPU
-    auto& mem_res_mgr = memory::memory_reservation_manager::get_instance();
-    const memory::memory_space* gpu_mem_space =
-      mem_res_mgr.get_memory_space(memory::Tier::GPU, i);  // Placeholder
+    auto& mem_res_mgr = cucascade::memory::memory_reservation_manager::get_instance();
+    const cucascade::memory::memory_space* gpu_mem_space =
+      mem_res_mgr.get_memory_space(cucascade::memory::Tier::GPU, i);  // Placeholder
     _gpu_executors.push_back(
       sirius::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
   }

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -34,8 +34,7 @@ pipeline_executor::pipeline_executor(task_executor_config config)
     auto& mem_res_mgr = cucascade::memory::memory_reservation_manager::get_instance();
     const cucascade::memory::memory_space* gpu_mem_space =
       mem_res_mgr.get_memory_space(cucascade::memory::Tier::GPU, i);  // Placeholder
-    _gpu_executors.push_back(
-      std::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
+    _gpu_executors.push_back(std::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
   }
   _task_request_queue = std::make_unique<task_request_queue>(config.num_threads);
 }

--- a/src/pipeline/pipeline_queue.cpp
+++ b/src/pipeline/pipeline_queue.cpp
@@ -32,11 +32,11 @@ void pipeline_queue::close()
   }
 }
 
-void pipeline_queue::push(sirius::unique_ptr<itask> task) { _task_queue.enqueue(std::move(task)); }
+void pipeline_queue::push(std::unique_ptr<itask> task) { _task_queue.enqueue(std::move(task)); }
 
-sirius::unique_ptr<itask> pipeline_queue::pull()
+std::unique_ptr<itask> pipeline_queue::pull()
 {
-  sirius::unique_ptr<itask> task;
+  std::unique_ptr<itask> task;
   while (true) {
     if (_task_queue.try_dequeue(task)) { return task; }
 

--- a/test/cpp/data/CMakeLists.txt
+++ b/test/cpp/data/CMakeLists.txt
@@ -19,6 +19,6 @@ set(TEST_SOURCES
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_data_batch.cpp
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_data_batch_view.cpp
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_data_repository.cpp
-    # ${CMAKE_CURRENT_SOURCE_DIR}/test_data_repository_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_data_repository_manager.cpp
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_data_representation.cpp
     PARENT_SCOPE)

--- a/test/cpp/data/test_data_batch.cpp
+++ b/test/cpp/data/test_data_batch.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 using namespace sirius;
+using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {

--- a/test/cpp/data/test_data_batch.cpp
+++ b/test/cpp/data/test_data_batch.cpp
@@ -77,7 +77,7 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
 
   std::size_t get_size_in_bytes() const override { return _size; }
 
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override
   {
@@ -93,7 +93,7 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
 TEST_CASE("data_batch Construction", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
   data_batch batch(1, manager, std::move(data));
 
   REQUIRE(batch.get_batch_id() == 1);
@@ -107,7 +107,7 @@ TEST_CASE("data_batch Construction", "[data_batch]")
 TEST_CASE("data_batch Move Constructor", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
   data_batch batch1(42, manager, std::move(data));
 
   REQUIRE(batch1.get_batch_id() == 42);
@@ -125,8 +125,8 @@ TEST_CASE("data_batch Move Constructor", "[data_batch]")
 TEST_CASE("data_batch Move Assignment", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data1 = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
-  auto data2 = sirius::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+  auto data1 = std::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
+  auto data2 = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
 
   data_batch batch1(10, manager, std::move(data1));
   data_batch batch2(20, manager, std::move(data2));
@@ -146,7 +146,7 @@ TEST_CASE("data_batch Move Assignment", "[data_batch]")
 TEST_CASE("data_batch Self Move Assignment", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(100, manager, std::move(data));
 
   // Self-assignment should not crash
@@ -160,7 +160,7 @@ TEST_CASE("data_batch Self Move Assignment", "[data_batch]")
 TEST_CASE("data_batch View Reference Counting", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   REQUIRE(batch.get_view_count() == 0);
@@ -194,7 +194,7 @@ TEST_CASE("data_batch View Reference Counting", "[data_batch]")
 TEST_CASE("data_batch Pin Reference Counting", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   REQUIRE(batch.get_pin_count() == 0);
@@ -224,7 +224,7 @@ TEST_CASE("data_batch Pin Reference Counting", "[data_batch]")
 TEST_CASE("data_batch increment_pin_ref_count GPU memory::Tier Validation", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Should throw because data is not in GPU memory::Tier
@@ -236,7 +236,7 @@ TEST_CASE("data_batch increment_pin_ref_count GPU memory::Tier Validation", "[da
 TEST_CASE("data_batch decrement_pin_ref_count GPU memory::Tier Validation", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // First increment while in GPU memory::Tier
@@ -252,7 +252,7 @@ TEST_CASE("data_batch decrement_pin_ref_count GPU memory::Tier Validation", "[da
 TEST_CASE("data_batch View Count No memory::Tier Validation", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // View count should work even when not in GPU memory::Tier
@@ -270,7 +270,7 @@ TEST_CASE("Multiple data_batch Instances", "[data_batch]")
   std::vector<data_batch> batches;
 
   for (uint64_t i = 0; i < 10; ++i) {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024 * (i + 1));
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024 * (i + 1));
     batches.emplace_back(i, manager, std::move(data));
   }
 
@@ -289,21 +289,21 @@ TEST_CASE("data_batch get_current_tier Delegation", "[data_batch]")
   data_repository_manager manager;
   // Test GPU memory::Tier
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     data_batch batch(1, manager, std::move(data));
     REQUIRE(batch.get_current_tier() == memory::Tier::GPU);
   }
 
   // Test HOST memory::Tier
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
     data_batch batch(2, manager, std::move(data));
     REQUIRE(batch.get_current_tier() == memory::Tier::HOST);
   }
 
   // Test DISK memory::Tier
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
     data_batch batch(3, manager, std::move(data));
     REQUIRE(batch.get_current_tier() == memory::Tier::DISK);
   }
@@ -313,7 +313,7 @@ TEST_CASE("data_batch get_current_tier Delegation", "[data_batch]")
 TEST_CASE("data_batch Thread-Safe View Reference Counting", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   constexpr int num_threads           = 10;
@@ -362,7 +362,7 @@ TEST_CASE("data_batch Thread-Safe View Reference Counting", "[data_batch]")
 TEST_CASE("data_batch Thread-Safe Pin Reference Counting", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   constexpr int num_threads           = 10;
@@ -411,7 +411,7 @@ TEST_CASE("data_batch Thread-Safe Pin Reference Counting", "[data_batch]")
 TEST_CASE("data_batch Concurrent View Increment and Decrement", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Pre-increment to avoid hitting zero during concurrent operations
@@ -459,7 +459,7 @@ TEST_CASE("data_batch Concurrent View Increment and Decrement", "[data_batch]")
 TEST_CASE("data_batch Concurrent Pin Increment and Decrement", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Pre-increment to avoid hitting zero during concurrent operations
@@ -512,7 +512,7 @@ TEST_CASE("data_batch Unique IDs", "[data_batch]")
   std::vector<data_batch> batches;
 
   for (auto id : batch_ids) {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     batches.emplace_back(id, manager, std::move(data));
   }
 
@@ -526,7 +526,7 @@ TEST_CASE("data_batch Unique IDs", "[data_batch]")
 TEST_CASE("data_batch Zero View Count", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Starting view count should be zero
@@ -549,7 +549,7 @@ TEST_CASE("data_batch Zero View Count", "[data_batch]")
 TEST_CASE("data_batch Zero Pin Count", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Starting pin count should be zero
@@ -575,7 +575,7 @@ TEST_CASE("data_batch With Different Data Sizes", "[data_batch]")
   std::vector<size_t> sizes = {0, 1, 1024, 1024 * 1024, 1024 * 1024 * 100};
 
   for (size_t size : sizes) {
-    auto data      = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, size);
+    auto data      = std::make_unique<mock_data_representation>(memory::Tier::GPU, size);
     auto* data_ptr = data.get();
     data_batch batch(1, manager, std::move(data));
 
@@ -591,7 +591,7 @@ TEST_CASE("data_batch Move Requires Zero Reference Counts", "[data_batch]")
   data_repository_manager manager;
   // Test that moving with active views throws
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     data_batch batch1(1, manager, std::move(data));
     batch1.increment_view_ref_count();
 
@@ -600,7 +600,7 @@ TEST_CASE("data_batch Move Requires Zero Reference Counts", "[data_batch]")
 
   // Test that moving with active pins throws
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     data_batch batch1(1, manager, std::move(data));
     batch1.increment_pin_ref_count();
 
@@ -609,7 +609,7 @@ TEST_CASE("data_batch Move Requires Zero Reference Counts", "[data_batch]")
 
   // Test that moving with both active views and pins throws
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     data_batch batch1(1, manager, std::move(data));
     batch1.increment_view_ref_count();
     batch1.increment_pin_ref_count();
@@ -619,7 +619,7 @@ TEST_CASE("data_batch Move Requires Zero Reference Counts", "[data_batch]")
 
   // Test that moving with zero counts succeeds
   {
-    auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     data_batch batch1(1, manager, std::move(data));
 
     REQUIRE(batch1.get_view_count() == 0);
@@ -637,7 +637,7 @@ TEST_CASE("data_batch Move Requires Zero Reference Counts", "[data_batch]")
 TEST_CASE("data_batch Rapid View Count Cycles", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Perform many cycles of increment and decrement
@@ -661,7 +661,7 @@ TEST_CASE("data_batch Rapid View Count Cycles", "[data_batch]")
 TEST_CASE("data_batch Rapid Pin Count Cycles", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Perform many cycles of increment and decrement
@@ -685,7 +685,7 @@ TEST_CASE("data_batch Rapid Pin Count Cycles", "[data_batch]")
 TEST_CASE("data_batch Independent View and Pin Counts", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Increment view count
@@ -721,13 +721,13 @@ TEST_CASE("data_batch With Data Repository Manager", "[data_batch][integration]"
 {
   data_repository_manager manager;
 
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
   auto* batch_ptr   = batch.get();
 
   // Add to manager
-  sirius::vector<size_t> empty_pipelines;
+  std::vector<size_t> empty_pipelines;
   manager.add_new_data_batch(std::move(batch), empty_pipelines);
 
   // Batch is now managed by the manager
@@ -747,7 +747,7 @@ TEST_CASE("data_batch With Data Repository Manager", "[data_batch][integration]"
 TEST_CASE("data_batch Decrement View Count Returns Old Value", "[data_batch]")
 {
   data_repository_manager manager;
-  auto data = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   data_batch batch(1, manager, std::move(data));
 
   // Increment to 5
@@ -785,13 +785,13 @@ TEST_CASE("data_batch Create View", "[data_batch][integration]")
 {
   data_repository_manager manager;
 
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
   auto* batch_ptr   = batch.get();
 
   // Add to manager
-  sirius::vector<size_t> empty_pipelines;
+  std::vector<size_t> empty_pipelines;
   manager.add_new_data_batch(std::move(batch), empty_pipelines);
 
   // Create view using the create_view method

--- a/test/cpp/data/test_data_batch_view.cpp
+++ b/test/cpp/data/test_data_batch_view.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 using namespace sirius;
+using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {

--- a/test/cpp/data/test_data_batch_view.cpp
+++ b/test/cpp/data/test_data_batch_view.cpp
@@ -77,7 +77,7 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
 
   std::size_t get_size_in_bytes() const override { return _size; }
 
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override
   {
@@ -96,13 +96,13 @@ std::pair<uint64_t, data_batch*> create_managed_batch(data_repository_manager& m
                                                       memory::Tier tier = memory::Tier::GPU,
                                                       size_t size       = 1024)
 {
-  auto data         = sirius::make_unique<mock_data_representation>(tier, size);
+  auto data         = std::make_unique<mock_data_representation>(tier, size);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
   auto* batch_ptr   = batch.get();
 
   // Store in manager with empty pipelines (no views created)
-  sirius::vector<size_t> empty_pipelines;
+  std::vector<size_t> empty_pipelines;
   manager.add_new_data_batch(std::move(batch), empty_pipelines);
 
   return {batch_id, batch_ptr};
@@ -118,12 +118,12 @@ struct managed_batch_holder {
 
   managed_batch_holder(memory::Tier tier = memory::Tier::GPU, size_t size = 1024)
   {
-    auto data  = sirius::make_unique<mock_data_representation>(tier, size);
+    auto data  = std::make_unique<mock_data_representation>(tier, size);
     batch_id   = manager.get_next_data_batch_id();
-    auto batch = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     batch_ptr  = batch.get();
 
-    sirius::vector<size_t> empty_pipelines;
+    std::vector<size_t> empty_pipelines;
     manager.add_new_data_batch(std::move(batch), empty_pipelines);
   }
 };
@@ -411,7 +411,7 @@ TEST_CASE("Multiple data_batch_views on Same Batch", "[data_batch_view]")
 TEST_CASE("data_batch_view Independent View and Pin Counts", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -445,7 +445,7 @@ TEST_CASE("data_batch_view Independent View and Pin Counts", "[data_batch_view]"
 TEST_CASE("data_batch_view Multiple Pin Unpin Cycles", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -472,7 +472,7 @@ TEST_CASE("data_batch_view Multiple Pin Unpin Cycles", "[data_batch_view]")
 TEST_CASE("data_batch_view Thread-Safe View Count", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -518,7 +518,7 @@ TEST_CASE("data_batch_view Thread-Safe View Count", "[data_batch_view]")
 TEST_CASE("data_batch_view Thread-Safe Pin Operations", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -588,7 +588,7 @@ TEST_CASE("data_batch_view Thread-Safe Pin Operations", "[data_batch_view]")
 TEST_CASE("data_batch_view Concurrent View Creation and Destruction", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -627,7 +627,7 @@ TEST_CASE("data_batch_view Concurrent View Creation and Destruction", "[data_bat
 TEST_CASE("data_batch_view Copy Does Not Copy Pin State", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -664,7 +664,7 @@ TEST_CASE("data_batch_view Copy Does Not Copy Pin State", "[data_batch_view]")
 TEST_CASE("data_batch_view Multiple Views Independent Pin States", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -713,7 +713,7 @@ TEST_CASE("data_batch_view Multiple Views Independent Pin States", "[data_batch_
 TEST_CASE("data_batch_view Rapid Creation and Destruction Cycles", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -742,9 +742,9 @@ TEST_CASE("data_batch_view Rapid Creation and Destruction Cycles", "[data_batch_
 TEST_CASE("data_batch_view Multiple Batches", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data1 = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto data2 = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
-  auto data3 = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
+  auto data1 = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data2 = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+  auto data3 = std::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
 
   auto* batch1 = new data_batch(1, manager, std::move(data1));
   auto* batch2 = new data_batch(2, manager, std::move(data2));
@@ -797,7 +797,7 @@ TEST_CASE("data_batch_view Multiple Batches", "[data_batch_view]")
 TEST_CASE("data_batch_view Stress Test", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -841,7 +841,7 @@ TEST_CASE("data_batch_view Stress Test", "[data_batch_view]")
 TEST_CASE("data_batch_view Mixed Lifetime Operations", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -890,7 +890,7 @@ TEST_CASE("data_batch_view Mixed Lifetime Operations", "[data_batch_view]")
 TEST_CASE("data_batch_view Destructor With Pinned View", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -922,7 +922,7 @@ TEST_CASE("data_batch_view Destructor With Pinned View", "[data_batch_view]")
 TEST_CASE("data_batch_view Zero to Non-Zero Pin Transitions", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete
@@ -960,7 +960,7 @@ TEST_CASE("data_batch_view Zero to Non-Zero Pin Transitions", "[data_batch_view]
 TEST_CASE("data_batch_view Rapid Pin Unpin Multiple Views", "[data_batch_view]")
 {
   data_repository_manager manager;
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
 
   // Increment to prevent auto-delete

--- a/test/cpp/data/test_data_repository.cpp
+++ b/test/cpp/data/test_data_repository.cpp
@@ -79,7 +79,7 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
 
   std::size_t get_size_in_bytes() const override { return _size; }
 
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override
   {
@@ -108,11 +108,11 @@ TEST_CASE("idata_repository Add and Pull Single Batch", "[data_repository]")
   idata_repository repository;
 
   // Create a batch and view
-  auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto* batch = new data_batch(1, manager, std::move(data));
   batch->increment_view_ref_count();  // Prevent auto-delete
 
-  auto view = sirius::make_unique<data_batch_view>(batch);
+  auto view = std::make_unique<data_batch_view>(batch);
 
   // Add to repository
   repository.add_new_data_batch_view(std::move(view));
@@ -140,12 +140,12 @@ TEST_CASE("idata_repository FIFO Order", "[data_repository]")
 
   // Create multiple batches and add them
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -176,12 +176,12 @@ TEST_CASE("idata_repository Multiple Add Pull Operations", "[data_repository]")
 
   // Add 3 batches
   for (uint64_t i = 1; i <= 3; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -193,12 +193,12 @@ TEST_CASE("idata_repository Multiple Add Pull Operations", "[data_repository]")
 
   // Add 2 more batches
   for (uint64_t i = 4; i <= 5; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -248,13 +248,13 @@ TEST_CASE("idata_repository Thread-Safe Adding", "[data_repository]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
-        auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+        auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         uint64_t batch_id = i * batches_per_thread + j;
         auto* batch       = new data_batch(batch_id, manager, std::move(data));
         batch->increment_view_ref_count();  // Prevent auto-delete
         thread_batches[i].push_back(batch);
 
-        auto view = sirius::make_unique<data_batch_view>(batch);
+        auto view = std::make_unique<data_batch_view>(batch);
         repository.add_new_data_batch_view(std::move(view));
       }
     });
@@ -293,12 +293,12 @@ TEST_CASE("idata_repository Thread-Safe Pulling", "[data_repository]")
 
   // Add many batches
   for (int i = 0; i < num_batches; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -357,13 +357,13 @@ TEST_CASE("idata_repository Concurrent Add and Pull", "[data_repository]")
   for (int i = 0; i < num_add_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
-        auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+        auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         uint64_t batch_id = i * batches_per_thread + j;
         auto* batch       = new data_batch(batch_id, manager, std::move(data));
         batch->increment_view_ref_count();  // Prevent auto-delete
         thread_batches[i].push_back(batch);
 
-        auto view = sirius::make_unique<data_batch_view>(batch);
+        auto view = std::make_unique<data_batch_view>(batch);
         repository.add_new_data_batch_view(std::move(view));
 
         // Small delay to allow pullers to work
@@ -416,12 +416,12 @@ TEST_CASE("idata_repository Large Number of Batches", "[data_repository]")
 
   // Add many batches
   for (int i = 0; i < num_batches; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -449,12 +449,12 @@ TEST_CASE("idata_repository Add After Pull All", "[data_repository]")
 
   // Add some batches
   for (int i = 0; i < 5; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -467,12 +467,12 @@ TEST_CASE("idata_repository Add After Pull All", "[data_repository]")
 
   // Add more batches
   for (int i = 5; i < 10; ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -500,12 +500,12 @@ TEST_CASE("idata_repository Different Batch Sizes", "[data_repository]")
 
   // Add batches with different sizes
   for (size_t i = 0; i < sizes.size(); ++i) {
-    auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, sizes[i]);
+    auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, sizes[i]);
     auto* batch = new data_batch(i, manager, std::move(data));
     batch->increment_view_ref_count();  // Prevent auto-delete
     batches.push_back(batch);
 
-    auto view = sirius::make_unique<data_batch_view>(batch);
+    auto view = std::make_unique<data_batch_view>(batch);
     repository.add_new_data_batch_view(std::move(view));
   }
 
@@ -534,12 +534,12 @@ TEST_CASE("idata_repository Interleaved Add and Pull", "[data_repository]")
   for (int cycle = 0; cycle < 50; ++cycle) {
     // Add some batches
     for (int i = 0; i < 3; ++i) {
-      auto data   = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+      auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
       auto* batch = new data_batch(cycle * 3 + i, manager, std::move(data));
       batch->increment_view_ref_count();  // Prevent auto-delete
       batches.push_back(batch);
 
-      auto view = sirius::make_unique<data_batch_view>(batch);
+      auto view = std::make_unique<data_batch_view>(batch);
       repository.add_new_data_batch_view(std::move(view));
     }
 

--- a/test/cpp/data/test_data_repository.cpp
+++ b/test/cpp/data/test_data_repository.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 using namespace sirius;
+using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {

--- a/test/cpp/data/test_data_repository_manager.cpp
+++ b/test/cpp/data/test_data_repository_manager.cpp
@@ -78,7 +78,7 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
 
   std::size_t get_size_in_bytes() const override { return _size; }
 
-  sirius::unique_ptr<idata_representation> convert_to_memory_space(
+  std::unique_ptr<idata_representation> convert_to_memory_space(
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default) override
   {
@@ -114,7 +114,7 @@ TEST_CASE("data_repository_manager Add Single Repository", "[data_repository_man
   data_repository_manager manager;
 
   size_t pipeline_id = 1;
-  auto repository    = sirius::make_unique<idata_repository>();
+  auto repository    = std::make_unique<idata_repository>();
   manager.add_new_repository(pipeline_id, std::move(repository));
 
   // Repository should be accessible
@@ -131,7 +131,7 @@ TEST_CASE("data_repository_manager Add Multiple Repositories", "[data_repository
 
   // Add repositories for multiple pipelines
   for (size_t i = 0; i < num_pipelines; ++i) {
-    auto repository = sirius::make_unique<idata_repository>();
+    auto repository = std::make_unique<idata_repository>();
     manager.add_new_repository(i, std::move(repository));
   }
 
@@ -150,14 +150,14 @@ TEST_CASE("data_repository_manager Replace Repository", "[data_repository_manage
   size_t pipeline_id = 5;
 
   // Add first repository
-  auto repository1 = sirius::make_unique<idata_repository>();
+  auto repository1 = std::make_unique<idata_repository>();
   auto* repo1_ptr  = repository1.get();
   manager.add_new_repository(pipeline_id, std::move(repository1));
 
   REQUIRE(manager.get_repository(pipeline_id).get() == repo1_ptr);
 
   // Replace with second repository
-  auto repository2 = sirius::make_unique<idata_repository>();
+  auto repository2 = std::make_unique<idata_repository>();
   auto* repo2_ptr  = repository2.get();
   manager.add_new_repository(pipeline_id, std::move(repository2));
 
@@ -172,8 +172,8 @@ TEST_CASE("data_repository_manager Access Non-Existent Repository", "[data_repos
   data_repository_manager manager;
 
   // Add some repositories
-  manager.add_new_repository(1, sirius::make_unique<idata_repository>());
-  manager.add_new_repository(2, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(1, std::make_unique<idata_repository>());
+  manager.add_new_repository(2, std::make_unique<idata_repository>());
 
   // Accessing non-existent repositories should throw
   REQUIRE_THROWS_AS(manager.get_repository(0), std::out_of_range);
@@ -236,14 +236,14 @@ TEST_CASE("data_repository_manager Add Data Batch Single Pipeline", "[data_repos
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   // Create and add batch
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
   manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
   // Repository should have the batch view
@@ -258,15 +258,15 @@ TEST_CASE("data_repository_manager Add Data Batch Multiple Pipelines", "[data_re
   data_repository_manager manager;
 
   // Add multiple repositories
-  sirius::vector<size_t> pipeline_ids = {1, 2, 3};
+  std::vector<size_t> pipeline_ids = {1, 2, 3};
   for (size_t id : pipeline_ids) {
-    manager.add_new_repository(id, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(id, std::make_unique<idata_repository>());
   }
 
   // Create and add batch to all pipelines
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
   manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
@@ -284,11 +284,11 @@ TEST_CASE("data_repository_manager Add Data Batch No Pipelines", "[data_reposito
   data_repository_manager manager;
 
   // Create and add batch with empty pipeline list
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  sirius::vector<size_t> empty_pipeline_ids;
+  std::vector<size_t> empty_pipeline_ids;
   manager.add_new_data_batch(std::move(batch), empty_pipeline_ids);
 
   // Batch is stored but no views are created
@@ -302,14 +302,14 @@ TEST_CASE("data_repository_manager Delete Data Batch", "[data_repository_manager
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   // Create and add batch
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
   manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
   // Pull the view from repository first (views hold pointers to the batch)
@@ -333,16 +333,16 @@ TEST_CASE("data_repository_manager Add Multiple Batches", "[data_repository_mana
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   constexpr int num_batches           = 10;
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add multiple batches
   for (int i = 0; i < num_batches; ++i) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
@@ -408,7 +408,7 @@ TEST_CASE("data_repository_manager Thread-Safe Add Repository", "[data_repositor
   // Launch threads to add repositories
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
-      auto repository = sirius::make_unique<idata_repository>();
+      auto repository = std::make_unique<idata_repository>();
       manager.add_new_repository(i, std::move(repository));
     });
   }
@@ -432,21 +432,21 @@ TEST_CASE("data_repository_manager Thread-Safe Add Batch", "[data_repository_man
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   constexpr int num_threads        = 10;
   constexpr int batches_per_thread = 50;
 
   std::vector<std::thread> threads;
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Launch threads to add batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
       for (int j = 0; j < batches_per_thread; ++j) {
-        auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+        auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         uint64_t batch_id = manager.get_next_data_batch_id();
-        auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+        auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
         manager.add_new_data_batch(std::move(batch), pipeline_ids);
       }
     });
@@ -473,24 +473,24 @@ TEST_CASE("data_repository_manager Thread-Safe Delete Batch", "[data_repository_
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   constexpr int num_batches           = 100;
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
   std::vector<uint64_t> batch_ids;
 
   // Add batches
   for (int i = 0; i < num_batches; ++i) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
   // Pull all views from repository to allow safe deletion
   auto& repo = manager.get_repository(pipeline_id);
-  std::vector<sirius::unique_ptr<data_batch_view>> views;
+  std::vector<std::unique_ptr<data_batch_view>> views;
   while (auto view = repo->pull_data_batch_view()) {
     views.push_back(std::move(view));
   }
@@ -525,7 +525,7 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
 
   // Add initial repositories
   for (int i = 0; i < 5; ++i) {
-    manager.add_new_repository(i, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(i, std::make_unique<idata_repository>());
   }
 
   constexpr int num_threads           = 10;
@@ -534,7 +534,7 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
   std::vector<std::thread> threads;
   std::atomic<int> batch_count{0};
   std::mutex view_mutex;
-  std::vector<sirius::unique_ptr<data_batch_view>> all_views;
+  std::vector<std::unique_ptr<data_batch_view>> all_views;
 
   // Launch threads doing mixed operations
   for (int i = 0; i < num_threads; ++i) {
@@ -545,9 +545,9 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
 
         // Add batch to random pipeline
         size_t pipeline_id = (i + j) % 5;
-        auto data          = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-        auto batch         = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
-        sirius::vector<size_t> pipeline_ids = {pipeline_id};
+        auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+        auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+        std::vector<size_t> pipeline_ids = {pipeline_id};
         manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
         ++batch_count;
@@ -585,7 +585,7 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
   // Add repositories for multiple pipelines
   constexpr int num_pipelines = 3;
   for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(i, std::make_unique<idata_repository>());
   }
 
   constexpr int num_adder_threads   = 5;
@@ -606,9 +606,9 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
 
         // Add batch to one or more pipelines
         size_t pipeline_id = (i + j) % num_pipelines;
-        auto data          = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-        auto batch         = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
-        sirius::vector<size_t> pipeline_ids = {pipeline_id};
+        auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+        auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+        std::vector<size_t> pipeline_ids = {pipeline_id};
         manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
         ++batches_added;
@@ -675,7 +675,7 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
 
   // Single pipeline for maximum contention
   size_t pipeline_id = 0;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   constexpr int num_threads           = 20;
   constexpr int operations_per_thread = 50;
@@ -688,13 +688,13 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
       auto& repo                          = manager.get_repository(pipeline_id);
-      sirius::vector<size_t> pipeline_ids = {pipeline_id};
+      std::vector<size_t> pipeline_ids = {pipeline_id};
 
       for (int j = 0; j < operations_per_thread; ++j) {
         // Add a batch
         uint64_t batch_id = manager.get_next_data_batch_id();
-        auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
-        auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+        auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
+        auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
         manager.add_new_data_batch(std::move(batch), pipeline_ids);
         ++total_added;
 
@@ -735,22 +735,22 @@ TEST_CASE("data_repository_manager Concurrent Add Delete Multiple Views per Batc
   // Add repositories
   constexpr int num_pipelines = 5;
   for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(i, std::make_unique<idata_repository>());
   }
 
   constexpr int num_batches = 50;
   std::atomic<int> views_deleted{0};
 
   // Add batches to ALL pipelines (each batch will have multiple views)
-  sirius::vector<size_t> all_pipeline_ids;
+  std::vector<size_t> all_pipeline_ids;
   for (int i = 0; i < num_pipelines; ++i) {
     all_pipeline_ids.push_back(i);
   }
 
   for (int i = 0; i < num_batches; ++i) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), all_pipeline_ids);
   }
 
@@ -796,9 +796,9 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
   data_repository_manager manager;
 
   // Setup: Create 3 pipelines
-  sirius::vector<size_t> pipeline_ids = {0, 1, 2};
+  std::vector<size_t> pipeline_ids = {0, 1, 2};
   for (size_t id : pipeline_ids) {
-    manager.add_new_repository(id, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(id, std::make_unique<idata_repository>());
   }
 
   // Add batches to different pipeline combinations
@@ -806,30 +806,30 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
 
   // Batch 0: All pipelines
   {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
   // Batch 1: Pipeline 0 only
   {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch                = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
-    sirius::vector<size_t> p0 = {0};
+    auto batch                = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    std::vector<size_t> p0 = {0};
     manager.add_new_data_batch(std::move(batch), p0);
   }
 
   // Batch 2: Pipelines 1 and 2
   {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
-    sirius::vector<size_t> p12 = {1, 2};
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    std::vector<size_t> p12 = {1, 2};
     manager.add_new_data_batch(std::move(batch), p12);
   }
 
@@ -874,17 +874,17 @@ TEST_CASE("data_repository_manager Replace Repository With Data", "[data_reposit
   size_t pipeline_id = 1;
 
   // Add first repository
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   // Add batch to first repository
-  auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
-  auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+  std::vector<size_t> pipeline_ids = {pipeline_id};
   manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
   // Replace repository
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   // New repository should be empty
   auto& new_repo = manager.get_repository(pipeline_id);
@@ -901,7 +901,7 @@ TEST_CASE("data_repository_manager Large Number of Pipelines", "[data_repository
 
   // Add many pipelines
   for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(i, std::make_unique<idata_repository>());
   }
 
   // All pipelines should be accessible
@@ -918,16 +918,16 @@ TEST_CASE("data_repository_manager Large Number of Batches", "[data_repository_m
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   constexpr int num_batches           = 1000;
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add many batches
   for (int i = 0; i < num_batches; ++i) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
@@ -950,7 +950,7 @@ TEST_CASE("data_repository_manager Pipeline ID Zero", "[data_repository_manager]
   data_repository_manager manager;
 
   // Pipeline ID 0 should work like any other ID
-  manager.add_new_repository(0, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(0, std::make_unique<idata_repository>());
 
   auto& repo = manager.get_repository(0);
   REQUIRE(repo != nullptr);
@@ -965,7 +965,7 @@ TEST_CASE("data_repository_manager Large Pipeline IDs", "[data_repository_manage
 
   // Add repositories with large IDs
   for (size_t id : large_ids) {
-    manager.add_new_repository(id, sirius::make_unique<idata_repository>());
+    manager.add_new_repository(id, std::make_unique<idata_repository>());
   }
 
   // All should be accessible
@@ -982,16 +982,16 @@ TEST_CASE("data_repository_manager Batches With Different Sizes", "[data_reposit
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   std::vector<size_t> sizes           = {1, 1024, 1024 * 1024, 1024 * 1024 * 10};
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add batches with different sizes
   for (size_t size : sizes) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, size);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, size);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
@@ -1011,16 +1011,16 @@ TEST_CASE("data_repository_manager Batches With Different Tiers", "[data_reposit
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   std::vector<memory::Tier> tiers     = {memory::Tier::GPU, memory::Tier::HOST, memory::Tier::DISK};
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add batches with different tiers
   for (memory::Tier tier : tiers) {
-    auto data         = sirius::make_unique<mock_data_representation>(tier, 1024);
+    auto data         = std::make_unique<mock_data_representation>(tier, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
   }
 
@@ -1040,16 +1040,16 @@ TEST_CASE("data_repository_manager Rapid Add Delete Cycles", "[data_repository_m
 
   // Add repository
   size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, sirius::make_unique<idata_repository>());
+  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  sirius::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> pipeline_ids = {pipeline_id};
   auto& repo                          = manager.get_repository(pipeline_id);
 
   // Perform many cycles of add and delete
   for (int cycle = 0; cycle < 100; ++cycle) {
-    auto data         = sirius::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
-    auto batch        = sirius::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     manager.add_new_data_batch(std::move(batch), pipeline_ids);
 
     // Pull and destroy the view, which triggers batch deletion

--- a/test/cpp/data/test_data_repository_manager.cpp
+++ b/test/cpp/data/test_data_repository_manager.cpp
@@ -28,7 +28,6 @@
 #include <thread>
 #include <vector>
 
-
 using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
@@ -333,7 +332,7 @@ TEST_CASE("data_repository_manager Add Multiple Batches", "[data_repository_mana
   size_t operator_id = 1;
   manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches = 10;
+  constexpr int num_batches                                       = 10;
   std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add multiple batches
@@ -473,7 +472,7 @@ TEST_CASE("data_repository_manager Thread-Safe Delete Batch", "[data_repository_
   size_t operator_id = 1;
   manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches = 100;
+  constexpr int num_batches                                       = 100;
   std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
   std::vector<uint64_t> batch_ids;
 
@@ -545,7 +544,8 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
         size_t operator_id = (i + j) % 5;
         auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+        std::vector<std::pair<size_t, std::string_view>> operator_ports = {
+          {operator_id, "default"}};
         manager.add_new_data_batch(std::move(batch), operator_ports);
 
         ++batch_count;
@@ -606,7 +606,8 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
         size_t operator_id = (i + j) % num_operators;
         auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+        std::vector<std::pair<size_t, std::string_view>> operator_ports = {
+          {operator_id, "default"}};
         manager.add_new_data_batch(std::move(batch), operator_ports);
 
         ++batches_added;
@@ -922,7 +923,7 @@ TEST_CASE("data_repository_manager Large Number of Batches", "[data_repository_m
   size_t operator_id = 1;
   manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches = 1000;
+  constexpr int num_batches                                       = 1000;
   std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add many batches

--- a/test/cpp/data/test_data_repository_manager.cpp
+++ b/test/cpp/data/test_data_repository_manager.cpp
@@ -28,27 +28,21 @@
 #include <thread>
 #include <vector>
 
-using namespace sirius;
+
 using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {
  public:
   mock_memory_space(memory::Tier tier, size_t device_id = 0)
-    : memory::memory_space(memory::memory_space_id{tier, static_cast<int>(device_id)},
-                           1024 * 1024 * 1024,
-                           (1024ULL * 1024ULL * 1024ULL) * 8 / 10,
-                           (1024ULL * 1024ULL * 1024ULL) / 2,
-                           create_null_allocators())
+    : memory::memory_space(tier,
+                           static_cast<int>(device_id),
+                           1024 * 1024 * 1024,                      // memory_limit
+                           (1024ULL * 1024ULL * 1024ULL) * 8 / 10,  // start_downgrading_threshold
+                           (1024ULL * 1024ULL * 1024ULL) / 2,       // stop_downgrading_threshold
+                           1024 * 1024 * 1024,                      // capacity
+                           std::make_unique<memory::null_device_memory_resource>())
   {
-  }
-
- private:
-  static std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> create_null_allocators()
-  {
-    std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> allocators;
-    allocators.push_back(std::make_unique<memory::null_device_memory_resource>());
-    return allocators;
   }
 };
 
@@ -101,7 +95,7 @@ TEST_CASE("data_repository_manager Construction", "[data_repository_manager]")
 
   // Manager should be empty initially
   // Accessing non-existent repository should throw
-  REQUIRE_THROWS_AS(manager.get_repository(0), std::out_of_range);
+  REQUIRE_THROWS_AS(manager.get_repository(0, "default"), std::out_of_range);
 }
 
 // =============================================================================
@@ -113,12 +107,12 @@ TEST_CASE("data_repository_manager Add Single Repository", "[data_repository_man
 {
   data_repository_manager manager;
 
-  size_t pipeline_id = 1;
+  size_t operator_id = 1;
   auto repository    = std::make_unique<idata_repository>();
-  manager.add_new_repository(pipeline_id, std::move(repository));
+  manager.add_new_repository(operator_id, "default", std::move(repository));
 
   // Repository should be accessible
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   REQUIRE(repo != nullptr);
 }
 
@@ -127,17 +121,17 @@ TEST_CASE("data_repository_manager Add Multiple Repositories", "[data_repository
 {
   data_repository_manager manager;
 
-  constexpr int num_pipelines = 10;
+  constexpr int num_operators = 10;
 
-  // Add repositories for multiple pipelines
-  for (size_t i = 0; i < num_pipelines; ++i) {
+  // Add repositories for multiple operators
+  for (size_t i = 0; i < num_operators; ++i) {
     auto repository = std::make_unique<idata_repository>();
-    manager.add_new_repository(i, std::move(repository));
+    manager.add_new_repository(i, "default", std::move(repository));
   }
 
   // All repositories should be accessible
-  for (size_t i = 0; i < num_pipelines; ++i) {
-    auto& repo = manager.get_repository(i);
+  for (size_t i = 0; i < num_operators; ++i) {
+    auto& repo = manager.get_repository(i, "default");
     REQUIRE(repo != nullptr);
   }
 }
@@ -147,23 +141,23 @@ TEST_CASE("data_repository_manager Replace Repository", "[data_repository_manage
 {
   data_repository_manager manager;
 
-  size_t pipeline_id = 5;
+  size_t operator_id = 5;
 
   // Add first repository
   auto repository1 = std::make_unique<idata_repository>();
   auto* repo1_ptr  = repository1.get();
-  manager.add_new_repository(pipeline_id, std::move(repository1));
+  manager.add_new_repository(operator_id, "default", std::move(repository1));
 
-  REQUIRE(manager.get_repository(pipeline_id).get() == repo1_ptr);
+  REQUIRE(manager.get_repository(operator_id, "default").get() == repo1_ptr);
 
   // Replace with second repository
   auto repository2 = std::make_unique<idata_repository>();
   auto* repo2_ptr  = repository2.get();
-  manager.add_new_repository(pipeline_id, std::move(repository2));
+  manager.add_new_repository(operator_id, "default", std::move(repository2));
 
   // Should now reference the new repository
-  REQUIRE(manager.get_repository(pipeline_id).get() == repo2_ptr);
-  REQUIRE(manager.get_repository(pipeline_id).get() != repo1_ptr);
+  REQUIRE(manager.get_repository(operator_id, "default").get() == repo2_ptr);
+  REQUIRE(manager.get_repository(operator_id, "default").get() != repo1_ptr);
 }
 
 // Test accessing non-existent repository
@@ -172,13 +166,13 @@ TEST_CASE("data_repository_manager Access Non-Existent Repository", "[data_repos
   data_repository_manager manager;
 
   // Add some repositories
-  manager.add_new_repository(1, std::make_unique<idata_repository>());
-  manager.add_new_repository(2, std::make_unique<idata_repository>());
+  manager.add_new_repository(1, "default", std::make_unique<idata_repository>());
+  manager.add_new_repository(2, "default", std::make_unique<idata_repository>());
 
   // Accessing non-existent repositories should throw
-  REQUIRE_THROWS_AS(manager.get_repository(0), std::out_of_range);
-  REQUIRE_THROWS_AS(manager.get_repository(3), std::out_of_range);
-  REQUIRE_THROWS_AS(manager.get_repository(999), std::out_of_range);
+  REQUIRE_THROWS_AS(manager.get_repository(0, "default"), std::out_of_range);
+  REQUIRE_THROWS_AS(manager.get_repository(3, "default"), std::out_of_range);
+  REQUIRE_THROWS_AS(manager.get_repository(999, "default"), std::out_of_range);
 }
 
 // =============================================================================
@@ -229,67 +223,71 @@ TEST_CASE("data_repository_manager Batch ID Initial Value", "[data_repository_ma
 // Data Batch Management Tests
 // =============================================================================
 
-// Test adding data batch to single pipeline
+// Test adding data batch to single operator
 TEST_CASE("data_repository_manager Add Data Batch Single Pipeline", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   // Create and add batch
   auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
   auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  std::vector<size_t> pipeline_ids = {pipeline_id};
-  manager.add_new_data_batch(std::move(batch), pipeline_ids);
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+  manager.add_new_data_batch(std::move(batch), operator_ports);
 
   // Repository should have the batch view
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   auto view  = repo->pull_data_batch_view();
   REQUIRE(view != nullptr);
 }
 
-// Test adding data batch to multiple pipelines
+// Test adding data batch to multiple operators
 TEST_CASE("data_repository_manager Add Data Batch Multiple Pipelines", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
   // Add multiple repositories
-  std::vector<size_t> pipeline_ids = {1, 2, 3};
-  for (size_t id : pipeline_ids) {
-    manager.add_new_repository(id, std::make_unique<idata_repository>());
+  std::vector<size_t> operator_ids = {1, 2, 3};
+  for (size_t id : operator_ids) {
+    manager.add_new_repository(id, "default", std::make_unique<idata_repository>());
   }
 
-  // Create and add batch to all pipelines
+  // Create and add batch to all operators
   auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
   auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  manager.add_new_data_batch(std::move(batch), pipeline_ids);
+  std::vector<std::pair<size_t, std::string_view>> operator_ports;
+  for (size_t id : operator_ids) {
+    operator_ports.push_back({id, "default"});
+  }
+  manager.add_new_data_batch(std::move(batch), operator_ports);
 
   // All repositories should have a view
-  for (size_t id : pipeline_ids) {
-    auto& repo = manager.get_repository(id);
+  for (size_t id : operator_ids) {
+    auto& repo = manager.get_repository(id, "default");
     auto view  = repo->pull_data_batch_view();
     REQUIRE(view != nullptr);
   }
 }
 
-// Test adding data batch with empty pipeline list
+// Test adding data batch with empty operator list
 TEST_CASE("data_repository_manager Add Data Batch No Pipelines", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
-  // Create and add batch with empty pipeline list
+  // Create and add batch with empty operator list
   auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
   auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  std::vector<size_t> empty_pipeline_ids;
-  manager.add_new_data_batch(std::move(batch), empty_pipeline_ids);
+  std::vector<std::pair<size_t, std::string_view>> empty_operator_ports;
+  manager.add_new_data_batch(std::move(batch), empty_operator_ports);
 
   // Batch is stored but no views are created
   // This should not crash
@@ -301,19 +299,19 @@ TEST_CASE("data_repository_manager Delete Data Batch", "[data_repository_manager
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   // Create and add batch
   auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
   auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
 
-  std::vector<size_t> pipeline_ids = {pipeline_id};
-  manager.add_new_data_batch(std::move(batch), pipeline_ids);
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+  manager.add_new_data_batch(std::move(batch), operator_ports);
 
   // Pull the view from repository first (views hold pointers to the batch)
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   auto view  = repo->pull_data_batch_view();
   REQUIRE(view != nullptr);
 
@@ -332,22 +330,22 @@ TEST_CASE("data_repository_manager Add Multiple Batches", "[data_repository_mana
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches        = 10;
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  constexpr int num_batches = 10;
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add multiple batches
   for (int i = 0; i < num_batches; ++i) {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
   }
 
   // Repository should have all batch views
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (auto view = repo->pull_data_batch_view()) {
     ++count;
@@ -409,7 +407,7 @@ TEST_CASE("data_repository_manager Thread-Safe Add Repository", "[data_repositor
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       auto repository = std::make_unique<idata_repository>();
-      manager.add_new_repository(i, std::move(repository));
+      manager.add_new_repository(i, "default", std::move(repository));
     });
   }
 
@@ -420,7 +418,7 @@ TEST_CASE("data_repository_manager Thread-Safe Add Repository", "[data_repositor
 
   // All repositories should be accessible
   for (int i = 0; i < num_threads; ++i) {
-    auto& repo = manager.get_repository(i);
+    auto& repo = manager.get_repository(i, "default");
     REQUIRE(repo != nullptr);
   }
 }
@@ -431,14 +429,14 @@ TEST_CASE("data_repository_manager Thread-Safe Add Batch", "[data_repository_man
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   constexpr int num_threads        = 10;
   constexpr int batches_per_thread = 50;
 
   std::vector<std::thread> threads;
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Launch threads to add batches
   for (int i = 0; i < num_threads; ++i) {
@@ -447,7 +445,7 @@ TEST_CASE("data_repository_manager Thread-Safe Add Batch", "[data_repository_man
         auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         uint64_t batch_id = manager.get_next_data_batch_id();
         auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        manager.add_new_data_batch(std::move(batch), pipeline_ids);
+        manager.add_new_data_batch(std::move(batch), operator_ports);
       }
     });
   }
@@ -458,7 +456,7 @@ TEST_CASE("data_repository_manager Thread-Safe Add Batch", "[data_repository_man
   }
 
   // Repository should have all batch views
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (auto view = repo->pull_data_batch_view()) {
     ++count;
@@ -472,11 +470,11 @@ TEST_CASE("data_repository_manager Thread-Safe Delete Batch", "[data_repository_
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches        = 100;
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  constexpr int num_batches = 100;
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
   std::vector<uint64_t> batch_ids;
 
   // Add batches
@@ -485,11 +483,11 @@ TEST_CASE("data_repository_manager Thread-Safe Delete Batch", "[data_repository_
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
     auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
   }
 
   // Pull all views from repository to allow safe deletion
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   std::vector<std::unique_ptr<data_batch_view>> views;
   while (auto view = repo->pull_data_batch_view()) {
     views.push_back(std::move(view));
@@ -525,7 +523,7 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
 
   // Add initial repositories
   for (int i = 0; i < 5; ++i) {
-    manager.add_new_repository(i, std::make_unique<idata_repository>());
+    manager.add_new_repository(i, "default", std::make_unique<idata_repository>());
   }
 
   constexpr int num_threads           = 10;
@@ -543,18 +541,18 @@ TEST_CASE("data_repository_manager Thread-Safe Mixed Operations", "[data_reposit
         // Generate batch ID
         uint64_t batch_id = manager.get_next_data_batch_id();
 
-        // Add batch to random pipeline
-        size_t pipeline_id = (i + j) % 5;
+        // Add batch to random operator
+        size_t operator_id = (i + j) % 5;
         auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        std::vector<size_t> pipeline_ids = {pipeline_id};
-        manager.add_new_data_batch(std::move(batch), pipeline_ids);
+        std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+        manager.add_new_data_batch(std::move(batch), operator_ports);
 
         ++batch_count;
 
         // Occasionally pull and store a view (to test concurrent pull operations)
         if (j % 10 == 0) {
-          auto& repo = manager.get_repository(pipeline_id);
+          auto& repo = manager.get_repository(operator_id, "default");
           if (auto view = repo->pull_data_batch_view()) {
             std::lock_guard<std::mutex> lock(view_mutex);
             all_views.push_back(std::move(view));
@@ -582,10 +580,10 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
 {
   data_repository_manager manager;
 
-  // Add repositories for multiple pipelines
-  constexpr int num_pipelines = 3;
-  for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, std::make_unique<idata_repository>());
+  // Add repositories for multiple operators
+  constexpr int num_operators = 3;
+  for (int i = 0; i < num_operators; ++i) {
+    manager.add_new_repository(i, "default", std::make_unique<idata_repository>());
   }
 
   constexpr int num_adder_threads   = 5;
@@ -604,12 +602,12 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
         // Generate batch ID
         uint64_t batch_id = manager.get_next_data_batch_id();
 
-        // Add batch to one or more pipelines
-        size_t pipeline_id = (i + j) % num_pipelines;
+        // Add batch to one or more operators
+        size_t operator_id = (i + j) % num_operators;
         auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
         auto batch         = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        std::vector<size_t> pipeline_ids = {pipeline_id};
-        manager.add_new_data_batch(std::move(batch), pipeline_ids);
+        std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+        manager.add_new_data_batch(std::move(batch), operator_ports);
 
         ++batches_added;
 
@@ -622,8 +620,8 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
   // Launch deleter threads - pull views and destroy them (triggers batch deletion)
   for (int i = 0; i < num_deleter_threads; ++i) {
     threads.emplace_back([&, i]() {
-      size_t pipeline_id = i % num_pipelines;
-      auto& repo         = manager.get_repository(pipeline_id);
+      size_t operator_id = i % num_operators;
+      auto& repo         = manager.get_repository(operator_id, "default");
 
       // Keep pulling and destroying views while adders are working
       while (keep_adding.load() || repo->pull_data_batch_view() != nullptr) {
@@ -661,8 +659,8 @@ TEST_CASE("data_repository_manager Concurrent Add and Delete via View Destructor
   REQUIRE(batches_deleted == num_adder_threads * batches_per_adder);
 
   // All repositories should be empty
-  for (int i = 0; i < num_pipelines; ++i) {
-    auto& repo = manager.get_repository(i);
+  for (int i = 0; i < num_operators; ++i) {
+    auto& repo = manager.get_repository(i, "default");
     REQUIRE(repo->pull_data_batch_view() == nullptr);
   }
 }
@@ -673,9 +671,9 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
 {
   data_repository_manager manager;
 
-  // Single pipeline for maximum contention
-  size_t pipeline_id = 0;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  // Single operator for maximum contention
+  size_t operator_id = 0;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   constexpr int num_threads           = 20;
   constexpr int operations_per_thread = 50;
@@ -687,15 +685,15 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
   // Launch threads doing both add and delete operations
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
-      auto& repo                       = manager.get_repository(pipeline_id);
-      std::vector<size_t> pipeline_ids = {pipeline_id};
+      auto& repo = manager.get_repository(operator_id, "default");
+      std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
       for (int j = 0; j < operations_per_thread; ++j) {
         // Add a batch
         uint64_t batch_id = manager.get_next_data_batch_id();
         auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
         auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-        manager.add_new_data_batch(std::move(batch), pipeline_ids);
+        manager.add_new_data_batch(std::move(batch), operator_ports);
         ++total_added;
 
         // Immediately try to pull and delete a batch (might be ours or someone else's)
@@ -717,7 +715,7 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
   REQUIRE(total_added == num_threads * operations_per_thread);
 
   // Clean up remaining batches
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   while (auto view = repo->pull_data_batch_view()) {
     ++total_deleted;
   }
@@ -733,36 +731,36 @@ TEST_CASE("data_repository_manager Concurrent Add Delete Multiple Views per Batc
   data_repository_manager manager;
 
   // Add repositories
-  constexpr int num_pipelines = 5;
-  for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, std::make_unique<idata_repository>());
+  constexpr int num_operators = 5;
+  for (int i = 0; i < num_operators; ++i) {
+    manager.add_new_repository(i, "default", std::make_unique<idata_repository>());
   }
 
   constexpr int num_batches = 50;
   std::atomic<int> views_deleted{0};
 
-  // Add batches to ALL pipelines (each batch will have multiple views)
-  std::vector<size_t> all_pipeline_ids;
-  for (int i = 0; i < num_pipelines; ++i) {
-    all_pipeline_ids.push_back(i);
+  // Add batches to ALL operators (each batch will have multiple views)
+  std::vector<std::pair<size_t, std::string_view>> all_operator_ports;
+  for (int i = 0; i < num_operators; ++i) {
+    all_operator_ports.push_back({i, "default"});
   }
 
   for (int i = 0; i < num_batches; ++i) {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), all_pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), all_operator_ports);
   }
 
-  // Now concurrently delete views from different pipelines
+  // Now concurrently delete views from different operators
   // The batch should only be deleted when ALL views are destroyed
   std::vector<std::thread> threads;
 
-  for (int i = 0; i < num_pipelines; ++i) {
+  for (int i = 0; i < num_operators; ++i) {
     threads.emplace_back([&, i]() {
-      auto& repo = manager.get_repository(i);
+      auto& repo = manager.get_repository(i, "default");
 
-      // Pull and destroy all views from this pipeline
+      // Pull and destroy all views from this operator
       while (auto view = repo->pull_data_batch_view()) {
         ++views_deleted;
         view.reset();  // Destructor called here
@@ -775,13 +773,13 @@ TEST_CASE("data_repository_manager Concurrent Add Delete Multiple Views per Batc
     thread.join();
   }
 
-  // Each batch was added to all pipelines, so we should have deleted
-  // num_batches * num_pipelines views
-  REQUIRE(views_deleted == num_batches * num_pipelines);
+  // Each batch was added to all operators, so we should have deleted
+  // num_batches * num_operators views
+  REQUIRE(views_deleted == num_batches * num_operators);
 
   // All repositories should be empty
-  for (int i = 0; i < num_pipelines; ++i) {
-    auto& repo = manager.get_repository(i);
+  for (int i = 0; i < num_operators; ++i) {
+    auto& repo = manager.get_repository(i, "default");
     REQUIRE(repo->pull_data_batch_view() == nullptr);
   }
 }
@@ -790,52 +788,56 @@ TEST_CASE("data_repository_manager Concurrent Add Delete Multiple Views per Batc
 // Integration Tests
 // =============================================================================
 
-// Test full workflow with multiple pipelines and batches
+// Test full workflow with multiple operators and batches
 TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
-  // Setup: Create 3 pipelines
-  std::vector<size_t> pipeline_ids = {0, 1, 2};
-  for (size_t id : pipeline_ids) {
-    manager.add_new_repository(id, std::make_unique<idata_repository>());
+  // Setup: Create 3 operators
+  std::vector<size_t> operator_ids = {0, 1, 2};
+  for (size_t id : operator_ids) {
+    manager.add_new_repository(id, "default", std::make_unique<idata_repository>());
   }
 
-  // Add batches to different pipeline combinations
+  // Add batches to different operator combinations
   std::vector<uint64_t> batch_ids;
 
-  // Batch 0: All pipelines
+  // Batch 0: All operators
   {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
     auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    std::vector<std::pair<size_t, std::string_view>> all_ports;
+    for (size_t id : operator_ids) {
+      all_ports.push_back({id, "default"});
+    }
+    manager.add_new_data_batch(std::move(batch), all_ports);
   }
 
-  // Batch 1: Pipeline 0 only
+  // Batch 1: Operator 0 only
   {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch             = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    std::vector<size_t> p0 = {0};
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    std::vector<std::pair<size_t, std::string_view>> p0 = {{0, "default"}};
     manager.add_new_data_batch(std::move(batch), p0);
   }
 
-  // Batch 2: Pipelines 1 and 2
+  // Batch 2: Operators 1 and 2
   {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch              = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    std::vector<size_t> p12 = {1, 2};
+    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    std::vector<std::pair<size_t, std::string_view>> p12 = {{1, "default"}, {2, "default"}};
     manager.add_new_data_batch(std::move(batch), p12);
   }
 
-  // Verify: Pipeline 0 should have 2 batches (batch 0 and 1)
+  // Verify: Operator 0 should have 2 batches (batch 0 and 1)
   {
-    auto& repo = manager.get_repository(0);
+    auto& repo = manager.get_repository(0, "default");
     int count  = 0;
     while (auto view = repo->pull_data_batch_view()) {
       ++count;
@@ -843,9 +845,9 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
     REQUIRE(count == 2);
   }
 
-  // Verify: Pipeline 1 should have 2 batches (batch 0 and 2)
+  // Verify: Operator 1 should have 2 batches (batch 0 and 2)
   {
-    auto& repo = manager.get_repository(1);
+    auto& repo = manager.get_repository(1, "default");
     int count  = 0;
     while (auto view = repo->pull_data_batch_view()) {
       ++count;
@@ -853,9 +855,9 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
     REQUIRE(count == 2);
   }
 
-  // Verify: Pipeline 2 should have 2 batches (batch 0 and 2)
+  // Verify: Operator 2 should have 2 batches (batch 0 and 2)
   {
-    auto& repo = manager.get_repository(2);
+    auto& repo = manager.get_repository(2, "default");
     int count  = 0;
     while (auto view = repo->pull_data_batch_view()) {
       ++count;
@@ -871,42 +873,42 @@ TEST_CASE("data_repository_manager Replace Repository With Data", "[data_reposit
 {
   data_repository_manager manager;
 
-  size_t pipeline_id = 1;
+  size_t operator_id = 1;
 
   // Add first repository
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   // Add batch to first repository
   auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   uint64_t batch_id = manager.get_next_data_batch_id();
   auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-  std::vector<size_t> pipeline_ids = {pipeline_id};
-  manager.add_new_data_batch(std::move(batch), pipeline_ids);
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+  manager.add_new_data_batch(std::move(batch), operator_ports);
 
   // Replace repository
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
   // New repository should be empty
-  auto& new_repo = manager.get_repository(pipeline_id);
+  auto& new_repo = manager.get_repository(operator_id, "default");
   auto view      = new_repo->pull_data_batch_view();
   REQUIRE(view == nullptr);
 }
 
-// Test large number of pipelines
+// Test large number of operators
 TEST_CASE("data_repository_manager Large Number of Pipelines", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
-  constexpr int num_pipelines = 1000;
+  constexpr int num_operators = 1000;
 
-  // Add many pipelines
-  for (int i = 0; i < num_pipelines; ++i) {
-    manager.add_new_repository(i, std::make_unique<idata_repository>());
+  // Add many operators
+  for (int i = 0; i < num_operators; ++i) {
+    manager.add_new_repository(i, "default", std::make_unique<idata_repository>());
   }
 
-  // All pipelines should be accessible
-  for (int i = 0; i < num_pipelines; ++i) {
-    auto& repo = manager.get_repository(i);
+  // All operators should be accessible
+  for (int i = 0; i < num_operators; ++i) {
+    auto& repo = manager.get_repository(i, "default");
     REQUIRE(repo != nullptr);
   }
 }
@@ -917,22 +919,22 @@ TEST_CASE("data_repository_manager Large Number of Batches", "[data_repository_m
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  constexpr int num_batches        = 1000;
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  constexpr int num_batches = 1000;
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add many batches
   for (int i = 0; i < num_batches; ++i) {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
   }
 
   // Repository should have all batches
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (auto view = repo->pull_data_batch_view()) {
     ++count;
@@ -944,19 +946,19 @@ TEST_CASE("data_repository_manager Large Number of Batches", "[data_repository_m
 // Edge Case Tests
 // =============================================================================
 
-// Test with pipeline ID zero
+// Test with operator ID zero
 TEST_CASE("data_repository_manager Pipeline ID Zero", "[data_repository_manager]")
 {
   data_repository_manager manager;
 
-  // Pipeline ID 0 should work like any other ID
-  manager.add_new_repository(0, std::make_unique<idata_repository>());
+  // Operator ID 0 should work like any other ID
+  manager.add_new_repository(0, "default", std::make_unique<idata_repository>());
 
-  auto& repo = manager.get_repository(0);
+  auto& repo = manager.get_repository(0, "default");
   REQUIRE(repo != nullptr);
 }
 
-// Test with large pipeline IDs
+// Test with large operator IDs
 TEST_CASE("data_repository_manager Large Pipeline IDs", "[data_repository_manager]")
 {
   data_repository_manager manager;
@@ -965,12 +967,12 @@ TEST_CASE("data_repository_manager Large Pipeline IDs", "[data_repository_manage
 
   // Add repositories with large IDs
   for (size_t id : large_ids) {
-    manager.add_new_repository(id, std::make_unique<idata_repository>());
+    manager.add_new_repository(id, "default", std::make_unique<idata_repository>());
   }
 
   // All should be accessible
   for (size_t id : large_ids) {
-    auto& repo = manager.get_repository(id);
+    auto& repo = manager.get_repository(id, "default");
     REQUIRE(repo != nullptr);
   }
 }
@@ -981,22 +983,22 @@ TEST_CASE("data_repository_manager Batches With Different Sizes", "[data_reposit
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  std::vector<size_t> sizes        = {1, 1024, 1024 * 1024, 1024 * 1024 * 10};
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<size_t> sizes = {1, 1024, 1024 * 1024, 1024 * 1024 * 10};
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add batches with different sizes
   for (size_t size : sizes) {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, size);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
   }
 
   // All batches should be accessible
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (auto view = repo->pull_data_batch_view()) {
     ++count;
@@ -1010,22 +1012,22 @@ TEST_CASE("data_repository_manager Batches With Different Tiers", "[data_reposit
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  std::vector<memory::Tier> tiers  = {memory::Tier::GPU, memory::Tier::HOST, memory::Tier::DISK};
-  std::vector<size_t> pipeline_ids = {pipeline_id};
+  std::vector<memory::Tier> tiers = {memory::Tier::GPU, memory::Tier::HOST, memory::Tier::DISK};
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
 
   // Add batches with different tiers
   for (memory::Tier tier : tiers) {
     auto data         = std::make_unique<mock_data_representation>(tier, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
   }
 
   // All batches should be accessible
-  auto& repo = manager.get_repository(pipeline_id);
+  auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (auto view = repo->pull_data_batch_view()) {
     ++count;
@@ -1039,18 +1041,18 @@ TEST_CASE("data_repository_manager Rapid Add Delete Cycles", "[data_repository_m
   data_repository_manager manager;
 
   // Add repository
-  size_t pipeline_id = 1;
-  manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
+  size_t operator_id = 1;
+  manager.add_new_repository(operator_id, "default", std::make_unique<idata_repository>());
 
-  std::vector<size_t> pipeline_ids = {pipeline_id};
-  auto& repo                       = manager.get_repository(pipeline_id);
+  std::vector<std::pair<size_t, std::string_view>> operator_ports = {{operator_id, "default"}};
+  auto& repo = manager.get_repository(operator_id, "default");
 
   // Perform many cycles of add and delete
   for (int cycle = 0; cycle < 100; ++cycle) {
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     uint64_t batch_id = manager.get_next_data_batch_id();
     auto batch        = std::make_unique<data_batch>(batch_id, manager, std::move(data));
-    manager.add_new_data_batch(std::move(batch), pipeline_ids);
+    manager.add_new_data_batch(std::move(batch), operator_ports);
 
     // Pull and destroy the view, which triggers batch deletion
     auto view = repo->pull_data_batch_view();

--- a/test/cpp/data/test_data_repository_manager.cpp
+++ b/test/cpp/data/test_data_repository_manager.cpp
@@ -335,7 +335,7 @@ TEST_CASE("data_repository_manager Add Multiple Batches", "[data_repository_mana
   size_t pipeline_id = 1;
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  constexpr int num_batches           = 10;
+  constexpr int num_batches        = 10;
   std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add multiple batches
@@ -475,7 +475,7 @@ TEST_CASE("data_repository_manager Thread-Safe Delete Batch", "[data_repository_
   size_t pipeline_id = 1;
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  constexpr int num_batches           = 100;
+  constexpr int num_batches        = 100;
   std::vector<size_t> pipeline_ids = {pipeline_id};
   std::vector<uint64_t> batch_ids;
 
@@ -687,7 +687,7 @@ TEST_CASE("data_repository_manager High Contention Add Delete via View Destructo
   // Launch threads doing both add and delete operations
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
-      auto& repo                          = manager.get_repository(pipeline_id);
+      auto& repo                       = manager.get_repository(pipeline_id);
       std::vector<size_t> pipeline_ids = {pipeline_id};
 
       for (int j = 0; j < operations_per_thread; ++j) {
@@ -818,7 +818,7 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch                = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch             = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     std::vector<size_t> p0 = {0};
     manager.add_new_data_batch(std::move(batch), p0);
   }
@@ -828,7 +828,7 @@ TEST_CASE("data_repository_manager Full Workflow", "[data_repository_manager]")
     auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 4096);
     uint64_t batch_id = manager.get_next_data_batch_id();
     batch_ids.push_back(batch_id);
-    auto batch = std::make_unique<data_batch>(batch_id, manager, std::move(data));
+    auto batch              = std::make_unique<data_batch>(batch_id, manager, std::move(data));
     std::vector<size_t> p12 = {1, 2};
     manager.add_new_data_batch(std::move(batch), p12);
   }
@@ -920,7 +920,7 @@ TEST_CASE("data_repository_manager Large Number of Batches", "[data_repository_m
   size_t pipeline_id = 1;
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  constexpr int num_batches           = 1000;
+  constexpr int num_batches        = 1000;
   std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add many batches
@@ -984,7 +984,7 @@ TEST_CASE("data_repository_manager Batches With Different Sizes", "[data_reposit
   size_t pipeline_id = 1;
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  std::vector<size_t> sizes           = {1, 1024, 1024 * 1024, 1024 * 1024 * 10};
+  std::vector<size_t> sizes        = {1, 1024, 1024 * 1024, 1024 * 1024 * 10};
   std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add batches with different sizes
@@ -1013,7 +1013,7 @@ TEST_CASE("data_repository_manager Batches With Different Tiers", "[data_reposit
   size_t pipeline_id = 1;
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
-  std::vector<memory::Tier> tiers     = {memory::Tier::GPU, memory::Tier::HOST, memory::Tier::DISK};
+  std::vector<memory::Tier> tiers  = {memory::Tier::GPU, memory::Tier::HOST, memory::Tier::DISK};
   std::vector<size_t> pipeline_ids = {pipeline_id};
 
   // Add batches with different tiers
@@ -1043,7 +1043,7 @@ TEST_CASE("data_repository_manager Rapid Add Delete Cycles", "[data_repository_m
   manager.add_new_repository(pipeline_id, std::make_unique<idata_repository>());
 
   std::vector<size_t> pipeline_ids = {pipeline_id};
-  auto& repo                          = manager.get_repository(pipeline_id);
+  auto& repo                       = manager.get_repository(pipeline_id);
 
   // Perform many cycles of add and delete
   for (int cycle = 0; cycle < 100; ++cycle) {

--- a/test/cpp/data/test_data_repository_manager.cpp
+++ b/test/cpp/data/test_data_repository_manager.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 using namespace sirius;
+using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {

--- a/test/cpp/data/test_data_representation.cpp
+++ b/test/cpp/data/test_data_representation.cpp
@@ -68,7 +68,7 @@ class mock_memory_space : public memory::memory_space {
 };
 
 // Helper function to create a mock host_table_allocation for testing
-sirius::unique_ptr<memory::host_table_allocation> create_mock_host_table_allocation(
+std::unique_ptr<memory::host_table_allocation> create_mock_host_table_allocation(
   std::size_t data_size)
 {
   // Create empty allocation blocks (we're not testing actual allocation here)
@@ -81,12 +81,12 @@ sirius::unique_ptr<memory::host_table_allocation> create_mock_host_table_allocat
   );
 
   // Create mock metadata
-  auto metadata = sirius::make_unique<sirius::vector<uint8_t>>();
+  auto metadata = std::make_unique<std::vector<uint8_t>>();
   metadata->push_back(0x01);
   metadata->push_back(0x02);
   metadata->push_back(0x03);
 
-  return sirius::make_unique<memory::host_table_allocation>(
+  return std::make_unique<memory::host_table_allocation>(
     std::move(empty_allocation), std::move(metadata), data_size);
 }
 
@@ -249,8 +249,8 @@ TEST_CASE("host_table_representation converts to GPU and preserves contents",
     }
   }
 
-  auto meta_copy  = sirius::make_unique<sirius::vector<uint8_t>>(*packed.metadata);
-  auto host_alloc = sirius::make_unique<memory::host_table_allocation>(
+  auto meta_copy  = std::make_unique<std::vector<uint8_t>>(*packed.metadata);
+  auto host_alloc = std::make_unique<memory::host_table_allocation>(
     std::move(allocation), std::move(meta_copy), packed.gpu_data->size());
   host_table_representation host_repr(std::move(host_alloc),
                                       const_cast<memory::memory_space*>(host_space));
@@ -419,7 +419,7 @@ TEST_CASE("gpu->host->gpu roundtrip preserves cudf table contents", "[gpu_data_r
     // Re-wrap into a host_table_representation to continue conversion
     host_table_representation host_repr2(std::move(host_alloc_uptr),
                                          const_cast<memory::memory_space*>(host_space));
-    cpu_any = sirius::make_unique<host_table_representation>(std::move(host_repr2));
+    cpu_any = std::make_unique<host_table_representation>(std::move(host_repr2));
   }
   auto gpu_any = cpu_any->convert_to_memory_space(gpu_space, chain_stream);
 

--- a/test/cpp/data/test_data_representation.cpp
+++ b/test/cpp/data/test_data_representation.cpp
@@ -44,6 +44,7 @@
 #include <vector>
 
 using namespace sirius;
+using namespace cucascade;
 
 // Mock memory_space for testing - provides a simple memory_space without real allocators
 class mock_memory_space : public memory::memory_space {
@@ -121,7 +122,7 @@ cudf::table create_simple_cudf_table(int num_rows = 100)
 // Initialize a minimal memory manager with one GPU(0) and one HOST(0)
 static void initialize_memory_for_conversions()
 {
-  using namespace sirius::memory;
+  using namespace cucascade::memory;
   memory_reservation_manager::reset_for_testing();
   std::vector<memory_reservation_manager::memory_space_config> configs;
   configs.emplace_back(
@@ -501,7 +502,7 @@ TEST_CASE("gpu->host->gpu roundtrip preserves cudf table contents", "[gpu_data_r
 // =============================================================================
 static void initialize_multi_gpu_for_conversions(int dev_a, int dev_b)
 {
-  using namespace sirius::memory;
+  using namespace cucascade::memory;
   memory_reservation_manager::reset_for_testing();
   std::vector<memory_reservation_manager::memory_space_config> configs;
   configs.emplace_back(Tier::GPU, dev_a, 2048ull * 1024 * 1024);

--- a/test/cpp/memory_management/test_memory_reservation_manager.cpp
+++ b/test/cpp/memory_management/test_memory_reservation_manager.cpp
@@ -45,7 +45,7 @@
 #include <memory>
 #include <vector>
 
-using namespace sirius::memory;
+using namespace cucascade::memory;
 
 // Expected memory capacities
 const size_t expected_gpu_capacity  = 2ull << 30;  // 2GB

--- a/test/cpp/memory_management/test_per_stream_tracking_resource_adaptor.cpp
+++ b/test/cpp/memory_management/test_per_stream_tracking_resource_adaptor.cpp
@@ -48,7 +48,7 @@
 
 #include <cuda_runtime.h>
 
-using namespace sirius::memory;
+using namespace cucascade::memory;
 
 // Test fixture for per-stream tracking tests
 class PerStreamTrackingTest {

--- a/test/cpp/memory_management/test_topology_discovery.cpp
+++ b/test/cpp/memory_management/test_topology_discovery.cpp
@@ -34,7 +34,7 @@
 #include <cstdlib>
 #include <vector>
 
-using namespace sirius::memory;
+using namespace cucascade::memory;
 
 // Test topology discovery
 TEST_CASE("Topology Discovery", "[hw_topology]")

--- a/test/cpp/operator/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/test_gpu_merge_impl.cpp
@@ -174,7 +174,7 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
   constexpr size_t num_rows_per_batch = 100;
   std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::STRING}};
+                                               cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
                                                      num_input_rows,
@@ -197,7 +197,7 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
     num_input_rows.push_back((i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::STRING}};
+                                               cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
                                                      num_input_rows,
@@ -218,7 +218,7 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
   constexpr size_t num_rows_per_batch = 100;
   std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::STRING}};
+                                               cudf::data_type{cudf::type_id::STRING}};
 
   // Invalid input: less than two input batches
   auto input_views = create_batches_with_random_data(num_batches,
@@ -240,7 +240,7 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
   constexpr size_t num_rows_per_batch = 0;
   std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::STRING}};
+                                               cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
                                                      num_input_rows,
@@ -263,7 +263,7 @@ TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merg
     num_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::STRING}};
+                                               cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
                                                      num_input_rows,
@@ -387,10 +387,9 @@ void validate_ungrouped_aggregate_numeric(const std::vector<cudf::table_view>& i
   }
 }
 
-void validate_ungrouped_aggregate(
-  const std::vector<std::unique_ptr<data_batch_view>>& input_views,
-  const cucascade::data_batch& output,
-  const std::vector<cudf::aggregation::Kind>& aggregates)
+void validate_ungrouped_aggregate(const std::vector<std::unique_ptr<data_batch_view>>& input_views,
+                                  const cucascade::data_batch& output,
+                                  const std::vector<cudf::aggregation::Kind>& aggregates)
 {
   std::vector<cudf::table_view> input_table_views;
   for (const auto& input_view : input_views) {
@@ -435,13 +434,13 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
 
   auto input_views = create_batches_with_local_ungrouped_agg_result(
     num_batches, num_base_input_rows, column_types, aggregates, data_repo_manager, *mem_space);
@@ -489,13 +488,13 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
 
   auto input_views = create_batches_with_local_ungrouped_agg_result(
     num_batches, num_base_input_rows, column_types, aggregates, data_repo_manager, *mem_space);
@@ -515,13 +514,13 @@ TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggreg
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
 
   auto input_views = create_batches_with_local_ungrouped_agg_result(
     num_batches, num_base_input_rows, column_types, aggregates, data_repo_manager, *mem_space);
@@ -604,11 +603,10 @@ void copy_data_to_host(cudf::table_view table, std::vector<std::vector<int64_t>>
   }
 }
 
-void validate_grouped_aggregate(
-  const std::vector<std::unique_ptr<data_batch_view>>& input_views,
-  const cucascade::data_batch& output,
-  int num_group_cols,
-  const std::vector<cudf::aggregation::Kind>& aggregates)
+void validate_grouped_aggregate(const std::vector<std::unique_ptr<data_batch_view>>& input_views,
+                                const cucascade::data_batch& output,
+                                int num_group_cols,
+                                const std::vector<cudf::aggregation::Kind>& aggregates)
 {
   std::vector<cudf::table_view> input_table_views;
   for (const auto& input_view : input_views) {
@@ -687,16 +685,16 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> group_idx                      = {0, 1};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
   std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
@@ -724,7 +722,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> group_idx                      = {0};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN};
   std::vector<int> aggregate_idx                  = {1};
@@ -770,16 +768,16 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> group_idx                      = {0, 1};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
   std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
@@ -810,16 +808,16 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> group_idx                      = {0, 1};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
   std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
@@ -848,14 +846,14 @@ TEST_CASE("Grouped merge aggregate with multiple aggregations on the same column
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64},
-                                                        cudf::data_type{cudf::type_id::INT32},
-                                                        cudf::data_type{cudf::type_id::INT64}};
+                                                     cudf::data_type{cudf::type_id::INT64},
+                                                     cudf::data_type{cudf::type_id::INT32},
+                                                     cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> group_idx                      = {0, 1};
   std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
-                                                        cudf::aggregation::Kind::MAX,
-                                                        cudf::aggregation::Kind::COUNT_ALL,
-                                                        cudf::aggregation::Kind::SUM};
+                                                     cudf::aggregation::Kind::MAX,
+                                                     cudf::aggregation::Kind::COUNT_ALL,
+                                                     cudf::aggregation::Kind::SUM};
   std::vector<int> aggregate_idx                  = {2, 3, 2, 3};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
@@ -877,8 +875,7 @@ TEST_CASE("Grouped merge aggregate with multiple aggregations on the same column
 
 namespace {
 
-std::vector<std::unique_ptr<data_batch_view>>
-create_batches_with_local_orderby_or_topn_result(
+std::vector<std::unique_ptr<data_batch_view>> create_batches_with_local_orderby_or_topn_result(
   const int num_batches,
   const std::vector<int> num_base_input_rows,
   const std::optional<std::pair<int, int>>& limit_offset,
@@ -978,9 +975,9 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1014,9 +1011,9 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1073,9 +1070,9 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1112,9 +1109,9 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1165,8 +1162,8 @@ void validate_top_n(const std::vector<std::unique_ptr<data_batch_view>>& input_v
   for (const auto& table : input_table_views) {
     copy_data_to_host(table, h_input_data);
   }
-  std::vector<std::vector<int64_t>> h_input_data_rows(
-    h_input_data[0].size(), std::vector<int64_t>(h_input_data.size()));
+  std::vector<std::vector<int64_t>> h_input_data_rows(h_input_data[0].size(),
+                                                      std::vector<int64_t>(h_input_data.size()));
   for (int r = 0; r < h_input_data_rows.size(); ++r) {
     for (int c = 0; c < h_input_data_rows[0].size(); ++c) {
       h_input_data_rows[r][c] = h_input_data[c][r];
@@ -1231,10 +1228,10 @@ TEST_CASE("Merge top-n basic", "[operator][merge_top_n]")
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset             = {10, 20};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::pair<int, int> limit_offset          = {10, 20};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1270,10 +1267,10 @@ TEST_CASE("Merge top-n with empty local top-n results", "[operator][merge_top_n]
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset             = {10, 20};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::pair<int, int> limit_offset          = {10, 20};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1312,10 +1309,10 @@ TEST_CASE("Merge top-n with mixed empty and non-empty local top-n results",
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset             = {10, 20};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::pair<int, int> limit_offset          = {10, 20};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1351,10 +1348,10 @@ TEST_CASE("Merge top-n with `limit = 0`", "[operator][merge_top_n]")
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset             = {0, 20};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::pair<int, int> limit_offset          = {0, 20};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
@@ -1391,10 +1388,10 @@ TEST_CASE("Merge top-n with `num_input_rows - limit <= offset < num_input-rows`"
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset             = {200, 900};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
+  std::pair<int, int> limit_offset          = {200, 900};
   std::vector<int> order_key_idx            = {0, 1, 2};
   std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};

--- a/test/cpp/operator/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/test_gpu_merge_impl.cpp
@@ -27,7 +27,8 @@
 #include <cudf/utilities/bit.hpp>
 
 using namespace sirius;
-using namespace sirius::memory;
+using namespace cucascade;
+using namespace cucascade::memory;
 using namespace sirius::op;
 
 namespace {
@@ -54,7 +55,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_random_d
   const sirius::vector<int> num_rows,
   const sirius::vector<cudf::data_type>& column_types,
   const sirius::vector<std::optional<std::pair<int, int>>>& ranges,
-  data_repository_manager& data_repo_manager,
+  cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   sirius::vector<sirius::unique_ptr<data_batch_view>> batches;
@@ -65,7 +66,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_random_d
                                                     ranges,
                                                     cudf::get_default_stream(),
                                                     mem_space.get_default_allocator());
-    auto gpu_repr = sirius::make_unique<gpu_table_representation>(*table, mem_space);
+    auto gpu_repr = sirius::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
     auto batch    = sirius::make_unique<data_batch>(
       data_repo_manager.get_next_data_batch_id(), data_repo_manager, std::move(gpu_repr));
 
@@ -79,7 +80,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_random_d
 }
 
 void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
-                     const sirius::data_batch& output)
+                     const cucascade::data_batch& output)
 {
   sirius::vector<cudf::table_view> input_table_views;
   int expected_num_rows = 0;
@@ -88,7 +89,7 @@ void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& 
     expected_num_rows += input_table_views.back().num_rows();
   }
   cudf::table_view output_table_view =
-    output.get_data()->cast<gpu_table_representation>().get_table().view();
+    output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
   REQUIRE(expected_num_rows == output_table_view.num_rows());
   REQUIRE(input_table_views[0].num_columns() == output_table_view.num_columns());
@@ -167,7 +168,7 @@ void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& 
 
 TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 10;
   constexpr size_t num_rows_per_batch = 100;
@@ -188,7 +189,7 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
 
 TEST_CASE("Concatenate multiple data batches with different size", "[operator][merge_concat]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_input_rows;
@@ -211,7 +212,7 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
 
 TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 1;
   constexpr size_t num_rows_per_batch = 100;
@@ -233,7 +234,7 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
 
 TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][merge_concat]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 10;
   constexpr size_t num_rows_per_batch = 0;
@@ -254,7 +255,7 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
 
 TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merge_concat]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_input_rows;
@@ -282,7 +283,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_un
   const sirius::vector<int> num_base_input_rows,
   const sirius::vector<cudf::data_type>& column_types,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
-  data_repository_manager& data_repo_manager,
+  cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches
@@ -388,7 +389,7 @@ void validate_ungrouped_aggregate_numeric(const sirius::vector<cudf::table_view>
 
 void validate_ungrouped_aggregate(
   const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
-  const sirius::data_batch& output,
+  const cucascade::data_batch& output,
   const sirius::vector<cudf::aggregation::Kind>& aggregates)
 {
   sirius::vector<cudf::table_view> input_table_views;
@@ -396,7 +397,7 @@ void validate_ungrouped_aggregate(
     input_table_views.push_back(input_view->get_cudf_table_view());
   }
   cudf::table_view output_table_view =
-    output.get_data()->cast<gpu_table_representation>().get_table().view();
+    output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
   REQUIRE(output_table_view.num_rows() == 1);
 
@@ -428,7 +429,7 @@ void validate_ungrouped_aggregate(
 
 TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_ungrouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -451,7 +452,7 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
 
 TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungrouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -482,7 +483,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
 TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
           "[operator][merge_ungrouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
@@ -506,7 +507,7 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
 TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggregate results",
           "[operator][merge_ungrouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_base_input_rows;
@@ -538,7 +539,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_gr
   const sirius::vector<int>& group_idx,
   const sirius::vector<cudf::aggregation::Kind>& aggregates,
   const sirius::vector<int>& aggregate_idx,
-  data_repository_manager& data_repo_manager,
+  cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches, make group key value ranges small so that we have multiple values in a
@@ -605,7 +606,7 @@ void copy_data_to_host(cudf::table_view table, sirius::vector<sirius::vector<int
 
 void validate_grouped_aggregate(
   const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
-  const sirius::data_batch& output,
+  const cucascade::data_batch& output,
   int num_group_cols,
   const sirius::vector<cudf::aggregation::Kind>& aggregates)
 {
@@ -614,7 +615,7 @@ void validate_grouped_aggregate(
     input_table_views.push_back(input_view->get_cudf_table_view());
   }
   cudf::table_view output_table_view =
-    output.get_data()->cast<gpu_table_representation>().get_table().view();
+    output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
   // Compute expected results
   sirius::vector<sirius::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
@@ -680,7 +681,7 @@ void validate_grouped_aggregate(
 
 TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -717,7 +718,7 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
 
 TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_grouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -763,7 +764,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
 TEST_CASE("Grouped merge aggregate with empty local aggregate results",
           "[operator][merge_grouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
@@ -801,7 +802,7 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
 TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregate results",
           "[operator][merge_grouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_base_input_rows;
@@ -841,7 +842,7 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
 TEST_CASE("Grouped merge aggregate with multiple aggregations on the same column",
           "[operator][merge_grouped_agg]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -885,7 +886,7 @@ create_batches_with_local_orderby_or_topn_result(
   const sirius::vector<int>& order_key_idx,
   const sirius::vector<cudf::order>& column_order,
   const sirius::vector<cudf::null_order>& null_precedence,
-  data_repository_manager& data_repo_manager,
+  cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches, make order key value ranges small so that some rows are compared by
@@ -932,7 +933,7 @@ create_batches_with_local_orderby_or_topn_result(
 }
 
 void validate_order_by(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
-                       const sirius::data_batch& output,
+                       const cucascade::data_batch& output,
                        const sirius::vector<int>& order_key_idx,
                        const sirius::vector<cudf::order>& column_order)
 {
@@ -943,7 +944,7 @@ void validate_order_by(const sirius::vector<sirius::unique_ptr<data_batch_view>>
     expected_num_rows += input_table_views.back().num_rows();
   }
   cudf::table_view output_table_view =
-    output.get_data()->cast<gpu_table_representation>().get_table().view();
+    output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
   REQUIRE(output_table_view.num_rows() == expected_num_rows);
   REQUIRE(output_table_view.num_columns() == input_table_views[0].num_columns());
@@ -971,7 +972,7 @@ void validate_order_by(const sirius::vector<sirius::unique_ptr<data_batch_view>>
 
 TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -1007,7 +1008,7 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
 
 TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -1066,7 +1067,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
 
 TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_order_by]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
@@ -1103,7 +1104,7 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
 TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results",
           "[operator][merge_order_by]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_base_input_rows;
@@ -1142,7 +1143,7 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
 namespace {
 
 void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
-                    const sirius::data_batch& output,
+                    const cucascade::data_batch& output,
                     const std::pair<int, int>& limit_offset,
                     const sirius::vector<int>& order_key_idx,
                     const sirius::vector<cudf::order>& column_order)
@@ -1155,7 +1156,7 @@ void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& i
   }
   int limit = limit_offset.first, offset = limit_offset.second;
   cudf::table_view output_table_view =
-    output.get_data()->cast<gpu_table_representation>().get_table().view();
+    output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
   int expected_num_rows =
     (limit + offset <= num_input_rows) ? limit : std::max(0, num_input_rows - offset);
 
@@ -1224,7 +1225,7 @@ void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& i
 
 TEST_CASE("Merge top-n basic", "[operator][merge_top_n]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -1263,7 +1264,7 @@ TEST_CASE("Merge top-n basic", "[operator][merge_top_n]")
 
 TEST_CASE("Merge top-n with empty local top-n results", "[operator][merge_top_n]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
@@ -1303,7 +1304,7 @@ TEST_CASE("Merge top-n with empty local top-n results", "[operator][merge_top_n]
 TEST_CASE("Merge top-n with mixed empty and non-empty local top-n results",
           "[operator][merge_top_n]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
   sirius::vector<int> num_base_input_rows;
@@ -1344,7 +1345,7 @@ TEST_CASE("Merge top-n with mixed empty and non-empty local top-n results",
 
 TEST_CASE("Merge top-n with `limit = 0`", "[operator][merge_top_n]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
@@ -1384,7 +1385,7 @@ TEST_CASE("Merge top-n with `limit = 0`", "[operator][merge_top_n]")
 TEST_CASE("Merge top-n with `num_input_rows - limit <= offset < num_input-rows`",
           "[operator][merge_top_n]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;

--- a/test/cpp/operator/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/test_gpu_merge_impl.cpp
@@ -50,15 +50,15 @@ memory_space* get_default_memory_space()
   return const_cast<memory_space*>(manager.get_memory_space(Tier::GPU, 0));
 }
 
-sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_random_data(
+std::vector<std::unique_ptr<data_batch_view>> create_batches_with_random_data(
   const int num_batches,
-  const sirius::vector<int> num_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<std::optional<std::pair<int, int>>>& ranges,
+  const std::vector<int> num_rows,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<std::optional<std::pair<int, int>>>& ranges,
   cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
-  sirius::vector<sirius::unique_ptr<data_batch_view>> batches;
+  std::vector<std::unique_ptr<data_batch_view>> batches;
   for (int i = 0; i < num_batches; ++i) {
     // Create a data batch
     auto table    = create_cudf_table_with_random_data(num_rows[i],
@@ -66,23 +66,23 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_random_d
                                                     ranges,
                                                     cudf::get_default_stream(),
                                                     mem_space.get_default_allocator());
-    auto gpu_repr = sirius::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
-    auto batch    = sirius::make_unique<data_batch>(
+    auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
+    auto batch    = std::make_unique<data_batch>(
       data_repo_manager.get_next_data_batch_id(), data_repo_manager, std::move(gpu_repr));
 
     // Put batch into repository, create a view, and pin it
     auto* batch_ptr = batch.get();
     data_repo_manager.add_new_data_batch(std::move(batch), {});
-    batches.push_back(sirius::make_unique<data_batch_view>(batch_ptr));
+    batches.push_back(std::make_unique<data_batch_view>(batch_ptr));
     batches.back()->pin();
   }
   return batches;
 }
 
-void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
+void validate_concat(const std::vector<std::unique_ptr<data_batch_view>>& input_views,
                      const cucascade::data_batch& output)
 {
-  sirius::vector<cudf::table_view> input_table_views;
+  std::vector<cudf::table_view> input_table_views;
   int expected_num_rows = 0;
   for (const auto& input_view : input_views) {
     input_table_views.push_back(input_view->get_cudf_table_view());
@@ -100,7 +100,7 @@ void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& 
 
     switch (output_table_view.column(c).type().id()) {
       case cudf::type_id::INT32: {
-        sirius::vector<int32_t> actual_data(expected_num_rows), expected_data(expected_num_rows);
+        std::vector<int32_t> actual_data(expected_num_rows), expected_data(expected_num_rows);
         cudaMemcpy(actual_data.data(),
                    output_table_view.column(c).data<int32_t>(),
                    sizeof(int32_t) * expected_num_rows,
@@ -119,23 +119,23 @@ void validate_concat(const sirius::vector<sirius::unique_ptr<data_batch_view>>& 
         break;
       }
       case cudf::type_id::STRING: {
-        sirius::vector<cudf::size_type> actual_offsets(expected_num_rows + 1);
+        std::vector<cudf::size_type> actual_offsets(expected_num_rows + 1);
         cudf::strings_column_view str_col(output_table_view.column(c));
         cudaMemcpy(actual_offsets.data(),
                    str_col.offsets().data<cudf::size_type>(),
                    (expected_num_rows + 1) * sizeof(cudf::size_type),
                    cudaMemcpyDeviceToHost);
-        sirius::vector<char> actual_data(actual_offsets.back());
+        std::vector<char> actual_data(actual_offsets.back());
         cudaMemcpy(actual_data.data(),
                    str_col.chars_begin(cudf::get_default_stream()),
                    actual_offsets.back(),
                    cudaMemcpyDeviceToHost);
 
-        sirius::vector<cudf::size_type> expected_offsets{0};
-        sirius::vector<char> expected_data(actual_data.size());
+        std::vector<cudf::size_type> expected_offsets{0};
+        std::vector<char> expected_data(actual_data.size());
         for (int i = 0; i < input_views.size(); ++i) {
           if (input_table_views[i].num_rows() == 0) { continue; }
-          sirius::vector<cudf::size_type> input_offsets(input_table_views[i].num_rows() + 1);
+          std::vector<cudf::size_type> input_offsets(input_table_views[i].num_rows() + 1);
           str_col = cudf::strings_column_view(input_table_views[i].column(c));
           cudaMemcpy(input_offsets.data(),
                      str_col.offsets().data<cudf::size_type>(),
@@ -172,8 +172,8 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 10;
   constexpr size_t num_rows_per_batch = 100;
-  sirius::vector<int> num_input_rows(num_batches, num_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
@@ -192,11 +192,11 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_input_rows;
+  std::vector<int> num_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_input_rows.push_back((i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
@@ -216,8 +216,8 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 1;
   constexpr size_t num_rows_per_batch = 100;
-  sirius::vector<int> num_input_rows(num_batches, num_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::STRING}};
 
   // Invalid input: less than two input batches
@@ -238,8 +238,8 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
   auto* mem_space                     = get_default_memory_space();
   constexpr int num_batches           = 10;
   constexpr size_t num_rows_per_batch = 0;
-  sirius::vector<int> num_input_rows(num_batches, num_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
@@ -258,11 +258,11 @@ TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merg
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_input_rows;
+  std::vector<int> num_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::STRING}};
 
   auto input_views = create_batches_with_random_data(num_batches,
@@ -278,11 +278,11 @@ TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merg
 
 namespace {
 
-sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_ungrouped_agg_result(
+std::vector<std::unique_ptr<data_batch_view>> create_batches_with_local_ungrouped_agg_result(
   const int num_batches,
-  const sirius::vector<int> num_base_input_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
+  const std::vector<int> num_base_input_rows,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
   cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
@@ -295,8 +295,8 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_un
                                                             mem_space);
 
   // Compute local ungrouped aggregates
-  sirius::vector<sirius::unique_ptr<data_batch_view>> local_aggregate_batches;
-  sirius::vector<int> aggregate_idx(aggregates.size());
+  std::vector<std::unique_ptr<data_batch_view>> local_aggregate_batches;
+  std::vector<int> aggregate_idx(aggregates.size());
   for (int i = 0; i < aggregates.size(); ++i) {
     aggregate_idx[i] = i;
   }
@@ -309,16 +309,16 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_un
                                                                data_repo_manager);
     auto* batch_ptr = batch.get();
     data_repo_manager.add_new_data_batch(std::move(batch), {});
-    local_aggregate_batches.push_back(sirius::make_unique<data_batch_view>(batch_ptr));
+    local_aggregate_batches.push_back(std::make_unique<data_batch_view>(batch_ptr));
     local_aggregate_batches.back()->pin();
   }
   return local_aggregate_batches;
 }
 
 template <typename T>
-void validate_ungrouped_aggregate_numeric(const sirius::vector<cudf::table_view>& input_table_views,
+void validate_ungrouped_aggregate_numeric(const std::vector<cudf::table_view>& input_table_views,
                                           cudf::table_view output_table_view,
-                                          const sirius::vector<cudf::aggregation::Kind>& aggregates,
+                                          const std::vector<cudf::aggregation::Kind>& aggregates,
                                           int c)
 {
   // Handle the case where there is no input
@@ -336,9 +336,9 @@ void validate_ungrouped_aggregate_numeric(const sirius::vector<cudf::table_view>
   T actual_result;
   cudaMemcpy(
     &actual_result, output_table_view.column(c).data<T>(), sizeof(T), cudaMemcpyDeviceToHost);
-  sirius::vector<T> input_data_without_nulls;
+  std::vector<T> input_data_without_nulls;
   for (const auto& input_table_view : input_table_views) {
-    sirius::vector<T> input_data(input_table_view.num_rows());
+    std::vector<T> input_data(input_table_view.num_rows());
     cudaMemcpy(input_data.data(),
                input_table_view.column(c).data<T>(),
                sizeof(T) * input_table_view.num_rows(),
@@ -388,11 +388,11 @@ void validate_ungrouped_aggregate_numeric(const sirius::vector<cudf::table_view>
 }
 
 void validate_ungrouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
+  const std::vector<std::unique_ptr<data_batch_view>>& input_views,
   const cucascade::data_batch& output,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates)
+  const std::vector<cudf::aggregation::Kind>& aggregates)
 {
-  sirius::vector<cudf::table_view> input_table_views;
+  std::vector<cudf::table_view> input_table_views;
   for (const auto& input_view : input_views) {
     input_table_views.push_back(input_view->get_cudf_table_view());
   }
@@ -433,12 +433,12 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
@@ -456,9 +456,9 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32}};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::SUM};
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32}};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::SUM};
 
   // Invalid input: less than two input batches
   auto input_views = create_batches_with_local_ungrouped_agg_result(
@@ -470,7 +470,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
 
   // Invalid input: mismatch between num columns and num aggregations
   num_batches         = 10;
-  num_base_input_rows = sirius::vector<int>(num_batches, num_base_input_rows_per_batch);
+  num_base_input_rows = std::vector<int>(num_batches, num_base_input_rows_per_batch);
   input_views         = create_batches_with_local_ungrouped_agg_result(
     num_batches, num_base_input_rows, column_types, aggregates, data_repo_manager, *mem_space);
   aggregates.push_back(cudf::aggregation::Kind::SUM);
@@ -487,12 +487,12 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
@@ -510,15 +510,15 @@ TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggreg
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_base_input_rows;
+  std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
@@ -532,19 +532,19 @@ TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggreg
 
 namespace {
 
-sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_grouped_agg_result(
+std::vector<std::unique_ptr<data_batch_view>> create_batches_with_local_grouped_agg_result(
   const int num_batches,
-  const sirius::vector<int> num_base_input_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<int>& group_idx,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates,
-  const sirius::vector<int>& aggregate_idx,
+  const std::vector<int> num_base_input_rows,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<int>& group_idx,
+  const std::vector<cudf::aggregation::Kind>& aggregates,
+  const std::vector<int>& aggregate_idx,
   cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches, make group key value ranges small so that we have multiple values in a
   // single group
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
   for (int group_col_id : group_idx) {
     ranges[group_col_id] = {0, 3};
   }
@@ -552,7 +552,7 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_gr
     num_batches, num_base_input_rows, column_types, ranges, data_repo_manager, mem_space);
 
   // Compute local grouped aggregates
-  sirius::vector<sirius::unique_ptr<data_batch_view>> local_aggregate_batches;
+  std::vector<std::unique_ptr<data_batch_view>> local_aggregate_batches;
   for (int i = 0; i < num_batches; ++i) {
     auto batch      = gpu_aggregate_impl::local_grouped_aggregate(*base_input_batches[i],
                                                              group_idx,
@@ -563,20 +563,20 @@ sirius::vector<sirius::unique_ptr<data_batch_view>> create_batches_with_local_gr
                                                              data_repo_manager);
     auto* batch_ptr = batch.get();
     data_repo_manager.add_new_data_batch(std::move(batch), {});
-    local_aggregate_batches.push_back(sirius::make_unique<data_batch_view>(batch_ptr));
+    local_aggregate_batches.push_back(std::make_unique<data_batch_view>(batch_ptr));
     local_aggregate_batches.back()->pin();
   }
 
   return local_aggregate_batches;
 }
 
-void copy_data_to_host(cudf::table_view table, sirius::vector<sirius::vector<int64_t>>& h_data)
+void copy_data_to_host(cudf::table_view table, std::vector<std::vector<int64_t>>& h_data)
 {
   for (int c = 0; c < table.num_columns(); ++c) {
     const auto& col = table.column(c);
     switch (col.type().id()) {
       case cudf::type_id::INT32: {
-        sirius::vector<int32_t> h_buf(table.num_rows());
+        std::vector<int32_t> h_buf(table.num_rows());
         cudaMemcpy(h_buf.data(),
                    col.data<int32_t>(),
                    sizeof(int32_t) * table.num_rows(),
@@ -587,7 +587,7 @@ void copy_data_to_host(cudf::table_view table, sirius::vector<sirius::vector<int
         break;
       }
       case cudf::type_id::INT64: {
-        sirius::vector<int64_t> h_buf(table.num_rows());
+        std::vector<int64_t> h_buf(table.num_rows());
         cudaMemcpy(h_buf.data(),
                    col.data<int64_t>(),
                    sizeof(int64_t) * table.num_rows(),
@@ -605,12 +605,12 @@ void copy_data_to_host(cudf::table_view table, sirius::vector<sirius::vector<int
 }
 
 void validate_grouped_aggregate(
-  const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
+  const std::vector<std::unique_ptr<data_batch_view>>& input_views,
   const cucascade::data_batch& output,
   int num_group_cols,
-  const sirius::vector<cudf::aggregation::Kind>& aggregates)
+  const std::vector<cudf::aggregation::Kind>& aggregates)
 {
-  sirius::vector<cudf::table_view> input_table_views;
+  std::vector<cudf::table_view> input_table_views;
   for (const auto& input_view : input_views) {
     input_table_views.push_back(input_view->get_cudf_table_view());
   }
@@ -618,13 +618,13 @@ void validate_grouped_aggregate(
     output.get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
   // Compute expected results
-  sirius::vector<sirius::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
+  std::vector<std::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
   for (const auto& table : input_table_views) {
     copy_data_to_host(table, h_input_data);
   }
-  sirius::vector<std::map<sirius::vector<int64_t>, int64_t>> expected(aggregates.size());
+  std::vector<std::map<std::vector<int64_t>, int64_t>> expected(aggregates.size());
   for (int r = 0; r < h_input_data[0].size(); ++r) {
-    sirius::vector<int64_t> group_key;
+    std::vector<int64_t> group_key;
     for (int c = 0; c < num_group_cols; ++c) {
       group_key.push_back(h_input_data[c][r]);
     }
@@ -658,14 +658,14 @@ void validate_grouped_aggregate(
   }
 
   // Get actual results
-  sirius::vector<sirius::vector<int64_t>> actual(output_table_view.num_columns());
+  std::vector<std::vector<int64_t>> actual(output_table_view.num_columns());
   copy_data_to_host(output_table_view, actual);
 
   // Check results
   REQUIRE(output_table_view.num_rows() == expected[0].size());
   REQUIRE(output_table_view.num_columns() == num_group_cols + aggregates.size());
   for (int r = 0; r < output_table_view.num_rows(); ++r) {
-    sirius::vector<int64_t> group_key;
+    std::vector<int64_t> group_key;
     for (int c = 0; c < num_group_cols; ++c) {
       group_key.push_back(actual[c][r]);
     }
@@ -685,19 +685,19 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> group_idx                      = {0, 1};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<int> group_idx                      = {0, 1};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
-  sirius::vector<int> aggregate_idx                  = {2, 3, 4, 5};
+  std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
                                                                   num_base_input_rows,
@@ -722,12 +722,12 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> group_idx                      = {0};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN};
-  sirius::vector<int> aggregate_idx                  = {1};
+  std::vector<int> group_idx                      = {0};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN};
+  std::vector<int> aggregate_idx                  = {1};
 
   // Invalid input: less than two input batches
   auto input_views = create_batches_with_local_grouped_agg_result(num_batches,
@@ -748,7 +748,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
 
   // Invalid input: mismatch between num columns, num_groups, and num aggregations
   num_batches         = 10;
-  num_base_input_rows = sirius::vector<int>(num_batches, num_base_input_rows_per_batch);
+  num_base_input_rows = std::vector<int>(num_batches, num_base_input_rows_per_batch);
   input_views         = create_batches_with_local_ungrouped_agg_result(
     num_batches, num_base_input_rows, column_types, aggregates, data_repo_manager, *mem_space);
   group_idx.push_back(1);
@@ -768,19 +768,19 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> group_idx                      = {0, 1};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<int> group_idx                      = {0, 1};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
-  sirius::vector<int> aggregate_idx                  = {2, 3, 4, 5};
+  std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
                                                                   num_base_input_rows,
@@ -805,22 +805,22 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_base_input_rows;
+  std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> group_idx                      = {0, 1};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<int> group_idx                      = {0, 1};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
-  sirius::vector<int> aggregate_idx                  = {2, 3, 4, 5};
+  std::vector<int> aggregate_idx                  = {2, 3, 4, 5};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
                                                                   num_base_input_rows,
@@ -846,17 +846,17 @@ TEST_CASE("Grouped merge aggregate with multiple aggregations on the same column
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types       = {cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64},
                                                         cudf::data_type{cudf::type_id::INT32},
                                                         cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> group_idx                      = {0, 1};
-  sirius::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
+  std::vector<int> group_idx                      = {0, 1};
+  std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::MIN,
                                                         cudf::aggregation::Kind::MAX,
                                                         cudf::aggregation::Kind::COUNT_ALL,
                                                         cudf::aggregation::Kind::SUM};
-  sirius::vector<int> aggregate_idx                  = {2, 3, 2, 3};
+  std::vector<int> aggregate_idx                  = {2, 3, 2, 3};
 
   auto input_views  = create_batches_with_local_grouped_agg_result(num_batches,
                                                                   num_base_input_rows,
@@ -877,21 +877,21 @@ TEST_CASE("Grouped merge aggregate with multiple aggregations on the same column
 
 namespace {
 
-sirius::vector<sirius::unique_ptr<data_batch_view>>
+std::vector<std::unique_ptr<data_batch_view>>
 create_batches_with_local_orderby_or_topn_result(
   const int num_batches,
-  const sirius::vector<int> num_base_input_rows,
+  const std::vector<int> num_base_input_rows,
   const std::optional<std::pair<int, int>>& limit_offset,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<int>& order_key_idx,
-  const sirius::vector<cudf::order>& column_order,
-  const sirius::vector<cudf::null_order>& null_precedence,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<int>& order_key_idx,
+  const std::vector<cudf::order>& column_order,
+  const std::vector<cudf::null_order>& null_precedence,
   cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches, make order key value ranges small so that some rows are compared by
   // multiple columns
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
   for (int idx : order_key_idx) {
     ranges[idx] = {0, 4};
   }
@@ -899,8 +899,8 @@ create_batches_with_local_orderby_or_topn_result(
     num_batches, num_base_input_rows, column_types, ranges, data_repo_manager, mem_space);
 
   // Compute local order_by
-  sirius::vector<sirius::unique_ptr<data_batch_view>> local_order_by_batches;
-  sirius::vector<int> projections(column_types.size());
+  std::vector<std::unique_ptr<data_batch_view>> local_order_by_batches;
+  std::vector<int> projections(column_types.size());
   for (int i = 0; i < column_types.size(); ++i) {
     projections[i] = i;
   }
@@ -926,18 +926,18 @@ create_batches_with_local_orderby_or_topn_result(
                                                     data_repo_manager);
     auto* batch_ptr = batch.get();
     data_repo_manager.add_new_data_batch(std::move(batch), {});
-    local_order_by_batches.push_back(sirius::make_unique<data_batch_view>(batch_ptr));
+    local_order_by_batches.push_back(std::make_unique<data_batch_view>(batch_ptr));
     local_order_by_batches.back()->pin();
   }
   return local_order_by_batches;
 }
 
-void validate_order_by(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
+void validate_order_by(const std::vector<std::unique_ptr<data_batch_view>>& input_views,
                        const cucascade::data_batch& output,
-                       const sirius::vector<int>& order_key_idx,
-                       const sirius::vector<cudf::order>& column_order)
+                       const std::vector<int>& order_key_idx,
+                       const std::vector<cudf::order>& column_order)
 {
-  sirius::vector<cudf::table_view> input_table_views;
+  std::vector<cudf::table_view> input_table_views;
   int expected_num_rows = 0;
   for (const auto& input_view : input_views) {
     input_table_views.push_back(input_view->get_cudf_table_view());
@@ -952,7 +952,7 @@ void validate_order_by(const sirius::vector<sirius::unique_ptr<data_batch_view>>
     REQUIRE(output_table_view.column(c).type().id() == input_table_views[0].column(c).type().id());
   }
 
-  sirius::vector<sirius::vector<int64_t>> actual(output_table_view.num_columns());
+  std::vector<std::vector<int64_t>> actual(output_table_view.num_columns());
   copy_data_to_host(output_table_view, actual);
   auto comp = [&](int r) {
     for (int i = 0; i < order_key_idx.size(); ++i) {
@@ -976,15 +976,15 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1012,15 +1012,15 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   auto* mem_space                                = get_default_memory_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   // Invalid input: less than two input batches
@@ -1044,7 +1044,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
 
   // Invalid input: mismatch between sizes of `order_key_idx`, `column_order`, and `null_precedence`
   num_batches         = 10;
-  num_base_input_rows = sirius::vector<int>(num_batches, num_base_input_rows_per_batch);
+  num_base_input_rows = std::vector<int>(num_batches, num_base_input_rows_per_batch);
   input_views         = create_batches_with_local_orderby_or_topn_result(num_batches,
                                                                  num_base_input_rows,
                                                                  std::nullopt,
@@ -1071,15 +1071,15 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1107,18 +1107,18 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_base_input_rows;
+  std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1142,13 +1142,13 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
 
 namespace {
 
-void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& input_views,
+void validate_top_n(const std::vector<std::unique_ptr<data_batch_view>>& input_views,
                     const cucascade::data_batch& output,
                     const std::pair<int, int>& limit_offset,
-                    const sirius::vector<int>& order_key_idx,
-                    const sirius::vector<cudf::order>& column_order)
+                    const std::vector<int>& order_key_idx,
+                    const std::vector<cudf::order>& column_order)
 {
-  sirius::vector<cudf::table_view> input_table_views;
+  std::vector<cudf::table_view> input_table_views;
   int num_input_rows = 0;
   for (const auto& input_view : input_views) {
     input_table_views.push_back(input_view->get_cudf_table_view());
@@ -1161,12 +1161,12 @@ void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& i
     (limit + offset <= num_input_rows) ? limit : std::max(0, num_input_rows - offset);
 
   // Compute sorted input
-  sirius::vector<sirius::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
+  std::vector<std::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
   for (const auto& table : input_table_views) {
     copy_data_to_host(table, h_input_data);
   }
-  sirius::vector<sirius::vector<int64_t>> h_input_data_rows(
-    h_input_data[0].size(), sirius::vector<int64_t>(h_input_data.size()));
+  std::vector<std::vector<int64_t>> h_input_data_rows(
+    h_input_data[0].size(), std::vector<int64_t>(h_input_data.size()));
   for (int r = 0; r < h_input_data_rows.size(); ++r) {
     for (int c = 0; c < h_input_data_rows[0].size(); ++c) {
       h_input_data_rows[r][c] = h_input_data[c][r];
@@ -1174,7 +1174,7 @@ void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& i
   }
   sort(h_input_data_rows.begin(),
        h_input_data_rows.end(),
-       [&](const sirius::vector<int64_t>& r1, const sirius::vector<int64_t>& r2) {
+       [&](const std::vector<int64_t>& r1, const std::vector<int64_t>& r2) {
          for (int i = 0; i < order_key_idx.size(); ++i) {
            int col = order_key_idx[i];
            if (r1[col] == r2[col]) { continue; }
@@ -1191,7 +1191,7 @@ void validate_top_n(const sirius::vector<sirius::unique_ptr<data_batch_view>>& i
     REQUIRE(output_table_view.column(c).type().id() == input_table_views[0].column(c).type().id());
   }
 
-  sirius::vector<sirius::vector<int64_t>> actual(output_table_view.num_columns());
+  std::vector<std::vector<int64_t>> actual(output_table_view.num_columns());
   copy_data_to_host(output_table_view, actual);
   auto comp_lower = [&](int r) {
     if (offset == 0) { return true; }
@@ -1229,16 +1229,16 @@ TEST_CASE("Merge top-n basic", "[operator][merge_top_n]")
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
   std::pair<int, int> limit_offset             = {10, 20};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1268,16 +1268,16 @@ TEST_CASE("Merge top-n with empty local top-n results", "[operator][merge_top_n]
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
   std::pair<int, int> limit_offset             = {10, 20};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1307,19 +1307,19 @@ TEST_CASE("Merge top-n with mixed empty and non-empty local top-n results",
   cucascade::data_repository_manager data_repo_manager;
   auto* mem_space           = get_default_memory_space();
   constexpr int num_batches = 10;
-  sirius::vector<int> num_base_input_rows;
+  std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
     num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
   }
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
   std::pair<int, int> limit_offset             = {10, 20};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1349,16 +1349,16 @@ TEST_CASE("Merge top-n with `limit = 0`", "[operator][merge_top_n]")
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
   std::pair<int, int> limit_offset             = {0, 20};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,
@@ -1389,16 +1389,16 @@ TEST_CASE("Merge top-n with `num_input_rows - limit <= offset < num_input-rows`"
   auto* mem_space                                = get_default_memory_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
-  sirius::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
   std::pair<int, int> limit_offset             = {200, 900};
-  sirius::vector<int> order_key_idx            = {0, 1, 2};
-  sirius::vector<cudf::order> column_order     = {
+  std::vector<int> order_key_idx            = {0, 1, 2};
+  std::vector<cudf::order> column_order     = {
     cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  sirius::vector<cudf::null_order> null_precedence = {
+  std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   auto input_views  = create_batches_with_local_orderby_or_topn_result(num_batches,

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -46,10 +46,10 @@ memory_space* get_default_memory_space()
   return const_cast<memory_space*>(manager.get_memory_space(Tier::GPU, 0));
 }
 
-sirius::unique_ptr<data_batch_view> create_batch_with_random_data(
+std::unique_ptr<data_batch_view> create_batch_with_random_data(
   const int num_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  sirius::vector<std::optional<std::pair<int, int>>>& ranges,
+  const std::vector<cudf::data_type>& column_types,
+  std::vector<std::optional<std::pair<int, int>>>& ranges,
   cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
@@ -59,25 +59,25 @@ sirius::unique_ptr<data_batch_view> create_batch_with_random_data(
   }
   auto table = create_cudf_table_with_random_data(
     num_rows, column_types, ranges, cudf::get_default_stream(), mem_space.get_default_allocator());
-  auto gpu_repr = sirius::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
-  auto batch    = sirius::make_unique<data_batch>(
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
+  auto batch    = std::make_unique<data_batch>(
     data_repo_manager.get_next_data_batch_id(), data_repo_manager, std::move(gpu_repr));
   auto* batch_ptr = batch.get();
   data_repo_manager.add_new_data_batch(std::move(batch), {});
-  auto batch_view = sirius::make_unique<data_batch_view>(batch_ptr);
+  auto batch_view = std::make_unique<data_batch_view>(batch_ptr);
   batch_view->pin();
   return batch_view;
 }
 
 void copy_data_to_host_by_rows(cudf::table_view table,
-                               sirius::vector<sirius::vector<int64_t>>& h_rows)
+                               std::vector<std::vector<int64_t>>& h_rows)
 {
-  sirius::vector<sirius::vector<int64_t>> h_cols(table.num_columns());
+  std::vector<std::vector<int64_t>> h_cols(table.num_columns());
   for (int c = 0; c < table.num_columns(); ++c) {
     const auto& col = table.column(c);
     switch (col.type().id()) {
       case cudf::type_id::INT32: {
-        sirius::vector<int32_t> h_buf(table.num_rows());
+        std::vector<int32_t> h_buf(table.num_rows());
         cudaMemcpy(h_buf.data(),
                    col.data<int32_t>(),
                    sizeof(int32_t) * table.num_rows(),
@@ -88,7 +88,7 @@ void copy_data_to_host_by_rows(cudf::table_view table,
         break;
       }
       case cudf::type_id::INT64: {
-        sirius::vector<int64_t> h_buf(table.num_rows());
+        std::vector<int64_t> h_buf(table.num_rows());
         cudaMemcpy(h_buf.data(),
                    col.data<int64_t>(),
                    sizeof(int64_t) * table.num_rows(),
@@ -113,11 +113,11 @@ void copy_data_to_host_by_rows(cudf::table_view table,
 }
 
 void validate_hash_partition(const cucascade::data_batch_view& input_view,
-                             const sirius::vector<sirius::unique_ptr<data_batch>>& output_batches,
+                             const std::vector<std::unique_ptr<data_batch>>& output_batches,
                              int num_partitions)
 {
   cudf::table_view input_table_view = input_view.get_cudf_table_view();
-  sirius::vector<cudf::table_view> output_table_views;
+  std::vector<cudf::table_view> output_table_views;
   for (const auto& output_batch : output_batches) {
     output_table_views.push_back(
       output_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
@@ -136,21 +136,21 @@ void validate_hash_partition(const cucascade::data_batch_view& input_view,
   REQUIRE(actual_num_rows == input_table_view.num_rows());
 
   // Check data
-  sirius::vector<sirius::vector<int64_t>> h_input_rows;
+  std::vector<std::vector<int64_t>> h_input_rows;
   copy_data_to_host_by_rows(input_table_view, h_input_rows);
-  sirius::vector<sirius::vector<sirius::vector<int64_t>>> h_output_rows(num_partitions);
+  std::vector<std::vector<std::vector<int64_t>>> h_output_rows(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {
     copy_data_to_host_by_rows(output_table_views[i], h_output_rows[i]);
   }
 
-  std::multiset<sirius::vector<int64_t>> output_set;
+  std::multiset<std::vector<int64_t>> output_set;
   for (const auto& partition : h_output_rows) {
     for (const auto& row : partition) {
       REQUIRE(!output_set.contains(row));
     }
     output_set.insert(partition.begin(), partition.end());
   }
-  std::multiset<sirius::vector<int64_t>> input_set(h_input_rows.begin(), h_input_rows.end());
+  std::multiset<std::vector<int64_t>> input_set(h_input_rows.begin(), h_input_rows.end());
   REQUIRE(input_set == output_set);
 }
 
@@ -162,12 +162,12 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> partition_key_idx        = {0, 1};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<int> partition_key_idx        = {0, 1};
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -186,12 +186,12 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 1;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> partition_key_idx        = {0, 1};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<int> partition_key_idx        = {0, 1};
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -210,12 +210,12 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 0;
   constexpr size_t num_partitions              = 4;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> partition_key_idx        = {0, 1};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<int> partition_key_idx        = {0, 1};
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -234,12 +234,12 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> partition_key_idx        = {0, 1};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges = {
+  std::vector<int> partition_key_idx        = {0, 1};
+  std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>({0, 0}),
     std::optional<std::pair<int, int>>({1, 1}),
     std::nullopt,
@@ -262,12 +262,12 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 10;
   constexpr size_t num_partitions              = 20;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<int> partition_key_idx        = {0, 1};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<int> partition_key_idx        = {0, 1};
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -283,11 +283,11 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
 namespace {
 
 void validate_evenly_partition(const cucascade::data_batch_view& input_view,
-                               const sirius::vector<sirius::unique_ptr<data_batch>>& output_batches,
+                               const std::vector<std::unique_ptr<data_batch>>& output_batches,
                                int num_partitions)
 {
   cudf::table_view input_table_view = input_view.get_cudf_table_view();
-  sirius::vector<cudf::table_view> output_table_views;
+  std::vector<cudf::table_view> output_table_views;
   for (const auto& output_batch : output_batches) {
     output_table_views.push_back(
       output_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
@@ -296,7 +296,7 @@ void validate_evenly_partition(const cucascade::data_batch_view& input_view,
   // Check metadata
   REQUIRE(output_batches.size() == num_partitions);
   int actual_num_rows = 0;
-  sirius::unordered_map<int, int> partition_num_rows_cnt;
+  std::unordered_map<int, int> partition_num_rows_cnt;
   for (const auto& output_table : output_table_views) {
     ++partition_num_rows_cnt[output_table.num_rows()];
     actual_num_rows += output_table.num_rows();
@@ -312,18 +312,18 @@ void validate_evenly_partition(const cucascade::data_batch_view& input_view,
           num_partitions - input_table_view.num_rows() % num_partitions);
 
   // Check data
-  sirius::vector<sirius::vector<int64_t>> h_input_rows;
+  std::vector<std::vector<int64_t>> h_input_rows;
   copy_data_to_host_by_rows(input_table_view, h_input_rows);
-  sirius::vector<sirius::vector<sirius::vector<int64_t>>> h_output_rows(num_partitions);
+  std::vector<std::vector<std::vector<int64_t>>> h_output_rows(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {
     copy_data_to_host_by_rows(output_table_views[i], h_output_rows[i]);
   }
 
-  std::multiset<sirius::vector<int64_t>> output_set;
+  std::multiset<std::vector<int64_t>> output_set;
   for (const auto& partition : h_output_rows) {
     output_set.insert(partition.begin(), partition.end());
   }
-  std::multiset<sirius::vector<int64_t>> input_set(h_input_rows.begin(), h_input_rows.end());
+  std::multiset<std::vector<int64_t>> input_set(h_input_rows.begin(), h_input_rows.end());
   REQUIRE(input_set == output_set);
 }
 
@@ -335,11 +335,11 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -354,11 +354,11 @@ TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partitio
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 0;
   constexpr size_t num_partitions              = 4;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);
@@ -374,11 +374,11 @@ TEST_CASE("Evenly partition basic with num partitions larger than input size",
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 10;
   constexpr size_t num_partitions              = 20;
-  sirius::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
+  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64},
                                                   cudf::data_type{cudf::type_id::INT32},
                                                   cudf::data_type{cudf::type_id::INT64}};
-  sirius::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
+  std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
     num_input_rows, column_types, ranges, data_repo_manager, *mem_space);

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -23,7 +23,8 @@
 #include "utils/utils.hpp"
 
 using namespace sirius;
-using namespace sirius::memory;
+using namespace cucascade;
+using namespace cucascade::memory;
 using namespace sirius::op;
 
 namespace {
@@ -49,7 +50,7 @@ sirius::unique_ptr<data_batch_view> create_batch_with_random_data(
   const int num_rows,
   const sirius::vector<cudf::data_type>& column_types,
   sirius::vector<std::optional<std::pair<int, int>>>& ranges,
-  data_repository_manager& data_repo_manager,
+  cucascade::data_repository_manager& data_repo_manager,
   memory_space& mem_space)
 {
   // Base input batches, make value ranges small so that we have duplicated partition keys
@@ -58,7 +59,7 @@ sirius::unique_ptr<data_batch_view> create_batch_with_random_data(
   }
   auto table = create_cudf_table_with_random_data(
     num_rows, column_types, ranges, cudf::get_default_stream(), mem_space.get_default_allocator());
-  auto gpu_repr = sirius::make_unique<gpu_table_representation>(*table, mem_space);
+  auto gpu_repr = sirius::make_unique<cucascade::gpu_table_representation>(*table, mem_space);
   auto batch    = sirius::make_unique<data_batch>(
     data_repo_manager.get_next_data_batch_id(), data_repo_manager, std::move(gpu_repr));
   auto* batch_ptr = batch.get();
@@ -111,7 +112,7 @@ void copy_data_to_host_by_rows(cudf::table_view table,
   }
 }
 
-void validate_hash_partition(const sirius::data_batch_view& input_view,
+void validate_hash_partition(const cucascade::data_batch_view& input_view,
                              const sirius::vector<sirius::unique_ptr<data_batch>>& output_batches,
                              int num_partitions)
 {
@@ -119,7 +120,7 @@ void validate_hash_partition(const sirius::data_batch_view& input_view,
   sirius::vector<cudf::table_view> output_table_views;
   for (const auto& output_batch : output_batches) {
     output_table_views.push_back(
-      output_batch->get_data()->cast<gpu_table_representation>().get_table().view());
+      output_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
   }
 
   // Check metadata
@@ -157,7 +158,7 @@ void validate_hash_partition(const sirius::data_batch_view& input_view,
 
 TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
@@ -181,7 +182,7 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 1;
@@ -205,7 +206,7 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 0;
   constexpr size_t num_partitions              = 4;
@@ -229,7 +230,7 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
@@ -257,7 +258,7 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
 
 TEST_CASE("Hash partition with num partitions larger than input size", "[operator][hash_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 10;
   constexpr size_t num_partitions              = 20;
@@ -281,7 +282,7 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
 
 namespace {
 
-void validate_evenly_partition(const sirius::data_batch_view& input_view,
+void validate_evenly_partition(const cucascade::data_batch_view& input_view,
                                const sirius::vector<sirius::unique_ptr<data_batch>>& output_batches,
                                int num_partitions)
 {
@@ -289,7 +290,7 @@ void validate_evenly_partition(const sirius::data_batch_view& input_view,
   sirius::vector<cudf::table_view> output_table_views;
   for (const auto& output_batch : output_batches) {
     output_table_views.push_back(
-      output_batch->get_data()->cast<gpu_table_representation>().get_table().view());
+      output_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
   }
 
   // Check metadata
@@ -330,7 +331,7 @@ void validate_evenly_partition(const sirius::data_batch_view& input_view,
 
 TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 100;
   constexpr size_t num_partitions              = 4;
@@ -349,7 +350,7 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 
 TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 0;
   constexpr size_t num_partitions              = 4;
@@ -369,7 +370,7 @@ TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partitio
 TEST_CASE("Evenly partition basic with num partitions larger than input size",
           "[operator][evenly_partition]")
 {
-  data_repository_manager data_repo_manager;
+  cucascade::data_repository_manager data_repo_manager;
   auto* mem_space                              = get_default_memory_space();
   constexpr size_t num_input_rows              = 10;
   constexpr size_t num_partitions              = 20;

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -69,8 +69,7 @@ std::unique_ptr<data_batch_view> create_batch_with_random_data(
   return batch_view;
 }
 
-void copy_data_to_host_by_rows(cudf::table_view table,
-                               std::vector<std::vector<int64_t>>& h_rows)
+void copy_data_to_host_by_rows(cudf::table_view table, std::vector<std::vector<int64_t>>& h_rows)
 {
   std::vector<std::vector<int64_t>> h_cols(table.num_columns());
   for (int c = 0; c < table.num_columns(); ++c) {
@@ -159,13 +158,13 @@ void validate_hash_partition(const cucascade::data_batch_view& input_view,
 TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 100;
-  constexpr size_t num_partitions              = 4;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 100;
+  constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> partition_key_idx        = {0, 1};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
@@ -183,13 +182,13 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 100;
-  constexpr size_t num_partitions              = 1;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 100;
+  constexpr size_t num_partitions           = 1;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> partition_key_idx        = {0, 1};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
@@ -207,13 +206,13 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 0;
-  constexpr size_t num_partitions              = 4;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 0;
+  constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> partition_key_idx        = {0, 1};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
@@ -231,14 +230,14 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 100;
-  constexpr size_t num_partitions              = 4;
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
-  std::vector<int> partition_key_idx        = {0, 1};
+  auto* mem_space                                        = get_default_memory_space();
+  constexpr size_t num_input_rows                        = 100;
+  constexpr size_t num_partitions                        = 4;
+  std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32},
+                                                            cudf::data_type{cudf::type_id::INT64},
+                                                            cudf::data_type{cudf::type_id::INT32},
+                                                            cudf::data_type{cudf::type_id::INT64}};
+  std::vector<int> partition_key_idx                     = {0, 1};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>({0, 0}),
     std::optional<std::pair<int, int>>({1, 1}),
@@ -259,13 +258,13 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
 TEST_CASE("Hash partition with num partitions larger than input size", "[operator][hash_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 10;
-  constexpr size_t num_partitions              = 20;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 10;
+  constexpr size_t num_partitions           = 20;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<int> partition_key_idx        = {0, 1};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
@@ -332,13 +331,13 @@ void validate_evenly_partition(const cucascade::data_batch_view& input_view,
 TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 100;
-  constexpr size_t num_partitions              = 4;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 100;
+  constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
@@ -351,13 +350,13 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 0;
-  constexpr size_t num_partitions              = 4;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 0;
+  constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(
@@ -371,13 +370,13 @@ TEST_CASE("Evenly partition basic with num partitions larger than input size",
           "[operator][evenly_partition]")
 {
   cucascade::data_repository_manager data_repo_manager;
-  auto* mem_space                              = get_default_memory_space();
-  constexpr size_t num_input_rows              = 10;
-  constexpr size_t num_partitions              = 20;
+  auto* mem_space                           = get_default_memory_space();
+  constexpr size_t num_input_rows           = 10;
+  constexpr size_t num_partitions           = 20;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64},
-                                                  cudf::data_type{cudf::type_id::INT32},
-                                                  cudf::data_type{cudf::type_id::INT64}};
+                                               cudf::data_type{cudf::type_id::INT64},
+                                               cudf::data_type{cudf::type_id::INT32},
+                                               cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges(column_types.size(), std::nullopt);
 
   auto input_view = create_batch_with_random_data(

--- a/test/cpp/utils/utils.cpp
+++ b/test/cpp/utils/utils.cpp
@@ -347,7 +347,7 @@ std::mt19937_64& global_rng()
 }
 
 template <typename T>
-sirius::unique_ptr<cudf::column> create_numeric_column_with_random_data(
+std::unique_ptr<cudf::column> create_numeric_column_with_random_data(
   size_t num_rows,
   const cudf::data_type& dtype,
   const std::optional<std::pair<int, int>>& range,
@@ -360,7 +360,7 @@ sirius::unique_ptr<cudf::column> create_numeric_column_with_random_data(
 
   auto dist = range.has_value() ? std::uniform_int_distribution<T>(range->first, range->second)
                                 : std::uniform_int_distribution<T>(0, 1000);
-  sirius::vector<T> h_data(num_rows);
+  std::vector<T> h_data(num_rows);
   for (size_t r = 0; r < num_rows; ++r)
     h_data[r] = dist(gen);
 
@@ -368,15 +368,15 @@ sirius::unique_ptr<cudf::column> create_numeric_column_with_random_data(
   return col;
 }
 
-sirius::unique_ptr<cudf::table> create_cudf_table_with_random_data(
+std::unique_ptr<cudf::table> create_cudf_table_with_random_data(
   size_t num_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<std::optional<std::pair<int, int>>>& ranges,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<std::optional<std::pair<int, int>>>& ranges,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   auto& gen = global_rng();
-  sirius::vector<sirius::unique_ptr<cudf::column>> cols;
+  std::vector<std::unique_ptr<cudf::column>> cols;
   cols.reserve(column_types.size());
 
   for (int c = 0; c < column_types.size(); ++c) {
@@ -396,8 +396,8 @@ sirius::unique_ptr<cudf::table> create_cudf_table_with_random_data(
         auto dist = ranges[c].has_value()
                       ? std::uniform_int_distribution<int>(ranges[c]->first, ranges[c]->second)
                       : std::uniform_int_distribution<int>(0, 1000);
-        sirius::vector<char> h_chars;
-        sirius::vector<cudf::size_type> h_offsets(num_rows + 1, 0);
+        std::vector<char> h_chars;
+        std::vector<cudf::size_type> h_offsets(num_rows + 1, 0);
         for (size_t r = 0; r < num_rows; ++r) {
           string h_str = "str_" + std::to_string(dist(gen));
           h_chars.insert(h_chars.end(), h_str.begin(), h_str.end());
@@ -426,7 +426,7 @@ sirius::unique_ptr<cudf::table> create_cudf_table_with_random_data(
     }
   }
 
-  return sirius::make_unique<cudf::table>(std::move(cols));
+  return std::make_unique<cudf::table>(std::move(cols));
 }
 
 }  // namespace sirius

--- a/test/cpp/utils/utils.hpp
+++ b/test/cpp/utils/utils.hpp
@@ -19,9 +19,11 @@
 #include "catch.hpp"
 #include "gpu_buffer_manager.hpp"
 #include "gpu_columns.hpp"
-#include "helper/helper.hpp"
 
+#include <memory>
+#include <optional>
 #include <random>
+#include <vector>
 
 namespace duckdb {
 
@@ -71,10 +73,10 @@ namespace sirius {
 
 std::mt19937_64& global_rng();
 
-sirius::unique_ptr<cudf::table> create_cudf_table_with_random_data(
+std::unique_ptr<cudf::table> create_cudf_table_with_random_data(
   size_t num_rows,
-  const sirius::vector<cudf::data_type>& column_types,
-  const sirius::vector<std::optional<std::pair<int, int>>>& ranges,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<std::optional<std::pair<int, int>>>& ranges,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 


### PR DESCRIPTION
Moving some of the code over to the cucascade namespace in preparation for moving it out. 

Goals are to remove some of the wrappers around things from the std library to increase portability, separate out things into their own namespace and try and clear up some of the warnings.