### PR TITLE
build error for missing noexcept

### DIFF
--- a/src/memory/sirius_memory_reservation_manager.cpp
+++ b/src/memory/sirius_memory_reservation_manager.cpp
@@ -66,14 +66,11 @@ class sirius_device_memory_resource : public rmm::mr::device_memory_resource {
     return it->second->allocate(bytes, stream);
   }
 
-  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
   {
     auto dev_id = rmm::get_current_cuda_device();
     auto it     = per_device_device_memory_resource_map_.find(dev_id.value());
-    if (it == per_device_device_memory_resource_map_.end()) {
-      throw std::runtime_error("No device memory resource found for device id: " +
-                               std::to_string(dev_id.value()));
-    }
+    assert(it != per_device_device_memory_resource_map_.end());
     it->second->deallocate(ptr, bytes, stream);
   }
 


### PR DESCRIPTION
Hi! Thanks for building this, it's really cool.

I was trying to build Sirius today and got the following compile error:
```
/home/awitt/code/sirius/src/memory/sirius_memory_reservation_manager.cpp:69:8: error: looser exception specification on overriding virtual function ‘virtual void sirius::memory::sirius_device_memory_resource::do_deallocate(void*, std::size_t, rmm::cuda_stream_view)’
   69 |   void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) override
```

It looks like do_deallocate needs to be marked noexcept, so this PR adds noexcept to that function.  After this change everything built for me!