### PR TITLE
Updating Sirius Pipeline Interface

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -118,7 +118,7 @@ void task_creator::process_next_task(op::sirius_physical_operator* node)
     schedule(std::make_unique<task_creation_info>(hint_node, pipeline));
   } else if (std::holds_alternative<duckdb::shared_ptr<pipeline::sirius_pipeline>>(hint)) {
     auto pipeline = std::get<duckdb::shared_ptr<pipeline::sirius_pipeline>>(hint);
-    process_next_task(&pipeline->get_inner_operators()[0].get());
+    process_next_task(&pipeline->get_operators()[0].get());
   } else {
     if (!_priority_scans.empty()) {
       duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline = _priority_scans.front();
@@ -202,21 +202,19 @@ void task_creator::worker_function(int worker_id)
         _duckdb_scan_executor.schedule(std::move(scan_task));
         // scheduling pipeline task
       } else {
-        auto inner_ops = info->_pipeline->get_inner_operators();
-        auto* sink_op  = info->_pipeline->get_sink().get();
-        if (inner_ops.empty() && sink_op == nullptr) {
+        auto inner_ops = info->_pipeline->get_operators();
+        if (inner_ops.empty()) {
           throw std::runtime_error("Pipeline has no operators to execute");
         }
-        duckdb::reference<sirius::op::sirius_physical_operator> node =
-          inner_ops.empty() ? duckdb::reference<sirius::op::sirius_physical_operator>(*sink_op)
-                            : inner_ops[0];
+        duckdb::reference<sirius::op::sirius_physical_operator> node = inner_ops[0];
         info->_pipeline->get_sink()->set_creator(this);
         // need to exhaust input batches until all ports are empty
         while (!node.get().all_ports_empty()) {
           std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
+          auto sink_op = info->_pipeline->get_sink().get();
           if (sink_op &&
-              (dynamic_cast<sirius::op::sirius_physical_top_n_merge*>(sink_op) ||
-               dynamic_cast<sirius::op::sirius_physical_ungrouped_aggregate_merge*>(sink_op))) {
+              (sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_TOP_N ||
+               sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_AGGREGATE)) {
             while (!node.get().all_ports_empty()) {
               auto next_batch = node.get().get_input_batch();
               if (next_batch.empty()) { break; }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -203,18 +203,15 @@ void task_creator::worker_function(int worker_id)
         // scheduling pipeline task
       } else {
         auto inner_ops = info->_pipeline->get_operators();
-        if (inner_ops.empty()) {
-          throw std::runtime_error("Pipeline has no operators to execute");
-        }
+        if (inner_ops.empty()) { throw std::runtime_error("Pipeline has no operators to execute"); }
         duckdb::reference<sirius::op::sirius_physical_operator> node = inner_ops[0];
         info->_pipeline->get_sink()->set_creator(this);
         // need to exhaust input batches until all ports are empty
         while (!node.get().all_ports_empty()) {
           std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
           auto sink_op = info->_pipeline->get_sink().get();
-          if (sink_op &&
-              (sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_TOP_N ||
-               sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_AGGREGATE)) {
+          if (sink_op && (sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_TOP_N ||
+                          sink_op->TYPE == op::SiriusPhysicalOperatorType::MERGE_AGGREGATE)) {
             while (!node.get().all_ports_empty()) {
               auto next_batch = node.get().get_input_batch();
               if (next_batch.empty()) { break; }

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -60,7 +60,7 @@ class task_creation_info {
       destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
     }
     if (_node->type == op::SiriusPhysicalOperatorType::TABLE_SCAN) {
-      auto& first_operator = _pipeline->get_inner_operators()[0].get();
+      auto& first_operator = _pipeline->get_operators()[0].get();
       destination_data_repositories.push_back(first_operator.get_port("scan")->repo);
     }
     if (_pipeline->get_sink()->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -208,6 +208,8 @@ class sirius_physical_operator {
   void add_port(std::string_view port_id, std::unique_ptr<port> p);
   //! Get a port from the operator
   port* get_port(std::string_view port_id);
+  //! Get all ports from the operator
+  std::vector<std::string_view> get_port_ids();
   //! Check if the source pipeline is finished
   bool is_source_pipeline_finished();
   //! Add a next port after sink

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -101,12 +101,12 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   // bool get_progress(double &current_percentage, duckdb::idx_t &estimated_cardinality);
 
   //! Returns a list of all operators (including source and sink) involved in this pipeline
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_all_operators();
+  // duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_all_operators();
 
-  duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> get_all_operators() const;
+  // duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> get_all_operators() const;
 
   //! Returns a list of all inner operators (excluding source and sink) involved in this pipeline
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_inner_operators();
+  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_operators();
 
   duckdb::optional_ptr<op::sirius_physical_operator> get_sink() { return sink; }
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -103,7 +103,8 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Returns a list of all operators (including source and sink) involved in this pipeline
   // duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_all_operators();
 
-  // duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> get_all_operators() const;
+  // duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> get_all_operators()
+  // const;
 
   //! Returns a list of all inner operators (excluding source and sink) involved in this pipeline
   duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_operators();

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -283,5 +283,17 @@ bool sirius_physical_operator::is_source_pipeline_finished()
   }
   return true;
 }
+
+// implement get_all_ports
+std::vector<std::string_view>
+sirius_physical_operator::get_port_ids()
+{
+  std::vector<std::string_view> result;
+  for (auto& [port_name, port_ptr] : ports) {
+    result.push_back(port_name);
+  }
+  return result;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -285,8 +285,7 @@ bool sirius_physical_operator::is_source_pipeline_finished()
 }
 
 // implement get_all_ports
-std::vector<std::string_view>
-sirius_physical_operator::get_port_ids()
+std::vector<std::string_view> sirius_physical_operator::get_port_ids()
 {
   std::vector<std::string_view> result;
   for (auto& [port_name, port_ptr] : ports) {

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -129,33 +129,33 @@ void sirius_pipeline::add_dependency(duckdb::shared_ptr<sirius_pipeline>& pipeli
 // 	}
 // }
 
-duckdb::vector<duckdb::reference<op::sirius_physical_operator>> sirius_pipeline::get_all_operators()
-{
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> result;
-  D_ASSERT(source);
-  result.push_back(*source);
-  for (auto& op : operators) {
-    result.push_back(op.get());
-  }
-  if (sink) { result.push_back(*sink); }
-  return result;
-}
+// duckdb::vector<duckdb::reference<op::sirius_physical_operator>> sirius_pipeline::get_all_operators()
+// {
+//   duckdb::vector<duckdb::reference<op::sirius_physical_operator>> result;
+//   D_ASSERT(source);
+//   result.push_back(*source);
+//   for (auto& op : operators) {
+//     result.push_back(op.get());
+//   }
+//   if (sink) { result.push_back(*sink); }
+//   return result;
+// }
 
-duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>>
-sirius_pipeline::get_all_operators() const
-{
-  duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> result;
-  D_ASSERT(source);
-  result.push_back(*source);
-  for (auto& op : operators) {
-    result.push_back(op.get());
-  }
-  if (sink) { result.push_back(*sink); }
-  return result;
-}
+// duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>>
+// sirius_pipeline::get_all_operators() const
+// {
+//   duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> result;
+//   D_ASSERT(source);
+//   result.push_back(*source);
+//   for (auto& op : operators) {
+//     result.push_back(op.get());
+//   }
+//   if (sink) { result.push_back(*sink); }
+//   return result;
+// }
 
 duckdb::vector<duckdb::reference<op::sirius_physical_operator>>
-sirius_pipeline::get_inner_operators()
+sirius_pipeline::get_operators()
 {
   return operators;
 }

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -129,7 +129,8 @@ void sirius_pipeline::add_dependency(duckdb::shared_ptr<sirius_pipeline>& pipeli
 // 	}
 // }
 
-// duckdb::vector<duckdb::reference<op::sirius_physical_operator>> sirius_pipeline::get_all_operators()
+// duckdb::vector<duckdb::reference<op::sirius_physical_operator>>
+// sirius_pipeline::get_all_operators()
 // {
 //   duckdb::vector<duckdb::reference<op::sirius_physical_operator>> result;
 //   D_ASSERT(source);
@@ -154,8 +155,7 @@ void sirius_pipeline::add_dependency(duckdb::shared_ptr<sirius_pipeline>& pipeli
 //   return result;
 // }
 
-duckdb::vector<duckdb::reference<op::sirius_physical_operator>>
-sirius_pipeline::get_operators()
+duckdb::vector<duckdb::reference<op::sirius_physical_operator>> sirius_pipeline::get_operators()
 {
   return operators;
 }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -171,9 +171,9 @@ void sirius_engine::execute()
   if (sirius_ctx == nullptr) {
     throw duckdb::InvalidInputException("Sirius context is not initialized.");
   }
-  
+
   // Convert vector to hashmap
-  sirius_pipeline_hashmap pipeline_map(new_scheduled);  
+  sirius_pipeline_hashmap pipeline_map(new_scheduled);
   auto& task_creator = sirius_ctx->get_task_creator();
   task_creator.set_pipeline_hashmap(pipeline_map);
 }
@@ -893,9 +893,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 
     // create invalid operators
     auto invalid_op = make_uniq<op::sirius_physical_operator>(
-      op::SiriusPhysicalOperatorType::INVALID,
-      duckdb::vector<duckdb::LogicalType>{},
-      0);
+      op::SiriusPhysicalOperatorType::INVALID, duckdb::vector<duckdb::LogicalType>{}, 0);
 
     // Assign pipeline IDs based on new_scheduled order
     for (size_t i = 0; i < new_scheduled.size(); i++) {

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -57,6 +57,7 @@ void sirius_engine::reset()
   total_pipelines   = 0;
   sirius_pipelines.clear();
   new_pipeline_breakers.clear();
+  new_scheduled.clear();
 }
 
 void sirius_engine::insert_repository(
@@ -64,9 +65,9 @@ void sirius_engine::insert_repository(
   duckdb::shared_ptr<pipeline::sirius_pipeline> input_pipeline,
   duckdb::shared_ptr<pipeline::sirius_pipeline> dependent_pipeline)
 {
-  auto next_op            = dependent_pipeline->get_inner_operators().size() == 0
+  auto next_op            = dependent_pipeline->get_operators().size() == 0
                               ? dependent_pipeline->get_sink().get()
-                              : &dependent_pipeline->get_inner_operators()[0].get();
+                              : &dependent_pipeline->get_operators()[0].get();
   size_t op_id            = next_op->operator_id;
   auto& data_repo_manager = context.registered_state->Get<duckdb::SiriusContext>("sirius_state")
                               ->get_data_repository_manager();
@@ -89,9 +90,9 @@ void sirius_engine::insert_repository(
 {
   auto& data_repo_manager = context.registered_state->Get<duckdb::SiriusContext>("sirius_state")
                               ->get_data_repository_manager();
-  auto next_op = dependent_pipeline->get_inner_operators().size() == 0
+  auto next_op = dependent_pipeline->get_operators().size() == 0
                    ? dependent_pipeline->get_sink().get()
-                   : &dependent_pipeline->get_inner_operators()[0].get();
+                   : &dependent_pipeline->get_operators()[0].get();
   size_t op_id = next_op->operator_id;
   data_repo_manager.add_new_repository(
     op_id, port_id, std::make_unique<::cucascade::shared_data_repository>());
@@ -122,7 +123,7 @@ duckdb::shared_ptr<pipeline::sirius_pipeline> sirius_engine::create_child_pipeli
   child_pipeline->source = &op;
 
   // the child pipeline has the same operators up until 'op'
-  for (auto current_op : current.get_inner_operators()) {
+  for (auto current_op : current.get_operators()) {
     if (&current_op.get() == &op) { break; }
     child_pipeline->operators.push_back(current_op);
   }
@@ -165,15 +166,16 @@ void sirius_engine::execute()
   // wait until the query finish
   // take the query result from sirius_physical_result_collector
   // return the result to duckdb
-  printf("Client Context Pointer on execute: %p\n", (void*)&context);
   // get sirius context
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (sirius_ctx == nullptr) {
     throw duckdb::InvalidInputException("Sirius context is not initialized.");
   }
-  printf("Sirius Context Pointer on execute: %p\n", (void*)sirius_ctx.get());
+  
+  // Convert vector to hashmap
+  sirius_pipeline_hashmap pipeline_map(new_scheduled);  
   auto& task_creator = sirius_ctx->get_task_creator();
-  printf("Task Creator get next task id: %lu\n", task_creator.get_next_task_id());
+  task_creator.set_pipeline_hashmap(pipeline_map);
 }
 
 duckdb::unique_ptr<op::sirius_physical_operator> sirius_engine::construct_sirius_specific_operator(
@@ -714,9 +716,9 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
         for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {
-          auto next_op             = dependent_pipeline->get_inner_operators().size() == 0
+          auto next_op             = dependent_pipeline->get_operators().size() == 0
                                        ? dependent_pipeline->get_sink().get()
-                                       : &dependent_pipeline->get_inner_operators()[0].get();
+                                       : &dependent_pipeline->get_operators()[0].get();
           size_t op_id             = next_op->operator_id;
           std::string_view port_id = "scan";
           data_repo_manager.add_new_repository(
@@ -734,11 +736,6 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
       } else {
         throw std::runtime_error("Unsupported sink type for modified pipeline");
       }
-    }
-
-    // Assign pipeline IDs based on new_scheduled order
-    for (size_t i = 0; i < new_scheduled.size(); i++) {
-      new_scheduled[i]->set_pipeline_id(i);
     }
 
     // Detailed pipeline debugging information
@@ -893,6 +890,25 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 
     // Flush immediately to ensure all debug output is written synchronously
     // spdlog::default_logger()->flush();
+
+    // create invalid operators
+    auto invalid_op = make_uniq<op::sirius_physical_operator>(
+      op::SiriusPhysicalOperatorType::INVALID,
+      duckdb::vector<duckdb::LogicalType>{},
+      0);
+
+    // Assign pipeline IDs based on new_scheduled order
+    for (size_t i = 0; i < new_scheduled.size(); i++) {
+      new_scheduled[i]->set_pipeline_id(i);
+      new_scheduled[i]->operators.push_back(*new_scheduled[i]->sink);
+      new_scheduled[i]->source = &new_scheduled[i]->operators[0].get();
+      new_scheduled[i]->parents.clear();
+      auto& first_op = new_scheduled[i]->operators[0].get();
+      // iterate through ports at first_op
+      for (auto port_id : first_op.get_port_ids()) {
+        new_scheduled[i]->parents.push_back(first_op.get_port(port_id)->src_pipeline);
+      }
+    }
 
     // collect all pipelines from the root pipelines (recursively) for the progress bar and verify
     // them


### PR DESCRIPTION
This PR implements the following
- Implement `get_parent()` in sirius pipeline
- Set pipeline hashmap in sirius engine
- Sink operator is now part of the `sirius_pipeline.operators`