### PR TITLE
Namespace change and adjustment to pipeline and scan executor

### DIFF
--- a/src/include/operator/gpu_physical_table_scan.hpp
+++ b/src/include/operator/gpu_physical_table_scan.hpp
@@ -156,6 +156,7 @@ class GPUPhysicalTableScan : public GPUPhysicalOperator {
   vector<ColumnIndex> orig_column_ids;
   vector<idx_t> orig_scanned_ids;
   vector<LogicalType> orig_scanned_types;
+  bool exhausted = false;
 
  public:
   SourceResultType GetData(GPUIntermediateRelation& output_relation) const override;

--- a/src/include/operator/scan/duckdb_scan_executor.hpp
+++ b/src/include/operator/scan/duckdb_scan_executor.hpp
@@ -20,7 +20,7 @@
 #include <parallel/task_executor.hpp>
 #include <scan/duckdb_scan_task_queue.hpp>
 
-namespace sirius::parallel {
+namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
 // DuckDB Scan Executor
@@ -33,11 +33,12 @@ namespace sirius::parallel {
  * duckdb_scan_task_queue.
  *
  */
-class duckdb_scan_executor : public itask_executor {
+class duckdb_scan_executor : public sirius::parallel::itask_executor {
  public:
   //===----------Constructor----------===//
-  explicit duckdb_scan_executor(task_executor_config config)
-    : itask_executor(std::make_unique<duckdb_scan_task_queue>(config.num_threads), config)
+  explicit duckdb_scan_executor(sirius::parallel::task_executor_config config)
+    : sirius::parallel::itask_executor(std::make_unique<duckdb_scan_task_queue>(config.num_threads),
+                                       config)
   {
   }
 
@@ -47,7 +48,7 @@ class duckdb_scan_executor : public itask_executor {
    *
    * @param task The task to be scheduled.
    */
-  void schedule(std::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<sirius::parallel::itask> task) override;
 
   /**
    * @brief Wait for all scheduled tasks to complete.
@@ -76,4 +77,4 @@ class duckdb_scan_executor : public itask_executor {
   std::condition_variable _finish_cv;         ///< Condition variable to signal task completion
 };
 
-}  // namespace sirius::parallel
+}  // namespace sirius::op::scan

--- a/src/include/operator/scan/duckdb_scan_task.hpp
+++ b/src/include/operator/scan/duckdb_scan_task.hpp
@@ -18,14 +18,13 @@
 
 // sirius
 #include <config.hpp>
-#include <data/data_repository_manager.hpp>
+#include <data/data_repository.hpp>
 #include <memory/fixed_size_host_memory_resource.hpp>
 #include <memory/memory_reservation.hpp>
 #include <memory/memory_reservation_manager.hpp>
 #include <operator/gpu_physical_table_scan.hpp>
 #include <parallel/task.hpp>
 #include <scan/duckdb_scan_executor.hpp>
-#include <scan/physical_table_scan_adapter.hpp>
 
 // duckdb
 #include <duckdb/common/types.hpp>
@@ -40,7 +39,7 @@
 #include <cstdint>
 #include <stdexcept>
 
-namespace sirius::parallel {
+namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
 // DuckDB Scan Task Global State
@@ -49,21 +48,22 @@ namespace sirius::parallel {
 /**
  * @brief The global state for a duckdb_scan_task.
  */
-class duckdb_scan_task_global_state : public itask_global_state, public duckdb::GlobalSourceState {
+class duckdb_scan_task_global_state : public sirius::parallel::itask_global_state,
+                                      public duckdb::GlobalSourceState {
  public:
   //===----------Constructor----------===//
   /**
    * @brief Construct a new duckdb_scan_task_global_state object
    *
-   * @param[in] pipeline_id The pipeline id to which this scan task belongs
+   * @param[in] pipeline The GPU pipeline to which this table scan belongs
    * @param[in] scan_exec The scan executor with which to schedule new scan tasks
    * @param[in] client_ctx The DuckDB client context
-   * @param[in] ptsa The physical table scan adapter being executed
+   * @param[in] gpu_pts The GPU physical table scan being executed
    */
-  duckdb_scan_task_global_state(uint64_t pipeline_id,
+  duckdb_scan_task_global_state(duckdb::shared_ptr<duckdb::GPUPipeline> pipeline,
                                 duckdb_scan_executor& scan_exec,
                                 duckdb::ClientContext& client_ctx,
-                                duckdb::physical_table_scan_adapter const& ptsa);
+                                duckdb::GPUPhysicalTableScan* scan_op);
 
   //===----------Methods----------===//
   /**
@@ -88,13 +88,14 @@ class duckdb_scan_task_global_state : public itask_global_state, public duckdb::
 
   //===----------Fields----------===//
   std::atomic<bool> source_drained{false};  ///< Whether the table scan source is fully drained
-  uint64_t pipeline_id;                     ///< The pipeline id to which this table scan belongs
-  uint64_t max_threads;                     ///< Maximum number of threads for this scan task
+  duckdb::shared_ptr<duckdb::GPUPipeline>
+    pipeline;            ///< The pipeline to which this table scan belongs
+  uint64_t max_threads;  ///< Maximum number of threads for this scan task
 
   unique_ptr<duckdb::GlobalTableFunctionState>
     global_tf_state;                    ///< Global state for the table function
   duckdb_scan_executor& scan_executor;  ///< The scan executor executing this scan task
-  const duckdb::PhysicalTableScan& op;  ///< The physical table scan being executed
+  duckdb::GPUPhysicalTableScan& op;     ///< The physical table scan being executed
 
   std::mutex scan_mutex;  ///< Mutex to protect table function calls
 };
@@ -305,7 +306,7 @@ struct multiple_blocks_allocation_accessor {
  * chunks into those buffers.
  *
  */
-class duckdb_scan_task_local_state : public itask_local_state {
+class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state {
  public:
   using multiple_blocks_allocation =
     cucascade::memory::fixed_size_host_memory_resource::multiple_blocks_allocation;
@@ -460,7 +461,7 @@ class duckdb_scan_task_local_state : public itask_local_state {
    *
    * @param[in] op The physical table scan operator being executed.
    */
-  void estimate_rows_per_batch(const duckdb::PhysicalTableScan& op);
+  void estimate_rows_per_batch(duckdb::GPUPhysicalTableScan const& op);
 
   /**
    * @brief Initializes the column builders.
@@ -474,7 +475,7 @@ class duckdb_scan_task_local_state : public itask_local_state {
    * @param[in] exec_ctx The duckdb execution context.
    * @param[in] global_tf_state The duckdb table function global state.
    */
-  void initialize_local_table_function_state(duckdb::PhysicalTableScan const& op,
+  void initialize_local_table_function_state(duckdb::GPUPhysicalTableScan const& op,
                                              duckdb::ExecutionContext& exec_ctx,
                                              duckdb::GlobalTableFunctionState* global_tf_state);
 };
@@ -491,8 +492,8 @@ class duckdb_scan_task_local_state : public itask_local_state {
  * the batch to the data repository and notifying the task creator. If the table scan is
  * incomplete upon task completion, the task will push a new scan_task onto the task queue.
  */
-class duckdb_scan_task : public itask {
-  using data_repository_manager = cucascade::shared_data_repository_manager;
+class duckdb_scan_task : public sirius::parallel::itask {
+  using shared_data_repository = cucascade::shared_data_repository;
   // Friend declaration for test access
   friend class test_scan_task;
 
@@ -502,15 +503,17 @@ class duckdb_scan_task : public itask {
    * @brief Construct a duckdb_scan_task object.
    *
    * @param[in] task_id The unique id of this scan task.
-   * @param[in] dr_mgr The data repository manager to which to push batches.
+   * @param[in] data_repo The data repository to which to push batches.
    * @param[in] l_state The local state for this scan task.
    * @param[in] g_state The shared global state for this scan task.
    */
   duckdb_scan_task(uint64_t task_id,
-                   data_repository_manager& dr_mgr,
+                   shared_data_repository* data_repo,
                    unique_ptr<duckdb_scan_task_local_state> l_state,
                    shared_ptr<duckdb_scan_task_global_state> g_state)
-    : task_id(task_id), dr_mgr(dr_mgr), itask(std::move(l_state), g_state) {};
+    : task_id(task_id),
+      _data_repo(data_repo),
+      sirius::parallel::itask(std::move(l_state), g_state) {};
 
   void execute() override;
 
@@ -564,8 +567,8 @@ class duckdb_scan_task : public itask {
 
  protected:
   //===----------Fields----------===//
-  data_repository_manager& dr_mgr;  ///< Data repository manager to which to push batches
-  uint64_t task_id;                 ///< The unique id of this scan task
+  shared_data_repository* _data_repo;  ///< Data repository to which to push batches
+  uint64_t task_id;                    ///< The unique id of this scan task
 };
 
-}  // namespace sirius::parallel
+}  // namespace sirius::op::scan

--- a/src/include/operator/scan/duckdb_scan_task_queue.hpp
+++ b/src/include/operator/scan/duckdb_scan_task_queue.hpp
@@ -26,7 +26,7 @@
 // standard library
 #include <atomic>
 
-namespace sirius::parallel {
+namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
 // DuckDB Scan Task Queue
@@ -40,7 +40,7 @@ namespace sirius::parallel {
  * default configuration for the underlying BlockingConcurrentQueue.
  *
  */
-class duckdb_scan_task_queue : public itask_queue {
+class duckdb_scan_task_queue : public sirius::parallel::itask_queue {
  public:
   //===----------Constructor & Destructor----------===//
   explicit duckdb_scan_task_queue(size_t num_threads) : _num_threads(num_threads), _queue() {}
@@ -58,11 +58,14 @@ class duckdb_scan_task_queue : public itask_queue {
     }
   }
 
-  void push(std::unique_ptr<itask> task) override { _queue.enqueue(std::move(task)); }
-
-  std::unique_ptr<itask> pull() override
+  void push(std::unique_ptr<sirius::parallel::itask> task) override
   {
-    std::unique_ptr<itask> task;
+    _queue.enqueue(std::move(task));
+  }
+
+  std::unique_ptr<sirius::parallel::itask> pull() override
+  {
+    std::unique_ptr<sirius::parallel::itask> task;
     while (true) {
       if (_queue.try_dequeue(task)) { return task; }
 
@@ -79,8 +82,8 @@ class duckdb_scan_task_queue : public itask_queue {
   //===----------Fields----------===//
   size_t _num_threads;                ///< Number of worker threads (for proper cleanup on close)
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
-  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<itask>>
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<sirius::parallel::itask>>
     _queue;  ///< The underlying concurrent queue
 };
 
-}  // namespace sirius::parallel
+}  // namespace sirius::op::scan

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -25,22 +25,22 @@
 #include <data/data_repository.hpp>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 class pipeline_executor;
 
 class local_task_buffer {
  public:
   local_task_buffer() = default;
-  void produce(std::unique_ptr<itask> task);
-  std::unique_ptr<itask> consume();
+  void produce(std::unique_ptr<sirius::parallel::itask> task);
+  std::unique_ptr<sirius::parallel::itask> consume();
   void open();
   void close();
 
  private:
   mutable std::mutex _mtx;
   std::condition_variable _cv;
-  std::queue<std::unique_ptr<itask>> _queue;
+  std::queue<std::unique_ptr<sirius::parallel::itask>> _queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 
@@ -51,14 +51,14 @@ class local_task_buffer {
  * task scheduling. It manages a pool of threads dedicated to executing GPU pipeline
  * tasks with specialized GPU resource management.
  */
-class gpu_pipeline_executor : public itask_executor {
+class gpu_pipeline_executor : public sirius::parallel::itask_executor {
  public:
   /**
    * @brief Constructs a new gpu_pipeline_executor with task execution configuration
    *
    * @param config Configuration for the task executor (thread count, retry policy, etc.)
    */
-  explicit gpu_pipeline_executor(task_executor_config config,
+  explicit gpu_pipeline_executor(sirius::parallel::task_executor_config config,
                                  const cucascade::memory::memory_space* mem_space,
                                  pipeline_executor* pipeline_exec);
 
@@ -82,7 +82,7 @@ class gpu_pipeline_executor : public itask_executor {
    *
    * @param task The task to schedule (must be a gpu_pipeline_task)
    */
-  void schedule(std::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<sirius::parallel::itask> task) override;
 
   /**
    * @brief Main worker loop for executing GPU pipeline tasks
@@ -138,7 +138,7 @@ class gpu_pipeline_executor : public itask_executor {
    * @return gpu_pipeline_task* The casted gpu_pipeline_task pointer
    * @throws std::bad_cast if the task is not of type gpu_pipeline_task
    */
-  gpu_pipeline_task* cast_to_gpu_pipeline_task(itask* task);
+  gpu_pipeline_task* cast_to_gpu_pipeline_task(sirius::parallel::itask* task);
 
   std::unique_ptr<std::thread> _gpu_pipeline_executor_manager_thread;
   std::unique_ptr<local_task_buffer> _local_task_buffer;
@@ -148,5 +148,5 @@ class gpu_pipeline_executor : public itask_executor {
                          // associated with this pipeline executor
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/gpu_pipeline_queue.hpp
+++ b/src/include/pipeline/gpu_pipeline_queue.hpp
@@ -28,7 +28,7 @@
 #include <memory>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 /**
  * @brief A task queue specifically for managing gpu_pipeline_task instances.
@@ -37,7 +37,7 @@ namespace parallel {
  * tasks. Currently it just uses the std::queue, but in the future we might want to implement a
  * more sophisticated queue that supports priority scheduling, task stealing, etc..
  */
-class gpu_pipeline_queue : public itask_queue {
+class gpu_pipeline_queue : public sirius::parallel::itask_queue {
  public:
   /**
    * @brief Construct a new gpu_pipeline_queue object
@@ -60,7 +60,7 @@ class gpu_pipeline_queue : public itask_queue {
    * @param task The task to be scheduled
    * @throws sirius::runtime_error If the scheduler is not currently accepting requests
    */
-  void push(std::unique_ptr<itask> task) override;
+  void push(std::unique_ptr<sirius::parallel::itask> task) override;
 
   /**
    * @brief Pull a task to execute.
@@ -72,13 +72,13 @@ class gpu_pipeline_queue : public itask_queue {
    * @throws sirius::runtime_error If the scheduler is not currently stopped and thus not returning
    * tasks
    */
-  std::unique_ptr<itask> pull() override;
+  std::unique_ptr<sirius::parallel::itask> pull() override;
 
  private:
   size_t _num_threads;
-  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<itask>> _task_queue;
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<sirius::parallel::itask>> _task_queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 /**
  * @brief Global state shared across all GPU pipeline tasks in an execution context.
@@ -40,34 +40,19 @@ namespace parallel {
  * for retrieving input data and a message queue for notifying the TaskCreator
  * about task completion events.
  */
-class gpu_pipeline_task_global_state : public itask_global_state {
+class gpu_pipeline_task_global_state : public sirius::parallel::itask_global_state {
  public:
   /**
    * @brief Construct a new gpu_pipeline_task_global_state object
    *
-   * @param pipeline_id Identifier for the pipeline this task belongs to
    * @param pipeline Shared pointer to the GPU pipeline to execute
-   * @param data_repo_mgr Reference to the data repository manager for accessing input data
-   * @param message_queue Reference to the message queue for task completion notifications
    */
-  explicit gpu_pipeline_task_global_state(uint64_t pipeline_id,
-                                          duckdb::shared_ptr<duckdb::GPUPipeline> pipeline,
-                                          cucascade::shared_data_repository_manager& data_repo_mgr,
-                                          task_completion_message_queue& message_queue)
-    : _pipeline_id(pipeline_id),
-      _pipeline(std::move(pipeline)),
-      _data_repo_mgr(data_repo_mgr),
-      _message_queue(message_queue)
+  explicit gpu_pipeline_task_global_state(duckdb::shared_ptr<duckdb::GPUPipeline> pipeline)
+    : _pipeline(std::move(pipeline))
   {
   }
-
-  cucascade::shared_data_repository_manager&
-    _data_repo_mgr;  ///< Reference to the data repository manager
-  task_completion_message_queue&
-    _message_queue;  ///< Message queue to notify TaskCreator about task completion
   duckdb::shared_ptr<duckdb::GPUPipeline>
-    _pipeline;            ///< Shared pointer to the GPU pipeline to execute
-  uint64_t _pipeline_id;  ///< Identifier for the pipeline this task belongs to
+    _pipeline;  ///< Shared pointer to the GPU pipeline to execute
 };
 
 /**
@@ -77,23 +62,21 @@ class gpu_pipeline_task_global_state : public itask_global_state {
  * execution. It holds the task and pipeline identifiers, the GPU pipeline to
  * execute, and the data batch views that serve as input to the pipeline.
  */
-class gpu_pipeline_task_local_state : public itask_local_state {
+class gpu_pipeline_task_local_state : public sirius::parallel::itask_local_state {
  public:
   /**
    * @brief Construct a new gpu_pipeline_task_local_state object
    *
-   * @param task_id Unique identifier for this task
-   * @param batches Vector of data batches serving as input to the pipeline
+   * @param batch_views Vector of data batches serving as input to the pipeline
+   * @param res Memory reservation for GPU resources
    */
   explicit gpu_pipeline_task_local_state(
-    uint64_t task_id,
     std::vector<std::shared_ptr<cucascade::data_batch>> batches,
     std::unique_ptr<cucascade::memory::reservation> res = nullptr)
-    : _task_id(task_id), _batches(std::move(batches)), _reservation(std::move(res))
+    : _batches(std::move(batches)), _reservation(std::move(res))
   {
   }
 
-  uint64_t _task_id;  ///< Unique identifier for this task
   std::vector<std::shared_ptr<cucascade::data_batch>>
     _batches;  ///< Input data batches for the pipeline
 
@@ -119,16 +102,20 @@ class gpu_pipeline_task_local_state : public itask_local_state {
  * Note that this class will be further derived to represent specific types of tasks such as build,
  * aggregation, etc..
  */
-class gpu_pipeline_task : public itask {
+class gpu_pipeline_task : public sirius::parallel::itask {
  public:
   /**
    * @brief Construct a new gpu_pipeline_task object
    *
+   * @param task_id The unique identifier for this task
+   * @param data_repos The data repositories to push the output of this task to
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  gpu_pipeline_task(std::unique_ptr<itask_local_state> local_state,
-                    std::shared_ptr<itask_global_state> global_state);
+  gpu_pipeline_task(uint64_t task_id,
+                    std::vector<cucascade::shared_data_repository*> data_repos,
+                    std::unique_ptr<sirius::parallel::itask_local_state> local_state,
+                    std::shared_ptr<sirius::parallel::itask_global_state> global_state);
 
   /**
    * @brief Method to actually execute the task
@@ -149,23 +136,10 @@ class gpu_pipeline_task : public itask {
    */
   const duckdb::GPUPipeline* get_pipeline() const;
 
-  /**
-   * @brief Method to mark that this task is completed
-   *
-   * This method informs that TaskCreator that the task is completed so that it can start scheduling
-   * tasks that were dependent on this task. This method should be called after pushing the output
-   * of this task to the Data Repository.
-   */
-  void mark_task_completion();
-
-  /**
-   * @brief Method to push the output of this task to the Data Repository
-   *
-   * @param batch The data batch to push
-   * @param pipeline_id The id of the pipeline that produced this data batch
-   */
-  void push_data_batch(std::shared_ptr<cucascade::data_batch> batch, uint64_t pipeline_id);
+ private:
+  uint64_t _task_id;
+  std::vector<cucascade::shared_data_repository*> _data_repos;
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -25,7 +25,7 @@
 #include <data/data_repository.hpp>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 /**
  * @brief Executor specialized for executing GPU pipeline operations.
@@ -34,14 +34,14 @@ namespace parallel {
  * task scheduling. It manages a pool of threads dedicated to executing GPU pipeline
  * tasks with specialized GPU resource management.
  */
-class pipeline_executor : public itask_executor {
+class pipeline_executor : public sirius::parallel::itask_executor {
  public:
   /**
    * @brief Constructs a new pipeline_executor with task execution configuration
    *
    * @param config Configuration for the task executor (thread count, retry policy, etc.)
    */
-  explicit pipeline_executor(task_executor_config config);
+  explicit pipeline_executor(sirius::parallel::task_executor_config config);
 
   /**
    * @brief Destructor for the gpu_pipeline_executor.
@@ -63,7 +63,7 @@ class pipeline_executor : public itask_executor {
    *
    * @param task The task to schedule (must be a gpu_pipeline_task)
    */
-  void schedule(std::unique_ptr<itask> task) override;
+  void schedule(std::unique_ptr<sirius::parallel::itask> task) override;
 
   /**
    * @brief Main worker loop for executing GPU pipeline tasks
@@ -100,7 +100,7 @@ class pipeline_executor : public itask_executor {
    * @param task The task to schedule
    * @param gpu_id The GPU ID to which the task should be scheduled
    */
-  void dispatch_to_gpu_executor(std::unique_ptr<itask> task, int gpu_id);
+  void dispatch_to_gpu_executor(std::unique_ptr<sirius::parallel::itask> task, int gpu_id);
 
   /**
    * @brief Submit a task request to task_request_queue
@@ -112,5 +112,5 @@ class pipeline_executor : public itask_executor {
   std::unique_ptr<task_request_queue> _task_request_queue;
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/pipeline_queue.hpp
+++ b/src/include/pipeline/pipeline_queue.hpp
@@ -29,7 +29,7 @@
 #include <semaphore>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 /**
  * @brief A task queue specifically for managing gpu_pipeline_task instances.
@@ -38,7 +38,7 @@ namespace parallel {
  * tasks. Currently it just uses the std::queue, but in the future we might want to implement a
  * more sophisticated queue that supports priority scheduling, task stealing, etc..
  */
-class pipeline_queue : public itask_queue {
+class pipeline_queue : public sirius::parallel::itask_queue {
  public:
   /**
    * @brief Construct a new pipeline_queue object
@@ -61,7 +61,7 @@ class pipeline_queue : public itask_queue {
    * @param task The task to be scheduled
    * @throws sirius::runtime_error If the scheduler is not currently accepting requests
    */
-  void push(std::unique_ptr<itask> task) override;
+  void push(std::unique_ptr<sirius::parallel::itask> task) override;
 
   /**
    * @brief Pull a task to execute.
@@ -73,7 +73,7 @@ class pipeline_queue : public itask_queue {
    * @throws sirius::runtime_error If the scheduler is not currently stopped and thus not returning
    * tasks
    */
-  std::unique_ptr<itask> pull() override;
+  std::unique_ptr<sirius::parallel::itask> pull() override;
 
   /**
    * @brief Check if the task queue is empty
@@ -84,9 +84,9 @@ class pipeline_queue : public itask_queue {
 
  private:
   size_t _num_threads;
-  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<itask>> _task_queue;
+  duckdb_moodycamel::BlockingConcurrentQueue<std::unique_ptr<sirius::parallel::itask>> _task_queue;
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/include/pipeline/task_request.hpp
+++ b/src/include/pipeline/task_request.hpp
@@ -24,7 +24,7 @@
 #include <data/data_repository.hpp>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 struct task_request {
   int device_id;
@@ -44,5 +44,5 @@ class task_request_queue {
   std::atomic<bool> _is_open{false};  ///< Whether the queue is open for pushing/pulling tasks
 };
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/operator/scan/duckdb_scan_executor.cpp
+++ b/src/operator/scan/duckdb_scan_executor.cpp
@@ -20,9 +20,9 @@
 // standard library
 #include <mutex>
 
-namespace sirius::parallel {
+namespace sirius::op::scan {
 
-void duckdb_scan_executor::schedule(std::unique_ptr<itask> task)
+void duckdb_scan_executor::schedule(std::unique_ptr<sirius::parallel::itask> task)
 {
   {
     std::unique_lock<std::mutex> lock(_finish_mutex);
@@ -65,4 +65,4 @@ void duckdb_scan_executor::worker_loop(int32_t worker_id)
   }
 }
 
-}  // namespace sirius::parallel
+}  // namespace sirius::op::scan

--- a/src/operator/scan/duckdb_scan_task.cpp
+++ b/src/operator/scan/duckdb_scan_task.cpp
@@ -27,20 +27,20 @@
 // standard library
 #include <cstddef>
 
-namespace sirius::parallel {
+namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
 // duckdb_scan_task_global_state
 //===----------------------------------------------------------------------===//
 duckdb_scan_task_global_state::duckdb_scan_task_global_state(
-  uint64_t pipeline_id,
+  duckdb::shared_ptr<duckdb::GPUPipeline> pipeline,
   duckdb_scan_executor& scan_exec,
   duckdb::ClientContext& client_ctx,
-  duckdb::physical_table_scan_adapter const& ptsa)
-  : pipeline_id(pipeline_id),
+  duckdb::GPUPhysicalTableScan* scan_op)
+  : pipeline(std::move(pipeline)),
     max_threads(scan_exec.get_num_threads()),
     scan_executor(scan_exec),
-    op(ptsa.get_physical_table_scan())
+    op(*scan_op)
 {
   // Initialize global table function state
   if (op.function.init_global) {
@@ -313,7 +313,7 @@ duckdb_scan_task_local_state::duckdb_scan_task_local_state(
   initialize_local_table_function_state(op, exec_ctx, g_state.global_tf_state.get());
 }
 
-void duckdb_scan_task_local_state::estimate_rows_per_batch(const duckdb::PhysicalTableScan& op)
+void duckdb_scan_task_local_state::estimate_rows_per_batch(duckdb::GPUPhysicalTableScan const& op)
 {
   assert(num_columns <= op.column_ids.size());
 
@@ -366,7 +366,7 @@ void duckdb_scan_task_local_state::initialize_builders()
 }
 
 void duckdb_scan_task_local_state::initialize_local_table_function_state(
-  duckdb::PhysicalTableScan const& op,
+  duckdb::GPUPhysicalTableScan const& op,
   duckdb::ExecutionContext& exec_ctx,
   duckdb::GlobalTableFunctionState* global_tf_state)
 {
@@ -478,7 +478,7 @@ void duckdb_scan_task::execute()
     auto shared_global_state =
       std::static_pointer_cast<duckdb_scan_task_global_state>(this->_global_state);
     auto next_task = std::make_unique<duckdb_scan_task>(
-      new_task_id, dr_mgr, std::move(new_local_state), shared_global_state);
+      new_task_id, _data_repo, std::move(new_local_state), shared_global_state);
     g_state.scan_executor.schedule(std::move(next_task));
   }
 
@@ -487,4 +487,4 @@ void duckdb_scan_task::execute()
   /// FUTURE WORK: Notify task_creator of completion by sending a message to the message queue
 }
 
-}  // namespace sirius::parallel
+}  // namespace sirius::op::scan

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -20,9 +20,9 @@
 #include "pipeline/pipeline_executor.hpp"
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
-void local_task_buffer::produce(std::unique_ptr<itask> task)
+void local_task_buffer::produce(std::unique_ptr<sirius::parallel::itask> task)
 {
   {
     std::lock_guard<std::mutex> lock(_mtx);
@@ -31,7 +31,7 @@ void local_task_buffer::produce(std::unique_ptr<itask> task)
   _cv.notify_one();  // wake consumer
 }
 
-std::unique_ptr<itask> local_task_buffer::consume()
+std::unique_ptr<sirius::parallel::itask> local_task_buffer::consume()
 {
   std::unique_lock<std::mutex> lock(_mtx);
   _cv.wait(lock, [&] { return (!_queue.empty()) || !_is_open.load(std::memory_order_acquire); });
@@ -48,7 +48,7 @@ void local_task_buffer::close()
   _cv.notify_all();
 }
 
-gpu_pipeline_executor::gpu_pipeline_executor(task_executor_config config,
+gpu_pipeline_executor::gpu_pipeline_executor(sirius::parallel::task_executor_config config,
                                              const cucascade::memory::memory_space* mem_space,
                                              pipeline_executor* pipeline_exec)
   : itask_executor(std::make_unique<gpu_pipeline_queue>(config.num_threads), config),
@@ -58,7 +58,7 @@ gpu_pipeline_executor::gpu_pipeline_executor(task_executor_config config,
 {
 }
 
-void gpu_pipeline_executor::schedule(std::unique_ptr<itask> task)
+void gpu_pipeline_executor::schedule(std::unique_ptr<sirius::parallel::itask> task)
 {
   _task_queue->push(std::move(task));
 }
@@ -82,7 +82,7 @@ void gpu_pipeline_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(std::make_unique<task_executor_thread>(
+    _threads.push_back(std::make_unique<sirius::parallel::task_executor_thread>(
       std::make_unique<std::thread>(&gpu_pipeline_executor::worker_loop, this, i)));
   }
   _gpu_pipeline_executor_manager_thread =
@@ -153,11 +153,11 @@ void gpu_pipeline_executor::manager_loop()
   }
 }
 
-gpu_pipeline_task* gpu_pipeline_executor::cast_to_gpu_pipeline_task(itask* task)
+gpu_pipeline_task* gpu_pipeline_executor::cast_to_gpu_pipeline_task(sirius::parallel::itask* task)
 {
   // Safely cast to gpu_pipeline_task
   return dynamic_cast<gpu_pipeline_task*>(task);
 }
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/gpu_pipeline_queue.cpp
+++ b/src/pipeline/gpu_pipeline_queue.cpp
@@ -19,7 +19,7 @@
 #include "config.hpp"
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 void gpu_pipeline_queue::open() { _is_open.store(true, std::memory_order_release); }
 
@@ -32,11 +32,14 @@ void gpu_pipeline_queue::close()
   }
 }
 
-void gpu_pipeline_queue::push(std::unique_ptr<itask> task) { _task_queue.enqueue(std::move(task)); }
-
-std::unique_ptr<itask> gpu_pipeline_queue::pull()
+void gpu_pipeline_queue::push(std::unique_ptr<sirius::parallel::itask> task)
 {
-  std::unique_ptr<itask> task;
+  _task_queue.enqueue(std::move(task));
+}
+
+std::unique_ptr<sirius::parallel::itask> gpu_pipeline_queue::pull()
+{
+  std::unique_ptr<sirius::parallel::itask> task;
   while (true) {
     if (_task_queue.try_dequeue(task)) { return task; }
 
@@ -49,5 +52,5 @@ std::unique_ptr<itask> gpu_pipeline_queue::pull()
   }
 }
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -17,21 +17,24 @@
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include <data/data_batch_utils.hpp>
+#include <data/data_repository.hpp>
 #include <data/data_repository_manager.hpp>
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
-gpu_pipeline_task::gpu_pipeline_task(std::unique_ptr<itask_local_state> local_state,
-                                     std::shared_ptr<itask_global_state> global_state)
-  : itask(std::move(local_state), std::move(global_state))
+gpu_pipeline_task::gpu_pipeline_task(
+  uint64_t task_id,
+  std::vector<cucascade::shared_data_repository*> data_repos,
+  std::unique_ptr<sirius::parallel::itask_local_state> local_state,
+  std::shared_ptr<sirius::parallel::itask_global_state> global_state)
+  : itask(std::move(local_state), std::move(global_state)),
+    _task_id(task_id),
+    _data_repos(std::move(data_repos))
 {
 }
 
-uint64_t gpu_pipeline_task::get_task_id() const
-{
-  return _local_state->cast<gpu_pipeline_task_local_state>()._task_id;
-}
+uint64_t gpu_pipeline_task::get_task_id() const { return _task_id; }
 
 const duckdb::GPUPipeline* gpu_pipeline_task::get_pipeline() const
 {
@@ -49,7 +52,6 @@ void gpu_pipeline_task::execute()
   if (!processing_handles) {
     // Some batch is being downgraded - cannot process right now
     // TODO: Add retry logic or re-queue the task
-    mark_task_completion();
     return;
   }
 
@@ -64,21 +66,7 @@ void gpu_pipeline_task::execute()
   // 5. Push output batches to the data repository
 
   // Processing handles are automatically released here when they go out of scope
-  mark_task_completion();
 }
 
-void gpu_pipeline_task::mark_task_completion()
-{
-  // notify TaskCreator about task completion
-  uint64_t task_id     = _local_state->cast<gpu_pipeline_task_local_state>()._task_id;
-  uint64_t pipeline_id = _global_state->cast<gpu_pipeline_task_global_state>()._pipeline_id;
-  auto message         = std::make_unique<sirius::task_completion_message>();
-  message->task_id     = task_id;
-  message->pipeline_id = pipeline_id;
-  message->source      = sirius::Source::PIPELINE;
-  _global_state->cast<gpu_pipeline_task_global_state>()._message_queue.enqueue_message(
-    std::move(message));
-}
-
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -22,24 +22,24 @@
 #include "pipeline/pipeline_queue.hpp"
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
-pipeline_executor::pipeline_executor(task_executor_config config)
-  : itask_executor(std::make_unique<pipeline_queue>(config.num_threads), config)
+pipeline_executor::pipeline_executor(sirius::parallel::task_executor_config config)
+  : sirius::parallel::itask_executor(std::make_unique<pipeline_queue>(config.num_threads), config)
 {
   // Initialize GPU pipeline executors for each available GPU
   _gpu_executors.reserve(Config::NUM_GPU);
   for (int i = 0; i < Config::NUM_GPU; ++i) {
-    // TODO: Initialize memory space for each GPU
-    auto& mem_res_mgr = sirius::memory_manager::get();
-    const cucascade::memory::memory_space* gpu_mem_space =
-      mem_res_mgr.get_memory_space(cucascade::memory::Tier::GPU, i);  // Placeholder
+    // auto& mem_res_mgr = cucascade::memory::memory_reservation_manager::get_instance();
+    // const cucascade::memory::memory_space* gpu_mem_space =
+    //   mem_res_mgr.get_memory_space(cucascade::memory::Tier::GPU, i);  // Placeholder
+    const cucascade::memory::memory_space* gpu_mem_space = nullptr;  // Placeholder
     _gpu_executors.push_back(std::make_unique<gpu_pipeline_executor>(config, gpu_mem_space, this));
   }
   _task_request_queue = std::make_unique<task_request_queue>(config.num_threads);
 }
 
-void pipeline_executor::schedule(std::unique_ptr<itask> task)
+void pipeline_executor::schedule(std::unique_ptr<sirius::parallel::itask> task)
 {
   _task_queue->push(std::move(task));
 }
@@ -63,7 +63,7 @@ void pipeline_executor::start()
   on_start();
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
-    _threads.push_back(std::make_unique<task_executor_thread>(
+    _threads.push_back(std::make_unique<sirius::parallel::task_executor_thread>(
       std::make_unique<std::thread>(&pipeline_executor::worker_loop, this, i)));
   }
   // Start all GPU executors
@@ -123,7 +123,8 @@ void pipeline_executor::submit_task_request(std::unique_ptr<task_request> reques
   _task_request_queue->push(std::move(request));
 }
 
-void pipeline_executor::dispatch_to_gpu_executor(std::unique_ptr<itask> task, int gpu_id)
+void pipeline_executor::dispatch_to_gpu_executor(std::unique_ptr<sirius::parallel::itask> task,
+                                                 int gpu_id)
 {
   if (gpu_id < 0 || gpu_id >= static_cast<int>(_gpu_executors.size())) {
     throw std::runtime_error("Invalid GPU ID: " + std::to_string(gpu_id));
@@ -131,5 +132,5 @@ void pipeline_executor::dispatch_to_gpu_executor(std::unique_ptr<itask> task, in
   _gpu_executors[gpu_id]->schedule(std::move(task));
 }
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/pipeline_queue.cpp
+++ b/src/pipeline/pipeline_queue.cpp
@@ -19,7 +19,7 @@
 #include "config.hpp"
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 void pipeline_queue::open() { _is_open.store(true, std::memory_order_release); }
 
@@ -32,11 +32,14 @@ void pipeline_queue::close()
   }
 }
 
-void pipeline_queue::push(std::unique_ptr<itask> task) { _task_queue.enqueue(std::move(task)); }
-
-std::unique_ptr<itask> pipeline_queue::pull()
+void pipeline_queue::push(std::unique_ptr<sirius::parallel::itask> task)
 {
-  std::unique_ptr<itask> task;
+  _task_queue.enqueue(std::move(task));
+}
+
+std::unique_ptr<sirius::parallel::itask> pipeline_queue::pull()
+{
+  std::unique_ptr<sirius::parallel::itask> task;
   while (true) {
     if (_task_queue.try_dequeue(task)) { return task; }
 
@@ -49,5 +52,5 @@ std::unique_ptr<itask> pipeline_queue::pull()
   }
 }
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/task_request.cpp
+++ b/src/pipeline/task_request.cpp
@@ -19,7 +19,7 @@
 #include "config.hpp"
 
 namespace sirius {
-namespace parallel {
+namespace pipeline {
 
 void task_request_queue::open() { _is_open.store(true, std::memory_order_release); }
 
@@ -52,5 +52,5 @@ unique_ptr<task_request> task_request_queue::pull()
   }
 }
 
-}  // namespace parallel
+}  // namespace pipeline
 }  // namespace sirius

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -28,7 +28,7 @@
 // standard library
 #include <numbers>
 
-using namespace sirius::parallel;
+using namespace sirius::op::scan;
 using namespace cucascade::memory;
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/scan/test_multiple_blocks_allocation_accessor.cpp
+++ b/test/cpp/scan/test_multiple_blocks_allocation_accessor.cpp
@@ -22,7 +22,7 @@
 #include <memory/numa_region_pinned_host_allocator.hpp>
 #include <scan/duckdb_scan_task.hpp>
 
-using namespace sirius::parallel;
+using namespace sirius::op::scan;
 using namespace cucascade::memory;
 
 // Standalone memory resource for testing with custom block size

--- a/test/cpp/scan/test_scan_executor.cpp
+++ b/test/cpp/scan/test_scan_executor.cpp
@@ -23,10 +23,9 @@
 // sirius
 #include <data/data_batch.hpp>
 #include <data/data_repository.hpp>
-#include <data/data_repository_manager.hpp>
+#include <operator/gpu_physical_table_scan.hpp>
 #include <scan/duckdb_scan_executor.hpp>
 #include <scan/duckdb_scan_task.hpp>
-#include <scan/physical_table_scan_adapter.hpp>
 
 // duckdb
 #include <duckdb.hpp>
@@ -34,7 +33,6 @@
 #include <duckdb/catalog/catalog_transaction.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/execution/execution_context.hpp>
-#include <duckdb/execution/operator/scan/physical_table_scan.hpp>
 #include <duckdb/function/table/table_scan.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/parallel/thread_context.hpp>
@@ -61,15 +59,15 @@ using namespace sirius;
  * and then reads data from the column_builders to append to a staging table. It is essentially a
  * replica of duckdb_scan_task that adds an append() hook at the end for validation.
  */
-class test_scan_task : public parallel::duckdb_scan_task {
+class test_scan_task : public op::scan::duckdb_scan_task {
  public:
   test_scan_task(uint64_t task_id,
-                 cucascade::shared_data_repository_manager& dr_mgr,
+                 cucascade::shared_data_repository* data_repo,
                  duckdb::Connection& con,
                  std::string const& table_name,
-                 std::unique_ptr<parallel::duckdb_scan_task_local_state> l_state,
-                 std::shared_ptr<parallel::duckdb_scan_task_global_state> g_state)
-    : duckdb_scan_task(task_id, dr_mgr, std::move(l_state), g_state),
+                 std::unique_ptr<op::scan::duckdb_scan_task_local_state> l_state,
+                 std::shared_ptr<op::scan::duckdb_scan_task_global_state> g_state)
+    : duckdb_scan_task(task_id, data_repo, std::move(l_state), g_state),
       con_(con),
       table_name_(table_name)
   {
@@ -77,8 +75,8 @@ class test_scan_task : public parallel::duckdb_scan_task {
 
   void execute() override
   {
-    auto& l_state = this->_local_state->cast<parallel::duckdb_scan_task_local_state>();
-    auto& g_state = this->_global_state->cast<parallel::duckdb_scan_task_global_state>();
+    auto& l_state = this->_local_state->cast<op::scan::duckdb_scan_task_local_state>();
+    auto& g_state = this->_global_state->cast<op::scan::duckdb_scan_task_global_state>();
 
     // Initialize the data chunk
     l_state.chunk.Initialize(duckdb::Allocator::Get(l_state.exec_ctx.client),
@@ -103,7 +101,7 @@ class test_scan_task : public parallel::duckdb_scan_task {
 
       // Create a new local state, passing the existing local_tf_state to continue the scan
       // This ensures DuckDB continues scanning from the current position rather than starting over
-      auto new_local_state = std::make_unique<parallel::duckdb_scan_task_local_state>(
+      auto new_local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
         g_state,
         l_state.exec_ctx,
         l_state.approximate_batch_size,
@@ -112,9 +110,13 @@ class test_scan_task : public parallel::duckdb_scan_task {
 
       // Create a new reference to the global state
       auto shared_global_state =
-        std::static_pointer_cast<parallel::duckdb_scan_task_global_state>(this->_global_state);
-      auto next_task = std::make_unique<test_scan_task>(
-        new_task_id, dr_mgr, con_, table_name_, std::move(new_local_state), shared_global_state);
+        std::static_pointer_cast<op::scan::duckdb_scan_task_global_state>(this->_global_state);
+      auto next_task = std::make_unique<test_scan_task>(new_task_id,
+                                                        _data_repo,
+                                                        con_,
+                                                        table_name_,
+                                                        std::move(new_local_state),
+                                                        shared_global_state);
       g_state.scan_executor.schedule(std::move(next_task));
     }
 
@@ -142,7 +144,7 @@ class test_scan_task : public parallel::duckdb_scan_task {
    * NOTE: Uses a mutex to protect DuckDB connection access since DuckDB connections
    * are not thread-safe for concurrent writes.
    */
-  void append_to_table(parallel::duckdb_scan_task_local_state& l_state)
+  void append_to_table(op::scan::duckdb_scan_task_local_state& l_state)
   {
     auto const num_rows = l_state.row_offset;
     if (num_rows == 0) {
@@ -412,7 +414,7 @@ static void validate_tables_equal(duckdb::Connection& con,
 /**
  * @brief Create a PhysicalTableScan for the given table
  */
-static std::unique_ptr<duckdb::PhysicalTableScan> make_physical_table_scan(
+static std::unique_ptr<duckdb::GPUPhysicalTableScan> make_physical_table_scan(
   duckdb::ClientContext& ctx, std::string const& table_name)
 {
   auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
@@ -447,8 +449,8 @@ static std::unique_ptr<duckdb::PhysicalTableScan> make_physical_table_scan(
   // Create extra operator info (must be a variable, not a temporary)
   duckdb::ExtraOperatorInfo extra_info;
 
-  // Create PhysicalTableScan with all required parameters
-  auto physical_scan = std::make_unique<duckdb::PhysicalTableScan>(
+  // Create GPUPhysicalTableScan with all required parameters
+  auto physical_scan = std::make_unique<duckdb::GPUPhysicalTableScan>(
     table_catalog_entry.GetTypes(),  // types
     table_scan_function,             // function
     std::move(bind_data),            // bind_data
@@ -503,9 +505,6 @@ static void run_scan_test(std::string const& table_name,
   auto physical_scan = make_physical_table_scan(client_ctx, table_name);
   REQUIRE(physical_scan);
 
-  // Create physical table scan adapter
-  duckdb::physical_table_scan_adapter ptsa(std::move(physical_scan));
-
   // Create staging table for scanned data
   std::string staging_table = table_name + "_scanned";
   auto create_result =
@@ -514,7 +513,7 @@ static void run_scan_test(std::string const& table_name,
   REQUIRE(!create_result->HasError());
 
   // Create scan executor (task scheduler)
-  parallel::duckdb_scan_executor scan_executor({num_threads, false});
+  op::scan::duckdb_scan_executor scan_executor({num_threads, false});
 
   // Create execution context using dummy query
   auto dummy_query = "SELECT * FROM " + table_name + " LIMIT 0";
@@ -529,20 +528,20 @@ static void run_scan_test(std::string const& table_name,
   duckdb::ExecutionContext exec_ctx(client_ctx, thread_ctx, nullptr);
 
   // Create global state
-  auto global_state = std::make_shared<parallel::duckdb_scan_task_global_state>(
-    pipeline_id, scan_executor, client_ctx, ptsa);
+  auto global_state = std::make_shared<op::scan::duckdb_scan_task_global_state>(
+    nullptr, scan_executor, client_ctx, physical_scan.get());
 
   // Create data repository manager (empty, unused for this test)
-  cucascade::shared_data_repository_manager dr_mgr;
+  cucascade::shared_data_repository data_repo;
 
   // Create local state
   auto local_state =
-    std::make_unique<parallel::duckdb_scan_task_local_state>(*global_state, exec_ctx, batch_size);
+    std::make_unique<op::scan::duckdb_scan_task_local_state>(*global_state, exec_ctx, batch_size);
 
   // Create and schedule test task
   uint64_t task_id = 1;
   auto task        = std::make_unique<test_scan_task>(
-    task_id, dr_mgr, con, staging_table, std::move(local_state), global_state);
+    task_id, &data_repo, con, staging_table, std::move(local_state), global_state);
   scan_executor.schedule(std::move(task));
 
   // Run task


### PR DESCRIPTION
This PR:
1. Address namespace change on Scan Executor and Pipeline Executor to follow the directory
2. Adjust scan executor to take GPUPhysicalTableScan instead of PhysicalTableScan