### PR TITLE
Feature/adding new physical operators

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -18,10 +18,12 @@
 
 #include "op/scan/duckdb_scan_task.hpp"
 #include "op/sirius_physical_table_scan.hpp"
+#include "op/sirius_physical_top_n.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include <duckdb/parallel/thread_context.hpp>
 
+#include <iterator>
 #include <queue>
 
 namespace sirius::creator {
@@ -197,12 +199,29 @@ void task_creator::worker_function(int worker_id)
         _duckdb_scan_executor.schedule(std::move(scan_task));
         // scheduling pipeline task
       } else {
+        auto inner_ops = info->_pipeline->get_inner_operators();
+        auto* sink_op  = info->_pipeline->get_sink().get();
+        if (inner_ops.empty() && sink_op == nullptr) {
+          throw std::runtime_error("Pipeline has no operators to execute");
+        }
         duckdb::reference<sirius::op::sirius_physical_operator> node =
-          info->_pipeline->get_inner_operators()[0];
+          inner_ops.empty() ? duckdb::reference<sirius::op::sirius_physical_operator>(*sink_op)
+                            : inner_ops[0];
         info->_pipeline->get_sink()->set_creator(this);
         // need to exhaust input batches until all ports are empty
         while (!node.get().all_ports_empty()) {
-          auto input_batch = node.get().get_input_batch();
+          std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
+          if (sink_op && dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(sink_op)) {
+            while (!node.get().all_ports_empty()) {
+              auto next_batch = node.get().get_input_batch();
+              if (next_batch.empty()) { break; }
+              input_batch.insert(input_batch.end(),
+                                 std::make_move_iterator(next_batch.begin()),
+                                 std::make_move_iterator(next_batch.end()));
+            }
+          } else {
+            input_batch = node.get().get_input_batch();
+          }
           auto global_state =
             std::make_shared<pipeline::gpu_pipeline_task_global_state>(info->_pipeline);
           auto local_state =

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -19,6 +19,7 @@
 #include "op/scan/duckdb_scan_task.hpp"
 #include "op/sirius_physical_table_scan.hpp"
 #include "op/sirius_physical_top_n.hpp"
+#include "op/sirius_physical_ungrouped_aggregate.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include <duckdb/parallel/thread_context.hpp>
@@ -211,7 +212,9 @@ void task_creator::worker_function(int worker_id)
         // need to exhaust input batches until all ports are empty
         while (!node.get().all_ports_empty()) {
           std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
-          if (sink_op && dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(sink_op)) {
+          if (sink_op &&
+              (dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(sink_op) ||
+               dynamic_cast<sirius::op::sirius_physical_ungrouped_aggregate_merge*>(sink_op))) {
             while (!node.get().all_ports_empty()) {
               auto next_batch = node.get().get_input_batch();
               if (next_batch.empty()) { break; }

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -317,7 +317,6 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
   // Apply the bitmap
   auto output_table =
     cudf::apply_boolean_mask(input_table, bitmap->view(), execution_stream, resource_ref);
-  // Create the data representation
   std::unique_ptr<cucascade::idata_representation> output_data_rep =
     std::make_unique<cucascade::gpu_table_representation>(*output_table,
                                                           *input_batch->get_memory_space());

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -17,7 +17,7 @@
 // sirius
 #include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
-#include <cudf_utils.hpp>
+#include <data/data_batch_utils.hpp>
 #include <expression_executor/gpu_dispatcher.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <expression_executor/gpu_expression_executor_state.hpp>
@@ -220,7 +220,6 @@ void GpuExpressionExecutor::Execute(const GPUIntermediateRelation& input_relatio
 
 std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
   std::shared_ptr<cucascade::data_batch> input_batch,
-  cucascade::data_repository_manager<std::shared_ptr<cucascade::data_batch>>& data_repo_mgr,
   rmm::cuda_stream_view stream)
 {
   assert(!expressions.empty());
@@ -256,7 +255,7 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
                                                           *input_batch->get_memory_space());
 
   // Create the data batch and return
-  auto const batch_id = data_repo_mgr.get_next_data_batch_id();
+  auto const batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
 }
 
@@ -296,7 +295,6 @@ void GpuExpressionExecutor::Select(GPUIntermediateRelation& input_relation,
 
 std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
   std::shared_ptr<cucascade::data_batch> input_batch,
-  cucascade::data_repository_manager<std::shared_ptr<cucascade::data_batch>>& data_repo_mgr,
   rmm::cuda_stream_view stream)
 {
   assert(expressions.size() == 1);
@@ -322,7 +320,7 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
                                                           *input_batch->get_memory_space());
 
   // Create the data batch and return
-  auto const batch_id = data_repo_mgr.get_next_data_batch_id();
+  auto const batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
 }
 

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -219,8 +219,7 @@ void GpuExpressionExecutor::Execute(const GPUIntermediateRelation& input_relatio
 }
 
 std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
-  std::shared_ptr<cucascade::data_batch> input_batch,
-  rmm::cuda_stream_view stream)
+  std::shared_ptr<cucascade::data_batch> input_batch, rmm::cuda_stream_view stream)
 {
   assert(!expressions.empty());
 
@@ -294,8 +293,7 @@ void GpuExpressionExecutor::Select(GPUIntermediateRelation& input_relation,
 }
 
 std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
-  std::shared_ptr<cucascade::data_batch> input_batch,
-  rmm::cuda_stream_view stream)
+  std::shared_ptr<cucascade::data_batch> input_batch, rmm::cuda_stream_view stream)
 {
   assert(expressions.size() == 1);
   assert(expressions[0]->return_type == LogicalType::BOOLEAN);

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -34,6 +34,7 @@
 #include "op/sirius_physical_result_collector.hpp"
 #include "op/sirius_physical_table_scan.hpp"
 #include "op/sirius_physical_top_n.hpp"
+#include "op/sirius_physical_ungrouped_aggregate.hpp"
 #include "operator/gpu_physical_concat.hpp"
 #include "operator/gpu_physical_cte.hpp"
 #include "operator/gpu_physical_delim_join.hpp"
@@ -808,9 +809,13 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
       for (size_t i = 0; i < new_scheduled.size(); i++) {
         const bool is_top_n_merge_sink = dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(
                                            new_scheduled[i]->sink.get()) != nullptr;
+        const bool is_ungrouped_agg_merge_sink =
+          dynamic_cast<sirius::op::sirius_physical_ungrouped_aggregate_merge*>(
+            new_scheduled[i]->sink.get()) != nullptr;
         if (new_scheduled[i]->sink->type == PhysicalOperatorType::HASH_GROUP_BY ||
             new_scheduled[i]->sink->type == PhysicalOperatorType::ORDER_BY ||
             new_scheduled[i]->sink->type == PhysicalOperatorType::TOP_N || is_top_n_merge_sink ||
+            is_ungrouped_agg_merge_sink ||
             new_scheduled[i]->sink->type == PhysicalOperatorType::UNGROUPED_AGGREGATE) {
           auto sink_op             = new_scheduled[i]->get_sink().get();
           std::string_view port_id = "default";
@@ -861,16 +866,15 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
           for (auto dependent_pipeline : source_to_pipelines[column_data_scan]) {
             insert_repository("default", column_data_scan, new_scheduled[i], dependent_pipeline);
           }
-        } else if (new_scheduled[i]->sink->type == PhysicalOperatorType::INVALID) {
-          auto& partition =
-            new_scheduled[i]->get_sink()->Cast<sirius::op::sirius_physical_partition>();
-          std::string_view port_id = partition.is_build_partition() ? "build" : "default";
+        } else if (auto* partition = dynamic_cast<sirius::op::sirius_physical_partition*>(
+                     new_scheduled[i]->sink.get())) {
+          std::string_view port_id = partition->is_build_partition() ? "build" : "default";
 
-          if (partition.is_build_partition()) {
+          if (partition->is_build_partition()) {
             // For build partitions, no pipeline uses it as source.
             // Instead, connect directly to the HASH_JOIN operator stored in parent_op.
             // Find the pipeline containing this HASH_JOIN as the first operator.
-            sirius::op::sirius_physical_operator* hash_join_op = partition.get_parent_op();
+            sirius::op::sirius_physical_operator* hash_join_op = partition->get_parent_op();
             bool found                                         = false;
             for (size_t j = 0; j < new_scheduled.size(); j++) {
               // The join is guaranteed to be the first operator in the pipeline
@@ -983,7 +987,7 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
                    dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(pipeline->sink.get()) !=
                      nullptr ||
                    pipeline->sink->type == PhysicalOperatorType::UNGROUPED_AGGREGATE ||
-                   pipeline->sink->type == PhysicalOperatorType::INVALID ||
+                   pipeline->sink->type == PhysicalOperatorType::EXTENSION ||
                    pipeline->sink->type == PhysicalOperatorType::CTE) {
           std::string msg = "Sink " + pipeline->sink->get_name() + " next op after sink: ";
           for (auto next_port : pipeline->sink->get_next_port_after_sink()) {

--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -33,6 +33,7 @@
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_result_collector.hpp"
 #include "op/sirius_physical_table_scan.hpp"
+#include "op/sirius_physical_top_n.hpp"
 #include "operator/gpu_physical_concat.hpp"
 #include "operator/gpu_physical_cte.hpp"
 #include "operator/gpu_physical_delim_join.hpp"
@@ -588,7 +589,6 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
         bool group_agg_sort_topn_sink = false;
         if (current_pipeline->sink->type == PhysicalOperatorType::HASH_GROUP_BY ||
             current_pipeline->sink->type == PhysicalOperatorType::ORDER_BY ||
-            current_pipeline->sink->type == PhysicalOperatorType::TOP_N ||
             current_pipeline->sink->type == PhysicalOperatorType::UNGROUPED_AGGREGATE) {
           group_agg_sort_topn_sink = true;
         }
@@ -806,9 +806,11 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
 
       // add data repositories and ports
       for (size_t i = 0; i < new_scheduled.size(); i++) {
+        const bool is_top_n_merge_sink = dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(
+                                           new_scheduled[i]->sink.get()) != nullptr;
         if (new_scheduled[i]->sink->type == PhysicalOperatorType::HASH_GROUP_BY ||
             new_scheduled[i]->sink->type == PhysicalOperatorType::ORDER_BY ||
-            new_scheduled[i]->sink->type == PhysicalOperatorType::TOP_N ||
+            new_scheduled[i]->sink->type == PhysicalOperatorType::TOP_N || is_top_n_merge_sink ||
             new_scheduled[i]->sink->type == PhysicalOperatorType::UNGROUPED_AGGREGATE) {
           auto sink_op             = new_scheduled[i]->get_sink().get();
           std::string_view port_id = "default";
@@ -978,6 +980,8 @@ void GPUExecutor::initialize_internal(::sirius::op::sirius_physical_operator& pl
         } else if (pipeline->sink->type == PhysicalOperatorType::HASH_GROUP_BY ||
                    pipeline->sink->type == PhysicalOperatorType::ORDER_BY ||
                    pipeline->sink->type == PhysicalOperatorType::TOP_N ||
+                   dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(pipeline->sink.get()) !=
+                     nullptr ||
                    pipeline->sink->type == PhysicalOperatorType::UNGROUPED_AGGREGATE ||
                    pipeline->sink->type == PhysicalOperatorType::INVALID ||
                    pipeline->sink->type == PhysicalOperatorType::CTE) {

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -53,6 +53,7 @@
 
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/types.hpp>
+
 #include <memory>
 #include <vector>
 

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -53,6 +53,8 @@
 
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/types.hpp>
+#include <memory>
+#include <vector>
 
 namespace duckdb {
 
@@ -114,6 +116,16 @@ inline cudf::data_type GetCudfType(const LogicalType& logical_type)
       throw InvalidInputException("GetCudfType: Unsupported duckdb type: %d",
                                   static_cast<int>(logical_type.id()));
   }
+}
+
+inline std::unique_ptr<cudf::table> make_empty_like(cudf::table_view input)
+{
+  std::vector<std::unique_ptr<cudf::column>> empty_cols;
+  empty_cols.reserve(input.num_columns());
+  for (cudf::size_type col_idx = 0; col_idx < input.num_columns(); ++col_idx) {
+    empty_cols.push_back(cudf::make_empty_column(input.column(col_idx).type()));
+  }
+  return std::make_unique<cudf::table>(std::move(empty_cols));
 }
 
 }  // namespace duckdb

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -135,7 +135,6 @@ struct GpuExpressionExecutor {
    * output batch holding the results.
    *
    * @param input_batch The input batch against which to evaluate expressions
-   * @param data_repo_mgr The data repository manager (for constructing a new output data batch)
    * @param stream The stream in which to execute the operations in the expression tree
    *
    * @return std::shared_ptr<cucascade::data_batch> The result of the evaluated expressions
@@ -143,14 +142,12 @@ struct GpuExpressionExecutor {
    * @note It is required that there is only one boolean expression in the current expression set.
    */
   std::shared_ptr<data_batch> execute(std::shared_ptr<data_batch> input_batch,
-                                      data_repository_manager& data_repo_mgr,
                                       rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   /**
    * @brief Evaluates a boolean expression and filters the input batch according to the result.
    *
    * @param input_batch The input batch against which to evaluate the expression
-   * @param data_repo_mgr The data repository manager (for constructing a new output data batch)
    * @param stream The stream in which to execute the operations in the expression tree
    *
    * @return std::shared_ptr<cucascade::data_batch> The input batch filtered by the boolean
@@ -158,7 +155,6 @@ struct GpuExpressionExecutor {
    */
   std::shared_ptr<cucascade::data_batch> select(
     std::shared_ptr<data_batch> input_batch,
-    data_repository_manager& data_repo_mgr,
     rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   // Execute the expression at the given index and return the result

--- a/src/include/op/merge/gpu_merge_impl.hpp
+++ b/src/include/op/merge/gpu_merge_impl.hpp
@@ -112,32 +112,6 @@ class gpu_merge_impl {
     const std::vector<cudf::null_order>& null_precedence,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space);
-
-  /**
-   * @brief Perform merge top-n on multiple data batches.
-   *
-   * @param input The input batches to be merged.
-   * @param limit The number of top rows to output in the final global result.
-   * @param offset The number of rows to skip in the final global result.
-   * @param order_key_idx The columns to sort on.
-   * @param column_order The desired sort order for each column.
-   * @param null_precedence The desired order of null compared to other elements for each column.
-   * Should have `order_idx.size() = column_order.size() = null_precedence.size()`, and the three
-   * parameters should be consistent to the top-n order of each input batch.
-   * @param stream CUDA stream used for device memory operations and kernel launches.
-   * @param memory_space The memory space used to allocate memory for the output data batch.
-   *
-   * @return The output data batch.
-   */
-  static std::shared_ptr<cucascade::data_batch> merge_top_n(
-    const std::vector<std::shared_ptr<cucascade::data_batch>>& input,
-    const int limit,
-    const int offset,
-    const std::vector<int>& order_key_idx,
-    const std::vector<cudf::order>& column_order,
-    const std::vector<cudf::null_order>& null_precedence,
-    rmm::cuda_stream_view stream,
-    cucascade::memory::memory_space& memory_space);
 };
 
 }  // namespace op

--- a/src/include/op/order/gpu_order_impl.hpp
+++ b/src/include/op/order/gpu_order_impl.hpp
@@ -56,33 +56,6 @@ class gpu_order_impl {
     const std::vector<int>& projections,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space);
-
-  /**
-   * @brief Perform local top-n (with offset) on the input data batch.
-   *
-   * @param input The input data batch.
-   * @param limit The number of top rows to output in the final global result.
-   * @param offset The number of rows to skip in the final global result.
-   * @param order_key_idx The columns to sort on.
-   * @param column_order The desired sort order for each column.
-   * @param null_precedence The desired order of null compared to other elements for each column.
-   * Should have `order_idx.size() = column_order.size() = null_precedence.size()`.
-   * @param projections The columns to construct output based on the sorted order.
-   * @param stream CUDA stream used for device memory operations and kernel launches.
-   * @param memory_space The memory space used to allocate memory for the output data batch.
-   *
-   * @return The output data batch.
-   */
-  static std::shared_ptr<cucascade::data_batch> local_top_n(
-    std::shared_ptr<cucascade::data_batch> input,
-    const int limit,
-    const int offset,
-    const std::vector<int>& order_key_idx,
-    const std::vector<cudf::order>& column_order,
-    const std::vector<cudf::null_order>& null_precedence,
-    const std::vector<int>& projections,
-    rmm::cuda_stream_view stream,
-    cucascade::memory::memory_space& memory_space);
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -29,7 +29,8 @@ namespace op {
 
 class sirius_physical_concat : public sirius_physical_operator {
  public:
-  static constexpr const duckdb::PhysicalOperatorType TYPE = duckdb::PhysicalOperatorType::INVALID;
+  static constexpr const duckdb::PhysicalOperatorType TYPE =
+    duckdb::PhysicalOperatorType::EXTENSION;
 
   explicit sirius_physical_concat(duckdb::vector<duckdb::LogicalType> types,
                                   duckdb::idx_t estimated_cardinality);

--- a/src/include/op/sirius_physical_filter.hpp
+++ b/src/include/op/sirius_physical_filter.hpp
@@ -31,8 +31,7 @@ class sirius_physical_filter : public sirius_physical_operator {
  public:
   sirius_physical_filter(duckdb::vector<duckdb::LogicalType> types,
                          duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-                         duckdb::idx_t estimated_cardinality,
-                         cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
+                         duckdb::idx_t estimated_cardinality);
 
   //! The filter expression
   duckdb::unique_ptr<duckdb::Expression> expression;

--- a/src/include/op/sirius_physical_filter.hpp
+++ b/src/include/op/sirius_physical_filter.hpp
@@ -31,10 +31,14 @@ class sirius_physical_filter : public sirius_physical_operator {
  public:
   sirius_physical_filter(duckdb::vector<duckdb::LogicalType> types,
                          duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-                         duckdb::idx_t estimated_cardinality);
+                         duckdb::idx_t estimated_cardinality,
+                         cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
 
   //! The filter expression
   duckdb::unique_ptr<duckdb::Expression> expression;
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 
   // sirius_expression_executor* sirius_expression_executor;
 

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -34,11 +34,15 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
                                   duckdb::BoundLimitNode limit_val_p,
                                   duckdb::BoundLimitNode offset_val_p,
                                   duckdb::idx_t estimated_cardinality,
-                                  bool parallel);
+                                  bool parallel,
+                                  ::cucascade::shared_data_repository_manager* data_repo_mgr);
 
   duckdb::BoundLimitNode limit_val;
   duckdb::BoundLimitNode offset_val;
   bool parallel;
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -34,8 +34,7 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
                                   duckdb::BoundLimitNode limit_val_p,
                                   duckdb::BoundLimitNode offset_val_p,
                                   duckdb::idx_t estimated_cardinality,
-                                  bool parallel,
-                                  ::cucascade::shared_data_repository_manager* data_repo_mgr);
+                                  bool parallel);
 
   duckdb::BoundLimitNode limit_val;
   duckdb::BoundLimitNode offset_val;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/enums/operator_result_type.hpp"
 #include "duckdb/common/enums/order_preservation_type.hpp"
 #include "duckdb/common/enums/physical_operator_type.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/execution_context.hpp"
@@ -31,6 +32,7 @@
 
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
+#include <cucascade/data/data_repository_manager.hpp>
 
 namespace duckdb {
 class GPUExecutor;
@@ -67,9 +69,17 @@ class sirius_physical_operator {
  public:
   sirius_physical_operator(duckdb::PhysicalOperatorType type,
                            duckdb::vector<duckdb::LogicalType> types,
-                           duckdb::idx_t estimated_cardinality)
-    : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality)
+                           duckdb::idx_t estimated_cardinality,
+                           ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr)
+    : type(type),
+      types(std::move(types)),
+      estimated_cardinality(estimated_cardinality),
+      data_repo_mgr(data_repo_mgr)
   {
+    if (data_repo_mgr == nullptr) {
+      throw duckdb::InternalException(
+        "sirius_physical_operator requires a non-null data_repository_manager");
+    }
   }
   sirius_physical_operator() = default;
 
@@ -225,6 +235,16 @@ class sirius_physical_operator {
   std::vector<std::pair<sirius_physical_operator*, std::string_view>> next_port_after_sink;
   //! The creator of the task
   creator::task_creator* creator;
+
+  //! Shared data repository manager (owned upstream, propagated to operators)
+  ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr;
+
+ public:
+  ::cucascade::shared_data_repository_manager* get_data_repository_manager() const
+  {
+    return data_repo_mgr;
+  }
+
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -70,7 +70,7 @@ class sirius_physical_operator {
   sirius_physical_operator(duckdb::PhysicalOperatorType type,
                            duckdb::vector<duckdb::LogicalType> types,
                            duckdb::idx_t estimated_cardinality,
-                           ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr)
+                           cucascade::shared_data_repository_manager* data_repo_mgr = nullptr)
     : type(type),
       types(std::move(types)),
       estimated_cardinality(estimated_cardinality),
@@ -237,10 +237,10 @@ class sirius_physical_operator {
   creator::task_creator* creator;
 
   //! Shared data repository manager (owned upstream, propagated to operators)
-  ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr;
+  cucascade::shared_data_repository_manager* data_repo_mgr = nullptr;
 
  public:
-  ::cucascade::shared_data_repository_manager* get_data_repository_manager() const
+  cucascade::shared_data_repository_manager* get_data_repository_manager() const
   {
     return data_repo_mgr;
   }

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -32,7 +32,6 @@
 
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
-#include <cucascade/data/data_repository_manager.hpp>
 
 namespace duckdb {
 class GPUExecutor;
@@ -69,17 +68,9 @@ class sirius_physical_operator {
  public:
   sirius_physical_operator(duckdb::PhysicalOperatorType type,
                            duckdb::vector<duckdb::LogicalType> types,
-                           duckdb::idx_t estimated_cardinality,
-                           cucascade::shared_data_repository_manager* data_repo_mgr = nullptr)
-    : type(type),
-      types(std::move(types)),
-      estimated_cardinality(estimated_cardinality),
-      data_repo_mgr(data_repo_mgr)
+                           duckdb::idx_t estimated_cardinality)
+    : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality)
   {
-    if (data_repo_mgr == nullptr) {
-      throw duckdb::InternalException(
-        "sirius_physical_operator requires a non-null data_repository_manager");
-    }
   }
   sirius_physical_operator() = default;
 
@@ -235,16 +226,6 @@ class sirius_physical_operator {
   std::vector<std::pair<sirius_physical_operator*, std::string_view>> next_port_after_sink;
   //! The creator of the task
   creator::task_creator* creator;
-
-  //! Shared data repository manager (owned upstream, propagated to operators)
-  cucascade::shared_data_repository_manager* data_repo_mgr = nullptr;
-
- public:
-  cucascade::shared_data_repository_manager* get_data_repository_manager() const
-  {
-    return data_repo_mgr;
-  }
-
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -31,7 +31,8 @@ namespace op {
 
 class sirius_physical_partition : public sirius_physical_operator {
  public:
-  static constexpr const duckdb::PhysicalOperatorType TYPE = duckdb::PhysicalOperatorType::INVALID;
+  static constexpr const duckdb::PhysicalOperatorType TYPE =
+    duckdb::PhysicalOperatorType::EXTENSION;
 
   explicit sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
                                      duckdb::idx_t estimated_cardinality,

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -30,8 +30,7 @@ class sirius_physical_projection : public sirius_physical_operator {
  public:
   sirius_physical_projection(duckdb::vector<duckdb::LogicalType> types,
                              duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-                             duckdb::idx_t estimated_cardinality,
-                             ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
+                             duckdb::idx_t estimated_cardinality);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -30,7 +30,11 @@ class sirius_physical_projection : public sirius_physical_operator {
  public:
   sirius_physical_projection(duckdb::vector<duckdb::LogicalType> types,
                              duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-                             duckdb::idx_t estimated_cardinality);
+                             duckdb::idx_t estimated_cardinality,
+                             ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
 };

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -66,7 +66,8 @@ class sirius_physical_top_n : public sirius_physical_operator {
 
 class sirius_physical_top_n_merge : public sirius_physical_operator {
  public:
-  static constexpr const duckdb::PhysicalOperatorType TYPE = duckdb::PhysicalOperatorType::INVALID;
+  static constexpr const duckdb::PhysicalOperatorType TYPE =
+    duckdb::PhysicalOperatorType::EXTENSION;
 
  public:
   sirius_physical_top_n_merge(duckdb::vector<duckdb::LogicalType> types_p,

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -22,7 +22,6 @@
 #include <cudf/table/table.hpp>
 
 #include <memory>
-#include <mutex>
 
 namespace duckdb {
 struct DynamicFilterData;
@@ -63,12 +62,38 @@ class sirius_physical_top_n : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
-    private:
-    struct topn_state {
-      std::mutex _mutex;
-      std::unique_ptr<cudf::table> _top_table;
-    };
-    std::shared_ptr<topn_state> _state;
+};
+
+class sirius_physical_top_n_merge : public sirius_physical_operator {
+ public:
+  static constexpr const duckdb::PhysicalOperatorType TYPE = duckdb::PhysicalOperatorType::INVALID;
+
+ public:
+  sirius_physical_top_n_merge(duckdb::vector<duckdb::LogicalType> types_p,
+                              duckdb::vector<duckdb::BoundOrderByNode> orders,
+                              duckdb::idx_t limit,
+                              duckdb::idx_t offset,
+                              duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter,
+                              duckdb::idx_t estimated_cardinality);
+  ~sirius_physical_top_n_merge() override;
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  duckdb::idx_t limit;
+  duckdb::idx_t offset;
+  //! Dynamic table filter (if any)
+  duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter;
+
+ public:
+  bool is_source() const override { return true; }
+  duckdb::OrderPreservationType source_order() const override
+  {
+    return duckdb::OrderPreservationType::FIXED_ORDER;
+  }
+
+ public:
+  bool is_sink() const override { return true; }
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -62,6 +62,14 @@ class sirius_physical_top_n : public sirius_physical_operator {
 
  public:
   bool is_sink() const override { return true; }
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
+    private:
+    struct topn_state {
+      std::mutex _mutex;
+      std::unique_ptr<cudf::table> _top_table;
+    };
+    std::shared_ptr<topn_state> _state;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -18,6 +18,12 @@
 
 #include "duckdb/planner/bound_query_node.hpp"
 #include "op/sirius_physical_operator.hpp"
+
+#include <cudf/table/table.hpp>
+
+#include <memory>
+#include <mutex>
+
 namespace duckdb {
 struct DynamicFilterData;
 }  // namespace duckdb
@@ -37,7 +43,8 @@ class sirius_physical_top_n : public sirius_physical_operator {
                         duckdb::idx_t limit,
                         duckdb::idx_t offset,
                         duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter,
-                        duckdb::idx_t estimated_cardinality);
+                        duckdb::idx_t estimated_cardinality,
+                        ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
   ~sirius_physical_top_n() override;
 
   duckdb::vector<duckdb::BoundOrderByNode> orders;

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -43,8 +43,7 @@ class sirius_physical_top_n : public sirius_physical_operator {
                         duckdb::idx_t limit,
                         duckdb::idx_t offset,
                         duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter,
-                        duckdb::idx_t estimated_cardinality,
-                        ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
+                        duckdb::idx_t estimated_cardinality);
   ~sirius_physical_top_n() override;
 
   duckdb::vector<duckdb::BoundOrderByNode> orders;

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -23,6 +23,8 @@
 #include "duckdb/parser/group_by_node.hpp"
 #include "op/sirius_physical_operator.hpp"
 
+#include <cudf/scalar/scalar.hpp>
+
 namespace sirius {
 namespace op {
 
@@ -51,7 +53,6 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 
-
  private:
   struct agg_state {
     std::mutex _mutex;
@@ -60,7 +61,6 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
     std::vector<int64_t> _running_counts;                        // for AVG/COUNT
   };
   std::shared_ptr<agg_state> _state = std::make_shared<agg_state>();
-
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -38,8 +38,7 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
     duckdb::vector<duckdb::LogicalType> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
     duckdb::idx_t estimated_cardinality,
-    duckdb::TupleDataValidityType distinct_validity,
-    ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
+    duckdb::TupleDataValidityType distinct_validity);
 
   //! The aggregates that have to be computed
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -36,7 +36,8 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
     duckdb::vector<duckdb::LogicalType> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
     duckdb::idx_t estimated_cardinality,
-    duckdb::TupleDataValidityType distinct_validity);
+    duckdb::TupleDataValidityType distinct_validity,
+    ::cucascade::shared_data_repository_manager* data_repo_mgr = nullptr);
 
   //! The aggregates that have to be computed
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
@@ -47,6 +48,19 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
 
  public:
   bool is_sink() const override { return true; }
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
+
+
+ private:
+  struct agg_state {
+    std::mutex _mutex;
+    bool _initialized = false;
+    std::vector<std::unique_ptr<cudf::scalar>> _running_values;  // one per aggregate
+    std::vector<int64_t> _running_counts;                        // for AVG/COUNT
+  };
+  std::shared_ptr<agg_state> _state = std::make_shared<agg_state>();
+
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -23,8 +23,6 @@
 #include "duckdb/parser/group_by_node.hpp"
 #include "op/sirius_physical_operator.hpp"
 
-#include <cudf/scalar/scalar.hpp>
-
 namespace sirius {
 namespace op {
 
@@ -51,15 +49,28 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
+};
 
- private:
-  struct agg_state {
-    std::mutex _mutex;
-    bool _initialized = false;
-    std::vector<std::unique_ptr<cudf::scalar>> _running_values;  // one per aggregate
-    std::vector<int64_t> _running_counts;                        // for AVG/COUNT
-  };
-  std::shared_ptr<agg_state> _state = std::make_shared<agg_state>();
+class sirius_physical_ungrouped_aggregate_merge : public sirius_physical_operator {
+ public:
+  static constexpr const duckdb::PhysicalOperatorType TYPE =
+    duckdb::PhysicalOperatorType::EXTENSION;
+
+ public:
+  sirius_physical_ungrouped_aggregate_merge(
+    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
+    duckdb::idx_t estimated_cardinality);
+
+  //! The aggregates that have to be computed
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
+
+  bool is_source() const override { return true; }
+
+ public:
+  bool is_sink() const override { return true; }
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches) override;
 };
 
 }  // namespace op

--- a/src/include/operator/gpu_physical_concat.hpp
+++ b/src/include/operator/gpu_physical_concat.hpp
@@ -28,7 +28,7 @@ namespace duckdb {
 
 class GPUPhysicalConcat : public GPUPhysicalOperator {
  public:
-  static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::INVALID;
+  static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
 
   explicit GPUPhysicalConcat(vector<LogicalType> types, idx_t estimated_cardinality);
 

--- a/src/include/operator/gpu_physical_partition.hpp
+++ b/src/include/operator/gpu_physical_partition.hpp
@@ -30,7 +30,7 @@ namespace duckdb {
 
 class GPUPhysicalPartition : public GPUPhysicalOperator {
  public:
-  static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::INVALID;
+  static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
 
   explicit GPUPhysicalPartition(vector<LogicalType> types,
                                 idx_t estimated_cardinality,

--- a/src/include/planner/sirius_plan_utils.hpp
+++ b/src/include/planner/sirius_plan_utils.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/planner/bound_result_modifier.hpp"
+
+namespace sirius::planner {
+
+inline duckdb::vector<duckdb::BoundOrderByNode> copy_order_nodes(
+  const duckdb::vector<duckdb::BoundOrderByNode>& orders)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> copies;
+  copies.reserve(orders.size());
+  for (const auto& order : orders) {
+    copies.push_back(order.Copy());
+  }
+  return copies;
+}
+
+}  // namespace sirius::planner

--- a/src/op/merge/gpu_merge_impl.cpp
+++ b/src/op/merge/gpu_merge_impl.cpp
@@ -16,6 +16,7 @@
 
 #include "op/merge/gpu_merge_impl.hpp"
 
+#include "cudf/cudf_utils.hpp"
 #include "data/data_batch_utils.hpp"
 
 #include <cudf/concatenate.hpp>
@@ -235,64 +236,6 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_order_by(
                                   null_precedence,
                                   stream,
                                   memory_space.get_default_allocator());
-
-  // Create the output data batch
-  return make_data_batch(std::move(output_table), memory_space);
-}
-
-std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_top_n(
-  const std::vector<std::shared_ptr<cucascade::data_batch>>& input,
-  const int limit,
-  const int offset,
-  const std::vector<int>& order_key_idx,
-  const std::vector<cudf::order>& column_order,
-  const std::vector<cudf::null_order>& null_precedence,
-  rmm::cuda_stream_view stream,
-  cucascade::memory::memory_space& memory_space)
-{
-  // Sanity check.
-  if (input.size() < 2) {
-    throw std::runtime_error("`input` in `merge_top_n()` should at least contain two data batches");
-  }
-  if (order_key_idx.size() != column_order.size() ||
-      order_key_idx.size() != null_precedence.size()) {
-    throw std::runtime_error(
-      "mismatch between the sizes of `order_key_idx`, `column_order`, and "
-      "`null_precedence` in `merge_top_n()`");
-  }
-
-  // Pull input cudf tables and merge.
-  std::vector<cudf::table_view> input_tables;
-  input_tables.reserve(input.size());
-  for (const auto& batch : input) {
-    input_tables.push_back(get_cudf_table_view(*batch));
-  }
-  auto merged_table = cudf::merge(input_tables,
-                                  order_key_idx,
-                                  column_order,
-                                  null_precedence,
-                                  stream,
-                                  memory_space.get_default_allocator());
-
-  // Process limit and offset
-  std::unique_ptr<cudf::table> output_table = nullptr;
-  if (offset >= merged_table->num_rows()) {
-    std::vector<std::unique_ptr<cudf::column>> empty_cols;
-    for (cudf::size_type c = 0; c < merged_table->num_columns(); ++c) {
-      empty_cols.push_back(cudf::make_empty_column(merged_table->get_column(c).type()));
-    }
-    output_table = std::make_unique<cudf::table>(std::move(empty_cols));
-  } else if (offset == 0 && limit >= merged_table->num_rows()) {
-    output_table = std::move(merged_table);
-  } else {
-    output_table = std::make_unique<cudf::table>(
-      cudf::slice(
-        merged_table->view(),
-        {offset, std::min(merged_table->num_rows(), static_cast<cudf::size_type>(offset + limit))},
-        stream)[0],
-      stream,
-      memory_space.get_default_allocator());
-  }
 
   // Create the output data batch
   return make_data_batch(std::move(output_table), memory_space);

--- a/src/op/order/gpu_order_impl.cpp
+++ b/src/op/order/gpu_order_impl.cpp
@@ -43,67 +43,22 @@ std::shared_ptr<cucascade::data_batch> gpu_order_impl::local_order_by(
   for (int idx : order_key_idx) {
     sort_cols.push_back(input_table.column(idx));
   }
-  auto sorted_order =
-    cudf::sorted_order(cudf::table_view(sort_cols), column_order, null_precedence);
+  auto sorted_order = cudf::sorted_order(cudf::table_view(sort_cols),
+                                         column_order,
+                                         null_precedence,
+                                         stream,
+                                         memory_space.get_default_allocator());
 
   // Do projection
   std::vector<cudf::column_view> project_input_cols;
   for (int idx : projections) {
     project_input_cols.push_back(input_table.column(idx));
   }
-  auto output_table = cudf::gather(cudf::table_view(project_input_cols), sorted_order->view());
-
-  // Create the output data batch
-  return make_data_batch(std::move(output_table), memory_space);
-}
-
-std::shared_ptr<cucascade::data_batch> gpu_order_impl::local_top_n(
-  std::shared_ptr<cucascade::data_batch> input,
-  const int limit,
-  const int offset,
-  const std::vector<int>& order_key_idx,
-  const std::vector<cudf::order>& column_order,
-  const std::vector<cudf::null_order>& null_precedence,
-  const std::vector<int>& projections,
-  rmm::cuda_stream_view stream,
-  cucascade::memory::memory_space& memory_space)
-{
-  if (order_key_idx.size() != column_order.size() ||
-      order_key_idx.size() != null_precedence.size()) {
-    throw std::runtime_error(
-      "mismatch between the sizes of `order_key_idx`, `column_order`, and "
-      "`null_precedence` in `local_top_n()`");
-  }
-
-  // Get sorted order
-  auto input_table = get_cudf_table_view(*input);
-  std::vector<cudf::column_view> sort_cols;
-  for (int idx : order_key_idx) {
-    sort_cols.push_back(input_table.column(idx));
-  }
-  auto sorted_order =
-    cudf::sorted_order(cudf::table_view(sort_cols), column_order, null_precedence);
-
-  // Get top `limit + offset` rows
-  std::unique_ptr<cudf::table> output_table = nullptr;
-  if (sorted_order->size() == 0) {
-    std::vector<std::unique_ptr<cudf::column>> empty_cols;
-    for (int idx : projections) {
-      empty_cols.push_back(cudf::make_empty_column(input_table.column(idx).type()));
-    }
-    output_table = std::make_unique<cudf::table>(std::move(empty_cols));
-  } else {
-    auto sliced_sorted_order =
-      (limit + offset >= static_cast<int>(sorted_order->size()))
-        ? sorted_order->view()
-        : cudf::slice(
-            sorted_order->view(), {0, static_cast<cudf::size_type>(limit + offset)}, stream)[0];
-    std::vector<cudf::column_view> project_input_cols;
-    for (int idx : projections) {
-      project_input_cols.push_back(input_table.column(idx));
-    }
-    output_table = cudf::gather(cudf::table_view(project_input_cols), sliced_sorted_order);
-  }
+  auto output_table = cudf::gather(cudf::table_view(project_input_cols),
+                                   sorted_order->view(),
+                                   cudf::out_of_bounds_policy::DONT_CHECK,
+                                   stream,
+                                   memory_space.get_default_allocator());
 
   // Create the output data batch
   return make_data_batch(std::move(output_table), memory_space);

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -31,7 +31,7 @@ namespace op {
 sirius_physical_concat::sirius_physical_concat(duckdb::vector<duckdb::LogicalType> types,
                                                duckdb::idx_t estimated_cardinality)
   : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::INVALID, std::move(types), estimated_cardinality)
+      duckdb::PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality)
 {
   _num_partitions = (estimated_cardinality + PARTITION_SIZE - 1) / PARTITION_SIZE;
 }

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -36,10 +36,9 @@ namespace op {
 sirius_physical_filter::sirius_physical_filter(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-  duckdb::idx_t estimated_cardinality,
-  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  duckdb::idx_t estimated_cardinality)
   : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality, data_repo_mgr)
+      duckdb::PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality)
 {
   D_ASSERT(select_list.size() > 0);
   if (select_list.size() > 1) {
@@ -64,18 +63,13 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_filter::exec
 
   // The executor uses the data_batch API to filter rows according to `expression`.
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*expression.get());
-  auto* data_repo_mgr = get_data_repository_manager();
-  if (data_repo_mgr == nullptr) {
-    throw duckdb::InternalException(
-      "sirius_physical_filter::execute requires a data_repository_manager to be set");
-  }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
-    auto filtered_batch = gpu_expression_executor.select(batch, *data_repo_mgr);
+    auto filtered_batch = gpu_expression_executor.select(batch);
     if (filtered_batch) { output_batches.push_back(std::move(filtered_batch)); }
   }
 

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -27,15 +27,19 @@
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "log/logging.hpp"
 
+#include <chrono>
+#include <stdexcept>
+
 namespace sirius {
 namespace op {
 
 sirius_physical_filter::sirius_physical_filter(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-  duckdb::idx_t estimated_cardinality)
+  duckdb::idx_t estimated_cardinality,
+  ::cucascade::shared_data_repository_manager* data_repo_mgr)
   : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality)
+      duckdb::PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality, data_repo_mgr)
 {
   D_ASSERT(select_list.size() > 0);
   if (select_list.size() > 1) {
@@ -50,6 +54,36 @@ sirius_physical_filter::sirius_physical_filter(
   } else {
     expression = std::move(select_list[0]);
   }
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_filter::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  SIRIUS_LOG_DEBUG("Executing expression {}", expression->ToString());
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // The executor uses the data_batch API to filter rows according to `expression`.
+  duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*expression.get());
+  auto* data_repo_mgr = get_data_repository_manager();
+  if (data_repo_mgr == nullptr) {
+    throw duckdb::InternalException(
+      "sirius_physical_filter::execute requires a data_repository_manager to be set");
+  }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(input_batches.size());
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto filtered_batch = gpu_expression_executor.select(batch, *data_repo_mgr);
+    if (filtered_batch) { output_batches.push_back(std::move(filtered_batch)); }
+  }
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG("Filter time: {:.2f} ms", duration.count() / 1000.0);
+
+  return output_batches;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -16,10 +16,11 @@
 
 #include "op/sirius_physical_limit.hpp"
 
+#include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_materialize.hpp"
-#include "data/data_batch_utils.hpp"
+
 #include <cudf/copying.hpp>
 
 #include <cucascade/data/gpu_data_representation.hpp>
@@ -33,9 +34,8 @@ sirius_physical_streaming_limit::sirius_physical_streaming_limit(
   duckdb::BoundLimitNode offset_val_p,
   duckdb::idx_t estimated_cardinality,
   bool parallel)
-  : sirius_physical_operator(duckdb::PhysicalOperatorType::STREAMING_LIMIT,
-                             std::move(types),
-                             estimated_cardinality),
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::STREAMING_LIMIT, std::move(types), estimated_cardinality),
     limit_val(std::move(limit_val_p)),
     offset_val(std::move(offset_val_p)),
     parallel(parallel)

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -20,6 +20,10 @@
 #include "log/logging.hpp"
 #include "operator/gpu_materialize.hpp"
 
+#include <cudf/copying.hpp>
+
+#include <cucascade/data/gpu_data_representation.hpp>
+
 namespace sirius {
 namespace op {
 
@@ -28,13 +32,73 @@ sirius_physical_streaming_limit::sirius_physical_streaming_limit(
   duckdb::BoundLimitNode limit_val_p,
   duckdb::BoundLimitNode offset_val_p,
   duckdb::idx_t estimated_cardinality,
-  bool parallel)
-  : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::STREAMING_LIMIT, std::move(types), estimated_cardinality),
+  bool parallel,
+  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  : sirius_physical_operator(duckdb::PhysicalOperatorType::STREAMING_LIMIT,
+                             std::move(types),
+                             estimated_cardinality,
+                             data_repo_mgr),
     limit_val(std::move(limit_val_p)),
     offset_val(std::move(offset_val_p)),
     parallel(parallel)
 {
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_limit::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  SIRIUS_LOG_DEBUG("Executing streaming limit");
+
+  if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE ||
+      offset_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
+    throw duckdb::NotImplementedException("Streaming limit with non-constant limit/offset");
+  }
+
+  auto limit_const  = static_cast<cudf::size_type>(limit_val.GetConstantValue());
+  auto offset_const = static_cast<cudf::size_type>(offset_val.GetConstantValue());
+
+  auto* data_repo_mgr = get_data_repository_manager();
+  if (data_repo_mgr == nullptr) {
+    throw duckdb::InternalException(
+      "sirius_physical_streaming_limit::execute requires a data_repository_manager to be set");
+  }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(input_batches.size());
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+
+    auto input_table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+    auto view        = input_table.view();
+
+    if (offset_const >= view.num_rows() || limit_const == 0) {
+      continue;  // nothing to output from this batch
+    }
+
+    auto end_row = std::min<cudf::size_type>(view.num_rows(), offset_const + limit_const);
+    auto slices  = cudf::slice(view, {offset_const, end_row});
+    if (slices.empty()) { continue; }
+
+    // cudf::slice returns a vector of table_views; materialize into a table
+    auto sliced_table = std::make_unique<cudf::table>(slices.front());
+
+    std::unique_ptr<cucascade::idata_representation> output_data =
+      std::make_unique<cucascade::gpu_table_representation>(std::move(*sliced_table),
+                                                            *batch->get_memory_space());
+
+    auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+    auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+    output_batches.push_back(std::move(output_batch));
+
+    // If we've satisfied the limit across batches, adjust remaining and break early
+    auto produced = end_row - offset_const;
+    if (produced >= limit_const) { break; }
+    limit_const -= produced;
+    offset_const = 0;  // offset only applies to the first batch with rows
+  }
+
+  return output_batches;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -19,7 +19,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_materialize.hpp"
-
+#include "data/data_batch_utils.hpp"
 #include <cudf/copying.hpp>
 
 #include <cucascade/data/gpu_data_representation.hpp>
@@ -32,12 +32,10 @@ sirius_physical_streaming_limit::sirius_physical_streaming_limit(
   duckdb::BoundLimitNode limit_val_p,
   duckdb::BoundLimitNode offset_val_p,
   duckdb::idx_t estimated_cardinality,
-  bool parallel,
-  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  bool parallel)
   : sirius_physical_operator(duckdb::PhysicalOperatorType::STREAMING_LIMIT,
                              std::move(types),
-                             estimated_cardinality,
-                             data_repo_mgr),
+                             estimated_cardinality),
     limit_val(std::move(limit_val_p)),
     offset_val(std::move(offset_val_p)),
     parallel(parallel)
@@ -56,12 +54,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_li
 
   auto limit_const  = static_cast<cudf::size_type>(limit_val.GetConstantValue());
   auto offset_const = static_cast<cudf::size_type>(offset_val.GetConstantValue());
-
-  auto* data_repo_mgr = get_data_repository_manager();
-  if (data_repo_mgr == nullptr) {
-    throw duckdb::InternalException(
-      "sirius_physical_streaming_limit::execute requires a data_repository_manager to be set");
-  }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(input_batches.size());
@@ -87,7 +79,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_li
       std::make_unique<cucascade::gpu_table_representation>(std::move(*sliced_table),
                                                             *batch->get_memory_space());
 
-    auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+    auto const batch_id = ::sirius::get_next_batch_id();
     auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
     output_batches.push_back(std::move(output_batch));
 

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -197,11 +197,11 @@ void sirius_physical_operator::sink(
   }
 }
 
-::std::vector<::std::shared_ptr<::cucascade::data_batch>> sirius_physical_operator::execute(
-  const ::std::vector<::std::shared_ptr<::cucascade::data_batch>>& input_batches)
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_operator::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
 {
   // not doing anything for now
-  return ::std::vector<::std::shared_ptr<::cucascade::data_batch>>{};
+  return std::vector<std::shared_ptr<cucascade::data_batch>>{};
 }
 
 void sirius_physical_operator::push_data_batch(std::string_view port_id,

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -86,14 +86,6 @@ void sirius_physical_partition::get_partition_keys(sirius_physical_operator* op,
         _partition_keys.push_back(expr->Cast<duckdb::BoundReferenceExpression>().index);
       }
     }
-  } else if (op->type == duckdb::PhysicalOperatorType::TOP_N) {
-    auto& top_n_op = op->Cast<sirius_physical_top_n>();
-    for (size_t order_idx = 0; order_idx < top_n_op.orders.size(); order_idx++) {
-      auto& expr = top_n_op.orders[order_idx].expression;
-      if (expr->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-        _partition_keys.push_back(expr->Cast<duckdb::BoundReferenceExpression>().index);
-      }
-    }
   }
 }
 

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -32,7 +32,7 @@ sirius_physical_partition::sirius_physical_partition(duckdb::vector<duckdb::Logi
                                                      sirius_physical_operator* parent_op,
                                                      bool is_build)
   : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::INVALID, std::move(types), estimated_cardinality)
+      duckdb::PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality)
 {
   _num_partitions = (estimated_cardinality + PARTITION_SIZE - 1) / PARTITION_SIZE;
   _parent_op      = parent_op;

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -34,12 +34,10 @@ namespace op {
 sirius_physical_projection::sirius_physical_projection(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-  duckdb::idx_t estimated_cardinality,
-  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  duckdb::idx_t estimated_cardinality)
   : sirius_physical_operator(duckdb::PhysicalOperatorType::PROJECTION,
                              std::move(types),
-                             estimated_cardinality,
-                             data_repo_mgr),
+                             estimated_cardinality),
     select_list(std::move(select_list))
 {
 }
@@ -50,12 +48,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_projection::
   SIRIUS_LOG_DEBUG("Executing projection");
   auto start = std::chrono::high_resolution_clock::now();
 
-  auto* data_repo_mgr = get_data_repository_manager();
-  if (data_repo_mgr == nullptr) {
-    throw duckdb::InternalException(
-      "sirius_physical_projection::execute requires a data_repository_manager to be set");
-  }
-
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(select_list);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
@@ -63,7 +55,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_projection::
 
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
-    auto projected_batch = gpu_expression_executor.execute(batch, *data_repo_mgr);
+    auto projected_batch = gpu_expression_executor.execute(batch);
     if (projected_batch) { output_batches.push_back(std::move(projected_batch)); }
   }
 

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -35,9 +35,8 @@ sirius_physical_projection::sirius_physical_projection(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
   duckdb::idx_t estimated_cardinality)
-  : sirius_physical_operator(duckdb::PhysicalOperatorType::PROJECTION,
-                             std::move(types),
-                             estimated_cardinality),
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::PROJECTION, std::move(types), estimated_cardinality),
     select_list(std::move(select_list))
 {
 }

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -26,17 +26,52 @@
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "log/logging.hpp"
 
+#include <chrono>
+
 namespace sirius {
 namespace op {
 
 sirius_physical_projection::sirius_physical_projection(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
-  duckdb::idx_t estimated_cardinality)
-  : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::PROJECTION, std::move(types), estimated_cardinality),
+  duckdb::idx_t estimated_cardinality,
+  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  : sirius_physical_operator(duckdb::PhysicalOperatorType::PROJECTION,
+                             std::move(types),
+                             estimated_cardinality,
+                             data_repo_mgr),
     select_list(std::move(select_list))
 {
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_projection::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  SIRIUS_LOG_DEBUG("Executing projection");
+  auto start = std::chrono::high_resolution_clock::now();
+
+  auto* data_repo_mgr = get_data_repository_manager();
+  if (data_repo_mgr == nullptr) {
+    throw duckdb::InternalException(
+      "sirius_physical_projection::execute requires a data_repository_manager to be set");
+  }
+
+  duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(select_list);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(input_batches.size());
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto projected_batch = gpu_expression_executor.execute(batch, *data_repo_mgr);
+    if (projected_batch) { output_batches.push_back(std::move(projected_batch)); }
+  }
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG("Projection time: {:.2f} ms", duration.count() / 1000.0);
+
+  return output_batches;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -30,7 +30,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/sorting.hpp>
 
-#include <data/gpu_data_representation.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -19,11 +19,22 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/create_sort_key.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "log/logging.hpp"
 #include "op/sirius_physical_order.hpp"
 #include "utils.hpp"
+
+#include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/sorting.hpp>
+
+#include <data/gpu_data_representation.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
 
 namespace sirius {
 namespace op {
@@ -34,21 +45,149 @@ sirius_physical_top_n::sirius_physical_top_n(
   duckdb::idx_t limit,
   duckdb::idx_t offset,
   duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
-  duckdb::idx_t estimated_cardinality)
-  : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::TOP_N, std::move(types_p), estimated_cardinality),
+  duckdb::idx_t estimated_cardinality,
+  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  : sirius_physical_operator(duckdb::PhysicalOperatorType::TOP_N,
+                             std::move(types_p),
+                             estimated_cardinality,
+                             data_repo_mgr),
     orders(std::move(orders)),
     limit(limit),
     offset(offset),
-    dynamic_filter(std::move(dynamic_filter_p))
+    dynamic_filter(std::move(dynamic_filter_p)),
+    state(std::make_shared<topn_state>())
 {
-  // sort_result = duckdb::make_shared_ptr<GPUIntermediateRelation>(types.size());
-  // for (int col = 0; col < types.size(); col++) {
-  //   sort_result->columns[col] = nullptr;
-  // }
 }
 
 sirius_physical_top_n::~sirius_physical_top_n() {}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  if (limit == 0) { return {}; }
+
+  auto* data_repo_mgr = get_data_repository_manager();
+  if (data_repo_mgr == nullptr) {
+    throw duckdb::InternalException(
+      "sirius_physical_top_n::execute requires a data_repository_manager to be set");
+  }
+
+  // Use the memory space from the first valid batch (all batches are expected to share the same
+  // space in practice).
+  cucascade::memory::memory_space* space = nullptr;
+  for (auto const& batch : input_batches) {
+    if (batch) {
+      space = batch->get_memory_space();
+      break;
+    }
+  }
+  if (space == nullptr) { return {}; }
+
+  std::unique_lock<std::mutex> lk(state->mutex);
+
+  std::vector<std::unique_ptr<cudf::table>> owned_tables;
+  std::vector<cudf::table_view> concat_views;
+  if (state->top_table) { concat_views.push_back(state->top_table->view()); }
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto table = std::make_unique<cudf::table>(
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table());
+    concat_views.push_back(table->view());
+    owned_tables.push_back(std::move(table));
+  }
+
+  if (concat_views.empty()) { return {}; }
+
+  std::unique_ptr<cudf::table> combined;
+  if (concat_views.size() == 1) {
+    combined = std::make_unique<cudf::table>(concat_views.front());
+  } else {
+    combined = cudf::concatenate(concat_views);
+  }
+
+  auto combined_view = combined->view();
+
+  std::unique_ptr<cudf::table> kept;
+  auto const keep_rows = std::min<cudf::size_type>(combined_view.num_rows(),
+                                                   static_cast<cudf::size_type>(offset + limit));
+
+  if (orders.size() == 1) {
+    auto const& ord = orders[0];
+    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      throw duckdb::NotImplementedException("TopN only supports bound reference expressions");
+    }
+    auto const idx =
+      static_cast<cudf::size_type>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    if (idx < 0 || idx >= combined_view.num_columns()) {
+      throw duckdb::InternalException("TopN order index out of range");
+    }
+
+    auto order =
+      ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING : cudf::order::DESCENDING;
+    auto indices  = cudf::top_k_order(combined_view.column(idx), keep_rows, order);
+    auto gathered = cudf::gather(combined_view, indices->view());
+    kept          = std::move(gathered);
+  } else {
+    // Multi-key: fall back to full sort_by_key
+    std::vector<cudf::column_view> key_views;
+    key_views.reserve(orders.size());
+    std::vector<cudf::order> key_orders;
+    key_orders.reserve(orders.size());
+    std::vector<cudf::null_order> null_orders;
+    null_orders.reserve(orders.size());
+
+    for (auto const& ord : orders) {
+      if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+        throw duckdb::NotImplementedException("TopN only supports bound reference expressions");
+      }
+      auto const idx = static_cast<cudf::size_type>(
+        ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+      if (idx < 0 || idx >= combined_view.num_columns()) {
+        throw duckdb::InternalException("TopN order index out of range");
+      }
+      key_views.push_back(combined_view.column(idx));
+      key_orders.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                    : cudf::order::DESCENDING);
+      null_orders.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                              ? cudf::null_order::BEFORE
+                              : cudf::null_order::AFTER);
+    }
+
+    auto keys_table = cudf::table_view(key_views);
+    auto sorted     = cudf::sort_by_key(combined_view, keys_table, key_orders, null_orders);
+
+    if (keep_rows == sorted->num_rows()) {
+      kept = std::move(sorted);
+    } else {
+      auto slices = cudf::slice(sorted->view(), {0, keep_rows});
+      kept        = std::make_unique<cudf::table>(slices.front());
+    }
+  }
+
+  // Prepare output slice applying offset
+  std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
+  if (keep_rows <= static_cast<cudf::size_type>(offset)) {
+    state->top_table = std::move(kept);
+    return outputs;
+  }
+
+  auto out_start = static_cast<cudf::size_type>(offset);
+  auto out_end   = keep_rows;
+  auto out_slices =
+    cudf::slice(kept->view(), {out_start, out_end});  // returns vector with one table_view
+  auto out_table = std::make_unique<cudf::table>(out_slices.front());
+
+  std::unique_ptr<cucascade::idata_representation> output_data =
+    std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
+
+  auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+  auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+  outputs.push_back(std::move(output_batch));
+
+  state->top_table = std::move(kept);
+  return outputs;
+}
 
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -181,7 +181,7 @@ sirius_physical_top_n_merge::sirius_physical_top_n_merge(
   duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
   duckdb::idx_t estimated_cardinality)
   : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::INVALID, std::move(types_p), estimated_cardinality),
+      duckdb::PhysicalOperatorType::EXTENSION, std::move(types_p), estimated_cardinality),
     orders(std::move(orders)),
     limit(limit),
     offset(offset),

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -55,7 +55,7 @@ sirius_physical_top_n::sirius_physical_top_n(
     limit(limit),
     offset(offset),
     dynamic_filter(std::move(dynamic_filter_p)),
-    state(std::make_shared<topn_state>())
+    _state(std::make_shared<topn_state>())
 {
 }
 
@@ -83,11 +83,11 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   }
   if (space == nullptr) { return {}; }
 
-  std::unique_lock<std::mutex> lk(state->mutex);
+  std::unique_lock<std::mutex> lk(_state->_mutex);
 
   std::vector<std::unique_ptr<cudf::table>> owned_tables;
   std::vector<cudf::table_view> concat_views;
-  if (state->top_table) { concat_views.push_back(state->top_table->view()); }
+  if (_state->_top_table) { concat_views.push_back(_state->_top_table->view()); }
 
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
@@ -168,7 +168,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   // Prepare output slice applying offset
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   if (keep_rows <= static_cast<cudf::size_type>(offset)) {
-    state->top_table = std::move(kept);
+    _state->_top_table = std::move(kept);
     return outputs;
   }
 
@@ -185,7 +185,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
   outputs.push_back(std::move(output_batch));
 
-  state->top_table = std::move(kept);
+  _state->_top_table = std::move(kept);
   return outputs;
 }
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "data/data_batch_utils.hpp"
 #include "op/sirius_physical_top_n.hpp"
 
+#include "data/data_batch_utils.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/create_sort_key.hpp"
@@ -27,84 +27,42 @@
 #include "op/sirius_physical_order.hpp"
 #include "utils.hpp"
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/cudf_utils.hpp>
 #include <cudf/sorting.hpp>
+
+#include <rmm/resource_ref.hpp>
 
 #include <cucascade/data/gpu_data_representation.hpp>
 
 #include <algorithm>
 #include <memory>
-#include <mutex>
 
 namespace sirius {
 namespace op {
 
-sirius_physical_top_n::sirius_physical_top_n(
-  duckdb::vector<duckdb::LogicalType> types_p,
-  duckdb::vector<duckdb::BoundOrderByNode> orders,
+namespace {
+
+std::unique_ptr<cudf::table> compute_top_n_table(
+  cudf::table_view input,
+  duckdb::vector<duckdb::BoundOrderByNode> const& orders,
   duckdb::idx_t limit,
   duckdb::idx_t offset,
-  duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
-  duckdb::idx_t estimated_cardinality)
-  : sirius_physical_operator(duckdb::PhysicalOperatorType::TOP_N,
-                             std::move(types_p),
-                             estimated_cardinality),
-    orders(std::move(orders)),
-    limit(limit),
-    offset(offset),
-    dynamic_filter(std::move(dynamic_filter_p)),
-    _state(std::make_shared<topn_state>())
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref memory_resource)
 {
-}
-
-sirius_physical_top_n::~sirius_physical_top_n() {}
-
-std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execute(
-  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
-{
-  if (limit == 0) { return {}; }
-
-  // Use the memory space from the first valid batch (all batches are expected to share the same
-  // space in practice).
-  cucascade::memory::memory_space* space = nullptr;
-  for (auto const& batch : input_batches) {
-    if (batch) {
-      space = batch->get_memory_space();
-      break;
-    }
-  }
-  if (space == nullptr) { return {}; }
-
-  std::unique_lock<std::mutex> lk(_state->_mutex);
-
-  std::vector<std::unique_ptr<cudf::table>> owned_tables;
-  std::vector<cudf::table_view> concat_views;
-  if (_state->_top_table) { concat_views.push_back(_state->_top_table->view()); }
-
-  for (auto const& batch : input_batches) {
-    if (!batch) { continue; }
-    auto table = std::make_unique<cudf::table>(
-      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table());
-    concat_views.push_back(table->view());
-    owned_tables.push_back(std::move(table));
+  if (limit == 0 || input.num_rows() == 0) { return duckdb::make_empty_like(input); }
+  if (orders.empty()) {
+    throw duckdb::InternalException("TopN requires at least one ordering key");
   }
 
-  if (concat_views.empty()) { return {}; }
-
-  std::unique_ptr<cudf::table> combined;
-  if (concat_views.size() == 1) {
-    combined = std::make_unique<cudf::table>(concat_views.front());
-  } else {
-    combined = cudf::concatenate(concat_views);
-  }
-
-  auto combined_view = combined->view();
+  auto const keep_rows =
+    std::min<cudf::size_type>(input.num_rows(), static_cast<cudf::size_type>(offset + limit));
+  if (keep_rows == 0) { return duckdb::make_empty_like(input); }
 
   std::unique_ptr<cudf::table> kept;
-  auto const keep_rows = std::min<cudf::size_type>(combined_view.num_rows(),
-                                                   static_cast<cudf::size_type>(offset + limit));
-
   if (orders.size() == 1) {
     auto const& ord = orders[0];
     if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
@@ -112,15 +70,15 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
     }
     auto const idx =
       static_cast<cudf::size_type>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
-    if (idx < 0 || idx >= combined_view.num_columns()) {
+    if (idx < 0 || idx >= input.num_columns()) {
       throw duckdb::InternalException("TopN order index out of range");
     }
 
     auto order =
       ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING : cudf::order::DESCENDING;
-    auto indices  = cudf::top_k_order(combined_view.column(idx), keep_rows, order);
-    auto gathered = cudf::gather(combined_view, indices->view());
-    kept          = std::move(gathered);
+    auto indices = cudf::top_k_order(input.column(idx), keep_rows, order, stream, memory_resource);
+    kept         = cudf::gather(
+      input, indices->view(), cudf::out_of_bounds_policy::DONT_CHECK, stream, memory_resource);
   } else {
     // Multi-key: fall back to full sort_by_key
     std::vector<cudf::column_view> key_views;
@@ -136,10 +94,10 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
       }
       auto const idx = static_cast<cudf::size_type>(
         ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
-      if (idx < 0 || idx >= combined_view.num_columns()) {
+      if (idx < 0 || idx >= input.num_columns()) {
         throw duckdb::InternalException("TopN order index out of range");
       }
-      key_views.push_back(combined_view.column(idx));
+      key_views.push_back(input.column(idx));
       key_orders.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
                                                                     : cudf::order::DESCENDING);
       null_orders.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
@@ -148,37 +106,147 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
     }
 
     auto keys_table = cudf::table_view(key_views);
-    auto sorted     = cudf::sort_by_key(combined_view, keys_table, key_orders, null_orders);
+    auto sorted =
+      cudf::sort_by_key(input, keys_table, key_orders, null_orders, stream, memory_resource);
 
     if (keep_rows == sorted->num_rows()) {
       kept = std::move(sorted);
     } else {
-      auto slices = cudf::slice(sorted->view(), {0, keep_rows});
-      kept        = std::make_unique<cudf::table>(slices.front());
+      auto slices = cudf::slice(sorted->view(), {0, keep_rows}, stream);
+      kept        = std::make_unique<cudf::table>(slices.front(), stream, memory_resource);
     }
   }
 
-  // Prepare output slice applying offset
+  return kept;
+}
+
+}  // namespace
+
+sirius_physical_top_n::sirius_physical_top_n(
+  duckdb::vector<duckdb::LogicalType> types_p,
+  duckdb::vector<duckdb::BoundOrderByNode> orders,
+  duckdb::idx_t limit,
+  duckdb::idx_t offset,
+  duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
+  duckdb::idx_t estimated_cardinality)
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::TOP_N, std::move(types_p), estimated_cardinality),
+    orders(std::move(orders)),
+    limit(limit),
+    offset(offset),
+    dynamic_filter(std::move(dynamic_filter_p))
+{
+}
+
+sirius_physical_top_n::~sirius_physical_top_n() {}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  if (limit == 0) { return {}; }
+
+  std::shared_ptr<cucascade::data_batch> input_batch;
+  for (auto const& batch : input_batches) {
+    if (batch) {
+      if (input_batch) {
+        throw duckdb::InternalException("TopN expects a single input batch per execution");
+      }
+      input_batch = batch;
+    }
+  }
+  if (!input_batch) { return {}; }
+
+  auto* space = input_batch->get_memory_space();
+  if (space == nullptr) { return {}; }
+
+  auto stream = space->acquire_stream();
+  auto input_table =
+    input_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+  auto output_table =
+    compute_top_n_table(input_table, orders, limit, offset, stream, space->get_default_allocator());
+
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
-  if (keep_rows <= static_cast<cudf::size_type>(offset)) {
-    _state->_top_table = std::move(kept);
-    return outputs;
+  std::unique_ptr<cucascade::idata_representation> output_data =
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, *space);
+  outputs.push_back(
+    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
+  return outputs;
+}
+
+sirius_physical_top_n_merge::sirius_physical_top_n_merge(
+  duckdb::vector<duckdb::LogicalType> types_p,
+  duckdb::vector<duckdb::BoundOrderByNode> orders,
+  duckdb::idx_t limit,
+  duckdb::idx_t offset,
+  duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
+  duckdb::idx_t estimated_cardinality)
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::INVALID, std::move(types_p), estimated_cardinality),
+    orders(std::move(orders)),
+    limit(limit),
+    offset(offset),
+    dynamic_filter(std::move(dynamic_filter_p))
+{
+}
+
+sirius_physical_top_n_merge::~sirius_physical_top_n_merge() {}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n_merge::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  if (limit == 0) { return {}; }
+
+  // Use the memory space from the first valid batch (all batches are expected to share the same
+  // space in practice).
+  cucascade::memory::memory_space* space = nullptr;
+  for (auto const& batch : input_batches) {
+    if (batch) {
+      space = batch->get_memory_space();
+      break;
+    }
+  }
+  if (space == nullptr) { return {}; }
+
+  auto stream = space->acquire_stream();
+  std::vector<std::unique_ptr<cudf::table>> owned_tables;
+  std::vector<cudf::table_view> concat_views;
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto table = std::make_unique<cudf::table>(
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table(),
+      stream,
+      space->get_default_allocator());
+    concat_views.push_back(table->view());
+    owned_tables.push_back(std::move(table));
   }
 
-  auto out_start = static_cast<cudf::size_type>(offset);
-  auto out_end   = keep_rows;
-  auto out_slices =
-    cudf::slice(kept->view(), {out_start, out_end});  // returns vector with one table_view
-  auto out_table = std::make_unique<cudf::table>(out_slices.front());
+  if (concat_views.empty()) { return {}; }
 
+  std::unique_ptr<cudf::table> combined;
+  if (concat_views.size() == 1) {
+    combined =
+      std::make_unique<cudf::table>(concat_views.front(), stream, space->get_default_allocator());
+  } else {
+    combined = cudf::concatenate(concat_views, stream, space->get_default_allocator());
+  }
+
+  auto output_table = compute_top_n_table(
+    combined->view(), orders, limit, offset, stream, space->get_default_allocator());
+  if (output_table->num_rows() <= static_cast<cudf::size_type>(offset)) {
+    output_table = duckdb::make_empty_like(output_table->view());
+  } else if (offset > 0) {
+    auto out_start = static_cast<cudf::size_type>(offset);
+    auto out_slices =
+      cudf::slice(output_table->view(), {out_start, output_table->num_rows()}, stream);
+    output_table =
+      std::make_unique<cudf::table>(out_slices.front(), stream, space->get_default_allocator());
+  }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   std::unique_ptr<cucascade::idata_representation> output_data =
-    std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
-
-  auto const batch_id = ::sirius::get_next_batch_id();
-  auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
-  outputs.push_back(std::move(output_batch));
-
-  _state->_top_table = std::move(kept);
+    std::make_unique<cucascade::gpu_table_representation>(*output_table, *space);
+  outputs.push_back(
+    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
   return outputs;
 }
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "data/data_batch_utils.hpp"
 #include "op/sirius_physical_top_n.hpp"
 
 #include "duckdb/common/assert.hpp"
@@ -45,12 +46,10 @@ sirius_physical_top_n::sirius_physical_top_n(
   duckdb::idx_t limit,
   duckdb::idx_t offset,
   duckdb::shared_ptr<duckdb::DynamicFilterData> dynamic_filter_p,
-  duckdb::idx_t estimated_cardinality,
-  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  duckdb::idx_t estimated_cardinality)
   : sirius_physical_operator(duckdb::PhysicalOperatorType::TOP_N,
                              std::move(types_p),
-                             estimated_cardinality,
-                             data_repo_mgr),
+                             estimated_cardinality),
     orders(std::move(orders)),
     limit(limit),
     offset(offset),
@@ -65,12 +64,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
 {
   if (limit == 0) { return {}; }
-
-  auto* data_repo_mgr = get_data_repository_manager();
-  if (data_repo_mgr == nullptr) {
-    throw duckdb::InternalException(
-      "sirius_physical_top_n::execute requires a data_repository_manager to be set");
-  }
 
   // Use the memory space from the first valid batch (all batches are expected to share the same
   // space in practice).
@@ -181,7 +174,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
 
-  auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+  auto const batch_id = ::sirius::get_next_batch_id();
   auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
   outputs.push_back(std::move(output_batch));
 

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -16,11 +16,11 @@
 
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 
+#include "cudf/cudf_utils.hpp"
 #include "data/data_batch_utils.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "expression_executor/gpu_expression_executor_state.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 
 #include <cudf/column/column_factories.hpp>
@@ -62,10 +62,7 @@ sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
 namespace {
 
 // Map LogicalType to cudf::data_type using existing utility
-cudf::data_type ToCudfType(const duckdb::LogicalType& t)
-{
-  return duckdb::sirius::GpuExpressionState::GetCudfType(t);
-}
+cudf::data_type ToCudfType(const duckdb::LogicalType& t) { return duckdb::GetCudfType(t); }
 
 template <typename ScalarType>
 ScalarType const& scalar_cast(const cudf::scalar& s)

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -30,8 +30,8 @@
 
 #include <cuda_runtime.h>
 
-#include <data/data_batch.hpp>
-#include <data/gpu_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <algorithm>
 #include <mutex>

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -17,7 +17,24 @@
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression_executor/gpu_expression_executor_state.hpp"
 #include "log/logging.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime.h>
+
+#include <data/data_batch.hpp>
+#include <data/gpu_data_representation.hpp>
+
+#include <algorithm>
+#include <mutex>
 
 namespace sirius {
 namespace op {
@@ -26,9 +43,12 @@ sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::idx_t estimated_cardinality,
-  duckdb::TupleDataValidityType distinct_validity)
-  : sirius_physical_operator(
-      duckdb::PhysicalOperatorType::UNGROUPED_AGGREGATE, std::move(types), estimated_cardinality),
+  duckdb::TupleDataValidityType distinct_validity,
+  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  : sirius_physical_operator(duckdb::PhysicalOperatorType::UNGROUPED_AGGREGATE,
+                             std::move(types),
+                             estimated_cardinality,
+                             data_repo_mgr),
     aggregates(std::move(expressions))
 {
   distinct_collection_info = duckdb::DistinctAggregateCollectionInfo::Create(aggregates);
@@ -36,6 +56,459 @@ sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
   if (!distinct_collection_info) { return; }
   distinct_data =
     duckdb::make_uniq<duckdb::DistinctAggregateData>(*distinct_collection_info, distinct_validity);
+}
+
+namespace {
+
+// Map LogicalType to cudf::data_type using existing utility
+cudf::data_type ToCudfType(const duckdb::LogicalType& t)
+{
+  return duckdb::sirius::GpuExpressionState::GetCudfType(t);
+}
+
+template <typename ScalarType>
+ScalarType const& scalar_cast(const cudf::scalar& s)
+{
+  return static_cast<ScalarType const&>(s);
+}
+
+template <typename ScalarType>
+ScalarType& scalar_cast(cudf::scalar& s)
+{
+  return static_cast<ScalarType&>(s);
+}
+
+template <typename T>
+void set_fixed_point_value(cudf::fixed_point_scalar<T>& s, typename T::rep value)
+{
+  cudaMemcpyAsync(
+    s.data(), &value, sizeof(value), cudaMemcpyHostToDevice, cudf::get_default_stream().value());
+}
+
+template <typename T>
+std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type type, T value)
+{
+  auto out = cudf::make_numeric_scalar(type);
+  scalar_cast<cudf::numeric_scalar<T>>(*out).set_value(value, cudf::get_default_stream());
+  return out;
+}
+
+template <typename Rep>
+std::unique_ptr<cudf::scalar> make_fixed_point_scalar_with_value(cudf::data_type type, Rep value)
+{
+  auto out = cudf::make_fixed_point_scalar(type, value);
+  return out;
+}
+
+// Sum two scalars of same type_id, returning updated accumulator (in-place)
+void accumulate_sum(cudf::scalar& acc, const cudf::scalar& incoming)
+{
+  auto id = acc.type().id();
+  switch (id) {
+    case cudf::type_id::INT8: {
+      auto v = scalar_cast<cudf::numeric_scalar<int8_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<int8_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<int8_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT16: {
+      auto v = scalar_cast<cudf::numeric_scalar<int16_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<int16_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<int16_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT32: {
+      auto v = scalar_cast<cudf::numeric_scalar<int32_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<int32_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<int32_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT64: {
+      auto v = scalar_cast<cudf::numeric_scalar<int64_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<int64_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<int64_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT8: {
+      auto v = scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<uint8_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT16: {
+      auto v = scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<uint16_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT32: {
+      auto v = scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<uint32_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT64: {
+      auto v = scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<uint64_t>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::FLOAT32: {
+      auto v = scalar_cast<cudf::numeric_scalar<float>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<float>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<float>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::FLOAT64: {
+      auto v = scalar_cast<cudf::numeric_scalar<double>>(acc).value() +
+               scalar_cast<cudf::numeric_scalar<double>>(incoming).value();
+      scalar_cast<cudf::numeric_scalar<double>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::DECIMAL32: {
+      using dec_t = numeric::decimal32;
+      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
+               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    case cudf::type_id::DECIMAL64: {
+      using dec_t = numeric::decimal64;
+      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
+               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    case cudf::type_id::DECIMAL128: {
+      using dec_t = numeric::decimal128;
+      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
+               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    default:
+      throw duckdb::NotImplementedException("Unsupported type for sum in GPU ungrouped aggregate");
+  }
+}
+
+// update min/max
+enum class minmax_op { MIN, MAX };
+void accumulate_minmax(cudf::scalar& acc, const cudf::scalar& incoming, minmax_op op)
+{
+  auto id         = acc.type().id();
+  auto choose_min = op == minmax_op::MIN;
+  switch (id) {
+    case cudf::type_id::INT8: {
+      auto a = scalar_cast<cudf::numeric_scalar<int8_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<int8_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<int8_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT16: {
+      auto a = scalar_cast<cudf::numeric_scalar<int16_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<int16_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<int16_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT32: {
+      auto a = scalar_cast<cudf::numeric_scalar<int32_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<int32_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<int32_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::INT64: {
+      auto a = scalar_cast<cudf::numeric_scalar<int64_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<int64_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<int64_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT8: {
+      auto a = scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<uint8_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT16: {
+      auto a = scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<uint16_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT32: {
+      auto a = scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<uint32_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::UINT64: {
+      auto a = scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<uint64_t>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::FLOAT32: {
+      auto a = scalar_cast<cudf::numeric_scalar<float>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<float>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<float>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::FLOAT64: {
+      auto a = scalar_cast<cudf::numeric_scalar<double>>(acc).value();
+      auto b = scalar_cast<cudf::numeric_scalar<double>>(incoming).value();
+      auto v = choose_min ? std::min(a, b) : std::max(a, b);
+      scalar_cast<cudf::numeric_scalar<double>>(acc).set_value(v, cudf::get_default_stream());
+      break;
+    }
+    case cudf::type_id::DECIMAL32: {
+      using dec_t = numeric::decimal32;
+      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
+      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    case cudf::type_id::DECIMAL64: {
+      using dec_t = numeric::decimal64;
+      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
+      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    case cudf::type_id::DECIMAL128: {
+      using dec_t = numeric::decimal128;
+      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
+      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
+      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
+      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
+      break;
+    }
+    default:
+      throw duckdb::NotImplementedException(
+        "Unsupported type for min/max in GPU ungrouped aggregate");
+  }
+}
+
+}  // namespace
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_aggregate::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  if (aggregates.empty()) { return {}; }
+
+  auto* data_repo_mgr = get_data_repository_manager();
+  if (data_repo_mgr == nullptr) {
+    throw duckdb::InternalException(
+      "sirius_physical_ungrouped_aggregate::execute requires a data_repository_manager to be set");
+  }
+
+  cucascade::memory::memory_space* space = nullptr;
+  for (auto const& batch : input_batches) {
+    if (batch) {
+      space = batch->get_memory_space();
+      break;
+    }
+  }
+  if (space == nullptr) { return {}; }
+
+  std::unique_lock<std::mutex> lk(_state->_mutex);
+  if (!_state->_initialized) {
+    _state->_running_values.resize(aggregates.size());
+    _state->_running_counts.resize(aggregates.size(), 0);
+    _state->_initialized = true;
+  }
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+    auto view  = table.view();
+
+    for (idx_t i = 0; i < aggregates.size(); ++i) {
+      auto& agg = aggregates[i]->Cast<duckdb::BoundAggregateExpression>();
+      if (agg.IsDistinct()) {
+        throw duckdb::NotImplementedException("Distinct aggregates not supported in GPU path yet");
+      }
+      auto fname = agg.function.name;
+
+      if (fname == "count_star") {
+        _state->_running_counts[i] += static_cast<int64_t>(view.num_rows());
+      } else if (fname == "count") {
+        D_ASSERT(agg.children.size() == 1);
+        auto idx    = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+        auto col    = view.column(static_cast<cudf::size_type>(idx));
+        auto agg_op = cudf::make_count_aggregation<cudf::reduce_aggregation>();
+        auto s      = cudf::reduce(col,
+                              *agg_op,
+                              cudf::data_type(cudf::type_id::INT64),
+                              std::nullopt,
+                              cudf::get_default_stream(),
+                              rmm::mr::get_current_device_resource());
+        _state->_running_counts[i] += static_cast<const cudf::numeric_scalar<int64_t>&>(*s).value();
+      } else {
+        D_ASSERT(agg.children.size() == 1);
+        auto idx      = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+        auto col      = view.column(static_cast<cudf::size_type>(idx));
+        auto out_type = ToCudfType(agg.return_type);
+        std::unique_ptr<cudf::scalar> s;
+        if (fname == "sum" || fname == "sum_no_overflow") {
+          auto agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+          s           = cudf::reduce(col,
+                           *agg_op,
+                           out_type,
+                           std::nullopt,
+                           cudf::get_default_stream(),
+                           rmm::mr::get_current_device_resource());
+          if (!_state->_running_values[i]) {
+            _state->_running_values[i] = std::move(s);
+          } else {
+            accumulate_sum(*_state->_running_values[i], *s);
+          }
+        } else if (fname == "min") {
+          auto agg_op = cudf::make_min_aggregation<cudf::reduce_aggregation>();
+          s           = cudf::reduce(col,
+                           *agg_op,
+                           out_type,
+                           std::nullopt,
+                           cudf::get_default_stream(),
+                           rmm::mr::get_current_device_resource());
+          if (!_state->_running_values[i]) {
+            _state->_running_values[i] = std::move(s);
+          } else {
+            accumulate_minmax(*_state->_running_values[i], *s, minmax_op::MIN);
+          }
+        } else if (fname == "max") {
+          auto agg_op = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+          s           = cudf::reduce(col,
+                           *agg_op,
+                           out_type,
+                           std::nullopt,
+                           cudf::get_default_stream(),
+                           rmm::mr::get_current_device_resource());
+          if (!_state->_running_values[i]) {
+            _state->_running_values[i] = std::move(s);
+          } else {
+            accumulate_minmax(*_state->_running_values[i], *s, minmax_op::MAX);
+          }
+        } else if (fname == "avg") {
+          auto agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+          s           = cudf::reduce(col,
+                           *agg_op,
+                           out_type,
+                           std::nullopt,
+                           cudf::get_default_stream(),
+                           rmm::mr::get_current_device_resource());
+          if (!_state->_running_values[i]) {
+            _state->_running_values[i] = std::move(s);
+          } else {
+            accumulate_sum(*_state->_running_values[i], *s);
+          }
+          _state->_running_counts[i] += static_cast<int64_t>(view.num_rows());
+        } else {
+          throw duckdb::NotImplementedException("Aggregate not supported: " + fname);
+        }
+      }
+    }
+  }
+
+  // Build output row
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.reserve(aggregates.size());
+  auto stream = cudf::get_default_stream();
+
+  for (idx_t i = 0; i < aggregates.size(); ++i) {
+    auto& agg = aggregates[i]->Cast<duckdb::BoundAggregateExpression>();
+    auto tid  = ToCudfType(agg.return_type);
+
+    std::unique_ptr<cudf::scalar> tmp_scalar;
+    const cudf::scalar* out_scalar = nullptr;
+    if (agg.function.name == "avg") {
+      auto const cnt = _state->_running_counts[i];
+      if (cnt == 0) {
+        // produce zero of target type
+        switch (tid.id()) {
+          case cudf::type_id::FLOAT32: {
+            tmp_scalar = make_numeric_scalar_with_value<float>(tid, 0.0f);
+            out_scalar = tmp_scalar.get();
+            break;
+          }
+          case cudf::type_id::FLOAT64: {
+            tmp_scalar = make_numeric_scalar_with_value<double>(tid, 0.0);
+            out_scalar = tmp_scalar.get();
+            break;
+          }
+          case cudf::type_id::INT32: {
+            tmp_scalar = make_numeric_scalar_with_value<int32_t>(tid, 0);
+            out_scalar = tmp_scalar.get();
+            break;
+          }
+          case cudf::type_id::INT64: {
+            tmp_scalar = make_numeric_scalar_with_value<int64_t>(tid, 0);
+            out_scalar = tmp_scalar.get();
+            break;
+          }
+          default: throw duckdb::NotImplementedException("AVG output type not supported");
+        }
+      } else {
+        // compute avg in double then cast to target type
+        double sum_host = 0.0;
+        switch (tid.id()) {
+          case cudf::type_id::FLOAT32:
+            sum_host =
+              scalar_cast<cudf::numeric_scalar<float>>(*_state->_running_values[i]).value();
+            _state->_running_values[i] =
+              make_numeric_scalar_with_value<float>(tid, static_cast<float>(sum_host / cnt));
+            break;
+          case cudf::type_id::FLOAT64:
+            sum_host =
+              scalar_cast<cudf::numeric_scalar<double>>(*_state->_running_values[i]).value();
+            _state->_running_values[i] =
+              make_numeric_scalar_with_value<double>(tid, sum_host / cnt);
+            break;
+          case cudf::type_id::INT32:
+            sum_host =
+              scalar_cast<cudf::numeric_scalar<int32_t>>(*_state->_running_values[i]).value();
+            _state->_running_values[i] =
+              make_numeric_scalar_with_value<int32_t>(tid, static_cast<int32_t>(sum_host / cnt));
+            break;
+          case cudf::type_id::INT64:
+            sum_host =
+              scalar_cast<cudf::numeric_scalar<int64_t>>(*_state->_running_values[i]).value();
+            _state->_running_values[i] =
+              make_numeric_scalar_with_value<int64_t>(tid, static_cast<int64_t>(sum_host / cnt));
+            break;
+          default: throw duckdb::NotImplementedException("AVG output type not supported");
+        }
+        out_scalar = _state->_running_values[i].get();
+      }
+    } else if (agg.function.name == "count" || agg.function.name == "count_star") {
+      tmp_scalar = make_numeric_scalar_with_value<int64_t>(cudf::data_type{cudf::type_id::INT64},
+                                                           _state->_running_counts[i]);
+      out_scalar = tmp_scalar.get();
+    } else {
+      // sum/min/max already accumulated in _running_values
+      out_scalar = _state->_running_values[i].get();  // non-owning
+    }
+
+    cols.push_back(cudf::make_column_from_scalar(
+      *out_scalar, 1, stream, rmm::mr::get_current_device_resource()));
+  }
+
+  auto out_table = std::make_unique<cudf::table>(std::move(cols));
+  std::unique_ptr<cucascade::idata_representation> output_data =
+    std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
+  auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+  auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+
+  return {std::move(output_batch)};
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "data/data_batch_utils.hpp"
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -43,12 +44,10 @@ sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
   duckdb::vector<duckdb::LogicalType> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::idx_t estimated_cardinality,
-  duckdb::TupleDataValidityType distinct_validity,
-  ::cucascade::shared_data_repository_manager* data_repo_mgr)
+  duckdb::TupleDataValidityType distinct_validity)
   : sirius_physical_operator(duckdb::PhysicalOperatorType::UNGROUPED_AGGREGATE,
                              std::move(types),
-                             estimated_cardinality,
-                             data_repo_mgr),
+                             estimated_cardinality),
     aggregates(std::move(expressions))
 {
   distinct_collection_info = duckdb::DistinctAggregateCollectionInfo::Create(aggregates);
@@ -305,12 +304,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_ag
 {
   if (aggregates.empty()) { return {}; }
 
-  auto* data_repo_mgr = get_data_repository_manager();
-  if (data_repo_mgr == nullptr) {
-    throw duckdb::InternalException(
-      "sirius_physical_ungrouped_aggregate::execute requires a data_repository_manager to be set");
-  }
-
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
     if (batch) {
@@ -505,7 +498,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_ag
   auto out_table = std::make_unique<cudf::table>(std::move(cols));
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
-  auto const batch_id = data_repo_mgr->get_next_data_batch_id();
+  auto const batch_id = ::sirius::get_next_batch_id();
   auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
 
   return {std::move(output_batch)};

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-#include "data/data_batch_utils.hpp"
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 
+#include "data/data_batch_utils.hpp"
+#include "duckdb/common/types/decimal.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_expression_executor_state.hpp"
-#include "log/logging.hpp"
+#include "op/merge/gpu_merge_impl.hpp"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
@@ -29,13 +31,14 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cuda_runtime.h>
+#include <rmm/resource_ref.hpp>
 
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 
 #include <algorithm>
-#include <mutex>
+#include <cmath>
+#include <limits>
 
 namespace sirius {
 namespace op {
@@ -45,9 +48,8 @@ sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::idx_t estimated_cardinality,
   duckdb::TupleDataValidityType distinct_validity)
-  : sirius_physical_operator(duckdb::PhysicalOperatorType::UNGROUPED_AGGREGATE,
-                             std::move(types),
-                             estimated_cardinality),
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::UNGROUPED_AGGREGATE, std::move(types), estimated_cardinality),
     aggregates(std::move(expressions))
 {
   distinct_collection_info = duckdb::DistinctAggregateCollectionInfo::Create(aggregates);
@@ -78,13 +80,6 @@ ScalarType& scalar_cast(cudf::scalar& s)
 }
 
 template <typename T>
-void set_fixed_point_value(cudf::fixed_point_scalar<T>& s, typename T::rep value)
-{
-  cudaMemcpyAsync(
-    s.data(), &value, sizeof(value), cudaMemcpyHostToDevice, cudf::get_default_stream().value());
-}
-
-template <typename T>
 std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type type, T value)
 {
   auto out = cudf::make_numeric_scalar(type);
@@ -92,209 +87,212 @@ std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type typ
   return out;
 }
 
-template <typename Rep>
-std::unique_ptr<cudf::scalar> make_fixed_point_scalar_with_value(cudf::data_type type, Rep value)
+enum class aggregate_kind { SUM, MIN, MAX, COUNT, COUNT_STAR, AVG };
+
+struct aggregate_spec {
+  aggregate_kind kind;
+  int input_idx;
+  duckdb::LogicalType return_type;
+  size_t local_sum_idx;
+  size_t local_count_idx;
+};
+
+struct aggregate_layout {
+  std::vector<aggregate_spec> aggregates;
+  std::vector<duckdb::LogicalType> local_types;
+  std::vector<cudf::aggregation::Kind> merge_kinds;
+  bool has_avg = false;
+};
+
+aggregate_layout build_aggregate_layout(
+  const duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& aggregates)
 {
-  auto out = cudf::make_fixed_point_scalar(type, value);
-  return out;
+  aggregate_layout layout;
+  size_t local_idx = 0;
+  layout.aggregates.reserve(aggregates.size());
+
+  for (size_t i = 0; i < aggregates.size(); ++i) {
+    auto& agg = aggregates[i]->Cast<duckdb::BoundAggregateExpression>();
+    if (agg.IsDistinct()) {
+      throw duckdb::NotImplementedException("Distinct aggregates not supported in GPU path yet");
+    }
+    if (agg.children.size() > 1) {
+      throw duckdb::NotImplementedException("Aggregates with multiple children not supported yet");
+    }
+
+    aggregate_spec spec;
+    spec.input_idx       = -1;
+    spec.return_type     = agg.return_type;
+    spec.local_sum_idx   = std::numeric_limits<size_t>::max();
+    spec.local_count_idx = std::numeric_limits<size_t>::max();
+
+    const auto& fname = agg.function.name;
+    if (fname == "count_star") {
+      spec.kind          = aggregate_kind::COUNT_STAR;
+      spec.return_type   = duckdb::LogicalType::BIGINT;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+    } else if (fname == "count") {
+      if (agg.children.empty()) {
+        throw duckdb::NotImplementedException("count() without arguments not supported");
+      }
+      spec.kind          = aggregate_kind::COUNT;
+      spec.return_type   = duckdb::LogicalType::BIGINT;
+      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+    } else if (fname == "sum" || fname == "sum_no_overflow") {
+      if (agg.children.empty()) {
+        throw duckdb::NotImplementedException("sum() without arguments not supported");
+      }
+      spec.kind          = aggregate_kind::SUM;
+      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(agg.return_type);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+    } else if (fname == "min") {
+      if (agg.children.empty()) {
+        throw duckdb::NotImplementedException("min() without arguments not supported");
+      }
+      spec.kind          = aggregate_kind::MIN;
+      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(agg.return_type);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::MIN);
+    } else if (fname == "max") {
+      if (agg.children.empty()) {
+        throw duckdb::NotImplementedException("max() without arguments not supported");
+      }
+      spec.kind          = aggregate_kind::MAX;
+      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(agg.return_type);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::MAX);
+    } else if (fname == "avg") {
+      if (agg.children.empty()) {
+        throw duckdb::NotImplementedException("avg() without arguments not supported");
+      }
+      spec.kind          = aggregate_kind::AVG;
+      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.local_sum_idx = local_idx++;
+      layout.local_types.push_back(agg.return_type);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+      spec.local_count_idx = local_idx++;
+      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+      layout.has_avg = true;
+    } else {
+      throw duckdb::NotImplementedException("Aggregate not supported: " + fname);
+    }
+
+    layout.aggregates.push_back(std::move(spec));
+  }
+
+  return layout;
 }
 
-// Sum two scalars of same type_id, returning updated accumulator (in-place)
-void accumulate_sum(cudf::scalar& acc, const cudf::scalar& incoming)
+std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
+                                              const cudf::column_view& count_view,
+                                              const duckdb::LogicalType& return_type,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref memory_resource)
 {
-  auto id = acc.type().id();
-  switch (id) {
-    case cudf::type_id::INT8: {
-      auto v = scalar_cast<cudf::numeric_scalar<int8_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<int8_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<int8_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::INT16: {
-      auto v = scalar_cast<cudf::numeric_scalar<int16_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<int16_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<int16_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::INT32: {
-      auto v = scalar_cast<cudf::numeric_scalar<int32_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<int32_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<int32_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::INT64: {
-      auto v = scalar_cast<cudf::numeric_scalar<int64_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<int64_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<int64_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT8: {
-      auto v = scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<uint8_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT16: {
-      auto v = scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<uint16_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT32: {
-      auto v = scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<uint32_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT64: {
-      auto v = scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<uint64_t>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::FLOAT32: {
-      auto v = scalar_cast<cudf::numeric_scalar<float>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<float>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<float>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::FLOAT64: {
-      auto v = scalar_cast<cudf::numeric_scalar<double>>(acc).value() +
-               scalar_cast<cudf::numeric_scalar<double>>(incoming).value();
-      scalar_cast<cudf::numeric_scalar<double>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::DECIMAL32: {
-      using dec_t = numeric::decimal32;
-      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
-               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    case cudf::type_id::DECIMAL64: {
-      using dec_t = numeric::decimal64;
-      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
-               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    case cudf::type_id::DECIMAL128: {
-      using dec_t = numeric::decimal128;
-      auto v      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value() +
-               scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    default:
-      throw duckdb::NotImplementedException("Unsupported type for sum in GPU ungrouped aggregate");
-  }
-}
+  auto sum_agg     = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+  auto sum_type    = ToCudfType(return_type);
+  auto sum_value   = cudf::reduce(sum_view, *sum_agg, sum_type, stream, memory_resource);
+  auto count_value = cudf::reduce(
+    count_view, *sum_agg, cudf::data_type(cudf::type_id::INT64), stream, memory_resource);
 
-// update min/max
-enum class minmax_op { MIN, MAX };
-void accumulate_minmax(cudf::scalar& acc, const cudf::scalar& incoming, minmax_op op)
-{
-  auto id         = acc.type().id();
-  auto choose_min = op == minmax_op::MIN;
-  switch (id) {
-    case cudf::type_id::INT8: {
-      auto a = scalar_cast<cudf::numeric_scalar<int8_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<int8_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<int8_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
+  auto const count_host = scalar_cast<cudf::numeric_scalar<int64_t>>(*count_value).value();
+  std::unique_ptr<cudf::scalar> out_scalar;
+  if (return_type.id() == duckdb::LogicalTypeId::DECIMAL) {
+    auto scale           = duckdb::DecimalType::GetScale(return_type);
+    auto width           = duckdb::DecimalType::GetWidth(return_type);
+    auto scale_type      = numeric::scale_type{-scale};
+    auto denom           = std::pow(10.0L, static_cast<long double>(scale));
+    long double sum_host = 0.0L;
+    switch (sum_type.id()) {
+      case cudf::type_id::DECIMAL32: {
+        auto& sum_scalar = static_cast<cudf::fixed_point_scalar<numeric::decimal32>&>(*sum_value);
+        sum_host         = static_cast<long double>(sum_scalar.value(stream)) / denom;
+        break;
+      }
+      case cudf::type_id::DECIMAL64: {
+        auto& sum_scalar = static_cast<cudf::fixed_point_scalar<numeric::decimal64>&>(*sum_value);
+        sum_host         = static_cast<long double>(sum_scalar.value(stream)) / denom;
+        break;
+      }
+      case cudf::type_id::DECIMAL128: {
+        auto& sum_scalar = static_cast<cudf::fixed_point_scalar<numeric::decimal128>&>(*sum_value);
+        sum_host         = static_cast<long double>(sum_scalar.value(stream)) / denom;
+        break;
+      }
+      default: throw duckdb::NotImplementedException("AVG decimal sum type not supported");
     }
-    case cudf::type_id::INT16: {
-      auto a = scalar_cast<cudf::numeric_scalar<int16_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<int16_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<int16_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
+    long double avg_host = (count_host == 0) ? 0.0L : (sum_host / count_host);
+    long double scaled   = avg_host * denom;
+    if (width <= duckdb::Decimal::MAX_WIDTH_INT32) {
+      auto rep   = static_cast<int32_t>(std::llround(scaled));
+      out_scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
+        rep, scale_type, true, stream, memory_resource);
+    } else if (width <= duckdb::Decimal::MAX_WIDTH_INT64) {
+      auto rep   = static_cast<int64_t>(std::llround(scaled));
+      out_scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
+        rep, scale_type, true, stream, memory_resource);
+    } else {
+      auto rep   = static_cast<__int128_t>(std::llround(scaled));
+      out_scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
+        rep, scale_type, true, stream, memory_resource);
     }
-    case cudf::type_id::INT32: {
-      auto a = scalar_cast<cudf::numeric_scalar<int32_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<int32_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<int32_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
+  } else {
+    if (count_host == 0) {
+      switch (sum_type.id()) {
+        case cudf::type_id::FLOAT32:
+          out_scalar = make_numeric_scalar_with_value<float>(sum_type, 0.0f);
+          break;
+        case cudf::type_id::FLOAT64:
+          out_scalar = make_numeric_scalar_with_value<double>(sum_type, 0.0);
+          break;
+        case cudf::type_id::INT32:
+          out_scalar = make_numeric_scalar_with_value<int32_t>(sum_type, 0);
+          break;
+        case cudf::type_id::INT64:
+          out_scalar = make_numeric_scalar_with_value<int64_t>(sum_type, 0);
+          break;
+        default: throw duckdb::NotImplementedException("AVG output type not supported");
+      }
+    } else {
+      switch (sum_type.id()) {
+        case cudf::type_id::FLOAT32: {
+          auto sum_host = scalar_cast<cudf::numeric_scalar<float>>(*sum_value).value();
+          out_scalar    = make_numeric_scalar_with_value<float>(sum_type, sum_host / count_host);
+          break;
+        }
+        case cudf::type_id::FLOAT64: {
+          auto sum_host = scalar_cast<cudf::numeric_scalar<double>>(*sum_value).value();
+          out_scalar    = make_numeric_scalar_with_value<double>(sum_type, sum_host / count_host);
+          break;
+        }
+        case cudf::type_id::INT32: {
+          auto sum_host = scalar_cast<cudf::numeric_scalar<int32_t>>(*sum_value).value();
+          out_scalar    = make_numeric_scalar_with_value<int32_t>(
+            sum_type, static_cast<int32_t>(sum_host / count_host));
+          break;
+        }
+        case cudf::type_id::INT64: {
+          auto sum_host = scalar_cast<cudf::numeric_scalar<int64_t>>(*sum_value).value();
+          out_scalar    = make_numeric_scalar_with_value<int64_t>(
+            sum_type, static_cast<int64_t>(sum_host / count_host));
+          break;
+        }
+        default: throw duckdb::NotImplementedException("AVG output type not supported");
+      }
     }
-    case cudf::type_id::INT64: {
-      auto a = scalar_cast<cudf::numeric_scalar<int64_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<int64_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<int64_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT8: {
-      auto a = scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<uint8_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<uint8_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT16: {
-      auto a = scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<uint16_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<uint16_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT32: {
-      auto a = scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<uint32_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<uint32_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::UINT64: {
-      auto a = scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<uint64_t>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<uint64_t>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::FLOAT32: {
-      auto a = scalar_cast<cudf::numeric_scalar<float>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<float>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<float>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::FLOAT64: {
-      auto a = scalar_cast<cudf::numeric_scalar<double>>(acc).value();
-      auto b = scalar_cast<cudf::numeric_scalar<double>>(incoming).value();
-      auto v = choose_min ? std::min(a, b) : std::max(a, b);
-      scalar_cast<cudf::numeric_scalar<double>>(acc).set_value(v, cudf::get_default_stream());
-      break;
-    }
-    case cudf::type_id::DECIMAL32: {
-      using dec_t = numeric::decimal32;
-      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
-      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    case cudf::type_id::DECIMAL64: {
-      using dec_t = numeric::decimal64;
-      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
-      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    case cudf::type_id::DECIMAL128: {
-      using dec_t = numeric::decimal128;
-      auto a      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc).value();
-      auto b      = scalar_cast<cudf::fixed_point_scalar<dec_t>>(incoming).value();
-      auto v      = choose_min ? std::min(a, b) : std::max(a, b);
-      set_fixed_point_value(scalar_cast<cudf::fixed_point_scalar<dec_t>>(acc), v);
-      break;
-    }
-    default:
-      throw duckdb::NotImplementedException(
-        "Unsupported type for min/max in GPU ungrouped aggregate");
   }
+
+  return cudf::make_column_from_scalar(*out_scalar, 1, stream, memory_resource);
 }
 
 }  // namespace
@@ -304,198 +302,141 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_ag
 {
   if (aggregates.empty()) { return {}; }
 
-  cucascade::memory::memory_space* space = nullptr;
-  for (auto const& batch : input_batches) {
-    if (batch) {
-      space = batch->get_memory_space();
-      break;
-    }
-  }
-  if (space == nullptr) { return {}; }
-
-  std::unique_lock<std::mutex> lk(_state->_mutex);
-  if (!_state->_initialized) {
-    _state->_running_values.resize(aggregates.size());
-    _state->_running_counts.resize(aggregates.size(), 0);
-    _state->_initialized = true;
-  }
+  auto layout = build_aggregate_layout(aggregates);
+  std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
+  outputs.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
-    auto table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
-    auto view  = table.view();
+    auto* space = batch->get_memory_space();
+    if (!space) { continue; }
 
-    for (idx_t i = 0; i < aggregates.size(); ++i) {
-      auto& agg = aggregates[i]->Cast<duckdb::BoundAggregateExpression>();
-      if (agg.IsDistinct()) {
-        throw duckdb::NotImplementedException("Distinct aggregates not supported in GPU path yet");
-      }
-      auto fname = agg.function.name;
+    auto stream = space->acquire_stream();
+    auto table  = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+    auto view   = table.view();
 
-      if (fname == "count_star") {
-        _state->_running_counts[i] += static_cast<int64_t>(view.num_rows());
-      } else if (fname == "count") {
-        D_ASSERT(agg.children.size() == 1);
-        auto idx    = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
-        auto col    = view.column(static_cast<cudf::size_type>(idx));
-        auto agg_op = cudf::make_count_aggregation<cudf::reduce_aggregation>();
-        auto s      = cudf::reduce(col,
-                              *agg_op,
-                              cudf::data_type(cudf::type_id::INT64),
-                              std::nullopt,
-                              cudf::get_default_stream(),
-                              rmm::mr::get_current_device_resource());
-        _state->_running_counts[i] += static_cast<const cudf::numeric_scalar<int64_t>&>(*s).value();
-      } else {
-        D_ASSERT(agg.children.size() == 1);
-        auto idx      = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
-        auto col      = view.column(static_cast<cudf::size_type>(idx));
-        auto out_type = ToCudfType(agg.return_type);
-        std::unique_ptr<cudf::scalar> s;
-        if (fname == "sum" || fname == "sum_no_overflow") {
-          auto agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-          s           = cudf::reduce(col,
-                           *agg_op,
-                           out_type,
-                           std::nullopt,
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
-          if (!_state->_running_values[i]) {
-            _state->_running_values[i] = std::move(s);
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.reserve(layout.local_types.size());
+
+    for (auto const& spec : layout.aggregates) {
+      switch (spec.kind) {
+        case aggregate_kind::COUNT_STAR: {
+          auto scalar = make_numeric_scalar_with_value<int64_t>(
+            cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()));
+          cols.push_back(
+            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+          break;
+        }
+        case aggregate_kind::COUNT: {
+          auto col    = view.column(static_cast<cudf::size_type>(spec.input_idx));
+          auto agg_op = cudf::make_count_aggregation<cudf::reduce_aggregation>();
+          auto scalar = cudf::reduce(col,
+                                     *agg_op,
+                                     cudf::data_type(cudf::type_id::INT64),
+                                     std::nullopt,
+                                     stream,
+                                     space->get_default_allocator());
+          cols.push_back(
+            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+          break;
+        }
+        case aggregate_kind::SUM:
+        case aggregate_kind::MIN:
+        case aggregate_kind::MAX:
+        case aggregate_kind::AVG: {
+          auto col      = view.column(static_cast<cudf::size_type>(spec.input_idx));
+          auto out_type = ToCudfType(spec.return_type);
+          std::unique_ptr<cudf::reduce_aggregation> agg_op;
+          if (spec.kind == aggregate_kind::MIN) {
+            agg_op = cudf::make_min_aggregation<cudf::reduce_aggregation>();
+          } else if (spec.kind == aggregate_kind::MAX) {
+            agg_op = cudf::make_max_aggregation<cudf::reduce_aggregation>();
           } else {
-            accumulate_sum(*_state->_running_values[i], *s);
+            agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
           }
-        } else if (fname == "min") {
-          auto agg_op = cudf::make_min_aggregation<cudf::reduce_aggregation>();
-          s           = cudf::reduce(col,
-                           *agg_op,
-                           out_type,
-                           std::nullopt,
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
-          if (!_state->_running_values[i]) {
-            _state->_running_values[i] = std::move(s);
-          } else {
-            accumulate_minmax(*_state->_running_values[i], *s, minmax_op::MIN);
+          auto scalar = cudf::reduce(
+            col, *agg_op, out_type, std::nullopt, stream, space->get_default_allocator());
+          cols.push_back(
+            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+          if (spec.kind == aggregate_kind::AVG) {
+            auto count_scalar = make_numeric_scalar_with_value<int64_t>(
+              cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()));
+            cols.push_back(cudf::make_column_from_scalar(
+              *count_scalar, 1, stream, space->get_default_allocator()));
           }
-        } else if (fname == "max") {
-          auto agg_op = cudf::make_max_aggregation<cudf::reduce_aggregation>();
-          s           = cudf::reduce(col,
-                           *agg_op,
-                           out_type,
-                           std::nullopt,
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
-          if (!_state->_running_values[i]) {
-            _state->_running_values[i] = std::move(s);
-          } else {
-            accumulate_minmax(*_state->_running_values[i], *s, minmax_op::MAX);
-          }
-        } else if (fname == "avg") {
-          auto agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-          s           = cudf::reduce(col,
-                           *agg_op,
-                           out_type,
-                           std::nullopt,
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
-          if (!_state->_running_values[i]) {
-            _state->_running_values[i] = std::move(s);
-          } else {
-            accumulate_sum(*_state->_running_values[i], *s);
-          }
-          _state->_running_counts[i] += static_cast<int64_t>(view.num_rows());
-        } else {
-          throw duckdb::NotImplementedException("Aggregate not supported: " + fname);
+          break;
         }
       }
     }
+
+    auto out_table = std::make_unique<cudf::table>(std::move(cols));
+    std::unique_ptr<cucascade::idata_representation> output_data =
+      std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
+    auto const batch_id = ::sirius::get_next_batch_id();
+    outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
   }
 
-  // Build output row
-  std::vector<std::unique_ptr<cudf::column>> cols;
-  cols.reserve(aggregates.size());
-  auto stream = cudf::get_default_stream();
+  return outputs;
+}
 
-  for (idx_t i = 0; i < aggregates.size(); ++i) {
-    auto& agg = aggregates[i]->Cast<duckdb::BoundAggregateExpression>();
-    auto tid  = ToCudfType(agg.return_type);
+sirius_physical_ungrouped_aggregate_merge::sirius_physical_ungrouped_aggregate_merge(
+  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
+  duckdb::idx_t estimated_cardinality)
+  : sirius_physical_operator(
+      duckdb::PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality),
+    aggregates(std::move(expressions))
+{
+}
 
-    std::unique_ptr<cudf::scalar> tmp_scalar;
-    const cudf::scalar* out_scalar = nullptr;
-    if (agg.function.name == "avg") {
-      auto const cnt = _state->_running_counts[i];
-      if (cnt == 0) {
-        // produce zero of target type
-        switch (tid.id()) {
-          case cudf::type_id::FLOAT32: {
-            tmp_scalar = make_numeric_scalar_with_value<float>(tid, 0.0f);
-            out_scalar = tmp_scalar.get();
-            break;
-          }
-          case cudf::type_id::FLOAT64: {
-            tmp_scalar = make_numeric_scalar_with_value<double>(tid, 0.0);
-            out_scalar = tmp_scalar.get();
-            break;
-          }
-          case cudf::type_id::INT32: {
-            tmp_scalar = make_numeric_scalar_with_value<int32_t>(tid, 0);
-            out_scalar = tmp_scalar.get();
-            break;
-          }
-          case cudf::type_id::INT64: {
-            tmp_scalar = make_numeric_scalar_with_value<int64_t>(tid, 0);
-            out_scalar = tmp_scalar.get();
-            break;
-          }
-          default: throw duckdb::NotImplementedException("AVG output type not supported");
-        }
-      } else {
-        // compute avg in double then cast to target type
-        double sum_host = 0.0;
-        switch (tid.id()) {
-          case cudf::type_id::FLOAT32:
-            sum_host =
-              scalar_cast<cudf::numeric_scalar<float>>(*_state->_running_values[i]).value();
-            _state->_running_values[i] =
-              make_numeric_scalar_with_value<float>(tid, static_cast<float>(sum_host / cnt));
-            break;
-          case cudf::type_id::FLOAT64:
-            sum_host =
-              scalar_cast<cudf::numeric_scalar<double>>(*_state->_running_values[i]).value();
-            _state->_running_values[i] =
-              make_numeric_scalar_with_value<double>(tid, sum_host / cnt);
-            break;
-          case cudf::type_id::INT32:
-            sum_host =
-              scalar_cast<cudf::numeric_scalar<int32_t>>(*_state->_running_values[i]).value();
-            _state->_running_values[i] =
-              make_numeric_scalar_with_value<int32_t>(tid, static_cast<int32_t>(sum_host / cnt));
-            break;
-          case cudf::type_id::INT64:
-            sum_host =
-              scalar_cast<cudf::numeric_scalar<int64_t>>(*_state->_running_values[i]).value();
-            _state->_running_values[i] =
-              make_numeric_scalar_with_value<int64_t>(tid, static_cast<int64_t>(sum_host / cnt));
-            break;
-          default: throw duckdb::NotImplementedException("AVG output type not supported");
-        }
-        out_scalar = _state->_running_values[i].get();
-      }
-    } else if (agg.function.name == "count" || agg.function.name == "count_star") {
-      tmp_scalar = make_numeric_scalar_with_value<int64_t>(cudf::data_type{cudf::type_id::INT64},
-                                                           _state->_running_counts[i]);
-      out_scalar = tmp_scalar.get();
+std::vector<std::shared_ptr<cucascade::data_batch>>
+sirius_physical_ungrouped_aggregate_merge::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
+{
+  if (aggregates.empty()) { return {}; }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
+  valid_batches.reserve(input_batches.size());
+  for (auto const& batch : input_batches) {
+    if (batch) { valid_batches.push_back(batch); }
+  }
+  if (valid_batches.empty()) { return {}; }
+
+  cucascade::memory::memory_space* space = valid_batches[0]->get_memory_space();
+  if (space == nullptr) { return {}; }
+
+  auto layout = build_aggregate_layout(aggregates);
+  auto stream = space->acquire_stream();
+  std::shared_ptr<cucascade::data_batch> merged_batch;
+  if (valid_batches.size() == 1) {
+    merged_batch = valid_batches[0];
+  } else {
+    merged_batch =
+      gpu_merge_impl::merge_ungrouped_aggregate(valid_batches, layout.merge_kinds, stream, *space);
+  }
+
+  if (!layout.has_avg) { return {std::move(merged_batch)}; }
+
+  auto merged_table =
+    merged_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+  auto merged_view = merged_table.view();
+
+  std::vector<std::unique_ptr<cudf::column>> output_cols;
+  output_cols.reserve(layout.aggregates.size());
+  for (auto const& spec : layout.aggregates) {
+    if (spec.kind == aggregate_kind::AVG) {
+      auto sum_view   = merged_view.column(static_cast<cudf::size_type>(spec.local_sum_idx));
+      auto count_view = merged_view.column(static_cast<cudf::size_type>(spec.local_count_idx));
+      output_cols.push_back(make_avg_column(
+        sum_view, count_view, spec.return_type, stream, space->get_default_allocator()));
     } else {
-      // sum/min/max already accumulated in _running_values
-      out_scalar = _state->_running_values[i].get();  // non-owning
+      auto col_view = merged_view.column(static_cast<cudf::size_type>(spec.local_sum_idx));
+      output_cols.push_back(
+        std::make_unique<cudf::column>(col_view, stream, space->get_default_allocator()));
     }
-
-    cols.push_back(cudf::make_column_from_scalar(
-      *out_scalar, 1, stream, rmm::mr::get_current_device_resource()));
   }
 
-  auto out_table = std::make_unique<cudf::table>(std::move(cols));
+  auto out_table = std::make_unique<cudf::table>(std::move(output_cols));
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(*out_table, *space);
   auto const batch_id = ::sirius::get_next_batch_id();

--- a/src/operator/gpu_physical_concat.cpp
+++ b/src/operator/gpu_physical_concat.cpp
@@ -28,7 +28,7 @@
 namespace duckdb {
 
 GPUPhysicalConcat::GPUPhysicalConcat(vector<LogicalType> types, idx_t estimated_cardinality)
-  : GPUPhysicalOperator(PhysicalOperatorType::INVALID, std::move(types), estimated_cardinality)
+  : GPUPhysicalOperator(PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality)
 {
   _num_partitions = (estimated_cardinality + PARTITION_SIZE - 1) / PARTITION_SIZE;
 }

--- a/src/operator/gpu_physical_partition.cpp
+++ b/src/operator/gpu_physical_partition.cpp
@@ -30,7 +30,7 @@ GPUPhysicalPartition::GPUPhysicalPartition(vector<LogicalType> types,
                                            idx_t estimated_cardinality,
                                            GPUPhysicalOperator* parent_op,
                                            bool is_build)
-  : GPUPhysicalOperator(PhysicalOperatorType::INVALID, std::move(types), estimated_cardinality)
+  : GPUPhysicalOperator(PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality)
 {
   _num_partitions = (estimated_cardinality + PARTITION_SIZE - 1) / PARTITION_SIZE;
   _parent_op      = parent_op;

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -230,6 +230,37 @@ static bool can_use_perfect_hash_aggregate(duckdb::ClientContext& context,
   return true;
 }
 
+static duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> copy_expressions(
+  const duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& input)
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> result;
+  result.reserve(input.size());
+  for (auto& expr : input) {
+    result.push_back(expr->Copy());
+  }
+  return result;
+}
+
+static duckdb::vector<duckdb::LogicalType> build_local_ungrouped_types(
+  const duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& aggregates)
+{
+  duckdb::vector<duckdb::LogicalType> local_types;
+  local_types.reserve(aggregates.size());
+  for (auto& expression : aggregates) {
+    auto& aggregate  = expression->Cast<duckdb::BoundAggregateExpression>();
+    const auto& name = aggregate.function.name;
+    if (name == "avg") {
+      local_types.push_back(aggregate.return_type);
+      local_types.push_back(duckdb::LogicalType::BIGINT);
+    } else if (name == "count" || name == "count_star") {
+      local_types.push_back(duckdb::LogicalType::BIGINT);
+    } else {
+      local_types.push_back(aggregate.return_type);
+    }
+  }
+  return local_types;
+}
+
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
 {
@@ -262,11 +293,24 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     // no groups, check if we can use a simple aggregation
     // special case: aggregate entire columns together
     if (can_use_simple_aggregation) {
-      auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
-                                             sirius::op::sirius_physical_ungrouped_aggregate>(
-        op.types, std::move(op.expressions), op.estimated_cardinality, op.distinct_validity);
-      group_by->children.push_back(std::move(plan));
-      return group_by;
+      auto local_expressions = copy_expressions(op.expressions);
+      auto merge_expressions = std::move(op.expressions);
+      auto local_types       = build_local_ungrouped_types(local_expressions);
+
+      auto local_group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
+                                                   sirius::op::sirius_physical_ungrouped_aggregate>(
+        std::move(local_types),
+        std::move(local_expressions),
+        op.estimated_cardinality,
+        op.distinct_validity);
+      local_group_by->children.push_back(std::move(plan));
+
+      auto merge_group_by =
+        duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
+                               sirius::op::sirius_physical_ungrouped_aggregate_merge>(
+          op.types, std::move(merge_expressions), op.estimated_cardinality);
+      merge_group_by->children.push_back(std::move(local_group_by));
+      return merge_group_by;
     }
     throw duckdb::NotImplementedException("Non simple aggregation is not supported");
     // auto &group_by =

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -72,8 +72,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalLimit& op)
                                                                          std::move(op.limit_val),
                                                                          std::move(op.offset_val),
                                                                          op.estimated_cardinality,
-                                                                         true,
-                                                                         gpu_context.GetGPUExecutor().data_repo_manager.get());
+                                                                         true);
       } else {
         throw duckdb::NotImplementedException(
           "Streaming limit with insertion order preservation not supported in GPU");

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "op/sirius_physical_limit.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "gpu_context.hpp"
 
 namespace sirius::planner {
 
@@ -71,7 +72,8 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalLimit& op)
                                                                          std::move(op.limit_val),
                                                                          std::move(op.offset_val),
                                                                          op.estimated_cardinality,
-                                                                         true);
+                                                                         true,
+                                                                         gpu_context.GetGPUExecutor().data_repo_manager.get());
       } else {
         throw duckdb::NotImplementedException(
           "Streaming limit with insertion order preservation not supported in GPU");

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -20,9 +20,9 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
+#include "gpu_context.hpp"
 #include "op/sirius_physical_limit.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
-#include "gpu_context.hpp"
 
 namespace sirius::planner {
 

--- a/src/planner/sirius_plan_top_n.cpp
+++ b/src/planner/sirius_plan_top_n.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/planner/operator/logical_top_n.hpp"
 #include "op/sirius_physical_top_n.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "planner/sirius_plan_utils.hpp"
 
 namespace sirius::planner {
 
@@ -27,15 +28,28 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalTopN& op)
 
   auto plan = create_plan(*op.children[0]);
 
-  auto top_n = duckdb::make_uniq<sirius::op::sirius_physical_top_n>(
+  auto merge_orders   = std::move(op.orders);
+  auto local_orders   = copy_order_nodes(merge_orders);
+  auto dynamic_filter = op.dynamic_filter;
+
+  auto local_top_n = duckdb::make_uniq<sirius::op::sirius_physical_top_n>(
     op.types,
-    std::move(op.orders),
+    std::move(local_orders),
     duckdb::NumericCast<duckdb::idx_t>(op.limit),
     duckdb::NumericCast<duckdb::idx_t>(op.offset),
-    std::move(op.dynamic_filter),
+    dynamic_filter,
     op.estimated_cardinality);
-  top_n->children.push_back(std::move(plan));
-  return std::move(top_n);
+  local_top_n->children.push_back(std::move(plan));
+
+  auto merge_top_n = duckdb::make_uniq<sirius::op::sirius_physical_top_n_merge>(
+    op.types,
+    std::move(merge_orders),
+    duckdb::NumericCast<duckdb::idx_t>(op.limit),
+    duckdb::NumericCast<duckdb::idx_t>(op.offset),
+    dynamic_filter,
+    op.estimated_cardinality);
+  merge_top_n->children.push_back(std::move(local_top_n));
+  return std::move(merge_top_n);
 }
 
 }  // namespace sirius::planner

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -19,8 +19,8 @@
 #include <utils/utils.hpp>
 
 // sirius
-#include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
+#include <data/data_batch_utils.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <memory/sirius_memory_manager.hpp>
 
@@ -41,8 +41,7 @@ using namespace duckdb;
 using namespace duckdb::sirius;
 using namespace cucascade;
 using namespace cucascade::memory;
-using data_repository_mgr = data_repository_manager<std::shared_ptr<data_batch>>;
-using memory_mgr          = ::sirius::memory_manager;
+using memory_mgr = ::sirius::memory_manager;
 
 namespace {
 
@@ -119,7 +118,6 @@ std::vector<std::string> copy_string_column_to_host(const cudf::column_view& col
 }
 
 std::shared_ptr<data_batch> make_input_batch(
-  data_repository_mgr& repo_mgr,
   memory_space& space,
   const std::vector<cudf::data_type>& column_types,
   const std::vector<std::optional<std::pair<int, int>>>& ranges)
@@ -128,12 +126,11 @@ std::shared_ptr<data_batch> make_input_batch(
   auto table = ::sirius::create_cudf_table_with_random_data(
     128, column_types, ranges, cudf::get_default_stream(), mr);
   auto gpu_repr = std::make_unique<gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
-  return std::make_shared<data_batch>(batch_id, repo_mgr, std::move(gpu_repr));
+  auto batch_id = ::sirius::get_next_batch_id();
+  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
 }
 
-std::shared_ptr<data_batch> make_int32_batch_with_nulls(data_repository_mgr& repo_mgr,
-                                                        memory_space& space,
+std::shared_ptr<data_batch> make_int32_batch_with_nulls(memory_space& space,
                                                         const std::vector<int32_t>& values,
                                                         const std::vector<bool>& valids)
 {
@@ -164,8 +161,8 @@ std::shared_ptr<data_batch> make_int32_batch_with_nulls(data_repository_mgr& rep
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
-  return std::make_shared<data_batch>(batch_id, repo_mgr, std::move(gpu_repr));
+  auto batch_id = ::sirius::get_next_batch_id();
+  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
 }
 
 }  // namespace
@@ -176,15 +173,13 @@ TEST_CASE("gpu_expression_executor execute(data_batch) projects references",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32},
                                                             cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 100}},
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 1000}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
   exprs.push_back(
@@ -193,7 +188,7 @@ TEST_CASE("gpu_expression_executor execute(data_batch) projects references",
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BIGINT}, 1));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.execute(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.execute(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());
@@ -222,15 +217,13 @@ TEST_CASE("gpu_expression_executor execute(data_batch) handles constants and com
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32},
                                                             cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 100}},
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 1000}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
   exprs.push_back(
@@ -244,7 +237,7 @@ TEST_CASE("gpu_expression_executor execute(data_batch) handles constants and com
     ExpressionType::COMPARE_LESSTHAN, std::move(left_expr), std::move(right_expr)));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.execute(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.execute(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
 
@@ -279,13 +272,11 @@ TEST_CASE("gpu_expression_executor select(data_batch) filters rows", "[expressio
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 9}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   auto left_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
@@ -295,7 +286,7 @@ TEST_CASE("gpu_expression_executor select(data_batch) filters rows", "[expressio
     ExpressionType::COMPARE_GREATERTHAN, std::move(left_expr), std::move(right_expr)));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.select(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.select(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());
@@ -326,15 +317,13 @@ TEST_CASE("gpu_expression_executor select(data_batch) handles conjunction and IN
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32},
                                                             cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 9}},
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 50}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
@@ -359,7 +348,7 @@ TEST_CASE("gpu_expression_executor select(data_batch) handles conjunction and IN
   exprs.push_back(std::move(conjunction));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.select(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.select(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());
@@ -401,13 +390,11 @@ TEST_CASE("gpu_expression_executor select(data_batch) handles empty result",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{0, 9}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   auto left_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
@@ -417,7 +404,7 @@ TEST_CASE("gpu_expression_executor select(data_batch) handles empty result",
     ExpressionType::COMPARE_GREATERTHAN, std::move(left_expr), std::move(right_expr)));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.select(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.select(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());
@@ -438,12 +425,10 @@ TEST_CASE("gpu_expression_executor select(data_batch) respects null mask behavio
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<int32_t> values = {1, 2, 3, 4, 5};
   std::vector<bool> valids    = {true, false, true, false, true};
 
-  auto input_batch = make_int32_batch_with_nulls(repo_mgr, *space, values, valids);
+  auto input_batch = make_int32_batch_with_nulls(*space, values, valids);
 
   auto left_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
@@ -453,7 +438,7 @@ TEST_CASE("gpu_expression_executor select(data_batch) respects null mask behavio
     ExpressionType::COMPARE_GREATERTHAN, std::move(left_expr), std::move(right_expr)));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.select(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.select(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());
@@ -478,13 +463,11 @@ TEST_CASE("gpu_expression_executor select(data_batch) filters strings", "[expres
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::STRING}};
   std::vector<std::optional<std::pair<int, int>>> ranges = {
     std::optional<std::pair<int, int>>{std::pair<int, int>{1, 3}}};
 
-  auto input_batch = make_input_batch(repo_mgr, *space, column_types, ranges);
+  auto input_batch = make_input_batch(*space, column_types, ranges);
 
   auto left_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0);
@@ -494,7 +477,7 @@ TEST_CASE("gpu_expression_executor select(data_batch) filters strings", "[expres
     ExpressionType::COMPARE_EQUAL, std::move(left_expr), std::move(right_expr)));
 
   GpuExpressionExecutor executor(exprs, get_resource_ref(*space));
-  auto output_batch = executor.select(input_batch, repo_mgr, cudf::get_default_stream());
+  auto output_batch = executor.select(input_batch, cudf::get_default_stream());
 
   REQUIRE(output_batch != nullptr);
   REQUIRE(output_batch->get_memory_space() == input_batch->get_memory_space());

--- a/test/cpp/operator/CMakeLists.txt
+++ b/test/cpp/operator/CMakeLists.txt
@@ -20,4 +20,6 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_partition_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_host_table_chunk_reader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sirius_physical_result_collector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_filter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_limit.cpp
     PARENT_SCOPE)

--- a/test/cpp/operator/CMakeLists.txt
+++ b/test/cpp/operator/CMakeLists.txt
@@ -22,4 +22,6 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_sirius_physical_result_collector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_filter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_limit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_top_n.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_projection.cpp
     PARENT_SCOPE)

--- a/test/cpp/operator/CMakeLists.txt
+++ b/test/cpp/operator/CMakeLists.txt
@@ -24,4 +24,5 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_limit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_top_n.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_projection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_ungrouped_aggregate.cpp
     PARENT_SCOPE)

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -28,9 +28,9 @@
 
 #include <cuda_runtime_api.h>
 
-#include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
 #include <utils/utils.hpp>
@@ -132,7 +132,6 @@ inline std::vector<T> copy_column_to_host(const cudf::column_view& col)
 
 template <typename T>
 inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
-  data_repository_mgr& repo_mgr,
   cucascade::memory::memory_space& space,
   const std::vector<T>& values,
   cudf::type_id type_id)
@@ -164,7 +163,7 @@ inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
+  auto batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
 }
 
@@ -219,7 +218,6 @@ inline std::unique_ptr<cudf::column> make_string_column(const std::vector<std::s
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_string_batch(
-  data_repository_mgr& repo_mgr,
   cucascade::memory::memory_space& space,
   const std::vector<std::string>& values)
 {
@@ -231,12 +229,11 @@ inline std::shared_ptr<cucascade::data_batch> make_string_batch(
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
+  auto batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
-  data_repository_mgr& repo_mgr,
   cucascade::memory::memory_space& space,
   const std::vector<int64_t>& values,
   int32_t scale)
@@ -260,13 +257,12 @@ inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
+  auto batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
 }
 
 template <typename T>
 inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
-  data_repository_mgr& repo_mgr,
   cucascade::memory::memory_space& space,
   const std::vector<T>& values,
   cudf::type_id ts_type_id)
@@ -296,13 +292,12 @@ inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
+  auto batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
 }
 
 template <typename TFirst, typename TSecond>
 inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
-  data_repository_mgr& repo_mgr,
   cucascade::memory::memory_space& space,
   const std::vector<TFirst>& col0_values,
   const std::vector<TSecond>& col1_values,
@@ -393,7 +388,7 @@ inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
   auto table = std::make_unique<cudf::table>(std::move(cols));
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
-  auto batch_id = repo_mgr.get_next_data_batch_id();
+  auto batch_id = ::sirius::get_next_batch_id();
   return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
 }
 

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cucascade/data/data_repository_manager.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <memory/sirius_memory_reservation_manager.hpp>
+
+#include <utils/utils.hpp>
+
+#include <optional>
+#include <type_traits>
+
+namespace sirius::test::operator_utils {
+
+using data_repository_mgr =
+  cucascade::data_repository_manager<std::shared_ptr<cucascade::data_batch>>;
+inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initialize_memory_manager(
+  std::size_t n_gpus = 1)
+{
+  // Reset converter registry to avoid cross-test leakage
+  sirius::converter_registry::reset_for_testing();
+
+  cucascade::memory::reservation_manager_configurator builder;
+
+  // Configure a modest GPU space
+  const size_t gpu_capacity = 512ull << 20;  // 512MB
+  const double limit_ratio  = 0.75;
+  const size_t host_capacity = 1ull << 30;  // 1GB
+
+  builder.set_number_of_gpus(n_gpus)
+    .set_gpu_usage_limit(gpu_capacity / n_gpus)
+    .set_reservation_fraction_per_gpu(limit_ratio)
+    .set_per_host_capacity(host_capacity / n_gpus)
+    .use_host_per_gpu()
+    .set_reservation_fraction_per_host(limit_ratio);
+
+  auto space_configs = builder.build();
+  auto manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
+    std::move(space_configs));
+
+  // Initialize converters used by data representations
+  sirius::converter_registry::initialize();
+  return manager;
+}
+
+inline cucascade::memory::memory_space* get_default_gpu_space()
+{
+  static auto manager = initialize_memory_manager();
+  return const_cast<cucascade::memory::memory_space*>(
+    manager->get_memory_space(cucascade::memory::Tier::GPU, 0));
+}
+
+inline rmm::device_async_resource_ref get_resource_ref(cucascade::memory::memory_space& space)
+{
+  return rmm::to_device_async_resource_ref_checked(space.get_default_allocator());
+}
+
+inline rmm::cuda_stream_view default_stream() { return cudf::get_default_stream(); }
+
+template <typename T>
+inline std::vector<T> copy_column_to_host(const cudf::column_view& col)
+{
+  if constexpr (std::is_same_v<T, bool>) {
+    std::vector<int8_t> tmp(col.size());
+    if (col.size() > 0) {
+      cudaMemcpy(
+        tmp.data(), col.data<int8_t>(), sizeof(int8_t) * col.size(), cudaMemcpyDeviceToHost);
+    }
+    std::vector<bool> host(col.size());
+    for (size_t i = 0; i < col.size(); ++i) {
+      host[i] = tmp[i] != 0;
+    }
+    return host;
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    std::vector<std::string> host;
+    if (col.size() == 0) { return host; }
+    cudf::strings_column_view str_col(col);
+    std::vector<cudf::size_type> offsets(col.size() + 1);
+    cudaMemcpy(offsets.data(),
+               str_col.offsets().data<cudf::size_type>(),
+               (col.size() + 1) * sizeof(cudf::size_type),
+               cudaMemcpyDeviceToHost);
+    std::vector<char> chars(offsets.back());
+    if (!chars.empty()) {
+      cudaMemcpy(chars.data(),
+                 str_col.chars_begin(cudf::get_default_stream()),
+                 offsets.back(),
+                 cudaMemcpyDeviceToHost);
+    }
+    host.reserve(col.size());
+    for (cudf::size_type i = 0; i < col.size(); ++i) {
+      host.emplace_back(chars.data() + offsets[i], chars.data() + offsets[i + 1]);
+    }
+    return host;
+  } else {
+    std::vector<T> host(col.size());
+    if (col.size() > 0) {
+      cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
+    }
+    return host;
+  }
+}
+
+template <typename T>
+inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
+  data_repository_mgr& repo_mgr,
+  cucascade::memory::memory_space& space,
+  const std::vector<T>& values,
+  cudf::type_id type_id)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(values.size());
+
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{type_id}, size, cudf::mask_state::UNALLOCATED, stream, mr);
+  if constexpr (std::is_same_v<T, bool>) {
+    std::vector<int8_t> tmp(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      tmp[i] = static_cast<int8_t>(values[i]);
+    }
+    cudaMemcpy(col->mutable_view().data<int8_t>(),
+               tmp.data(),
+               sizeof(int8_t) * tmp.size(),
+               cudaMemcpyHostToDevice);
+  } else {
+    cudaMemcpy(col->mutable_view().data<T>(),
+               values.data(),
+               sizeof(T) * values.size(),
+               cudaMemcpyHostToDevice);
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
+  auto batch_id = repo_mgr.get_next_data_batch_id();
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+inline std::unique_ptr<cudf::column> make_string_column(const std::vector<std::string>& values,
+                                                        rmm::cuda_stream_view stream,
+                                                        rmm::device_async_resource_ref mr)
+{
+  auto const strings_count = static_cast<cudf::size_type>(values.size());
+
+  // Build offsets and chars on host
+  std::vector<cudf::size_type> offsets(strings_count + 1, 0);
+  cudf::size_type total_chars = 0;
+  for (cudf::size_type i = 0; i < strings_count; ++i) {
+    offsets[i + 1] = offsets[i] + static_cast<cudf::size_type>(values[i].size());
+    total_chars    = offsets[i + 1];
+  }
+  std::vector<char> chars(static_cast<std::size_t>(total_chars));
+  cudf::size_type cursor = 0;
+  for (cudf::size_type i = 0; i < strings_count; ++i) {
+    auto const& s = values[i];
+    std::memcpy(chars.data() + cursor, s.data(), s.size());
+    cursor += static_cast<cudf::size_type>(s.size());
+  }
+
+  // Offsets column
+  auto offsets_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                               static_cast<cudf::size_type>(offsets.size()),
+                                               cudf::mask_state::UNALLOCATED,
+                                               stream,
+                                               mr);
+  cudaMemcpyAsync(offsets_col->mutable_view().data<cudf::size_type>(),
+                  offsets.data(),
+                  offsets.size() * sizeof(cudf::size_type),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+
+  // Chars buffer
+  rmm::device_buffer chars_buf(total_chars, stream, mr);
+  if (total_chars > 0) {
+    cudaMemcpyAsync(chars_buf.data(),
+                    chars.data(),
+                    chars.size() * sizeof(char),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+  }
+
+  return cudf::make_strings_column(strings_count,
+                                   std::move(offsets_col),
+                                   std::move(chars_buf),
+                                   0,
+                                   rmm::device_buffer{0, stream, mr});
+}
+
+inline std::shared_ptr<cucascade::data_batch> make_string_batch(
+  data_repository_mgr& repo_mgr,
+  cucascade::memory::memory_space& space,
+  const std::vector<std::string>& values)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_string_column(values, stream, mr));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
+  auto batch_id = repo_mgr.get_next_data_batch_id();
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
+  data_repository_mgr& repo_mgr,
+  cucascade::memory::memory_space& space,
+  const std::vector<int64_t>& values,
+  int32_t scale)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(values.size());
+
+  auto col = cudf::make_fixed_point_column(cudf::data_type{cudf::type_id::DECIMAL64, scale},
+                                           size,
+                                           cudf::mask_state::UNALLOCATED,
+                                           stream,
+                                           mr);
+  cudaMemcpy(col->mutable_view().data<int64_t>(),
+             values.data(),
+             sizeof(int64_t) * values.size(),
+             cudaMemcpyHostToDevice);
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
+  auto batch_id = repo_mgr.get_next_data_batch_id();
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+template <typename T>
+inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
+  data_repository_mgr& repo_mgr,
+  cucascade::memory::memory_space& space,
+  const std::vector<T>& values,
+  cudf::type_id ts_type_id)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(values.size());
+
+  auto col = cudf::make_timestamp_column(
+    cudf::data_type{ts_type_id}, size, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  // TIMESTAMP_DAYS uses 32-bit underlying storage; others use 64-bit
+  if (ts_type_id == cudf::type_id::TIMESTAMP_DAYS) {
+    cudaMemcpy(col->mutable_view().data<int32_t>(),
+               values.data(),
+               sizeof(int32_t) * values.size(),
+               cudaMemcpyHostToDevice);
+  } else {
+    cudaMemcpy(col->mutable_view().data<int64_t>(),
+               values.data(),
+               sizeof(int64_t) * values.size(),
+               cudaMemcpyHostToDevice);
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
+  auto batch_id = repo_mgr.get_next_data_batch_id();
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+template <typename TFirst, typename TSecond>
+inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
+  data_repository_mgr& repo_mgr,
+  cucascade::memory::memory_space& space,
+  const std::vector<TFirst>& col0_values,
+  const std::vector<TSecond>& col1_values,
+  cudf::type_id col1_type_id,
+  std::optional<int32_t> decimal_scale      = std::nullopt,
+  std::optional<cudf::type_id> col0_type_id = std::nullopt)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+
+  // Column 0: INT64 filter column
+  auto col0 =
+    cudf::make_numeric_column(cudf::data_type{col0_type_id.value_or(cudf::type_id::INT64)},
+                              static_cast<cudf::size_type>(col0_values.size()),
+                              cudf::mask_state::UNALLOCATED,
+                              stream,
+                              mr);
+  cudaMemcpy(col0->mutable_view().data<TFirst>(),
+             col0_values.data(),
+             sizeof(TFirst) * col0_values.size(),
+             cudaMemcpyHostToDevice);
+
+  std::unique_ptr<cudf::column> col1;
+  if constexpr (std::is_same_v<TSecond, bool>) {
+    std::vector<int8_t> tmp(col1_values.size());
+    for (size_t i = 0; i < col1_values.size(); ++i) {
+      tmp[i] = static_cast<int8_t>(col1_values[i]);
+    }
+    col1 = cudf::make_numeric_column(cudf::data_type{col1_type_id},
+                                     static_cast<cudf::size_type>(col1_values.size()),
+                                     cudf::mask_state::UNALLOCATED,
+                                     stream,
+                                     mr);
+    cudaMemcpy(col1->mutable_view().data<int8_t>(),
+               tmp.data(),
+               sizeof(int8_t) * tmp.size(),
+               cudaMemcpyHostToDevice);
+  } else if constexpr (std::is_same_v<TSecond, std::string>) {
+    col1 = make_string_column(col1_values, stream, mr);
+  } else if (col1_type_id == cudf::type_id::DECIMAL64 && decimal_scale.has_value()) {
+    col1 = cudf::make_numeric_column(cudf::data_type{col1_type_id, *decimal_scale},
+                                     static_cast<cudf::size_type>(col1_values.size()),
+                                     cudf::mask_state::UNALLOCATED,
+                                     stream,
+                                     mr);
+    cudaMemcpy(col1->mutable_view().data<int64_t>(),
+               col1_values.data(),
+               sizeof(int64_t) * col1_values.size(),
+               cudaMemcpyHostToDevice);
+  } else if (col1_type_id == cudf::type_id::TIMESTAMP_DAYS ||
+             col1_type_id == cudf::type_id::TIMESTAMP_MICROSECONDS ||
+             col1_type_id == cudf::type_id::TIMESTAMP_MILLISECONDS ||
+             col1_type_id == cudf::type_id::TIMESTAMP_SECONDS ||
+             col1_type_id == cudf::type_id::TIMESTAMP_NANOSECONDS) {
+    col1 = cudf::make_timestamp_column(cudf::data_type{col1_type_id},
+                                       static_cast<cudf::size_type>(col1_values.size()),
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       mr);
+    if (col1_type_id == cudf::type_id::TIMESTAMP_DAYS) {
+      cudaMemcpy(col1->mutable_view().data<int32_t>(),
+                 col1_values.data(),
+                 sizeof(int32_t) * col1_values.size(),
+                 cudaMemcpyHostToDevice);
+    } else {
+      cudaMemcpy(col1->mutable_view().data<int64_t>(),
+                 col1_values.data(),
+                 sizeof(int64_t) * col1_values.size(),
+                 cudaMemcpyHostToDevice);
+    }
+  } else if (col1_type_id == cudf::type_id::DECIMAL32 || col1_type_id == cudf::type_id::DECIMAL64 ||
+             col1_type_id == cudf::type_id::DECIMAL128) {
+    auto data_type = cudf::data_type{col1_type_id, decimal_scale.value_or(0)};
+    col1           = cudf::make_fixed_point_column(data_type,
+                                         static_cast<cudf::size_type>(col1_values.size()),
+                                         cudf::mask_state::UNALLOCATED,
+                                         stream,
+                                         mr);
+    cudaMemcpy(col1->mutable_view().data<int64_t>(),
+               col1_values.data(),
+               sizeof(int64_t) * col1_values.size(),
+               cudaMemcpyHostToDevice);
+  } else {
+    col1 = cudf::make_numeric_column(cudf::data_type{col1_type_id},
+                                     static_cast<cudf::size_type>(col1_values.size()),
+                                     cudf::mask_state::UNALLOCATED,
+                                     stream,
+                                     mr);
+    cudaMemcpy(col1->mutable_view().data<TSecond>(),
+               col1_values.data(),
+               sizeof(TSecond) * col1_values.size(),
+               cudaMemcpyHostToDevice);
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col0));
+  cols.push_back(std::move(col1));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(*table, space);
+  auto batch_id = repo_mgr.get_next_data_batch_id();
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+}  // namespace sirius::test::operator_utils

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "scan/test_utils.hpp"
+
 #include <cudf/column/column_factories.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/null_mask.hpp>
@@ -34,7 +36,6 @@
 #include <data/sirius_converter_registry.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
 #include <utils/utils.hpp>
-#include "scan/test_utils.hpp"
 
 #include <optional>
 #include <type_traits>
@@ -131,9 +132,7 @@ inline std::vector<T> copy_column_to_host(const cudf::column_view& col)
 
 template <typename T>
 inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
-  cucascade::memory::memory_space& space,
-  const std::vector<T>& values,
-  cudf::type_id type_id)
+  cucascade::memory::memory_space& space, const std::vector<T>& values, cudf::type_id type_id)
 {
   auto mr     = get_resource_ref(space);
   auto stream = default_stream();
@@ -217,8 +216,7 @@ inline std::unique_ptr<cudf::column> make_string_column(const std::vector<std::s
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_string_batch(
-  cucascade::memory::memory_space& space,
-  const std::vector<std::string>& values)
+  cucascade::memory::memory_space& space, const std::vector<std::string>& values)
 {
   auto mr     = get_resource_ref(space);
   auto stream = default_stream();
@@ -233,9 +231,7 @@ inline std::shared_ptr<cucascade::data_batch> make_string_batch(
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
-  cucascade::memory::memory_space& space,
-  const std::vector<int64_t>& values,
-  int32_t scale)
+  cucascade::memory::memory_space& space, const std::vector<int64_t>& values, int32_t scale)
 {
   auto mr     = get_resource_ref(space);
   auto stream = default_stream();
@@ -262,9 +258,7 @@ inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
 
 template <typename T>
 inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
-  cucascade::memory::memory_space& space,
-  const std::vector<T>& values,
-  cudf::type_id ts_type_id)
+  cucascade::memory::memory_space& space, const std::vector<T>& values, cudf::type_id ts_type_id)
 {
   auto mr     = get_resource_ref(space);
   auto stream = default_stream();

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -342,16 +342,6 @@ inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
                cudaMemcpyHostToDevice);
   } else if constexpr (std::is_same_v<TSecond, std::string>) {
     col1 = make_string_column(col1_values, stream, mr);
-  } else if (col1_type_id == cudf::type_id::DECIMAL64 && decimal_scale.has_value()) {
-    col1 = cudf::make_numeric_column(cudf::data_type{col1_type_id, *decimal_scale},
-                                     static_cast<cudf::size_type>(col1_values.size()),
-                                     cudf::mask_state::UNALLOCATED,
-                                     stream,
-                                     mr);
-    cudaMemcpy(col1->mutable_view().data<int64_t>(),
-               col1_values.data(),
-               sizeof(int64_t) * col1_values.size(),
-               cudaMemcpyHostToDevice);
   } else if (col1_type_id == cudf::type_id::TIMESTAMP_DAYS ||
              col1_type_id == cudf::type_id::TIMESTAMP_MICROSECONDS ||
              col1_type_id == cudf::type_id::TIMESTAMP_MILLISECONDS ||

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -53,8 +53,8 @@ inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initia
   cucascade::memory::reservation_manager_configurator builder;
 
   // Configure a modest GPU space
-  const size_t gpu_capacity = 512ull << 20;  // 512MB
-  const double limit_ratio  = 0.75;
+  const size_t gpu_capacity  = 512ull << 20;  // 512MB
+  const double limit_ratio   = 0.75;
   const size_t host_capacity = 1ull << 30;  // 1GB
 
   builder.set_number_of_gpus(n_gpus)
@@ -65,8 +65,8 @@ inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initia
     .set_reservation_fraction_per_host(limit_ratio);
 
   auto space_configs = builder.build();
-  auto manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
-    std::move(space_configs));
+  auto manager =
+    std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
 
   // Initialize converters used by data representations
   sirius::converter_registry::initialize();

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -33,8 +33,8 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/sirius_converter_registry.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
-
 #include <utils/utils.hpp>
+#include "scan/test_utils.hpp"
 
 #include <optional>
 #include <type_traits>

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -78,7 +78,6 @@ inline cucascade::memory::memory_space* get_default_gpu_space()
   return const_cast<cucascade::memory::memory_space*>(
     manager->get_memory_space(cucascade::memory::Tier::GPU, 0));
 }
-
 inline rmm::device_async_resource_ref get_resource_ref(cucascade::memory::memory_space& space)
 {
   return rmm::to_device_async_resource_ref_checked(space.get_default_allocator());

--- a/test/cpp/operator/operator_type_traits.hpp
+++ b/test/cpp/operator/operator_type_traits.hpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <duckdb/common/types.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace sirius::test::operator_utils {
+
+template <typename T>
+struct gpu_type_traits;
+
+template <>
+struct gpu_type_traits<int32_t> {
+  using type = int32_t;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::INT32;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {1, 3, 5, 7}; }
+  static type threshold() { return 3; }
+};
+
+template <>
+struct gpu_type_traits<int64_t> {
+  using type = int64_t;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::INT64;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {2, 4, 6, 8}; }
+  static type threshold() { return 4; }
+};
+
+template <>
+struct gpu_type_traits<float> {
+  using type = float;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::FLOAT);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::FLOAT32;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {1.0F, 2.5F, 4.5F}; }
+  static type threshold() { return 2.0F; }
+};
+
+template <>
+struct gpu_type_traits<double> {
+  using type = double;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::DOUBLE);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::FLOAT64;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {1.5, 2.5, 3.5}; }
+  static type threshold() { return 2.0; }
+};
+
+template <>
+struct gpu_type_traits<int16_t> {
+  using type = int16_t;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::SMALLINT);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::INT16;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {static_cast<type>(1), static_cast<type>(2)}; }
+  static type threshold() { return static_cast<type>(1); }
+};
+
+template <>
+struct gpu_type_traits<bool> {
+  using type = bool;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::BOOLEAN);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::BOOL8;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {false, true, true}; }
+  static type threshold() { return false; }  // filter keeps true values
+};
+
+struct decimal64_tag {};
+template <>
+struct gpu_type_traits<decimal64_tag> {
+  using type = int64_t;  // underlying storage
+  static duckdb::LogicalType logical_type() { return duckdb::LogicalType::DECIMAL(18, 2); }
+  // Use INT64 physical column for tests to avoid cudf fixed-point factory limitations in mask paths
+  static constexpr cudf::type_id cudf_type = cudf::type_id::INT64;
+  static constexpr int32_t scale           = -2;  // retained for reference
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {100, 250, 350}; }  // 1.00, 2.50, 3.50
+  static type threshold() { return 200; }                               // 2.00
+};
+
+struct string_tag {};
+template <>
+struct gpu_type_traits<string_tag> {
+  using type = std::string;
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::STRING;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = true;
+  static constexpr bool is_ts              = false;
+  static std::vector<type> sample_values() { return {"apple", "banana", "cherry"}; }
+  static type threshold() { return std::string("banana"); }  // lex compare
+};
+
+struct timestamp_us_tag {};
+template <>
+struct gpu_type_traits<timestamp_us_tag> {
+  using type = int64_t;  // microseconds since epoch
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::TIMESTAMP);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::TIMESTAMP_MICROSECONDS;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = true;
+  static std::vector<type> sample_values() { return {1'000'000, 2'000'000, 3'000'000}; }
+  static type threshold() { return 1'500'000; }
+};
+
+struct date32_tag {};
+template <>
+struct gpu_type_traits<date32_tag> {
+  using type = int32_t;  // days since epoch
+  static duckdb::LogicalType logical_type()
+  {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::DATE);
+  }
+  static constexpr cudf::type_id cudf_type = cudf::type_id::TIMESTAMP_DAYS;
+  static constexpr bool is_decimal         = false;
+  static constexpr bool is_string          = false;
+  static constexpr bool is_ts              = true;
+  static std::vector<type> sample_values() { return {0, 1, 5}; }
+  static type threshold() { return 1; }
+};
+
+}  // namespace sirius::test::operator_utils

--- a/test/cpp/operator/operator_type_traits.hpp
+++ b/test/cpp/operator/operator_type_traits.hpp
@@ -123,10 +123,9 @@ template <>
 struct gpu_type_traits<decimal64_tag> {
   using type = int64_t;  // underlying storage
   static duckdb::LogicalType logical_type() { return duckdb::LogicalType::DECIMAL(18, 2); }
-  // Use INT64 physical column for tests to avoid cudf fixed-point factory limitations in mask paths
-  static constexpr cudf::type_id cudf_type = cudf::type_id::INT64;
-  static constexpr int32_t scale           = -2;  // retained for reference
-  static constexpr bool is_decimal         = false;
+  static constexpr cudf::type_id cudf_type = cudf::type_id::DECIMAL64;
+  static constexpr int32_t scale           = -2;
+  static constexpr bool is_decimal         = true;
   static constexpr bool is_string          = false;
   static constexpr bool is_ts              = false;
   static std::vector<type> sample_values() { return {100, 250, 350}; }  // 1.00, 2.50, 3.50

--- a/test/cpp/operator/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/test_gpu_merge_impl.cpp
@@ -777,10 +777,9 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
 
 namespace {
 
-batches_with_handles create_batches_with_local_orderby_or_topn_result(
+batches_with_handles create_batches_with_local_orderby_result(
   const int num_batches,
   const std::vector<int>& num_base_input_rows,
-  const std::optional<std::pair<int, int>>& limit_offset,
   const std::vector<cudf::data_type>& column_types,
   const std::vector<int>& order_key_idx,
   const std::vector<cudf::order>& column_order,
@@ -802,23 +801,13 @@ batches_with_handles create_batches_with_local_orderby_or_topn_result(
     projections[i] = i;
   }
   for (int i = 0; i < num_batches; ++i) {
-    auto batch = limit_offset.has_value()
-                   ? gpu_order_impl::local_top_n(base_input.batches[i],
-                                                 limit_offset->first,
-                                                 limit_offset->second,
-                                                 order_key_idx,
-                                                 column_order,
-                                                 null_precedence,
-                                                 projections,
-                                                 cudf::get_default_stream(),
-                                                 mem_space)
-                   : gpu_order_impl::local_order_by(base_input.batches[i],
-                                                    order_key_idx,
-                                                    column_order,
-                                                    null_precedence,
-                                                    projections,
-                                                    cudf::get_default_stream(),
-                                                    mem_space);
+    auto batch = gpu_order_impl::local_order_by(base_input.batches[i],
+                                                order_key_idx,
+                                                column_order,
+                                                null_precedence,
+                                                projections,
+                                                cudf::get_default_stream(),
+                                                mem_space);
     REQUIRE(batch->try_to_create_task());
     auto lock_result = batch->try_to_lock_for_processing(mem_space.get_id());
     REQUIRE(lock_result.success);
@@ -882,14 +871,13 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
   std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                std::nullopt,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
+  auto input        = create_batches_with_local_orderby_result(num_batches,
+                                                        num_base_input_rows,
+                                                        column_types,
+                                                        order_key_idx,
+                                                        column_order,
+                                                        null_precedence,
+                                                        *mem_space);
   auto output_batch = gpu_merge_impl::merge_order_by(input.batches,
                                                      order_key_idx,
                                                      column_order,
@@ -917,14 +905,13 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
   // Invalid input: less than two input batches
-  auto input = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                std::nullopt,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
+  auto input = create_batches_with_local_orderby_result(num_batches,
+                                                        num_base_input_rows,
+                                                        column_types,
+                                                        order_key_idx,
+                                                        column_order,
+                                                        null_precedence,
+                                                        *mem_space);
   REQUIRE_THROWS_AS(gpu_merge_impl::merge_order_by(input.batches,
                                                    order_key_idx,
                                                    column_order,
@@ -936,14 +923,13 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   // Invalid input: mismatch between sizes of `order_key_idx`, `column_order`, and `null_precedence`
   num_batches         = 10;
   num_base_input_rows = std::vector<int>(num_batches, num_base_input_rows_per_batch);
-  auto input2         = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                 num_base_input_rows,
-                                                                 std::nullopt,
-                                                                 column_types,
-                                                                 order_key_idx,
-                                                                 column_order,
-                                                                 null_precedence,
-                                                                 *mem_space);
+  auto input2         = create_batches_with_local_orderby_result(num_batches,
+                                                         num_base_input_rows,
+                                                         column_types,
+                                                         order_key_idx,
+                                                         column_order,
+                                                         null_precedence,
+                                                         *mem_space);
   order_key_idx.push_back(3);
   REQUIRE_THROWS_AS(gpu_merge_impl::merge_order_by(input2.batches,
                                                    order_key_idx,
@@ -971,14 +957,13 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
   std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                std::nullopt,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
+  auto input        = create_batches_with_local_orderby_result(num_batches,
+                                                        num_base_input_rows,
+                                                        column_types,
+                                                        order_key_idx,
+                                                        column_order,
+                                                        null_precedence,
+                                                        *mem_space);
   auto output_batch = gpu_merge_impl::merge_order_by(input.batches,
                                                      order_key_idx,
                                                      column_order,
@@ -1008,14 +993,13 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
   std::vector<cudf::null_order> null_precedence = {
     cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
 
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                std::nullopt,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
+  auto input        = create_batches_with_local_orderby_result(num_batches,
+                                                        num_base_input_rows,
+                                                        column_types,
+                                                        order_key_idx,
+                                                        column_order,
+                                                        null_precedence,
+                                                        *mem_space);
   auto output_batch = gpu_merge_impl::merge_order_by(input.batches,
                                                      order_key_idx,
                                                      column_order,
@@ -1023,275 +1007,4 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
                                                      cudf::get_default_stream(),
                                                      *mem_space);
   validate_order_by(input.batches, *output_batch, order_key_idx, column_order);
-}
-
-namespace {
-
-void validate_top_n(const std::vector<std::shared_ptr<data_batch>>& input_batches,
-                    const data_batch& output,
-                    const std::pair<int, int>& limit_offset,
-                    const std::vector<int>& order_key_idx,
-                    const std::vector<cudf::order>& column_order)
-{
-  std::vector<cudf::table_view> input_table_views;
-  int num_input_rows = 0;
-  for (const auto& input_batch : input_batches) {
-    input_table_views.push_back(sirius::get_cudf_table_view(*input_batch));
-    num_input_rows += input_table_views.back().num_rows();
-  }
-  int limit = limit_offset.first, offset = limit_offset.second;
-  cudf::table_view output_table_view = sirius::get_cudf_table_view(output);
-  int expected_num_rows =
-    (limit + offset <= num_input_rows) ? limit : std::max(0, num_input_rows - offset);
-
-  // Compute sorted input
-  std::vector<std::vector<int64_t>> h_input_data(input_table_views[0].num_columns());
-  for (const auto& table : input_table_views) {
-    copy_data_to_host(table, h_input_data);
-  }
-  std::vector<std::vector<int64_t>> h_input_data_rows(h_input_data[0].size(),
-                                                      std::vector<int64_t>(h_input_data.size()));
-  for (size_t r = 0; r < h_input_data_rows.size(); ++r) {
-    for (size_t c = 0; c < h_input_data_rows[0].size(); ++c) {
-      h_input_data_rows[r][c] = h_input_data[c][r];
-    }
-  }
-  std::sort(h_input_data_rows.begin(),
-            h_input_data_rows.end(),
-            [&](const std::vector<int64_t>& r1, const std::vector<int64_t>& r2) {
-              for (size_t i = 0; i < order_key_idx.size(); ++i) {
-                int col = order_key_idx[i];
-                if (r1[col] == r2[col]) { continue; }
-                return (column_order[i] == cudf::order::ASCENDING && r1[col] < r2[col]) ||
-                       (column_order[i] == cudf::order::DESCENDING && r1[col] > r2[col]);
-              }
-              return false;
-            });
-
-  // Check
-  REQUIRE(output_table_view.num_rows() == expected_num_rows);
-  REQUIRE(output_table_view.num_columns() == input_table_views[0].num_columns());
-  for (int c = 0; c < output_table_view.num_columns(); ++c) {
-    REQUIRE(output_table_view.column(c).type().id() == input_table_views[0].column(c).type().id());
-  }
-
-  std::vector<std::vector<int64_t>> actual(output_table_view.num_columns());
-  copy_data_to_host(output_table_view, actual);
-  auto comp_lower = [&](int r) {
-    if (offset == 0) { return true; }
-    const auto& lower = h_input_data_rows[offset - 1];
-    for (size_t i = 0; i < order_key_idx.size(); ++i) {
-      int col = order_key_idx[i];
-      if (actual[col][r] == lower[col]) { continue; }
-      return (column_order[i] == cudf::order::ASCENDING && actual[col][r] > lower[col]) ||
-             (column_order[i] == cudf::order::DESCENDING && actual[col][r] < lower[col]);
-    }
-    return true;
-  };
-  auto comp_upper = [&](int r) {
-    if (offset + limit >= num_input_rows) { return true; }
-    const auto& upper = h_input_data_rows[offset + limit];
-    for (size_t i = 0; i < order_key_idx.size(); ++i) {
-      int col = order_key_idx[i];
-      if (actual[col][r] == upper[col]) { continue; }
-      return (column_order[i] == cudf::order::ASCENDING && actual[col][r] < upper[col]) ||
-             (column_order[i] == cudf::order::DESCENDING && actual[col][r] > upper[col]);
-    }
-    return true;
-  };
-  for (int r = 0; r < output_table_view.num_rows(); ++r) {
-    REQUIRE(comp_lower(r));
-    REQUIRE(comp_upper(r));
-  }
-}
-
-}  // namespace
-
-TEST_CASE("Merge top-n basic", "[operator][merge_top_n]")
-{
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
-  constexpr int num_batches                      = 10;
-  constexpr size_t num_base_input_rows_per_batch = 100;
-  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64},
-                                               cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset          = {10, 20};
-  std::vector<int> order_key_idx            = {0, 1, 2};
-  std::vector<cudf::order> column_order     = {
-    cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  std::vector<cudf::null_order> null_precedence = {
-    cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
-
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                limit_offset,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
-  auto output_batch = gpu_merge_impl::merge_top_n(input.batches,
-                                                  limit_offset.first,
-                                                  limit_offset.second,
-                                                  order_key_idx,
-                                                  column_order,
-                                                  null_precedence,
-                                                  cudf::get_default_stream(),
-                                                  *mem_space);
-  validate_top_n(input.batches, *output_batch, limit_offset, order_key_idx, column_order);
-}
-
-TEST_CASE("Merge top-n with empty local top-n results", "[operator][merge_top_n]")
-{
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
-  constexpr int num_batches                      = 10;
-  constexpr size_t num_base_input_rows_per_batch = 0;
-  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64},
-                                               cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset          = {10, 20};
-  std::vector<int> order_key_idx            = {0, 1, 2};
-  std::vector<cudf::order> column_order     = {
-    cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  std::vector<cudf::null_order> null_precedence = {
-    cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
-
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                limit_offset,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
-  auto output_batch = gpu_merge_impl::merge_top_n(input.batches,
-                                                  limit_offset.first,
-                                                  limit_offset.second,
-                                                  order_key_idx,
-                                                  column_order,
-                                                  null_precedence,
-                                                  cudf::get_default_stream(),
-                                                  *mem_space);
-  validate_top_n(input.batches, *output_batch, limit_offset, order_key_idx, column_order);
-}
-
-TEST_CASE("Merge top-n with mixed empty and non-empty local top-n results",
-          "[operator][merge_top_n]")
-{
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
-  constexpr int num_batches = 10;
-  std::vector<int> num_base_input_rows;
-  for (int i = 0; i < num_batches; ++i) {
-    num_base_input_rows.push_back(i % 2 == 1 ? 0 : (i + 1) * 10);
-  }
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64},
-                                               cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset          = {10, 20};
-  std::vector<int> order_key_idx            = {0, 1, 2};
-  std::vector<cudf::order> column_order     = {
-    cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  std::vector<cudf::null_order> null_precedence = {
-    cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
-
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                limit_offset,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
-  auto output_batch = gpu_merge_impl::merge_top_n(input.batches,
-                                                  limit_offset.first,
-                                                  limit_offset.second,
-                                                  order_key_idx,
-                                                  column_order,
-                                                  null_precedence,
-                                                  cudf::get_default_stream(),
-                                                  *mem_space);
-  validate_top_n(input.batches, *output_batch, limit_offset, order_key_idx, column_order);
-}
-
-TEST_CASE("Merge top-n with `limit = 0`", "[operator][merge_top_n]")
-{
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
-  constexpr int num_batches                      = 10;
-  constexpr size_t num_base_input_rows_per_batch = 100;
-  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64},
-                                               cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset          = {0, 20};
-  std::vector<int> order_key_idx            = {0, 1, 2};
-  std::vector<cudf::order> column_order     = {
-    cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  std::vector<cudf::null_order> null_precedence = {
-    cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
-
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                limit_offset,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
-  auto output_batch = gpu_merge_impl::merge_top_n(input.batches,
-                                                  limit_offset.first,
-                                                  limit_offset.second,
-                                                  order_key_idx,
-                                                  column_order,
-                                                  null_precedence,
-                                                  cudf::get_default_stream(),
-                                                  *mem_space);
-  validate_top_n(input.batches, *output_batch, limit_offset, order_key_idx, column_order);
-}
-
-TEST_CASE("Merge top-n with `num_input_rows - limit <= offset < num_input-rows`",
-          "[operator][merge_top_n]")
-{
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
-  constexpr int num_batches                      = 10;
-  constexpr size_t num_base_input_rows_per_batch = 100;
-  std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
-  std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64},
-                                               cudf::data_type{cudf::type_id::INT32},
-                                               cudf::data_type{cudf::type_id::INT64}};
-  std::pair<int, int> limit_offset          = {200, 900};
-  std::vector<int> order_key_idx            = {0, 1, 2};
-  std::vector<cudf::order> column_order     = {
-    cudf::order::ASCENDING, cudf::order::DESCENDING, cudf::order::ASCENDING};
-  std::vector<cudf::null_order> null_precedence = {
-    cudf::null_order::AFTER, cudf::null_order::BEFORE, cudf::null_order::AFTER};
-
-  auto input        = create_batches_with_local_orderby_or_topn_result(num_batches,
-                                                                num_base_input_rows,
-                                                                limit_offset,
-                                                                column_types,
-                                                                order_key_idx,
-                                                                column_order,
-                                                                null_precedence,
-                                                                *mem_space);
-  auto output_batch = gpu_merge_impl::merge_top_n(input.batches,
-                                                  limit_offset.first,
-                                                  limit_offset.second,
-                                                  order_key_idx,
-                                                  column_order,
-                                                  null_precedence,
-                                                  cudf::get_default_stream(),
-                                                  *mem_space);
-  validate_top_n(input.batches, *output_batch, limit_offset, order_key_idx, column_order);
 }

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -58,7 +58,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -103,7 +103,8 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
 
   sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
 
-  auto outputs = filter.execute({input_batch});
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+  auto outputs = filter.execute(inputs);
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -52,7 +52,8 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
   // Build filter column (int64) and data column (TestType)

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
+
+#include <catch.hpp>
+#include <duckdb/common/types/date.hpp>
+#include <duckdb/common/types/timestamp.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_filter.hpp>
+
+#include <variant>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+}  // namespace
+
+TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple numeric types",
+                   "[physical_filter]",
+                   int32_t,
+                   int64_t,
+                   float,
+                   double,
+                   int16_t,
+                   bool,
+                   decimal64_tag,
+                   string_tag,
+                   timestamp_us_tag,
+                   date32_tag)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  // Build filter column (int64) and data column (TestType)
+  std::vector<int64_t> filter_vals{1, 2, 3, 5, 7};
+  auto data_vals = Traits::sample_values();
+  // align lengths
+  while (data_vals.size() < filter_vals.size()) {
+    data_vals.push_back(data_vals.back());
+  }
+  data_vals.resize(filter_vals.size());
+
+  std::shared_ptr<data_batch> input_batch;
+  if constexpr (Traits::is_string) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+  } else if constexpr (Traits::is_decimal) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, Traits::scale);
+  } else if constexpr (Traits::is_ts) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+  } else {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+  }
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
+  exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_GREATERTHAN,
+    duckdb::make_uniq<BoundReferenceExpression>(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
+                                                0),
+    duckdb::make_uniq<BoundConstantExpression>(duckdb::Value::BIGINT(3))));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));  // filter column
+  types.push_back(Traits::logical_type());
+
+  sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size(), &repo_mgr);
+
+  auto outputs = filter.execute({input_batch});
+  REQUIRE(outputs.size() == 1);
+  auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto out_view     = output_table.view();
+  auto host_vals    = copy_column_to_host<typename Traits::type>(out_view.column(1));
+  auto host_filter  = copy_column_to_host<int64_t>(out_view.column(0));
+
+  std::vector<typename Traits::type> expected_data;
+  std::vector<int64_t> expected_filter;
+  for (size_t i = 0; i < filter_vals.size(); ++i) {
+    if (filter_vals[i] > 3) {
+      expected_data.push_back(data_vals[i]);
+      expected_filter.push_back(filter_vals[i]);
+    }
+  }
+
+  REQUIRE(host_filter == expected_filter);
+  REQUIRE(host_vals == expected_data);
+}

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -55,8 +55,6 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   // Build filter column (int64) and data column (TestType)
   std::vector<int64_t> filter_vals{1, 2, 3, 5, 7};
   auto data_vals = Traits::sample_values();
@@ -69,10 +67,9 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   std::shared_ptr<data_batch> input_batch;
   if constexpr (Traits::is_string) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(repo_mgr,
-                                                                        *space,
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(*space,
                                                                         filter_vals,
                                                                         data_vals,
                                                                         Traits::cudf_type,
@@ -80,10 +77,10 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
                                                                         cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   }
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
@@ -97,7 +94,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));  // filter column
   types.push_back(Traits::logical_type());
 
-  sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size(), &repo_mgr);
+  sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
 
   auto outputs = filter.execute({input_batch});
   REQUIRE(outputs.size() == 1);

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include "operator_test_utils.hpp"
-#include "operator_type_traits.hpp"
+
 
 #include <catch.hpp>
 #include <duckdb/common/types/date.hpp>
@@ -23,7 +22,14 @@
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include "memory/sirius_memory_reservation_manager.hpp"
 #include <op/sirius_physical_filter.hpp>
+
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
+
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/memory_space.hpp>
 
 #include <variant>
 
@@ -54,7 +60,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
 
   auto memory_manager = initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
-  REQUIRE(space != nullptr);
+  REQUIRE(space);
 
   // Build filter column (int64) and data column (TestType)
   std::vector<int64_t> filter_vals{1, 2, 3, 5, 7};

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -71,8 +71,13 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, Traits::scale);
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(repo_mgr,
+                                                                        *space,
+                                                                        filter_vals,
+                                                                        data_vals,
+                                                                        Traits::cudf_type,
+                                                                        Traits::scale,
+                                                                        cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       repo_mgr, *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-
+#include "memory/sirius_memory_reservation_manager.hpp"
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
 
 #include <catch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/memory_space.hpp>
 #include <duckdb/common/types/date.hpp>
 #include <duckdb/common/types/timestamp.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
-#include "memory/sirius_memory_reservation_manager.hpp"
 #include <op/sirius_physical_filter.hpp>
-
-#include "operator_test_utils.hpp"
-#include "operator_type_traits.hpp"
-
-#include <cucascade/data/gpu_data_representation.hpp>
-#include <cucascade/memory/memory_space.hpp>
 
 #include <variant>
 
@@ -59,7 +56,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   // Build filter column (int64) and data column (TestType)
@@ -76,12 +73,8 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(*space,
-                                                                        filter_vals,
-                                                                        data_vals,
-                                                                        Traits::cudf_type,
-                                                                        Traits::scale,
-                                                                        cudf::type_id::INT64);
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      *space, filter_vals, data_vals, Traits::cudf_type, Traits::scale, cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       *space, filter_vals, data_vals, Traits::cudf_type, std::nullopt);

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -48,7 +48,7 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<typename Traits::type> values(10);
@@ -94,11 +94,8 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(Traits::logical_type());
 
-  sirius_physical_streaming_limit limiter(std::move(types),
-                                          std::move(limit_node),
-                                          std::move(offset_node),
-                                          values.size(),
-                                          false);
+  sirius_physical_streaming_limit limiter(
+    std::move(types), std::move(limit_node), std::move(offset_node), values.size(), false);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = limiter.execute(inputs);

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
+
+#include <catch.hpp>
+#include <op/sirius_physical_limit.hpp>
+
+#include <numeric>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+}  // namespace
+
+TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
+                   "[physical_limit]",
+                   int32_t,
+                   int64_t,
+                   float,
+                   double,
+                   int16_t,
+                   bool,
+                   decimal64_tag,
+                   string_tag,
+                   timestamp_us_tag,
+                   date32_tag)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  std::vector<typename Traits::type> values(10);
+  if constexpr (Traits::is_string) {
+    values = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"};
+  } else if constexpr (Traits::is_decimal) {
+    for (int i = 0; i < 10; ++i) {
+      values[i] = static_cast<typename Traits::type>(i * 100);
+    }
+  } else if constexpr (Traits::is_ts) {
+    for (int i = 0; i < 10; ++i) {
+      values[i] = static_cast<typename Traits::type>(i * 1'000'000);
+    }
+  } else if constexpr (std::is_same_v<typename Traits::type, int32_t> ||
+                       std::is_same_v<typename Traits::type, int64_t> ||
+                       std::is_same_v<typename Traits::type, int16_t>) {
+    std::iota(values.begin(), values.end(), static_cast<typename Traits::type>(0));
+  } else if constexpr (std::is_same_v<typename Traits::type, float> ||
+                       std::is_same_v<typename Traits::type, double>) {
+    for (int i = 0; i < 10; ++i) {
+      values[i] = static_cast<typename Traits::type>(i);
+    }
+  } else if constexpr (std::is_same_v<typename Traits::type, bool>) {
+    for (int i = 0; i < 10; ++i) {
+      values[i] = (i % 2 == 0);
+    }
+  }
+
+  std::shared_ptr<data_batch> input_batch;
+  if constexpr (Traits::is_string) {
+    input_batch = make_string_batch(repo_mgr, *space, values);
+  } else if constexpr (Traits::is_decimal) {
+    input_batch = make_decimal64_batch(repo_mgr, *space, values, Traits::scale);
+  } else if constexpr (Traits::is_ts) {
+    input_batch = make_timestamp_batch(repo_mgr, *space, values, Traits::cudf_type);
+  } else {
+    input_batch =
+      make_numeric_batch<typename Traits::type>(repo_mgr, *space, values, Traits::cudf_type);
+  }
+
+  auto limit_node  = duckdb::BoundLimitNode::ConstantValue(3);
+  auto offset_node = duckdb::BoundLimitNode::ConstantValue(2);
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(Traits::logical_type());
+
+  sirius_physical_streaming_limit limiter(std::move(types),
+                                          std::move(limit_node),
+                                          std::move(offset_node),
+                                          values.size(),
+                                          false,
+                                          &repo_mgr);
+
+  auto outputs = limiter.execute({input_batch});
+  REQUIRE(outputs.size() == 1);
+  auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto host_vals    = copy_column_to_host<typename Traits::type>(output_table.view().column(0));
+
+  std::vector<typename Traits::type> expected = {values[2], values[3], values[4]};
+  REQUIRE(host_vals == expected);
+}

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -47,8 +47,9 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   std::vector<typename Traits::type> values(10);
   if constexpr (Traits::is_string) {

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -50,8 +50,6 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<typename Traits::type> values(10);
   if constexpr (Traits::is_string) {
     values = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"};
@@ -80,14 +78,13 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
 
   std::shared_ptr<data_batch> input_batch;
   if constexpr (Traits::is_string) {
-    input_batch = make_string_batch(repo_mgr, *space, values);
+    input_batch = make_string_batch(*space, values);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_decimal64_batch(repo_mgr, *space, values, Traits::scale);
+    input_batch = make_decimal64_batch(*space, values, Traits::scale);
   } else if constexpr (Traits::is_ts) {
-    input_batch = make_timestamp_batch(repo_mgr, *space, values, Traits::cudf_type);
+    input_batch = make_timestamp_batch(*space, values, Traits::cudf_type);
   } else {
-    input_batch =
-      make_numeric_batch<typename Traits::type>(repo_mgr, *space, values, Traits::cudf_type);
+    input_batch = make_numeric_batch<typename Traits::type>(*space, values, Traits::cudf_type);
   }
 
   auto limit_node  = duckdb::BoundLimitNode::ConstantValue(3);
@@ -100,8 +97,7 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
                                           std::move(limit_node),
                                           std::move(offset_node),
                                           values.size(),
-                                          false,
-                                          &repo_mgr);
+                                          false);
 
   auto outputs = limiter.execute({input_batch});
   REQUIRE(outputs.size() == 1);

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -47,7 +47,7 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -100,7 +100,8 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
                                           values.size(),
                                           false);
 
-  auto outputs = limiter.execute({input_batch});
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+  auto outputs = limiter.execute(inputs);
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto host_vals    = copy_column_to_host<typename Traits::type>(output_table.view().column(0));

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -64,8 +64,13 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, Traits::scale);
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(repo_mgr,
+                                                                        *space,
+                                                                        key_vals,
+                                                                        data_vals,
+                                                                        Traits::cudf_type,
+                                                                        Traits::scale,
+                                                                        cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
@@ -95,24 +100,9 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   auto host_data = copy_column_to_host<typename Traits::type>(out_view.column(0));
   auto host_keys = copy_column_to_host<int64_t>(out_view.column(1));
 
-  auto logical          = Traits::logical_type();
-  constexpr bool is_dec = Traits::is_decimal || std::is_same_v<TestType, decimal64_tag>;
-  if constexpr (is_dec) {
-    auto scale  = duckdb::DecimalType::GetScale(logical);
-    int64_t mul = 1;
-    for (int i = 0; i < scale; ++i) {
-      mul *= 10;
-    }
-
-    std::vector<int64_t> expected_scaled;
-    expected_scaled.reserve(data_vals.size());
-    for (auto v : data_vals) {
-      expected_scaled.push_back(static_cast<int64_t>(v) * mul);
-    }
-    REQUIRE(host_data == expected_scaled);
-  } else {
-    REQUIRE(host_data == data_vals);
-  }
+  auto logical = Traits::logical_type();
+  // Projection should pass through values unchanged
+  REQUIRE(host_data == data_vals);
   REQUIRE(host_keys == key_vals);
 }
 

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -47,8 +47,9 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   std::vector<int64_t> key_vals{10, 20, 30, 40};
   auto data_vals = Traits::sample_values();
@@ -109,8 +110,9 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   std::vector<int64_t> key_vals{10, 20, 30};
   auto data_vals = Traits::sample_values();
@@ -147,8 +149,9 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   std::vector<int64_t> key_vals{100, 200, 300};
   auto data_vals = Traits::sample_values();

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -47,7 +47,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -90,7 +90,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   sirius_physical_projection projection(
     std::move(types), std::move(exprs), key_vals.size());
 
-  auto outputs = projection.execute({input_batch});
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+  auto outputs = projection.execute(inputs);
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();
@@ -110,7 +111,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -134,7 +135,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   sirius_physical_projection projection(
     std::move(types), std::move(exprs), key_vals.size());
 
-  auto outputs = projection.execute({input_batch});
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+  auto outputs = projection.execute(inputs);
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();
@@ -149,7 +151,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -179,7 +181,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   sirius_physical_projection projection(
     std::move(types), std::move(exprs), key_vals.size());
 
-  auto outputs = projection.execute({input_batch});
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
+  auto outputs = projection.execute(inputs);
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -50,8 +50,6 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<int64_t> key_vals{10, 20, 30, 40};
   auto data_vals = Traits::sample_values();
   while (data_vals.size() < key_vals.size()) {
@@ -62,10 +60,9 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   std::shared_ptr<data_batch> input_batch;
   if constexpr (Traits::is_string) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(repo_mgr,
-                                                                        *space,
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(*space,
                                                                         key_vals,
                                                                         data_vals,
                                                                         Traits::cudf_type,
@@ -73,10 +70,10 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
                                                                         cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+      *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
   }
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
@@ -90,7 +87,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
   sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+    std::move(types), std::move(exprs), key_vals.size());
 
   auto outputs = projection.execute({input_batch});
   REQUIRE(outputs.size() == 1);
@@ -115,8 +112,6 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<int64_t> key_vals{10, 20, 30};
   auto data_vals = Traits::sample_values();
   while (data_vals.size() < key_vals.size()) {
@@ -125,7 +120,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   data_vals.resize(key_vals.size());
 
   auto input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-    repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+    *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
 
   // Select only the data column
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
@@ -135,7 +130,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   types.push_back(Traits::logical_type());
 
   sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+    std::move(types), std::move(exprs), key_vals.size());
 
   auto outputs = projection.execute({input_batch});
   REQUIRE(outputs.size() == 1);
@@ -155,8 +150,6 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<int64_t> key_vals{100, 200, 300};
   auto data_vals = Traits::sample_values();
   while (data_vals.size() < key_vals.size()) {
@@ -165,7 +158,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   data_vals.resize(key_vals.size());
 
   auto input_batch = make_two_column_batch<int64_t, typename Traits::type>(
-    repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+    *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
 
   // Output order: key, data, key (duplicate)
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
@@ -181,7 +174,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
   sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+    std::move(types), std::move(exprs), key_vals.size());
 
   auto outputs = projection.execute({input_batch});
   REQUIRE(outputs.size() == 1);

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -48,7 +48,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<int64_t> key_vals{10, 20, 30, 40};
@@ -63,12 +63,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
   } else if constexpr (Traits::is_decimal) {
-    input_batch = make_two_column_batch<int64_t, typename Traits::type>(*space,
-                                                                        key_vals,
-                                                                        data_vals,
-                                                                        Traits::cudf_type,
-                                                                        Traits::scale,
-                                                                        cudf::type_id::INT64);
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      *space, key_vals, data_vals, Traits::cudf_type, Traits::scale, cudf::type_id::INT64);
   } else if constexpr (Traits::is_ts) {
     input_batch = make_two_column_batch<int64_t, typename Traits::type>(
       *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
@@ -87,8 +83,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   types.push_back(Traits::logical_type());
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(inputs);
@@ -112,7 +107,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<int64_t> key_vals{10, 20, 30};
@@ -132,8 +127,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(Traits::logical_type());
 
-  sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(inputs);
@@ -152,7 +146,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<int64_t> key_vals{100, 200, 300};
@@ -178,8 +172,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   types.push_back(Traits::logical_type());
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_projection projection(
-    std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(inputs);

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
+
+#include <catch.hpp>
+#include <duckdb/common/types/decimal.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_projection.hpp>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+}  // namespace
+
+TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multiple types",
+                   "[physical_projection]",
+                   int32_t,
+                   int64_t,
+                   float,
+                   double,
+                   int16_t,
+                   bool,
+                   decimal64_tag,
+                   string_tag,
+                   timestamp_us_tag,
+                   date32_tag)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  std::vector<int64_t> key_vals{10, 20, 30, 40};
+  auto data_vals = Traits::sample_values();
+  while (data_vals.size() < key_vals.size()) {
+    data_vals.push_back(data_vals.back());
+  }
+  data_vals.resize(key_vals.size());
+
+  std::shared_ptr<data_batch> input_batch;
+  if constexpr (Traits::is_string) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+  } else if constexpr (Traits::is_decimal) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, Traits::scale);
+  } else if constexpr (Traits::is_ts) {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+  } else {
+    input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+      repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+  }
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
+  exprs.push_back(
+    duckdb::make_uniq<BoundReferenceExpression>(Traits::logical_type(), 1));  // data column first
+  exprs.push_back(duckdb::make_uniq<BoundReferenceExpression>(
+    duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0));  // key column second
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(Traits::logical_type());
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  sirius_physical_projection projection(
+    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+
+  auto outputs = projection.execute({input_batch});
+  REQUIRE(outputs.size() == 1);
+  auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto out_view     = output_table.view();
+
+  auto host_data = copy_column_to_host<typename Traits::type>(out_view.column(0));
+  auto host_keys = copy_column_to_host<int64_t>(out_view.column(1));
+
+  auto logical          = Traits::logical_type();
+  constexpr bool is_dec = Traits::is_decimal || std::is_same_v<TestType, decimal64_tag>;
+  if constexpr (is_dec) {
+    auto scale  = duckdb::DecimalType::GetScale(logical);
+    int64_t mul = 1;
+    for (int i = 0; i < scale; ++i) {
+      mul *= 10;
+    }
+
+    std::vector<int64_t> expected_scaled;
+    expected_scaled.reserve(data_vals.size());
+    for (auto v : data_vals) {
+      expected_scaled.push_back(static_cast<int64_t>(v) * mul);
+    }
+    REQUIRE(host_data == expected_scaled);
+  } else {
+    REQUIRE(host_data == data_vals);
+  }
+  REQUIRE(host_keys == key_vals);
+}
+
+TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
+                   "[physical_projection][subset]",
+                   int64_t)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  std::vector<int64_t> key_vals{10, 20, 30};
+  auto data_vals = Traits::sample_values();
+  while (data_vals.size() < key_vals.size()) {
+    data_vals.push_back(data_vals.back());
+  }
+  data_vals.resize(key_vals.size());
+
+  auto input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+    repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+
+  // Select only the data column
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
+  exprs.push_back(duckdb::make_uniq<BoundReferenceExpression>(Traits::logical_type(), 1));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(Traits::logical_type());
+
+  sirius_physical_projection projection(
+    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+
+  auto outputs = projection.execute({input_batch});
+  REQUIRE(outputs.size() == 1);
+  auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto out_view     = output_table.view();
+
+  auto host_data = copy_column_to_host<typename Traits::type>(out_view.column(0));
+  REQUIRE(host_data == data_vals);
+}
+
+TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
+                   "[physical_projection][reorder]",
+                   int64_t)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  std::vector<int64_t> key_vals{100, 200, 300};
+  auto data_vals = Traits::sample_values();
+  while (data_vals.size() < key_vals.size()) {
+    data_vals.push_back(data_vals.back());
+  }
+  data_vals.resize(key_vals.size());
+
+  auto input_batch = make_two_column_batch<int64_t, typename Traits::type>(
+    repo_mgr, *space, key_vals, data_vals, Traits::cudf_type, std::nullopt);
+
+  // Output order: key, data, key (duplicate)
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
+  exprs.push_back(duckdb::make_uniq<BoundReferenceExpression>(
+    duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0));
+  exprs.push_back(duckdb::make_uniq<BoundReferenceExpression>(Traits::logical_type(), 1));
+  exprs.push_back(duckdb::make_uniq<BoundReferenceExpression>(
+    duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), 0));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(Traits::logical_type());
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  sirius_physical_projection projection(
+    std::move(types), std::move(exprs), key_vals.size(), &repo_mgr);
+
+  auto outputs = projection.execute({input_batch});
+  REQUIRE(outputs.size() == 1);
+  auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto out_view     = output_table.view();
+
+  auto host_key0 = copy_column_to_host<int64_t>(out_view.column(0));
+  auto host_data = copy_column_to_host<typename Traits::type>(out_view.column(1));
+  auto host_key1 = copy_column_to_host<int64_t>(out_view.column(2));
+
+  REQUIRE(host_key0 == key_vals);
+  REQUIRE(host_key1 == key_vals);
+  REQUIRE(host_data == data_vals);
+}

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -50,8 +50,9 @@ std::shared_ptr<data_batch> make_batch(memory_space& space,
 
 TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches", "[physical_top_n]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   std::vector<std::shared_ptr<data_batch>> batches;
   batches.push_back(make_batch(*space, {5, 1}, {50, 10}));
@@ -93,8 +94,9 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches",
 
 TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physical_top_n]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
   // order by col0 desc, then col1 asc
   std::vector<std::shared_ptr<data_batch>> batches;

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -46,19 +46,33 @@ std::shared_ptr<data_batch> make_batch(memory_space& space,
     space, order_vals, payload_vals, cudf::type_id::INT64, std::nullopt);
 }
 
+std::shared_ptr<data_batch> make_range_batch(memory_space& space,
+                                             int64_t start,
+                                             int64_t count,
+                                             int64_t payload_scale)
+{
+  std::vector<int64_t> order_vals;
+  std::vector<int64_t> payload_vals;
+  order_vals.reserve(count);
+  payload_vals.reserve(count);
+  for (int64_t i = 0; i < count; ++i) {
+    auto value = start + i;
+    order_vals.push_back(value);
+    payload_vals.push_back(value * payload_scale);
+  }
+  return make_batch(space, order_vals, payload_vals);
+}
+
 }  // namespace
 
-TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches", "[physical_top_n]")
+TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_top_n]")
 {
   auto memory_manager = initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<std::shared_ptr<data_batch>> batches;
-  batches.push_back(make_batch(*space, {5, 1}, {50, 10}));
-  batches.push_back(make_batch(*space, {7, 3}, {70, 30}));
-  batches.push_back(make_batch(*space, {9}, {90}));
-  batches.push_back(make_batch(*space, {2, 8}, {20, 80}));
+  batches.push_back(make_batch(*space, {5, 1, 7, 3, 9, 2, 8}, {50, 10, 70, 30, 90, 20, 80}));
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::BIGINT);  // order column
@@ -74,13 +88,10 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches",
                              nullptr,
                              0);
 
-  // Feed in two batches, then two more, ensuring accumulation via internal state.
-  auto out1 = topn.execute({batches[0], batches[1]});
-  REQUIRE(out1.size() == 1);
-  auto out2 = topn.execute({batches[2], batches[3]});
-  REQUIRE(out2.size() == 1);
+  auto out = topn.execute({batches[0]});
+  REQUIRE(out.size() == 1);
 
-  auto table       = out2[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view        = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
@@ -100,10 +111,7 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
 
   // order by col0 desc, then col1 asc
   std::vector<std::shared_ptr<data_batch>> batches;
-  batches.push_back(make_batch(*space, {5, 5}, {2, 1}));
-  batches.push_back(make_batch(*space, {7, 7}, {3, 4}));
-  batches.push_back(make_batch(*space, {7, 6}, {1, 9}));
-  batches.push_back(make_batch(*space, {4, 8}, {5, 0}));
+  batches.push_back(make_batch(*space, {5, 5, 7, 7, 7, 6, 4, 8}, {2, 1, 3, 4, 1, 9, 5, 0}));
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::BIGINT);  // order
@@ -120,12 +128,10 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
                              nullptr,
                              0);
 
-  auto out1 = topn.execute({batches[0], batches[1]});
-  REQUIRE(out1.size() == 1);
-  auto out2 = topn.execute({batches[2], batches[3]});
-  REQUIRE(out2.size() == 1);
+  auto out = topn.execute({batches[0]});
+  REQUIRE(out.size() == 1);
 
-  auto table       = out2[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view        = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
@@ -136,4 +142,100 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
 
   REQUIRE(orders_out == expected_order);
   REQUIRE(payload_out == expected_payload);
+}
+
+TEST_CASE("sirius_physical_top_n_merge applies offset and limit", "[physical_top_n_merge]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  std::vector<std::shared_ptr<data_batch>> batches;
+  batches.push_back(make_range_batch(*space, 0, 10, 10));
+  batches.push_back(make_range_batch(*space, 10, 10, 10));
+  batches.push_back(make_range_batch(*space, 20, 10, 10));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType::BIGINT);
+  types.push_back(duckdb::LogicalType::BIGINT);
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, OrderType::DESCENDING));
+
+  sirius_physical_top_n_merge topn_merge(std::move(types),
+                                         std::move(orders),
+                                         /*limit=*/5,
+                                         /*offset=*/3,
+                                         nullptr,
+                                         0);
+
+  auto out = topn_merge.execute(batches);
+  REQUIRE(out.size() == 1);
+
+  auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view        = table.view();
+  auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
+  auto payload_out = copy_column_to_host<int64_t>(view.column(1));
+
+  std::vector<int64_t> expected_order{26, 25, 24, 23, 22};
+  std::vector<int64_t> expected_payload{260, 250, 240, 230, 220};
+
+  REQUIRE(orders_out == expected_order);
+  REQUIRE(payload_out == expected_payload);
+}
+
+TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_top_n_merge]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  std::vector<std::shared_ptr<data_batch>> batches;
+  batches.push_back(make_range_batch(*space, 0, 5, 1));
+  batches.push_back(make_range_batch(*space, 5, 5, 1));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType::BIGINT);
+  types.push_back(duckdb::LogicalType::BIGINT);
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, OrderType::DESCENDING));
+
+  sirius_physical_top_n_merge topn_merge(std::move(types),
+                                         std::move(orders),
+                                         /*limit=*/0,
+                                         /*offset=*/2,
+                                         nullptr,
+                                         0);
+
+  auto out = topn_merge.execute(batches);
+  REQUIRE(out.empty());
+}
+
+TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_merge]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  std::vector<std::shared_ptr<data_batch>> batches;
+  batches.push_back(make_batch(*space, {}, {}));
+  batches.push_back(make_batch(*space, {}, {}));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType::BIGINT);
+  types.push_back(duckdb::LogicalType::BIGINT);
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, OrderType::DESCENDING));
+
+  sirius_physical_top_n_merge topn_merge(std::move(types),
+                                         std::move(orders),
+                                         /*limit=*/3,
+                                         /*offset=*/0,
+                                         nullptr,
+                                         0);
+
+  auto out = topn_merge.execute(batches);
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  REQUIRE(table.num_rows() == 0);
 }

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -38,13 +38,12 @@ BoundOrderByNode make_order(idx_t col_idx, OrderType dir = OrderType::DESCENDING
                           make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, col_idx));
 }
 
-std::shared_ptr<data_batch> make_batch(data_repository_mgr& repo_mgr,
-                                       memory_space& space,
+std::shared_ptr<data_batch> make_batch(memory_space& space,
                                        const std::vector<int64_t>& order_vals,
                                        const std::vector<int64_t>& payload_vals)
 {
   return make_two_column_batch<int64_t, int64_t>(
-    repo_mgr, space, order_vals, payload_vals, cudf::type_id::INT64, std::nullopt);
+    space, order_vals, payload_vals, cudf::type_id::INT64, std::nullopt);
 }
 
 }  // namespace
@@ -54,13 +53,11 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches",
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   std::vector<std::shared_ptr<data_batch>> batches;
-  batches.push_back(make_batch(repo_mgr, *space, {5, 1}, {50, 10}));
-  batches.push_back(make_batch(repo_mgr, *space, {7, 3}, {70, 30}));
-  batches.push_back(make_batch(repo_mgr, *space, {9}, {90}));
-  batches.push_back(make_batch(repo_mgr, *space, {2, 8}, {20, 80}));
+  batches.push_back(make_batch(*space, {5, 1}, {50, 10}));
+  batches.push_back(make_batch(*space, {7, 3}, {70, 30}));
+  batches.push_back(make_batch(*space, {9}, {90}));
+  batches.push_back(make_batch(*space, {2, 8}, {20, 80}));
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::BIGINT);  // order column
@@ -74,8 +71,7 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches",
                              /*limit=*/3,
                              /*offset=*/0,
                              nullptr,
-                             0,
-                             &repo_mgr);
+                             0);
 
   // Feed in two batches, then two more, ensuring accumulation via internal state.
   auto out1 = topn.execute({batches[0], batches[1]});
@@ -100,14 +96,12 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
-
   // order by col0 desc, then col1 asc
   std::vector<std::shared_ptr<data_batch>> batches;
-  batches.push_back(make_batch(repo_mgr, *space, {5, 5}, {2, 1}));
-  batches.push_back(make_batch(repo_mgr, *space, {7, 7}, {3, 4}));
-  batches.push_back(make_batch(repo_mgr, *space, {7, 6}, {1, 9}));
-  batches.push_back(make_batch(repo_mgr, *space, {4, 8}, {5, 0}));
+  batches.push_back(make_batch(*space, {5, 5}, {2, 1}));
+  batches.push_back(make_batch(*space, {7, 7}, {3, 4}));
+  batches.push_back(make_batch(*space, {7, 6}, {1, 9}));
+  batches.push_back(make_batch(*space, {4, 8}, {5, 0}));
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::BIGINT);  // order
@@ -122,8 +116,7 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
                              /*limit=*/4,
                              /*offset=*/0,
                              nullptr,
-                             0,
-                             &repo_mgr);
+                             0);
 
   auto out1 = topn.execute({batches[0], batches[1]});
   REQUIRE(out1.size() == 1);

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -68,7 +68,7 @@ std::shared_ptr<data_batch> make_range_batch(memory_space& space,
 TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_top_n]")
 {
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   std::vector<std::shared_ptr<data_batch>> batches;
@@ -106,7 +106,7 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
 TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physical_top_n]")
 {
   auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
   // order by col0 desc, then col1 asc

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <duckdb/common/types.hpp>
+#include <duckdb/planner/bound_query_node.hpp>
+#include <duckdb/planner/bound_result_modifier.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_top_n.hpp>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::test::operator_utils;
+
+namespace {
+
+BoundOrderByNode make_order(idx_t col_idx, OrderType dir = OrderType::DESCENDING)
+{
+  return BoundOrderByNode(dir,
+                          OrderByNullType::NULLS_LAST,
+                          make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, col_idx));
+}
+
+std::shared_ptr<data_batch> make_batch(data_repository_mgr& repo_mgr,
+                                       memory_space& space,
+                                       const std::vector<int64_t>& order_vals,
+                                       const std::vector<int64_t>& payload_vals)
+{
+  return make_two_column_batch<int64_t, int64_t>(
+    repo_mgr, space, order_vals, payload_vals, cudf::type_id::INT64, std::nullopt);
+}
+
+}  // namespace
+
+TEST_CASE("sirius_physical_top_n single-key uses top_k across multiple batches", "[physical_top_n]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  std::vector<std::shared_ptr<data_batch>> batches;
+  batches.push_back(make_batch(repo_mgr, *space, {5, 1}, {50, 10}));
+  batches.push_back(make_batch(repo_mgr, *space, {7, 3}, {70, 30}));
+  batches.push_back(make_batch(repo_mgr, *space, {9}, {90}));
+  batches.push_back(make_batch(repo_mgr, *space, {2, 8}, {20, 80}));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType::BIGINT);  // order column
+  types.push_back(duckdb::LogicalType::BIGINT);  // payload
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, OrderType::DESCENDING));
+
+  sirius_physical_top_n topn(std::move(types),
+                             std::move(orders),
+                             /*limit=*/3,
+                             /*offset=*/0,
+                             nullptr,
+                             0,
+                             &repo_mgr);
+
+  // Feed in two batches, then two more, ensuring accumulation via internal state.
+  auto out1 = topn.execute({batches[0], batches[1]});
+  REQUIRE(out1.size() == 1);
+  auto out2 = topn.execute({batches[2], batches[3]});
+  REQUIRE(out2.size() == 1);
+
+  auto table       = out2[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view        = table.view();
+  auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
+  auto payload_out = copy_column_to_host<int64_t>(view.column(1));
+
+  std::vector<int64_t> expected_order{9, 8, 7};
+  std::vector<int64_t> expected_payload{90, 80, 70};
+
+  REQUIRE(orders_out == expected_order);
+  REQUIRE(payload_out == expected_payload);
+}
+
+TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physical_top_n]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  // order by col0 desc, then col1 asc
+  std::vector<std::shared_ptr<data_batch>> batches;
+  batches.push_back(make_batch(repo_mgr, *space, {5, 5}, {2, 1}));
+  batches.push_back(make_batch(repo_mgr, *space, {7, 7}, {3, 4}));
+  batches.push_back(make_batch(repo_mgr, *space, {7, 6}, {1, 9}));
+  batches.push_back(make_batch(repo_mgr, *space, {4, 8}, {5, 0}));
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType::BIGINT);  // order
+  types.push_back(duckdb::LogicalType::BIGINT);  // payload
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, OrderType::DESCENDING));
+  orders.push_back(make_order(1, OrderType::ASCENDING));
+
+  sirius_physical_top_n topn(std::move(types),
+                             std::move(orders),
+                             /*limit=*/4,
+                             /*offset=*/0,
+                             nullptr,
+                             0,
+                             &repo_mgr);
+
+  auto out1 = topn.execute({batches[0], batches[1]});
+  REQUIRE(out1.size() == 1);
+  auto out2 = topn.execute({batches[2], batches[3]});
+  REQUIRE(out2.size() == 1);
+
+  auto table       = out2[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view        = table.view();
+  auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
+  auto payload_out = copy_column_to_host<int64_t>(view.column(1));
+
+  // Expected ordering: (8,0), (7,1), (7,3), (7,4)
+  std::vector<int64_t> expected_order{8, 7, 7, 7};
+  std::vector<int64_t> expected_payload{0, 1, 3, 4};
+
+  REQUIRE(orders_out == expected_order);
+  REQUIRE(payload_out == expected_payload);
+}

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<data_batch> make_range_batch(memory_space& space,
 
 TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_top_n]")
 {
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -105,7 +105,7 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
 
 TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physical_top_n]")
 {
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -50,7 +50,7 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 
@@ -222,7 +222,7 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto memory_manager = initialize_memory_manager();
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
 

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -22,6 +22,8 @@
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <op/sirius_physical_ungrouped_aggregate.hpp>
 
+#include <iterator>
+
 using namespace duckdb;
 using namespace sirius::op;
 using namespace cucascade;
@@ -49,9 +51,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   using Traits = gpu_type_traits<TestType>;
 
   auto memory_manager = initialize_memory_manager();
-  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space);
-
 
   // Create values for batches
   auto vals = Traits::sample_values();
@@ -80,79 +81,98 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   // 4. COUNT(col0)
   // 5. COUNT(*)
 
-  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
-  duckdb::vector<duckdb::LogicalType> ret_types;
+  auto make_aggregates = [&](duckdb::vector<duckdb::LogicalType>& ret_types) {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
 
-  // SUM
-  {
-    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
-    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
-    aggregates.push_back(make_uniq<BoundAggregateExpression>(
-      MakeDummyAggregate("sum", {Traits::logical_type()}, Traits::logical_type()),
-      std::move(children),
-      nullptr,
-      nullptr,
-      AggregateType::NON_DISTINCT));
-    ret_types.push_back(Traits::logical_type());
-  }
+    // SUM
+    {
+      duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+      children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+      aggregates.push_back(make_uniq<BoundAggregateExpression>(
+        MakeDummyAggregate("sum", {Traits::logical_type()}, Traits::logical_type()),
+        std::move(children),
+        nullptr,
+        nullptr,
+        AggregateType::NON_DISTINCT));
+      ret_types.push_back(Traits::logical_type());
+    }
 
-  // MIN
-  {
-    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
-    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
-    aggregates.push_back(make_uniq<BoundAggregateExpression>(
-      MakeDummyAggregate("min", {Traits::logical_type()}, Traits::logical_type()),
-      std::move(children),
-      nullptr,
-      nullptr,
-      AggregateType::NON_DISTINCT));
-    ret_types.push_back(Traits::logical_type());
-  }
+    // MIN
+    {
+      duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+      children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+      aggregates.push_back(make_uniq<BoundAggregateExpression>(
+        MakeDummyAggregate("min", {Traits::logical_type()}, Traits::logical_type()),
+        std::move(children),
+        nullptr,
+        nullptr,
+        AggregateType::NON_DISTINCT));
+      ret_types.push_back(Traits::logical_type());
+    }
 
-  // MAX
-  {
-    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
-    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
-    aggregates.push_back(make_uniq<BoundAggregateExpression>(
-      MakeDummyAggregate("max", {Traits::logical_type()}, Traits::logical_type()),
-      std::move(children),
-      nullptr,
-      nullptr,
-      AggregateType::NON_DISTINCT));
-    ret_types.push_back(Traits::logical_type());
-  }
+    // MAX
+    {
+      duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+      children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+      aggregates.push_back(make_uniq<BoundAggregateExpression>(
+        MakeDummyAggregate("max", {Traits::logical_type()}, Traits::logical_type()),
+        std::move(children),
+        nullptr,
+        nullptr,
+        AggregateType::NON_DISTINCT));
+      ret_types.push_back(Traits::logical_type());
+    }
 
-  // COUNT
-  {
-    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
-    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
-    aggregates.push_back(make_uniq<BoundAggregateExpression>(
-      MakeDummyAggregate("count", {Traits::logical_type()}, LogicalType::BIGINT),
-      std::move(children),
-      nullptr,
-      nullptr,
-      AggregateType::NON_DISTINCT));
-    ret_types.push_back(LogicalType::BIGINT);
-  }
+    // COUNT
+    {
+      duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+      children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+      aggregates.push_back(make_uniq<BoundAggregateExpression>(
+        MakeDummyAggregate("count", {Traits::logical_type()}, LogicalType::BIGINT),
+        std::move(children),
+        nullptr,
+        nullptr,
+        AggregateType::NON_DISTINCT));
+      ret_types.push_back(LogicalType::BIGINT);
+    }
 
-  // COUNT_STAR
-  {
-    aggregates.push_back(
-      make_uniq<BoundAggregateExpression>(MakeDummyAggregate("count_star", {}, LogicalType::BIGINT),
-                                          duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
-                                          nullptr,
-                                          nullptr,
-                                          AggregateType::NON_DISTINCT));
-    ret_types.push_back(LogicalType::BIGINT);
-  }
+    // COUNT_STAR
+    {
+      aggregates.push_back(make_uniq<BoundAggregateExpression>(
+        MakeDummyAggregate("count_star", {}, LogicalType::BIGINT),
+        duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
+        nullptr,
+        nullptr,
+        AggregateType::NON_DISTINCT));
+      ret_types.push_back(LogicalType::BIGINT);
+    }
 
-  sirius_physical_ungrouped_aggregate agg_op(std::move(ret_types),
-                                             std::move(aggregates),
-                                             0,
-                                             duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
+    return aggregates;
+  };
 
-  // Execute with multiple batches to test state accumulation
-  auto out = agg_op.execute({b1, b2});
+  duckdb::vector<duckdb::LogicalType> local_types;
+  auto local_aggregates = make_aggregates(local_types);
+  duckdb::vector<duckdb::LogicalType> merge_types;
+  auto merge_aggregates = make_aggregates(merge_types);
+
+  sirius_physical_ungrouped_aggregate local_op(
+    std::move(local_types),
+    std::move(local_aggregates),
+    0,
+    duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
+  sirius_physical_ungrouped_aggregate_merge merge_op(
+    std::move(merge_types), std::move(merge_aggregates), 0);
+
+  auto local_out1 = local_op.execute({b1});
+  auto local_out2 = local_op.execute({b2});
+  std::vector<std::shared_ptr<data_batch>> merge_inputs;
+  merge_inputs.insert(merge_inputs.end(),
+                      std::make_move_iterator(local_out1.begin()),
+                      std::make_move_iterator(local_out1.end()));
+  merge_inputs.insert(merge_inputs.end(),
+                      std::make_move_iterator(local_out2.begin()),
+                      std::make_move_iterator(local_out2.end()));
+  auto out = merge_op.execute(merge_inputs);
   REQUIRE(out.size() == 1);
 
   auto table = out[0]->get_data()->template cast<gpu_table_representation>().get_table();
@@ -191,4 +211,85 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
 
   REQUIRE(count_out[0] == 4);
   REQUIRE(count_star_out[0] == 4);
+}
+
+TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
+                   "[physical_ungrouped_aggregate]",
+                   int32_t,
+                   int64_t,
+                   float,
+                   double)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto memory_manager = initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
+
+  auto vals = Traits::sample_values();
+  while (vals.size() < 4) {
+    vals.insert(vals.end(), vals.begin(), vals.end());
+  }
+  if (vals.size() > 4) { vals.resize(4); }
+
+  std::vector<typename Traits::type> batch1_vals(vals.begin(), vals.begin() + 2);
+  std::vector<typename Traits::type> batch2_vals(vals.begin() + 2, vals.begin() + 4);
+
+  std::shared_ptr<data_batch> b1, b2;
+  b1 = make_numeric_batch<typename Traits::type>(*space, batch1_vals, Traits::cudf_type);
+  b2 = make_numeric_batch<typename Traits::type>(*space, batch2_vals, Traits::cudf_type);
+
+  auto make_avg_aggregates = [&](duckdb::vector<duckdb::LogicalType>& ret_types) {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    aggregates.push_back(make_uniq<BoundAggregateExpression>(
+      MakeDummyAggregate("avg", {Traits::logical_type()}, LogicalType::DOUBLE),
+      std::move(children),
+      nullptr,
+      nullptr,
+      AggregateType::NON_DISTINCT));
+    ret_types.push_back(LogicalType::DOUBLE);
+    return aggregates;
+  };
+
+  duckdb::vector<duckdb::LogicalType> local_types;
+  auto local_aggregates = make_avg_aggregates(local_types);
+  local_types.push_back(LogicalType::BIGINT);
+  duckdb::vector<duckdb::LogicalType> merge_types;
+  auto merge_aggregates = make_avg_aggregates(merge_types);
+
+  sirius_physical_ungrouped_aggregate local_op(
+    std::move(local_types),
+    std::move(local_aggregates),
+    0,
+    duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
+  sirius_physical_ungrouped_aggregate_merge merge_op(
+    std::move(merge_types), std::move(merge_aggregates), 0);
+
+  auto local_out1 = local_op.execute({b1});
+  auto local_out2 = local_op.execute({b2});
+  std::vector<std::shared_ptr<data_batch>> merge_inputs;
+  merge_inputs.insert(merge_inputs.end(),
+                      std::make_move_iterator(local_out1.begin()),
+                      std::make_move_iterator(local_out1.end()));
+  merge_inputs.insert(merge_inputs.end(),
+                      std::make_move_iterator(local_out2.begin()),
+                      std::make_move_iterator(local_out2.end()));
+
+  auto out = merge_op.execute(merge_inputs);
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
+  REQUIRE(view.num_columns() == 1);
+  REQUIRE(view.num_rows() == 1);
+
+  auto avg_out        = copy_column_to_host<double>(view.column(0));
+  double expected_sum = 0.0;
+  for (auto v : vals) {
+    expected_sum += static_cast<double>(v);
+  }
+  double expected_avg = expected_sum / static_cast<double>(vals.size());
+  REQUIRE(avg_out[0] == Approx(expected_avg));
 }

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -51,7 +51,6 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
 
-  data_repository_mgr repo_mgr;
 
   // Create values for batches
   auto vals = Traits::sample_values();
@@ -67,13 +66,11 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   std::shared_ptr<data_batch> b1, b2;
 
   if constexpr (Traits::is_decimal) {
-    b1 = make_decimal64_batch(repo_mgr, *space, batch1_vals, Traits::scale);
-    b2 = make_decimal64_batch(repo_mgr, *space, batch2_vals, Traits::scale);
+    b1 = make_decimal64_batch(*space, batch1_vals, Traits::scale);
+    b2 = make_decimal64_batch(*space, batch2_vals, Traits::scale);
   } else {
-    b1 =
-      make_numeric_batch<typename Traits::type>(repo_mgr, *space, batch1_vals, Traits::cudf_type);
-    b2 =
-      make_numeric_batch<typename Traits::type>(repo_mgr, *space, batch2_vals, Traits::cudf_type);
+    b1 = make_numeric_batch<typename Traits::type>(*space, batch1_vals, Traits::cudf_type);
+    b2 = make_numeric_batch<typename Traits::type>(*space, batch2_vals, Traits::cudf_type);
   }
 
   // 1. SUM(col0)
@@ -151,8 +148,7 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   sirius_physical_ungrouped_aggregate agg_op(std::move(ret_types),
                                              std::move(aggregates),
                                              0,
-                                             duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES,
-                                             &repo_mgr);
+                                             duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
   // Execute with multiple batches to test state accumulation
   auto out = agg_op.execute({b1, b2});

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -48,8 +48,9 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
 {
   using Traits = gpu_type_traits<TestType>;
 
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
+  auto memory_manager = initialize_memory_manager();
+  auto* space = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  REQUIRE(space);
 
 
   // Create values for batches

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+#include "operator_type_traits.hpp"
+
+#include <catch.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_ungrouped_aggregate.hpp>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::test::operator_utils;
+
+// Helper to create a dummy AggregateFunction since we only need the name and types for the GPU
+// operator
+AggregateFunction MakeDummyAggregate(const std::string& name,
+                                     const duckdb::vector<LogicalType>& args,
+                                     const LogicalType& ret_type)
+{
+  return AggregateFunction(
+    name, args, ret_type, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+}
+
+TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COUNT",
+                   "[physical_ungrouped_aggregate]",
+                   int32_t,
+                   int64_t,
+                   float,
+                   double,
+                   decimal64_tag)
+{
+  using Traits = gpu_type_traits<TestType>;
+
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  data_repository_mgr repo_mgr;
+
+  // Create values for batches
+  auto vals = Traits::sample_values();
+  // Ensure we have at least 4 values to split across 2 batches
+  while (vals.size() < 4) {
+    vals.insert(vals.end(), vals.begin(), vals.end());
+  }
+  if (vals.size() > 4) { vals.resize(4); }
+
+  std::vector<typename Traits::type> batch1_vals(vals.begin(), vals.begin() + 2);
+  std::vector<typename Traits::type> batch2_vals(vals.begin() + 2, vals.begin() + 4);
+
+  std::shared_ptr<data_batch> b1, b2;
+
+  if constexpr (Traits::is_decimal) {
+    b1 = make_decimal64_batch(repo_mgr, *space, batch1_vals, Traits::scale);
+    b2 = make_decimal64_batch(repo_mgr, *space, batch2_vals, Traits::scale);
+  } else {
+    b1 =
+      make_numeric_batch<typename Traits::type>(repo_mgr, *space, batch1_vals, Traits::cudf_type);
+    b2 =
+      make_numeric_batch<typename Traits::type>(repo_mgr, *space, batch2_vals, Traits::cudf_type);
+  }
+
+  // 1. SUM(col0)
+  // 2. MIN(col0)
+  // 3. MAX(col0)
+  // 4. COUNT(col0)
+  // 5. COUNT(*)
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
+  duckdb::vector<duckdb::LogicalType> ret_types;
+
+  // SUM
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    aggregates.push_back(make_uniq<BoundAggregateExpression>(
+      MakeDummyAggregate("sum", {Traits::logical_type()}, Traits::logical_type()),
+      std::move(children),
+      nullptr,
+      nullptr,
+      AggregateType::NON_DISTINCT));
+    ret_types.push_back(Traits::logical_type());
+  }
+
+  // MIN
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    aggregates.push_back(make_uniq<BoundAggregateExpression>(
+      MakeDummyAggregate("min", {Traits::logical_type()}, Traits::logical_type()),
+      std::move(children),
+      nullptr,
+      nullptr,
+      AggregateType::NON_DISTINCT));
+    ret_types.push_back(Traits::logical_type());
+  }
+
+  // MAX
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    aggregates.push_back(make_uniq<BoundAggregateExpression>(
+      MakeDummyAggregate("max", {Traits::logical_type()}, Traits::logical_type()),
+      std::move(children),
+      nullptr,
+      nullptr,
+      AggregateType::NON_DISTINCT));
+    ret_types.push_back(Traits::logical_type());
+  }
+
+  // COUNT
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+    children.push_back(make_uniq<BoundReferenceExpression>(Traits::logical_type(), 0));
+    aggregates.push_back(make_uniq<BoundAggregateExpression>(
+      MakeDummyAggregate("count", {Traits::logical_type()}, LogicalType::BIGINT),
+      std::move(children),
+      nullptr,
+      nullptr,
+      AggregateType::NON_DISTINCT));
+    ret_types.push_back(LogicalType::BIGINT);
+  }
+
+  // COUNT_STAR
+  {
+    aggregates.push_back(
+      make_uniq<BoundAggregateExpression>(MakeDummyAggregate("count_star", {}, LogicalType::BIGINT),
+                                          duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
+                                          nullptr,
+                                          nullptr,
+                                          AggregateType::NON_DISTINCT));
+    ret_types.push_back(LogicalType::BIGINT);
+  }
+
+  sirius_physical_ungrouped_aggregate agg_op(std::move(ret_types),
+                                             std::move(aggregates),
+                                             0,
+                                             duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES,
+                                             &repo_mgr);
+
+  // Execute with multiple batches to test state accumulation
+  auto out = agg_op.execute({b1, b2});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
+
+  REQUIRE(view.num_columns() == 5);
+  REQUIRE(view.num_rows() == 1);
+
+  // Verify
+  auto sum_out        = copy_column_to_host<typename Traits::type>(view.column(0));
+  auto min_out        = copy_column_to_host<typename Traits::type>(view.column(1));
+  auto max_out        = copy_column_to_host<typename Traits::type>(view.column(2));
+  auto count_out      = copy_column_to_host<int64_t>(view.column(3));
+  auto count_star_out = copy_column_to_host<int64_t>(view.column(4));
+
+  typename Traits::type expected_sum = 0;
+  typename Traits::type expected_min = vals[0];
+  typename Traits::type expected_max = vals[0];
+
+  for (auto v : vals) {
+    expected_sum += v;
+    if (v < expected_min) expected_min = v;
+    if (v > expected_max) expected_max = v;
+  }
+
+  // Approximate check for floats
+  if constexpr (std::is_floating_point_v<typename Traits::type>) {
+    REQUIRE(sum_out[0] == Approx(expected_sum));
+    REQUIRE(min_out[0] == Approx(expected_min));
+    REQUIRE(max_out[0] == Approx(expected_max));
+  } else {
+    REQUIRE(sum_out[0] == expected_sum);
+    REQUIRE(min_out[0] == expected_min);
+    REQUIRE(max_out[0] == expected_max);
+  }
+
+  REQUIRE(count_out[0] == 4);
+  REQUIRE(count_star_out[0] == 4);
+}

--- a/test/cpp/pipeline/test_modified_pipeline.cpp
+++ b/test/cpp/pipeline/test_modified_pipeline.cpp
@@ -439,13 +439,13 @@ build_source_to_pipelines_map(const duckdb::vector<duckdb::shared_ptr<sirius_pip
 }
 
 /**
- * @brief Count pipelines with PARTITION sinks (type=INVALID)
+ * @brief Count pipelines with PARTITION sinks
  */
 size_t count_partition_sinks(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines)
 {
   size_t count = 0;
   for (const auto& pipeline : pipelines) {
-    if (pipeline->get_sink()->type == PhysicalOperatorType::INVALID) { count++; }
+    if (dynamic_cast<sirius_physical_partition*>(pipeline->get_sink().get())) { count++; }
   }
   return count;
 }
@@ -501,7 +501,7 @@ PipelineBreakdownInfo analyze_pipeline_breakdown(
     auto sink = pipeline->get_sink();
 
     // Count PARTITION sinks
-    if (sink->type == PhysicalOperatorType::INVALID) {
+    if (dynamic_cast<sirius_physical_partition*>(sink.get())) {
       info.partition_count++;
       info.has_partition_before_agg = true;
 
@@ -586,10 +586,8 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
     auto sink = pipeline->get_sink();
 
     // Check PARTITION sinks
-    if (sink->type == PhysicalOperatorType::INVALID) {
-      auto& partition = sink->Cast<sirius_physical_partition>();
-
-      if (partition.is_build_partition()) {
+    if (auto* partition = dynamic_cast<sirius_physical_partition*>(sink.get())) {
+      if (partition->is_build_partition()) {
         // Build side partition
         info.build_partition_count++;
 
@@ -610,9 +608,9 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
       }
 
       // Check if this partition connects to a pipeline with HASH_JOIN
-      if (partition.is_build_partition()) {
+      if (partition->is_build_partition()) {
         // For build partitions: find pipeline where HASH_JOIN is the first operator
-        sirius_physical_operator* hash_join_op = partition.get_parent_op();
+        sirius_physical_operator* hash_join_op = partition->get_parent_op();
         for (const auto& dep_pipeline : pipelines) {
           auto inner_ops = dep_pipeline->get_inner_operators();
           if (inner_ops.size() > 0 && &inner_ops[0].get() == hash_join_op) {
@@ -667,7 +665,7 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
     }
 
     // Check for pipelines that have PARTITION source and contain HASH_JOIN
-    if (pipeline->get_source()->type == PhysicalOperatorType::INVALID) {
+    if (dynamic_cast<sirius_physical_partition*>(pipeline->get_source().get())) {
       auto ops = pipeline->get_inner_operators();
       for (auto& op : ops) {
         if (op.get().type == PhysicalOperatorType::HASH_JOIN ||
@@ -743,14 +741,12 @@ void validate_modified_pipeline_structure(GPUExecutor& executor, const std::stri
                                    ")";
 
     // Validate based on sink type
-    if (sink->type == PhysicalOperatorType::INVALID) {
-      // This is a PARTITION operator
-      auto& partition     = sink->Cast<sirius_physical_partition>();
-      std::string port_id = partition.is_build_partition() ? "build" : "default";
+    if (auto* partition = dynamic_cast<sirius_physical_partition*>(sink.get())) {
+      std::string port_id = partition->is_build_partition() ? "build" : "default";
 
-      if (partition.is_build_partition()) {
+      if (partition->is_build_partition()) {
         // For build partitions: find pipeline where HASH_JOIN is the first operator
-        sirius_physical_operator* hash_join_op = partition.get_parent_op();
+        sirius_physical_operator* hash_join_op = partition->get_parent_op();
         for (const auto& dep_pipeline : new_scheduled) {
           auto inner_ops = dep_pipeline->get_inner_operators();
           if (inner_ops.size() > 0 && &inner_ops[0].get() == hash_join_op) {
@@ -791,7 +787,23 @@ void validate_modified_pipeline_structure(GPUExecutor& executor, const std::stri
         REQUIRE(next_op != nullptr);
         REQUIRE(std::string(next_port_id) == port_id);
       }
-
+    } else if (sink->type == PhysicalOperatorType::EXTENSION) {
+      // Extension sinks should use "default"
+      auto it = source_to_pipelines.find(sink.get());
+      if (it != source_to_pipelines.end()) {
+        for (auto& dep_pipeline : it->second) {
+          auto inner_ops = dep_pipeline->get_inner_operators();
+          sirius_physical_operator* next_op =
+            inner_ops.size() > 0 ? &inner_ops[0].get() : dep_pipeline->get_sink().get();
+          auto* port = next_op->get_port("default");
+          std::string context =
+            pipeline_context + " -> " + sink->get_name() + " with port 'default'";
+          validate_port_repository(port, context);
+          INFO("EXTENSION sink port validation: " << context);
+          REQUIRE(port->src_pipeline == pipeline);
+          REQUIRE(port->dest_pipeline == dep_pipeline);
+        }
+      }
     } else if (sink->type == PhysicalOperatorType::HASH_GROUP_BY ||
                sink->type == PhysicalOperatorType::ORDER_BY ||
                sink->type == PhysicalOperatorType::TOP_N ||
@@ -1177,11 +1189,10 @@ TEST_CASE("Pipeline breakdown - HASH_JOIN build side validation",
   bool found_build_partition_with_port = false;
   for (const auto& pipeline : executor.new_scheduled) {
     auto sink = pipeline->get_sink();
-    if (sink->type == PhysicalOperatorType::INVALID) {
-      auto& partition = sink->Cast<sirius_physical_partition>();
-      if (partition.is_build_partition()) {
+    if (auto* partition = dynamic_cast<sirius_physical_partition*>(sink.get())) {
+      if (partition->is_build_partition()) {
         // The partition's parent_op is the HASH_JOIN
-        sirius_physical_operator* hash_join_op = partition.get_parent_op();
+        sirius_physical_operator* hash_join_op = partition->get_parent_op();
         REQUIRE(hash_join_op != nullptr);
         REQUIRE(hash_join_op->type == PhysicalOperatorType::HASH_JOIN);
 
@@ -1250,9 +1261,8 @@ TEST_CASE("Pipeline breakdown - HASH_JOIN probe side validation",
   bool found_join_after_probe_partition = false;
   for (const auto& pipeline : executor.new_scheduled) {
     auto sink = pipeline->get_sink();
-    if (sink->type == PhysicalOperatorType::INVALID) {
-      auto& partition = sink->Cast<sirius_physical_partition>();
-      if (!partition.is_build_partition()) {
+    if (auto* partition = dynamic_cast<sirius_physical_partition*>(sink.get())) {
+      if (!partition->is_build_partition()) {
         // This is a probe partition - check it uses "default" port
         auto& next_ports = sink->get_next_port_after_sink();
         for (auto& [next_op, port_id] : next_ports) {

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -42,6 +42,9 @@ using namespace cucascade::memory;
 inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initialize_memory_manager(
   std::size_t n_gpus = 1)
 {
+  // Reset converter registry to avoid cross-test leakage
+  sirius::converter_registry::reset_for_testing();
+
   reservation_manager_configurator builder;
 
   // Configure GPU (2GB limit, 75% reservation ratio)
@@ -57,6 +60,10 @@ inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initia
     .set_reservation_fraction_per_host(limit_ratio);
 
   auto space_configs = builder.build();
-  return std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
+  auto manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
     std::move(space_configs));
+
+  // Initialize converters used by data representations
+  sirius::converter_registry::initialize();
+  return manager;
 }

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -60,8 +60,8 @@ inline std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> initia
     .set_reservation_fraction_per_host(limit_ratio);
 
   auto space_configs = builder.build();
-  auto manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
-    std::move(space_configs));
+  auto manager =
+    std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
 
   // Initialize converters used by data representations
   sirius::converter_registry::initialize();


### PR DESCRIPTION
Started adding execute methods to the physical operators in the op directory. 

Implemented:
Limit
Filter
ungrouped aggregation
topn
projection

topn and ungrouped aggregation both require state. I need to make sure that it is available to all the gpus scheduling tasks so that is going to need some work


things left to do:
1. need to make sure we lock the global state in topn and ungrouped aggregation to prevent race conditions
2. need to make topn and ungrouped aggregation available on multiple gpus, we might do something like let each gpu accumulate its own state and then reconcile them all
