### PR TITLE
Fix cuCascade API compatibility issues

### DIFF
--- a/src/include/memory/sirius_memory_manager.hpp
+++ b/src/include/memory/sirius_memory_manager.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "memory/config.hpp"
 #include "memory/memory_reservation_manager.hpp"
 
 #include <memory>
@@ -41,7 +42,7 @@ namespace sirius {
 class memory_manager {
  public:
   using manager_type = cucascade::memory::memory_reservation_manager;
-  using config_type  = manager_type::memory_space_config;
+  using config_type  = cucascade::memory::memory_space_config;
 
   /**
    * @brief Initialize the global memory reservation manager.

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -54,7 +54,7 @@ inline void initialize_memory_manager()
     // Configure HOST (4GB capacity, 75% reservation ratio)
     const size_t host_capacity = 4ull << 30;  // 4GB
     builder.set_capacity_per_numa_node(host_capacity);
-    builder.set_host_id_to_numa_maps({{0, -1}});
+    builder.use_gpu_ids_as_host();
     builder.set_reservation_limit_ratio_per_numa_node(limit_ratio);
 
     // Build configuration with topology detection


### PR DESCRIPTION
This PR fixes compilation errors caused by cuCascade API changes:

- Updates memory_space_config reference to use cucascade namespace directly instead of accessing through manager_type
- Replaces deprecated set_host_id_to_numa_maps() with use_gpu_ids_as_host()
- Adds missing config.hpp include for memory manager

**Testing:**
✅ Build completes successfully
✅ All unit tests pass

Resolves build failures on systems with the latest cuCascade version.