### PR TITLE
fix CustomTopNString bugs

### DIFF
--- a/src/cuda/cudf/cudf_orderby.cu
+++ b/src/cuda/cudf/cudf_orderby.cu
@@ -138,7 +138,7 @@ struct CustomTopNMin {
   template <typename T>
   __device__ __forceinline__ T operator()(const T& a, const T& b) const
   {
-    return a < b;
+    return a < b ? a : b;
   }
 };
 
@@ -268,7 +268,7 @@ void CustomStringTopN(vector<shared_ptr<GPUColumn>>& keys,
                                    num_records,
                                    prefix_less_than_compartor);
   } else {
-    CustomTopNStringPrefixLessThan prefix_greater_than_compartor;
+    CustomTopNStringPrefixGreaterThan prefix_greater_than_compartor;
     cub::DeviceMergeSort::SortKeys(d_prefix_sort_temp_storage,
                                    prefix_sort_temp_storage_bytes,
                                    d_records,


### PR DESCRIPTION
```shell
select l_comment from lineitem order by l_comment limit 10;
```
the sql is extremly slower than duckdb,  then I found out:
in the custom string topN prefix sort stage, the reduction op CustomTopNMin may be not right, it causes more rows are passed to the second full key sort stage

and,  fixed typo: 
```cpp
CustomTopNStringPrefixLessThan prefix_greater_than_compartor;  
```

local test:
after this change, on tpch10 datasets with RTX3070, the hotrun time decreased from 1.5s to 50ms
