### PR TITLE
[WIP] Column builder optimizations

### DIFF
--- a/src/include/helper/utils.hpp
+++ b/src/include/helper/utils.hpp
@@ -17,6 +17,8 @@
 #pragma once
 
 // standard library
+#include <bit>
+#include <cstdint>
 #include <type_traits>
 
 namespace sirius::utils {
@@ -24,49 +26,76 @@ namespace sirius::utils {
 template <typename T>
 inline constexpr T ceil_div(T a, T b)
 {
-  static_assert(std::is_integral<T>::value, "ceil_div requires an integral type");
+  static_assert(std::is_integral_v<T>, "ceil_div requires an integral type");
   return (a + b - 1) / b;
 }
 
 template <typename T>
 inline constexpr T ceil_div_8(T a)
 {
-  static_assert(std::is_integral<T>::value, "ceil_div_8 requires an integral type");
-  static_assert(std::is_unsigned<T>::value, "ceil_div_8 requires an unsigned type");
+  static_assert(std::is_integral_v<T>, "ceil_div_8 requires an integral type");
+  static_assert(std::is_integral_v<T>, "ceil_div_8 requires an unsigned type");
   return (a + 7) >> 3;
 }
 
 template <typename T>
 inline constexpr T div_8(T a)
 {
-  static_assert(std::is_integral<T>::value, "div_8 requires an integral type");
-  static_assert(std::is_unsigned<T>::value, "div_8 requires an unsigned type");
+  static_assert(std::is_integral_v<T>, "div_8 requires an integral type");
+  static_assert(std::is_integral_v<T>, "div_8 requires an unsigned type");
   return a >> 3;
+}
+
+template <uint64_t Divisor, typename T>
+inline constexpr T div(T a)
+{
+  static_assert(std::is_integral_v<T>, "div requires an integral type");
+  static_assert(std::is_integral_v<T>, "div requires an unsigned type");
+  static_assert(std::has_single_bit(Divisor), "div requires Divisor to be a power of two");
+  uint64_t constexpr shift = std::countr_zero(Divisor);
+  return a >> shift;
 }
 
 template <typename T>
 inline constexpr T mul_8(T a)
 {
-  static_assert(std::is_integral<T>::value, "mul_8 requires an integral type");
-  static_assert(std::is_unsigned<T>::value, "mul_8 requires an unsigned type");
+  static_assert(std::is_integral_v<T>, "mul_8 requires an integral type");
+  static_assert(std::is_integral_v<T>, "mul_8 requires an unsigned type");
   return a << 3;
 }
 
 template <typename T>
 inline constexpr T mod_8(T a)
 {
-  static_assert(std::is_integral<T>::value, "mod_8 requires an integral type");
-  static_assert(std::is_unsigned<T>::value, "mod_8 requires an unsigned type");
+  static_assert(std::is_integral_v<T>, "mod_8 requires an integral type");
+  static_assert(std::is_integral_v<T>, "mod_8 requires an unsigned type");
   return a & 7;
+}
+
+template <uint64_t Divisor, typename T>
+inline constexpr T mod(T a)
+{
+  static_assert(std::is_integral_v<T>, "mod requires an integral type");
+  static_assert(std::is_integral_v<T>, "mod requires an unsigned type");
+  static_assert(std::has_single_bit(Divisor), "mod requires Divisor to be a power of two");
+  return a & static_cast<T>(Divisor - 1);
+}
+
+template <typename T>
+inline constexpr T align_8(T a)
+{
+  static_assert(std::is_integral_v<T>, "align_8 requires an integral type");
+  static_assert(std::is_unsigned_v<T>, "align_8 requires an unsigned type");
+  return (a + 7) & ~static_cast<T>(7);
 }
 
 template <typename S, typename T>
 inline constexpr S make_mask(T num_bits)
 {
-  static_assert(std::is_integral<T>::value, "make_mask requires an integral type for num_bits");
-  static_assert(std::is_unsigned<T>::value, "make_mask requires an unsigned type for num_bits");
-  static_assert(std::is_integral<S>::value, "make_mask requires an integral type for return");
-  static_assert(std::is_unsigned<S>::value, "make_mask requires an unsigned type for return");
+  static_assert(std::is_integral_v<T>, "make_mask requires an integral type for num_bits");
+  static_assert(std::is_integral_v<T>, "make_mask requires an unsigned type for num_bits");
+  static_assert(std::is_integral_v<S>, "make_mask requires an integral type for return");
+  static_assert(std::is_integral_v<S>, "make_mask requires an unsigned type for return");
   return static_cast<S>((static_cast<S>(1) << num_bits) - 1);
 }
 

--- a/src/include/memory/multiple_blocks_allocation_accessor.hpp
+++ b/src/include/memory/multiple_blocks_allocation_accessor.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include <helper/utils.hpp>
+
 // cucascade
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
@@ -40,8 +43,8 @@ namespace sirius::memory {
  * NOTE: the caller is responsible for ensuring the cursor does not go out of bounds. Otherwise,
  * behavior is undefined.
  *
- * @tparam T The underlying data type to be accessed. It is assumed that T is aligned with the block
- * size of the allocation.
+ * @tparam T The underlying data type to be accessed. It must be aligned with the block size of the
+ * allocation.
  */
 template <typename T>
 struct multiple_blocks_allocation_accessor {
@@ -128,6 +131,7 @@ struct multiple_blocks_allocation_accessor {
    *
    * @tparam S The type to which to cast the value.
    * @param[in] allocation The allocation.
+   * @return The value at the current position cast to type S.
    */
   template <typename S>
   [[nodiscard]] S get_current_as(
@@ -145,6 +149,7 @@ struct multiple_blocks_allocation_accessor {
    * @brief Get the value at the current position in the allocation using the underlying type.
    *
    * @param[in] allocation The allocation.
+   * @return The value at the current position.
    */
   [[nodiscard]] T get_current(std::unique_ptr<multiple_blocks_allocation> const& allocation) const
   {
@@ -153,9 +158,16 @@ struct multiple_blocks_allocation_accessor {
 
   /**
    * @brief Get the value at a specific offset position from the initial offset.
+   *
+   * @param[in] offset The offset position from the initial byte offset.
+   * @param[in] allocation The allocation.
+   * @return The value at the specified offset.
+   *
+   *@note Use of this API is discouraged. It is necessary in arrow->duckdb string conversion to get
+   *the total data size for a bulk copy into a vector.
    */
   [[nodiscard]] T get(size_t offset,
-                      const std::unique_ptr<multiple_blocks_allocation>& allocation) const
+                      std::unique_ptr<multiple_blocks_allocation> const& allocation) const
   {
     size_t global_offset        = initial_byte_offset + sizeof(T) * offset;
     size_t temp_block_index     = global_offset / allocation->block_size();
@@ -252,10 +264,54 @@ struct multiple_blocks_allocation_accessor {
   }
 
   /**
+   * @brief Copy from a given source buffer into the allocation starting at the current position,
+   * returning the popcount of the copied data.
+   *
+   * We need to count the number of bits set to correctly set the null_count metadata for a
+   * host_table_allocation. This method only supports uint64_t underlying_type.
+   *
+   * @param[in] src Pointer to the source buffer.
+   * @param[in] words Number of uint64_t words to copy from the source buffer.
+   * @param[in,out] allocation The allocation.
+   * @return The total popcount of the copied data.
+   *
+   * @note This is used in the copy of duckdb validity masks to host_table_allocation masks to avoid
+   * an extra pass over the duckdb validity mask to count the number of nulls in the data chunk.
+   */
+  size_t memcpy_from_with_popcount(uint64_t const* src,
+                                   size_t words,
+                                   std::unique_ptr<multiple_blocks_allocation>& allocation)
+  {
+    static_assert(std::is_same_v<underlying_type, uint64_t>,
+                  "memcpy_from_popcount only supports uint64_t underlying_type");
+    size_t count        = 0;
+    size_t words_copied = 0;
+    while (words_copied < words) {
+      assert(block_index < allocation->get_blocks().size());
+      auto const words_to_copy =
+        std::min(words - words_copied, utils::div_8(allocation->block_size() - offset_in_block));
+      auto* dst = reinterpret_cast<uint64_t*>(allocation->get_blocks()[block_index]) +
+                  utils::div_8(offset_in_block);
+      for (size_t w = 0; w < words_to_copy; ++w) {
+        auto const val = src[words_copied + w];
+        dst[w]         = val;
+        count += std::popcount(val);
+      }
+      words_copied += words_to_copy;
+      offset_in_block += utils::mul_8(words_to_copy);
+      if (offset_in_block == allocation->block_size()) {
+        ++block_index;
+        offset_in_block = 0;
+      }
+    }
+    return count;
+  }
+
+  /**
    * @brief Copy the data from the allocation to a destination buffer.
    *
    * @param[in] allocation The allocation.
-   * @param[in] dest Pointer to the destination buffer.
+   * @param[in,out] dest Pointer to the destination buffer.
    * @param[in] bytes Number of bytes to copy to the destination buffer.
    */
   void memcpy_to(std::unique_ptr<multiple_blocks_allocation> const& allocation,

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -54,7 +54,7 @@ namespace sirius::op::scan {
 /**
  * @brief The global state for a duckdb_scan_task.
  */
-class duckdb_scan_task_global_state : public sirius::parallel::itask_global_state,
+class duckdb_scan_task_global_state : public parallel::itask_global_state,
                                       public duckdb::GlobalSourceState {
   friend class duckdb_scan_task;
   friend class duckdb_scan_task_local_state;
@@ -140,7 +140,7 @@ class duckdb_scan_task_global_state : public sirius::parallel::itask_global_stat
  * chunks into those buffers.
  *
  */
-class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state {
+class duckdb_scan_task_local_state : public parallel::itask_local_state {
   using data_batch = cucascade::data_batch;
 
  public:
@@ -171,7 +171,7 @@ class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state 
 
     // The allocation accessors for the column data, mask, and offsets
     memory::multiple_blocks_allocation_accessor<uint8_t> data_blocks_accessor;
-    memory::multiple_blocks_allocation_accessor<uint8_t> mask_blocks_accessor;
+    memory::multiple_blocks_allocation_accessor<uint64_t> mask_blocks_accessor;
     memory::multiple_blocks_allocation_accessor<int64_t> offset_blocks_accessor;
 
     //===----------Constructors & Destructor----------===//
@@ -285,7 +285,7 @@ class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state 
 
  private:
   //===----------Fields----------===//
-  size_t _approximate_batch_size;                ///< Approximate target batch size in bytes
+  size_t _batch_size;                            ///< Batch size in bytes
   size_t _default_varchar_size;                  ///< Default size for VARCHAR columns in bytes
   size_t _num_columns;                           ///< Number of columns to be scanned
   size_t _estimated_rows_per_batch;              ///< Estimated number of rows per batch
@@ -314,7 +314,7 @@ class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state 
    *
    * @return The byte offset within the allocation where the column data ends.
    */
-  [[nodiscard]] size_t get_tail_byte_offset() const;
+  [[nodiscard]] size_t get_last_byte_offset() const;
 
   /**
    * @brief Estimate the maximum number of rows to process for a batch given the target batch size.
@@ -354,10 +354,8 @@ class duckdb_scan_task_local_state : public sirius::parallel::itask_local_state 
  * the batch to the data repository and notifying the task creator. If the table scan is
  * incomplete upon task completion, the task will push a new scan_task onto the task queue.
  */
-class duckdb_scan_task : public sirius::parallel::itask {
+class duckdb_scan_task : public parallel::itask {
   using shared_data_repository = cucascade::shared_data_repository;
-  // Friend declaration for test access
-  friend class test_scan_task;
 
  public:
   //===----------Constructor----------===//
@@ -373,9 +371,7 @@ class duckdb_scan_task : public sirius::parallel::itask {
                    shared_data_repository* data_repo,
                    std::unique_ptr<duckdb_scan_task_local_state> l_state,
                    std::shared_ptr<duckdb_scan_task_global_state> g_state)
-    : _task_id(task_id),
-      _data_repo(data_repo),
-      sirius::parallel::itask(std::move(l_state), g_state) {};
+    : _task_id(task_id), _data_repo(data_repo), parallel::itask(std::move(l_state), g_state) {};
 
   void execute() override;
 

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -29,6 +29,10 @@
 #include <duckdb/common/types.hpp>
 #include <duckdb/function/table_function.hpp>
 
+// standard library
+#include <limits>
+#include <numeric>
+
 namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
@@ -87,6 +91,7 @@ void duckdb_scan_task_local_state::column_builder::initialize_accessors(
 {
   assert(allocation != nullptr);
   assert(!allocation->get_blocks().empty());
+  assert(utils::mod_8(byte_offset) == 0);  // byte_offset must be 8B-aligned
 
   if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
     // Initialize offset accessor
@@ -94,33 +99,30 @@ void duckdb_scan_task_local_state::column_builder::initialize_accessors(
     // Write the initial offset value of 0
     offset_blocks_accessor.set_current(0, allocation);
     // Initialize data accessor
-    total_data_bytes_allocated = estimated_num_rows * type_size;
-    size_t data_byte_offset    = byte_offset + (estimated_num_rows + 1) * sizeof(int64_t);
+    auto const data_byte_offset = byte_offset + (estimated_num_rows + 1) * sizeof(int64_t);
     data_blocks_accessor.initialize(data_byte_offset, allocation);
     // Initialize mask accessor
-    size_t mask_byte_offset = data_byte_offset + total_data_bytes_allocated;
+    total_data_bytes_allocated  = utils::align_8(estimated_num_rows * type_size);
+    auto const mask_byte_offset = data_byte_offset + total_data_bytes_allocated;
     mask_blocks_accessor.initialize(mask_byte_offset, allocation);
   } else {
     // Fixed-width column
     data_blocks_accessor.initialize(byte_offset, allocation);
-    size_t mask_byte_offset = byte_offset + estimated_num_rows * type_size;
+    auto const mask_byte_offset = utils::align_8(byte_offset + estimated_num_rows * type_size);
     mask_blocks_accessor.initialize(mask_byte_offset, allocation);
   }
 }
 
-// This method should be called only on variable-length data
 bool duckdb_scan_task_local_state::column_builder::sufficient_space_for_column(
   duckdb::Vector& vec, duckdb::ValidityMask const& validity, size_t num_rows)
 {
-  size_t data_bytes = 0;
-  if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
-    auto const* str_data = reinterpret_cast<duckdb::string_t const*>(vec.GetData());
-    for (size_t row = 0; row < num_rows; ++row) {
-      if (validity.RowIsValid(row)) { data_bytes += str_data[row].GetSize(); }
-    }
-  } else {
-    // Fixed-width column
-    data_bytes = type_size * num_rows;
+  // This method should be called only on variable-length data
+  assert(type.InternalType() == duckdb::PhysicalType::VARCHAR);
+
+  size_t data_bytes    = 0;
+  auto const* str_data = reinterpret_cast<duckdb::string_t const*>(vec.GetData());
+  for (size_t row = 0; row < num_rows; ++row) {
+    if (validity.RowIsValid(row)) { data_bytes += str_data[row].GetSize(); }
   }
   return data_bytes + total_data_bytes <= total_data_bytes_allocated;
 }
@@ -131,80 +133,116 @@ void duckdb_scan_task_local_state::column_builder::process_mask_for_column(
   size_t row_offset,
   std::unique_ptr<multiple_blocks_allocation>& allocation)
 {
-  auto const* src_valid = reinterpret_cast<uint8_t const*>(validity.GetData());
-  auto const cur_bit    = utils::mod_8(row_offset);  //< bit offset in current byte
+  uint64_t constexpr bit_width = std::numeric_limits<uint64_t>::digits;
+
+  auto const* src_valid = validity.GetData();
+  auto const cur_bit    = utils::mod<bit_width>(row_offset);
   auto const num_bits   = num_rows;
 
+  if (cur_bit == 0) {
+    //===----------Byte Aligned Case----------===//
+    auto const full_words = utils::div<bit_width>(num_rows);
+    auto const tail_bits  = utils::mod<bit_width>(num_rows);
+    if (src_valid == nullptr) {
+      //===----------All Valid----------===//
+      // Set all bits in the mask to valid
+      if (full_words != 0) {
+        mask_blocks_accessor.memset(FULL_MASK, full_words * sizeof(uint64_t), allocation);
+      }
+      if (tail_bits != 0) {
+        auto const tail_mask = utils::make_mask<uint64_t>(tail_bits);
+        mask_blocks_accessor.set_current(tail_mask, allocation);
+      }
+      return;
+    }
+    //===----------Some Invalid----------===//
+    size_t valid_count = 0;
+    if (full_words != 0) {
+      valid_count =
+        mask_blocks_accessor.memcpy_from_with_popcount(src_valid, full_words, allocation);
+    }
+    if (tail_bits != 0) {
+      auto const tail_mask = utils::make_mask<uint64_t>(tail_bits);
+      auto const tail      = src_valid[full_words] & tail_mask;
+      mask_blocks_accessor.set_current(tail, allocation);
+      valid_count += std::popcount(tail);
+    }
+    null_count += num_rows - valid_count;
+    return;
+  }
+
+  //===----------Byte Unaligned Case----------===//
   if (src_valid == nullptr) {
     //===----------All Valid----------===//
-    // Set all bits in the mask to valid
-    size_t full_bytes = 0;
-    size_t tail_bits  = 0;
-    if (cur_bit != 0) {
-      //===----------Byte Unaligned Case----------===//
-      auto const bits_in_current_byte = std::min<uint32_t>(CHAR_BIT - cur_bit, num_bits);
-      auto const remaining_bits =
-        num_bits - bits_in_current_byte;  // Remaining bits after filling current byte
-      full_bytes = utils::div_8(remaining_bits);
-      tail_bits  = utils::mod_8(remaining_bits);
+    auto const bits_in_current_word = std::min(bit_width - cur_bit, num_bits);
+    auto const remaining_bits =
+      num_bits - bits_in_current_word;  // Remaining bits after filling current word
+    auto const full_words = utils::div<bit_width>(remaining_bits);
+    auto const tail_bits  = utils::mod<bit_width>(remaining_bits);
 
-      // Set bits in the current byte
-      auto const current_byte_mask =
-        static_cast<uint8_t>(utils::make_mask<uint8_t>(bits_in_current_byte) << cur_bit);
-      auto const current_byte = mask_blocks_accessor.get_current(allocation);
-      mask_blocks_accessor.set_current(current_byte | current_byte_mask, allocation);
-      if (bits_in_current_byte + cur_bit == CHAR_BIT) { mask_blocks_accessor.advance(); }
-    } else {
-      //===----------Byte Aligned Case----------===//
-      full_bytes = utils::div_8(num_bits);
-      tail_bits  = utils::mod_8(num_bits);
+    // Set bits in the current byte
+    auto const current_word_mask =
+      static_cast<uint64_t>(utils::make_mask<uint64_t>(bits_in_current_word) << cur_bit);
+    auto const current_word = mask_blocks_accessor.get_current(allocation);
+    mask_blocks_accessor.set_current(current_word | current_word_mask, allocation);
+    if (bits_in_current_word + cur_bit == bit_width) { mask_blocks_accessor.advance(); }
+    if (full_words != 0) {
+      // Set full words to all valid
+      mask_blocks_accessor.memset(FULL_MASK, full_words * sizeof(uint64_t), allocation);
     }
-    if (full_bytes != 0) { mask_blocks_accessor.memset(FULL_MASK, full_bytes, allocation); }
     if (tail_bits != 0) {
-      auto const tail_mask = utils::make_mask<uint8_t>(tail_bits);
+      // Set tail bits
+      auto const tail_mask = utils::make_mask<uint64_t>(tail_bits);
       mask_blocks_accessor.set_current(tail_mask, allocation);
     }
     return;
   }
-  // condition: src_valid != nullptr
+  //===----------Some Invalid----------===//
+  // THIS CODE PATH IS PERFORMANCE HOTSPOT
+  auto const full_words = utils::div<bit_width>(num_bits);
+  auto const tail_bits  = utils::mod<bit_width>(num_bits);
+  auto const cur_shift  = static_cast<uint64_t>(cur_bit);
+  auto const upper_mask = utils::make_mask<uint64_t>(cur_shift);
+  auto const next_shift = static_cast<uint64_t>(bit_width - cur_bit);
+  auto const lower_mask = utils::make_mask<uint64_t>(next_shift);
 
-  // Update the null count
-  null_count += num_rows - validity.CountValid(num_rows);
-
-  auto const full_bytes = utils::div_8(num_bits);
-  auto const tail_bits  = utils::mod_8(num_bits);
-  if (cur_bit == 0) {
-    //===----------Byte Aligned Case----------===//
-    mask_blocks_accessor.memcpy_from(src_valid, full_bytes, allocation);
-    if (tail_bits > 0) {
-      auto const tail_mask = utils::make_mask<uint8_t>(tail_bits);
-      auto const tail      = src_valid[full_bytes] & tail_mask;
-      mask_blocks_accessor.set_current(tail, allocation);
+  auto* block_words =
+    reinterpret_cast<uint64_t*>(allocation->get_blocks()[mask_blocks_accessor.block_index] +
+                                mask_blocks_accessor.offset_in_block);
+  uint64_t upper_bits    = block_words[0] & upper_mask;
+  size_t words_processed = 0;
+  while (words_processed < full_words) {
+    auto const words_to_process = std::min(
+      full_words - words_processed,
+      (allocation->block_size() - mask_blocks_accessor.offset_in_block) / sizeof(uint64_t));
+    for (size_t w = 0; w < words_to_process; ++w) {
+      auto const src_word = src_valid[words_processed + w];
+      null_count += bit_width - std::popcount(src_word);
+      auto const lower_bits  = static_cast<uint64_t>((src_word & lower_mask) << cur_shift);
+      auto const word_to_set = upper_bits | lower_bits;
+      block_words[w]         = word_to_set;
+      upper_bits             = static_cast<uint64_t>((src_word >> next_shift) & upper_mask);
     }
-  } else {
-    //===----------Byte Unaligned Case----------===//
-    auto const cur_shift  = static_cast<uint8_t>(cur_bit);
-    auto const upper_mask = utils::make_mask<uint8_t>(cur_shift);
-    auto const next_shift = static_cast<uint8_t>(CHAR_BIT - cur_bit);
-    auto const lower_mask = utils::make_mask<uint8_t>(next_shift);
-    auto current_byte     = mask_blocks_accessor.get_current(allocation);
-    for (size_t b = 0; b < full_bytes; ++b) {
-      auto const src_byte   = src_valid[b];
-      auto const lower_bits = static_cast<uint8_t>((src_byte & lower_mask) << cur_shift);
-      mask_blocks_accessor.set_current(current_byte | lower_bits, allocation);
+    words_processed += words_to_process;
+    mask_blocks_accessor.offset_in_block += words_to_process * sizeof(uint64_t);
+    if (mask_blocks_accessor.offset_in_block == allocation->block_size()) {
+      // Advance to next block
+      mask_blocks_accessor.block_index++;
+      mask_blocks_accessor.offset_in_block = 0;
+      block_words =
+        reinterpret_cast<uint64_t*>(allocation->get_blocks()[mask_blocks_accessor.block_index]);
+    }
+  }
+  if (tail_bits != 0) {
+    auto const src_block = src_valid[full_words] & utils::make_mask<uint64_t>(tail_bits);
+    null_count += tail_bits - std::popcount(src_block);
+    auto const lower_bits  = static_cast<uint64_t>((src_block & lower_mask) << cur_shift);
+    auto const word_to_set = upper_bits | lower_bits;
+    mask_blocks_accessor.set_current(word_to_set, allocation);
+    if (tail_bits >= next_shift) {
+      upper_bits = static_cast<uint64_t>((src_block >> next_shift) & upper_mask);
       mask_blocks_accessor.advance();
-      current_byte = static_cast<uint8_t>((src_byte >> next_shift) & upper_mask);
-    }
-    if (tail_bits != 0) {
-      auto const tail_mask  = utils::make_mask<uint8_t>(tail_bits);
-      auto const src_byte   = src_valid[full_bytes] & tail_mask;
-      auto const lower_bits = static_cast<uint8_t>((src_byte & lower_mask) << cur_shift);
-      mask_blocks_accessor.set_current(current_byte | lower_bits, allocation);
-      if (tail_bits >= next_shift) {
-        mask_blocks_accessor.advance();
-        auto const upper_bits = static_cast<uint8_t>((src_byte >> next_shift) & upper_mask);
-        mask_blocks_accessor.set_current(upper_bits, allocation);
-      }
+      mask_blocks_accessor.set_current(upper_bits, allocation);
     }
   }
 }
@@ -278,22 +316,26 @@ duckdb_scan_task_local_state::duckdb_scan_task_local_state(
   size_t approximate_batch_size,
   size_t default_varchar_size,
   std::unique_ptr<duckdb::LocalTableFunctionState> existing_local_tf_state)
-  : _approximate_batch_size(approximate_batch_size),
+  : _batch_size(approximate_batch_size),
     _default_varchar_size(default_varchar_size),
     _exec_ctx(exec_ctx)
 {
   auto const& op = g_state._op;
   _num_columns   = op.projection_ids.size();
 
+  // Reuse existing local table function state if provided
   if (existing_local_tf_state) {
     _local_tf_state = std::move(existing_local_tf_state);
   } else {
     g_state.increment_local_states();
   }
 
+  // Estimate the number of rows per bach and adjust batch size accordingly
+  estimate_rows_per_batch(op);
+
   // Make the memory reservation request
   auto& mem_res_mgr = g_state._sirius_ctx->get_memory_manager();
-  _reservation      = mem_res_mgr.request_reservation(_res_request, approximate_batch_size);
+  _reservation      = mem_res_mgr.request_reservation(_res_request, _batch_size);
 
   // Make the allocation
   auto& mem_space = _reservation->get_memory_space();
@@ -307,9 +349,6 @@ duckdb_scan_task_local_state::duckdb_scan_task_local_state(
   }
   _allocation = allocator->allocate_multiple_blocks(approximate_batch_size, _reservation.get());
 
-  // Estimate number of rows per batch
-  estimate_rows_per_batch(op);
-
   // Initialize the column builders
   initialize_builders();
 
@@ -317,12 +356,12 @@ duckdb_scan_task_local_state::duckdb_scan_task_local_state(
   initialize_local_table_function_state(op, exec_ctx, g_state._global_tf_state.get());
 }
 
-size_t duckdb_scan_task_local_state::get_tail_byte_offset() const
+size_t duckdb_scan_task_local_state::get_last_byte_offset() const
 {
   auto const& last_builder = _column_builders.back();
   auto last_byte_offset    = last_builder.mask_blocks_accessor.get_current_global_byte_offset();
   if (utils::mod_8(_row_offset) != 0) {
-    last_byte_offset++;  // Round up to next byte if partially filled
+    last_byte_offset++;  // Round up to next byte if mask is partially filled
   }
   return std::min(last_byte_offset, _allocation->size_bytes());
 }
@@ -331,33 +370,42 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_table
 {
   assert(num_columns <= op.column_ids.size());
 
-  size_t estimated_row_bytes = 0;
+  // Construct column builders and collect the VARCHAR column indices
+  // Also compute the base row size in bytes to estimate the rows per batch
+  size_t base_row_bytes = 0;
   _column_builders.reserve(_num_columns);
   for (size_t i = 0; i < _num_columns; ++i) {
     auto const col_type = op.returned_types[op.column_ids[i].GetPrimaryIndex()];
     _column_builders.emplace_back(col_type, _default_varchar_size);
+    base_row_bytes += _column_builders.back().type_size;
     if (col_type.InternalType() == duckdb::PhysicalType::VARCHAR) {
       _varchar_indices.push_back(i);
-      estimated_row_bytes += (sizeof(int64_t) + _default_varchar_size);  // offset + data + mask
-    } else {
-      estimated_row_bytes += duckdb::GetTypeIdSize(col_type.InternalType());  // data + mask
+      base_row_bytes += sizeof(int64_t);
     }
   }
+  base_row_bytes += utils::ceil_div_8(_num_columns);  // Mask bytes
+  _estimated_rows_per_batch = std::max<size_t>(
+    _batch_size / base_row_bytes, STANDARD_VECTOR_SIZE);  // Ensure at least 1 vector can fit
 
-  // We must make space for the mask bytes (1 bit per row, rounded up to bytes)
-  // Add mask bytes to the estimated row size
-  size_t mask_bytes_per_row = utils::ceil_div_8(_num_columns);
-  estimated_row_bytes += mask_bytes_per_row;
+  auto bytes_for_rows = [this](size_t rows) {
+    size_t bytes = 0;
+    for (auto const& builder : _column_builders) {
+      if (builder.type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+        auto const offset_bytes = (rows + 1) * sizeof(int64_t);
+        auto const data_bytes   = utils::align_8(rows * _default_varchar_size);
+        auto const mask_bytes   = utils::align_8(utils::ceil_div_8(rows));
+        bytes += offset_bytes + data_bytes + mask_bytes;
+      } else {
+        auto const data_bytes = utils::align_8(rows * builder.type_size);
+        auto const mask_bytes = utils::align_8(utils::ceil_div_8(rows));
+        bytes += data_bytes + mask_bytes;
+      }
+    }
+    return bytes;
+  };
 
-  // For VARCHAR columns, add space for the extra offset at the end
-  size_t extra_varchar_offset_bytes = _varchar_indices.size() * sizeof(int64_t);
-
-  // Calculate rows that fit in the batch
-  _estimated_rows_per_batch =
-    (_approximate_batch_size - extra_varchar_offset_bytes) / estimated_row_bytes;
-
-  // Ensure at least 1 vector can fit, otherwise the task will be a no-op
-  _estimated_rows_per_batch = std::max<size_t>(_estimated_rows_per_batch, STANDARD_VECTOR_SIZE);
+  // Revise the batch size allocation based on the number of estimated rows
+  _batch_size = bytes_for_rows(_estimated_rows_per_batch);
 }
 
 void duckdb_scan_task_local_state::initialize_builders()
@@ -368,13 +416,16 @@ void duckdb_scan_task_local_state::initialize_builders()
     // Update byte_offset for next column
     if (_column_builders[i].type.InternalType() == duckdb::PhysicalType::VARCHAR) {
       // VARCHAR column (offsets + data + mask)
-      byte_offset += (_estimated_rows_per_batch + 1) * sizeof(int64_t) +
-                     _estimated_rows_per_batch * _default_varchar_size +
-                     utils::ceil_div_8(_estimated_rows_per_batch);
+      auto const offset_bytes = (_estimated_rows_per_batch + 1) * sizeof(int64_t);
+      auto const data_bytes   = utils::align_8(_estimated_rows_per_batch * _default_varchar_size);
+      auto const mask_bytes   = utils::align_8(utils::ceil_div_8(_estimated_rows_per_batch));
+      byte_offset += offset_bytes + data_bytes + mask_bytes;
     } else {
       // Fixed-width column (data + mask)
-      byte_offset += _estimated_rows_per_batch * _column_builders[i].type_size +
-                     utils::ceil_div_8(_estimated_rows_per_batch);
+      auto const data_bytes =
+        utils::align_8(_estimated_rows_per_batch * _column_builders[i].type_size);
+      auto const mask_bytes = utils::align_8(utils::ceil_div_8(_estimated_rows_per_batch));
+      byte_offset += data_bytes + mask_bytes;
     }
   }
 }
@@ -408,7 +459,7 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   auto metadata = std::make_unique<std::vector<uint8_t>>(pack_metadata_from_nodes(column_metadata));
 
   // Make the host table allocation
-  auto const sz = get_tail_byte_offset();
+  auto const sz = get_last_byte_offset();
   // auto const sz = allocation->size_bytes();
   auto table_allocation =
     std::make_unique<host_table_allocation>(std::move(_allocation), std::move(metadata), sz);
@@ -508,7 +559,7 @@ void duckdb_scan_task::execute()
     auto new_local_state =
       std::make_unique<duckdb_scan_task_local_state>(g_state,
                                                      l_state._exec_ctx,
-                                                     l_state._approximate_batch_size,
+                                                     l_state._batch_size,
                                                      l_state._default_varchar_size,
                                                      std::move(l_state._local_tf_state));
 

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -90,6 +90,22 @@ std::vector<cudf::bitmask_type> copy_null_mask(const cudf::column_view& col)
   return mask;
 }
 
+size_t aligned_mask_bytes(size_t rows)
+{
+  return sirius::utils::align_8(sirius::utils::ceil_div_8(rows));
+}
+
+size_t aligned_fixed_column_bytes(size_t rows, size_t type_size)
+{
+  return sirius::utils::align_8(rows * type_size) + aligned_mask_bytes(rows);
+}
+
+size_t aligned_varchar_column_bytes(size_t rows, size_t default_varchar_size)
+{
+  return (rows + 1) * sizeof(int64_t) + sirius::utils::align_8(rows * default_varchar_size) +
+         aligned_mask_bytes(rows);
+}
+
 void verify_validity_mask(const cudf::column_view& col, const std::vector<bool>& expected_valid)
 {
   size_t expected_nulls = 0;
@@ -370,14 +386,12 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
   REQUIRE(allocator != nullptr);
 
   size_t num_rows       = 1024;
-  size_t mask_bytes     = 0;
   size_t total_size     = 0;
   auto const block_size = allocator->get_block_size();
   while (true) {
-    mask_bytes = sirius::utils::ceil_div_8(num_rows);
-    total_size = num_rows * sizeof(int32_t) + mask_bytes + (num_rows + 1) * sizeof(int64_t) +
-                 num_rows * kDefaultVarcharSize + mask_bytes + num_rows * sizeof(int64_t) +
-                 mask_bytes;
+    total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t)) +
+                 aligned_varchar_column_bytes(num_rows, kDefaultVarcharSize) +
+                 aligned_fixed_column_bytes(num_rows, sizeof(int64_t));
     if (total_size > block_size) { break; }
     num_rows *= 2;
   }
@@ -396,9 +410,9 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
 
   size_t byte_offset = 0;
   int_builder.initialize_accessors(num_rows, byte_offset, allocation);
-  byte_offset += num_rows * sizeof(int32_t) + mask_bytes;
+  byte_offset += aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
   str_builder.initialize_accessors(num_rows, byte_offset, allocation);
-  byte_offset += (num_rows + 1) * sizeof(int64_t) + num_rows * kDefaultVarcharSize + mask_bytes;
+  byte_offset += aligned_varchar_column_bytes(num_rows, kDefaultVarcharSize);
   big_builder.initialize_accessors(num_rows, byte_offset, allocation);
 
   duckdb::Vector int_vec(int_type, num_rows);
@@ -505,14 +519,11 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
 
   constexpr size_t kSmallVarcharSize = 8;
   size_t num_rows_expected           = 256;
-  size_t mask_bytes                  = 0;
   size_t total_size                  = 0;
   auto const block_size              = allocator->get_block_size();
   while (true) {
-    mask_bytes = sirius::utils::ceil_div_8(num_rows_expected);
-    total_size = num_rows_expected * sizeof(int32_t) + mask_bytes +
-                 (num_rows_expected + 1) * sizeof(int64_t) + num_rows_expected * kSmallVarcharSize +
-                 mask_bytes;
+    total_size = aligned_fixed_column_bytes(num_rows_expected, sizeof(int32_t)) +
+                 aligned_varchar_column_bytes(num_rows_expected, kSmallVarcharSize);
     if (total_size > block_size) { break; }
     num_rows_expected *= 2;
   }
@@ -529,7 +540,7 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
 
   size_t byte_offset = 0;
   int_builder.initialize_accessors(num_rows_expected, byte_offset, allocation);
-  byte_offset += num_rows_expected * sizeof(int32_t) + mask_bytes;
+  byte_offset += aligned_fixed_column_bytes(num_rows_expected, sizeof(int32_t));
   str_builder.initialize_accessors(num_rows_expected, byte_offset, allocation);
 
   duckdb::Vector int_vec(int_type, num_rows_expected);

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -28,8 +28,12 @@
 #include <duckdb/common/types/vector.hpp>
 
 // standard library
+#include <chrono>
 #include <climits>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
+#include <iostream>
 #include <numbers>
 
 using namespace sirius::op::scan;
@@ -52,6 +56,22 @@ static memory_space* get_host_space(duckdb::SiriusContext& sirius_ctx)
   auto spaces = mem_mgr.get_memory_spaces_for_tier(Tier::HOST);
   if (!spaces.empty()) { return const_cast<memory_space*>(spaces.front()); }
   return nullptr;
+}
+
+static size_t aligned_mask_bytes(size_t rows)
+{
+  return sirius::utils::align_8(sirius::utils::ceil_div_8(rows));
+}
+
+static size_t aligned_fixed_column_bytes(size_t rows, size_t type_size)
+{
+  return sirius::utils::align_8(rows * type_size) + aligned_mask_bytes(rows);
+}
+
+static size_t aligned_varchar_column_bytes(size_t rows, size_t default_varchar_size)
+{
+  return (rows + 1) * sizeof(int64_t) + sirius::utils::align_8(rows * default_varchar_size) +
+         aligned_mask_bytes(rows);
 }
 
 //===----------------------------------------------------------------------===//
@@ -146,7 +166,7 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
 
     size_t num_rows = 100;
     // Calculate total size needed: data + mask
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
 
     auto allocation = create_test_allocation(total_size);
 
@@ -158,7 +178,7 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
     REQUIRE(builder.data_blocks_accessor.offset_in_block == 0);
     REQUIRE(builder.mask_blocks_accessor.block_index == 0);
     // Mask starts after data
-    size_t expected_mask_offset = sizeof(int32_t) * num_rows;
+    size_t expected_mask_offset = sirius::utils::align_8(sizeof(int32_t) * num_rows);
     REQUIRE(builder.mask_blocks_accessor.offset_in_block ==
             expected_mask_offset % allocator->get_block_size());
   }
@@ -169,10 +189,8 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows = 100;
-    // Calculate total size needed: offsets + data + mask
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        DEFAULT_VARCHAR_SIZE * num_rows +     // data
-                        sirius::utils::ceil_div_8(num_rows);  // mask
+    // Calculate total size needed: offsets + aligned data + aligned mask
+    size_t total_size = aligned_varchar_column_bytes(num_rows, DEFAULT_VARCHAR_SIZE);
 
     // Use the helper to create the allocation
     auto allocation = create_test_allocation(total_size);
@@ -183,7 +201,8 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
     // Verify accessors were initialized correctly
     REQUIRE(builder.offset_blocks_accessor.block_index == 0);
     REQUIRE(builder.offset_blocks_accessor.offset_in_block == 0);
-    REQUIRE(builder.total_data_bytes_allocated == DEFAULT_VARCHAR_SIZE * num_rows);
+    REQUIRE(builder.total_data_bytes_allocated ==
+            sirius::utils::align_8(DEFAULT_VARCHAR_SIZE * num_rows));
 
     // Verify offset is initialized to zero
     REQUIRE(builder.offset_blocks_accessor.get_current(allocation) == 0);
@@ -210,9 +229,7 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
 
     // Allocate space for 100 rows with default VARCHAR size
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        DEFAULT_VARCHAR_SIZE * num_rows +     // data
-                        sirius::utils::ceil_div_8(num_rows);  // mask
+    size_t total_size = aligned_varchar_column_bytes(num_rows, DEFAULT_VARCHAR_SIZE);
 
     // Use the helper to create the allocation
     auto allocation = create_test_allocation(total_size);
@@ -243,9 +260,7 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
 
     // Allocate space for 10 rows with small VARCHAR size (10 bytes per row)
     size_t num_rows   = 10;
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        10 * num_rows +                       // data (10 bytes per row)
-                        sirius::utils::ceil_div_8(num_rows);  // mask
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 10);
 
     // Use the helper to create the allocation
     auto allocation = create_test_allocation(total_size);
@@ -282,7 +297,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -298,10 +313,10 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     builder.process_mask_for_column(validity, 16, 0, allocation);
 
     // Verify the mask was copied correctly
-    builder.mask_blocks_accessor.set_cursor(0);
-    auto mask_byte_0 = builder.mask_blocks_accessor.get_current(allocation);
-    builder.mask_blocks_accessor.advance();
-    auto mask_byte_1 = builder.mask_blocks_accessor.get_current(allocation);
+    builder.mask_blocks_accessor.reset_cursor();
+    auto mask_byte_0 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
+    auto mask_byte_1 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
 
     // Bit 3 and 7 should be 0 (invalid) in first byte
     REQUIRE((mask_byte_0 & (1 << 3)) == 0);
@@ -317,7 +332,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -335,11 +350,222 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     builder.process_mask_for_column(validity2, 8, 3, allocation);
 
     // Verify the unaligned write worked
-    builder.mask_blocks_accessor.set_cursor(0);
-    auto mask_byte_0 = builder.mask_blocks_accessor.get_current(allocation);
+    builder.mask_blocks_accessor.reset_cursor();
+    auto mask_byte_0 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
 
     // Bit 5 should be 0 (invalid)
     REQUIRE((mask_byte_0 & (1 << 5)) == 0);
+  }
+
+  SECTION("byte-unaligned all-valid small tail keeps cursor on partial byte")
+  {
+    auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+
+    size_t num_rows   = 16;
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    auto allocation   = create_test_allocation(total_size);
+    builder.initialize_accessors(num_rows, 0, allocation);
+
+    // Clear mask bytes for deterministic checks
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+    builder.mask_blocks_accessor.memset(0, aligned_mask_bytes(num_rows), allocation);
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+
+    // All-valid mask (GetData() == nullptr), unaligned and does NOT fill the byte
+    duckdb::ValidityMask validity(2);
+    builder.process_mask_for_column(validity, 2, 3, allocation);
+
+    auto const expected_offset = builder.mask_blocks_accessor.initial_byte_offset;
+    REQUIRE(builder.mask_blocks_accessor.block_index == expected_offset / allocation->block_size());
+    REQUIRE(builder.mask_blocks_accessor.offset_in_block ==
+            expected_offset % allocation->block_size());
+
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+    auto const mask_byte = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    REQUIRE((mask_byte & (1 << 3)) != 0);
+    REQUIRE((mask_byte & (1 << 4)) != 0);
+  }
+
+  SECTION("byte-unaligned non-null small tail keeps cursor on partial byte")
+  {
+    auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+
+    size_t num_rows   = 16;
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    auto allocation   = create_test_allocation(total_size);
+    builder.initialize_accessors(num_rows, 0, allocation);
+
+    // Clear mask bytes for deterministic checks
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+    builder.mask_blocks_accessor.memset(0, aligned_mask_bytes(num_rows), allocation);
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+
+    duckdb::ValidityMask validity(2);
+    validity.Initialize(2);
+    validity.SetAllValid(2);
+    validity.SetInvalid(1);  // Second bit should be 0
+    builder.process_mask_for_column(validity, 2, 3, allocation);
+
+    auto const expected_offset = builder.mask_blocks_accessor.initial_byte_offset;
+    REQUIRE(builder.mask_blocks_accessor.block_index == expected_offset / allocation->block_size());
+    REQUIRE(builder.mask_blocks_accessor.offset_in_block ==
+            expected_offset % allocation->block_size());
+
+    builder.mask_blocks_accessor.set_cursor(builder.mask_blocks_accessor.initial_byte_offset);
+    auto const mask_byte = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    REQUIRE((mask_byte & (1 << 3)) != 0);
+    REQUIRE((mask_byte & (1 << 4)) == 0);
+  }
+
+  SECTION("byte-unaligned mask processing - large tail across 64-bit boundary")
+  {
+    auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+
+    size_t const row_offset = 63;
+    size_t const num_rows   = 130;
+    size_t const total_rows = row_offset + num_rows;
+    size_t total_size       = aligned_fixed_column_bytes(total_rows, sizeof(int32_t));
+    auto allocation         = create_test_allocation(total_size);
+    builder.initialize_accessors(total_rows, 0, allocation);
+
+    duckdb::ValidityMask prefix_validity(row_offset);
+    prefix_validity.Initialize(row_offset);
+    prefix_validity.SetAllValid(row_offset);
+    builder.process_mask_for_column(prefix_validity, row_offset, 0, allocation);
+
+    duckdb::ValidityMask validity(num_rows);
+    validity.Initialize(num_rows);
+    validity.SetAllValid(num_rows);
+    validity.SetInvalid(0);
+    validity.SetInvalid(1);
+    validity.SetInvalid(63);
+    validity.SetInvalid(64);
+    validity.SetInvalid(129);
+    builder.process_mask_for_column(validity, num_rows, row_offset, allocation);
+
+    size_t const mask_offset = builder.mask_blocks_accessor.initial_byte_offset;
+    auto get_mask_bit        = [&](size_t bit_index) {
+      size_t const byte_index  = bit_index / 8;
+      size_t const bit_in_byte = bit_index % 8;
+      builder.mask_blocks_accessor.set_cursor(mask_offset + byte_index);
+      auto const mask_byte = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+      return (mask_byte >> bit_in_byte) & 0x1;
+    };
+
+    REQUIRE(get_mask_bit(0) == 1);
+    REQUIRE(get_mask_bit(62) == 1);
+    REQUIRE(get_mask_bit(row_offset + 0) == 0);
+    REQUIRE(get_mask_bit(row_offset + 1) == 0);
+    REQUIRE(get_mask_bit(row_offset + 63) == 0);
+    REQUIRE(get_mask_bit(row_offset + 64) == 0);
+    REQUIRE(get_mask_bit(row_offset + 129) == 0);
+    REQUIRE(get_mask_bit(row_offset + 2) == 1);
+    REQUIRE(get_mask_bit(row_offset + 128) == 1);
+  }
+
+  SECTION("byte-unaligned tail writes expected invalid bits")
+  {
+    auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+
+    size_t const total_rows = 128;
+    size_t const row_offset = 3;
+    size_t const num_rows   = 60;
+    size_t total_size       = aligned_fixed_column_bytes(total_rows, sizeof(int32_t));
+    auto allocation         = create_test_allocation(total_size);
+    builder.initialize_accessors(total_rows, 0, allocation);
+
+    duckdb::ValidityMask prefix_validity(row_offset);
+    prefix_validity.Initialize(row_offset);
+    prefix_validity.SetAllValid(row_offset);
+    builder.process_mask_for_column(prefix_validity, row_offset, 0, allocation);
+
+    duckdb::ValidityMask validity(num_rows);
+    validity.Initialize(num_rows);
+    validity.SetAllValid(num_rows);
+    validity.SetInvalid(10);
+    validity.SetInvalid(59);
+    size_t const mask_offset = builder.mask_blocks_accessor.initial_byte_offset;
+    builder.mask_blocks_accessor.set_cursor(mask_offset + row_offset / 8);
+    builder.process_mask_for_column(validity, num_rows, row_offset, allocation);
+
+    auto get_mask_bit = [&](size_t bit_index) {
+      size_t const byte_index  = bit_index / 8;
+      size_t const bit_in_byte = bit_index % 8;
+      builder.mask_blocks_accessor.set_cursor(mask_offset + byte_index);
+      auto const mask_byte = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+      return (mask_byte >> bit_in_byte) & 0x1;
+    };
+
+    REQUIRE(get_mask_bit(row_offset - 1) == 1);
+    REQUIRE(get_mask_bit(row_offset + 10) == 0);
+    REQUIRE(get_mask_bit(row_offset + 59) == 0);
+  }
+
+  SECTION("byte-unaligned mask processing (perf, manual)")
+  {
+    // sysbench reports Ming's machine as having 6.3 GB/s memory bandwidth
+    if (std::getenv("SIRIUS_BENCH_MASK") == nullptr) {
+      SUCCEED("Set SIRIUS_BENCH_MASK=1 to enable perf loop.");
+      return;
+    }
+
+    auto parse_env_size = [](const char* name, size_t default_value) {
+      if (auto* value = std::getenv(name)) {
+        char* end   = nullptr;
+        auto parsed = std::strtoull(value, &end, 10);
+        if (end != value && parsed > 0) { return static_cast<size_t>(parsed); }
+      }
+      return default_value;
+    };
+
+    auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
+    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+
+    size_t const num_rows = parse_env_size("SIRIUS_BENCH_MASK_ROWS", 1 << 24);
+    size_t const iters    = parse_env_size("SIRIUS_BENCH_MASK_ITERS", 1000);
+    size_t total_size     = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    auto allocation       = create_test_allocation(total_size);
+    builder.initialize_accessors(num_rows, 0, allocation);
+
+    for (auto* block : allocation->get_blocks()) {
+      std::memset(block, 0, allocation->block_size());
+    }
+
+    duckdb::ValidityMask validity(num_rows);
+    validity.Initialize(num_rows);
+    validity.SetAllValid(num_rows);
+
+    size_t const row_offset = 3;
+    builder.mask_blocks_accessor.reset_cursor();
+    builder.mask_blocks_accessor.set_current(
+      static_cast<uint64_t>(sirius::utils::make_mask<uint64_t>(row_offset)), allocation);
+
+    // Warm-up
+    for (size_t i = 0; i < 5; ++i) {
+      builder.mask_blocks_accessor.reset_cursor();
+      builder.process_mask_for_column(validity, num_rows, row_offset, allocation);
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < iters; ++i) {
+      builder.mask_blocks_accessor.reset_cursor();
+      builder.process_mask_for_column(validity, num_rows, row_offset, allocation);
+    }
+    auto end         = std::chrono::steady_clock::now();
+    auto elapsed     = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+    auto avg_us      = static_cast<double>(elapsed) / static_cast<double>(iters);
+    auto mask_bytes  = static_cast<double>(sirius::utils::ceil_div_8(num_rows));
+    auto total_bytes = mask_bytes * static_cast<double>(iters);
+    auto seconds     = static_cast<double>(elapsed) / 1'000'000.0;
+    auto mb_per_sec  = seconds > 0.0 ? (2 * total_bytes / (1024.0 * 1024.0)) / seconds : 0.0;
+
+    std::cout << "[bench] process_mask_for_column unaligned rows=" << num_rows << " iters=" << iters
+              << " total_us=" << elapsed << " avg_us=" << avg_us << " MB/s=" << mb_per_sec
+              << std::endl;
   }
 
   SECTION("null_count reflects invalid rows in validity mask")
@@ -348,7 +574,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -372,7 +598,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -395,7 +621,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -424,7 +650,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -463,7 +689,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
     duckdb_scan_task_local_state::column_builder builder(bigint_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int64_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int64_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -500,7 +726,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
     duckdb_scan_task_local_state::column_builder builder(double_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(double) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(double));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -538,10 +764,8 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
     duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows   = 10;
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        DEFAULT_VARCHAR_SIZE * num_rows +     // data
-                        sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    size_t total_size = aligned_varchar_column_bytes(num_rows, DEFAULT_VARCHAR_SIZE);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with string data
@@ -584,10 +808,8 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
     duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows   = 10;
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        DEFAULT_VARCHAR_SIZE * num_rows +     // data
-                        sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    size_t total_size = aligned_varchar_column_bytes(num_rows, DEFAULT_VARCHAR_SIZE);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with string data
@@ -638,7 +860,7 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -674,10 +896,8 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
     duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
 
     size_t num_rows   = 20;
-    size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
-                        256 * num_rows +                      // data
-                        sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 256);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Process first batch
@@ -719,7 +939,7 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -754,10 +974,10 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
 
     // Verify mask has correct NULLs (rows 2, 5, and 9 should be NULL)
     // In DuckDB validity masks: 1 = valid, 0 = invalid
-    builder.mask_blocks_accessor.set_cursor(0);
-    auto mask_byte_0 = builder.mask_blocks_accessor.get_current(allocation);
-    builder.mask_blocks_accessor.advance();
-    auto mask_byte_1 = builder.mask_blocks_accessor.get_current(allocation);
+    builder.mask_blocks_accessor.reset_cursor();
+    auto mask_byte_0 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
+    auto mask_byte_1 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
 
     // Row 2 should be NULL (bit 2 in first byte should be 0)
     REQUIRE((mask_byte_0 & (1 << 2)) == 0);
@@ -780,7 +1000,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -801,7 +1021,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 100;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -821,11 +1041,11 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     // The mask accessor starts at byte offset (sizeof(int32_t) * 100) in the allocation
     // After process_column, it should be at the correct position to read the mask
     // Reset to the mask start position
-    size_t mask_offset = sizeof(int32_t) * num_rows;
+    size_t mask_offset = sirius::utils::align_8(sizeof(int32_t) * num_rows);
     builder.mask_blocks_accessor.set_cursor(mask_offset);
-    auto mask_byte_0 = builder.mask_blocks_accessor.get_current(allocation);
-    builder.mask_blocks_accessor.advance();
-    auto mask_byte_1 = builder.mask_blocks_accessor.get_current(allocation);
+    auto mask_byte_0 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
+    auto mask_byte_1 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
 
     REQUIRE(mask_byte_0 == 0);
     auto const tail_bits = static_cast<uint8_t>(processed_rows % CHAR_BIT);
@@ -842,11 +1062,9 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
 
-    size_t num_rows      = 10;
-    size_t max_data_size = 1024;
-    size_t total_size =
-      max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    size_t num_rows   = 10;
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 256);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create vector with empty strings
@@ -886,11 +1104,9 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
 
-    size_t num_rows      = 10;
-    size_t max_data_size = 1024;
-    size_t total_size =
-      max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    size_t num_rows   = 10;
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 256);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Mix of empty and non-empty strings
@@ -936,7 +1152,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     duckdb_scan_task_local_state::column_builder builder(int_type, 256);
 
     size_t num_rows   = 10;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -978,12 +1194,10 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     duckdb_scan_task_local_state::column_builder int_builder(int_type, 256);
     duckdb_scan_task_local_state::column_builder bigint_builder(bigint_type, 256);
 
-    size_t num_rows         = 10;
-    size_t int_data_size    = sizeof(int32_t) * num_rows;
-    size_t int_mask_size    = sirius::utils::ceil_div_8(num_rows);
-    size_t bigint_data_size = sizeof(int64_t) * num_rows;
-    size_t bigint_mask_size = sirius::utils::ceil_div_8(num_rows);
-    size_t total_size       = int_data_size + int_mask_size + bigint_data_size + bigint_mask_size;
+    size_t num_rows            = 10;
+    size_t int_column_bytes    = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    size_t bigint_column_bytes = aligned_fixed_column_bytes(num_rows, sizeof(int64_t));
+    size_t total_size          = int_column_bytes + bigint_column_bytes;
 
     auto allocation = create_test_allocation(total_size);
 
@@ -992,7 +1206,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     int_builder.initialize_accessors(num_rows, int_byte_offset, allocation);
 
     // Initialize BIGINT column after INT column
-    size_t bigint_byte_offset = int_data_size + int_mask_size;
+    size_t bigint_byte_offset = int_column_bytes;
     bigint_builder.initialize_accessors(num_rows, bigint_byte_offset, allocation);
 
     // Process INT data
@@ -1043,14 +1257,10 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     duckdb_scan_task_local_state::column_builder int_builder(int_type, 256);
     duckdb_scan_task_local_state::column_builder varchar_builder(varchar_type, 256);
 
-    size_t num_rows            = 5;
-    size_t int_data_size       = sizeof(int32_t) * num_rows;
-    size_t int_mask_size       = sirius::utils::ceil_div_8(num_rows);
-    size_t varchar_offset_size = (num_rows + 1) * sizeof(int64_t);
-    size_t varchar_data_size   = 256 * num_rows;  // Max data size
-    size_t varchar_mask_size   = sirius::utils::ceil_div_8(num_rows);
-    size_t total_size =
-      int_data_size + int_mask_size + varchar_offset_size + varchar_data_size + varchar_mask_size;
+    size_t num_rows             = 5;
+    size_t int_column_bytes     = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    size_t varchar_column_bytes = aligned_varchar_column_bytes(num_rows, 256);
+    size_t total_size           = int_column_bytes + varchar_column_bytes;
 
     auto allocation = create_test_allocation(total_size);
 
@@ -1059,7 +1269,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     int_builder.initialize_accessors(num_rows, int_byte_offset, allocation);
 
     // Initialize VARCHAR column after INT column
-    size_t varchar_byte_offset = int_data_size + int_mask_size;
+    size_t varchar_byte_offset = int_column_bytes;
     varchar_builder.initialize_accessors(num_rows, varchar_byte_offset, allocation);
 
     // Process INT data
@@ -1124,12 +1334,11 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     duckdb_scan_task_local_state::column_builder double_builder(double_type, 256);
     duckdb_scan_task_local_state::column_builder varchar_builder(varchar_type, 256);
 
-    size_t num_rows    = 8;
-    size_t int_size    = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    size_t double_size = sizeof(double) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    size_t varchar_size =
-      (num_rows + 1) * sizeof(int64_t) + 256 * num_rows + sirius::utils::ceil_div_8(num_rows);
-    size_t total_size = int_size + double_size + varchar_size;
+    size_t num_rows     = 8;
+    size_t int_size     = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
+    size_t double_size  = aligned_fixed_column_bytes(num_rows, sizeof(double));
+    size_t varchar_size = aligned_varchar_column_bytes(num_rows, 256);
+    size_t total_size   = int_size + double_size + varchar_size;
 
     auto allocation = create_test_allocation(total_size);
 
@@ -1182,16 +1391,17 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     REQUIRE(varchar_builder.null_count == 2);
 
     // Verify INT NULLs
-    int_builder.mask_blocks_accessor.set_cursor(sizeof(int32_t) * num_rows);
-    uint8_t int_mask = int_builder.mask_blocks_accessor.get_current(allocation);
+    int_builder.mask_blocks_accessor.set_cursor(sirius::utils::align_8(sizeof(int32_t) * num_rows));
+    uint8_t int_mask = int_builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
     REQUIRE((int_mask & (1 << 2)) == 0);  // Row 2 is NULL
     REQUIRE((int_mask & (1 << 5)) == 0);  // Row 5 is NULL
     REQUIRE((int_mask & (1 << 0)) != 0);  // Row 0 is valid
     REQUIRE((int_mask & (1 << 1)) != 0);  // Row 1 is valid
 
     // Verify DOUBLE NULLs
-    double_builder.mask_blocks_accessor.set_cursor(int_size + sizeof(double) * num_rows);
-    uint8_t double_mask = double_builder.mask_blocks_accessor.get_current(allocation);
+    double_builder.mask_blocks_accessor.set_cursor(
+      sirius::utils::align_8(int_size + sizeof(double) * num_rows));
+    uint8_t double_mask = double_builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
     REQUIRE((double_mask & (1 << 1)) == 0);  // Row 1 is NULL
     REQUIRE((double_mask & (1 << 6)) == 0);  // Row 6 is NULL
     REQUIRE((double_mask & (1 << 0)) != 0);  // Row 0 is valid
@@ -1201,9 +1411,9 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     // Where total_data_bytes_allocated = num_rows * default_varchar_size = 8 * 256 = 2048
     size_t varchar_data_offset = int_size + double_size + (num_rows + 1) * sizeof(int64_t);
     size_t varchar_mask_offset =
-      varchar_data_offset + (num_rows * 256);  // 256 is default_varchar_size
+      varchar_data_offset + sirius::utils::align_8(num_rows * 256);  // 256 is default_varchar_size
     varchar_builder.mask_blocks_accessor.set_cursor(varchar_mask_offset);
-    uint8_t varchar_mask = varchar_builder.mask_blocks_accessor.get_current(allocation);
+    uint8_t varchar_mask = varchar_builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
     REQUIRE((varchar_mask & (1 << 0)) == 0);  // Row 0 is NULL
     REQUIRE((varchar_mask & (1 << 7)) == 0);  // Row 7 is NULL
     REQUIRE((varchar_mask & (1 << 1)) != 0);  // Row 1 is valid
@@ -1221,13 +1431,11 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(
-      varchar_type, 4);  // Small default size: 5 rows * 4 bytes = 20 bytes allocated
+      varchar_type, 4);  // Small default size: 5 rows * 4 bytes = 20 bytes (aligned to 24)
 
-    size_t num_rows      = 5;
-    size_t max_data_size = 20;  // Only 20 bytes of data space
-    size_t total_size =
-      max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    size_t num_rows   = 5;
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 4);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create vector with strings that exceed allocated space
@@ -1259,11 +1467,9 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
 
-    size_t num_rows      = 10;
-    size_t max_data_size = 1024;
-    size_t total_size =
-      max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    size_t num_rows   = 10;
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 256);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // All NULLs - strings don't matter
@@ -1296,11 +1502,9 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
 
-    size_t num_rows      = 10;
-    size_t max_data_size = 1024;
-    size_t total_size =
-      max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    size_t num_rows   = 10;
+    size_t total_size = aligned_varchar_column_bytes(num_rows, 256);
+    auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     duckdb::Vector vec(varchar_type, 10);
@@ -1350,7 +1554,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
 
     // Test with exactly 16 rows (2 mask bytes)
     size_t num_rows   = 16;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -1372,10 +1576,10 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     REQUIRE(builder.null_count == 2);
 
     // Check mask bytes
-    builder.mask_blocks_accessor.set_cursor(sizeof(int32_t) * num_rows);
-    uint8_t mask_byte_0 = builder.mask_blocks_accessor.get_current(allocation);
-    builder.mask_blocks_accessor.advance();
-    uint8_t mask_byte_1 = builder.mask_blocks_accessor.get_current(allocation);
+    builder.mask_blocks_accessor.set_cursor(sirius::utils::align_8(sizeof(int32_t) * num_rows));
+    uint8_t mask_byte_0 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
+    uint8_t mask_byte_1 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
 
     // Bit 7 of first byte should be 0
     REQUIRE((mask_byte_0 & (1 << 7)) == 0);
@@ -1395,7 +1599,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
 
     // Test with 24 rows (3 mask bytes)
     size_t num_rows   = 24;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -1409,11 +1613,11 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     REQUIRE(builder.null_count == 24);
 
     // All mask bytes should be 0 (all rows NULL)
-    builder.mask_blocks_accessor.set_cursor(sizeof(int32_t) * num_rows);
+    builder.mask_blocks_accessor.set_cursor(sirius::utils::align_8(sizeof(int32_t) * num_rows));
     for (size_t i = 0; i < 3; ++i) {
-      uint8_t mask_byte = builder.mask_blocks_accessor.get_current(allocation);
+      uint8_t mask_byte = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
       REQUIRE(mask_byte == 0);
-      builder.mask_blocks_accessor.advance();
+      builder.mask_blocks_accessor.advance_as<uint8_t>();
     }
   }
 
@@ -1424,7 +1628,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
 
     // Test with 20 rows (3 mask bytes, last one partial)
     size_t num_rows   = 20;
-    size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
+    size_t total_size = aligned_fixed_column_bytes(num_rows, sizeof(int32_t));
     auto allocation   = create_test_allocation(total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -1443,13 +1647,13 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     REQUIRE(builder.null_count == 0);
 
     // First two mask bytes should be 0xFF (all valid)
-    builder.mask_blocks_accessor.set_cursor(sizeof(int32_t) * num_rows);
-    REQUIRE(builder.mask_blocks_accessor.get_current(allocation) == 0xFF);
-    builder.mask_blocks_accessor.advance();
-    REQUIRE(builder.mask_blocks_accessor.get_current(allocation) == 0xFF);
-    builder.mask_blocks_accessor.advance();
+    builder.mask_blocks_accessor.set_cursor(sirius::utils::align_8(sizeof(int32_t) * num_rows));
+    REQUIRE(builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation) == 0xFF);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
+    REQUIRE(builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation) == 0xFF);
+    builder.mask_blocks_accessor.advance_as<uint8_t>();
     // Third mask byte should have first 4 bits set (rows 16-19)
-    uint8_t mask_byte_2 = builder.mask_blocks_accessor.get_current(allocation);
+    uint8_t mask_byte_2 = builder.mask_blocks_accessor.get_current_as<uint8_t>(allocation);
     REQUIRE((mask_byte_2 & 0x0F) == 0x0F);
   }
 }

--- a/test/cpp/scan/test_scan_executor.cpp
+++ b/test/cpp/scan/test_scan_executor.cpp
@@ -405,8 +405,9 @@ TEST_CASE("scan_executor - single threaded small table", "[scan_executor][single
 TEST_CASE("scan_executor - single threaded with small batches", "[scan_executor][single_thread]")
 {
   // Use a small batch size to force multiple batches
-  // With 4 columns (INT + BIGINT + DOUBLE + VARCHAR(256)) = 4 + 8 + 8 + 256 = 276 bytes per row
-  // So ~600000 bytes should fit about 2175 rows (1 vector)
+  // With 4 columns (INT + BIGINT + DOUBLE + VARCHAR(256)) plus VARCHAR offset + mask bytes
+  // Base estimate = 4 + 8 + 8 + 256 + 8 + 1 = 285 bytes per row
+  // So ~600000 bytes should fit about 2105 rows (1 vector)
   run_scan_test("test_medium", 10000, 1, 600000);
 }
 


### PR DESCRIPTION
This PR will introduce optimizations for the `column_builder` component of the duckdb scan, which is responsible for converting/copying data in duckdb`DataChunk`s to a packed `multiple_blocks_allocation`. There are 2 main sources of inefficiency, which were left unaddressed in the initial implementation in the interest of 'make it work, then make it fast':

1. mask copy logic when the initial bit offset is 'unaligned`.
2. string copy logic.

The first is an issue because it makes bulk copy impossible, as every byte in the new validity mask needs to get downshifted to fit into the remaining bits of the byte left from the previous `DataChunk`. It's worth noting that the duckdb code for the duckdb -> arrow validity mask conversion sets bits one by one (!!!): [code](https://github.com/duckdb/duckdb/blob/c87733c87b41704b22f97ea2ba97c0f7d30c0974/src/common/arrow/appender/append_data.cpp#L5)

The second is also an issue because it makes bulk copy impossible. Since the duckdb `string_t` inlines strings that are `<=` 12 bytes, duckdb strings need to be parsed one-by-one to determine the source from which to copy the data bytes: the inlined string data or the data on the string heap. This is also reflected in the duckdb code for the duckdb -> arrow string conversion: [code](https://github.com/duckdb/duckdb/blob/c87733c87b41704b22f97ea2ba97c0f7d30c0974/src/include/duckdb/common/arrow/appender/varchar_data.hpp#L136). The existing code follows this pattern.

Here is a list of the changes this PR introduces to mitigate some of these issues:
1. The unaligned mask copy logic now processes 8B at a time instead of 1. To make this as efficient as possible, all offsets into the `multiple_blocks_allocation` are 8B aligned, which was not true before.
2. When the validity mask is not null, in the mask copying logic `popcount` is used to increment the null count, which is needed to construct the metadata for a `host_table_allocation`. Previously, the duckdb API `CountValid()` was used, which introduced another pass over the mask data. Now it is single-pass.
3. Still figuring out how to optimize the string part...

Speedup summary:
`memcpy` bandwidth on test machine (`mbw 256 -t0`): ~6.5 GiB/s.
Bandwidth of existing unaligned mask copy logic:  ~0.9 GiB/s
Bandwidth of updated unaligned mask copy logic: ~4 GiB/s
