### PR TITLE
Add NVIDIA CUDA-X libraries mention to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
   <img src="sirius-full.png" alt="Diagram" width="500"/>
 </p>
 
-Sirius is a GPU-native SQL engine. It plugs into existing databases such as DuckDB via the standard Substrait query format, requiring no query rewrites or major system changes. Sirius currently supports DuckDB and Doris (coming soon), other systems marked with * are on our roadmap.
+Sirius is a GPU-native SQL engine. It plugs into existing databases such as DuckDB via the standard Substrait query format, requiring no query rewrites or major system changes. Sirius currently supports DuckDB and Doris (coming soon), other systems marked with * are on our roadmap. Built on NVIDIA CUDA-X libraries including cuDF and RAPIDS Memory Manager (RMM), Sirius delivers high-performance GPU-accelerated analytics.
 
 <!-- ![Architecture](sirius-architecture.png) -->
 <p align="center">


### PR DESCRIPTION
This PR updates the README introduction to highlight that Sirius is built on NVIDIA CUDA-X libraries, including cuDF and RAPIDS Memory Manager (RMM), which deliver high-performance GPU-accelerated analytics.