### PR TITLE
updated to rapids 26.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,4 +34,4 @@ jobs:
           pixi-version: v0.59.0
           activate-environment: true
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - run: make
+      - run: make -j$(nproc)

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/__pycache__/
 tpch-data/dbgen
 .vscode/
 *.duckdb
+!test/cpp/integration/integration.duckdb
 duckdb/*
 CMakeFiles/
 CMakeCache.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        exclude: 'test/cpp/integration/integration\.duckdb'
       - id: check-case-conflict
       - id: check-json
       - id: check-merge-conflict

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,5 +194,6 @@ set(TEST_EXEC_DIR "${CMAKE_CURRENT_BINARY_DIR}/test/cpp")
 set(TEST_LOG_DIR "${CMAKE_CURRENT_BINARY_DIR}/test/cpp/log")
 set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                               "${TEST_EXEC_DIR}")
-target_compile_definitions(${TEST_NAME}
-                           PRIVATE SIRIUS_UNITTEST_LOG_DIR="${TEST_LOG_DIR}")
+target_compile_definitions(
+  ${TEST_NAME} PRIVATE SIRIUS_UNITTEST_LOG_DIR="${TEST_LOG_DIR}"
+                       SIRIUS_PROJECT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/legacy/test_cudf.cu
+++ b/legacy/test_cudf.cu
@@ -23,9 +23,9 @@
 #include <cudf/table/table.hpp>
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <stdlib.h>
 

--- a/legacy/test_sorting.cu
+++ b/legacy/test_sorting.cu
@@ -29,9 +29,9 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 template <typename T>
 __global__ void print_gpu_column(T* a, int32_t N)

--- a/pixi.lock
+++ b/pixi.lock
@@ -2,19 +2,17 @@ version: 6
 environments:
   cuda12:
     channels:
-    - url: https://conda.anaconda.org/rapidsai/
+    - url: https://conda.anaconda.org/rapidsai-nightly/
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/nvidia/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
@@ -22,7 +20,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.3-hc85cc9f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
@@ -33,11 +31,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
@@ -47,23 +45,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dlpack-0.8-h59595ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.4.4-h332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-he8b2097_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h310e576_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hb1e0a52_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h3c3a7a4_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.0-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libconfig-1.7.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.12.00-cuda12_251210_580975be.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libcudf-26.04.00a162-cuda12_260205_b441c77f.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
@@ -72,29 +71,29 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.12.00-cuda12_251210_61297197.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libkvikio-26.04.00a18-cuda12_260205_593245b7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-hb7e823c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-hb7e823c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.1.0.21-hb7e823c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.1.0.21-hb7e823c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.12.00-cuda12_251210_86731e05.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_16.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/librmm-26.04.00a23-cuda12_260205_7fff28e1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
@@ -104,24 +103,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.2-h32b2ec7_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.4.4-py314ha160325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.13.0-he64ecbb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py314h9891dd4_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -130,9 +130,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45.1-default_hf1166c9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.11.0-hdceaead_0.conda
@@ -140,7 +140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.3-hc9d863e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-12.9.27-h579c4fd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-12.9.86-h579c4fd_2.conda
@@ -151,11 +151,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-12.9.79-h3ae8b8a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-12.9.79-h3ae8b8a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-12.9.79-h3ae8b8a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-12.9.86-ha346c71_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-12.9.86-ha346c71_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-12.9.86-h4310d6a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-12.9.86-h614329b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-12.9.86-h614329b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-12.9.86-h44c6fc4_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-12.9.86-h44c6fc4_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-12.9.79-h40ab4d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-12.9.86-h8f3c8d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
@@ -165,23 +165,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.11.0-h7b35c40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dlpack-0.8-h2f0025b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.4.4-h332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hda29b82_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-h7476c01_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-h42fc7e9_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-ha7c1ae4_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hb1525cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.0-cxx17_h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libconfig-1.7.3-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.12.00-cuda12_251210_580975be.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libcudf-26.04.00a162-cuda12_260205_b441c77f.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.14.1.1-had8bf56_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.14.1.1-he38c790_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.3.10.19-he38c790_1.conda
@@ -190,29 +191,29 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.3-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-hd65408f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.12.00-cuda12_251210_61297197.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libkvikio-26.04.00a18-cuda12_260205_593245b7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.2-he30d5cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.67.0-ha888d0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnuma-2.0.18-h86ecc28_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-h6defbd5_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-h6defbd5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.1.0.21-h6defbd5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.1.0.21-h6defbd5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-12.9.86-h8f3c8d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-12.9.86-h579c4fd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.12.00-cuda12_251210_86731e05.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_16.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/librmm-26.04.00a23-cuda12_260205_7fff28e1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_116.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
@@ -222,268 +223,273 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.0-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.2-hb06a95a_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.3-hb06a95a_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-duckdb-1.4.4-py314h02b5315_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-61.0-h1f0f388_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.13.0-hb434046_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h561c983_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py314hd7d8586_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.1.0-py314hd7d8586_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unzip-6.0-he30d5cf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   default:
     channels:
-    - url: https://conda.anaconda.org/rapidsai/
+    - url: https://conda.anaconda.org/rapidsai-nightly/
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/nvidia/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.1.3-hc85cc9f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.1.80-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.1.80-h376f20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.1.115-hcdd1206_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.1.115-he91c749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.1.115-h85509e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.1.115-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.1.115-hb2fc203_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.1.115-hffce074_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.1.115-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.115-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.1.115-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dlpack-0.8-h59595ed_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h319ec69_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-he6f32d1_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.4.4-h332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hb1e0a52_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h3c3a7a4_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.0-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libconfig-1.7.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.12.00-cuda13_251210_580975be.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libcudf-26.04.00a162-cuda13_260205_b441c77f.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.16.1.26-hd07211c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.16.1.26-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.1.81-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.1.81-h676940d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_115.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_15.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.12.00-cuda13_251210_61297197.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libkvikio-26.04.00a18-cuda13_260205_593245b7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-hb9d3cd8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-h7bcfba5_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-h7bcfba5_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.12.00-cuda13_251210_86731e05.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.1.0.21-h7bcfba5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.1.0.21-h7bcfba5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.1.115-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.1.115-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/librmm-26.04.00a23-cuda13_260205_7fff28e1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_115.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.2-h32b2ec7_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.4.4-py314ha160325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.12.0-he64ecbb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.13.0-he64ecbb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py314h9891dd4_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/arm-variant-1.2.0-sbsa.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45.1-default_hf1166c9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.11.0-hdceaead_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.1.3-hc9d863e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.0.87-h40ab4d6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.1.115-ha346c71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.1.115-h4310d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.1.115-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.1.115-h614329b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.1.115-h9ee44f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.1.115-h40ab4d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.1.115-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.115-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.1.115-h7b14b0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.11.0-h7b35c40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dlpack-0.8-h2f0025b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hadc3402_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-hef95cfa_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.4.4-h332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-h42fc7e9_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-ha7c1ae4_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.2-hb1525cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20260107.0-cxx17_h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-h68e9139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libconfig-1.7.3-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.12.00-cuda13_251210_580975be.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.17.0-h7bfdcfb_0.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libcudf-26.04.00a162-cuda13_260205_b441c77f.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.16.1.26-hbf501ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.16.1.26-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.1.81-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.1.81-he38c790_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.3-hfae3067_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-hd65408f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_115.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_15.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.12.00-cuda13_251210_61297197.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libkvikio-26.04.00a18-cuda13_260205_593245b7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.2-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.67.0-ha888d0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.11.0-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnuma-2.0.18-h86ecc28_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-he387df4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-he387df4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.12.00-cuda13_251210_86731e05.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.1-h022381a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.1.0.21-he387df4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.1.0.21-he387df4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.1.115-h8f3c8d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/librmm-26.04.00a23-cuda13_260205_7fff28e1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_115.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.2-h1022ec0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_117.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.0-h8e36d6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.2-hb06a95a_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.3-hb06a95a_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-duckdb-1.4.4-py314h02b5315_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/rapidsai/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+      - conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-61.0-h1f0f388_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.12.0-hb434046_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h561c983_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.13.0-hb434046_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py314hd7d8586_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.1.0-py314hd7d8586_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unzip-6.0-he30d5cf_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
 packages:
@@ -544,122 +550,58 @@ packages:
   license_family: GPL
   size: 74992
   timestamp: 1660065534958
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_104.conda
-  sha256: 1625ea421e0f44dbdde01e3e7d2c4958bea6c55731e6ac6954ba912d339982c2
-  md5: d351e4894d6c4d9d8775bf169a97089d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+  sha256: 2851d34944b056d028543f0440fb631aeeff204151ea09589d8d9c13882395de
+  md5: 9902aeb08445c03fb31e01beeb173988
   depends:
-  - binutils_impl_linux-64 >=2.45,<2.46.0a0
+  - binutils_impl_linux-64 >=2.45.1,<2.45.2.0a0
   license: GPL-3.0-only
-  license_family: GPL
-  size: 35316
-  timestamp: 1764007880473
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_105.conda
-  sha256: fe2580dfa3711d7de59ae7e044f7eea6bfdd969cc5c36d814a569225d7f7f243
-  md5: 1bc3e6c577a1a206c36456bdeae406de
+  size: 35128
+  timestamp: 1770267175160
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45.1-default_hf1166c9_101.conda
+  sha256: 7113440420c6f31742c2b29d7590900362007a0bb0d31f9bc5c9a1379d9ab702
+  md5: 77f58300ab7d95ce79f9c2c13ad72d5c
   depends:
-  - binutils_impl_linux-64 >=2.45,<2.46.0a0
+  - binutils_impl_linux-aarch64 >=2.45.1,<2.45.2.0a0
   license: GPL-3.0-only
-  license_family: GPL
-  size: 35432
-  timestamp: 1766513140840
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_104.conda
-  sha256: 9bc583e5f93353723d7889ec18b9bca2c1cecf6fec14ea27ae5f758a28258cf9
-  md5: c8a3dbfe30387152a796e2d1d4196131
+  size: 35322
+  timestamp: 1770267247190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+  sha256: 74341b26a2b9475dc14ba3cf12432fcd10a23af285101883e720216d81d44676
+  md5: 83aa53cb3f5fc849851a84d777a60551
   depends:
-  - binutils_impl_linux-aarch64 >=2.45,<2.46.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 35396
-  timestamp: 1764007964053
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.45-default_hf1166c9_105.conda
-  sha256: 6925e0b95ac229c95da12fc6624e07238bf58ae5ce82b90e4f5bb60e6c5db9d8
-  md5: 9a1a19fdd691e3a100a00c9a83303863
-  depends:
-  - binutils_impl_linux-aarch64 >=2.45,<2.46.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 35382
-  timestamp: 1766513231847
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
-  sha256: 054a77ccab631071a803737ea8e5d04b5b18e57db5b0826a04495bd3fdf39a7c
-  md5: a7a67bf132a4a2dea92a7cb498cdc5b1
-  depends:
-  - ld_impl_linux-64 2.45 default_hbd61a6d_104
+  - ld_impl_linux-64 2.45.1 default_hbd61a6d_101
   - sysroot_linux-64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
-  license_family: GPL
-  size: 3747046
-  timestamp: 1764007847963
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
-  sha256: 17fbb32191430310d3eb8309f80a8df54f0d66eda9cf84b2ae5113e6d74e24d8
-  md5: e410a8f80e22eb6d840e39ac6a34bd0e
+  size: 3744895
+  timestamp: 1770267152681
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_101.conda
+  sha256: e90ab42a5225dc1eaa6e4e7201cd7b8ed52dad6ec46814be7e5a4039433ae85c
+  md5: df6e1dc38cbe5642350fa09d4a1d546b
   depends:
-  - ld_impl_linux-64 2.45 default_hbd61a6d_105
-  - sysroot_linux-64
-  - zstd >=1.5.7,<1.6.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 3719982
-  timestamp: 1766513109980
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_104.conda
-  sha256: b7694c53943941a5234406b77b168e28d92227f8e69c697edda3faf436dd26c1
-  md5: 8107322440b07ab4234815368d1785a9
-  depends:
-  - ld_impl_linux-aarch64 2.45 default_h1979696_104
+  - ld_impl_linux-aarch64 2.45.1 default_h1979696_101
   - sysroot_linux-aarch64
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
-  license_family: GPL
-  size: 4850743
-  timestamp: 1764007931341
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45-default_h5f4c503_105.conda
-  sha256: 7398706fe428530777a7b1e69925c94e46cd45182c52f8a84f34cd601c8d2584
-  md5: 3cee44d70779b513523a9a46146da3f9
+  size: 4741684
+  timestamp: 1770267224406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
+  sha256: 4826f97d33cbe54459970a1e84500dbe0cccf8326aaf370e707372ae20ec5a47
+  md5: dec96579f9a7035a59492bf6ee613b53
   depends:
-  - ld_impl_linux-aarch64 2.45 default_h1979696_105
-  - sysroot_linux-aarch64
-  - zstd >=1.5.7,<1.6.0a0
+  - binutils_impl_linux-64 2.45.1 default_hfdba357_101
   license: GPL-3.0-only
-  license_family: GPL
-  size: 4848132
-  timestamp: 1766513201703
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
-  sha256: ed23fee4db69ad82320cca400fc77404c3874cd866606651a20bf743acd1a9b1
-  md5: e30e71d685e23cc1e5ac1c1990ba1f81
+  size: 36060
+  timestamp: 1770267177798
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45.1-default_hf1166c9_101.conda
+  sha256: 4ed3cf8af327b1c8b7e71433c98eb0154027e07b726136e81235276e9025489a
+  md5: 99924e610d9960dc3d8b865614787cec
   depends:
-  - binutils_impl_linux-64 2.45 default_hfdba357_104
+  - binutils_impl_linux-aarch64 2.45.1 default_h5f4c503_101
   license: GPL-3.0-only
-  license_family: GPL
-  size: 36180
-  timestamp: 1764007883258
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_105.conda
-  sha256: 0eae8088e00edc7fe7a728d64f6614d2cf17a2df010e835eccefe30bfc726759
-  md5: 4b1e4ae87a52e9724a9ec0c7b822bc89
-  depends:
-  - binutils_impl_linux-64 2.45 default_hfdba357_105
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 36310
-  timestamp: 1766513143566
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_104.conda
-  sha256: c93628f369264e5c7375915a5f589624d3211b5f4eb26a49395b1824976aeeb9
-  md5: ddc3eece92177305e59ed62f95342d4b
-  depends:
-  - binutils_impl_linux-aarch64 2.45 default_h5f4c503_104
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 36380
-  timestamp: 1764007966890
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.45-default_hf1166c9_105.conda
-  sha256: e9441a6802726d72d36f3c814e98388bd6167ba44c480c4a168911a37b501734
-  md5: 5ac81369b4efb28d9215b858f92aee07
-  depends:
-  - binutils_impl_linux-aarch64 2.45 default_h5f4c503_105
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 36406
-  timestamp: 1766513234691
+  size: 36223
+  timestamp: 1770267249899
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
   sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
   md5: 51a19bba1b8ebfb60df25cde030b7ebc
@@ -679,16 +621,6 @@ packages:
   license_family: BSD
   size: 192536
   timestamp: 1757437302703
-- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
-  sha256: f8003bef369f57396593ccd03d08a8e21966157269426f71e943f96e4b579aeb
-  md5: f7f0d6cc2dc986d42ac2689ec88192be
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 206884
-  timestamp: 1744127994291
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
   sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
   md5: 920bb03579f15389b9e512095ad995b7
@@ -699,15 +631,6 @@ packages:
   license_family: MIT
   size: 207882
   timestamp: 1765214722852
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
-  sha256: ccae98c665d86723993d4cb0b456bd23804af5b0645052c09a31c9634eebc8df
-  md5: 5deaa903d46d62a1f8077ad359c3062e
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 215950
-  timestamp: 1744127972012
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
   sha256: 7ec8a68efe479e2e298558cbc2e79d29430d5c7508254268818c0ae19b206519
   md5: 1dfbec0d08f112103405756181304c16
@@ -739,14 +662,6 @@ packages:
   license_family: BSD
   size: 6721
   timestamp: 1753098688332
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
-  sha256: b986ba796d42c9d3265602bc038f6f5264095702dd546c14bc684e60c385e773
-  md5: f0991f0f84902f6b6009b4d2350a83aa
-  depends:
-  - __unix
-  license: ISC
-  size: 152432
-  timestamp: 1762967197890
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
   sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
   md5: bddacf101bb4dd0e51811cb69c7790e2
@@ -830,40 +745,22 @@ packages:
   license_family: BSD
   size: 20521629
   timestamp: 1763512243490
-- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_15.conda
-  sha256: 24709cfc0b12ef8248ec4ebf854bacfeb36868e1757a89d3e01c636f110f886b
-  md5: 93b9b94788b52e6f79cf6ae88de40c76
+- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_17.conda
+  sha256: 522e7a22da3e8f30c8e8c80831c4d7399d8797fce154acbdf904111501d637f6
+  md5: 4e58f090f75b2941346da3685564e7a7
   depends:
   - gcc_impl_linux-64 >=14.3.0,<14.3.1.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 30973
-  timestamp: 1764836751487
-- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_16.conda
-  sha256: 387cd20bc18c9cabae357fec1b73f691b8b6a6bafbf843b8ff17241eae0dd1d5
-  md5: 77e54ea3bd0888e65ed821f19f5d23ad
-  depends:
-  - gcc_impl_linux-64 >=14.3.0,<14.3.1.0a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 31314
-  timestamp: 1765256147792
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_15.conda
-  sha256: 79af3f48724988e059468a7293bc524732038a3e1d122e4e358c64342cc46d3c
-  md5: d8ef968a2027db34adc6450eed26a9a5
+  size: 31646
+  timestamp: 1770252240343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_17.conda
+  sha256: 482a585f043279805dad18b2179169737dac52cd0713f5759fc62304d5e44432
+  md5: bf539220ad6caf2028d5e5cc6d320220
   depends:
   - gcc_impl_linux-aarch64 >=14.3.0,<14.3.1.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 30750
-  timestamp: 1764836639741
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/conda-gcc-specs-14.3.0-hadff5d6_16.conda
-  sha256: b63926b9041527ca4f2d196483e8e2368860f66f6bc9866fb443a5325f5ec207
-  md5: 5b4371e8c3e0245dd41c76fce4314e13
-  depends:
-  - gcc_impl_linux-aarch64 >=14.3.0,<14.3.1.0a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 31165
-  timestamp: 1765256726234
+  size: 31455
+  timestamp: 1770252181142
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
   sha256: 2ee3b9564ca326226e5cda41d11b251482df8e7c757e333d28ec75213c75d126
   md5: 87ff6381e33b76e5b9b179a2cdd005ec
@@ -872,14 +769,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 1150650
   timestamp: 1746189825236
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
-  sha256: a6e372858d440e3adcea6902a013f9e5df5794ac414532bf21340919565406fc
-  md5: 9cdd4053158422e3ef9d7a3feb31e40d
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 0715f15da71587238600f0584bc8d243d8fde602c3d8856f421b58dff3fb9422
+  md5: a179486129ff28d053bb16fdb533568e
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1143068
-  timestamp: 1757017456077
+  size: 1277295
+  timestamp: 1768272295906
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-12.9.27-h579c4fd_0.conda
   sha256: b4efaee8fa95b9ec97a462dc343914a138ece704895e33caa52ac55968f7adfa
   md5: 71e4d87a72bf003bd05f05a502288b2a
@@ -889,15 +786,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 1149299
   timestamp: 1746189919921
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.0.85-h579c4fd_0.conda
-  sha256: 89d1251bfb27d9d861764cd1daae2b835588045ba920debab66a79e208484032
-  md5: 6739a8321047a32fe33edc982b570c9c
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 82fcc47ac040e4db316d9548f9d50f26cf958ce5a91d808a5ad9ab30068b7256
+  md5: 5fb57a3acae0fa3ba0b3050142879d01
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1141138
-  timestamp: 1757017459617
+  size: 1280034
+  timestamp: 1768272332978
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
   sha256: e6257534c4b4b6b8a1192f84191c34906ab9968c92680fa09f639e7846a87304
   md5: 79d280de61e18010df5997daea4743df
@@ -906,14 +803,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 94239
   timestamp: 1753975242354
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: dff9f97d3c8f47e1e4b6d486401d11a2d8aa9474a07adbd177b042a8cb640e1f
-  md5: 99dddaab1ca61632434f37079fce52e9
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 82ae1f3e492146722e258e237daa537f4d4df8157b2dfa49a0869eb41a11d284
+  md5: 3723bca2a84e6cc0f0a98427b71bec73
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 95746
-  timestamp: 1757021345670
+  size: 96480
+  timestamp: 1768280269206
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
   sha256: 1db1f3ff4b0f445ce4064eb323733f7612ce28bc879dd6849e162b1504b7474a
   md5: 86be43a4154301b74f823bc6fe476629
@@ -923,15 +820,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 94794
   timestamp: 1753975199249
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 5ffbb6e143bd16951c1bc71d32f8137f9ed890df9420e1c9d5d30c12823b951e
-  md5: 766775e40dac3236cd90077f460552db
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 960ded06dffe01b8decdb31d24c151c549d10e0f4b862086310057bea96e1d60
+  md5: c6c2265e35eb85d66f8c4ea753fd306c
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 95711
-  timestamp: 1757021337458
+  size: 96143
+  timestamp: 1768280061409
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
   sha256: 2da9964591af14ba11b2379bed01d56e7185260ee0998d1a939add7fb752db45
   md5: 503a94e20d2690d534d676a764a1852c
@@ -940,14 +837,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 29138
   timestamp: 1753975252445
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
-  sha256: c7fc9f3c3f0c51678dc92b1caa46dbce35a1dc6e6176771f0a87272a22a35256
-  md5: d72c22960bc7ec9144bedaeb6138a261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.1.115-ha770c72_0.conda
+  sha256: 272c3e100c40f261f3322613ed3829b7cbec7e107bf25bd5c3328ec9416dc341
+  md5: 2463b351f519d6a915e05a60668aea13
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29931
-  timestamp: 1757021356880
+  size: 30124
+  timestamp: 1768280280700
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-12.9.86-h579c4fd_2.conda
   sha256: dad493fdcef9a5b84269bdd22b5dfbe73300d99057f2fc1a1ad1114a944167c7
   md5: 6f66ef2abe496ac82066ea6b9f33ab90
@@ -957,15 +854,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 29186
   timestamp: 1753975202369
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.0.88-h579c4fd_0.conda
-  sha256: 564b166a587e62c92c6e0b4044955cedab42168ae2730f74694fe89ef61b9fd3
-  md5: 75359c125cfd48ee457a6659b561a764
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-crt-tools-13.1.115-h579c4fd_0.conda
+  sha256: a76bcffda612363cef641748251273003d3bd43ae70fa51a0a0c01be106de3e5
+  md5: fdc4479b45ce5ddd362a268ad2847b6d
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 30038
-  timestamp: 1757021339160
+  size: 30165
+  timestamp: 1768280063313
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
   sha256: 57d1294ecfaf9dc8cdb5fc4be3e63ebc7614538bddb5de53cfd9b1b7de43aed5
   md5: cb15315d19b58bd9cd424084e58ad081
@@ -978,18 +875,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23242
   timestamp: 1749218416505
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.0.96-hecca717_0.conda
-  sha256: 22f6466441812649da65ef47792854e9552e566d7ac6c3682d81dbb480de529c
-  md5: b585052893126ed45c015bcab43ff12a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-13.1.80-hecca717_0.conda
+  sha256: 00acb7564e7c7dd60be431bd2a1a937856e38a86535d72281461cd193500a0a4
+  md5: 2e2b71c8d67f6ceb1d3820aa438f3580
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart_linux-64 13.0.96 h376f20c_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart_linux-64 13.1.80 h376f20c_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24027
-  timestamp: 1760034148822
+  size: 24159
+  timestamp: 1764883525821
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-12.9.79-h3ae8b8a_0.conda
   sha256: 3d6699fc27ffabf28a9d359b48e7b88437e4d945844718a58608627998db5d1b
   md5: df78e19e5fe656631d1470aa0fcf6ced
@@ -1002,18 +899,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23466
   timestamp: 1749218349235
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.0.96-h8f3c8d4_0.conda
-  sha256: 0387b104ebf74f83ed911cd90aebb064ed1d2ffb147c36cb6c268415302431a8
-  md5: fd19003beb0686dd8e47466bbab1b11f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-13.1.80-h8f3c8d4_0.conda
+  sha256: 90500d6db4a888b4e5711315a01f459f41538990b292909b4f175f0a5bdf8462
+  md5: 99ed9d9d1746fc1e2ef0799a4b4c1ce6
   depends:
   - arm-variant * sbsa
-  - cuda-cudart_linux-aarch64 13.0.96 h8f3c8d4_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart_linux-aarch64 13.1.80 h8f3c8d4_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24195
-  timestamp: 1760034124717
+  size: 24317
+  timestamp: 1764883513493
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-12.9.79-h5888daf_0.conda
   sha256: 04d8235cb3cb3510c0492c3515a9d1a6053b50ef39be42b60cafb05044b5f4c6
   md5: ba38a7c3b4c14625de45784b773f0c71
@@ -1028,20 +925,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23687
   timestamp: 1749218464010
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.0.96-hecca717_0.conda
-  sha256: 5af0357651051bc0a308eb007955d928dd6d6a5aafdc96e2868526fc2c87bda8
-  md5: 5e325914e6b2ed97a412e54755268217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-dev-13.1.80-hecca717_0.conda
+  sha256: 12aa5dcf82cdf863be18a48a9ad4d271aa864ef985752bc9707371b84085f0c8
+  md5: e3cbe24bf8ae135e9f82450be520e886
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart 13.0.96 hecca717_0
-  - cuda-cudart-dev_linux-64 13.0.96 h376f20c_0
-  - cuda-cudart-static 13.0.96 hecca717_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart 13.1.80 hecca717_0
+  - cuda-cudart-dev_linux-64 13.1.80 h376f20c_0
+  - cuda-cudart-static 13.1.80 hecca717_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24515
-  timestamp: 1760034188804
+  size: 24597
+  timestamp: 1764883573873
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-12.9.79-h3ae8b8a_0.conda
   sha256: d70f85411992e03494f2fe94a9852d79f366a92f40ba791611eda5551044afe9
   md5: d58cc487273764a11637456c06399ff0
@@ -1056,20 +953,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23911
   timestamp: 1749218369632
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.0.96-h8f3c8d4_0.conda
-  sha256: 2965f65bc5031da466cd26b7a9e056e67cae206ff04483958617a591928f610f
-  md5: 647578ce75f6ac021ad50daf7dd6c5ef
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-dev-13.1.80-h8f3c8d4_0.conda
+  sha256: 197d42db4942a7ab945cff3b1d7091013cf9f13ae29d1ac6fe83d8e528c800e1
+  md5: bddd3d4373e9097a51ae6c69e4172130
   depends:
   - arm-variant * sbsa
-  - cuda-cudart 13.0.96 h8f3c8d4_0
-  - cuda-cudart-dev_linux-aarch64 13.0.96 h8f3c8d4_0
-  - cuda-cudart-static 13.0.96 h8f3c8d4_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart 13.1.80 h8f3c8d4_0
+  - cuda-cudart-dev_linux-aarch64 13.1.80 h8f3c8d4_0
+  - cuda-cudart-static 13.1.80 h8f3c8d4_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24661
-  timestamp: 1760034143509
+  size: 24764
+  timestamp: 1764883540232
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-12.9.79-h3f2d84a_0.conda
   sha256: ffe86ed0144315b276f18020d836c8ef05bf971054cf7c3eb167af92494080d5
   md5: 86e40eb67d83f1a58bdafdd44e5a77c6
@@ -1081,17 +978,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 389140
   timestamp: 1749218427266
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.0.96-h376f20c_0.conda
-  sha256: 9730992d8a9696cb740420a40340e8ae142e26ec42e0cb3a74c6bfb9f3d43d75
-  md5: 452f0e77df30da17b08e3295ef279df2
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-64-13.1.80-h376f20c_0.conda
+  sha256: 41a1cc86f2759ef6ae47cc68e2180baaeb4b989709931366ee0cdc90f8e10f5f
+  md5: a36776a49ae0e47a26e129bdc82aeb3e
   depends:
   - cuda-cccl_linux-64
   - cuda-cudart-static_linux-64
   - cuda-cudart_linux-64
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 385615
-  timestamp: 1760034157020
+  size: 392459
+  timestamp: 1764883538793
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-12.9.79-h3ae8b8a_0.conda
   sha256: ad64a1ecfc933172dbc6407d71b1abb78dc7ffcd5cc871baee238350307a7c0c
   md5: 60e07c05a51d5549bec1e7ee38849feb
@@ -1104,18 +1001,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 388797
   timestamp: 1749218354725
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: a56da2191e818e0e54be0c9956fec02e26940b0ac6ca1747c1badae2804cae40
-  md5: c9fa4020ff1370f7b5216c24f222d584
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+  sha256: 17ee6c49ff17c51bd62dc6dd0204244680b508ed1c3e412e8a7a106fd70d3acf
+  md5: abba14a505537bb3afab83a385993c88
   depends:
   - arm-variant * sbsa
   - cuda-cccl_linux-aarch64
   - cuda-cudart-static_linux-aarch64
   - cuda-cudart_linux-aarch64
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 385612
-  timestamp: 1760034129929
+  size: 393363
+  timestamp: 1764883521187
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-12.9.79-h5888daf_0.conda
   sha256: 6261e1d9af80e1ec308e3e5e2ff825d189ef922d24093beaf6efca12e67ce060
   md5: d3c4ac48f4967f09dd910d9c15d40c81
@@ -1128,18 +1025,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23283
   timestamp: 1749218442382
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.0.96-hecca717_0.conda
-  sha256: c158fb5fdb660181e480d50dcc9df40febeb313a9bbed71954093305373994ba
-  md5: 36d04d463e960a0273fdb788c11b87e4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-static-13.1.80-hecca717_0.conda
+  sha256: 7cbf145b3e59d360052556bfe9425753b119c33cbba0c1f20f0191a7330ced5c
+  md5: 0e5edde73725a13f7d62ddf96b7656b9
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart-static_linux-64 13.0.96 h376f20c_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart-static_linux-64 13.1.80 h376f20c_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24031
-  timestamp: 1760034170778
+  size: 24119
+  timestamp: 1764883551735
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-12.9.79-h3ae8b8a_0.conda
   sha256: dac33edcebbf557563a41521f67961039186efbc276903d937b32243ef3be937
   md5: 365adcddf99b81eb323698fda31d507c
@@ -1152,18 +1049,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23507
   timestamp: 1749218358755
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.0.96-h8f3c8d4_0.conda
-  sha256: 5e5c99dfb2dc675e84d46ebcb560eeefcf20f30c7447af8d6bd1257e2b91540c
-  md5: 51205a311969eaea7b25773345b03395
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-cudart-static-13.1.80-h8f3c8d4_0.conda
+  sha256: 07e46f12ee8e4f46eb5d06ada680d7570c3e66bead6dd082029951bd2aee5d1a
+  md5: da7da4e604b0f7399d4800f1cd78bff8
   depends:
   - arm-variant * sbsa
-  - cuda-cudart-static_linux-aarch64 13.0.96 h8f3c8d4_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-cudart-static_linux-aarch64 13.1.80 h8f3c8d4_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24201
-  timestamp: 1760034133545
+  size: 24299
+  timestamp: 1764883524952
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-12.9.79-h3f2d84a_0.conda
   sha256: d435f8a19b59b52ce460ee3a6bfd877288a0d1d645119a6ba60f1c3627dc5032
   md5: b87bf315d81218dd63eb46cc1eaef775
@@ -1172,14 +1069,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 1148889
   timestamp: 1749218381225
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.0.96-h376f20c_0.conda
-  sha256: b1b626540ff0e19f15036433f9c64aad5cc37b503e0cc7cbd4abeef678db63ab
-  md5: 3317a47036e9e0c31462454635c50457
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-64-13.1.80-h376f20c_0.conda
+  sha256: 2252e12fa9a806f685684b6395a660d845dc95bdc95e52a6bc09dba8a9eccec3
+  md5: be9f8ef5a01fca1f28c8d523f8501771
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1077227
-  timestamp: 1760034117715
+  size: 1121385
+  timestamp: 1764883490595
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-12.9.79-h3ae8b8a_0.conda
   sha256: d4be038bad9abf0eac1e88dc57c8db6a469db8eb5d7c281085dfbb018ef84212
   md5: 52498fedeb43bbd4c45f84a0fb722d21
@@ -1189,15 +1086,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 1152498
   timestamp: 1749218333554
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: 773eed1956cafeadb6460699fe98db274b1732c164ce82b02a2d10810994d3d2
-  md5: 038c4cf5847929f1269dd01aedc32a4f
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart-static_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+  sha256: f960a80869fe97a93a09142bb3f27eb4159bed1d37154c0f6d4cfdf86b254dd4
+  md5: 77c4f050cfa534b3ac526bde2f4a9b7d
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 1080940
-  timestamp: 1760034110333
+  size: 1126421
+  timestamp: 1764883494387
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
   sha256: 6cde0ace2b995b49d0db2eefb7bc30bf00ffc06bb98ef7113632dec8f8907475
   md5: 64508631775fbbf9eca83c84b1df0cae
@@ -1206,14 +1103,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 197249
   timestamp: 1749218394213
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.0.96-h376f20c_0.conda
-  sha256: a24fc5d9d229328c4165c1e08a53717a804b70832ef5365ed3071c7e8ef2d72f
-  md5: c4bbc81db4cf35b6766436f2d774ead5
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-13.1.80-h376f20c_0.conda
+  sha256: fca2951815564c36cf5a4e0f7ed0222429d206fda3d4e1aa3d52a969a293b868
+  md5: 4dc4c3a1e010e06035f01d661c1b70bd
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 185278
-  timestamp: 1760034128147
+  size: 199654
+  timestamp: 1764883502803
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-12.9.79-h3ae8b8a_0.conda
   sha256: 4900ff2f000a4f8a70a7bc8576469640aa6590618fa9e73c84e066e025dcb760
   md5: cc2459ad427431e089d78d760cf24437
@@ -1223,15 +1120,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 212993
   timestamp: 1749218341193
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: c1be1727a13bcaf6ef9a76e1d1d00845e37556a40530d559406939fbc618fdb2
-  md5: ae0425af7774272e8926e6d3b4ca4f50
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+  sha256: f2bdaa44907b88d33a0334b1bf2599284867320baf7760742256060901c4fe87
+  md5: 5f91ddf790bc69f8aeae89cca63eb069
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 199749
-  timestamp: 1760034117080
+  size: 214179
+  timestamp: 1764883503236
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-12.9.79-h3f2d84a_0.conda
   sha256: a15574d966e73135a79d5e6570c87e13accdb44bd432449b5deea71644ad442c
   md5: d411828daa36ac84eab210ba3bbe5a64
@@ -1240,14 +1137,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 37714
   timestamp: 1749218405324
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.0.96-h376f20c_0.conda
-  sha256: 00baf846f6e109df717f8b1602118ad1c46e3ba9b1864d676e420e3544d416ac
-  md5: f44904debd095f95ad8e523f7d26eff9
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-64-13.1.80-h376f20c_0.conda
+  sha256: 83bf37d5a3b4a85853cded6a8b90db302b014845b7d9461ccdb84db8c2abfbc3
+  md5: 1d7073905d0359ff234545494a933d59
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 38400
-  timestamp: 1760034138622
+  size: 38992
+  timestamp: 1764883514338
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-12.9.79-h3ae8b8a_0.conda
   sha256: d0a7d9e834995d4698af50591e4334fc4095bfc58888cfebc28bcecad1632765
   md5: 6b1e176272e1f8376b2ba130affc058c
@@ -1257,55 +1154,55 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 39184
   timestamp: 1749218343753
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.0.96-h8f3c8d4_0.conda
-  sha256: 56b88567441810285d448e7332b00ee9253a3713e620c84594d11bc5e7b0a1bd
-  md5: ebeb2cae11008509872411f0301a603c
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-driver-dev_linux-aarch64-13.1.80-h8f3c8d4_0.conda
+  sha256: 5044b24e730842bcbeea368918f9775560d8babb226854ad1769836b5f5cade5
+  md5: 0145253ad2f098cf9f24185708441e82
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 40113
-  timestamp: 1760034119535
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_4.conda
-  sha256: 6e7ae2315528ff031a37b2ee35b2bede5f5686304e7a67ea4d9d5df9328bc6b5
-  md5: 67cf694a2c7349d0e921c25783a4a642
+  size: 41071
+  timestamp: 1764883505707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-12.9.86-hcdd1206_5.conda
+  sha256: 1e99bde86e8c82cc8877d630502acfb0efb6aea3f54f6044300d8d4933c4c037
+  md5: be8c5964b2cda90f37559366311b1681
   depends:
   - cuda-nvcc_linux-64 12.9.86.*
   - gcc_linux-64
   - gxx_linux-64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24793
-  timestamp: 1761847836018
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.0.88-hcdd1206_4.conda
-  sha256: a616d6b91f7bc58f0a2bca5871e1d94abe120c1baab090826762a7df36bb42a3
-  md5: a41247f1d8976ca80c81d457bafee5db
+  size: 25483
+  timestamp: 1770146775542
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-13.1.115-hcdd1206_1.conda
+  sha256: 1d097fdff0cb9ae37b60aa5bbd87a94be6286c45d839a97172247303164717a7
+  md5: b63b7c9f0f192033ccaf1734b333bf9a
   depends:
-  - cuda-nvcc_linux-64 13.0.88.*
+  - cuda-nvcc_linux-64 13.1.115.*
   - gcc_linux-64
   - gxx_linux-64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24902
-  timestamp: 1762289415743
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-12.9.86-ha346c71_104.conda
-  sha256: 66e1da19f1ae6a44aaf57ae2e3ad04143c3c383529604a93b13ec74d11770978
-  md5: dcf0356363334117c32d03cc19f8d2dd
+  size: 25463
+  timestamp: 1770189590423
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-12.9.86-ha346c71_105.conda
+  sha256: 7999405236e4e126e59b54b6c6ea4d9cc67414886a01a97475a41a6bd409068f
+  md5: 9bc3f38db182f5d6ef9b27654a79bc15
   depends:
   - cuda-nvcc_linux-aarch64 12.9.86.*
   - gcc_linux-aarch64
   - gxx_linux-aarch64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24939
-  timestamp: 1761847820
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.0.88-ha346c71_104.conda
-  sha256: d18550073d02ba6fa43be7ba49829f3b9ddfe3a98e4bb9854541a0f5f8c470e3
-  md5: f21892aa190d6862ec3c381ad6ae1e80
+  size: 25571
+  timestamp: 1770146792542
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-13.1.115-ha346c71_1.conda
+  sha256: ff7266685adfd545c722786fbbb77f70c36ea11ed0e34fc05cf8f9c3e35c3247
+  md5: 8d5f798dd76e5333096134ad65890e13
   depends:
-  - cuda-nvcc_linux-aarch64 13.0.88.*
+  - cuda-nvcc_linux-aarch64 13.1.115.*
   - gcc_linux-aarch64
   - gxx_linux-aarch64
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24944
-  timestamp: 1762289394229
+  size: 25494
+  timestamp: 1770189608991
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-12.9.86-he91c749_2.conda
   sha256: a1672a34439a72869de9e011e935d41b62fc8dfb1a2700e85ed8a7a129b79981
   md5: 19d4e090217f0ea89d30bedb7461c048
@@ -1320,20 +1217,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 28121
   timestamp: 1753975535813
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.0.88-he91c749_0.conda
-  sha256: 9da527d5f0f4aa801d087def466deecec166fe89713aaccb94ef6dc392fcb912
-  md5: 592146b39bcd34626389655523d8d39f
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-64-13.1.115-he91c749_0.conda
+  sha256: 2d63a4f43bd4410ecef87c41aeffa2035f511870d7fc696eb0b3a9d05595cc66
+  md5: 59397a8efd2c86c8d0d4ea6c1fcd9c8b
   depends:
-  - cuda-crt-dev_linux-64 13.0.88 ha770c72_0
-  - cuda-nvvm-dev_linux-64 13.0.88 ha770c72_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-crt-dev_linux-64 13.1.115 ha770c72_0
+  - cuda-nvvm-dev_linux-64 13.1.115 ha770c72_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=6
-  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
+  - libnvptxcompiler-dev_linux-64 13.1.115 ha770c72_0
   constrains:
   - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28946
-  timestamp: 1757021683159
+  size: 29084
+  timestamp: 1768280571872
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-12.9.86-h4310d6a_2.conda
   sha256: f4b2917f38867dd1ad9cfb029c790cfdbee89f79919cd43b7ce0142cc77bfd35
   md5: e508550bd3d76ef97eaf5aab9ca757cd
@@ -1349,21 +1246,21 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 28252
   timestamp: 1753975422031
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.0.88-h4310d6a_0.conda
-  sha256: c44ddb96258a53762ef6a28ad1023f0096d04233397f496c27f4b113186bfca0
-  md5: 2dbf71edc5f9ea2dd38d52814bedffe3
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvcc-dev_linux-aarch64-13.1.115-h4310d6a_0.conda
+  sha256: 195cbbee2a694d9f8932c5933073e85b4ea447acf6ff4b49891e59ddc280e49f
+  md5: 4ad7de91e5224f197c1b957b7989a0f6
   depends:
   - arm-variant * sbsa
-  - cuda-crt-dev_linux-aarch64 13.0.88 h579c4fd_0
-  - cuda-nvvm-dev_linux-aarch64 13.0.88 h579c4fd_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-crt-dev_linux-aarch64 13.1.115 h579c4fd_0
+  - cuda-nvvm-dev_linux-aarch64 13.1.115 h579c4fd_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=6
-  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
+  - libnvptxcompiler-dev_linux-aarch64 13.1.115 h579c4fd_0
   constrains:
   - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29072
-  timestamp: 1757021613549
+  size: 29142
+  timestamp: 1768280307772
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-12.9.86-h85509e4_2.conda
   sha256: 961cf20d411b7685cd744e6c6ed35efea547d095c62151d6f3053d9931bb994d
   md5: 67458d2685e7503933efa550f3ee40f3
@@ -1380,22 +1277,22 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27215
   timestamp: 1753975546846
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.0.88-h85509e4_0.conda
-  sha256: 259e1ae6a7729ef77b515e9a491f9f820ef0db1837b43f7156c58161fdb451ed
-  md5: 5eafe62a4236322ca351653d3dadab20
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-impl-13.1.115-h85509e4_0.conda
+  sha256: 5c6a64f9a8f40d31d58c1df848d0125b61405ab4e0e695501cdd0fc2b657f675
+  md5: 45ee3f07446a4f800060d7f868d1d5e3
   depends:
-  - cuda-cudart >=13.0.88,<14.0a0
+  - cuda-cudart >=13.1.80,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-64 13.0.88 he91c749_0
-  - cuda-nvcc-tools 13.0.88 he02047a_0
-  - cuda-nvvm-impl 13.0.88 h4bc722e_0
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev 13.0.88 ha770c72_0
+  - cuda-nvcc-dev_linux-64 13.1.115 he91c749_0
+  - cuda-nvcc-tools 13.1.115 he02047a_0
+  - cuda-nvvm-impl 13.1.115 h4bc722e_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev 13.1.115 ha770c72_0
   constrains:
   - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28077
-  timestamp: 1757021695541
+  size: 28190
+  timestamp: 1768280584899
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-12.9.86-h614329b_2.conda
   sha256: 60ca00b86a28f3f1abd080df6685c415a51f9a0267e65b3a56783b9b97265486
   md5: 7ad15773a6b7617fb36cc3d92034f3e9
@@ -1413,23 +1310,23 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27322
   timestamp: 1753975427660
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.0.88-h614329b_0.conda
-  sha256: 81b16bd2edf9a581be49e03f8bf0d8ff048d47aff4278bfe38f49ee4a379a10c
-  md5: 58b623409f1b5bdea63bc46849ff1852
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-impl-13.1.115-h614329b_0.conda
+  sha256: 3ab080230970fd0109cd1c3208d262f5e5ada17062a94722a4cc22c464938ada
+  md5: 00f628bdd96dc63f5ddc1fc4fb98d53e
   depends:
   - arm-variant * sbsa
-  - cuda-cudart >=13.0.88,<14.0a0
+  - cuda-cudart >=13.1.80,<14.0a0
   - cuda-cudart-dev
-  - cuda-nvcc-dev_linux-aarch64 13.0.88 h4310d6a_0
-  - cuda-nvcc-tools 13.0.88 h614329b_0
-  - cuda-nvvm-impl 13.0.88 h7b14b0b_0
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev 13.0.88 h579c4fd_0
+  - cuda-nvcc-dev_linux-aarch64 13.1.115 h4310d6a_0
+  - cuda-nvcc-tools 13.1.115 h614329b_0
+  - cuda-nvvm-impl 13.1.115 h7b14b0b_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev 13.1.115 h579c4fd_0
   constrains:
   - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28154
-  timestamp: 1757021621068
+  size: 28311
+  timestamp: 1768280315857
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
   sha256: 0e849be7b5e4832ca218ec2c48a9ba3a15a984f629e2e54f38a53f4f57220341
   md5: dc256c9864c2e8e9c817fbca1c84a4bc
@@ -1445,21 +1342,21 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27380012
   timestamp: 1753975454194
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.0.88-he02047a_0.conda
-  sha256: b9cd738b3bb8eeba112c423acc3a922a6526ed6b7c72d1857cf3ade55073dc76
-  md5: 994f869d05c03cc1b5a9fc9911183a62
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-13.1.115-he02047a_0.conda
+  sha256: b3c2a01616140c721b6b862f9292b9f90f9a7dc63f82cfd8e4f4d5abf006109a
+  md5: 92d8589fde5681db8c996572b43aa276
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-crt-tools 13.0.88 ha770c72_0
-  - cuda-nvvm-tools 13.0.88 h4bc722e_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-crt-tools 13.1.115 ha770c72_0
+  - cuda-nvvm-tools 13.1.115 h4bc722e_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   - libstdcxx >=12
   constrains:
   - gcc_impl_linux-64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28824961
-  timestamp: 1757021588514
+  size: 32524161
+  timestamp: 1768280483844
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-12.9.86-h614329b_2.conda
   sha256: 1cc064e076c417bca2de7fb6ee28df0964cbad25eada2131a48b43ab36cdea33
   md5: ab332ca8da729b13bf7e5b0022c2702c
@@ -1475,24 +1372,24 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 23974390
   timestamp: 1753975366926
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.0.88-h614329b_0.conda
-  sha256: e425fc791c68c4cb4d849cff2487bf3d7021405dc94fcbc5e00eb975bec33a1f
-  md5: b1e9a6c10d9cfb3e5ab63e8e4a3c1a47
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc-tools-13.1.115-h614329b_0.conda
+  sha256: 57e04b654fae96fb9702c4900248e2e22bef5a3c7ece24e72cf6f9bfa4e7f7fb
+  md5: 6ea312f22e8e8874f64a2e3c21075fe5
   depends:
   - arm-variant * sbsa
-  - cuda-crt-tools 13.0.88 h579c4fd_0
-  - cuda-nvvm-tools 13.0.88 h7b14b0b_0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-crt-tools 13.1.115 h579c4fd_0
+  - cuda-nvvm-tools 13.1.115 h7b14b0b_0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   - libstdcxx >=12
   constrains:
   - gcc_impl_linux-aarch64 >=6,<16.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 25207775
-  timestamp: 1757021545690
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_4.conda
-  sha256: 876da1de112e849d5aaf158d1be536a41239d6f0ebe3aaa07486aef87ad7d1ce
-  md5: a19c47e6723125bbc9ad2b807f686c5f
+  size: 26832356
+  timestamp: 1768280248459
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-12.9.86-he0b4e1d_5.conda
+  sha256: 33277b7e263b5371ddbd5fb27cdde3b8170417410468fd3df506042533f25fcc
+  md5: 53e06d27407dc50dfbd5594ddfd81376
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-cudart-dev_linux-64 12.9.*
@@ -1502,25 +1399,25 @@ packages:
   - cuda-nvcc-tools 12.9.86.*
   - sysroot_linux-64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26801
-  timestamp: 1761847835326
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.0.88-hb2fc203_4.conda
-  sha256: 99e27429c56f1b0120d32cef1996c5124f96f439291ce379dc00ee10b1e576c6
-  md5: 5ae59e3f3be0a3ba8ae96acd435a1d48
+  size: 27627
+  timestamp: 1770146775037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc_linux-64-13.1.115-hb2fc203_1.conda
+  sha256: 66c753967580fd402efc0a9b358afdb9c395f5f490548721f3ded149d2d56b35
+  md5: d7393ae38f48773a24e36c9eae425ca4
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-cudart-dev_linux-64 13.0.*
-  - cuda-driver-dev_linux-64 13.0.*
-  - cuda-nvcc-dev_linux-64 13.0.88.*
-  - cuda-nvcc-impl 13.0.88.*
-  - cuda-nvcc-tools 13.0.88.*
+  - cuda-cudart-dev_linux-64 13.1.*
+  - cuda-driver-dev_linux-64 13.1.*
+  - cuda-nvcc-dev_linux-64 13.1.115.*
+  - cuda-nvcc-impl 13.1.115.*
+  - cuda-nvcc-tools 13.1.115.*
   - sysroot_linux-64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26850
-  timestamp: 1762289415201
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-12.9.86-h44c6fc4_104.conda
-  sha256: c7c2fc3222057db23e934022396766eb8a4b67e5ee95a65d69e8165b4425dd47
-  md5: 7ac9d84affbfc258d7c5f5f4b8a92056
+  size: 27525
+  timestamp: 1770189589918
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-12.9.86-h44c6fc4_105.conda
+  sha256: d77e65cbef377dafa633bac671c0de704682d7befb52f63cbc1b79da7da82737
+  md5: 2bf074cdb3b27d47a96694869fe8f136
   depends:
   - arm-variant * sbsa
   - cuda-cudart-dev_linux-aarch64 12.9.*
@@ -1530,22 +1427,22 @@ packages:
   - cuda-nvcc-tools 12.9.86.*
   - sysroot_linux-aarch64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26908
-  timestamp: 1761847819360
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.0.88-h9ee44f0_104.conda
-  sha256: 80754283b3ebeaa21fc797cd800e1849a6b3f280acb8ff9778f4160d4b2c5530
-  md5: 2cecef0f16fdc6892f39ef44132de812
+  size: 27747
+  timestamp: 1770146791938
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvcc_linux-aarch64-13.1.115-h9ee44f0_1.conda
+  sha256: 065df2f1b1987570e578cb12719942af0b41e3a75cbc5a2c89d3835ad34f9089
+  md5: 04d5d9035aa973aaadd665d9db7c12e1
   depends:
   - arm-variant * sbsa
-  - cuda-cudart-dev_linux-aarch64 13.0.*
-  - cuda-driver-dev_linux-aarch64 13.0.*
-  - cuda-nvcc-dev_linux-aarch64 13.0.88.*
-  - cuda-nvcc-impl 13.0.88.*
-  - cuda-nvcc-tools 13.0.88.*
+  - cuda-cudart-dev_linux-aarch64 13.1.*
+  - cuda-driver-dev_linux-aarch64 13.1.*
+  - cuda-nvcc-dev_linux-aarch64 13.1.115.*
+  - cuda-nvcc-impl 13.1.115.*
+  - cuda-nvcc-tools 13.1.115.*
   - sysroot_linux-aarch64 >=2.17,<3.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 26954
-  timestamp: 1762289393657
+  size: 27626
+  timestamp: 1770189608358
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-12.9.79-hffce074_1.conda
   sha256: 82138fc5a18e0b3204749f8690936976a822d79bac35c525b6fad3554fd19bc3
   md5: bf934cd6425e6fcc02d35815b84947b0
@@ -1557,17 +1454,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 143347
   timestamp: 1761098728630
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.0.87-hffce074_0.conda
-  sha256: 7f5d6a04fcdc6e5afb626e26e551456fe7c0eb7c98e5cf1c331f49f2cab612c5
-  md5: b2ed25d01b04defac0a8fafe87c9d00c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvml-dev-13.1.115-hffce074_0.conda
+  sha256: 8fd6a47d61efd61958b38842682d297f1deaad95772d4e41b4d62b5ca73d08bb
+  md5: 39d7c11c10d1eb8e424915bfd67628aa
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 147542
-  timestamp: 1757018416900
+  size: 151982
+  timestamp: 1768272845889
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-12.9.79-h40ab4d6_1.conda
   sha256: 345c04b8c4c48c6207bf00260281d78b6a4b3e7e78907d3050d67730a32f333d
   md5: dcbde6e9d701bc25e09890d98aee5c68
@@ -1579,19 +1476,19 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 146473
   timestamp: 1761098779240
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.0.87-h40ab4d6_0.conda
-  sha256: f9a7b189dbb3ed1be36a766519cb5dc46a2fe49de68872755f60dc3d9dca1e57
-  md5: 8acec65bd2edb2406cbadc1f429d0a66
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvml-dev-13.1.115-h40ab4d6_0.conda
+  sha256: e7ed4e1fe3f062f8c2c4066b41f996c61f768295bba05fef2b2f7f00d9882664
+  md5: 3ccba4abbf0df404639166689c2f96af
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 154141
-  timestamp: 1757018436399
+  size: 156802
+  timestamp: 1768272875537
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
   sha256: 68f81268c25befa9b70dc49af469ab0eb131960e3700b9a4edb46a32da343a28
   md5: 53f0062e2243b26e43ddac0b5267c6a3
@@ -1603,17 +1500,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 67168282
   timestamp: 1760723629347
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.0.88-hecca717_0.conda
-  sha256: e84b749251df8111359420c313b800fa896d18d44c07c7c3eec1abd155bb6b69
-  md5: dd4b7cf241cc912e4ade183911c24b7f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-13.1.115-hecca717_0.conda
+  sha256: 9cc4f9df70c02eea5121cdb0e865207b04cd52591f57ebcac2ba44fada10eb5b
+  md5: df16c9049d882cdaf4f83a5b90079589
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 68354405
-  timestamp: 1757018387981
+  size: 35339417
+  timestamp: 1768272955912
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-12.9.86-h8f3c8d4_1.conda
   sha256: e7f8d835d7bf993dcad9fba6db5af89c35b2b4f0282799b729bf6ad2c3bd896d
   md5: 48187c09673a42f9930764e8170b8787
@@ -1625,17 +1522,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 33382016
   timestamp: 1760723722396
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.0.88-h8f3c8d4_0.conda
-  sha256: 723785ec1502d3f10c23e647358f9dcdfa9affc2b0542e6cdbe0770533f5e372
-  md5: f368bf1ceda5c36745b408b88fdd71a8
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvrtc-13.1.115-h8f3c8d4_0.conda
+  sha256: a1ec61512cecb093797e00590ad381ecd5852d2a32440ff22b34f78c743f3d5a
+  md5: 34da2ff2c64054d65eb8f04d76c40cca
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 32555050
-  timestamp: 1757018424779
+  size: 33616576
+  timestamp: 1768272976976
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-12.9.86-ha770c72_2.conda
   sha256: 522722dcaffd133e0c7500c69dc70e21ac34d6762dcbaabfe847439f944028f0
   md5: 7b386291414c7eea113d25ac28a33772
@@ -1644,14 +1541,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27096
   timestamp: 1753975261562
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: 65b4851cf4ad2fc906875d70ce85faf612d26fc0bb7dfe4266e5cc84994eab23
-  md5: 155fa228684274e8fe1227186a04d7f2
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: cae8dd604706bed7c5a19d35cabdab2ce549182e98cfd603c5b603a5c787cfdd
+  md5: f468fd93b5f654b49799daaccd0067fc
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27954
-  timestamp: 1757021367553
+  size: 28066
+  timestamp: 1768280291614
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
   sha256: 5f27299818ecef44d6cf46a99465671744f6074c14618b5f8491a03a62942a7f
   md5: c59b036058d7bf78ac0a99618c321e85
@@ -1661,15 +1558,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27218
   timestamp: 1753975206503
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 37201c22627900dfd0591ec6d8325814df64f7713c8ac87af96c1ae042067aa2
-  md5: dfe7a4d9546dd7cd3face2640e321897
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-nvvm-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 81c2e2c1cd27b03b4f2dbb2045324bc51b93b8991752d9ca45b46aa79c65ec2b
+  md5: a9b9e6db86417d145e9db74f41fcd1f1
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 28061
-  timestamp: 1757021345227
+  size: 28157
+  timestamp: 1768280070110
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-12.9.86-h4bc722e_2.conda
   sha256: f4d34556174e4faa9d374ba2244707082870e1bbc1bb441ad3d9d2cea37da6af
   md5: 82125dd3c0c4aa009faa00e2829b93d8
@@ -1680,16 +1577,16 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 21425520
   timestamp: 1753975283188
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.0.88-h4bc722e_0.conda
-  sha256: 1972fd15941a0f33c59e1f6b93045945cb1678b6efa0f8101c1cb24112093af5
-  md5: bd78fee8953411bfe1e70b184756fa42
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-impl-13.1.115-h4bc722e_0.conda
+  sha256: 12d84615684f1279799c023ce4ccc7c34f151bec2a90e0c8d04798a8c8af437c
+  md5: bf76661bc0de83a60537c4913f339fb3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 21662718
-  timestamp: 1757021391692
+  size: 21873791
+  timestamp: 1768280315627
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-12.9.86-h7b14b0b_2.conda
   sha256: 100accfc6f608004ddef4b9004ee5179eddbac19e7d5c4c7bd5e6e8b71bd7c5d
   md5: 8e9fceb7b677be7107cc9c20f8d71d86
@@ -1700,16 +1597,16 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 21601172
   timestamp: 1753975236344
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.0.88-h7b14b0b_0.conda
-  sha256: 1d5c24588585639fd4b340b42dc2180dae7eae045f14ede1ccc7f5038cc124a0
-  md5: f615684b985e74817ee584446d6c23dd
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-impl-13.1.115-h7b14b0b_0.conda
+  sha256: d27caee8c6426ea736369907d70439383bb71ddb97f3a4b8e11b88867194dabc
+  md5: ecf7142519e1e19edf4c2ab867f6907f
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20784164
-  timestamp: 1757021384178
+  size: 21022191
+  timestamp: 1768280105208
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
   sha256: 45f5e881ed0d973132a5475a0b5c066db6e748ef3a831a14dba8374b252e0067
   md5: f9af26e4079adcd72688a8e8dbecb229
@@ -1720,16 +1617,16 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 24246736
   timestamp: 1753975332907
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
-  sha256: 248e9c7df5fe8aebe403dadc3ae79ae710d518d760ea9c0e9714c3b5e21800a5
-  md5: 07a6762db5ed5ff0887a24ad1675375b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.1.115-h4bc722e_0.conda
+  sha256: 51641c065fbb78af45e7040e19866404d217c26901734866218e9cee6a511a8e
+  md5: a9ec91462847137689ab1fa2c0652f05
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 24519392
-  timestamp: 1757021447444
+  size: 25639587
+  timestamp: 1768280358414
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-12.9.86-h7b14b0b_2.conda
   sha256: f5cf91e491e150e37cd224fa648c07f6b1cd2cbfee5affba10625df7ba0b0425
   md5: 9a35dcda5573a713183f5159ec282364
@@ -1740,16 +1637,16 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 24411824
   timestamp: 1753975273689
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.0.88-h7b14b0b_0.conda
-  sha256: ab31f55fd176e886d2ce3ee730f0a775dd9c4bb7374e6692a44045170834d322
-  md5: 302f4b10ac0b239c5d74fc1ca46966a7
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cuda-nvvm-tools-13.1.115-h7b14b0b_0.conda
+  sha256: c75e60b49f451c3f107990e84036ee30a657af66fc545b060a2e141582046002
+  md5: 2878a252bae4afd35fc8ffb5d324ae90
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=12
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 23566779
-  timestamp: 1757021431631
+  size: 24677366
+  timestamp: 1768280141435
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
   sha256: 5f5f428031933f117ff9f7fcc650e6ea1b3fef5936cf84aa24af79167513b656
   md5: b6d5d7f1c171cbd228ea06b556cfa859
@@ -1759,15 +1656,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 21578
   timestamp: 1746134436166
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.0-hc7b4dd1_3.conda
-  sha256: b0511bf95bf784096866c8add22afe365ff534c5d87f033119653d6d3c57d4bc
-  md5: 2f875735837c072c78894980f96c50df
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
+  sha256: 176ac20fdb95611af8fb2bf0d3d16fee998019b1d0f12fc9ddd5fa0df4553992
+  md5: d85448460c25ee43ff2f8346bb9ad52b
   constrains:
+  - cudatoolkit 13.1|13.1.*
   - __cuda >=13
-  - cudatoolkit 13.0|13.0.*
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 21542
-  timestamp: 1754337583956
+  size: 21511
+  timestamp: 1757017115788
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
   sha256: 3fcc97ae3e89c150401a50a4de58794ffc67b1ed0e1851468fcc376980201e25
   md5: 5da8c935dca9186673987f79cef0b2a5
@@ -1819,14 +1716,15 @@ packages:
   license_family: MIT
   size: 15146
   timestamp: 1700452982288
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-  sha256: 19025a4078ff3940d97eb0da29983d5e0deac9c3e09b0eabf897daeaf9d1114e
-  md5: 66b8b26023b8efdf8fcb23bac4b6325d
+- conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.4.4-h332efcf_0.conda
+  sha256: 73f1f70749af1aadc2126bfd61751730f0bbdbb34e74ec2a9ceb2a71636c4961
+  md5: 81ad5dea88c418df76adb189dc063dc2
   depends:
-  - python >=3.10
-  license: Unlicense
-  size: 17976
-  timestamp: 1759948208140
+  - python-duckdb >=1.4.4,<1.4.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 7758
+  timestamp: 1769722999926
 - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
   sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
   md5: 2cfaaccf085c133a477f0a7a8657afe9
@@ -1835,280 +1733,136 @@ packages:
   license: Unlicense
   size: 18661
   timestamp: 1768022315929
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_15.conda
-  sha256: 939aa3a61a7cdf5fd624b8406cf2246dc156748b02522217f8ab01804ae6b4f3
-  md5: 893d79ba69d21198012ff8212a8c563a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_17.conda
+  sha256: e3eb2b4655d8a65488fdfbe470705a290121c4265f9559933a8071aa9aac5b91
+  md5: dfcfcc0c20762eeb840771eda366940e
   depends:
   - conda-gcc-specs
-  - gcc_impl_linux-64 14.3.0 h319ec69_15
+  - gcc_impl_linux-64 14.3.0 hb1e0a52_17
   license: BSD-3-Clause
-  size: 28650
-  timestamp: 1764836909143
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_16.conda
-  sha256: 4581ce836a04a591a2622c2a0f15b81d7a87cec614facb3a405c070c8fdb7ac8
-  md5: dcaf539ffe75649239192101037f1406
+  size: 29381
+  timestamp: 1770252396987
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_17.conda
+  sha256: 71c4e925d2969d2591402b8b4c5ad533d8d93153049df1f393b2388bde30590f
+  md5: a87db0cd95e1390f0ae9d528efda0594
   depends:
   - conda-gcc-specs
-  - gcc_impl_linux-64 14.3.0 he8b2097_16
+  - gcc_impl_linux-aarch64 14.3.0 h42fc7e9_17
   license: BSD-3-Clause
-  license_family: BSD
-  size: 29022
-  timestamp: 1765256332962
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_15.conda
-  sha256: ecc12d2bdf7bd30d8fd84b3ec6bf6968af296fbcb49567f86e18c78a2653ae8d
-  md5: e810ed1b6477bb035562e379192c5a1f
-  depends:
-  - conda-gcc-specs
-  - gcc_impl_linux-aarch64 14.3.0 hadc3402_15
-  license: BSD-3-Clause
-  size: 28730
-  timestamp: 1764836783909
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-14.3.0-h2e72a27_16.conda
-  sha256: bebeefc5271f2564584d69fb0a8de5a0d7f67febfb66797a71ef6383edebbfc8
-  md5: d4495fad7efde408149a2bedf22a9cdd
-  depends:
-  - conda-gcc-specs
-  - gcc_impl_linux-aarch64 14.3.0 hda29b82_16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 29062
-  timestamp: 1765256869890
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h319ec69_15.conda
-  sha256: 9eea0459c4ea20e22be9eb77237043fe6648caf7c092652033b7e8b20c1de51c
-  md5: 042695cf5fb55a63294f3575c33a468c
+  size: 29414
+  timestamp: 1770252322845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hb1e0a52_17.conda
+  sha256: bc7014fcc7fcd54ae922fc3453ad8d88a26f439570bb6a89f785f8b5793306b2
+  md5: f5c501fe2a016ed0103f7a89d2ac0412
   depends:
   - binutils_impl_linux-64 >=2.45
   - libgcc >=14.3.0
-  - libgcc-devel_linux-64 14.3.0 hf649bbc_115
+  - libgcc-devel_linux-64 14.3.0 hf649bbc_117
   - libgomp >=14.3.0
-  - libsanitizer 14.3.0 h8f1669f_15
+  - libsanitizer 14.3.0 h8f1669f_17
   - libstdcxx >=14.3.0
-  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_115
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_117
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 76389083
-  timestamp: 1764836637441
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-he8b2097_16.conda
-  sha256: 4acf50b7d5673250d585a256a40aabdd922e0947ca12cdbad0cef960ee1a9509
-  md5: d274bf1343507683e6eb2954d1871569
-  depends:
-  - binutils_impl_linux-64 >=2.45
-  - libgcc >=14.3.0
-  - libgcc-devel_linux-64 14.3.0 hf649bbc_116
-  - libgomp >=14.3.0
-  - libsanitizer 14.3.0 h8f1669f_16
-  - libstdcxx >=14.3.0
-  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_116
-  - sysroot_linux-64
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 75290045
-  timestamp: 1765256021903
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hadc3402_15.conda
-  sha256: dc422160f22e0ff9eb94a01f59cdab308872ee5e69a06303882fc59a80ec74a0
-  md5: 2889b9b96ee6dbd70bbf8964f5de6680
+  size: 74850589
+  timestamp: 1770252142196
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-h42fc7e9_17.conda
+  sha256: 501e50a703a8efbe98d0a2d4bdd951d70e822268468bb9c753fb0b5afd31f900
+  md5: adbd02950b463e72c70fb30d6a23fef8
   depends:
   - binutils_impl_linux-aarch64 >=2.45
   - libgcc >=14.3.0
-  - libgcc-devel_linux-aarch64 14.3.0 h25ba3ff_115
+  - libgcc-devel_linux-aarch64 14.3.0 h25ba3ff_117
   - libgomp >=14.3.0
-  - libsanitizer 14.3.0 hedb4206_15
+  - libsanitizer 14.3.0 hedb4206_17
   - libstdcxx >=14.3.0
-  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_115
+  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_117
   - sysroot_linux-aarch64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 68056499
-  timestamp: 1764836536614
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-14.3.0-hda29b82_16.conda
-  sha256: b00ba1fdeaeb5869cde719f6c3d25de3eae0afa3dec42983f3275cac746ec8e8
-  md5: 773a1fcf84e229456d4b15689f5d35ae
-  depends:
-  - binutils_impl_linux-aarch64 >=2.45
-  - libgcc >=14.3.0
-  - libgcc-devel_linux-aarch64 14.3.0 h25ba3ff_116
-  - libgomp >=14.3.0
-  - libsanitizer 14.3.0 hedb4206_16
-  - libstdcxx >=14.3.0
-  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_116
-  - sysroot_linux-aarch64
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 69075162
-  timestamp: 1765256604036
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_14.conda
-  sha256: 4e99d5903113dfbb36a0a1510450c6a6e3ffc4a4c69d2d1e03c3efa1f1ba4e8f
-  md5: fe0c2ac970a0b10835f3432a3dfd4542
+  size: 69913509
+  timestamp: 1770252075641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_20.conda
+  sha256: 5dd1fc1757e6d0354b6fd8f1917b334d46f01995401da02d7c4d5185edc0d895
+  md5: 6a7d74012f6ff0b58fb8fcb5286fa584
   depends:
   - gcc_impl_linux-64 14.3.0.*
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 27980
-  timestamp: 1763757768300
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_17.conda
-  sha256: 7b9585c201c175c024c56b46658d9e4b5db85a32df54517798109281a90d03bb
-  md5: 50dc15ac993bb5859f923979c81fafc8
-  depends:
-  - gcc_impl_linux-64 14.3.0.*
-  - binutils_linux-64
-  - sysroot_linux-64
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28913
-  timestamp: 1766347929374
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_14.conda
-  sha256: 7ef2b23a2a2453d23afaf0b5878d0afd7c80654a8a49e6070404a34f6cac7735
-  md5: 640d2d54860f54ca66eb4aa5cd243fca
+  size: 28918
+  timestamp: 1770277530099
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_20.conda
+  sha256: cc5f16fceda2b02a23029a85be951ecc7c5ab81319f36c1a12445f2183ccded7
+  md5: d845fcf2225019ead4e7451ff837d838
   depends:
   - gcc_impl_linux-aarch64 14.3.0.*
   - binutils_linux-aarch64
   - sysroot_linux-aarch64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 27754
-  timestamp: 1763757746591
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-14.3.0-h118592a_17.conda
-  sha256: 471f7af664ebb24de29707c16dd482ca6531cc9cd3c33eb6dcb8cc37e820783f
-  md5: 13ecb1936d6531fb8f031ecbf0cde7ba
+  size: 28672
+  timestamp: 1770277570517
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_17.conda
+  sha256: 13280aa6d2e8313e7bf15d066d1a6767b749e8a3485116fb8744d1a3db93c279
+  md5: eae8e3fb1f5eecb829dd7347d33ecacb
   depends:
-  - gcc_impl_linux-aarch64 14.3.0.*
-  - binutils_linux-aarch64
-  - sysroot_linux-aarch64
+  - gcc 14.3.0 h0dff253_17
+  - gxx_impl_linux-64 14.3.0 h2185e75_17
   license: BSD-3-Clause
-  license_family: BSD
-  size: 28654
-  timestamp: 1766347983463
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_15.conda
-  sha256: 2acf26462f5ed61727e54a8fd2d55cdf50c13558f2692485b4da87e257439965
-  md5: 0b1faa0b6a877261a8b4ec692d41b7c4
+  size: 28708
+  timestamp: 1770252431123
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_17.conda
+  sha256: d05fb34c124b95ef31621c5e0773b6c9afb88d4166e0ede844ecf50144b7e6c2
+  md5: 3209fc2f9de68ee8a9f6d30db9bfbd78
   depends:
-  - gcc 14.3.0 h0dff253_15
-  - gxx_impl_linux-64 14.3.0 h2185e75_15
+  - gcc 14.3.0 h2e72a27_17
+  - gxx_impl_linux-aarch64 14.3.0 h0d4f5d4_17
   license: BSD-3-Clause
-  size: 27999
-  timestamp: 1764836941729
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-14.3.0-h76987e4_16.conda
-  sha256: 5a4174e7723a95eca2305f4e4b3d19fa8c714eadd921b993e1a893fe47e5d3d7
-  md5: a3aa64ee3486f51eb61018939c88ef12
+  size: 28806
+  timestamp: 1770252347686
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_17.conda
+  sha256: d43556d0cc5bc636ef02a21fdfc08167430846538a5a92b4ee9a0dedad13ba8f
+  md5: 8f02f68c780b0a6eeba034af3ed1c00a
   depends:
-  - gcc 14.3.0 h0dff253_16
-  - gxx_impl_linux-64 14.3.0 h2185e75_16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28403
-  timestamp: 1765256369945
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_15.conda
-  sha256: 9136315161c07f414f378b0420e39113be10396b2ddd42820b3d462157c77471
-  md5: 8d11fa1414490069c774fd548cbcb071
-  depends:
-  - gcc 14.3.0 h2e72a27_15
-  - gxx_impl_linux-aarch64 14.3.0 h0d4f5d4_15
-  license: BSD-3-Clause
-  size: 28152
-  timestamp: 1764836809459
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-14.3.0-ha384071_16.conda
-  sha256: a6957b656cabbaa11206e4316b4312ad81b5d63eacf4c28a8e2c012e96407b97
-  md5: 232deada90533c2621a13e3535317cb9
-  depends:
-  - gcc 14.3.0 h2e72a27_16
-  - gxx_impl_linux-aarch64 14.3.0 h0d4f5d4_16
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28489
-  timestamp: 1765256896301
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_15.conda
-  sha256: 3b4e2b0977e29af8baff5867009717d360879c9e95bda0118a3339cd4445e45a
-  md5: a27be47954f8b96b0e4c383632bc80f9
-  depends:
-  - gcc_impl_linux-64 14.3.0 h319ec69_15
-  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_115
+  - gcc_impl_linux-64 14.3.0 hb1e0a52_17
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_117
   - sysroot_linux-64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 14753044
-  timestamp: 1764836860648
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_16.conda
-  sha256: 71a6672af972c4d072d79514e9755c9e9ea359d46613fd9333adcb3b08c0c008
-  md5: 8729b9d902631b9ee604346a90a50031
+  size: 15251260
+  timestamp: 1770252349885
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_17.conda
+  sha256: e64506fc747cb4a5be60812b06f0181bb8abd2c95be27024351fcfcf35fe669a
+  md5: 066e76b4c4bdf5796f3d83bb80be27db
   depends:
-  - gcc_impl_linux-64 14.3.0 he8b2097_16
-  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_116
-  - sysroot_linux-64
-  - tzdata
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 15255410
-  timestamp: 1765256273332
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_15.conda
-  sha256: 52f055176320a12e1cbb429848575f90f60ecab174a22d91fa57bdab3c49381a
-  md5: 69e200514a79fa79796fec4e40644ad8
-  depends:
-  - gcc_impl_linux-aarch64 14.3.0 hadc3402_15
-  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_115
+  - gcc_impl_linux-aarch64 14.3.0 h42fc7e9_17
+  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_117
   - sysroot_linux-aarch64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 13536240
-  timestamp: 1764836744606
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-14.3.0-h0d4f5d4_16.conda
-  sha256: 060c16a21fa60ba7ff632a7dfa56167a5b8e833b199b270ffc8831313370aa49
-  md5: c31908937ef3f628f64728135b7fa6b3
-  depends:
-  - gcc_impl_linux-aarch64 14.3.0 hda29b82_16
-  - libstdcxx-devel_linux-aarch64 14.3.0 h57c8d61_116
-  - sysroot_linux-aarch64
-  - tzdata
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 13534642
-  timestamp: 1765256828434
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h310e576_17.conda
-  sha256: 90ccb0df50254feb5b4e539b06e3d2c3baf5c37e40579224a277ab164566a6a0
-  md5: 94474857477981fedf74cf7c47c88ba5
+  size: 13535649
+  timestamp: 1770252285310
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-h3c3a7a4_20.conda
+  sha256: 88e2ca2a6da454a11d1971e00c6e94f020fe9137f61838daba48b15886eaae84
+  md5: 4b46597b58a2495ec48c215a40e42f0c
   depends:
   - gxx_impl_linux-64 14.3.0.*
-  - gcc_linux-64 ==14.3.0 h298d278_17
+  - gcc_linux-64 ==14.3.0 h298d278_20
   - binutils_linux-64
   - sysroot_linux-64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 27464
-  timestamp: 1766347929379
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-he6f32d1_14.conda
-  sha256: ae338fa6e156a79cf69db2e296ec862fd41e09ed42ab6c1cbab5fbf50a750307
-  md5: 9c792be16fc0c2b5ed6d1f3b768876e8
-  depends:
-  - gxx_impl_linux-64 14.3.0.*
-  - gcc_linux-64 ==14.3.0 h298d278_14
-  - binutils_linux-64
-  - sysroot_linux-64
-  license: BSD-3-Clause
-  size: 27404
-  timestamp: 1764713544855
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-h7476c01_17.conda
-  sha256: d8934358913c36e58273b09e3e81d74b78e7dfb41157717ce7b9fbb1bf6da538
-  md5: 8b396fba15df31abf963a948e3e5af50
+  size: 27482
+  timestamp: 1770277530104
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-ha7c1ae4_20.conda
+  sha256: d94bd329d1cb45cf13402dbb1b2bf912d482d074b1785a748b25b0e78e71ad47
+  md5: 6dbe8e35c78904decb22d41cfac645a3
   depends:
   - gxx_impl_linux-aarch64 14.3.0.*
-  - gcc_linux-aarch64 ==14.3.0 h118592a_17
+  - gcc_linux-aarch64 ==14.3.0 h118592a_20
   - binutils_linux-aarch64
   - sysroot_linux-aarch64
   license: BSD-3-Clause
-  license_family: BSD
-  size: 27209
-  timestamp: 1766347983467
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-14.3.0-hef95cfa_14.conda
-  sha256: 899e11c611d3bc315d88333be8547124f1e47092798065bb497e9a98d103d658
-  md5: ba095fd345f927689347487a8020a598
-  depends:
-  - gxx_impl_linux-aarch64 14.3.0.*
-  - gcc_linux-aarch64 ==14.3.0 h118592a_14
-  - binutils_linux-aarch64
-  - sysroot_linux-aarch64
-  license: BSD-3-Clause
-  size: 27162
-  timestamp: 1764713836536
+  size: 27225
+  timestamp: 1770277570522
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
   sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
   md5: 186a18e3ba246eccfc7cff00cd19a870
@@ -2130,16 +1884,6 @@ packages:
   license_family: MIT
   size: 12852963
   timestamp: 1767975394622
-- conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.15-pyhd8ed1ab_0.conda
-  sha256: 32d5007d12e5731867908cbf5345f5cd44a6c8755a2e8e63e15a184826a51f82
-  md5: 25f954b7dae6dd7b0dc004dab74f1ce9
-  depends:
-  - python >=3.10
-  - ukkonen
-  license: MIT
-  license_family: MIT
-  size: 79151
-  timestamp: 1759437561529
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
   sha256: 6a88cdde151469131df1948839ac2315ada99cf8d38aaacc9a7a5984e9cd8c19
   md5: 8bc5851c415865334882157127e75799
@@ -2150,15 +1894,6 @@ packages:
   license_family: MIT
   size: 79302
   timestamp: 1768295306539
-- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
-  sha256: 305c22a251db227679343fd73bfde121e555d466af86e537847f4c8b9436be0d
-  md5: ff007ab0f0fdc53d245972bba8a6d40c
-  constrains:
-  - sysroot_linux-64 ==2.28
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
-  license_family: GPL
-  size: 1272697
-  timestamp: 1752669126073
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
   sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
   md5: 86d9cba083cd041bfbf242a01a7a1999
@@ -2168,15 +1903,6 @@ packages:
   license_family: GPL
   size: 1278712
   timestamp: 1765578681495
-- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_8.conda
-  sha256: 9d0a86bd0c52c39db8821405f6057bc984789d36e15e70fa5c697f8ba83c1a19
-  md5: 2ab884dda7f1a08758fe12c32cc31d08
-  constrains:
-  - sysroot_linux-aarch64 ==2.28
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
-  license_family: GPL
-  size: 1244709
-  timestamp: 1752669116535
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
   sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
   md5: bb3b7cad9005f2cbf9d169fb30263f3e
@@ -2231,52 +1957,27 @@ packages:
   license_family: MIT
   size: 1474620
   timestamp: 1719463205834
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
-  sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
-  md5: a6abd2796fc332536735f68ba23f7901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+  sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
+  md5: 12bd9a3f089ee6c9266a37dab82afabd
   depends:
   - __glibc >=2.17,<3.0.a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-64 2.45
+  - binutils_impl_linux-64 2.45.1
   license: GPL-3.0-only
-  license_family: GPL
-  size: 725545
-  timestamp: 1764007826689
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
-  sha256: 1027bd8aa0d5144e954e426ab6218fd5c14e54a98f571985675468b339c808ca
-  md5: 3ec0aa5037d39b06554109a01e6fb0c6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.45
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 730831
-  timestamp: 1766513089214
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_104.conda
-  sha256: 7a13072581fa23f658a04f62f62c4677c57d3c9696fbc01cc954a88fc354b44d
-  md5: 28035705fe0c977ea33963489cd008ad
+  size: 725507
+  timestamp: 1770267139900
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
+  sha256: 44527364aa333be631913451c32eb0cae1e09343827e9ce3ccabd8d962584226
+  md5: 35b2ae7fadf364b8e5fb8185aaeb80e5
   depends:
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-aarch64 2.45
+  - binutils_impl_linux-aarch64 2.45.1
   license: GPL-3.0-only
-  license_family: GPL
-  size: 875534
-  timestamp: 1764007911054
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45-default_h1979696_105.conda
-  sha256: 12e7341b89e9ea319a3b4de03d02cd988fa02b8a678f4e46779515009b5e475c
-  md5: 849c4cbbf8dd1d71e66c13afed1d2f12
-  depends:
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-aarch64 2.45
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 876257
-  timestamp: 1766513180236
+  size: 875924
+  timestamp: 1770267209884
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.0-cxx17_h7b12aa8_0.conda
   sha256: 4fede984871c04a51b128db194d9cb934973eb38f45a1409921a656163d200cc
   md5: 84b8463a0baf635729d08be74957800a
@@ -2343,96 +2044,86 @@ packages:
   license: LGPL-2.1-only
   size: 107929
   timestamp: 1711802451678
-- conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.12.00-cuda12_251210_580975be.conda
-  sha256: a0159bc6d8e67cf859102940a15bd5b29e70428dd8bef215b6eb9d80a23ce109
-  md5: 4c029d721587c92116ac0b320945a6b4
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libcudf-26.04.00a162-cuda12_260205_b441c77f.conda
+  sha256: ac6e65ce6b7fba3b12339bfe1a6e12f292f708e6ced31d39c4d082e0e502b96e
+  md5: e2c83efec3bc5dded70533ee4b5dc8b0
   depends:
   - cuda-version >=12,<13.0a0
   - cuda-nvrtc
+  - libnvjitlink >=12.9
   - libcufile
-  - librmm 25.12.*
-  - libkvikio 25.12.*
-  - libnvcomp-dev 5.0.0.6.*
+  - librmm 26.4.*
+  - libkvikio 26.4.*
+  - libnvcomp-dev 5.1.0.21.*
   - dlpack >=0.8,<1.0
   - rapids-logger 0.2.*
   - libgcc >=14
   - __glibc >=2.28,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
-  - libnvcomp >=5.0.0.6,<6.0a0
-  - libnvjitlink >=12.9.86,<13.0a0
-  - libnvcomp >=5.0.0.6,<6.0a0
+  - libnvcomp >=5.1.0.21,<6.0a0
   license: Apache-2.0
-  size: 366889786
-  timestamp: 1765406159960
-- conda: https://conda.anaconda.org/rapidsai/linux-64/libcudf-25.12.00-cuda13_251210_580975be.conda
-  sha256: a72d11d96bda907c1526560bff6a339ade9222a309d2ff983b9c59b038ce801f
-  md5: fb66aca492fbc45205aab7b482cd2c0c
+  size: 401578694
+  timestamp: 1770329954651
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libcudf-26.04.00a162-cuda13_260205_b441c77f.conda
+  sha256: 2b48f9f72cd69ea60d09979882bbef564579171463be13a0ef5abbe245847807
+  md5: 74c05f52943b54d0ed1e952285978d83
   depends:
   - cuda-version >=13,<14.0a0
   - cuda-nvrtc
+  - libnvjitlink >=13.1
   - libcufile
-  - librmm 25.12.*
-  - libkvikio 25.12.*
-  - libnvcomp-dev 5.0.0.6.*
+  - librmm 26.4.*
+  - libkvikio 26.4.*
+  - libnvcomp-dev 5.1.0.21.*
   - dlpack >=0.8,<1.0
   - rapids-logger 0.2.*
   - libgcc >=14
   - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - libnvcomp >=5.0.0.6,<6.0a0
-  - libnvjitlink >=13.0.88,<14.0a0
-  - libnvcomp >=5.0.0.6,<6.0a0
+  - libnvcomp >=5.1.0.21,<6.0a0
   license: Apache-2.0
-  size: 257061054
-  timestamp: 1765406213213
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.12.00-cuda12_251210_580975be.conda
-  sha256: b6ac035974e27ef15d0f962172a48cd12d62209491dfc35c13f71e46ac07796c
-  md5: ac42562b02a060011f0a028b41f8de43
+  size: 306483195
+  timestamp: 1770329955590
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libcudf-26.04.00a162-cuda12_260205_b441c77f.conda
+  sha256: 47ea4c95b25cbb3ebd0289ade9c6727d4ab53547b268835be44d60177fe3ee74
+  md5: 2a3f067b52c86d08a38f6b4596d1b624
   depends:
   - cuda-version >=12,<13.0a0
   - cuda-nvrtc
-  - librmm 25.12.*
-  - libkvikio 25.12.*
-  - libnvcomp-dev 5.0.0.6.*
+  - libnvjitlink >=12.9
+  - librmm 26.4.*
+  - libkvikio 26.4.*
+  - libnvcomp-dev 5.1.0.21.*
   - dlpack >=0.8,<1.0
   - rapids-logger 0.2.*
   - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - arm-variant * sbsa
-  - libgcc >=14
   - __glibc >=2.28,<3.0.a0
-  - libnvcomp >=5.0.0.6,<6.0a0
-  - libnvjitlink >=12.9.86,<13.0a0
-  - libnvcomp >=5.0.0.6,<6.0a0
+  - libstdcxx >=14
+  - libnvcomp >=5.1.0.21,<6.0a0
   license: Apache-2.0
-  size: 365865438
-  timestamp: 1765406157600
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libcudf-25.12.00-cuda13_251210_580975be.conda
-  sha256: ad9bb6761e90fe8c9c4312bcb1f1e58d05b18fc41eac77bc55704604ea2085ca
-  md5: f63a8ac56cdf0e031536c05dfbca243f
+  size: 397825407
+  timestamp: 1770329949499
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libcudf-26.04.00a162-cuda13_260205_b441c77f.conda
+  sha256: 476dfa07b7ea4d87172663cf6e07f4a60372370622ddbb25b88b41994954242c
+  md5: af8f35c4f84d0521b8d6d94d8e765497
   depends:
   - cuda-version >=13,<14.0a0
   - cuda-nvrtc
-  - librmm 25.12.*
-  - libkvikio 25.12.*
-  - libnvcomp-dev 5.0.0.6.*
+  - libnvjitlink >=13.1
+  - librmm 26.4.*
+  - libkvikio 26.4.*
+  - libnvcomp-dev 5.1.0.21.*
   - dlpack >=0.8,<1.0
   - rapids-logger 0.2.*
   - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
   - arm-variant * sbsa
-  - libnvcomp >=5.0.0.6,<6.0a0
-  - libnvjitlink >=13.0.88,<14.0a0
+  - libstdcxx >=14
+  - __glibc >=2.28,<3.0.a0
+  - libnvcomp >=5.1.0.21,<6.0a0
   license: Apache-2.0
-  size: 255051516
-  timestamp: 1765406161082
+  size: 303353801
+  timestamp: 1770329954016
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
   sha256: 5fa43e8a8d335fc0c3a6aeb2e7b0debc7d8495b8a60a56ac30f23b0e852ab74a
   md5: cab1818eada3952ed09c8dcbb7c26af7
@@ -2445,18 +2136,18 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 969845
   timestamp: 1761098818759
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.15.1.6-hbc026e6_0.conda
-  sha256: 2cddb2fc468c8469b0dc932cb9792940187f64caacf2a59367a4db86dccbe27e
-  md5: bdd53a936c0bba2ff2a28268dde33b6c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.16.1.26-hd07211c_0.conda
+  sha256: 8c44b5bf947afad827df0df49fe7483cf1b2916694081b2db4fecdfd6a2bacd1
+  md5: 48418c48dac04671fa46cb446122b8a5
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - rdma-core >=59.0
+  - rdma-core >=60.0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 977986
-  timestamp: 1757021650640
+  size: 990938
+  timestamp: 1768273732081
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.14.1.1-had8bf56_1.conda
   sha256: fbc1fa6b3ddf946b2999c9820310682739505df71e1e2ac513a72efb951fa3e5
   md5: ee136db5a5409dddc78eaf7658fccffe
@@ -2470,21 +2161,21 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 909365
   timestamp: 1761098964619
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.15.1.6-had8bf56_0.conda
-  sha256: 21b70a25a0cdc0ef64411af25ab19b6229a4f15543b20ffc84fe60b043f50f5d
-  md5: 078227cbdf7463d09dc2e560f042e055
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-1.16.1.26-hbf501ad_0.conda
+  sha256: 7451b3e2204e6cad21db501052dfe595c3440213ef3e22c0f9c784012f6a8419
+  md5: ee60a24c702ce02de95ae1982c4841d8
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - rdma-core >=59.0
+  - rdma-core >=60.0
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 908076
-  timestamp: 1757021699745
+  size: 891752
+  timestamp: 1768273724252
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.14.1.1-hecca717_1.conda
   sha256: 3a7c726419017319df149ff67ea3efae37d668ecfc1aa2ac3273b21c4c76d68b
   md5: 74a93e4c8fd24d535abc546c6fee2155
@@ -2499,20 +2190,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 36377
   timestamp: 1761098841141
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.15.1.6-hecca717_0.conda
-  sha256: cd9ca750b5605faf4c7a90f44dc6cf8040188234587e258f2c0d02b1b96df451
-  md5: 227ab9f14df261b66e0e420f56501e4a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-dev-1.16.1.26-h676940d_0.conda
+  sha256: 5591968330a0786c373e3ce0f825c2a68435837756fb25fa36345cda0ec81966
+  md5: 0838909b3bb642435bda188ad72986f7
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 hbc026e6_0
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=13.1,<13.2.0a0
+  - libcufile 1.16.1.26 hd07211c_0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
-  - libcufile-static >=1.15.1.6
+  - libcufile-static >=1.16.1.26
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 40775
-  timestamp: 1757021671143
+  size: 42484
+  timestamp: 1768273767069
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.14.1.1-he38c790_1.conda
   sha256: 1d20ed52cd0a08fae11bdfba5762c50864651860f0d9f02ecf0eaed37a573a83
   md5: 7c4d86e9dd8643ed77ba3c918637bb3e
@@ -2528,22 +2219,22 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 36798
   timestamp: 1761098993768
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.15.1.6-he38c790_0.conda
-  sha256: 80cfea59157864e420b1a7aaa0c12879708389218f17af05c04a3b145be1dabb
-  md5: 5c9cd78953fd68ca33b9747353e90fd4
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcufile-dev-1.16.1.26-he38c790_0.conda
+  sha256: 2c7263521faf4587861defedd691b7b59faaa707931c4bb3d84ea2e6a32f77a5
+  md5: 27a7619bae381ee35b2b80ebf754e1b1
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libcufile 1.15.1.6 had8bf56_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libcufile 1.16.1.26 hbf501ad_0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
-  - libcufile-static >=1.15.1.6
+  - libcufile-static >=1.16.1.26
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 41023
-  timestamp: 1757021720713
+  size: 42754
+  timestamp: 1768273751163
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
   sha256: 3d40daf956b220cc367a6306ede1e259446fb844051bcfed87c46539cc1aaf03
   md5: 2a91559a9345bedf09af8b7903deb6e6
@@ -2555,17 +2246,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 46221876
   timestamp: 1761098855347
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.0.35-h676940d_1.conda
-  sha256: 803570e401b3841ba426163f941a89e255d8408efff83fcdfee37214e5f92927
-  md5: 0fbddc6e0a54358e806221f9bd5a4f83
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.4.1.81-h676940d_0.conda
+  sha256: bba28a650b35f221eaad9537df4a6f1d86b2fa617e52f56194ad2a959f84736c
+  md5: 5926fbc6df184a110130a310608cb5e8
   depends:
   - __glibc >=2.28,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43597395
-  timestamp: 1759327581167
+  size: 43775293
+  timestamp: 1768273736749
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.3.10.19-he38c790_1.conda
   sha256: d30eb348862da49dce2942907f00035643557dbd670050c63b1b66f644edd835
   md5: 663ff3c11db9560f82d0910c21700655
@@ -2578,20 +2269,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 46186075
   timestamp: 1761098914581
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.0.35-he38c790_1.conda
-  sha256: 47d62d514bd90dc1e772daecad8bab202cc7eb90a2a4f6aff5a6d3800913c123
-  md5: 7d214813bd19bc72b1cae48662fce35d
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-10.4.1.81-he38c790_0.conda
+  sha256: ef4300b83ea202e459e917a4f159478074fdc10c51f3061374361e9b89b6ba04
+  md5: b02eb8fbb430bd99f7a870382a91c24d
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 43897229
-  timestamp: 1759327764810
+  size: 44099763
+  timestamp: 1768273767993
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.3.10.19-h676940d_1.conda
   sha256: b506f93e7bea6d0e060f09f4bac6db3f57586084ac309db0d44b3756f5b0bc80
   md5: fc716aaff5af15b80ccbd28b3e67672c
@@ -2606,20 +2297,20 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 249874
   timestamp: 1761098955940
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.0.35-h676940d_1.conda
-  sha256: 9f8cd71ba7a4a61e3788895ee1f60d10970318e27aa624c90c175954df89cdc1
-  md5: a2e7bd789f12f442fb89878bf9889a7e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-dev-10.4.1.81-h676940d_0.conda
+  sha256: 540769d264e49e570728af8004a825a5e5568d257e45edbd3d38c38abd25fd9c
+  md5: 0da5b52b18ece7e23a73ae39298eca7b
   depends:
   - __glibc >=2.28,<3.0.a0
-  - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 h676940d_1
+  - cuda-version >=13.1,<13.2.0a0
+  - libcurand 10.4.1.81 h676940d_0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
-  - libcurand-static >=10.4.0.35
+  - libcurand-static >=10.4.1.81
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 266784
-  timestamp: 1759327649403
+  size: 249505
+  timestamp: 1768273810825
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.3.10.19-he38c790_1.conda
   sha256: 7ab691c753bbde5c1cb2d0a0d68609cf8523f0cc0fee8a6c43ef56c4ef635474
   md5: 24c50ef3f4b113317c09bb7f55b12bff
@@ -2635,38 +2326,22 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 257587
   timestamp: 1761099025650
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.0.35-he38c790_1.conda
-  sha256: 8026db45a0607f49670349976628e937c51fc9d8ae4c6ab3e203d638a615d43a
-  md5: b5edc27749d59d16f7da066367435baa
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurand-dev-10.4.1.81-he38c790_0.conda
+  sha256: 12a1e21ca078b7d7a94c1ca3afcfe52d0613acf16d9888ed1bb1f191f15d2a21
+  md5: 3fe709de30132c888012d75c27e543f7
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libcurand 10.4.0.35 he38c790_1
+  - cuda-version >=13.1,<13.2.0a0
+  - libcurand 10.4.1.81 he38c790_0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
-  - libcurand-static >=10.4.0.35
   - arm-variant * sbsa
+  - libcurand-static >=10.4.1.81
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 262323
-  timestamp: 1759327877841
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.17.0-h4e3cde8_0.conda
-  sha256: 100e29ca864c32af15a5cc354f502d07b2600218740fdf2439fa7d66b50b3529
-  md5: 01e149d4a53185622dc2e788281961f2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=14
-  - libnghttp2 >=1.67.0,<2.0a0
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 460366
-  timestamp: 1762333743748
+  size: 253671
+  timestamp: 1768273851592
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
   sha256: 5454709d9fb6e9c3dd6423bc284fa7835a7823bfa8323f6e8786cdd555101fab
   md5: 0a5563efed19ca4461cf927419b6eb73
@@ -2683,21 +2358,6 @@ packages:
   license_family: MIT
   size: 462942
   timestamp: 1767821743793
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.17.0-h7bfdcfb_0.conda
-  sha256: 100443d6cc03bd31f07082190d151fc84734a64624a79778e792b9b70754ffe5
-  md5: 468c392e41a0cfc30aed58139fc8d58f
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=14
-  - libnghttp2 >=1.67.0,<2.0a0
-  - libssh2 >=1.11.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.4,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 478880
-  timestamp: 1762333723924
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.18.0-h7bfdcfb_0.conda
   sha256: bf9d50e78df63b807c5cc98f44dc06a6555ab499edcd2949e9a07a5a785a11ee
   md5: dc4f2007c6a30a45dfcf1c3a97b6aba6
@@ -2777,175 +2437,98 @@ packages:
   license_family: MIT
   size: 76201
   timestamp: 1763549910086
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
-  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
-  md5: 35f29eec58405aaf55e01cb470d8c26a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 57821
-  timestamp: 1760295480630
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-hd65408f_0.conda
-  sha256: 6c3332e78a975e092e54f87771611db81dcb5515a3847a3641021621de76caea
-  md5: 0c5ad486dcfb188885e3cf8ba209b97b
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+  sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
+  md5: 2f364feefb6a7c00423e80dcb12db62a
   depends:
   - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 55586
-  timestamp: 1760295405021
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_15.conda
-  sha256: 37f2edde2f8281672987c63f13c85a57d04d889dc929ce38204426d5eb2059cc
-  md5: a5d86b0496174a412d531eac03af9174
+  size: 55952
+  timestamp: 1769456078358
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+  sha256: 43860222cf3abf04ded0cf24541a105aa388e0e1d4d6ca46258e186d4e87ae3e
+  md5: 3c281169ea25b987311400d7a7e28445
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 15.2.0 he0feb66_15
-  - libgcc-ng ==15.2.0=*_15
+  - libgcc-ng ==15.2.0=*_17
+  - libgomp 15.2.0 he0feb66_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 1041379
-  timestamp: 1764836112865
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
-  sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
-  md5: 6d0363467e6ed84f11435eb309f2ff06
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_16
-  - libgomp 15.2.0 he0feb66_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1042798
-  timestamp: 1765256792743
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_15.conda
-  sha256: ff184dbe54493b663eab2d62fa0b5a689eb84bec6401fcaeb44265c7f31ae4c6
-  md5: cfdf8700e69902a113f2611e3cc09b55
+  size: 1040478
+  timestamp: 1770252533873
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_17.conda
+  sha256: 3709e656917d282b5d3d78928a7a101bd638aaa9d17fb8689e6f95428d519056
+  md5: 0d842d2053b95a6dbb83554948e7cbfe
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.2.0=*_15
-  - libgomp 15.2.0 h8acb6b2_15
+  - libgomp 15.2.0 h8acb6b2_17
+  - libgcc-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 621200
-  timestamp: 1764836146613
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_16.conda
-  sha256: 44bfc6fe16236babb271e0c693fe7fd978f336542e23c9c30e700483796ed30b
-  md5: cf9cd6739a3b694dcf551d898e112331
-  depends:
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgomp 15.2.0 h8acb6b2_16
-  - libgcc-ng ==15.2.0=*_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 620637
-  timestamp: 1765256938043
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_115.conda
-  sha256: ef6e085bfde0339853fb5737fb8f24c201c35b6717754cee5b44550b0e24ce76
-  md5: eedcd688f597873e1d16f0529f4d6d10
+  size: 622154
+  timestamp: 1770252127670
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
+  sha256: 57ef92396b4dc06c5a34792c0f601bc49793a963712e8419d5f03cb4ff87729f
+  md5: 50d5470d29a25808d108d3917426d24b
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 3089251
-  timestamp: 1764836386115
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_116.conda
-  sha256: 812f2b3f523fc0aabaf4e5e1b44a029c5205671179e574dd32dc57b65e072e0f
-  md5: 0141e19cb0cd5602c49c84f920e81921
+  size: 3081070
+  timestamp: 1770251857403
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_117.conda
+  sha256: 95af3b1042280e45c993e548a46fe348d19a73b41b0ee6d09728d3482ee7fd64
+  md5: 93c0f96be96b3d7ce129c41d5cda6a0c
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 3082749
-  timestamp: 1765255729247
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_115.conda
-  sha256: 72213376322152a1e3e7745ce95b587876830451d26f196f07a2ac3081791549
-  md5: 3e4c04a124cc3e660223267b8a150395
+  size: 2344472
+  timestamp: 1770251861164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+  sha256: bdfe50501e4a2d904a5eae65a7ae26e2b7a29b473ab084ad55d96080b966502e
+  md5: 1478bfa85224a65ab096d69ffd2af1e5
   depends:
-  - __unix
+  - libgcc 15.2.0 he0feb66_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 2343273
-  timestamp: 1764836330285
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_116.conda
-  sha256: d9443aff6c8421f32ec79cd2801567b78cddc4e9bd1ba001adce0de98e53c5be
-  md5: c72ff594b1830f8e0b205965281620ad
+  size: 27541
+  timestamp: 1770252546553
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_17.conda
+  sha256: 308bd5fe9cd4b19b08c07437a626cf02a1d70a43216d68469d17003aece63202
+  md5: bcd31f4a57798bd158dfc0647fa77ca3
   depends:
-  - __unix
+  - libgcc 15.2.0 h8acb6b2_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2371620
-  timestamp: 1765256387487
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_15.conda
-  sha256: 497d8cdba0da8fa154613d1c15f585674cadc194964ed1b4fe7c2809938dc41f
-  md5: 7b742943660c5173bb6a5c823021c9a0
-  depends:
-  - libgcc 15.2.0 he0feb66_15
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 26834
-  timestamp: 1764836127111
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
-  sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
-  md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
-  depends:
-  - libgcc 15.2.0 he0feb66_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27256
-  timestamp: 1765256804124
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_15.conda
-  sha256: 80e6135b5b0083ad6f0f00b8368d666fb148923fe2d3ab7d8cdca3eaf575eeff
-  md5: ad92990dc6f608f412a01540a7c9510e
-  depends:
-  - libgcc 15.2.0 h8acb6b2_15
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 26927
-  timestamp: 1764836155568
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_16.conda
-  sha256: 22d7e63a00c880bd14fbbc514ec6f553b9325d705f08582e9076c7e73c93a2e1
-  md5: 3e54a6d0f2ff0172903c0acfda9efc0e
-  depends:
-  - libgcc 15.2.0 h8acb6b2_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27356
-  timestamp: 1765256948637
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_15.conda
-  sha256: b3c4e39be7aba6f5a8695d428362c5c918b96a281ce0a7037f1e889dfc340615
-  md5: a90d6983da0757f4c09bb8fcfaf34e71
+  size: 27555
+  timestamp: 1770252134574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+  sha256: b961b5dd9761907a7179678b58a69bb4fc16b940eb477f635aea3aec0a3f17a6
+  md5: 51b78c6a757575c0d12f4401ffc67029
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 602978
-  timestamp: 1764836011147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
-  sha256: 5b3e5e4e9270ecfcd48f47e3a68f037f5ab0f529ccb223e8e5d5ac75a58fc687
-  md5: 26c46f90d0e727e95c6c9498a33a09f3
-  depends:
-  - __glibc >=2.17,<3.0.a0
+  size: 603334
+  timestamp: 1770252441199
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_17.conda
+  sha256: ffa6169ef78e5333ecb08152141932c5f8ca4f4d3742b1a5eec67173e70b907a
+  md5: 0ad9074c91b35dbf8b58bc68a9f9bda0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 603284
-  timestamp: 1765256703881
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_15.conda
-  sha256: d76cbb7e76af310828c74396a78c59a3b305431da25c9337e420bb441d2e8ca0
-  md5: 0719da240fd6086c34c4c30080329806
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 587301
-  timestamp: 1764836050907
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_16.conda
-  sha256: 0a9d77c920db691eb42b78c734d70c5a1d00b3110c0867cfff18e9dd69bc3c29
-  md5: 4d2f224e8186e7881d53e3aead912f6c
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 587924
-  timestamp: 1765256821307
-- conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.12.00-cuda12_251210_61297197.conda
+  size: 587183
+  timestamp: 1770252042141
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libkvikio-26.04.00a18-cuda12_260205_593245b7.conda
   build_number: 0
-  sha256: 3857ae3fb45883e2dc2a53f801aa0ce7db04ed9a837eb0635d365606891fb4e5
-  md5: 1287df1fe344808d3bdcb4dc63ead9dc
+  sha256: 0b2c1c077fe08aa61f98bb5f30beb7b78c93db7cd85b09a51cabcb72bc0c1429
+  md5: c4d7c71cf64cf473b650f3ee4ec32daf
   depends:
   - cuda-version >=12.2.0a0,<13.0a0
   - libcufile-dev
@@ -2955,73 +2538,57 @@ packages:
   - libgcc >=14
   - libcurl >=8.5.0,<9.0a0
   - libnuma >=2.0.18,<3.0a0
-  - libcurl >=8.5.0,<9.0a0
   license: Apache-2.0
-  size: 411905
-  timestamp: 1765404798234
-- conda: https://conda.anaconda.org/rapidsai/linux-64/libkvikio-25.12.00-cuda13_251210_61297197.conda
+  size: 421807
+  timestamp: 1770325183301
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/libkvikio-26.04.00a18-cuda13_260205_593245b7.conda
   build_number: 0
-  sha256: 3689de7eb04c94257e1691f14589e89371f8a4e8b6389c59558ad6335c2b7d83
-  md5: d57ec372edd1616173946a8debddf04a
+  sha256: 513855f06ea467375fa840ec8193ff57c41a171ac4b2bdf02b3cb9ee029726d2
+  md5: 05797ad2bd7b9b9255179fdf51636c58
   depends:
   - cuda-version >=13,<14.0a0
   - libcufile-dev
   - libgcc >=15
-  - libstdcxx >=15
-  - libgcc >=15
   - __glibc >=2.28,<3.0.a0
+  - libstdcxx >=15
   - libcurl >=8.5.0,<9.0a0
   - libnuma >=2.0.18,<3.0a0
-  - libcurl >=8.5.0,<9.0a0
   license: Apache-2.0
-  size: 408477
-  timestamp: 1765404804374
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.12.00-cuda12_251210_61297197.conda
+  size: 418665
+  timestamp: 1770325186161
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libkvikio-26.04.00a18-cuda12_260205_593245b7.conda
   build_number: 0
-  sha256: 17722febc44672279d169d28b4a52e4f3e818f6d66c79b03a6bf7d0382b83504
-  md5: de04babe19d829e9601dd884ab569489
+  sha256: 42cbfd9b0f833cd9a5a9fd43db1945a4fc8248a1137a9f6a95a299895e38113b
+  md5: 4f3eb59b317caefa833b8db0f8e8f046
   depends:
   - cuda-version >=12.2.0a0,<13.0a0
   - libcufile-dev
   - libgcc >=15
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
   - libgcc >=14
   - arm-variant * sbsa
+  - __glibc >=2.28,<3.0.a0
   - libcurl >=8.5.0,<9.0a0
   - libnuma >=2.0.18,<3.0a0
   license: Apache-2.0
-  size: 401784
-  timestamp: 1765404798118
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/libkvikio-25.12.00-cuda13_251210_61297197.conda
+  size: 413650
+  timestamp: 1770325155334
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/libkvikio-26.04.00a18-cuda13_260205_593245b7.conda
   build_number: 0
-  sha256: c94156af47c87ed78097d355020b73799d502af5a0f3cc7ffe249de6c873df50
-  md5: fcc32ddfd349d6cb12dfe98fc2ea4f3f
+  sha256: e07af235382be1e0be7f84c865e5ebd32dc748f49d5751ff5252097decdc8624
+  md5: e29ec9e4c5b77be4ba595176db6f10e4
   depends:
   - cuda-version >=13,<14.0a0
   - libcufile-dev
   - libgcc >=15
-  - libstdcxx >=15
-  - libgcc >=15
   - arm-variant * sbsa
+  - libstdcxx >=15
   - __glibc >=2.28,<3.0.a0
   - libcurl >=8.5.0,<9.0a0
   - libnuma >=2.0.18,<3.0a0
   license: Apache-2.0
-  size: 405699
-  timestamp: 1765404800285
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
-  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
-  md5: 1a580f7796c7bf6393fddb8bbbde58dc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  size: 112894
-  timestamp: 1749230047870
+  size: 417841
+  timestamp: 1770325153161
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
   sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
   md5: c7c83eecbb72d88b940c249af56c8b17
@@ -3033,16 +2600,6 @@ packages:
   license: 0BSD
   size: 113207
   timestamp: 1768752626120
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
-  sha256: 498ea4b29155df69d7f20990a7028d75d91dbea24d04b2eb8a3d6ef328806849
-  md5: 7d362346a479256857ab338588190da0
-  depends:
-  - libgcc >=13
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  size: 125103
-  timestamp: 1749232230009
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.2-he30d5cf_0.conda
   sha256: 843c46e20519651a3e357a8928352b16c5b94f4cd3d5481acc48be2e93e8f6a3
   md5: 96944e3c92386a12755b94619bae0b35
@@ -3053,25 +2610,25 @@ packages:
   license: 0BSD
   size: 125916
   timestamp: 1768754941722
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
-  sha256: 3aa92d4074d4063f2a162cd8ecb45dccac93e543e565c01a787e16a43501f7ee
-  md5: c7e925f37e3b40d893459e625f6a53f1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
-  size: 91183
-  timestamp: 1748393666725
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-h86ecc28_0.conda
-  sha256: ef8697f934c80b347bf9d7ed45650928079e303bad01bd064995b0e3166d6e7a
-  md5: 78cfed3f76d6f3f279736789d319af76
+  size: 92400
+  timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
+  sha256: 57c0dd12d506e84541c4e877898bd2a59cca141df493d34036f18b2751e0a453
+  md5: 7b9813e885482e3ccb1fa212b86d7fd0
   depends:
-  - libgcc >=13
+  - libgcc >=14
   license: BSD-2-Clause
   license_family: BSD
-  size: 114064
-  timestamp: 1748393729243
+  size: 114056
+  timestamp: 1769482343003
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
   sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
   md5: b499ce4b026493a13774bcf0f4c33849
@@ -3139,42 +2696,42 @@ packages:
   license: LGPL-2.1-only
   size: 47464
   timestamp: 1749575391929
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-h7bcfba5_3.conda
-  sha256: 1f8c39a1cc0e8e907b0d88538981c05fddc349df9a4cf1c83c8095560f11736e
-  md5: 1cf33f4c8d53a318608a5ee6469d8259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.1.0.21-h7bcfba5_0.conda
+  sha256: 9b980d2585f96bbf0f4a0a2d340f3f60d2f0b33eefc8e19726d3d91267b17d17
+  md5: f190898e8238de48ab74e392028faa03
   depends:
   - __glibc >=2.28,<3.0.a0
   - cuda-version >=13,<14.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18555137
-  timestamp: 1757690091969
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.0.0.6-hb7e823c_3.conda
-  sha256: 5075ed5848df549e007816997ce47c6d8fe8578958d4852c224794aeb0c4df15
-  md5: 924ce19736414089b7c174a21299b3fd
+  size: 18537560
+  timestamp: 1764712514067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-5.1.0.21-hb7e823c_0.conda
+  sha256: 353bc179da18fa1d3c7e02120f248719356b622e8af51456c6d59c11d87f4922
+  md5: c3b09b2378d35bbc72bbbe2a47c11240
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=12,<13.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20617677
-  timestamp: 1757690038073
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-h6defbd5_3.conda
-  sha256: 2cc26383a425e8c8bd0732c648308af46d763f34b837ac0e99bdb8bee8b1bed7
-  md5: 402f0a349c561ba37de48519fd5a90fd
+  size: 20561593
+  timestamp: 1764712658869
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.1.0.21-h6defbd5_0.conda
+  sha256: 5f15aff2dac7528850bebeef3889ba39ad0bc3f95bc4938120e03c2da2c3a45e
+  md5: 52d7671e7a02d8e416336ddeeac9b663
   depends:
   - arm-variant * sbsa
   - cuda-version >=12,<13.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 20593723
-  timestamp: 1757690084484
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.0.0.6-he387df4_3.conda
-  sha256: 034c44f77cb9fa758a89de13568493bf5b17336bf737d5a737bc3ddd93e05123
-  md5: 781ae707c7f2808463f37f95ce7e323d
+  size: 20548852
+  timestamp: 1764712661065
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-5.1.0.21-he387df4_0.conda
+  sha256: e2eef42a571fb58d9fb7d72d613803dc676954e8ca69d88ce62329efeba85211
+  md5: 80f7db05a74a4eb709ed416d43be479f
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
@@ -3182,57 +2739,57 @@ packages:
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 18714665
-  timestamp: 1757690087167
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-h7bcfba5_3.conda
-  sha256: d725a0f63de3958f1d946c2f905ea31c418abbb14dd3d9cc1df2d7fbef667263
-  md5: 1a4bb1a3dce7fe3de201ac4cdf8e7d35
+  size: 18468452
+  timestamp: 1764712666088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.1.0.21-h7bcfba5_0.conda
+  sha256: 14879d7ee11ff8142368fa16241b529ba4fcc8688904195ef78e9ceb13a619c9
+  md5: f9cbb292e3d53067e9eeca20e6273413
   depends:
   - __glibc >=2.28,<3.0.a0
   - cuda-version >=13,<14.0a0
   - libgcc >=14
-  - libnvcomp 5.0.0.6 h7bcfba5_3
+  - libnvcomp 5.1.0.21 h7bcfba5_0
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 51918
-  timestamp: 1757690106774
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.0.0.6-hb7e823c_3.conda
-  sha256: 6916b481409c746446e0a4b5769f6b27f50fe6df222bb288f1896f1d756ae63a
-  md5: 72e93b6fdfddc1b6ad1c64c892dd55a2
+  size: 52246
+  timestamp: 1764712530624
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvcomp-dev-5.1.0.21-hb7e823c_0.conda
+  sha256: 0afc084708324ae72eaa27defd43107b19695150394fbdf90b40735125153e08
+  md5: 3dfd1f10e4229815cd96450ca20b45d6
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-version >=12,<13.0a0
   - libgcc >=14
-  - libnvcomp 5.0.0.6 hb7e823c_3
+  - libnvcomp 5.1.0.21 hb7e823c_0
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 51946
-  timestamp: 1757690057310
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-h6defbd5_3.conda
-  sha256: eaa095f41cd357dda96e22efc30b742e4fbe8ae422ee50a563a6ba2723475bc2
-  md5: ebfa3c41681982c55c2541f37b1cdeaa
+  size: 52323
+  timestamp: 1764712698462
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.1.0.21-h6defbd5_0.conda
+  sha256: 0a1c8cca82ebae4a6330edd52a976f759ca2613229e099d01f1e87c188c6acc6
+  md5: 170a2fce71bfa8b4ff88dffcf1d6c631
   depends:
   - arm-variant * sbsa
   - cuda-version >=12,<13.0a0
   - libgcc >=14
-  - libnvcomp 5.0.0.6 h6defbd5_3
+  - libnvcomp 5.1.0.21 h6defbd5_0
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 51908
-  timestamp: 1757690101941
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.0.0.6-he387df4_3.conda
-  sha256: e7c0882b1b5421e0073938c1001f930c44161f273ec72a52fafda4e9ea4c3eec
-  md5: 9db322973402f405a186ff8a17877f5b
+  size: 52361
+  timestamp: 1764712690657
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvcomp-dev-5.1.0.21-he387df4_0.conda
+  sha256: ef83e2d01fa5c7120f5e402ade87b321cfb22b5008f2952cc379a987979e161e
+  md5: 16c34c91d511c099bb73011286382979
   depends:
   - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
   - cuda-version >=13,<14.0a0
   - libgcc >=14
-  - libnvcomp 5.0.0.6 he387df4_3
+  - libnvcomp 5.1.0.21 he387df4_0
   - libstdcxx >=14
   license: LicenseRef-nvCOMP-Software-License-Agreement AND LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 52087
-  timestamp: 1757690097598
+  size: 52528
+  timestamp: 1764712687080
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
   sha256: 3b1c851f4fc42d347ce1c1606bdd195343a47f121e0fceb7a1f1e5aa1d497da9
   md5: 3461b0f2d5cbb7973d361f9e85241d98
@@ -3244,17 +2801,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 30515495
   timestamp: 1760723776293
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.0.88-hecca717_0.conda
-  sha256: 3cb21ce5d8dd92024e7ae983964231bf45aefada70509ca0a85e3aab32923f2f
-  md5: dddda2b83f5c5106ba9b02550f6278b2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-13.1.115-hecca717_0.conda
+  sha256: 1ce8ac2f6fb3aaab065599f74b1e1bc68affc0804a081da239ab2c727abdc1cb
+  md5: 6cd0aefa03c679824ee5047ed39b0a09
   depends:
   - __glibc >=2.17,<3.0.a0
-  - cuda-version >=13,<13.1.0a0
+  - cuda-version >=13,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 31218311
-  timestamp: 1757021832026
+  size: 31331227
+  timestamp: 1768274146966
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-12.9.86-h8f3c8d4_2.conda
   sha256: d5ff36f46250069a23b18d557052c6656f40a002333885e8c5332071e873b48e
   md5: e318a6573fea150226d5f417d1c0807a
@@ -3266,19 +2823,19 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 30323952
   timestamp: 1760723774770
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.0.88-h8f3c8d4_0.conda
-  sha256: 3a8b45998babc28786af0ef37787a81a1a8f05a681836d05cec7de3400705964
-  md5: 69a51843fab75153ebd35a551c5e4b29
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvjitlink-13.1.115-h8f3c8d4_0.conda
+  sha256: 49ff65205602d2535586e646008ff0577a92bf6f16de9c4cc6a10473caf3d700
+  md5: e211b0e0846d538f23296214de1d35a6
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13,<13.1.0a0
+  - cuda-version >=13,<13.2.0a0
   - libgcc >=14
   - libstdcxx >=14
   constrains:
   - arm-variant * sbsa
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 29710724
-  timestamp: 1757021907780
+  size: 29775481
+  timestamp: 1768274109937
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-12.9.86-ha770c72_2.conda
   sha256: 1e7a7b34f8639a5feb75ba864127059e4d83edfe1a516547f0dbb9941e7b8f8b
   md5: 3fd926c321c6dbf386aa14bd8b125bfb
@@ -3288,15 +2845,15 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27046
   timestamp: 1753975516342
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.0.88-ha770c72_0.conda
-  sha256: 23990b93978cc18a316e31fe71f7a8bf5e1c54d561c73cad36a583aaef510b44
-  md5: 60fe2b4386aa893d66dea5b01326b3a6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvptxcompiler-dev-13.1.115-ha770c72_0.conda
+  sha256: 9af66ab3c0218f30bbf37e680545a4c37da855adbbd0d8ff119056ad775d07ea
+  md5: 825f9cb1309a5975f5b9c1879d3b3050
   depends:
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev_linux-64 13.0.88 ha770c72_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_linux-64 13.1.115 ha770c72_0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27918
-  timestamp: 1757021661262
+  size: 28045
+  timestamp: 1768280548127
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-12.9.86-h579c4fd_2.conda
   sha256: 20cc92d163571b6d67efcfcb05dec042916219f29846152fdb696d499fa9fade
   md5: 096a5f4ddc263418d1b8160413a16c61
@@ -3307,16 +2864,16 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 27138
   timestamp: 1753975408006
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.0.88-h579c4fd_0.conda
-  sha256: ab241802ffe60f910804a84eba32404c7bea484debc5bcf672ce658bfbdb1680
-  md5: 415dd15457ce91bb59ce584dcfc641a4
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnvptxcompiler-dev-13.1.115-h579c4fd_0.conda
+  sha256: 813cee152bf71d84363d3b50a398e2e983b4d492a58aa0a343998d3589759648
+  md5: 6192d6f0ccf1223e528b6ec46a9bbd4e
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
-  - libnvptxcompiler-dev_linux-aarch64 13.0.88 h579c4fd_0
+  - cuda-version >=13.1,<13.2.0a0
+  - libnvptxcompiler-dev_linux-aarch64 13.1.115 h579c4fd_0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 27986
-  timestamp: 1757021596258
+  size: 28094
+  timestamp: 1768280288643
 - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-12.9.86-ha770c72_2.conda
   sha256: 17952c32eac197a59c119fdf3fb6f08c6a29c225a80bae141ac904ad212b87dd
   md5: a66a909acf08924aced622903832a937
@@ -3325,14 +2882,14 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 14422867
   timestamp: 1753975387297
-- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.0.88-ha770c72_0.conda
-  sha256: fa318fe80e61e698db006103e6daaf1b8318db1974f332df8c8e2b698f987cfc
-  md5: d9b0c4f42d730faf187ea126e075fe5f
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.1.115-ha770c72_0.conda
+  sha256: 98b1ed15bebeeae411785e211aae2d7f303c5124b88fe2433e9080d8fad2f3a9
+  md5: 8cbe7a9e462f1c0bd9e4bbdab1005337
   depends:
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 15040180
-  timestamp: 1757021509018
+  size: 16510519
+  timestamp: 1768280407864
 - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-12.9.86-h579c4fd_2.conda
   sha256: 0b0b96f4bb99d9f9fccfcd34fcb5b0f465c05373c9628ffa32951ed5fc7ab379
   md5: 3f6edd278c0a724f427d2655111c1c72
@@ -3342,19 +2899,19 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 13939480
   timestamp: 1753975314178
-- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.0.88-h579c4fd_0.conda
-  sha256: 01a61c4933c07293e820d460f128500f34a6038fb4f87805fbedafb7eab63cd6
-  md5: 24bebae254ac9789d1f8dd8e02031cba
+- conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-aarch64-13.1.115-h579c4fd_0.conda
+  sha256: 6597b5ed7242289d31116f4358fbe3f43a079725fcda66a3830f296de455d97f
+  md5: 1542f255f31f58cd4585fc4cc07c8cca
   depends:
   - arm-variant * sbsa
-  - cuda-version >=13.0,<13.1.0a0
+  - cuda-version >=13.1,<13.2.0a0
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  size: 14217893
-  timestamp: 1757021478031
-- conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.12.00-cuda12_251210_86731e05.conda
+  size: 15945605
+  timestamp: 1768280179983
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/librmm-26.04.00a23-cuda12_260205_7fff28e1.conda
   build_number: 0
-  sha256: e11c3c47cb876dbf9437d741d88de229ec6ffbb10bad2497e0f7f5087b2080c0
-  md5: f9f6da83924d858296f81033bae7364b
+  sha256: a4bcb7058bb9ad983f167aa77cca72ddddc56eba8c6eaaa947a6927cbd28607a
+  md5: f6a70fc6985778d4c55c5dea1b963cbf
   depends:
   - cuda-version >=12,<13.0a0
   - cuda-cudart
@@ -3362,15 +2919,13 @@ packages:
   - __glibc >=2.28,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
   license: Apache-2.0
-  size: 1450116
-  timestamp: 1765400131789
-- conda: https://conda.anaconda.org/rapidsai/linux-64/librmm-25.12.00-cuda13_251210_86731e05.conda
+  size: 1590997
+  timestamp: 1770323123357
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/librmm-26.04.00a23-cuda13_260205_7fff28e1.conda
   build_number: 0
-  sha256: 4e3d5b4065e78ee28e56ebcd9415b33332014c4e313024ba79d99f6041f5c871
-  md5: bb6e918750da0c08ed0b9cd52321fa5f
+  sha256: 777b4cac672385bc2c483f4c8f4c4d942ea9ec183c0191864b082fef9eaa2784
+  md5: 9e208c4a29a2ca837d7712bfb8b92cea
   depends:
   - cuda-version >=13,<14.0a0
   - cuda-cudart
@@ -3378,94 +2933,58 @@ packages:
   - __glibc >=2.28,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
   license: Apache-2.0
-  size: 1450312
-  timestamp: 1765400096165
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.12.00-cuda12_251210_86731e05.conda
+  size: 1590945
+  timestamp: 1770323119507
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/librmm-26.04.00a23-cuda12_260205_7fff28e1.conda
   build_number: 0
-  sha256: 7ea52b2ac87da55ccdc97532939ac712f0bd8df2c4bf8885742f0e18e3a10b69
-  md5: e9be0050e02d8f9894c1036b014d1670
+  sha256: 72daf8c0d67055ac0c978946eaa17c39244852955bb952bd1b123011bce105c9
+  md5: 01be8b8b77fe746b56ab9f5dbcf5dd9b
   depends:
   - cuda-version >=12,<13.0a0
   - cuda-cudart
   - rapids-logger 0.2.*
   - __glibc >=2.28,<3.0.a0
-  - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
   - arm-variant * sbsa
-  - libgcc >=14
+  - libstdcxx >=14
   license: Apache-2.0
-  size: 1459683
-  timestamp: 1765400103323
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/librmm-25.12.00-cuda13_251210_86731e05.conda
+  size: 1601223
+  timestamp: 1770323119578
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/librmm-26.04.00a23-cuda13_260205_7fff28e1.conda
   build_number: 0
-  sha256: 11fa9977780863d1889518d45506e098c83978d4b3c9fb29a124c6ebc336c9c9
-  md5: c03395a4e0dbfdddf2bffbe295cf595b
+  sha256: 1775931b53475a2234cf4d43c993a702c84b3a3e396b4740f2fd8e0197deb2a5
+  md5: b2d57df106627b49a39eb8df392963ff
   depends:
   - cuda-version >=13,<14.0a0
   - cuda-cudart
   - rapids-logger 0.2.*
   - __glibc >=2.28,<3.0.a0
   - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
   - arm-variant * sbsa
-  - __glibc >=2.28,<3.0.a0
+  - libstdcxx >=14
   license: Apache-2.0
-  size: 1459886
-  timestamp: 1765400110727
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_15.conda
-  sha256: 35965892734289a769266e7ad3c117f8fabe74f0e01d8bdd478e0d59cc49affd
-  md5: 9e82f96224931323c6ed53d88fb3241b
+  size: 1601294
+  timestamp: 1770323118338
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_17.conda
+  sha256: 48a1e008a44b7d630f1243915261628d72df1c1f477f44af2e93350937b496df
+  md5: 5edfb6baf1af52fa7c0a7072a42d1558
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14.3.0
   - libstdcxx >=14.3.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 7947918
-  timestamp: 1764836564921
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_16.conda
-  sha256: 21765d3fa780eb98055a9f40e9d4defa1eaffe254ee271a3e49555a89e37d6c9
-  md5: 0617b134e4dc4474c1038707499f7eed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14.3.0
-  - libstdcxx >=14.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 7946383
-  timestamp: 1765255939536
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_15.conda
-  sha256: 0491a1217ad365351349291732522c934e485f6efa39128943ba83abe5bef815
-  md5: b283c0151246b072a4a6ce3703d03fda
+  size: 7237991
+  timestamp: 1770252070009
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_17.conda
+  sha256: 5e0cba4ff5d228ac41510ae9bd1e003ea7d021224af2375a9e6bf1579a918e8c
+  md5: 10863ae634cf12aa03b4c6c371721ca7
   depends:
   - libgcc >=14.3.0
   - libstdcxx >=14.3.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 7197687
-  timestamp: 1764836471948
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-14.3.0-hedb4206_16.conda
-  sha256: b11c446a551d26cd117d26062ba3e782247b4462d1e2a8aacd22fc87333308ea
-  md5: bb08040cd8e7924026a2ad42b100ec7a
-  depends:
-  - libgcc >=14.3.0
-  - libstdcxx >=14.3.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 7545993
-  timestamp: 1765256538975
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
-  sha256: 6f0e8a812e8e33a4d8b7a0e595efe28373080d27b78ee4828aa4f6649a088454
-  md5: 2e1b84d273b01835256e53fd938de355
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: blessing
-  size: 938979
-  timestamp: 1764359444435
+  size: 7213512
+  timestamp: 1770252010479
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
   sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
   md5: da5be73701eecd0e8454423fd6ffcf30
@@ -3477,15 +2996,6 @@ packages:
   license: blessing
   size: 942808
   timestamp: 1768147973361
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.1-h022381a_0.conda
-  sha256: e394dd772b71dbcd653d078f3aacf6e26e3478bd6736a687ab86e463a2f153a8
-  md5: 233efdd411317d2dc5fde72464b3df7a
-  depends:
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: blessing
-  size: 939207
-  timestamp: 1764359457549
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.51.2-h10b116e_0.conda
   sha256: 5f8230ccaf9ffaab369adc894ef530699e96111dac0a8ff9b735a871f8ba8f8b
   md5: 4e3ba0d5d192f99217b85f07a0761e64
@@ -3519,128 +3029,59 @@ packages:
   license_family: BSD
   size: 311396
   timestamp: 1745609845915
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_15.conda
-  sha256: 2648485aa2dcd5ca385423841a728f262458aec5d814a79da5ab75098e223e3f
-  md5: fccfb26375ec5e4a2192dee6604b6d02
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+  sha256: 50c48cd3716a2e58e8e2e02edc78fef2d08fffe1e3b1ed40eb5f87e7e2d07889
+  md5: 24c2fe35fa45cd71214beba6f337c071
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_15
+  - libgcc 15.2.0 he0feb66_17
   constrains:
-  - libstdcxx-ng ==15.2.0=*_15
+  - libstdcxx-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 5856371
-  timestamp: 1764836166363
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-  sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
-  md5: 68f68355000ec3f1d6f26ea13e8f525f
+  size: 5852406
+  timestamp: 1770252584235
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_17.conda
+  sha256: fe425c07aa3116e7d5f537efe010d545bb43ac120cb565fbfb5ece8cb725aa80
+  md5: 500d275cb616d81b5d9828aedffc4bc3
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_16
+  - libgcc 15.2.0 h8acb6b2_17
   constrains:
-  - libstdcxx-ng ==15.2.0=*_16
+  - libstdcxx-ng ==15.2.0=*_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5856456
-  timestamp: 1765256838573
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_15.conda
-  sha256: f6347ce1d1a8a9ecfa16fc118594b0a5cab9194a8dcc7e79cd02a7497822d1d2
-  md5: 2873f805cdabcf33b880b19077cf6180
-  depends:
-  - libgcc 15.2.0 h8acb6b2_15
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_15
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 5540090
-  timestamp: 1764836183565
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_16.conda
-  sha256: 4db11a903707068ae37aa6909511c68e9af6a2e97890d1b73b0a8d87cb74aba9
-  md5: 52d9df8055af3f1665ba471cce77da48
-  depends:
-  - libgcc 15.2.0 h8acb6b2_16
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5541149
-  timestamp: 1765256980783
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_115.conda
-  sha256: e4912489035a077a8e7c754fea33fd5a96d95bd41042ad6b5d60b881049048be
-  md5: 1ef1a0376c610365eb26e67f5da5e48d
+  size: 5542688
+  timestamp: 1770252159760
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
+  sha256: ffb164d31e09b18cf95c6330bfce9268c1ce799103e56b7c004250332e7f9ede
+  md5: 97f8b7e451f960200c057ca83d92f9be
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 19600238
-  timestamp: 1764836425209
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_116.conda
-  sha256: 278a6b7ebb02f1e983db06c6091b130c9a99f967acb526eac1a67077fd863da8
-  md5: badba6a9f0e90fdaff87b06b54736ea6
+  size: 20497917
+  timestamp: 1770251920997
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_117.conda
+  sha256: f877682aa48055b275c225f9afa31cf23a258bd36fad48b5d820f39ef85a36ec
+  md5: 2f654cab4c3f9b8b03fe6707df4c3dfe
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 20538116
-  timestamp: 1765255773242
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_115.conda
-  sha256: 483ace48a26071a78fdcacf333a6515b88e194beea2b706cfc33a51666a5a281
-  md5: bac3774b052191747439e80a88d4f074
+  size: 17620200
+  timestamp: 1770251887693
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+  sha256: ca3fb322dab3373946b1064da686ec076f5b1b9caf0a2823dad00d0b0f704928
+  md5: ea12f5a6bf12c88c06750d9803e1a570
   depends:
-  - __unix
+  - libstdcxx 15.2.0 h934c35e_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 17302972
-  timestamp: 1764836355263
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_116.conda
-  sha256: cddbbef6da59eafaf3067329f54b1011e99a959fdf200453564823b38f45dbd4
-  md5: 8608a3438eabba3f9af24ffff0b8094b
+  size: 27573
+  timestamp: 1770252638797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_17.conda
+  sha256: 3842e84b5ad187cb30c7a1c8b5c0a33d70b7b3ce91b27dfcb2a6f2c2f055f07d
+  md5: beb8c015b02b7a1c2eea6d7a9847f8f5
   depends:
-  - __unix
+  - libstdcxx 15.2.0 hef695bb_17
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 17508577
-  timestamp: 1765256413043
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_15.conda
-  sha256: 2ffaec42c561f53dcc025277043aa02e2557dc0db62bc009be4c7559a7f19f09
-  md5: 20a8584ff8677ac9d724345b9d4eb757
-  depends:
-  - libstdcxx 15.2.0 h934c35e_15
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 26905
-  timestamp: 1764836222826
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
-  sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
-  md5: 1b3152694d236cf233b76b8c56bf0eae
-  depends:
-  - libstdcxx 15.2.0 h934c35e_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27300
-  timestamp: 1765256885128
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_15.conda
-  sha256: 73d026540bd2ec75186bc82c164fbfa51cbe44c4c27ed64b57bf52b10f6f3d63
-  md5: 7a99de7c14096347968d1fd574b46bb2
-  depends:
-  - libstdcxx 15.2.0 hef695bb_15
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  size: 26977
-  timestamp: 1764836231696
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_16.conda
-  sha256: dd5c813ae5a4dac6fa946352674e0c21b1847994a717ef67bd6cc77bc15920be
-  md5: 20b7f96f58ccbe8931c3a20778fb3b32
-  depends:
-  - libstdcxx 15.2.0 hef695bb_16
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27376
-  timestamp: 1765257033344
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_2.conda
-  sha256: b30c06f60f03c2cf101afeb3452f48f12a2553b4cb631c9460c8a8ccf0813ae5
-  md5: b04e0a2163a72588a40cde1afd6f2d18
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 491211
-  timestamp: 1763011323224
+  size: 27614
+  timestamp: 1770252201381
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_3.conda
   sha256: b3a7f89462dc95c1bba9f663210d20ff3ac5f7db458684e0f3a7ae5784f8c132
   md5: 70d1de6301b58ed99fea01490a9802a3
@@ -3651,15 +3092,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 491268
   timestamp: 1765552759709
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_2.conda
-  sha256: 22e5bc2b72eb4a104927d34d06954573dbbdef1981fd7f73520f2ca82f0b7101
-  md5: e7a86e3cdea9c37bf12005778d490148
-  depends:
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 517490
-  timestamp: 1763011526609
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.10-hf9559e3_3.conda
   sha256: 57fe7a9f0c289e4f2fdf5200271848adc9f102921056d5904173942628b472cd
   md5: 254474a19793a5f06de7cf3e3e2359fb
@@ -3669,16 +3101,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 517687
   timestamp: 1765552618501
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_2.conda
-  sha256: 751cf346f0f56cc9bfa43f7b5c9c30df2fcec8d84d164ac0cd74a27a3af79f30
-  md5: 2f6b30acaa0d6e231d01166549108e2c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 144395
-  timestamp: 1763011330153
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
   sha256: 977e7e4955ea1581e441e429c2c1b498bc915767f1cac77a97b283c469d5298c
   md5: 3934f4cf65a06100d526b33395fb9cd2
@@ -3689,15 +3111,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 145023
   timestamp: 1765552781358
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_2.conda
-  sha256: dd1ec27fef9f74ebdd0211ad875ba037f924931c81be164e7ff756b5d86ffc72
-  md5: 4fc935d5bebd8e6e070a861544a71a34
-  depends:
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 156835
-  timestamp: 1763011535779
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.10-hf9559e3_3.conda
   sha256: 39bdad22998d1ef5b366d9c557b5ca8a2ee2bea1f05eab9e1b20fbfef9d6d7a4
   md5: 8da19c1b9138b2f0a57012c31e3ad81d
@@ -3707,16 +3120,6 @@ packages:
   license: LGPL-2.1-or-later
   size: 156695
   timestamp: 1765552629955
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
-  sha256: 030447cf827c471abd37092ab9714fde82b8222106f22fde94bc7a64e2704c40
-  md5: 41f5c09a211985c3ce642d60721e7c3e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 40235
-  timestamp: 1764790744114
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
   sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
   md5: db409b7c1720428638e7c0d509d3e1b5
@@ -3727,15 +3130,6 @@ packages:
   license_family: BSD
   size: 40311
   timestamp: 1766271528534
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.2-h1022ec0_1.conda
-  sha256: 3113c857e36779d94cf9a18236a710ceca0e94230b3bfeba0d134f33ee8c9ecd
-  md5: 15b2cc72b9b05bcb141810b1bada654f
-  depends:
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 43415
-  timestamp: 1764790752623
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.41.3-h1022ec0_0.conda
   sha256: c37a8e89b700646f3252608f8368e7eb8e2a44886b92776e57ad7601fc402a11
   md5: cf2861212053d05f27ec49c3784ff8bb
@@ -3854,37 +3248,27 @@ packages:
   license_family: BSD
   size: 40866
   timestamp: 1766261270149
-- conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-  sha256: 3636eec0e60466a00069b47ce94b6d88b01419b6577d8e393da44bb5bc8d3468
-  md5: 7ba3f09fceae6a120d664217e58fe686
-  depends:
-  - python >=3.9
-  - setuptools
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 34574
-  timestamp: 1734112236147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
-  sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
-  md5: 9ee58d5c534af06558933af3c845a780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
+  md5: f61eb8cd60ff9057122a3d338b99c00f
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
-  size: 3165399
-  timestamp: 1762839186699
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.0-h8e36d6e_0.conda
-  sha256: 8dd3b4c31fe176a3e51c5729b2c7f4c836a2ce3bd5c82082dc2a503ba9ee0af3
-  md5: 7624c6e01aecba942e9115e0f5a2af9d
+  size: 3164551
+  timestamp: 1769555830639
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
+  sha256: 7f8048c0e75b2620254218d72b4ae7f14136f1981c5eb555ef61645a9344505f
+  md5: 25f5885f11e8b1f075bccf4a2da91c60
   depends:
   - ca-certificates
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
-  size: 3705625
-  timestamp: 1762841024958
+  size: 3692030
+  timestamp: 1769557678657
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
   sha256: 04c64fb78c520e5c396b6e07bc9082735a5cc28175dbe23138201d0a9441800b
   md5: 1bd2e65c8c7ef24f4639ae6e850dacc2
@@ -3895,20 +3279,6 @@ packages:
   license_family: MIT
   size: 23922
   timestamp: 1764950726246
-- conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.0-pyha770c72_0.conda
-  sha256: 8481f4939b1f81cf0db12456819368b41e3f998e4463e41611de4b13752b2c08
-  md5: af8d4882203bccefec6f1aeed70030c6
-  depends:
-  - cfgv >=2.0.0
-  - identify >=1.0.0
-  - nodeenv >=0.11.1
-  - python >=3.10
-  - pyyaml >=5.1
-  - virtualenv >=20.10.0
-  license: MIT
-  license_family: MIT
-  size: 201265
-  timestamp: 1764067809524
 - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
   sha256: 5b81b7516d4baf43d0c185896b245fa7384b25dc5615e7baa504b7fa4e07b706
   md5: 7f3ac694319c7eaf81a0325d6405e974
@@ -3933,10 +3303,10 @@ packages:
   license_family: BSD
   size: 110100
   timestamp: 1733195786147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.2-h32b2ec7_100_cp314.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_100_cp314.conda
   build_number: 100
-  sha256: a120fb2da4e4d51dd32918c149b04a08815fd2bd52099dad1334647984bb07f1
-  md5: 1cef1236a05c3a98f68c33ae9425f656
+  sha256: ff087b19d158644d3b0708eca10a5e40d692cdc8e95f53715f4490c6959f3768
+  md5: b40594d5da041824087eebe12228af42
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -3944,48 +3314,74 @@ packages:
   - libexpat >=2.7.3,<3.0a0
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
-  - liblzma >=5.8.1,<6.0a0
+  - liblzma >=5.8.2,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.51.1,<4.0a0
-  - libuuid >=2.41.2,<3.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libuuid >=2.41.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - python_abi 3.14.* *_cp314
-  - readline >=8.2,<9.0a0
+  - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 36790521
-  timestamp: 1765021515427
+  size: 36529771
+  timestamp: 1770271970971
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.2-hb06a95a_100_cp314.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.3-hb06a95a_100_cp314.conda
   build_number: 100
-  sha256: 41adf6ee7a953ef4f35551a4a910a196b0a75e1ded458df5e73ef321863cb3f2
-  md5: 432459e6961a5bc4cfe7cd080aee721a
+  sha256: 81e5b2d7e110c36309623ecb28096c218f23930a44f1236b3e169026810d83ed
+  md5: 13c0f5d64ac53aaa39a723baf42aa9b7
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-aarch64 >=2.36.1
   - libexpat >=2.7.3,<3.0a0
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
-  - liblzma >=5.8.1,<6.0a0
+  - liblzma >=5.8.2,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.51.1,<4.0a0
-  - libuuid >=2.41.2,<3.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libuuid >=2.41.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   - python_abi 3.14.* *_cp314
-  - readline >=8.2,<9.0a0
+  - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 37217543
-  timestamp: 1765020325291
+  size: 37325031
+  timestamp: 1770270771449
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.4.4-py314ha160325_0.conda
+  sha256: 1852e14fef6eda130196f1a345c2b85c820cdb8e805eae0beda761b8b23764ac
+  md5: bbae0419113914395680532186acd4d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  size: 16324839
+  timestamp: 1769722870168
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-duckdb-1.4.4-py314h02b5315_0.conda
+  sha256: d972927fccbdbf9697ab4fa383268f99b6beb16166d94112e210de8485418e6d
+  md5: 09365c87ecf28fc95401db95af0ce12c
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  size: 15035898
+  timestamp: 1769723223182
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8
   sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
@@ -3996,19 +3392,33 @@ packages:
   license_family: BSD
   size: 6989
   timestamp: 1752805904792
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-6.0.3-pyh7db6752_0.conda
-  sha256: 828af2fd7bb66afc9ab1c564c2046be391aaf66c0215f05afaf6d7a9a270fe2a
-  md5: b12f41c0d7fb5ab81709fcc86579688f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+  sha256: b318fb070c7a1f89980ef124b80a0b5ccf3928143708a85e0053cde0169c699d
+  md5: 2035f68f96be30dc60a5dfd7452c7941
   depends:
-  - python >=3.10.*
-  - yaml
-  track_features:
-  - pyyaml_no_compile
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
-  size: 45223
-  timestamp: 1758891992558
-- conda: https://conda.anaconda.org/rapidsai/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
+  size: 202391
+  timestamp: 1770223462836
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
+  sha256: 496b5e65dfdd0aaaaa5de0dcaaf3bceea00fcb4398acf152f89e567c82ec1046
+  md5: 9ae2c92975118058bd720e9ba2bb7c58
+  depends:
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 195678
+  timestamp: 1770223441816
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-64/rapids-logger-0.2.3-h98325ef_0.conda
   sha256: 6d0416d415128ce1219fe9d094447b12a612e02e7317006b3dcb3050a0f7f8d9
   md5: 81257f29bfcc1e58f0405d7bc9feb309
   depends:
@@ -4019,7 +3429,7 @@ packages:
   license: Apache-2.0
   size: 161775
   timestamp: 1759854063007
-- conda: https://conda.anaconda.org/rapidsai/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
+- conda: https://conda.anaconda.org/rapidsai-nightly/linux-aarch64/rapids-logger-0.2.3-h4f43097_0.conda
   sha256: cb75dcd7bfd660b8393de2b99da25c4ed832d600028565a8aac7d27bd98bf9a8
   md5: 80b24b10af3bc2116c047f7cf0390490
   depends:
@@ -4028,33 +3438,33 @@ packages:
   license: Apache-2.0
   size: 225119
   timestamp: 1759854009923
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-60.0-hecca717_0.conda
-  sha256: 5c09b833b698ecd19da14f5ff903063cf174382d6b32c86166984a93d427d681
-  md5: fe7412835a65cd99eacf3afbb124c7ac
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
+  sha256: 8e0b7962cf8bec9a016cd91a6c6dc1f9ebc8e7e316b1d572f7b9047d0de54717
+  md5: d487d93d170e332ab39803e05912a762
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libnl >=3.11.0,<4.0a0
   - libstdcxx >=14
-  - libsystemd0 >=257.9
-  - libudev1 >=257.9
+  - libsystemd0 >=257.10
+  - libudev1 >=257.10
   license: Linux-OpenIB
   license_family: BSD
-  size: 1244282
-  timestamp: 1761557737114
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-60.0-he839754_0.conda
-  sha256: c6ebff176e112940a7a9f269b671a51bc83708e6846fa0d7be451b74e18b9b4b
-  md5: 9e7498e2faf70daf30bd982c50038ffc
+  size: 1268666
+  timestamp: 1769154883613
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-61.0-h1f0f388_0.conda
+  sha256: 1c69fab2e833080d48f24d5ac06ea6745c470a8ef779d526bd1edd846184da7e
+  md5: 58f1eb9b507e3e098091840c6f1f9c11
   depends:
   - libgcc >=14
   - libnl >=3.11.0,<4.0a0
   - libstdcxx >=14
-  - libsystemd0 >=257.9
-  - libudev1 >=257.9
+  - libsystemd0 >=257.10
+  - libudev1 >=257.10
   license: Linux-OpenIB
   license_family: BSD
-  size: 1313626
-  timestamp: 1761557755128
+  size: 1341616
+  timestamp: 1769154919140
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -4063,6 +3473,7 @@ packages:
   - libgcc >=14
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
+  license_family: GPL
   size: 345073
   timestamp: 1765813471974
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
@@ -4072,6 +3483,7 @@ packages:
   - libgcc >=14
   - ncurses >=6.5,<7.0a0
   license: GPL-3.0-only
+  license_family: GPL
   size: 357597
   timestamp: 1765815673644
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
@@ -4093,19 +3505,6 @@ packages:
   license_family: MIT
   size: 207475
   timestamp: 1748644952027
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.12.0-he64ecbb_0.conda
-  sha256: c2fb2cb9eb41ead52001079524fb4aa00dac89cbed2cb80e9db835cd56ff7cd4
-  md5: 54f0b80bf39017285fdfa997b7426772
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - openssl >=3.5.4,<4.0a0
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6164069
-  timestamp: 1761009066321
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sccache-0.13.0-he64ecbb_0.conda
   sha256: 0fb3e7b2241715ab8db5de5667695fdc3a45b542bbf4c9e1a9fdc3fae48944db
   md5: d0b2ae6ccfd0375af8d03928b9e36089
@@ -4119,18 +3518,6 @@ packages:
   license_family: APACHE
   size: 6029394
   timestamp: 1768382654724
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.12.0-hb434046_0.conda
-  sha256: a442b109c84762303578645f61df2339c3df0715e51224bd35c71e486b8b3b2d
-  md5: a6e1d3d1cce788b667247554d01ddf4e
-  depends:
-  - libgcc >=14
-  - openssl >=3.5.4,<4.0a0
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6095971
-  timestamp: 1761009205819
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sccache-0.13.0-hb434046_0.conda
   sha256: 348b3761cd0fbec56890d2a0b1f9cc8257cb487d36d865322f85ccf85e8d4de3
   md5: 8544961884c5c91e329a5b3235216232
@@ -4143,26 +3530,15 @@ packages:
   license_family: APACHE
   size: 5944817
   timestamp: 1768382803294
-- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-  sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
-  md5: 4de79c071274a53dcaf2a8c749d1499e
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+  sha256: f5fcb7854d2b7639a5b1aca41dd0f2d5a69a60bbc313e7f192e2dc385ca52f86
+  md5: 7b446fcbb6779ee479debb4fd7453e6c
   depends:
-  - python >=3.9
+  - python >=3.10
   license: MIT
   license_family: MIT
-  size: 748788
-  timestamp: 1748804951958
-- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_8.conda
-  sha256: 0053c17ffbd9f8af1a7f864995d70121c292e317804120be4667f37c92805426
-  md5: 1bad93f0aa428d618875ef3a588a889e
-  depends:
-  - __glibc >=2.28
-  - kernel-headers_linux-64 4.18.0 he073ed8_8
-  - tzdata
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
-  license_family: GPL
-  size: 24210909
-  timestamp: 1752669140965
+  size: 678888
+  timestamp: 1769601206751
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
   sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
   md5: 13dc3adbc692664cd3beabd216434749
@@ -4174,17 +3550,6 @@ packages:
   license_family: GPL
   size: 24008591
   timestamp: 1765578833462
-- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_8.conda
-  sha256: 8ab275b5c5fbe36416c7d3fb8b71241eca2d024e222361f8e15c479f17050c0e
-  md5: 1263d6ac8dadaea7c60b29f1b4af45b8
-  depends:
-  - __glibc >=2.28
-  - kernel-headers_linux-aarch64 4.18.0 h05a177a_8
-  - tzdata
-  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
-  license_family: GPL
-  size: 23863575
-  timestamp: 1752669129101
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
   sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
   md5: fdf07ab944a222ff28c754914fdb0740
@@ -4196,31 +3561,31 @@ packages:
   license_family: GPL
   size: 23644746
   timestamp: 1765578629426
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
-  sha256: 1544760538a40bcd8ace2b1d8ebe3eb5807ac268641f8acdc18c69c5ebfeaf64
-  md5: 86bc20552bf46075e3d92b67f089172d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   constrains:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3284905
-  timestamp: 1763054914403
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h561c983_103.conda
-  sha256: 154e73f6269f92ad5257aa2039278b083998fd19d371e150f307483fb93c07ae
-  md5: 631db4799bc2bfe4daccf80bb3cbc433
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+  sha256: e25c314b52764219f842b41aea2c98a059f06437392268f09b03561e4f6e5309
+  md5: 7fc6affb9b01e567d2ef1d05b84aa6ed
   depends:
-  - libgcc >=13
+  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   constrains:
   - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3333495
-  timestamp: 1763059192223
+  size: 3368666
+  timestamp: 1769464148928
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
   md5: 0caa1af407ecff61170c9437a808404d
@@ -4231,21 +3596,15 @@ packages:
   license_family: PSF
   size: 51692
   timestamp: 1756220668932
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
-  md5: 4222072737ccff51314b5ece9c7d6f5a
-  license: LicenseRef-Public-Domain
-  size: 122968
-  timestamp: 1742727099393
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
   license: LicenseRef-Public-Domain
   size: 119135
   timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py314h9891dd4_6.conda
-  sha256: ef6753f6febaa74d35253e4e0dd09dc9497af8e370893bd97c479f59346daa57
-  md5: 28303a78c48916ab07b95ffdbffdfd6c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
+  sha256: c84034056dc938c853e4f61e72e5bd37e2ec91927a661fb9762f678cbea52d43
+  md5: 5d3c008e54c7f49592fca9c32896a76f
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi
@@ -4255,11 +3614,11 @@ packages:
   - python_abi 3.14.* *_cp314
   license: MIT
   license_family: MIT
-  size: 14762
-  timestamp: 1761594960135
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py314hd7d8586_6.conda
-  sha256: 0e323578e0def2dda684dad27f619dadea6ffa7364641c0ff6610d10aa285464
-  md5: 64e3941607577d1fe2deb09f45a8c90d
+  size: 15004
+  timestamp: 1769438727085
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.1.0-py314hd7d8586_0.conda
+  sha256: 0a7efe469d7e2a34a1d017bc51cf6fb9a51436730256983694c5ad74a33bd4e0
+  md5: f3a967efabf9cf450b7741487318ea6e
   depends:
   - cffi
   - libgcc >=14
@@ -4269,8 +3628,8 @@ packages:
   - python_abi 3.14.* *_cp314
   license: MIT
   license_family: MIT
-  size: 15565
-  timestamp: 1761595014547
+  size: 15756
+  timestamp: 1769438772414
 - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
   sha256: 489ee14dcc1080e45d07531e89b1c690a8df68ca6a817ade536e6ef4cdc77b9e
   md5: 7f58240fa4cd5b42607606333cf8b550
@@ -4288,19 +3647,6 @@ packages:
   license: LicenseRef-BSD-like
   size: 162036
   timestamp: 1754913052303
-- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
-  sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
-  md5: cfccfd4e8d9de82ed75c8e2c91cab375
-  depends:
-  - distlib >=0.3.7,<1
-  - filelock >=3.12.2,<4
-  - platformdirs >=3.9.1,<5
-  - python >=3.10
-  - typing_extensions >=4.13.2
-  license: MIT
-  license_family: MIT
-  size: 4401341
-  timestamp: 1761726489722
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.36.1-pyhd8ed1ab_0.conda
   sha256: fa0a21fdcd0a8e6cf64cc8cd349ed6ceb373f09854fd3c4365f0bc4586dccf9a
   md5: 6b0259cea8ffa6b66b35bae0ca01c447
@@ -4340,6 +3686,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
+  license_family: BSD
   size: 601375
   timestamp: 1764777111296
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
@@ -4348,5 +3695,6 @@ packages:
   depends:
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
+  license_family: BSD
   size: 614429
   timestamp: 1764777145593

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [workspace]
-channels = ["rapidsai", "conda-forge", "nvidia" ]
+channels = ["rapidsai-nightly", "conda-forge", "nvidia" ]
 name = "sirius"
 platforms = ["linux-64", "linux-aarch64"]
 requires-pixi = ">=0.59"
@@ -17,11 +17,13 @@ ninja = "*"
 sccache = "*"
 unzip = "*"
 
-libcudf = "25.12.*"
+libcudf = "26.04.*"
+librmm = "26.04.*"
 libcurand-dev = "*"
 pre-commit = "*"
 libconfig = "*"
 libabseil = ">=20260107.0"
+duckdb = ">=1.4.4,<2"
 
 [tasks]
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -60,6 +60,14 @@ void task_creator::set_pipeline_executor(sirius::pipeline::pipeline_executor& pi
   _pipeline_executor = &pipeline_executor;
 }
 
+void task_creator::drain_pending_tasks()
+{
+  // Drain any queued task creation requests that haven't been picked up yet
+  _task_creation_queue.drain();
+  // Wait for any in-flight task creation lambdas to finish
+  _kiosk.wait_all();
+}
+
 void task_creator::reset()
 {
   // Clear the scan operator global state map for the new query

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -311,6 +311,8 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
   // Get the bitmap
   auto bitmap = ExecuteExpression(0);
 
+  // (debug traces removed)
+
   // Apply the bitmap
   auto output_table =
     cudf::apply_boolean_mask(input_table, bitmap->view(), execution_stream, resource_ref);

--- a/src/expression_executor/regex/regex_playground.cpp
+++ b/src/expression_executor/regex/regex_playground.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<cudf::column> regex_playground::jit_transform_clickbench_q28_reg
   const cudf::column_view& input)
 {
   auto udf = R"***(
-__device__ void extract_domain(cudf::string_view* out, cuda::std::optional<cudf::string_view> const url_opt) {
+__device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda::std::optional<cudf::string_view> const url_opt) {
     // Skip null
     if (!url_opt.has_value()) {
         return;

--- a/src/gpu_buffer_manager.cpp
+++ b/src/gpu_buffer_manager.cpp
@@ -27,6 +27,7 @@
 #include "utils.hpp"
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 #define NUM_GPUS 1
 
@@ -209,7 +210,7 @@ GPUBufferManager::~GPUBufferManager()
     callCudaFree<uint8_t>(gpuCache[gpu], gpu);
     if (cpuCache[gpu] != nullptr) { freePinnedCPUMemory(cpuCache[gpu]); }
     // callCudaFree<uint8_t>(gpuProcessing[gpu], gpu);
-    mr->deallocate((void*)gpuProcessing[gpu], processing_size_per_gpu);
+    mr->deallocate(rmm::cuda_stream_view{}, (void*)gpuProcessing[gpu], processing_size_per_gpu);
   }
   Config::USE_PIN_MEM_FOR_CPU_PROCESSING ? freePinnedCPUMemory(cpuProcessing)
                                          : freePageableCPUMemory(cpuProcessing);
@@ -236,7 +237,7 @@ void GPUBufferManager::ResetBuffer()
       auto size = it->second;
       if (ptr != nullptr) {
         // customCudaFree<uint8_t>(reinterpret_cast<uint8_t*>(ptr), size, 0);
-        mr->deallocate((void*)ptr, size);
+        mr->deallocate(rmm::cuda_stream_view{}, (void*)ptr, size);
         // SIRIUS_LOG_DEBUG("Deallocating Pointer {} size {}", static_cast<void*>(ptr), size);
         // allocation_table[gpu].erase(it);
       }
@@ -253,7 +254,7 @@ void GPUBufferManager::ResetBuffer()
       if (ptr != nullptr) {
         // SIRIUS_LOG_DEBUG("Deallocating Locked Pointer {} size {}", static_cast<void*>(ptr),
         // size);
-        mr->deallocate((void*)ptr, size);
+        mr->deallocate(rmm::cuda_stream_view{}, (void*)ptr, size);
       }
     }
     locked_allocation_table[gpu].clear();
@@ -325,7 +326,7 @@ T* GPUBufferManager::customCudaMalloc(size_t size, int gpu, bool caching)
     return ptr;
   } else {
     cudf::set_current_device_resource(mr);
-    void* ptr = mr->allocate(alloc);
+    void* ptr = mr->allocate(rmm::cuda_stream_view{}, alloc);
     // SIRIUS_LOG_DEBUG("Allocating Pointer {} size {}", static_cast<void*>(ptr), alloc);
     if (ptr == nullptr) throw InvalidInputException("Pointer is nullptr");
     if (allocation_table[gpu].find(ptr) != allocation_table[gpu].end()) {
@@ -360,7 +361,7 @@ void GPUBufferManager::customCudaFree(uint8_t* ptr, int gpu)
   auto it = allocation_table[gpu].find(reinterpret_cast<void*>(ptr));
   if (it != allocation_table[gpu].end()) {
     // SIRIUS_LOG_DEBUG("Deallocating Pointer {} size {}", static_cast<void*>(ptr), it->second);
-    mr->deallocate((void*)ptr, it->second);
+    mr->deallocate(rmm::cuda_stream_view{}, (void*)ptr, it->second);
     allocation_table[gpu].erase(it);
   } else {
     auto locked_it = locked_allocation_table[gpu].find(reinterpret_cast<void*>(ptr));

--- a/src/include/cpu_cache.hpp
+++ b/src/include/cpu_cache.hpp
@@ -25,8 +25,6 @@
 #include <utility>
 #include <vector>
 
-using namespace std;
-
 namespace duckdb {
 
 class CPUCache {

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -222,6 +222,14 @@ class task_creator {
   void stop_thread_pool();
 
   /**
+   * @brief Drain all pending task creation requests and wait for in-flight tasks to complete.
+   *
+   * Call this after a query completes (future resolved) but before destroying the engine/operators
+   * to ensure no stale operator pointers are accessed by the task creator threads.
+   */
+  void drain_pending_tasks();
+
+  /**
    * @brief Schedule a task creation info for processing.
    *
    * @param info The task creation info to schedule.

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -47,9 +47,9 @@
 #include <cudf/unary.hpp>
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/types.hpp>

--- a/src/include/gpu_columns.hpp
+++ b/src/include/gpu_columns.hpp
@@ -19,7 +19,6 @@
 #include "cudf_utils.hpp"
 #include "duckdb/common/types.hpp"
 #include "helper/common.h"
-using namespace std;
 
 namespace duckdb {
 

--- a/src/include/memory/sirius_memory_reservation_manager.hpp
+++ b/src/include/memory/sirius_memory_reservation_manager.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 
 #include <cucascade/memory/memory_reservation_manager.hpp>
 

--- a/src/memory/sirius_memory_reservation_manager.cpp
+++ b/src/memory/sirius_memory_reservation_manager.cpp
@@ -19,7 +19,7 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 
 #include <cucascade/memory/memory_reservation_manager.hpp>
 
@@ -63,7 +63,7 @@ class sirius_device_memory_resource : public rmm::mr::device_memory_resource {
       throw std::runtime_error("No device memory resource found for device id: " +
                                std::to_string(dev_id.value()));
     }
-    return it->second->allocate(bytes, stream);
+    return it->second->allocate(stream, bytes);
   }
 
   void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
@@ -71,7 +71,7 @@ class sirius_device_memory_resource : public rmm::mr::device_memory_resource {
     auto dev_id = rmm::get_current_cuda_device();
     auto it     = per_device_device_memory_resource_map_.find(dev_id.value());
     assert(it != per_device_device_memory_resource_map_.end());
-    it->second->deallocate(ptr, bytes, stream);
+    it->second->deallocate(stream, ptr, bytes);
   }
 
   [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -207,7 +207,7 @@ void duckdb_scan_executor::manager_loop()
         auto batches   = get_scan_output(scan_task);
         scan_task->publish_output(std::move(batches));
         t.reset();
-        if (_task_creator) {
+        if (_task_creator && !(_completion_handler && _completion_handler->is_completed())) {
           for (auto* consumer : consumers) {
             _task_creator->schedule(consumer);
           }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -50,8 +50,11 @@ duckdb_scan_task_global_state::duckdb_scan_task_global_state(
 {
   // Initialize global table function state
   if (_op.function.init_global) {
-    duckdb::TableFunctionInitInput tf_input(
-      _op.bind_data.get(), _op.column_ids, _op.scanned_ids, nullptr, _op.extra_info.sample_options);
+    duckdb::TableFunctionInitInput tf_input(_op.bind_data.get(),
+                                            _op.column_ids,
+                                            _op.scanned_ids,
+                                            _op.table_filters.get(),
+                                            _op.extra_info.sample_options);
     _global_tf_state = _op.function.init_global(client_ctx, tf_input);
   }
 
@@ -388,8 +391,11 @@ void duckdb_scan_task_local_state::initialize_local_table_function_state(
   // Note: local_tf_state might already be set if it was moved from a previous task
   // Only create a new one if it doesn't exist
   if (!_local_tf_state && op.function.init_local) {
-    duckdb::TableFunctionInitInput tf_input(
-      op.bind_data.get(), op.column_ids, op.projection_ids, nullptr, op.extra_info.sample_options);
+    duckdb::TableFunctionInitInput tf_input(op.bind_data.get(),
+                                            op.column_ids,
+                                            op.projection_ids,
+                                            op.table_filters.get(),
+                                            op.extra_info.sample_options);
     _local_tf_state = op.function.init_local(exec_ctx, tf_input, global_tf_state);
   }
 }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -49,11 +49,14 @@ duckdb_scan_task_global_state::duckdb_scan_task_global_state(
     _op(*scan_op)
 {
   // Initialize global table function state
+  // Note: We pass nullptr for table_filters because filters are applied by the Sirius physical
+  // table scan operator, not by the DuckDB table function. This ensures consistent filtering
+  // behavior and allows GPU-accelerated filter execution.
   if (_op.function.init_global) {
     duckdb::TableFunctionInitInput tf_input(_op.bind_data.get(),
                                             _op.column_ids,
                                             _op.scanned_ids,
-                                            _op.table_filters.get(),
+                                            nullptr,  // Don't pass filters to DuckDB
                                             _op.extra_info.sample_options);
     _global_tf_state = _op.function.init_global(client_ctx, tf_input);
   }
@@ -64,7 +67,8 @@ duckdb_scan_task_global_state::duckdb_scan_task_global_state(
       "In-out table functions are not supported in sirius table scans.");
   }
 
-  // For caching reasons, we do not push table filters into the scan
+  // Dynamic filters (from joins) are not supported. Regular table_filters (from WHERE clauses) are
+  // supported.
   if (_op.dynamic_filters) {
     throw duckdb::NotImplementedException(
       "Dynamic table filters are not supported in sirius table scans.");
@@ -390,11 +394,12 @@ void duckdb_scan_task_local_state::initialize_local_table_function_state(
 {
   // Note: local_tf_state might already be set if it was moved from a previous task
   // Only create a new one if it doesn't exist
+  // Don't pass filters to DuckDB - they're applied by Sirius physical table scan
   if (!_local_tf_state && op.function.init_local) {
     duckdb::TableFunctionInitInput tf_input(op.bind_data.get(),
                                             op.column_ids,
                                             op.projection_ids,
-                                            op.table_filters.get(),
+                                            nullptr,  // Don't pass filters to DuckDB
                                             op.extra_info.sample_options);
     _local_tf_state = op.function.init_local(exec_ctx, tf_input, global_tf_state);
   }

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -47,13 +47,18 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_li
 {
   SIRIUS_LOG_DEBUG("Executing streaming limit");
 
-  if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE ||
-      offset_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
-    throw duckdb::NotImplementedException("Streaming limit with non-constant limit/offset");
+  if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
+    throw duckdb::NotImplementedException("Streaming limit with non-constant limit value");
+  }
+  if (offset_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE &&
+      offset_val.Type() != duckdb::LimitNodeType::UNSET) {
+    throw duckdb::NotImplementedException("Streaming limit with non-constant offset value");
   }
 
   auto limit_const  = static_cast<cudf::size_type>(limit_val.GetConstantValue());
-  auto offset_const = static_cast<cudf::size_type>(offset_val.GetConstantValue());
+  auto offset_const = offset_val.Type() == duckdb::LimitNodeType::CONSTANT_VALUE
+                        ? static_cast<cudf::size_type>(offset_val.GetConstantValue())
+                        : cudf::size_type{0};
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(input_batches.size());

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -224,9 +224,6 @@ std::optional<task_creation_hint> sirius_physical_operator::get_next_task_hint()
     auto* producer = &(unfinished_barrier->second->src_pipeline->get_operators()[0].get());
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
   }
-  // WSM TODO: we may want to implement the status of where it says that all tasks are scheduled but
-  // not complete yet. so that we dont return a waiting for input data which will result in no task
-  // getting created
 
   // if no unfinished barriers, then is this operator ready to create a task?
   if (std::all_of(ports.begin(), ports.end(), [](const auto& port_pair) {

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -28,6 +28,10 @@
 #include "log/logging.hpp"
 #include "utils.hpp"
 
+#include <cudf/table/table.hpp>
+
+#include <cucascade/data/gpu_data_representation.hpp>
+
 namespace sirius {
 namespace op {
 
@@ -65,12 +69,7 @@ sirius_physical_table_scan::sirius_physical_table_scan(
     gen_row_id_column(column_ids.back().GetPrimaryIndex() == duckdb::DConstants::INVALID_INDEX)
 {
   auto num_cols = column_ids.size() - gen_row_id_column;
-  // duckdb::GPUBufferManager* gpuBufferManager = &(duckdb::GPUBufferManager::GetInstance());
-  // column_size = gpuBufferManager->customCudaHostAlloc<uint64_t>(column_ids.size());
-  // mask_size   = gpuBufferManager->customCudaHostAlloc<uint64_t>(column_ids.size());
   for (int col = 0; col < num_cols; col++) {
-    // column_size[col] = 0;
-    // mask_size[col]   = 0;
     scanned_types.push_back(returned_types[column_ids[col].GetPrimaryIndex()]);
     scanned_ids.push_back(col);
   }
@@ -80,21 +79,14 @@ sirius_physical_table_scan::sirius_physical_table_scan(
   }
 
   fake_table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  // already_cached     = gpuBufferManager->customCudaHostAlloc<bool>(column_ids.size());
-  // if (Config::USE_OPT_TABLE_SCAN) {
-  //   num_rows = 0;
-  //   cuda_streams.resize(Config::OPT_TABLE_SCAN_NUM_CUDA_STREAMS);
-  //   for (int i = 0; i < Config::OPT_TABLE_SCAN_NUM_CUDA_STREAMS; i++) {
-  //     cudaStreamCreate(&cuda_streams[i]);
-  //   }
-  // }
   SIRIUS_LOG_DEBUG("Table scan column ids: {}", column_ids.size());
 }
 
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
-  const duckdb::vector<duckdb::LogicalType>& returned_types)
+  const duckdb::vector<duckdb::LogicalType>& returned_types,
+  const duckdb::vector<duckdb::idx_t>& projection_ids)
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> filter_expressions;
 
@@ -105,12 +97,20 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
       continue;
     }
 
-    // Create column reference for this filter
-    auto col_type   = returned_types[column_ids[column_index].GetPrimaryIndex()];
-    auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(col_type, column_index);
+    auto primary_idx = column_ids[column_index].GetPrimaryIndex();
+    auto col_type    = returned_types[primary_idx];
+
+    // The batch columns are produced by DuckDB scan in the same order as column_ids.
+    // So the batch column index is just the column_index itself.
+    duckdb::idx_t batch_column_index = column_index;
+
+    // Create column reference for this filter - uses the batch column index
+    auto column_ref =
+      duckdb::make_uniq<duckdb::BoundReferenceExpression>(col_type, batch_column_index);
 
     // Convert filter to expression
-    filter_expressions.push_back(filter->ToExpression(*column_ref));
+    auto expr = filter->ToExpression(*column_ref);
+    filter_expressions.push_back(std::move(expr));
   }
 
   // No filters to apply
@@ -132,23 +132,23 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_table_scan::
   const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches)
 {
   auto start = std::chrono::high_resolution_clock::now();
-  SIRIUS_LOG_DEBUG("Executing table scan");
+
   duckdb::unique_ptr<duckdb::Expression> filter_expr;
   if (table_filters) {
-    filter_expr = convert_table_filters_to_expression(*table_filters, column_ids, returned_types);
+    filter_expr = convert_table_filters_to_expression(
+      *table_filters, column_ids, returned_types, projection_ids);
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(input_batches.size());
 
   if (filter_expr != nullptr) {
-    SIRIUS_LOG_DEBUG("Converted table filters to expression: {}", filter_expr->ToString());
-
     // The executor uses the data_batch API to filter rows according to `expression`.
-
     duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*filter_expr);
-    for (auto const& batch : input_batches) {
+    for (size_t batch_idx = 0; batch_idx < input_batches.size(); batch_idx++) {
+      auto const& batch = input_batches[batch_idx];
       if (!batch) { continue; }
+
       auto filtered_batch = gpu_expression_executor.select(batch);
       if (filtered_batch) { output_batches.push_back(std::move(filtered_batch)); }
     }
@@ -156,6 +156,54 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_table_scan::
     for (auto const& batch : input_batches) {
       if (batch) { output_batches.push_back(batch); }
     }
+  }
+
+  // After filtering, we may need to project away filter-only columns.
+  // The 'types' member indicates the expected output columns (not including filter-only columns).
+  // If we have more columns than expected output types, we need to project.
+  duckdb::idx_t expected_output_columns = types.size();
+  bool needs_projection                 = false;
+
+  if (!output_batches.empty() && output_batches[0]) {
+    auto& first_batch_rep =
+      output_batches[0]->get_data()->cast<cucascade::gpu_table_representation>();
+    auto& first_table = first_batch_rep.get_table();
+    if (first_table.num_columns() > expected_output_columns) { needs_projection = true; }
+  }
+
+  if (needs_projection) {
+    // The batch columns are in the same order as column_ids.
+    // projection_ids tells us which column_ids indices to select for output.
+    // We want the first expected_output_columns elements from projection_ids.
+    std::vector<std::shared_ptr<cucascade::data_batch>> projected_batches;
+    projected_batches.reserve(output_batches.size());
+
+    for (auto& batch : output_batches) {
+      if (!batch) { continue; }
+
+      // Release the table from the batch (zero-copy: we're the sole consumer)
+      auto& gpu_rep = batch->get_data()->cast<cucascade::gpu_table_representation>();
+      auto table    = gpu_rep.release_table();
+      auto columns  = table->release();
+
+      // Select only the output columns by moving ownership
+      std::vector<std::unique_ptr<cudf::column>> selected;
+      selected.reserve(expected_output_columns);
+      for (duckdb::idx_t i = 0; i < expected_output_columns; i++) {
+        selected.push_back(std::move(columns[projection_ids[i]]));
+      }
+
+      auto projected_table = std::make_unique<cudf::table>(std::move(selected));
+      auto* space          = batch->get_memory_space();
+      auto projected_rep =
+        std::make_unique<cucascade::gpu_table_representation>(std::move(projected_table), *space);
+      auto projected_batch =
+        std::make_shared<cucascade::data_batch>(batch->get_batch_id(), std::move(projected_rep));
+
+      projected_batches.push_back(std::move(projected_batch));
+    }
+
+    output_batches = std::move(projected_batches);
   }
 
   auto end      = std::chrono::high_resolution_clock::now();

--- a/src/operator/gpu_physical_limit.cpp
+++ b/src/operator/gpu_physical_limit.cpp
@@ -20,6 +20,8 @@
 #include "log/logging.hpp"
 #include "operator/gpu_materialize.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 GPUPhysicalStreamingLimit::GPUPhysicalStreamingLimit(vector<LogicalType> types,
@@ -55,7 +57,7 @@ OperatorResultType GPUPhysicalStreamingLimit::Execute(
     shared_ptr<GPUColumn> materialize_column =
       HandleMaterializeExpression(input_relation.columns[col_idx], gpuBufferManager);
 
-    limit_const = min(limit_const, materialize_column->column_length);
+    limit_const = std::min(limit_const, materialize_column->column_length);
     output_relation.columns[col_idx] =
       make_shared_ptr<GPUColumn>(limit_const,
                                  materialize_column->data_wrapper.type,

--- a/src/operator/gpu_physical_top_n.cpp
+++ b/src/operator/gpu_physical_top_n.cpp
@@ -27,6 +27,8 @@
 #include "log/logging.hpp"
 #include "utils.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 GPUPhysicalTopN::GPUPhysicalTopN(vector<LogicalType> types_p,
@@ -154,8 +156,8 @@ SourceResultType GPUPhysicalTopN::GetData(GPUIntermediateRelation& output_relati
                                    sort_result->columns[col]->data_wrapper.is_string_data,
                                    nullptr);
     } else {
-      auto limit_const              = min(limit, sort_result->columns[col]->column_length - offset);
-      uint8_t* output_col_data      = sort_result->columns[col]->data_wrapper.data;
+      auto limit_const         = std::min(limit, sort_result->columns[col]->column_length - offset);
+      uint8_t* output_col_data = sort_result->columns[col]->data_wrapper.data;
       uint64_t* output_col_offset   = sort_result->columns[col]->data_wrapper.offset;
       uint64_t output_col_num_bytes = sort_result->columns[col]->data_wrapper.num_bytes;
       if (sort_result->columns[col]->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR) {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -116,19 +116,25 @@ void gpu_pipeline_executor::manager_loop()
       }
       task.reset();
 
-      if (_task_creator) {
+      // Check if query is complete BEFORE scheduling downstream tasks.
+      // mark_completed() signals the future that engine.execute() is waiting on,
+      // which may destroy the engine and its operators. We must not schedule
+      // tasks that reference those operators after signaling completion.
+      bool query_complete = false;
+      if (_completion_handler && pipeline) {
+        auto sink = pipeline->get_sink();
+        if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+          query_complete = pipeline->is_pipeline_finished();
+        }
+      }
+
+      if (!query_complete && _task_creator) {
         for (auto* consumer : consumers) {
           _task_creator->schedule(consumer);
         }
       }
 
-      // Check if query is complete (sink is RESULT_COLLECTOR and pipeline is finished)
-      if (_completion_handler && pipeline) {
-        auto sink = pipeline->get_sink();
-        if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
-          if (pipeline->is_pipeline_finished()) { _completion_handler->mark_completed(); }
-        }
-      }
+      if (query_complete && _completion_handler) { _completion_handler->mark_completed(); }
     });
   }
 }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -207,10 +207,12 @@ std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consume
       _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get() == nullptr) {
     return output_consumers;
   }
-  auto parents =
-    _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_parents();
-  for (auto& parent : parents) {
-    output_consumers.push_back(&parent->get_operators()[0].get());
+  auto* pipeline = _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get();
+  auto sink      = pipeline->get_sink();
+  if (!sink) { return output_consumers; }
+  auto& ports = sink->get_next_port_after_sink();
+  for (auto& [child, port_id] : ports) {
+    output_consumers.push_back(child);
   }
   return output_consumers;
 }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -207,12 +207,10 @@ std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consume
       _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get() == nullptr) {
     return output_consumers;
   }
-  auto* pipeline = _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get();
-  auto sink      = pipeline->get_sink();
-  if (!sink) { return output_consumers; }
-  auto& ports = sink->get_next_port_after_sink();
-  for (auto& [child, port_id] : ports) {
-    output_consumers.push_back(child);
+  auto parents =
+    _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_parents();
+  for (auto& parent : parents) {
+    output_consumers.push_back(&parent->get_operators()[0].get());
   }
   return output_consumers;
 }

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -230,10 +230,29 @@ static bool can_use_perfect_hash_aggregate(duckdb::ClientContext& context,
   return true;
 }
 
+/// cuDF does not support HUGEINT (int128). DuckDB widens aggregates like sum(int32) to HUGEINT
+/// to avoid overflow. We downcast to BIGINT at the plan level so all downstream operators
+/// (including the result collector) use the correct type.
+static void downcast_hugeint_types(duckdb::vector<duckdb::LogicalType>& types,
+                                   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& exprs)
+{
+  for (auto& type : types) {
+    if (type == duckdb::LogicalType::HUGEINT) { type = duckdb::LogicalType::BIGINT; }
+  }
+  for (auto& expr : exprs) {
+    if (expr->return_type == duckdb::LogicalType::HUGEINT) {
+      expr->return_type = duckdb::LogicalType::BIGINT;
+    }
+  }
+}
+
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
 {
   D_ASSERT(op.children.size() == 1);
+
+  // Downcast HUGEINT to BIGINT since cuDF does not support int128
+  downcast_hugeint_types(op.types, op.expressions);
 
   auto plan = create_plan(*op.children[0]);
 

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -114,9 +114,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> filter;
   auto& projection_ids = op.projection_ids;
 
+  // With FILTER_PUSHDOWN optimizer disabled, table_filters should always be empty.
+  // The filter is handled as a separate LogicalFilter operator in the plan.
   if (table_filters && op.function.supports_pushdown_type) {
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
-    duckdb::unique_ptr<duckdb::Expression> unsupported_filter;
     duckdb::unordered_set<duckdb::idx_t> to_remove;
     for (auto& entry : table_filters->filters) {
       auto column_id = column_ids[entry.first].GetPrimaryIndex();

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -54,49 +54,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   auto column_ids = op.GetColumnIds();
   if (!op.children.empty()) {
     throw duckdb::NotImplementedException("Table Input Output functions are not supported yet");
-    // duckdb::reference<sirius::op::sirius_physical_operator> child =
-    // ResolveAndPlan(std::move(op.children[0])); auto &child_types = child.get().types;
-
-    // // this is for table producing functions that consume subquery results
-    // // push a projection node with casts if required
-    // if (child_types.size() < op.input_table_types.size()) {
-    // 	throw duckdb::InternalException(
-    // 	    "Mismatch between input table types and child node types - expected %llu but got %llu",
-    // 	    op.input_table_types.size(), child_types.size());
-    // }
-
-    // duckdb::vector<duckdb::LogicalType> return_types;
-    // duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions;
-    // bool any_cast_required = false;
-    // for (duckdb::idx_t proj_idx = 0; proj_idx < child_types.size(); proj_idx++) {
-    // 	auto ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(child_types[proj_idx],
-    // proj_idx); 	auto &target_type = 	    proj_idx < op.input_table_types.size() ?
-    // op.input_table_types[proj_idx] : child_types[proj_idx]; 	if (child_types[proj_idx] !=
-    // target_type) {
-    // 		// cast is required - push a cast
-    // 		any_cast_required = true;
-    // 		auto cast = duckdb::BoundCastExpression::AddCastToType(context, std::move(ref),
-    // target_type); 		expressions.push_back(std::move(cast)); 	} else {
-    // 		expressions.push_back(std::move(ref));
-    // 	}
-    // 	return_types.push_back(target_type);
-    // }
-
-    // if (any_cast_required) {
-    // 	auto &proj = Make<sirius::op::sirius_physical_operator>(std::move(return_types),
-    // std::move(expressions), child.get().estimated_cardinality); 	proj.children.push_back(child);
-    // 	child = proj;
-    // }
-
-    // auto &table_in_out =
-    //     Make<PhysicalTableInOutFunction>(op.types, op.function, std::move(op.bind_data),
-    //     column_ids,
-    //                                      op.estimated_cardinality,
-    //                                      std::move(op.projected_input));
-    // table_in_out.children.push_back(child);
-    // auto &cast_table_in_out = table_in_out.Cast<PhysicalTableInOutFunction>();
-    // cast_table_in_out.ordinality_idx = op.ordinality_idx;
-    // return table_in_out;
   }
 
   if (!op.projected_input.empty()) {
@@ -114,28 +71,46 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> filter;
   auto& projection_ids = op.projection_ids;
 
-  // With FILTER_PUSHDOWN optimizer disabled, table_filters should always be empty.
-  // The filter is handled as a separate LogicalFilter operator in the plan.
+  // With FILTER_PUSHDOWN enabled, filters from WHERE clauses are pushed into table_filters.
+  // Since we don't pass filters to the DuckDB table function (they're applied by Sirius),
+  // we need to ensure all filter columns are included in BOTH column_ids and projection_ids.
+  // We track the original projection_ids so we can project back after filtering.
+  duckdb::vector<duckdb::idx_t> original_projection_ids = projection_ids;
+
+  // Save the original types before we modify projection_ids, because modifying projection_ids
+  // might affect the types when we call ResolveOperatorTypes()
+  duckdb::vector<duckdb::LogicalType> original_types = op.types;
+
+  if (table_filters) {
+    for (auto& entry : table_filters->filters) {
+      // entry.first is the column index in the table_filters (after remapping by
+      // create_table_filter_set) We need to ensure this column is in projection_ids so it gets
+      // scanned by DuckDB
+
+      bool found_in_projection = false;
+      for (duckdb::idx_t j = 0; j < projection_ids.size(); j++) {
+        if (projection_ids[j] == entry.first) {
+          found_in_projection = true;
+          break;
+        }
+      }
+
+      if (!found_in_projection) { projection_ids.push_back(entry.first); }
+    }
+  }
+
+  // Handle cases where table function doesn't support pushdown for specific column types
   if (table_filters && op.function.supports_pushdown_type) {
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
     duckdb::unordered_set<duckdb::idx_t> to_remove;
     for (auto& entry : table_filters->filters) {
       auto column_id = column_ids[entry.first].GetPrimaryIndex();
       auto& type     = op.returned_types[column_id];
+
+      // If the table function doesn't support pushdown for this column type,
+      // create a separate filter operator for it
       if (!op.function.supports_pushdown_type(*op.bind_data, column_id)) {
         duckdb::idx_t column_id_filter = entry.first;
-        bool found_projection          = false;
-        for (duckdb::idx_t i = 0; i < projection_ids.size(); i++) {
-          if (column_ids[projection_ids[i]] == column_ids[entry.first]) {
-            column_id_filter = i;
-            found_projection = true;
-            break;
-          }
-        }
-        if (!found_projection) {
-          projection_ids.push_back(entry.first);
-          column_id_filter = projection_ids.size() - 1;
-        }
         auto column = duckdb::make_uniq<duckdb::BoundReferenceExpression>(type, column_id_filter);
         select_list.push_back(entry.second->ToExpression(*column));
         to_remove.insert(entry.first);
@@ -159,12 +134,6 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   // create the table scan node
   if (!op.function.projection_pushdown) {
     // function does not support projection pushdown
-    // auto &table_scan = Make<sirius::op::sirius_physical_table_scan>(
-    //     op.returned_types, op.function, std::move(op.bind_data), op.returned_types, column_ids,
-    //     duckdb::vector<duckdb::column_t>(), op.names, std::move(table_filters),
-    //     op.estimated_cardinality, std::move(op.extra_info), std::move(op.parameters),
-    //     std::move(op.virtual_columns));
-
     auto node =
       duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(op.returned_types,
                                                                 op.function,
@@ -222,19 +191,19 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     return std::move(projection);
   }
 
-  auto node =
-    duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(op.types,
-                                                              op.function,
-                                                              std::move(op.bind_data),
-                                                              op.returned_types,
-                                                              column_ids,
-                                                              op.projection_ids,
-                                                              op.names,
-                                                              std::move(table_filters),
-                                                              op.estimated_cardinality,
-                                                              std::move(op.extra_info),
-                                                              std::move(op.parameters),
-                                                              std::move(op.virtual_columns));
+  auto node = duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(
+    original_types,  // Use original types, not modified
+    op.function,
+    std::move(op.bind_data),
+    op.returned_types,
+    column_ids,
+    op.projection_ids,
+    op.names,
+    std::move(table_filters),
+    op.estimated_cardinality,
+    std::move(op.extra_info),
+    std::move(op.parameters),
+    std::move(op.virtual_columns));
   node->dynamic_filters = op.dynamic_filters;
   if (filter) {
     filter->children.push_back(std::move(node));

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -64,30 +64,14 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalLimit& op)
       //                                         op.estimated_cardinality);
       break;
     default:
-      if (!preserve_insertion_order(*plan)) {
-        // use parallel streaming limit if insertion order is not important
-        limit =
-          duckdb::make_uniq<sirius::op::sirius_physical_streaming_limit>(op.types,
-                                                                         std::move(op.limit_val),
-                                                                         std::move(op.offset_val),
-                                                                         op.estimated_cardinality,
-                                                                         true);
-      } else {
-        throw duckdb::NotImplementedException(
-          "Streaming limit with insertion order preservation not supported in GPU");
-        // maintaining insertion order is important
-        // 	if (use_batch_index(*plan) && use_batch_limit(op.limit_val, op.offset_val)) {
-        // 		// source supports batch index: use parallel batch limit
-        // 		throw duckdb::NotImplementedException("Batch limit not supported in GPU");
-        // 		// limit = duckdb::make_uniq<PhysicalLimit>(op.types, std::move(op.limit_val),
-        // std::move(op.offset_val),
-        // 		//                                  op.estimated_cardinality);
-        // 	} else {
-        // 		// source does not support batch index: use a non-parallel streaming limit
-        // 		limit = duckdb::make_uniq<sirius::op::sirius_physical_streaming_limit>(op.types,
-        // std::move(op.limit_val), std::move(op.offset_val), op.estimated_cardinality, false);
-        // 	}
-      }
+      // GPU pipeline compares all limits at the end, so insertion order does not matter.
+      // Always use parallel streaming limit.
+      limit =
+        duckdb::make_uniq<sirius::op::sirius_physical_streaming_limit>(op.types,
+                                                                       std::move(op.limit_val),
+                                                                       std::move(op.offset_val),
+                                                                       op.estimated_cardinality,
+                                                                       true);
       break;
   }
 

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -321,8 +321,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
     // get data_repo_manager from sirius context
     auto& data_repo_manager = context.registered_state->Get<duckdb::SiriusContext>("sirius_state")
                                 ->get_data_repository_manager();
-    unordered_map<const op::sirius_physical_operator*,
-                  duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>>
+    std::unordered_map<const op::sirius_physical_operator*,
+                       duckdb::vector<duckdb::shared_ptr<pipeline::sirius_pipeline>>>
       source_to_pipelines;
 
     for (size_t i = 0; i < copied_scheduled.size(); i++) {
@@ -728,7 +728,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
                               data_repo_manager.get_repository(op_id, port_id).get(),
                               new_scheduled[i],
                               dependent_pipeline));
-          new_scheduled[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
+          new_scheduled[i]->get_sink()->add_next_port_after_sink(std::make_pair(next_op, port_id));
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
         // No action needed for RESULT_COLLECTOR sinks

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -356,6 +356,7 @@ unique_ptr<FunctionData> SiriusExtension::GPUExecutionBind(ClientContext& contex
                                                            vector<string>& names)
 {
   auto result              = make_uniq<SiriusTableFunctionData>();
+  result->conn             = make_uniq<Connection>(*context.db);
   result->query            = input.inputs[0].ToString();
   result->enable_optimizer = true;
   result->sirius_iface     = make_uniq<::sirius::sirius_interface>(context);
@@ -419,6 +420,7 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
       data.res =
         data.sirius_iface->sirius_execute_query(context, data.query, data.gpu_prepared, {});
       if (data.res->HasError()) {
+        fprintf(stderr, "SiriusExecuteQuery error: %s\n", data.res->GetError().c_str());
         printf(
           "=============================================\nError in SiriusExecuteQuery, fallback to "
           "DuckDB\n=============================================\n");

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -89,6 +89,9 @@ struct GPUTableFunctionData : public TableFunctionData {
       DBConfig::GetConfig(context).options.disabled_optimizers;
     disabled_optimizers.insert(OptimizerType::IN_CLAUSE);
     disabled_optimizers.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+    // The Sirius scan does not apply table_filters (for caching), so keep filters
+    // as explicit LogicalFilter operators rather than pushing them into the scan.
+    disabled_optimizers.insert(OptimizerType::FILTER_PUSHDOWN);
     // disabled_optimizers.insert(OptimizerType::MATERIALIZED_CTE);
     // If error(varchar) gets implemented in substrait this can be removed
     // context.config.scalar_subquery_error_on_multiple_rows = false;
@@ -172,6 +175,9 @@ struct SiriusTableFunctionData : public TableFunctionData {
       DBConfig::GetConfig(context).options.disabled_optimizers;
     disabled_optimizers.insert(OptimizerType::IN_CLAUSE);
     disabled_optimizers.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+    // The Sirius scan does not apply table_filters (for caching), so keep filters
+    // as explicit LogicalFilter operators rather than pushing them into the scan.
+    disabled_optimizers.insert(OptimizerType::FILTER_PUSHDOWN);
     // disabled_optimizers.insert(OptimizerType::MATERIALIZED_CTE);
     // If error(varchar) gets implemented in substrait this can be removed
     // context.config.scalar_subquery_error_on_multiple_rows = false;
@@ -372,6 +378,12 @@ unique_ptr<FunctionData> SiriusExtension::GPUExecutionBind(ClientContext& contex
   planner.CreatePlan(std::move(parser.statements[0]));
   D_ASSERT(planner.plan);
 
+  // cuDF does not support HUGEINT (int128). DuckDB widens aggregates like sum(int32) to HUGEINT.
+  // Downcast to BIGINT so all downstream operators and the result collector use a supported type.
+  for (auto& type : planner.types) {
+    if (type == LogicalType::HUGEINT) { type = LogicalType::BIGINT; }
+  }
+
   auto prepared       = make_shared_ptr<PreparedStatementData>(statement_type);
   prepared->names     = planner.names;
   prepared->types     = planner.types;
@@ -420,7 +432,7 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
       data.res =
         data.sirius_iface->sirius_execute_query(context, data.query, data.gpu_prepared, {});
       if (data.res->HasError()) {
-        fprintf(stderr, "SiriusExecuteQuery error: %s\n", data.res->GetError().c_str());
+        SIRIUS_LOG_ERROR("SiriusExecuteQuery error: {}", data.res->GetError());
         printf(
           "=============================================\nError in SiriusExecuteQuery, fallback to "
           "DuckDB\n=============================================\n");

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -89,9 +89,6 @@ struct GPUTableFunctionData : public TableFunctionData {
       DBConfig::GetConfig(context).options.disabled_optimizers;
     disabled_optimizers.insert(OptimizerType::IN_CLAUSE);
     disabled_optimizers.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
-    // The Sirius scan does not apply table_filters (for caching), so keep filters
-    // as explicit LogicalFilter operators rather than pushing them into the scan.
-    disabled_optimizers.insert(OptimizerType::FILTER_PUSHDOWN);
     // disabled_optimizers.insert(OptimizerType::MATERIALIZED_CTE);
     // If error(varchar) gets implemented in substrait this can be removed
     // context.config.scalar_subquery_error_on_multiple_rows = false;
@@ -175,9 +172,6 @@ struct SiriusTableFunctionData : public TableFunctionData {
       DBConfig::GetConfig(context).options.disabled_optimizers;
     disabled_optimizers.insert(OptimizerType::IN_CLAUSE);
     disabled_optimizers.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
-    // The Sirius scan does not apply table_filters (for caching), so keep filters
-    // as explicit LogicalFilter operators rather than pushing them into the scan.
-    disabled_optimizers.insert(OptimizerType::FILTER_PUSHDOWN);
     // disabled_optimizers.insert(OptimizerType::MATERIALIZED_CTE);
     // If error(varchar) gets implemented in substrait this can be removed
     // context.config.scalar_subquery_error_on_multiple_rows = false;

--- a/test/cpp/integration/CMakeLists.txt
+++ b/test/cpp/integration/CMakeLists.txt
@@ -14,21 +14,6 @@
 # the License.
 # =============================================================================
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-add_subdirectory(utils)
-add_subdirectory(memory)
-add_subdirectory(memory_management)
-add_subdirectory(parallel)
-add_subdirectory(data)
-add_subdirectory(operator)
-add_subdirectory(scan)
-add_subdirectory(pipeline)
-add_subdirectory(creator)
-add_subdirectory(config)
-add_subdirectory(exec)
-add_subdirectory(integration)
-
 set(TEST_SOURCES
-    ${TEST_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/unittest.cpp
+    ${TEST_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_execution_tpch.cpp
     PARENT_SCOPE)

--- a/test/cpp/integration/integration.cfg
+++ b/test/cpp/integration/integration.cfg
@@ -1,0 +1,31 @@
+sirius = {
+    topology = {
+        num_gpus = 1;
+    };
+    memory = {
+        gpu = {
+            usage_limit_fraction = 0.2;
+            reservation_limit_fraction = 1.0;
+        }
+        host = {
+            capacity_bytes = 32000000000;
+            initial_number_pools = 10;
+            pool_size = 512;
+            block_size = 1048576;
+        };
+    };
+    executor = {
+        pipeline = {
+            num_threads = 1;
+        };
+        duckdb_scan = {
+            num_threads = 1;
+        };
+        task_creator = {
+            num_threads = 1;
+        };
+        downgrade = {
+            num_threads = 1;
+        };
+    };
+};

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <set>
 #include <string>
 
 namespace fs = std::filesystem;
@@ -39,12 +40,6 @@ static fs::path get_tpch_db_path()
   return db_path;
 }
 
-/**
- * @brief RAII guard to set SIRIUS_CONFIG_FILE env var for the duration of a test.
- *
- * Points to the integration.cfg config which sets up GPU/host memory spaces
- * and the pipeline executor configuration needed by gpu_execution.
- */
 struct config_env_guard {
   config_env_guard()
   {
@@ -56,92 +51,117 @@ struct config_env_guard {
 };
 
 /**
- * @brief Run a query through gpu_execution and return the result.
+ * @brief Run a query through gpu_execution and through DuckDB CPU, then compare results.
+ *
+ * Values are compared as strings via Value::ToString() which normalizes type differences
+ * (e.g., HUGEINT vs BIGINT both render "50"). Row order is ignored by collecting rows
+ * as sorted sets of string tuples.
  */
-static duckdb::unique_ptr<duckdb::MaterializedQueryResult> run_gpu_execution(
-  duckdb::Connection& con, const std::string& query)
+static void compare_gpu_vs_cpu(duckdb::Connection& con, const std::string& query)
 {
-  auto sql    = "CALL gpu_execution('" + query + "')";
-  auto result = con.Query(sql);
-  REQUIRE(result);
-  if (result->HasError()) { UNSCOPED_INFO("gpu_execution error: " << result->GetError()); }
-  REQUIRE_FALSE(result->HasError());
-  return result;
+  // Run on GPU
+  auto gpu_sql    = "CALL gpu_execution('" + query + "')";
+  auto gpu_result = con.Query(gpu_sql);
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) { UNSCOPED_INFO("gpu_execution error: " << gpu_result->GetError()); }
+  REQUIRE_FALSE(gpu_result->HasError());
+
+  // Run on CPU (plain DuckDB)
+  auto cpu_result = con.Query(query);
+  REQUIRE(cpu_result);
+  REQUIRE_FALSE(cpu_result->HasError());
+
+  // Compare dimensions
+  REQUIRE(gpu_result->ColumnCount() == cpu_result->ColumnCount());
+  REQUIRE(gpu_result->RowCount() == cpu_result->RowCount());
+
+  // Use DuckDB to sort both result sets by all columns for deterministic comparison.
+  // This avoids lexicographic vs numeric sort issues.
+  auto ncols               = gpu_result->ColumnCount();
+  std::string order_clause = " ORDER BY ";
+  for (duckdb::idx_t c = 0; c < ncols; c++) {
+    if (c > 0) order_clause += ", ";
+    order_clause += std::to_string(c + 1);
+  }
+
+  // Strip trailing semicolons from query for subquery wrapping
+  auto clean_query = query;
+  while (!clean_query.empty() && (clean_query.back() == ';' || clean_query.back() == ' '))
+    clean_query.pop_back();
+
+  auto gpu_sorted = con.Query("SELECT * FROM gpu_execution('" + clean_query + "')" + order_clause);
+  auto cpu_sorted = con.Query("SELECT * FROM (" + clean_query + ") t" + order_clause);
+  REQUIRE(gpu_sorted);
+  if (gpu_sorted->HasError()) { UNSCOPED_INFO("gpu sorted error: " << gpu_sorted->GetError()); }
+  REQUIRE_FALSE(gpu_sorted->HasError());
+  REQUIRE(cpu_sorted);
+  if (cpu_sorted->HasError()) { UNSCOPED_INFO("cpu sorted error: " << cpu_sorted->GetError()); }
+  REQUIRE_FALSE(cpu_sorted->HasError());
+
+  // Compare row by row using string values (handles type differences like HUGEINT vs BIGINT)
+  for (duckdb::idx_t r = 0; r < gpu_sorted->RowCount(); r++) {
+    for (duckdb::idx_t c = 0; c < gpu_sorted->ColumnCount(); c++) {
+      auto gpu_val = gpu_sorted->GetValue(c, r).ToString();
+      auto cpu_val = cpu_sorted->GetValue(c, r).ToString();
+      if (gpu_val != cpu_val) {
+        UNSCOPED_INFO("Row " << r << " Col " << c << " mismatch: GPU=[" << gpu_val << "] CPU=["
+                             << cpu_val << "]");
+      }
+      REQUIRE(gpu_val == cpu_val);
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//
-// Scan tests - basic table reads
+// Scan tests
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("gpu_execution - scan single column from nation", "[integration][gpu_execution][scan]")
+TEST_CASE("gpu_execution - scan single column", "[integration][gpu_execution][scan]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey from nation;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 1);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation;");
 }
 
-TEST_CASE("gpu_execution - scan multiple integer columns from nation",
-          "[integration][gpu_execution][scan]")
+TEST_CASE("gpu_execution - scan multiple columns", "[integration][gpu_execution][scan]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey, n_regionkey from nation;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 2);
+  compare_gpu_vs_cpu(con, "select n_nationkey, n_regionkey from nation;");
 }
 
-TEST_CASE("gpu_execution - scan from region table", "[integration][gpu_execution][scan]")
+TEST_CASE("gpu_execution - scan region table", "[integration][gpu_execution][scan]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select r_regionkey from region;");
-
-  REQUIRE(result->RowCount() == 5);
-  REQUIRE(result->ColumnCount() == 1);
+  compare_gpu_vs_cpu(con, "select r_regionkey from region;");
 }
 
 //===----------------------------------------------------------------------===//
-// Projection tests - computed columns / expressions
+// Projection tests
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("gpu_execution - projection with arithmetic expression",
-          "[integration][gpu_execution][projection]")
+TEST_CASE("gpu_execution - projection add", "[integration][gpu_execution][projection]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey + n_regionkey as total from nation;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 1);
+  compare_gpu_vs_cpu(con, "select n_nationkey + n_regionkey as total from nation;");
 }
 
-TEST_CASE("gpu_execution - projection with multiply", "[integration][gpu_execution][projection]")
+TEST_CASE("gpu_execution - projection multiply", "[integration][gpu_execution][projection]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result =
-    run_gpu_execution(con, "select n_nationkey * 2 as doubled, n_regionkey from nation;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 2);
+  compare_gpu_vs_cpu(con, "select n_nationkey * 2 as doubled, n_regionkey from nation;");
 }
 
 //===----------------------------------------------------------------------===//
-// Filter tests - WHERE clause predicates
+// Filter tests
 //===----------------------------------------------------------------------===//
 
 TEST_CASE("gpu_execution - filter equality", "[integration][gpu_execution][filter]")
@@ -149,12 +169,7 @@ TEST_CASE("gpu_execution - filter equality", "[integration][gpu_execution][filte
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey = 1;");
-
-  REQUIRE(result->ColumnCount() == 1);
-  // TPCH has 5 nations in region 1: ARGENTINA, BRAZIL, CANADA, PERU, UNITED STATES
-  REQUIRE(result->RowCount() == 5);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation where n_regionkey = 1;");
 }
 
 TEST_CASE("gpu_execution - filter greater than", "[integration][gpu_execution][filter]")
@@ -162,11 +177,7 @@ TEST_CASE("gpu_execution - filter greater than", "[integration][gpu_execution][f
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey > 2;");
-
-  REQUIRE(result->ColumnCount() == 1);
-  REQUIRE(result->RowCount() > 0);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation where n_regionkey > 2;");
 }
 
 TEST_CASE("gpu_execution - filter not equal", "[integration][gpu_execution][filter]")
@@ -174,11 +185,7 @@ TEST_CASE("gpu_execution - filter not equal", "[integration][gpu_execution][filt
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select r_regionkey from region where r_regionkey != 3;");
-
-  REQUIRE(result->ColumnCount() == 1);
-  REQUIRE(result->RowCount() == 4);
+  compare_gpu_vs_cpu(con, "select r_regionkey from region where r_regionkey != 3;");
 }
 
 TEST_CASE("gpu_execution - filter with projection", "[integration][gpu_execution][filter]")
@@ -186,48 +193,88 @@ TEST_CASE("gpu_execution - filter with projection", "[integration][gpu_execution
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result =
-    run_gpu_execution(con, "select n_nationkey, n_regionkey from nation where n_regionkey = 0;");
-
-  REQUIRE(result->ColumnCount() == 2);
-  // TPCH has 5 nations in region 0: ALGERIA, ETHIOPIA, KENYA, MOROCCO, MOZAMBIQUE
-  REQUIRE(result->RowCount() == 5);
+  compare_gpu_vs_cpu(con, "select n_nationkey, n_regionkey from nation where n_regionkey = 0;");
 }
 
-// Pre-existing issue: empty result set causes "Port default not found in operator RESULT_COLLECTOR"
+//===----------------------------------------------------------------------===//
+// Ungrouped aggregate tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_execution - ungrouped min max", "[integration][gpu_execution][aggregate]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select min(n_regionkey), max(n_nationkey) from nation;");
+}
+
+TEST_CASE("gpu_execution - ungrouped min with filter", "[integration][gpu_execution][aggregate]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select min(n_nationkey) from nation where n_regionkey = 1;");
+}
+
+TEST_CASE("gpu_execution - ungrouped sum count", "[integration][gpu_execution][aggregate]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select sum(n_regionkey), count(n_nationkey) from nation;");
+}
+
+TEST_CASE("gpu_execution - ungrouped all agg functions", "[integration][gpu_execution][aggregate]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(
+    con,
+    "select sum(n_regionkey), min(n_nationkey), max(n_regionkey), count(n_nationkey) from nation;");
+}
+
+//===----------------------------------------------------------------------===//
+// Limit tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_execution - limit", "[integration][gpu_execution][limit]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation limit 10;");
+}
+
+TEST_CASE("gpu_execution - limit with filter", "[integration][gpu_execution][limit]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con,
+                     "select n_nationkey, n_regionkey from nation where n_regionkey = 1 limit 3;");
+}
+
+//===----------------------------------------------------------------------===//
+// Disabled tests - known issues
+//===----------------------------------------------------------------------===//
+
+// Empty result set: "Port default not found in operator RESULT_COLLECTOR"
 TEST_CASE("gpu_execution - filter returns empty result", "[.][integration_disabled][gpu_execution]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey = 99;");
-
-  REQUIRE(result->ColumnCount() == 1);
-  REQUIRE(result->RowCount() == 0);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation where n_regionkey = 99;");
 }
 
-//===----------------------------------------------------------------------===//
-// Multi-pipeline queries (pre-existing hang issue - hidden by default)
-// These are hidden with [.] tag and only run when explicitly requested.
-//===----------------------------------------------------------------------===//
-
-// Pre-existing issue: multi-pipeline queries hang because completion is not
-// signaled across pipeline boundaries. Affects GROUP BY, ORDER BY, JOINs, etc.
-
-TEST_CASE("gpu_execution - aggregation count by regionkey",
-          "[.][integration_disabled][gpu_execution]")
+// Multi-pipeline queries hang (GROUP BY, ORDER BY, JOINs)
+TEST_CASE("gpu_execution - group by", "[.][integration_disabled][gpu_execution]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result =
-    run_gpu_execution(con, "select n_regionkey, count(*) from nation group by n_regionkey;");
-
-  REQUIRE(result->RowCount() == 5);
-  REQUIRE(result->ColumnCount() == 2);
+  compare_gpu_vs_cpu(con, "select n_regionkey, count(*) from nation group by n_regionkey;");
 }
 
 TEST_CASE("gpu_execution - order by", "[.][integration_disabled][gpu_execution]")
@@ -235,37 +282,24 @@ TEST_CASE("gpu_execution - order by", "[.][integration_disabled][gpu_execution]"
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(con, "select n_nationkey from nation order by n_regionkey;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 1);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation order by n_regionkey;");
 }
 
-TEST_CASE("gpu_execution - top n (order by + limit)", "[.][integration_disabled][gpu_execution]")
+TEST_CASE("gpu_execution - top n", "[.][integration_disabled][gpu_execution]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result =
-    run_gpu_execution(con, "select n_nationkey from nation order by n_regionkey desc limit 5;");
-
-  REQUIRE(result->RowCount() == 5);
-  REQUIRE(result->ColumnCount() == 1);
+  compare_gpu_vs_cpu(con, "select n_nationkey from nation order by n_regionkey desc limit 5;");
 }
 
-TEST_CASE("gpu_execution - join nation and region", "[.][integration_disabled][gpu_execution]")
+TEST_CASE("gpu_execution - join", "[.][integration_disabled][gpu_execution]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-
-  auto result = run_gpu_execution(
+  compare_gpu_vs_cpu(
     con,
     "select n.n_nationkey, r.r_regionkey from nation n join region r on n.n_regionkey = "
     "r.r_regionkey;");
-
-  REQUIRE(result->RowCount() == 25);
-  REQUIRE(result->ColumnCount() == 2);
 }

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static fs::path get_project_root()
+{
+#ifdef SIRIUS_PROJECT_ROOT
+  return fs::path(SIRIUS_PROJECT_ROOT);
+#else
+  return fs::path(__FILE__).parent_path().parent_path().parent_path().parent_path();
+#endif
+}
+
+static fs::path get_tpch_db_path()
+{
+  auto db_path = get_project_root() / "tpch.duckdb";
+  REQUIRE(fs::exists(db_path));
+  return db_path;
+}
+
+/**
+ * @brief RAII guard to set SIRIUS_CONFIG_FILE env var for the duration of a test.
+ *
+ * Points to the integration.cfg config which sets up GPU/host memory spaces
+ * and the pipeline executor configuration needed by gpu_execution.
+ */
+struct config_env_guard {
+  config_env_guard()
+  {
+    auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
+    REQUIRE(fs::exists(cfg_path));
+    setenv("SIRIUS_CONFIG_FILE", cfg_path.string().c_str(), 1);
+  }
+  ~config_env_guard() { unsetenv("SIRIUS_CONFIG_FILE"); }
+};
+
+/**
+ * @brief Run a query through gpu_execution and return the result.
+ */
+static duckdb::unique_ptr<duckdb::MaterializedQueryResult> run_gpu_execution(
+  duckdb::Connection& con, const std::string& query)
+{
+  auto sql    = "CALL gpu_execution('" + query + "')";
+  auto result = con.Query(sql);
+  REQUIRE(result);
+  if (result->HasError()) { UNSCOPED_INFO("gpu_execution error: " << result->GetError()); }
+  REQUIRE_FALSE(result->HasError());
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Scan tests - basic table reads
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_execution - scan single column from nation", "[integration][gpu_execution][scan]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey from nation;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 1);
+}
+
+TEST_CASE("gpu_execution - scan multiple integer columns from nation",
+          "[integration][gpu_execution][scan]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey, n_regionkey from nation;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 2);
+}
+
+TEST_CASE("gpu_execution - scan from region table", "[integration][gpu_execution][scan]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select r_regionkey from region;");
+
+  REQUIRE(result->RowCount() == 5);
+  REQUIRE(result->ColumnCount() == 1);
+}
+
+//===----------------------------------------------------------------------===//
+// Projection tests - computed columns / expressions
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_execution - projection with arithmetic expression",
+          "[integration][gpu_execution][projection]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey + n_regionkey as total from nation;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 1);
+}
+
+TEST_CASE("gpu_execution - projection with multiply", "[integration][gpu_execution][projection]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result =
+    run_gpu_execution(con, "select n_nationkey * 2 as doubled, n_regionkey from nation;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 2);
+}
+
+//===----------------------------------------------------------------------===//
+// Filter tests - WHERE clause predicates
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_execution - filter equality", "[integration][gpu_execution][filter]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey = 1;");
+
+  REQUIRE(result->ColumnCount() == 1);
+  // TPCH has 5 nations in region 1: ARGENTINA, BRAZIL, CANADA, PERU, UNITED STATES
+  REQUIRE(result->RowCount() == 5);
+}
+
+TEST_CASE("gpu_execution - filter greater than", "[integration][gpu_execution][filter]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey > 2;");
+
+  REQUIRE(result->ColumnCount() == 1);
+  REQUIRE(result->RowCount() > 0);
+}
+
+TEST_CASE("gpu_execution - filter not equal", "[integration][gpu_execution][filter]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select r_regionkey from region where r_regionkey != 3;");
+
+  REQUIRE(result->ColumnCount() == 1);
+  REQUIRE(result->RowCount() == 4);
+}
+
+TEST_CASE("gpu_execution - filter with projection", "[integration][gpu_execution][filter]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result =
+    run_gpu_execution(con, "select n_nationkey, n_regionkey from nation where n_regionkey = 0;");
+
+  REQUIRE(result->ColumnCount() == 2);
+  // TPCH has 5 nations in region 0: ALGERIA, ETHIOPIA, KENYA, MOROCCO, MOZAMBIQUE
+  REQUIRE(result->RowCount() == 5);
+}
+
+// Pre-existing issue: empty result set causes "Port default not found in operator RESULT_COLLECTOR"
+TEST_CASE("gpu_execution - filter returns empty result", "[.][integration_disabled][gpu_execution]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey from nation where n_regionkey = 99;");
+
+  REQUIRE(result->ColumnCount() == 1);
+  REQUIRE(result->RowCount() == 0);
+}
+
+//===----------------------------------------------------------------------===//
+// Multi-pipeline queries (pre-existing hang issue - hidden by default)
+// These are hidden with [.] tag and only run when explicitly requested.
+//===----------------------------------------------------------------------===//
+
+// Pre-existing issue: multi-pipeline queries hang because completion is not
+// signaled across pipeline boundaries. Affects GROUP BY, ORDER BY, JOINs, etc.
+
+TEST_CASE("gpu_execution - aggregation count by regionkey",
+          "[.][integration_disabled][gpu_execution]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result =
+    run_gpu_execution(con, "select n_regionkey, count(*) from nation group by n_regionkey;");
+
+  REQUIRE(result->RowCount() == 5);
+  REQUIRE(result->ColumnCount() == 2);
+}
+
+TEST_CASE("gpu_execution - order by", "[.][integration_disabled][gpu_execution]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(con, "select n_nationkey from nation order by n_regionkey;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 1);
+}
+
+TEST_CASE("gpu_execution - top n (order by + limit)", "[.][integration_disabled][gpu_execution]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result =
+    run_gpu_execution(con, "select n_nationkey from nation order by n_regionkey desc limit 5;");
+
+  REQUIRE(result->RowCount() == 5);
+  REQUIRE(result->ColumnCount() == 1);
+}
+
+TEST_CASE("gpu_execution - join nation and region", "[.][integration_disabled][gpu_execution]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  auto result = run_gpu_execution(
+    con,
+    "select n.n_nationkey, r.r_regionkey from nation n join region r on n.n_regionkey = "
+    "r.r_regionkey;");
+
+  REQUIRE(result->RowCount() == 25);
+  REQUIRE(result->ColumnCount() == 2);
+}

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -35,7 +35,7 @@ static fs::path get_project_root()
 
 static fs::path get_tpch_db_path()
 {
-  auto db_path = get_project_root() / "tpch.duckdb";
+  auto db_path = fs::path(__FILE__).parent_path() / "integration.duckdb";
   REQUIRE(fs::exists(db_path));
   return db_path;
 }

--- a/test/cpp/operator/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/test_gpu_merge_impl.cpp
@@ -36,6 +36,19 @@ using namespace sirius::op;
 namespace {
 
 /**
+ * @brief Get a shared memory space that persists across all test cases.
+ *
+ * Uses static initialization to create the memory manager only once,
+ * avoiding repeated CUDA memory pool creation/destruction which can
+ * crash the CUDA driver.
+ */
+memory_space* get_shared_mem_space()
+{
+  static auto manager = initialize_memory_manager();
+  return manager->get_memory_space(Tier::GPU, 0);
+}
+
+/**
  * @brief Container for batches with their processing handles.
  *
  * In production, tasks hold processing handles while operating on batches
@@ -161,8 +174,7 @@ void validate_concat(const std::vector<std::shared_ptr<data_batch>>& input_batch
 
 TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
 {
-  auto manager    = initialize_memory_manager();
-  auto* mem_space = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space = get_shared_mem_space();
   REQUIRE(mem_space);
 
   constexpr int num_batches           = 10;
@@ -180,8 +192,7 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
 
 TEST_CASE("Concatenate multiple data batches with different size", "[operator][merge_concat]")
 {
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space           = get_shared_mem_space();
   constexpr int num_batches = 10;
   std::vector<int> num_input_rows;
   for (int i = 0; i < num_batches; ++i) {
@@ -198,8 +209,7 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
 
 TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
 {
-  auto manager                        = initialize_memory_manager();
-  auto* mem_space                     = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                     = get_shared_mem_space();
   constexpr int num_batches           = 1;
   constexpr size_t num_rows_per_batch = 100;
   std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
@@ -215,8 +225,7 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
 
 TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][merge_concat]")
 {
-  auto manager                        = initialize_memory_manager();
-  auto* mem_space                     = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                     = get_shared_mem_space();
   constexpr int num_batches           = 10;
   constexpr size_t num_rows_per_batch = 0;
   std::vector<int> num_input_rows(num_batches, num_rows_per_batch);
@@ -231,8 +240,7 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
 
 TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merge_concat]")
 {
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space           = get_shared_mem_space();
   constexpr int num_batches = 10;
   std::vector<int> num_input_rows;
   for (int i = 0; i < num_batches; ++i) {
@@ -391,8 +399,7 @@ void validate_ungrouped_aggregate(const std::vector<std::shared_ptr<data_batch>>
 
 TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_ungrouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -414,8 +421,7 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
 
 TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungrouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -443,8 +449,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
 TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
           "[operator][merge_ungrouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -467,8 +472,7 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
 TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggregate results",
           "[operator][merge_ungrouped_agg]")
 {
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space           = get_shared_mem_space();
   constexpr int num_batches = 10;
   std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
@@ -639,8 +643,7 @@ void validate_grouped_aggregate(const std::vector<std::shared_ptr<data_batch>>& 
 
 TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -671,8 +674,7 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
 
 TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_grouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -710,8 +712,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
 TEST_CASE("Grouped merge aggregate with empty local aggregate results",
           "[operator][merge_grouped_agg]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -743,8 +744,7 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
 TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregate results",
           "[operator][merge_grouped_agg]")
 {
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space           = get_shared_mem_space();
   constexpr int num_batches = 10;
   std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {
@@ -856,8 +856,7 @@ void validate_order_by(const std::vector<std::shared_ptr<data_batch>>& input_bat
 
 TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -889,8 +888,7 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
 
 TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   int num_batches                                = 1;
   constexpr size_t num_base_input_rows_per_batch = 100;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -942,8 +940,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
 
 TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_order_by]")
 {
-  auto manager                                   = initialize_memory_manager();
-  auto* mem_space                                = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                = get_shared_mem_space();
   constexpr int num_batches                      = 10;
   constexpr size_t num_base_input_rows_per_batch = 0;
   std::vector<int> num_base_input_rows(num_batches, num_base_input_rows_per_batch);
@@ -976,8 +973,7 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
 TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results",
           "[operator][merge_order_by]")
 {
-  auto manager              = initialize_memory_manager();
-  auto* mem_space           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space           = get_shared_mem_space();
   constexpr int num_batches = 10;
   std::vector<int> num_base_input_rows;
   for (int i = 0; i < num_batches; ++i) {

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -31,6 +31,12 @@ using namespace sirius::op;
 
 namespace {
 
+memory_space* get_shared_mem_space()
+{
+  static auto manager = initialize_memory_manager();
+  return manager->get_memory_space(Tier::GPU, 0);
+}
+
 /**
  * @brief Create a batch with random data and acquire a processing handle.
  *
@@ -149,8 +155,7 @@ void validate_hash_partition(const data_batch& input_batch,
 
 TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 100;
   constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -171,8 +176,7 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 100;
   constexpr size_t num_partitions           = 1;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -192,8 +196,7 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 0;
   constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -212,8 +215,7 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
 
 TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash_partition]")
 {
-  auto manager                                           = initialize_memory_manager();
-  auto* mem_space                                        = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                                        = get_shared_mem_space();
   constexpr size_t num_input_rows                        = 100;
   constexpr size_t num_partitions                        = 4;
   std::vector<cudf::data_type> column_types              = {cudf::data_type{cudf::type_id::INT32},
@@ -236,8 +238,7 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
 
 TEST_CASE("Hash partition with num partitions larger than input size", "[operator][hash_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 10;
   constexpr size_t num_partitions           = 20;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -304,8 +305,7 @@ void validate_evenly_partition(const data_batch& input_batch,
 
 TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 100;
   constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -323,8 +323,7 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
 
 TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 0;
   constexpr size_t num_partitions           = 4;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},
@@ -343,8 +342,7 @@ TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partitio
 TEST_CASE("Evenly partition basic with num partitions larger than input size",
           "[operator][evenly_partition]")
 {
-  auto manager                              = initialize_memory_manager();
-  auto* mem_space                           = manager->get_memory_space(Tier::GPU, 0);
+  auto* mem_space                           = get_shared_mem_space();
   constexpr size_t num_input_rows           = 10;
   constexpr size_t num_partitions           = 20;
   std::vector<cudf::data_type> column_types = {cudf::data_type{cudf::type_id::INT32},

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -22,7 +22,7 @@
 #include "pipeline/task_request.hpp"
 #include "scan/test_utils.hpp"
 
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
@@ -107,7 +107,7 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
 
     void* allocation = nullptr;
     try {
-      allocation = allocator->allocate(kAllocationBytes, stream);
+      allocation = allocator->allocate(stream, kAllocationBytes);
     } catch (const std::exception& e) {
       global.add_error(std::string("GPU allocation failed: ") + e.what());
       allocator->reset_stream_reservation(stream);
@@ -115,7 +115,7 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
       return;
     }
 
-    allocator->deallocate(allocation, kAllocationBytes, stream);
+    allocator->deallocate(stream, allocation, kAllocationBytes);
 
     auto consumed_bytes = mem_space.get_total_reserved_memory();
     {

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 // rmm
-#include <rmm/mr/device/cuda_async_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
 
 using namespace cucascade::memory;
 

--- a/test/cpp/utils/utils.cpp
+++ b/test/cpp/utils/utils.cpp
@@ -400,7 +400,7 @@ std::unique_ptr<cudf::table> create_cudf_table_with_random_data(
         std::vector<char> h_chars;
         std::vector<int64_t> h_offsets(num_rows + 1, 0);
         for (size_t r = 0; r < num_rows; ++r) {
-          string h_str = "str_" + std::to_string(dist(gen));
+          std::string h_str = "str_" + std::to_string(dist(gen));
           h_chars.insert(h_chars.end(), h_str.begin(), h_str.end());
           h_offsets[r + 1] = h_offsets[r] + static_cast<int64_t>(h_str.size());
         }


### PR DESCRIPTION
Updated to rapids 26.04
removed deprecated memory resources
changed memory resource apis

removed "using std" which conflicted with the cuda::std name space cause CUB to not be able to build
