### PR TITLE
Fix SIRIUS_LOG_DEBUG not showing up

### DIFF
--- a/src/gpu_executor.cpp
+++ b/src/gpu_executor.cpp
@@ -92,8 +92,6 @@ void GPUExecutor::Execute()
   SIRIUS_LOG_DEBUG("Total meta pipelines {}", scheduled.size());
 
   for (const auto& pipeline : scheduled) {
-    SIRIUS_LOG_DEBUG("Executing pipeline (Source Operator ID: {})", pipeline->source->operator_id);
-
     // TODO: This is temporary solution
     // if (pipeline->source->type == PhysicalOperatorType::HASH_JOIN || pipeline->source->type ==
     // PhysicalOperatorType::RESULT_COLLECTOR) { 	continue;

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -16,17 +16,16 @@
 
 #pragma once
 
-#include <spdlog/common.h>
 #ifndef SPDLOG_ACTIVE_LEVEL
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+#else
+#warning "SPDLOG_ACTIVE_LEVEL is overridden, output may be lost"
 #endif
 
 #include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/spdlog.h>
 
 #include <cstdlib>
-#include <iostream>
-#include <memory>
 #include <optional>
 #include <string>
 
@@ -39,7 +38,9 @@
 
 namespace duckdb {
 
-inline constexpr int SIRIUS_LOG_FLUSH_SEC = 3;
+inline constexpr int SIRIUS_LOG_FLUSH_SEC         = 3;
+inline constexpr const char* SIRIUS_LOG_LEVEL_ENV = "SIRIUS_LOG_LEVEL";
+inline constexpr const char* SIRIUS_LOG_DIR_ENV   = "SIRIUS_LOG_DIR";
 
 inline std::optional<std::string> GetEnvVar(const std::string& name)
 {
@@ -53,7 +54,7 @@ inline std::optional<std::string> GetEnvVar(const std::string& name)
 
 inline spdlog::level::level_enum GetLogLevel()
 {
-  auto log_level_str = GetEnvVar("SIRIUS_LOG_LEVEL");
+  auto log_level_str = GetEnvVar(SIRIUS_LOG_LEVEL_ENV);
   if (log_level_str.has_value()) {
     if (*log_level_str == "trace") return spdlog::level::trace;
     if (*log_level_str == "debug") return spdlog::level::debug;
@@ -68,7 +69,7 @@ inline spdlog::level::level_enum GetLogLevel()
 
 inline std::string GetLogDir()
 {
-  auto log_dir_str = GetEnvVar("SIRIUS_LOG_DIR");
+  auto log_dir_str = GetEnvVar(SIRIUS_LOG_DIR_ENV);
   if (log_dir_str.has_value()) { return *log_dir_str; }
   return SIRIUS_DEFAULT_LOG_DIR;
 }
@@ -84,11 +85,12 @@ inline void InitGlobalLogger(std::string log_file = "")
   file_sink->set_pattern("[%Y-%m-%d %T.%e] [%l] [%s:%#] %v");
 
   // Logger
-  auto logger = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{file_sink});
-  spdlog::set_default_logger(logger);
+  auto logger    = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{file_sink});
   auto log_level = GetLogLevel();
   logger->set_level(log_level);
-  auto log_level_str = GetEnvVar("SIRIUS_LOG_LEVEL");
+  spdlog::set_default_logger(logger);
+  spdlog::set_level(log_level);  // Also set the global level
+  auto log_level_str = GetEnvVar(SIRIUS_LOG_LEVEL_ENV);
   if (log_level_str.has_value()) {
     spdlog::flush_on(log_level);
   } else {


### PR DESCRIPTION
Fixes the spdlog swallowing all debug print statements by removing an include that sets the compile-time filter to INFO.