### PR TITLE
fix: Use HTTPS for duckdb-python submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,4 +16,4 @@
 	branch = main
 [submodule "duckdb-python"]
 	path = duckdb-python
-	url = git@github.com:duckdb/duckdb-python.git
+	url = https://github.com/duckdb/duckdb-python.git


### PR DESCRIPTION
Switched duckdb-python submodule URL to HTTPS to allow cloning in CI environments (and local dev) without SSH keys.