### PR TITLE
fix: update cucascade submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,8 @@
 	branch = main
 [submodule "cucascade"]
 	path = cucascade
-	# url = https://github.com/NVIDIA/cuCascade.git
-	# branch = main
-	url = https://github.com/wmalpica/cuCascade.git
-	branch = improvement/add_partitioned_data_repo
+	url = https://github.com/NVIDIA/cuCascade.git
+	branch = main
 [submodule "duckdb-python"]
 	path = duckdb-python
 	url = https://github.com/duckdb/duckdb-python.git


### PR DESCRIPTION
Follow-up of #169. Reverts `.gitmodules` changes and bumps `cucascade` submodule (the required changes were merged).