### PR TITLE
Add cuCascade as a submodule and update CMake configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = substrait
 	url = https://github.com/duckdb/substrait.git
 	branch = main
+[submodule "cucascade"]
+	path = cucascade
+	url = https://github.com/NVIDIA/cuCascade.git
+	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,13 +147,22 @@ target_link_libraries(${LOADABLE_EXTENSION_NAME} substrait_extension cudf::cudf
                       rmm::rmm)
 
 # Link third-party libraries
-target_link_libraries(${EXTENSION_NAME} spdlog::spdlog cucascade::cucascade)
+target_link_libraries(${EXTENSION_NAME} spdlog::spdlog cuCascade::cucascade)
 target_link_libraries(${LOADABLE_EXTENSION_NAME} spdlog::spdlog
-                      cucascade::cucascade)
+                      cuCascade::cucascade)
 
-# Ensure cuCascade is built before extensions
-add_dependencies(${EXTENSION_NAME} cucascade_ep spdlog_ep)
-add_dependencies(${LOADABLE_EXTENSION_NAME} cucascade_ep spdlog_ep)
+# Ensure third-party libraries are built before extensions Note: cucascade is
+# added via add_subdirectory, so dependencies are automatic
+add_dependencies(${EXTENSION_NAME} spdlog_ep)
+add_dependencies(${LOADABLE_EXTENSION_NAME} spdlog_ep)
+
+# Install cucascade_static to the DuckDB export set (required for
+# sirius_extension export)
+install(
+  TARGETS cucascade_static
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 channels = ["rapidsai", "conda-forge", "nvidia" ]
 name = "sirius"
 platforms = ["linux-64", "linux-aarch64"]
-requires-pixi = "0.59.*"
+requires-pixi = ">=0.59"
 
 [system-requirements]
 cuda = "13"

--- a/src/include/memory/sirius_memory_manager.hpp
+++ b/src/include/memory/sirius_memory_manager.hpp
@@ -41,7 +41,7 @@ namespace sirius {
 class memory_manager {
  public:
   using manager_type = cucascade::memory::memory_reservation_manager;
-  using config_type  = manager_type::memory_space_config;
+  using config_type  = cucascade::memory::memory_space_config;
 
   /**
    * @brief Initialize the global memory reservation manager.

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -54,7 +54,7 @@ inline void initialize_memory_manager()
     // Configure HOST (4GB capacity, 75% reservation ratio)
     const size_t host_capacity = 4ull << 30;  // 4GB
     builder.set_capacity_per_numa_node(host_capacity);
-    builder.set_host_id_to_numa_maps({{0, -1}});
+    builder.use_gpu_ids_as_host();
     builder.set_reservation_limit_ratio_per_numa_node(limit_ratio);
 
     // Build configuration with topology detection

--- a/third_party/cucascade.cmake
+++ b/third_party/cucascade.cmake
@@ -1,46 +1,78 @@
-# cuCascade - GPU Memory Reservation Library
+# cuCascade - GPU Memory Reservation Library (submodule)
+#
+# Options: CUCASCADE_GIT_TAG          - Specific git tag/commit hash to checkout
+# (empty = use current) CUCASCADE_UPDATE_SUBMODULE - Update submodule to latest
+# remote before building (OFF by default)
 
-set(CUCASCADE_VERSION "main")
-set(CUCASCADE_GIT_URL "https://github.com/NVIDIA/cuCascade.git")
+set(CUCASCADE_GIT_TAG
+    ""
+    CACHE STRING
+          "Specific git tag/commit hash for cuCascade (empty = use current)")
+option(CUCASCADE_UPDATE_SUBMODULE "Update cuCascade submodule to latest remote"
+       OFF)
 
-include(ExternalProject)
+# #region agent log - Debug CMake directory variables (H1, H2, H3, H4)
+message(STATUS "[DEBUG] CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+message(STATUS "[DEBUG] CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "[DEBUG] PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
+message(STATUS "[DEBUG] sirius_SOURCE_DIR: ${sirius_SOURCE_DIR}")
+# #endregion
 
-set(CUCASCADE_BASE cucascade_ep)
-set(CUCASCADE_PREFIX ${DEPS_PREFIX}/${CUCASCADE_BASE})
-set(CUCASCADE_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CUCASCADE_PREFIX})
-set(CUCASCADE_SOURCE_DIR ${CUCASCADE_BASE_DIR}/src/${CUCASCADE_BASE})
-set(CUCASCADE_BUILD_DIR ${CUCASCADE_SOURCE_DIR}/build/release)
-set(CUCASCADE_INCLUDE_DIR ${CUCASCADE_SOURCE_DIR}/include)
-set(CUCASCADE_LIB_DIR ${CUCASCADE_BUILD_DIR})
-set(CUCASCADE_STATIC_LIB
-    ${CUCASCADE_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}cucascade${CMAKE_STATIC_LIBRARY_SUFFIX}
-)
+set(CUCASCADE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cucascade")
 
-ExternalProject_Add(
-  ${CUCASCADE_BASE}
-  PREFIX ${CUCASCADE_BASE_DIR}
-  GIT_REPOSITORY ${CUCASCADE_GIT_URL}
-  GIT_TAG ${CUCASCADE_VERSION}
-  GIT_PROGRESS ON
-  GIT_SHALLOW ON
-  UPDATE_DISCONNECTED TRUE
-  BUILD_BYPRODUCTS ${CUCASCADE_STATIC_LIB}
-  CONFIGURE_COMMAND
-    ${CMAKE_COMMAND} -E env "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
-    ${CMAKE_COMMAND} --preset release -S <SOURCE_DIR> -B
-    <SOURCE_DIR>/build/release
-  BUILD_COMMAND ${CMAKE_COMMAND} --build <SOURCE_DIR>/build/release
-  INSTALL_COMMAND ""
-  BUILD_IN_SOURCE FALSE)
+message(STATUS "CUCASCADE_SOURCE_DIR: ${CUCASCADE_SOURCE_DIR}")
 
-file(MAKE_DIRECTORY ${CUCASCADE_INCLUDE_DIR}) # Include directory needs to exist
-                                              # to run configure
+# Verify submodule exists
+if(NOT EXISTS "${CUCASCADE_SOURCE_DIR}/CMakeLists.txt")
+  message(
+    FATAL_ERROR "cuCascade submodule not found at ${CUCASCADE_SOURCE_DIR}. "
+                "Please run: git submodule update --init cucascade")
+endif()
 
-add_library(cucascade::cucascade STATIC IMPORTED)
-set_target_properties(cucascade::cucascade PROPERTIES IMPORTED_LOCATION
-                                                      ${CUCASCADE_STATIC_LIB})
-target_include_directories(cucascade::cucascade
-                           INTERFACE ${CUCASCADE_INCLUDE_DIR})
-# cuCascade uses NUMA-aware memory allocation
-set_property(TARGET cucascade::cucascade PROPERTY INTERFACE_LINK_LIBRARIES numa)
-add_dependencies(cucascade::cucascade ${CUCASCADE_BASE})
+# Handle submodule update if requested
+if(CUCASCADE_UPDATE_SUBMODULE)
+  message(STATUS "Updating cuCascade submodule to latest remote...")
+  execute_process(
+    COMMAND git submodule update --remote cucascade
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE GIT_SUBMODULE_RESULT)
+  if(NOT GIT_SUBMODULE_RESULT EQUAL 0)
+    message(WARNING "Failed to update cuCascade submodule")
+  endif()
+endif()
+
+# Handle specific git tag/commit checkout
+if(CUCASCADE_GIT_TAG)
+  message(STATUS "Checking out cuCascade at: ${CUCASCADE_GIT_TAG}")
+  execute_process(
+    COMMAND git checkout ${CUCASCADE_GIT_TAG}
+    WORKING_DIRECTORY "${CUCASCADE_SOURCE_DIR}"
+    RESULT_VARIABLE GIT_CHECKOUT_RESULT)
+  if(NOT GIT_CHECKOUT_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to checkout cuCascade at ${CUCASCADE_GIT_TAG}")
+  endif()
+endif()
+
+# Configure cuCascade build options
+set(BUILD_TESTS
+    OFF
+    CACHE BOOL "Disable cuCascade tests" FORCE)
+set(BUILD_SHARED_LIBS
+    OFF
+    CACHE BOOL "Disable cuCascade shared lib" FORCE)
+set(BUILD_STATIC_LIBS
+    ON
+    CACHE BOOL "Enable cuCascade static lib" FORCE)
+set(WARNINGS_AS_ERRORS
+    OFF
+    CACHE BOOL "Disable warnings as errors for cuCascade" FORCE)
+
+# Add cuCascade subdirectory (EXCLUDE_FROM_ALL prevents cuCascade's own install
+# rules)
+add_subdirectory("${CUCASCADE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/cucascade"
+                 EXCLUDE_FROM_ALL)
+
+# Set include directory for use in main CMakeLists.txt
+set(CUCASCADE_INCLUDE_DIR
+    "${CUCASCADE_SOURCE_DIR}/include"
+    CACHE PATH "cuCascade include directory")


### PR DESCRIPTION
- Added cuCascade submodule to .gitmodules for GPU memory reservation.
- Updated cucascade.cmake to handle submodule existence, update options, and build configurations.
- Adjusted CMakeLists.txt to ensure proper dependencies for extensions without explicit cuCascade dependency management.
- add tags to cucascade and ability to update the module without having to rebuild entire code base