### PR TITLE
WIP: operator_data concept

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -202,11 +202,11 @@ void task_creator::worker_function(int worker_id)
         info->_pipeline->get_sink()->set_creator(this);
         // need to exhaust input batches until all ports are empty
         while (!node.get().all_ports_empty()) {
-          auto input_batch = node.get().get_input_batch();
+          auto input_data = node.get().get_input_batch();
           auto global_state =
             std::make_shared<pipeline::gpu_pipeline_task_global_state>(info->_pipeline);
           auto local_state =
-            std::make_unique<pipeline::gpu_pipeline_task_local_state>(input_batch, nullptr);
+            std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data), nullptr);
           auto task =
             std::make_unique<pipeline::gpu_pipeline_task>(get_next_task_id(),
                                                           info->destination_data_repositories,

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -58,6 +58,55 @@ using task_creation_hint = std::variant<std::monostate,
 namespace op {
 enum class MemoryBarrierType { PIPELINE, PARTIAL, FULL };
 
+/**
+ * @brief Container for operator data batches.
+ *
+ * Wraps a collection of data batches that can be passed between operators.
+ */
+class operator_data {
+ public:
+  operator_data() = default;
+  explicit operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>> data_batches)
+    : _data_batches(std::move(data_batches)) {}
+
+  virtual ~operator_data() = default;
+
+  /**
+   * @brief Get the data batches.
+   * @return Vector of data batch pointers
+   */
+  [[nodiscard]] std::vector<std::shared_ptr<::cucascade::data_batch>> get_data_batches() const {
+    return _data_batches;
+  }
+
+ private:
+  std::vector<std::shared_ptr<::cucascade::data_batch>> _data_batches;
+};
+
+/**
+ * @brief Container for partitioned operator data.
+ *
+ * Extends operator_data to include partition index information.
+ */
+class partitioned_operator_data : public operator_data {
+ public:
+  partitioned_operator_data() = default;
+  partitioned_operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>> data_batches,
+                           std::size_t partition_idx)
+    : operator_data(std::move(data_batches)), _partition_idx(partition_idx) {}
+
+  /**
+   * @brief Get the partition index.
+   * @return Partition index
+   */
+  [[nodiscard]] std::size_t get_partition_idx() const {
+    return _partition_idx;
+  }
+
+ private:
+  std::size_t _partition_idx = 0;
+};
+
 //! sirius_physical_operator is the base class of the physical operators present in the
 //! execution plan
 class sirius_physical_operator {
@@ -117,8 +166,7 @@ class sirius_physical_operator {
   virtual duckdb::unique_ptr<duckdb::GlobalOperatorState> get_global_operator_state(
     duckdb::ClientContext& context) const;
 
-  virtual std::vector<std::shared_ptr<::cucascade::data_batch>> execute(
-    const std::vector<std::shared_ptr<::cucascade::data_batch>>& input_batches);
+  virtual operator_data execute(const operator_data& input_data);
 
   //! The influence the operator has on order (insertion order means no influence)
   virtual duckdb::OrderPreservationType operator_order() const
@@ -150,7 +198,7 @@ class sirius_physical_operator {
   virtual duckdb::unique_ptr<duckdb::GlobalSinkState> get_global_sink_state(
     duckdb::ClientContext& context) const;
 
-  virtual void sink(const std::vector<std::shared_ptr<::cucascade::data_batch>>& input_batches);
+  virtual void sink(const operator_data& input_data);
 
   virtual bool is_sink() const { return false; }
 
@@ -210,7 +258,7 @@ class sirius_physical_operator {
   //! Get the next task hint
   virtual creator::task_creation_hint get_next_task_hint();
   //! Get the input batch
-  std::vector<std::shared_ptr<::cucascade::data_batch>> get_input_batch();
+  operator_data get_input_batch();
   //! Check if all ports are empty
   bool all_ports_empty();
   //! Check if the pipeline is finished

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -30,6 +30,10 @@
 #include <vector>
 
 namespace sirius {
+namespace op {
+class operator_data;
+}
+
 namespace pipeline {
 
 /**
@@ -66,18 +70,17 @@ class gpu_pipeline_task_local_state : public sirius::parallel::itask_local_state
   /**
    * @brief Construct a new gpu_pipeline_task_local_state object
    *
-   * @param batch_views Vector of data batches serving as input to the pipeline
+   * @param input_data Operator data containing input data batches for the pipeline
    * @param res Memory reservation for GPU resources
    */
   explicit gpu_pipeline_task_local_state(
-    std::vector<std::shared_ptr<cucascade::data_batch>> batches,
+    sirius::op::operator_data input_data,
     std::unique_ptr<cucascade::memory::reservation> res = nullptr)
-    : _batches(std::move(batches)), _reservation(std::move(res))
+    : _batches(std::move(input_data)), _reservation(std::move(res))
   {
   }
 
-  std::vector<std::shared_ptr<cucascade::data_batch>>
-    _batches;  ///< Input data batches for the pipeline
+  sirius::op::operator_data _batches;  ///< Input data batches for the pipeline
 
   void set_reservation(std::unique_ptr<cucascade::memory::reservation> res)
   {

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -173,10 +173,10 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
   return it->second.get();
 }
 
-void sirius_physical_operator::sink(
-  const ::std::vector<::std::shared_ptr<::cucascade::data_batch>>& input_batches)
+void sirius_physical_operator::sink(const operator_data& input_data)
 {
-  auto output_batches = execute(input_batches);
+  auto output_data = execute(input_data);
+  auto output_batches = output_data.get_data_batches();
   for (auto& batch : output_batches) {
     for (auto& [next_op, port_id] : next_port_after_sink) {
       next_op->push_data_batch(port_id, batch);
@@ -197,11 +197,10 @@ void sirius_physical_operator::sink(
   }
 }
 
-::std::vector<::std::shared_ptr<::cucascade::data_batch>> sirius_physical_operator::execute(
-  const ::std::vector<::std::shared_ptr<::cucascade::data_batch>>& input_batches)
+operator_data sirius_physical_operator::execute(const operator_data& input_data)
 {
   // not doing anything for now
-  return ::std::vector<::std::shared_ptr<::cucascade::data_batch>>{};
+  return operator_data();
 }
 
 void sirius_physical_operator::push_data_batch(std::string_view port_id,
@@ -248,19 +247,19 @@ creator::task_creation_hint sirius_physical_operator::get_next_task_hint()
   return creator::task_creation_hint(std::monostate{});
 }
 
-std::vector<::std::shared_ptr<::cucascade::data_batch>> sirius_physical_operator::get_input_batch()
+operator_data sirius_physical_operator::get_input_batch()
 {
   // take one data batch from each port and schedule a task (a task takes one data batch from each
   // port), do this repeatedly until all ports are empty
-  std::vector<::std::shared_ptr<::cucascade::data_batch>> input_batch;
+  std::vector<::std::shared_ptr<::cucascade::data_batch>> input_batches;
   for (auto& [port_name, port_ptr] : ports) {
     // For Pipeline barrier: need at least one data batch in the port's repository
     // TODO: later on we will adjust to the new data repository interface in cuCascade
     auto batch_and_handle = port_ptr->repo->pop_data_batch(::cucascade::batch_state::task_created);
-    if (batch_and_handle) { input_batch.push_back(std::move(batch_and_handle)); }
+    if (batch_and_handle) { input_batches.push_back(std::move(batch_and_handle)); }
   }
-  if (input_batch.empty()) { return std::vector<::std::shared_ptr<::cucascade::data_batch>>{}; }
-  return input_batch;
+  if (input_batches.empty()) { return operator_data(); }
+  return operator_data(std::move(input_batches));
 }
 
 bool sirius_physical_operator::all_ports_empty()

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -120,9 +120,10 @@ void gpu_pipeline_task::execute()
   const auto* requested_memory_space =
     reservation != nullptr ? &reservation->get_memory_space() : nullptr;
   std::vector<cucascade::data_batch_processing_handle> processing_handles;
-  processing_handles.reserve(local_state._batches.size());
+  auto batches = local_state._batches.get_data_batches();
+  processing_handles.reserve(batches.size());
 
-  for (const auto& batch : local_state._batches) {
+  for (const auto& batch : batches) {
     auto handle = lock_or_prepare_batch(batch, requested_memory_space);
     if (!handle) {
       // Failed to lock (or convert) one of the batches. Caller can retry later.

--- a/test/cpp/pipeline/test_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_pipeline_executor.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "catch.hpp"
+#include "op/sirius_physical_operator.hpp"
 #include "pipeline/gpu_pipeline_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/pipeline_executor.hpp"
@@ -51,7 +52,7 @@ class mock_gpu_pipeline_task_global_state : public gpu_pipeline_task_global_stat
 class mock_gpu_pipeline_task_local_state : public gpu_pipeline_task_local_state {
  public:
   mock_gpu_pipeline_task_local_state(int task_id, int expected_gpu_id)
-    : gpu_pipeline_task_local_state(std::vector<std::shared_ptr<cucascade::data_batch>>{}),
+    : gpu_pipeline_task_local_state(sirius::op::operator_data()),
       _task_id(task_id),
       _expected_gpu_id(expected_gpu_id)
   {


### PR DESCRIPTION
This PR is to demonstrate the `operator_data` class concept, which is a wrapper for a `std::vector<std::shared_ptr<cucascade::data_batch>` that allows for adding operator dependent metadata to a batch that is type-erasable.