### PR TITLE
Add duckdb-python submod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = cucascade
 	url = https://github.com/NVIDIA/cuCascade.git
 	branch = main
+[submodule "duckdb-python"]
+	path = duckdb-python
+	url = git@github.com:duckdb/duckdb-python.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -176,9 +176,9 @@ Note that if building the extension consumes too much memory, try reducing the `
 
 Optionally, to use the Python API in Sirius, we also need to build the duckdb-python package with the following commands:
 ```
-cd duckdb/tools/pythonpkg/
+pushd duckdb-python
 pip install .
-cd $SIRIUS_HOME_PATH
+popd
 ```
 Common issues: If `pip install .` only works inside an environment, then do the following from the Sirius home directory before the installation:
 ```


### PR DESCRIPTION
Duckdb moved its python package sources into a separate repository, this PR adds that as a submodule. It uses the same tag as our toplevel duckdb submodule.