### PR TITLE
Feature/add stream to tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
 endif()
 
 project(${TARGET_NAME} LANGUAGES CXX CUDA)
+
+# Optional features
+option(ENABLE_STREAM_CHECK "Enable stream check library for debugging default stream usage" OFF)
+
 find_package(cudf REQUIRED CONFIG)
 find_package(libconfig++ REQUIRED)
 find_package(absl REQUIRED)
@@ -100,7 +104,8 @@ set(EXTENSION_SOURCES
     src/sirius_interface.cpp
     src/extension_lock.cpp
     src/sirius_engine.cpp
-    src/parallel/task_executor.cpp)
+    src/parallel/task_executor.cpp
+    src/util/stream_check_wrapper.cpp)
 # Note: Memory module sources are now provided by cuCascade library
 add_subdirectory(src/operator)
 add_subdirectory(src/plan)
@@ -182,6 +187,22 @@ install(
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+
+# Stream check utility library (optional, for debugging)
+# This is built separately and loaded dynamically at runtime via dlopen
+# No recompilation needed - just build or don't build the library
+if(ENABLE_STREAM_CHECK)
+  message(STATUS "Stream check library will be built (loaded dynamically at runtime)")
+  add_subdirectory(utils/stream_check)
+  
+  # Install stream_check library (optional runtime dependency)
+  install(
+    TARGETS stream_check
+    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+else()
+  message(STATUS "Stream check library will not be built (runtime loading will gracefully fail)")
+endif()
 
 # Unit tests
 set(TEST_NAME ${TARGET_NAME}_unittest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ endif()
 project(${TARGET_NAME} LANGUAGES CXX CUDA)
 
 # Optional features
-option(ENABLE_STREAM_CHECK "Enable stream check library for debugging default stream usage" OFF)
+option(ENABLE_STREAM_CHECK
+       "Enable stream check library for debugging default stream usage" OFF)
 
 find_package(cudf REQUIRED CONFIG)
 find_package(libconfig++ REQUIRED)
@@ -188,20 +189,24 @@ install(
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
-# Stream check utility library (optional, for debugging)
-# This is built separately and loaded dynamically at runtime via dlopen
-# No recompilation needed - just build or don't build the library
+# Stream check utility library (optional, for debugging) This is built
+# separately and loaded dynamically at runtime via dlopen No recompilation
+# needed - just build or don't build the library
 if(ENABLE_STREAM_CHECK)
-  message(STATUS "Stream check library will be built (loaded dynamically at runtime)")
+  message(
+    STATUS "Stream check library will be built (loaded dynamically at runtime)")
   add_subdirectory(utils/stream_check)
-  
+
   # Install stream_check library (optional runtime dependency)
   install(
     TARGETS stream_check
     LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
     ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 else()
-  message(STATUS "Stream check library will not be built (runtime loading will gracefully fail)")
+  message(
+    STATUS
+      "Stream check library will not be built (runtime loading will gracefully fail)"
+  )
 endif()
 
 # Unit tests

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -74,7 +74,7 @@ void downgrade_executor::worker_loop(int worker_id)
       break;
     }
     try {
-      task->execute();
+      task->execute(cudf::get_default_stream());
     } catch (const std::exception& e) {
       on_task_error(worker_id, std::move(task), e);
     }

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -29,10 +29,8 @@
 namespace sirius {
 namespace parallel {
 
-void downgrade_task::execute()
+void downgrade_task::execute(rmm::cuda_stream_view stream)
 {
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default;
-
   auto& batch = _local_state->cast<downgrade_task_local_state>()._batch;
 
   // Check if already on host tier - nothing to do

--- a/src/extension_lock.cpp
+++ b/src/extension_lock.cpp
@@ -30,8 +30,9 @@
 
 namespace sirius {
 
-extension_lock::extension_lock(const std::string& extension_name)
-  : lock_path_("/var/tmp/" + extension_name + ".lock")
+extension_lock::extension_lock(const std::string& extension_name,
+                               const std::string& lock_prefix)
+  : lock_path_(lock_prefix + "/" + extension_name + ".lock")
 {
   fd_ = open(lock_path_.c_str(), O_CREAT | O_RDWR, 0666);
   if (fd_ == -1) {

--- a/src/extension_lock.cpp
+++ b/src/extension_lock.cpp
@@ -62,11 +62,11 @@ extension_lock::~extension_lock()
     flock(fd_, LOCK_UN);
     close(fd_);
 
-    // Optional: Remove the file to keep /var/tmp clean.
+    // Remove the file to keep the lock directory clean.
     // Note: This creates a tiny race condition window if a new process
     // creates the file just as we unlink it, but for locking logic
     // it is generally safe as the lock is on the inode/fd.
-    // std::filesystem::remove(lock_path_);
+    std::filesystem::remove(lock_path_);
   }
 }
 

--- a/src/extension_lock.cpp
+++ b/src/extension_lock.cpp
@@ -57,15 +57,8 @@ extension_lock::extension_lock(const std::string& extension_name, const std::str
 extension_lock::~extension_lock()
 {
   if (fd_ != -1) {
-    // Explicitly unlocking is optional; closing the FD releases it.
-    // However, being explicit is good practice.
     flock(fd_, LOCK_UN);
     close(fd_);
-
-    // Remove the file to keep the lock directory clean.
-    // Note: This creates a tiny race condition window if a new process
-    // creates the file just as we unlink it, but for locking logic
-    // it is generally safe as the lock is on the inode/fd.
     std::filesystem::remove(lock_path_);
   }
 }

--- a/src/extension_lock.cpp
+++ b/src/extension_lock.cpp
@@ -30,8 +30,7 @@
 
 namespace sirius {
 
-extension_lock::extension_lock(const std::string& extension_name,
-                               const std::string& lock_prefix)
+extension_lock::extension_lock(const std::string& extension_name, const std::string& lock_prefix)
   : lock_path_(lock_prefix + "/" + extension_name + ".lock")
 {
   fd_ = open(lock_path_.c_str(), O_CREAT | O_RDWR, 0666);

--- a/src/include/config_option.hpp
+++ b/src/include/config_option.hpp
@@ -146,8 +146,9 @@ struct config_to_type_traits<std::string> {
 
 template <IsBackInsertableWithValue T>
 struct config_to_type_traits<T> {
-  static constexpr libconfig::Setting::Type type =
-    (IsBasicConfig<T>) ? libconfig::Setting::TypeArray : libconfig::Setting::TypeList;
+  static constexpr libconfig::Setting::Type type = (IsBasicConfig<typename T::value_type>)
+                                                     ? libconfig::Setting::TypeArray
+                                                     : libconfig::Setting::TypeList;
   static T parse_value(std::string_view str_value)
   {
     throw std::invalid_argument("No parse_value implementation for this type.");
@@ -395,19 +396,6 @@ struct variant_value_holder {
   std::reference_wrapper<std::variant<Args...>> var_;
 };
 
-inline std::string prepare_env_var_name(std::string_view path)
-{
-  std::string env_var = std::string(path);
-  for (char c : path) {
-    if (c == '.' || c == '-') {
-      env_var += '_';
-    } else {
-      env_var += std::toupper(c);
-    }
-  }
-  return env_var;
-}
-
 template <typename T, typename holder = value_holder<T>>
 struct registered_config : config_base {
   template <typename ConfigType>
@@ -465,6 +453,118 @@ struct registered_config : config_base {
   bool is_required_{false};
 };
 
+// Specialized registered_config for variant types with validation
+template <typename T, typename... Args>
+struct registered_config_variant : config_base {
+  explicit registered_config_variant(std::string_view name,
+                                     std::variant<Args...>& var,
+                                     std::function<bool(const T&)> validator,
+                                     bool is_required = false)
+    : path_(name.data()), var_(var), predicate_(std::move(validator)), is_required_(is_required)
+  {
+  }
+
+  void apply(const libconfig::Setting& cfg) override
+  {
+    if (predicate_) {
+      T temp_value{};
+      config_value_applicator<T>::assign(temp_value, cfg);
+      if (!predicate_(temp_value)) {
+        throw std::invalid_argument(
+          fmt::format("Invalid configuration value for variant option {}", path_.data()));
+      }
+      var_.get_or_create() = std::move(temp_value);
+    } else {
+      config_value_applicator<T>::assign(var_.get_or_create(), cfg);
+    }
+  }
+
+  void write(libconfig::Setting& setting) const override
+  {
+    auto* ptr = var_.get_or_null();
+    if (ptr) {
+      libconfig::Setting& cfg = setting.add(path_.data(), type());
+      config_value_exporter<T>::write(cfg, *ptr);
+    }
+  }
+
+  [[nodiscard]] std::string_view path() const noexcept override { return path_; }
+
+  [[nodiscard]] libconfig::Setting::Type type() const noexcept override
+  {
+    return config_to_type_traits<T>::type;
+  }
+
+  [[nodiscard]] bool is_required() const noexcept override { return is_required_; }
+
+ private:
+  std::string path_;
+  variant_value_holder<T, Args...> var_;
+  std::function<bool(const T&)> predicate_{nullptr};
+  bool is_required_{false};
+};
+
+// Specialized registered_config for iterable types with element validation
+template <IsBackInsertableWithValue T, typename holder>
+struct registered_config_iterable : config_base {
+  using value_type = typename T::value_type;
+
+  template <typename ConfigType>
+  explicit registered_config_iterable(std::string_view name,
+                                      ConfigType& var,
+                                      std::function<bool(const value_type&)> element_validator,
+                                      bool is_required = false)
+    : path_(name.data()),
+      var_(var),
+      element_predicate_(std::move(element_validator)),
+      is_required_(is_required)
+  {
+  }
+
+  void apply(const libconfig::Setting& cfg) override
+  {
+    T& container   = var_.get_or_create();
+    using assigner = config_value_applicator<value_type>;
+
+    for (const auto& item : cfg) {
+      value_type v{};
+      assigner::assign(v, item);
+
+      // Validate each element if predicate is provided
+      if (element_predicate_ && !element_predicate_(v)) {
+        throw std::invalid_argument(
+          fmt::format("Invalid element value in configuration array for option {}", path_.data()));
+      }
+
+      container.push_back(std::move(v));
+    }
+  }
+
+  void write(libconfig::Setting& setting) const override
+  {
+    auto* ptr = var_.get_or_null();
+    if (ptr) {
+      libconfig::Setting& cfg = setting.add(path_.data(), type());
+      config_value_exporter<T>::write(cfg, *ptr);
+    }
+  }
+
+  [[nodiscard]] std::string_view path() const noexcept override { return path_; }
+
+  [[nodiscard]] libconfig::Setting::Type type() const noexcept override
+  {
+    return config_to_type_traits<T>::type;
+  }
+
+  [[nodiscard]] bool is_required() const noexcept override { return is_required_; }
+
+ private:
+  std::string path_;
+  holder var_;
+  std::function<bool(const value_type&)> element_predicate_{nullptr};
+  bool is_required_{false};
+};
+
 // ================ validators ================= //
 
 template <typename T>
@@ -476,7 +576,7 @@ struct less_than {
 template <typename T>
 struct greater_than {
   T threshold;
-  bool operator()(const T& value) const noexcept { return value < threshold; }
+  bool operator()(const T& value) const noexcept { return value > threshold; }
 };
 
 template <typename T>
@@ -536,6 +636,30 @@ struct configuration_setter {
         name, instance));
   }
 
+  // Add variant config with validation
+  template <typename ConfigType, typename... Args>
+  void add_variant_config(std::string_view name,
+                          std::variant<Args...>& instance,
+                          std::predicate<const ConfigType&> auto validator,
+                          config_requirement requirement = config_requirement::optional)
+  {
+    bool is_required = (requirement == config_requirement::required);
+    configs_.emplace_back(std::make_unique<registered_config_variant<ConfigType, Args...>>(
+      name, instance, std::move(validator), is_required));
+  }
+
+  // Add iterable config with element-level validation
+  template <IsBackInsertableWithValue T>
+  void add_config(std::string_view name,
+                  T& container,
+                  std::predicate<const typename T::value_type&> auto element_validator,
+                  config_requirement requirement = config_requirement::optional)
+  {
+    bool is_required = (requirement == config_requirement::required);
+    configs_.emplace_back(std::make_unique<registered_config_iterable<T, value_holder<T>>>(
+      name, container, std::move(element_validator), is_required));
+  }
+
   template <typename T>
     requires IsBasicConfig<T>
   void add_optional_config(std::string_view name,
@@ -551,6 +675,16 @@ struct configuration_setter {
   {
     configs_.emplace_back(
       std::make_unique<registered_config<T, optional_value_holder<T>>>(name, opt));
+  }
+
+  // Add optional iterable config with element-level validation
+  template <IsBackInsertableWithValue T>
+  void add_optional_config(std::string_view name,
+                           std::optional<T>& container,
+                           std::predicate<const typename T::value_type&> auto element_validator)
+  {
+    configs_.emplace_back(std::make_unique<registered_config_iterable<T, optional_value_holder<T>>>(
+      name, container, std::move(element_validator)));
   }
 
   static const libconfig::Setting* safe_lookup(const libconfig::Setting& setting,

--- a/src/include/config_option.hpp
+++ b/src/include/config_option.hpp
@@ -86,7 +86,7 @@ struct config_to_type_traits<T> : public config_to_type_traits<std::underlying_t
 
 template <HasStringToEnum T>
 struct config_to_type_traits<T> {
-  static constexpr libconfig::Setting::Type type = libconfig::Setting::TypeGroup;
+  static constexpr libconfig::Setting::Type type = libconfig::Setting::TypeString;
 
   static T parse_value(std::string_view str_value)
   {
@@ -396,6 +396,41 @@ struct variant_value_holder {
   std::reference_wrapper<std::variant<Args...>> var_;
 };
 
+// Helper function to create nested groups and return the parent setting
+// For path "server.network.port", creates "server" and "server.network" groups
+// and returns reference to "network" group along with final component "port"
+static std::pair<libconfig::Setting*, std::string> ensure_parent_path(libconfig::Setting& setting,
+                                                                      std::string_view path)
+{
+  libconfig::Setting* current = &setting;
+  std::string path_str(path);
+  size_t pos = 0;
+  std::string last_component;
+
+  while (pos < path_str.length()) {
+    size_t dot_pos = path_str.find('.', pos);
+    std::string component =
+      (dot_pos == std::string::npos) ? path_str.substr(pos) : path_str.substr(pos, dot_pos - pos);
+
+    // If this is the last component, save it and return
+    if (dot_pos == std::string::npos) {
+      last_component = component;
+      break;
+    }
+
+    // Create or get the group for this component
+    if (!current->exists(component)) {
+      current = &current->add(component, libconfig::Setting::TypeGroup);
+    } else {
+      current = &(*current)[component];
+    }
+
+    pos = dot_pos + 1;
+  }
+
+  return {current, last_component};
+}
+
 template <typename T, typename holder = value_holder<T>>
 struct registered_config : config_base {
   template <typename ConfigType>
@@ -432,7 +467,8 @@ struct registered_config : config_base {
   {
     auto* ptr = var_.get_or_null();
     if (ptr) {
-      libconfig::Setting& cfg = setting.add(path_.data(), type());
+      auto [parent, name]     = ensure_parent_path(setting, path_);
+      libconfig::Setting& cfg = parent->add(name, type());
       config_value_exporter<T>::write(cfg, *ptr);
     }
   }
@@ -483,7 +519,8 @@ struct registered_config_variant : config_base {
   {
     auto* ptr = var_.get_or_null();
     if (ptr) {
-      libconfig::Setting& cfg = setting.add(path_.data(), type());
+      auto [parent, name]     = ensure_parent_path(setting, path_);
+      libconfig::Setting& cfg = parent->add(name, type());
       config_value_exporter<T>::write(cfg, *ptr);
     }
   }
@@ -544,7 +581,8 @@ struct registered_config_iterable : config_base {
   {
     auto* ptr = var_.get_or_null();
     if (ptr) {
-      libconfig::Setting& cfg = setting.add(path_.data(), type());
+      auto [parent, name]     = ensure_parent_path(setting, path_);
+      libconfig::Setting& cfg = parent->add(name, type());
       config_value_exporter<T>::write(cfg, *ptr);
     }
   }

--- a/src/include/config_option.hpp
+++ b/src/include/config_option.hpp
@@ -553,19 +553,40 @@ struct configuration_setter {
       std::make_unique<registered_config<T, optional_value_holder<T>>>(name, opt));
   }
 
+  static const libconfig::Setting* safe_lookup(const libconfig::Setting& setting,
+                                               std::string_view path)
+  {
+    const libconfig::Setting* current = &setting;
+    std::string path_str(path);
+    size_t pos = 0;
+
+    while (pos < path_str.length()) {
+      size_t dot_pos = path_str.find('.', pos);
+      std::string component =
+        (dot_pos == std::string::npos) ? path_str.substr(pos) : path_str.substr(pos, dot_pos - pos);
+
+      if (!current->exists(component)) { return nullptr; }
+
+      current = &(*current)[component];
+
+      if (dot_pos == std::string::npos) { break; }
+      pos = dot_pos + 1;
+    }
+
+    return current;
+  }
+
   void apply(const libconfig::Setting& setting)
   {
     std::for_each(configs_.begin(), configs_.end(), [&](auto& setter) {
-      auto path = setter->path();
-      try {
-        const libconfig::Setting& cfg = setting.lookup(path.data());
-        setter->apply(cfg);
-      } catch (const libconfig::SettingNotFoundException&) {
-        if (setter->is_required()) {
-          throw std::invalid_argument(
-            fmt::format("Missing required configuration option: {}", path.data()));
-        }
-        return;
+      auto path                     = setter->path();
+      const libconfig::Setting* cfg = safe_lookup(setting, path);
+
+      if (cfg) {
+        setter->apply(*cfg);
+      } else if (setter->is_required()) {
+        throw std::invalid_argument(
+          fmt::format("Missing required configuration option: {}", path.data()));
       }
     });
   }

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -109,8 +109,10 @@ class downgrade_task : public itask {
    *
    * This method performs the actual downgrading of data from a higher memory tier
    * to a lower memory tier.
+   *
+   * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void execute() override;
+  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   /**
    * @brief Get the unique identifier for this task

--- a/src/include/extension_lock.hpp
+++ b/src/include/extension_lock.hpp
@@ -22,7 +22,8 @@ namespace sirius {
 
 class extension_lock {
  public:
-  explicit extension_lock(const std::string& extension_name);
+  explicit extension_lock(const std::string& extension_name,
+                          const std::string& lock_prefix = "/var/tmp");
 
   ~extension_lock();
 

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -180,7 +180,7 @@ class duckdb_scan_executor {
   void submit_scan_request();
 
   std::vector<std::shared_ptr<cucascade::data_batch>> get_scan_output(
-    op::scan::duckdb_scan_task* task);
+    op::scan::duckdb_scan_task* task, rmm::cuda_stream_view stream);
 
   struct cache_entry {
     std::vector<std::vector<std::shared_ptr<cucascade::data_batch>>> batches;

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -409,7 +409,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
   //===----------Destructor----------===//
   ~duckdb_scan_task();
 
-  void execute() override;
+  void execute([[maybe_unused]] rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
  private:
   //===----------Methods----------===//
@@ -464,9 +464,11 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    *
    * Scans data from the DuckDB table function and accumulates it into data batches.
    *
+   * @param stream CUDA stream used for device memory operations and kernel launches
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
-  std::vector<std::shared_ptr<cucascade::data_batch>> compute_task() override;
+  std::vector<std::shared_ptr<cucascade::data_batch>> compute_task(
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   /**
    * @brief Publish the computed output batches to the data repository.

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -411,7 +411,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
   //===----------Destructor----------===//
   ~duckdb_scan_task();
 
-  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  void execute(rmm::cuda_stream_view stream) override;
 
  private:
   //===----------Methods----------===//
@@ -470,7 +470,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
   std::vector<std::shared_ptr<cucascade::data_batch>> compute_task(
-    [[maybe_unused]] rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    [[maybe_unused]] rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Publish the computed output batches to the data repository.
@@ -480,7 +480,8 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(std::vector<std::shared_ptr<cucascade::data_batch>> output_batches) override;
+  void publish_output(std::vector<std::shared_ptr<cucascade::data_batch>> output_batches,
+                      rmm::cuda_stream_view stream) override;
 
   std::size_t get_estimated_reservation_size() const override
   {

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -17,6 +17,8 @@
 #pragma once
 
 // sirius
+#include <cudf/utilities/default_stream.hpp>
+
 #include <config.hpp>
 #include <memory/host_table_utils.hpp>
 #include <memory/multiple_blocks_allocation_accessor.hpp>
@@ -409,7 +411,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
   //===----------Destructor----------===//
   ~duckdb_scan_task();
 
-  void execute([[maybe_unused]] rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
  private:
   //===----------Methods----------===//
@@ -468,7 +470,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
   std::vector<std::shared_ptr<cucascade::data_batch>> compute_task(
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    [[maybe_unused]] rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   /**
    * @brief Publish the computed output batches to the data repository.

--- a/src/include/op/sirius_physical_filter.hpp
+++ b/src/include/op/sirius_physical_filter.hpp
@@ -38,7 +38,7 @@ class sirius_physical_filter : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 
   // sirius_expression_executor* sirius_expression_executor;
 

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -42,7 +42,7 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -129,7 +129,7 @@ class sirius_physical_operator {
 
   virtual std::vector<std::shared_ptr<::cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<::cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream());
+    rmm::cuda_stream_view stream);
 
   //! The influence the operator has on order (insertion order means no influence)
   virtual duckdb::OrderPreservationType operator_order() const
@@ -162,7 +162,7 @@ class sirius_physical_operator {
     duckdb::ClientContext& context) const;
 
   virtual void sink(const std::vector<std::shared_ptr<::cucascade::data_batch>>& input_batches,
-                    rmm::cuda_stream_view stream = cudf::get_default_stream());
+                    rmm::cuda_stream_view stream);
 
   virtual bool is_sink() const { return false; }
 

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -33,7 +33,7 @@ class sirius_physical_projection : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
 };

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -46,7 +46,7 @@ class sirius_physical_result_collector : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 
   duckdb::StatementType statement_type;
   duckdb::StatementProperties properties;
@@ -96,7 +96,7 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
    * data representations and invoke one such here.
    */
   void sink(const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-            rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+            rmm::cuda_stream_view stream) override;
 
  private:
   duckdb::ClientContext& _client_ctx;

--- a/src/include/op/sirius_physical_table_scan.hpp
+++ b/src/include/op/sirius_physical_table_scan.hpp
@@ -120,7 +120,7 @@ class sirius_physical_table_scan : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 
  public:
   bool is_source() const override { return true; }

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -62,7 +62,7 @@ class sirius_physical_top_n : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_top_n_merge.hpp
+++ b/src/include/op/sirius_physical_top_n_merge.hpp
@@ -64,7 +64,7 @@ class sirius_physical_top_n_merge : public sirius_physical_operator {
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -49,7 +49,7 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
@@ -57,7 +57,7 @@ class sirius_physical_ungrouped_aggregate_merge : public sirius_physical_operato
 
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+    rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -19,6 +19,7 @@
 #include "helper/helper.hpp"
 
 #include <cudf/utilities/default_stream.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cucascade/memory/memory_reservation.hpp>

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -19,6 +19,7 @@
 #include "helper/helper.hpp"
 
 #include <cudf/utilities/default_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <cucascade/memory/memory_reservation.hpp>
 
@@ -91,7 +92,7 @@ class itask {
   itask& operator=(itask&&)      = default;
 
   // Execution function.
-  virtual void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) = 0;
+  virtual void execute(rmm::cuda_stream_view stream) = 0;
 
   template <typename T>
   T* as() noexcept

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -18,6 +18,8 @@
 
 #include "helper/helper.hpp"
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <cucascade/memory/memory_reservation.hpp>
 
 #include <memory>
@@ -76,7 +78,7 @@ class itask {
  public:
   itask(std::unique_ptr<itask_local_state> local_state,
         std::shared_ptr<itask_global_state> global_state)
-    : _local_state(std::move(local_state)), _global_state(global_state)
+    : _local_state(std::move(local_state)), _global_state(std::move(global_state))
   {
   }
 
@@ -89,7 +91,7 @@ class itask {
   itask& operator=(itask&&)      = default;
 
   // Execution function.
-  virtual void execute() = 0;
+  virtual void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) = 0;
 
   template <typename T>
   T* as() noexcept
@@ -104,13 +106,13 @@ class itask {
   }
 
   template <typename T>
-  bool is() const noexcept
+  [[nodiscard]] bool is() const noexcept
   {
     return dynamic_cast<const T*>(this) != nullptr;
   }
 
   itask_local_state* local_state() noexcept { return _local_state.get(); }
-  itask_global_state* global_state() noexcept { return _global_state.get(); }
+  [[nodiscard]] itask_global_state* global_state() noexcept { return _global_state.get(); }
 
  protected:
   std::unique_ptr<itask_local_state> _local_state;

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -121,7 +121,7 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    *
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  void execute(rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Get the unique identifier for this task
@@ -155,7 +155,8 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(std::vector<std::shared_ptr<cucascade::data_batch>> output_batches) override;
+  void publish_output(std::vector<std::shared_ptr<cucascade::data_batch>> output_batches,
+                      rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Get the input size for this task

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -118,8 +118,10 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
 
   /**
    * @brief Method to actually execute the task
+   *
+   * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  void execute() override;
+  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   /**
    * @brief Get the unique identifier for this task
@@ -140,9 +142,11 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    *
    * Executes the GPU pipeline on the input batches and returns the computed results.
    *
+   * @param stream CUDA stream used for device memory operations and kernel launches
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
-  std::vector<std::shared_ptr<cucascade::data_batch>> compute_task() override;
+  std::vector<std::shared_ptr<cucascade::data_batch>> compute_task(
+    rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Publish the computed output batches to data repositories.

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -71,8 +71,8 @@ class sirius_pipeline_itask : public parallel::itask {
    *
    * @param output_batches The data batches to publish (typically the result of compute_task())
    */
-  virtual void publish_output(
-    std::vector<std::shared_ptr<cucascade::data_batch>> output_batches) = 0;
+  virtual void publish_output(std::vector<std::shared_ptr<cucascade::data_batch>> output_batches,
+                              rmm::cuda_stream_view stream) = 0;
 
   /**
    * @brief Get the estimated reservation memory size needed for this task.
@@ -86,10 +86,10 @@ class sirius_pipeline_itask : public parallel::itask {
   /// @brief Get the output consumer operators for this task.
   virtual std::vector<op::sirius_physical_operator*> get_output_consumers() = 0;
 
-  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override
+  void execute(rmm::cuda_stream_view stream) override
   {
     auto output_batches = compute_task(stream);
-    publish_output(output_batches);
+    publish_output(output_batches, stream);
   }
 
  protected:

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -22,9 +22,9 @@
 
 #include <cudf/utilities/default_stream.hpp>
 
-#include <cucascade/data/data_batch.hpp>
-
 #include <rmm/cuda_stream_view.hpp>
+
+#include <cucascade/data/data_batch.hpp>
 
 #include <memory>
 #include <vector>

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -20,7 +20,11 @@
 #include "parallel/task.hpp"
 #include "pipeline/sirius_pipeline_itask_local_state.hpp"
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <cucascade/data/data_batch.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
 #include <vector>
@@ -51,10 +55,12 @@ class sirius_pipeline_itask : public parallel::itask {
    * the resulting data batches. The computation may involve reading input batches,
    * executing GPU operators, scanning database tables, etc.
    *
+   * @param stream CUDA stream used for device memory operations and kernel launches
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output
    *         data batches, which may be empty if no output is produced.
    */
-  virtual std::vector<std::shared_ptr<cucascade::data_batch>> compute_task() = 0;
+  virtual std::vector<std::shared_ptr<cucascade::data_batch>> compute_task(
+    rmm::cuda_stream_view stream) = 0;
 
   /**
    * @brief Publish the computed output batches to appropriate destinations.
@@ -80,9 +86,9 @@ class sirius_pipeline_itask : public parallel::itask {
   /// @brief Get the output consumer operators for this task.
   virtual std::vector<op::sirius_physical_operator*> get_output_consumers() = 0;
 
-  void execute() override
+  void execute(rmm::cuda_stream_view stream = cudf::get_default_stream()) override
   {
-    auto output_batches = compute_task();
+    auto output_batches = compute_task(stream);
     publish_output(output_batches);
   }
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -55,7 +55,7 @@ struct sirius_config {
   [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return enable_scan_caching_; }
 
  private:
-  cucascade::memory::system_topology_info _hw_topology;
+  cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
   exec::thread_pool_config _task_creator_config{.num_threads        = 2,
                                                 .thread_name_prefix = "task_creator"};

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -52,7 +52,7 @@ struct sirius_config {
 
   [[nodiscard]] const exec::thread_pool_config& get_duckdb_scan_executor_config() const noexcept;
 
-  [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return enable_scan_caching_; }
+  [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return _enable_scan_caching; }
 
  private:
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
@@ -65,7 +65,7 @@ struct sirius_config {
                                                       .thread_name_prefix = "downgrade"};
   exec::thread_pool_config _duckdb_scan_executor_config{.num_threads        = 4,
                                                         .thread_name_prefix = "duckdb_scan"};
-  bool enable_scan_caching_ = false;
+  bool _enable_scan_caching = false;
 };
 
 }  // namespace sirius

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "config.hpp"
+#include "config_option.hpp"
 #include "exec/config.hpp"
 
 #include <cucascade/memory/config.hpp>

--- a/src/include/util/stream_check_wrapper.hpp
+++ b/src/include/util/stream_check_wrapper.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace sirius {
+namespace util {
+
+/**
+ * @brief Enable logging on default CUDA stream access (no-op if stream_check not available)
+ * 
+ * When ENABLE_STREAM_CHECK is defined at compile time, this will attempt to dynamically
+ * load the stream_check library and enable logging. If the library is not found or
+ * ENABLE_STREAM_CHECK is not defined, this is a no-op.
+ */
+void enable_log_on_default_stream() noexcept;
+
+/**
+ * @brief Disable logging on default CUDA stream access (no-op if stream_check not available)
+ * 
+ * When ENABLE_STREAM_CHECK is defined at compile time, this will attempt to dynamically
+ * load the stream_check library and disable logging. If the library is not found or
+ * ENABLE_STREAM_CHECK is not defined, this is a no-op.
+ */
+void disable_log_on_default_stream() noexcept;
+
+/**
+ * @brief Set the log file path for stream check (no-op if stream_check not available)
+ * 
+ * @param path Path to the log file where stack traces will be written
+ */
+void set_stream_check_log_file(const char* path) noexcept;
+
+}  // namespace util
+}  // namespace sirius

--- a/src/include/util/stream_check_wrapper.hpp
+++ b/src/include/util/stream_check_wrapper.hpp
@@ -21,7 +21,7 @@ namespace util {
 
 /**
  * @brief Enable logging on default CUDA stream access (no-op if stream_check not available)
- * 
+ *
  * When ENABLE_STREAM_CHECK is defined at compile time, this will attempt to dynamically
  * load the stream_check library and enable logging. If the library is not found or
  * ENABLE_STREAM_CHECK is not defined, this is a no-op.
@@ -30,7 +30,7 @@ void enable_log_on_default_stream() noexcept;
 
 /**
  * @brief Disable logging on default CUDA stream access (no-op if stream_check not available)
- * 
+ *
  * When ENABLE_STREAM_CHECK is defined at compile time, this will attempt to dynamically
  * load the stream_check library and disable logging. If the library is not found or
  * ENABLE_STREAM_CHECK is not defined, this is a no-op.
@@ -39,7 +39,7 @@ void disable_log_on_default_stream() noexcept;
 
 /**
  * @brief Set the log file path for stream check (no-op if stream_check not available)
- * 
+ *
  * @param path Path to the log file where stack traces will be written
  */
 void set_stream_check_log_file(const char* path) noexcept;

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggre
     auto output_scalar = cudf::reduce(
       input_col, *reduce_aggregation, output_type, stream, memory_space.get_default_allocator());
     output_cols.push_back(cudf::make_column_from_scalar(
-      *output_scalar, 1, cudf::get_default_stream(), memory_space.get_default_allocator()));
+      *output_scalar, 1, stream, memory_space.get_default_allocator()));
   }
   auto output_table = std::make_unique<cudf::table>(
     std::move(output_cols), stream, memory_space.get_default_allocator());

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -24,6 +24,7 @@
 #include "pipeline/sirius_pipeline_itask_local_state.hpp"
 
 #include <cudf/utilities/default_stream.hpp>
+
 #include <cucascade/memory/common.hpp>
 
 namespace sirius::op::scan {

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -23,6 +23,7 @@
 #include "pipeline/completion_handler.hpp"
 #include "pipeline/sirius_pipeline_itask_local_state.hpp"
 
+#include <cudf/utilities/default_stream.hpp>
 #include <cucascade/memory/common.hpp>
 
 namespace sirius::op::scan {
@@ -132,10 +133,10 @@ void duckdb_scan_executor::submit_scan_request()
 }
 
 std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_executor::get_scan_output(
-  op::scan::duckdb_scan_task* task)
+  op::scan::duckdb_scan_task* task, rmm::cuda_stream_view stream)
 {
   if (!_caching_enabled) {
-    return task->compute_task();
+    return task->compute_task(stream);
   } else {
     auto pipe_id = task->get_pipeline_id();
     std::lock_guard<std::mutex> lock(_cache_mutex);
@@ -148,7 +149,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_executor::get_sc
       }
       return entry->batches[entry->batch_index++];
     } else {
-      auto batches = task->compute_task();
+      auto batches = task->compute_task(stream);
       entry->batches.push_back(batches);
       return batches;
     }
@@ -198,14 +199,16 @@ void duckdb_scan_executor::manager_loop()
       }
     }
 
+    auto stream = cudf::get_default_stream();
     _thread_pool->schedule([this,
                             ticket    = std::move(ticket),
+                            stream    = std::move(stream),
                             t         = std::move(task),
                             scan_task = std::move(scan_task)]() mutable {
       try {
         auto consumers = scan_task->get_output_consumers();
-        auto batches   = get_scan_output(scan_task);
-        scan_task->publish_output(std::move(batches));
+        auto batches   = get_scan_output(scan_task, stream);
+        scan_task->publish_output(std::move(batches), stream);
         t.reset();
         if (_task_creator && !(_completion_handler && _completion_handler->is_completed())) {
           for (auto* consumer : consumers) {

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -493,13 +493,14 @@ void duckdb_scan_task::process_chunk(duckdb_scan_task_local_state& l_state)
   l_state._row_offset += l_state._chunk.size();
 }
 
-void duckdb_scan_task::execute()
+void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
 {
-  auto output_batches = compute_task();
+  auto output_batches = compute_task(stream);
   publish_output(output_batches);
 }
 
-std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_task::compute_task()
+std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_task::compute_task(
+  rmm::cuda_stream_view stream)
 {
   // Cast base task states to DuckDB scan task states
   auto& l_state = this->_local_state->cast<duckdb_scan_task_local_state>();

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -496,7 +496,7 @@ void duckdb_scan_task::process_chunk(duckdb_scan_task_local_state& l_state)
 void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
 {
   auto output_batches = compute_task(stream);
-  publish_output(output_batches);
+  publish_output(output_batches, stream);
 }
 
 std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_task::compute_task(
@@ -559,7 +559,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_task::compute_ta
 }
 
 void duckdb_scan_task::publish_output(
-  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches)
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches, rmm::cuda_stream_view stream)
 {
   std::for_each(std::make_move_iterator(output_batches.begin()),
                 std::make_move_iterator(output_batches.end()),

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -80,7 +80,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_streaming_li
 
     // cudf::slice returns a vector of table_views; materialize into a table
     auto sliced_table = std::make_unique<cudf::table>(
-      slices.front(), stream, *batch->get_memory_space()->get_default_allocator());
+      slices.front(), stream, batch->get_memory_space()->get_default_allocator());
     std::unique_ptr<cucascade::idata_representation> output_data =
       std::make_unique<cucascade::gpu_table_representation>(std::move(sliced_table),
                                                             *batch->get_memory_space());

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type typ
                                                              T value,
                                                              rmm::cuda_stream_view stream)
 {
-  auto out = cudf::make_numeric_scalar(type);
+  auto out = cudf::make_numeric_scalar(type, stream);
   scalar_cast<cudf::numeric_scalar<T>>(*out).set_value(value, stream);
   return out;
 }
@@ -458,7 +458,7 @@ sirius_physical_ungrouped_aggregate_merge::execute(
     }
   }
 
-  auto out_table = std::make_unique<cudf::table>(std::move(output_cols), stream);
+  auto out_table = std::make_unique<cudf::table>(std::move(output_cols), stream, cudf::get_current_device_resource_ref());
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
   auto const batch_id = ::sirius::get_next_batch_id();

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -458,7 +458,8 @@ sirius_physical_ungrouped_aggregate_merge::execute(
     }
   }
 
-  auto out_table = std::make_unique<cudf::table>(std::move(output_cols), stream, cudf::get_current_device_resource_ref());
+  auto out_table = std::make_unique<cudf::table>(
+    std::move(output_cols), stream, cudf::get_current_device_resource_ref());
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
   auto const batch_id = ::sirius::get_next_batch_id();

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -31,6 +31,7 @@
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/resource_ref.hpp>
 
@@ -78,10 +79,12 @@ ScalarType& scalar_cast(cudf::scalar& s)
 }
 
 template <typename T>
-std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type type, T value)
+std::unique_ptr<cudf::scalar> make_numeric_scalar_with_value(cudf::data_type type,
+                                                             T value,
+                                                             rmm::cuda_stream_view stream)
 {
   auto out = cudf::make_numeric_scalar(type);
-  scalar_cast<cudf::numeric_scalar<T>>(*out).set_value(value, cudf::get_default_stream());
+  scalar_cast<cudf::numeric_scalar<T>>(*out).set_value(value, stream);
   return out;
 }
 
@@ -248,16 +251,16 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
     if (count_host == 0) {
       switch (sum_type.id()) {
         case cudf::type_id::FLOAT32:
-          out_scalar = make_numeric_scalar_with_value<float>(sum_type, 0.0f);
+          out_scalar = make_numeric_scalar_with_value<float>(sum_type, 0.0f, stream);
           break;
         case cudf::type_id::FLOAT64:
-          out_scalar = make_numeric_scalar_with_value<double>(sum_type, 0.0);
+          out_scalar = make_numeric_scalar_with_value<double>(sum_type, 0.0, stream);
           break;
         case cudf::type_id::INT32:
-          out_scalar = make_numeric_scalar_with_value<int32_t>(sum_type, 0);
+          out_scalar = make_numeric_scalar_with_value<int32_t>(sum_type, 0, stream);
           break;
         case cudf::type_id::INT64:
-          out_scalar = make_numeric_scalar_with_value<int64_t>(sum_type, 0);
+          out_scalar = make_numeric_scalar_with_value<int64_t>(sum_type, 0, stream);
           break;
         default: throw duckdb::NotImplementedException("AVG output type not supported");
       }
@@ -265,24 +268,26 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
       switch (sum_type.id()) {
         case cudf::type_id::FLOAT32: {
           auto sum_host = scalar_cast<cudf::numeric_scalar<float>>(*sum_value).value();
-          out_scalar    = make_numeric_scalar_with_value<float>(sum_type, sum_host / count_host);
+          out_scalar =
+            make_numeric_scalar_with_value<float>(sum_type, sum_host / count_host, stream);
           break;
         }
         case cudf::type_id::FLOAT64: {
           auto sum_host = scalar_cast<cudf::numeric_scalar<double>>(*sum_value).value();
-          out_scalar    = make_numeric_scalar_with_value<double>(sum_type, sum_host / count_host);
+          out_scalar =
+            make_numeric_scalar_with_value<double>(sum_type, sum_host / count_host, stream);
           break;
         }
         case cudf::type_id::INT32: {
           auto sum_host = scalar_cast<cudf::numeric_scalar<int32_t>>(*sum_value).value();
           out_scalar    = make_numeric_scalar_with_value<int32_t>(
-            sum_type, static_cast<int32_t>(sum_host / count_host));
+            sum_type, static_cast<int32_t>(sum_host / count_host), stream);
           break;
         }
         case cudf::type_id::INT64: {
           auto sum_host = scalar_cast<cudf::numeric_scalar<int64_t>>(*sum_value).value();
           out_scalar    = make_numeric_scalar_with_value<int64_t>(
-            sum_type, static_cast<int64_t>(sum_host / count_host));
+            sum_type, static_cast<int64_t>(sum_host / count_host), stream);
           break;
         }
         default: throw duckdb::NotImplementedException("AVG output type not supported");
@@ -320,22 +325,16 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_ag
       switch (spec.kind) {
         case aggregate_kind::COUNT_STAR: {
           auto scalar = make_numeric_scalar_with_value<int64_t>(
-            cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()));
-          cols.push_back(
-            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+            cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()), stream);
+          cols.push_back(cudf::make_column_from_scalar(*scalar, 1, stream));
           break;
         }
         case aggregate_kind::COUNT: {
           auto col    = view.column(static_cast<cudf::size_type>(spec.input_idx));
           auto agg_op = cudf::make_count_aggregation<cudf::reduce_aggregation>();
-          auto scalar = cudf::reduce(col,
-                                     *agg_op,
-                                     cudf::data_type(cudf::type_id::INT64),
-                                     std::nullopt,
-                                     stream,
-                                     space->get_default_allocator());
-          cols.push_back(
-            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+          auto scalar =
+            cudf::reduce(col, *agg_op, cudf::data_type(cudf::type_id::INT64), std::nullopt, stream);
+          cols.push_back(cudf::make_column_from_scalar(*scalar, 1, stream));
           break;
         }
         case aggregate_kind::SUM:
@@ -352,22 +351,19 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_ungrouped_ag
           } else {
             agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
           }
-          auto scalar = cudf::reduce(
-            col, *agg_op, out_type, std::nullopt, stream, space->get_default_allocator());
-          cols.push_back(
-            cudf::make_column_from_scalar(*scalar, 1, stream, space->get_default_allocator()));
+          auto scalar = cudf::reduce(col, *agg_op, out_type, std::nullopt, stream);
+          cols.push_back(cudf::make_column_from_scalar(*scalar, 1, stream));
           if (spec.kind == aggregate_kind::AVG) {
             auto count_scalar = make_numeric_scalar_with_value<int64_t>(
-              cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()));
-            cols.push_back(cudf::make_column_from_scalar(
-              *count_scalar, 1, stream, space->get_default_allocator()));
+              cudf::data_type{cudf::type_id::INT64}, static_cast<int64_t>(view.num_rows()), stream);
+            cols.push_back(cudf::make_column_from_scalar(*count_scalar, 1, stream));
           }
           break;
         }
       }
     }
 
-    auto out_table = std::make_unique<cudf::table>(std::move(cols));
+    auto out_table = std::make_unique<cudf::table>(std::move(cols), stream);
     std::unique_ptr<cucascade::idata_representation> output_data =
       std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
     auto const batch_id = ::sirius::get_next_batch_id();
@@ -455,16 +451,14 @@ sirius_physical_ungrouped_aggregate_merge::execute(
       auto sum_view   = merged_view.column(static_cast<cudf::size_type>(spec.local_sum_idx));
       auto count_view = merged_view.column(static_cast<cudf::size_type>(spec.local_count_idx));
       output_cols.push_back(make_avg_column(
-        sum_view, count_view, spec.return_type, stream, space->get_default_allocator()));
+        sum_view, count_view, spec.return_type, stream, cudf::get_current_device_resource_ref()));
     } else {
       auto col_view = merged_view.column(static_cast<cudf::size_type>(spec.local_sum_idx));
-      output_cols.push_back(
-        std::make_unique<cudf::column>(col_view, stream, space->get_default_allocator()));
+      output_cols.push_back(std::make_unique<cudf::column>(col_view, stream));
     }
   }
 
-  auto out_table =
-    std::make_unique<cudf::table>(std::move(output_cols), stream, space->get_default_allocator());
+  auto out_table = std::make_unique<cudf::table>(std::move(output_cols), stream);
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
   auto const batch_id = ::sirius::get_next_batch_id();

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <cudf/utilities/default_stream.hpp>
-
 #include "parallel/task_executor.hpp"
+
+#include <cudf/utilities/default_stream.hpp>
 
 namespace sirius {
 namespace parallel {

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include "parallel/task_executor.hpp"
 
 namespace sirius {
@@ -71,7 +73,7 @@ void itask_executor::worker_loop(int worker_id)
       break;
     }
     try {
-      task->execute();
+      task->execute(cudf::get_default_stream());
     } catch (const std::exception& e) {
       on_task_error(worker_id, std::move(task), e);
     }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -26,6 +26,7 @@
 #include "pipeline/task_request.hpp"
 
 #include <rmm/cuda_device.hpp>
+
 #include <util/stream_check_wrapper.hpp>
 
 namespace sirius {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -17,12 +17,15 @@
 #include "pipeline/gpu_pipeline_executor.hpp"
 
 #include "creator/task_creator.hpp"
+#include "cucascade/memory/stream_pool.hpp"
 #include "cuda_runtime_api.h"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_queue.hpp"
 #include "pipeline/task_request.hpp"
+
+#include <rmm/cuda_device.hpp>
 
 namespace sirius {
 namespace pipeline {
@@ -33,6 +36,7 @@ gpu_pipeline_executor::gpu_pipeline_executor(
   cucascade::memory::memory_space* mem_space,
   exec::publisher<std::unique_ptr<task_request>> task_request_publisher)
   : _config(config),
+    _stream_pool(rmm::cuda_device_id{mem_space->get_device_id()}, _config.num_threads),
     _task_request_publisher(std::move(task_request_publisher)),
     _memory_space(mem_space)
 {
@@ -70,6 +74,7 @@ void gpu_pipeline_executor::stop()
 
 void gpu_pipeline_executor::manager_loop()
 {
+  rmm::cuda_set_device_raii set_device_guard(rmm::cuda_device_id{_memory_space->get_device_id()});
   while (_running.load()) {
     auto ticket = _kiosk.acquire();  // block till a thread is available
     if (!ticket.is_valid()) {
@@ -104,11 +109,13 @@ void gpu_pipeline_executor::manager_loop()
     }
     auto output_consumers = gpu_task->get_output_consumers();
     auto* pipeline        = gpu_task->get_pipeline();
-    // todo(amin) acquire stream and pass stream to schedule
+    auto exc_stream       = _stream_pool.acquire_stream(
+      cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
     _thread_pool->schedule([this,
-                            task      = std::move(pipeline_task),
-                            ticket    = std::move(ticket),
-                            consumers = std::move(output_consumers),
+                            task       = std::move(pipeline_task),
+                            ticket     = std::move(ticket),
+                            exc_stream = std::move(exc_stream),
+                            consumers  = std::move(output_consumers),
                             pipeline]() mutable {
       try {
         // todo(amin) pass stream to execute

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -26,10 +26,7 @@
 #include "pipeline/task_request.hpp"
 
 #include <rmm/cuda_device.hpp>
-
-#ifdef ENABLE_STREAM_CHECK
-#include <stream_check.hpp>
-#endif
+#include <util/stream_check_wrapper.hpp>
 
 namespace sirius {
 namespace pipeline {
@@ -62,9 +59,7 @@ void gpu_pipeline_executor::start()
                                         _config.cpu_affinity_list,
                                         [device_id = _memory_space->get_device_id()]() noexcept {
                                           cudaSetDevice(device_id);
-#ifdef ENABLE_STREAM_CHECK
-                                          enable_log_on_default_stream();
-#endif
+                                          sirius::util::enable_log_on_default_stream();
                                         });
   _manager_thread = std::thread(&gpu_pipeline_executor::manager_loop, this);
 }
@@ -83,9 +78,7 @@ void gpu_pipeline_executor::stop()
 void gpu_pipeline_executor::manager_loop()
 {
   rmm::cuda_set_device_raii set_device_guard(rmm::cuda_device_id{_memory_space->get_device_id()});
-#ifdef ENABLE_STREAM_CHECK
-  enable_log_on_default_stream();
-#endif
+  sirius::util::enable_log_on_default_stream();
   while (_running.load()) {
     auto ticket = _kiosk.acquire();  // block till a thread is available
     if (!ticket.is_valid()) {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -118,8 +118,7 @@ void gpu_pipeline_executor::manager_loop()
                             consumers  = std::move(output_consumers),
                             pipeline]() mutable {
       try {
-        // todo(amin) pass stream to execute
-        task->execute();
+        task->execute(exc_stream);
       } catch (...) {
         if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         return;

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -27,10 +27,13 @@
 
 #include <rmm/cuda_device.hpp>
 
+#ifdef ENABLE_STREAM_CHECK
+#include <stream_check.hpp>
+#endif
+
 namespace sirius {
 namespace pipeline {
 
-// todo (amin): add stream pool to constructor
 gpu_pipeline_executor::gpu_pipeline_executor(
   exec::thread_pool_config config,
   cucascade::memory::memory_space* mem_space,
@@ -53,11 +56,16 @@ void gpu_pipeline_executor::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  _thread_pool = std::make_unique<exec::thread_pool>(
-    _config.num_threads,
-    _config.thread_name_prefix,
-    _config.cpu_affinity_list,
-    [device_id = _memory_space->get_device_id()]() noexcept { cudaSetDevice(device_id); });
+  _thread_pool =
+    std::make_unique<exec::thread_pool>(_config.num_threads,
+                                        _config.thread_name_prefix,
+                                        _config.cpu_affinity_list,
+                                        [device_id = _memory_space->get_device_id()]() noexcept {
+                                          cudaSetDevice(device_id);
+#ifdef ENABLE_STREAM_CHECK
+                                          enable_log_on_default_stream();
+#endif
+                                        });
   _manager_thread = std::thread(&gpu_pipeline_executor::manager_loop, this);
 }
 
@@ -75,6 +83,9 @@ void gpu_pipeline_executor::stop()
 void gpu_pipeline_executor::manager_loop()
 {
   rmm::cuda_set_device_raii set_device_guard(rmm::cuda_device_id{_memory_space->get_device_id()});
+#ifdef ENABLE_STREAM_CHECK
+  enable_log_on_default_stream();
+#endif
   while (_running.load()) {
     auto ticket = _kiosk.acquire();  // block till a thread is available
     if (!ticket.is_valid()) {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -134,12 +134,12 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_pipeline_task::compute_t
 }
 
 void gpu_pipeline_task::publish_output(
-  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches)
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches, rmm::cuda_stream_view stream)
 {
   auto sink_operators =
     _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_sink();
   if (sink_operators) {
-    sink_operators.get()->sink(output_batches);
+    sink_operators.get()->sink(output_batches, stream);
   } else {
     throw std::runtime_error("Sink operator not found");
   }
@@ -188,7 +188,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   // 3. Execute cudf operators on the pipeline
   auto output_batches = compute_task(stream);
   stream.synchronize();
-  publish_output(output_batches);
+  publish_output(output_batches, stream);
   // 4. After each cudf operator, get peak total bytes to collect statistics
   // 5. Push output batches to the data repository
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -33,7 +33,8 @@ namespace {
 
 std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
   const std::shared_ptr<cucascade::data_batch>& batch,
-  const cucascade::memory::memory_space* requested_memory_space)
+  const cucascade::memory::memory_space* requested_memory_space,
+  rmm::cuda_stream_view stream)
 {
   const auto* target_space =
     requested_memory_space != nullptr ? requested_memory_space : batch->get_memory_space();
@@ -50,7 +51,6 @@ std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
   if (!lock_result.success && needs_conversion) {
     try {
       auto& registry = sirius::converter_registry::get();
-      auto stream    = requested_memory_space->acquire_stream();
       switch (requested_memory_space->get_tier()) {
         case cucascade::memory::Tier::GPU: {
           auto prev_state = batch->get_state();
@@ -121,14 +121,14 @@ const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
   return _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get();
 }
 
-std::vector<std::shared_ptr<cucascade::data_batch>> gpu_pipeline_task::compute_task()
+std::vector<std::shared_ptr<cucascade::data_batch>> gpu_pipeline_task::compute_task(
+  rmm::cuda_stream_view stream)
 {
   auto& local_state = _local_state->cast<gpu_pipeline_task_local_state>();
   auto data_batches = local_state._batches;
   for (auto& op :
        _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_operators()) {
-    // todo (amin) pass stream to execute
-    data_batches = op.get().execute(data_batches);
+    data_batches = op.get().execute(data_batches, stream);
   }
   return std::move(data_batches);
 }
@@ -145,7 +145,7 @@ void gpu_pipeline_task::publish_output(
   }
 }
 
-void gpu_pipeline_task::execute()
+void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 {
   auto& local_state = _local_state->cast<gpu_pipeline_task_local_state>();
 
@@ -165,8 +165,7 @@ void gpu_pipeline_task::execute()
   processing_handles.reserve(local_state._batches.size());
 
   for (const auto& batch : local_state._batches) {
-    // todo (amin) pass stream to lock_or_prepare_batch
-    auto handle = lock_or_prepare_batch(batch, requested_memory_space);
+    auto handle = lock_or_prepare_batch(batch, requested_memory_space, stream);
     if (!handle) {
       // Failed to lock (or convert) one of the batches. Caller can retry later.
       return;
@@ -187,9 +186,8 @@ void gpu_pipeline_task::execute()
 
   // 2. Set reservation_aware_memory_resource_ref as the default cudf allocator
   // 3. Execute cudf operators on the pipeline
-  // todo(amin) pass stream to compute_task
-  auto output_batches = compute_task();
-  // todo (amin) synchronize stream before publishing output
+  auto output_batches = compute_task(stream);
+  stream.synchronize();
   publish_output(output_batches);
   // 4. After each cudf operator, get peak total bytes to collect statistics
   // 5. Push output batches to the data repository

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -239,7 +239,7 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
   config_setter.add_config("sirius.executor.pipeline", _gpu_pipeline_executor_config);
   config_setter.add_config("sirius.executor.downgrade", _downgrade_executor_config);
   config_setter.add_config("sirius.executor.duckdb_scan", _duckdb_scan_executor_config);
-  config_setter.add_config("sirius.executor.duckdb_scan.cache", enable_scan_caching_);
+  config_setter.add_config("sirius.executor.duckdb_scan.cache", _enable_scan_caching);
 
   config_setter.add_config("sirius.space.gpu", gpu_memory_space_configs);
   config_setter.add_config("sirius.space.host", host_memory_space_configs);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -21,6 +21,7 @@
 
 #include <cucascade/memory/config.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <libconfig.h++>
 
 #include <exception>
 #include <vector>
@@ -266,7 +267,8 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
             disk_memory_space_configs.end(),
             std::back_inserter(_memory_space_configs));
 
-  if (_memory_space_configs.empty()) {
+  bool using_configurator = _memory_space_configs.empty();
+  if (using_configurator) {
     cucascade::memory::reservation_manager_configurator builder;
     builder.set_number_of_gpus(topology_instance.num_gpus);
     gpu_memory_config_instance.setup_configurator(builder);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -77,7 +77,7 @@ struct sirius::config::custom_config_registrar<sirius::exec::thread_pool_config>
   static void config(sirius::config::configuration_setter& setter,
                      sirius::exec::thread_pool_config& opt)
   {
-    setter.add_config("num_threads", opt.num_threads);
+    setter.add_config("num_threads", opt.num_threads, sirius::config::greater_than<size_t>{0});
     setter.add_config("thread_name_prefix", opt.thread_name_prefix);
     setter.add_config("cpu_affinity", opt.cpu_affinity_list);
   }
@@ -167,14 +167,16 @@ struct sirius::config::custom_config_registrar<sirius::gpu_mem_config> {
   static void config(sirius::config::configuration_setter& setter, sirius::gpu_mem_config& opt)
   {
     opt.track_per_stream_reservation = false;
-    setter.add_variant_config<double>("usage_limit_fraction", opt.usage_limit_fraction_or_bytes);
+    setter.add_variant_config<double>(
+      "usage_limit_fraction", opt.usage_limit_fraction_or_bytes, fraction<double>{});
     setter.add_variant_config<size_t>("usage_limit_bytes", opt.usage_limit_fraction_or_bytes);
-    setter.add_variant_config<double>("reservation_limit_fraction",
-                                      opt.reservation_limit_fraction_or_bytes);
+    setter.add_variant_config<double>(
+      "reservation_limit_fraction", opt.reservation_limit_fraction_or_bytes, fraction<double>{});
     setter.add_variant_config<size_t>("reservation_limit_bytes",
                                       opt.reservation_limit_fraction_or_bytes);
-    setter.add_config("downgrade_trigger_fraction", opt.downgrade_trigger_fraction_);
-    setter.add_config("downgrade_stop_fraction", opt.downgrade_stop_fraction_);
+    setter.add_config(
+      "downgrade_trigger_fraction", opt.downgrade_trigger_fraction_, fraction<double>{});
+    setter.add_config("downgrade_stop_fraction", opt.downgrade_stop_fraction_, fraction<double>{});
     setter.add_config("track_per_stream_reservation", opt.track_per_stream_reservation);
   }
 };
@@ -184,12 +186,13 @@ struct sirius::config::custom_config_registrar<sirius::host_mem_config> {
   static void config(sirius::config::configuration_setter& setter, sirius::host_mem_config& opt)
   {
     setter.add_config("capacity_bytes", opt.numa_region_capacity_bytes);
-    setter.add_variant_config<double>("reservation_limit_fraction",
-                                      opt.reservation_limit_fraction_or_bytes);
+    setter.add_variant_config<double>(
+      "reservation_limit_fraction", opt.reservation_limit_fraction_or_bytes, fraction<double>{});
     setter.add_variant_config<size_t>("reservation_limit_bytes",
                                       opt.reservation_limit_fraction_or_bytes);
-    setter.add_config("downgrade_trigger_fraction", opt.downgrade_trigger_fraction_);
-    setter.add_config("downgrade_stop_fraction", opt.downgrade_stop_fraction_);
+    setter.add_config(
+      "downgrade_trigger_fraction", opt.downgrade_trigger_fraction_, fraction<double>{});
+    setter.add_config("downgrade_stop_fraction", opt.downgrade_stop_fraction_, fraction<double>{});
     setter.add_config("block_size", opt.block_size);
     setter.add_config("pool_size", opt.pool_size);
     setter.add_config("initial_number_pools", opt.initial_number_pools);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -269,7 +269,21 @@ void SiriusContextExtensionCallback::read_config_file_if_exists()
   }
   config_.load_from_file(config_path);
   spdlog::info("Loaded Sirius configuration from file: {}", config_path);
-  extension_lock_ = std::make_unique<sirius::extension_lock>("sirius");
+
+  // Determine lock prefix: check if $HOME/.sirius directory exists
+  std::string lock_prefix = "/var/tmp";
+  const char* home_dir    = std::getenv("HOME");
+  if (home_dir != nullptr) {
+    std::string sirius_dir = std::string(home_dir) + "/" + std::string(CONFIG_FILE_DIR);
+    if (!std::filesystem::exists(sirius_dir)) {
+      // Create the directory if it doesn't exist
+      std::filesystem::create_directories(sirius_dir);
+      spdlog::info("Created Sirius directory: {}", sirius_dir);
+    }
+    lock_prefix = sirius_dir;
+  }
+
+  extension_lock_ = std::make_unique<sirius::extension_lock>("sirius", lock_prefix);
   context_        = duckdb::make_shared_ptr<SiriusContext>();
   context_->initialize(config_);
 }

--- a/src/util/stream_check_wrapper.cpp
+++ b/src/util/stream_check_wrapper.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/stream_check_wrapper.hpp"
+
+#include <dlfcn.h>
+#include <mutex>
+#include <iostream>
+
+namespace sirius {
+namespace util {
+
+namespace {
+
+// Function pointer types matching stream_check API
+using enable_log_fn_t = void(*)();
+using disable_log_fn_t = void(*)();
+using set_log_file_fn_t = void(*)(const char*);
+
+// Lazy-loaded function pointers
+enable_log_fn_t g_enable_log_fn = nullptr;
+disable_log_fn_t g_disable_log_fn = nullptr;
+set_log_file_fn_t g_set_log_file_fn = nullptr;
+
+// Handle to the loaded library
+void* g_stream_check_handle = nullptr;
+
+// For thread-safe one-time initialization
+std::once_flag g_init_flag;
+bool g_init_success = false;
+
+/**
+ * @brief Attempt to dynamically load the stream_check library and resolve symbols
+ * 
+ * This is called once on first use via std::call_once. If the library can't be 
+ * found or symbols can't be resolved, subsequent calls will be no-ops.
+ */
+void lazy_init() noexcept {
+    
+    // Try to load the stream_check library
+    // Search in standard locations only (not build directory)
+    // This allows controlling whether it's loaded without recompiling
+    const char* lib_names[] = {
+        "libstream_check.so",           // Standard location (LD_LIBRARY_PATH, install dir)
+        "./libstream_check.so",          // Current directory
+        nullptr
+    };
+    
+    // Check for environment variable override
+    const char* env_path = std::getenv("SIRIUS_STREAM_CHECK_LIB");
+    if (env_path && env_path[0] != '\0') {
+        g_stream_check_handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
+        if (g_stream_check_handle) {
+            std::cerr << "Stream check: loaded from SIRIUS_STREAM_CHECK_LIB: " << env_path << std::endl;
+            // Continue to resolve symbols below
+        } else {
+            std::cerr << "Stream check: failed to load from SIRIUS_STREAM_CHECK_LIB: " 
+                      << env_path << " - " << dlerror() << std::endl;
+        }
+    }
+    
+    // If not loaded from environment variable, try standard search paths
+    if (!g_stream_check_handle) {
+        for (int i = 0; lib_names[i] != nullptr; ++i) {
+            g_stream_check_handle = dlopen(lib_names[i], RTLD_LAZY | RTLD_LOCAL);
+            if (g_stream_check_handle) {
+                std::cerr << "Stream check: loaded from: " << lib_names[i] << std::endl;
+                break;
+            }
+        }
+    }
+    
+    if (!g_stream_check_handle) {
+        // Not an error - library is optional
+        return;
+    }
+    
+    // Clear any existing errors
+    dlerror();
+    
+    // Resolve symbols
+    g_enable_log_fn = reinterpret_cast<enable_log_fn_t>(
+        dlsym(g_stream_check_handle, "enable_log_on_default_stream"));
+    if (!g_enable_log_fn) {
+        std::cerr << "Stream check: failed to resolve enable_log_on_default_stream: " 
+                  << dlerror() << std::endl;
+        dlclose(g_stream_check_handle);
+        g_stream_check_handle = nullptr;
+        return;
+    }
+    
+    g_disable_log_fn = reinterpret_cast<disable_log_fn_t>(
+        dlsym(g_stream_check_handle, "disable_log_on_default_stream"));
+    if (!g_disable_log_fn) {
+        std::cerr << "Stream check: failed to resolve disable_log_on_default_stream: " 
+                  << dlerror() << std::endl;
+        dlclose(g_stream_check_handle);
+        g_stream_check_handle = nullptr;
+        g_enable_log_fn = nullptr;
+        return;
+    }
+    
+    g_set_log_file_fn = reinterpret_cast<set_log_file_fn_t>(
+        dlsym(g_stream_check_handle, "set_stream_check_log_file"));
+    if (!g_set_log_file_fn) {
+        std::cerr << "Stream check: failed to resolve set_stream_check_log_file: " 
+                  << dlerror() << std::endl;
+        dlclose(g_stream_check_handle);
+        g_stream_check_handle = nullptr;
+        g_enable_log_fn = nullptr;
+        g_disable_log_fn = nullptr;
+        return;
+    }
+    
+    g_init_success = true;
+    std::cerr << "Stream check: library loaded successfully" << std::endl;
+}
+
+}  // anonymous namespace
+
+void enable_log_on_default_stream() noexcept {
+    std::call_once(g_init_flag, lazy_init);
+    if (g_init_success && g_enable_log_fn) {
+        g_enable_log_fn();
+    }
+}
+
+void disable_log_on_default_stream() noexcept {
+    std::call_once(g_init_flag, lazy_init);
+    if (g_init_success && g_disable_log_fn) {
+        g_disable_log_fn();
+    }
+}
+
+void set_stream_check_log_file(const char* path) noexcept {
+    std::call_once(g_init_flag, lazy_init);
+    if (g_init_success && g_set_log_file_fn) {
+        g_set_log_file_fn(path);
+    }
+}
+
+}  // namespace util
+}  // namespace sirius

--- a/src/util/stream_check_wrapper.cpp
+++ b/src/util/stream_check_wrapper.cpp
@@ -17,8 +17,9 @@
 #include "util/stream_check_wrapper.hpp"
 
 #include <dlfcn.h>
-#include <mutex>
+
 #include <iostream>
+#include <mutex>
 
 namespace sirius {
 namespace util {
@@ -26,13 +27,13 @@ namespace util {
 namespace {
 
 // Function pointer types matching stream_check API
-using enable_log_fn_t = void(*)();
-using disable_log_fn_t = void(*)();
-using set_log_file_fn_t = void(*)(const char*);
+using enable_log_fn_t   = void (*)();
+using disable_log_fn_t  = void (*)();
+using set_log_file_fn_t = void (*)(const char*);
 
 // Lazy-loaded function pointers
-enable_log_fn_t g_enable_log_fn = nullptr;
-disable_log_fn_t g_disable_log_fn = nullptr;
+enable_log_fn_t g_enable_log_fn     = nullptr;
+disable_log_fn_t g_disable_log_fn   = nullptr;
 set_log_file_fn_t g_set_log_file_fn = nullptr;
 
 // Handle to the loaded library
@@ -44,112 +45,108 @@ bool g_init_success = false;
 
 /**
  * @brief Attempt to dynamically load the stream_check library and resolve symbols
- * 
- * This is called once on first use via std::call_once. If the library can't be 
+ *
+ * This is called once on first use via std::call_once. If the library can't be
  * found or symbols can't be resolved, subsequent calls will be no-ops.
  */
-void lazy_init() noexcept {
-    
-    // Try to load the stream_check library
-    // Search in standard locations only (not build directory)
-    // This allows controlling whether it's loaded without recompiling
-    const char* lib_names[] = {
-        "libstream_check.so",           // Standard location (LD_LIBRARY_PATH, install dir)
-        "./libstream_check.so",          // Current directory
-        nullptr
-    };
-    
-    // Check for environment variable override
-    const char* env_path = std::getenv("SIRIUS_STREAM_CHECK_LIB");
-    if (env_path && env_path[0] != '\0') {
-        g_stream_check_handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
-        if (g_stream_check_handle) {
-            std::cerr << "Stream check: loaded from SIRIUS_STREAM_CHECK_LIB: " << env_path << std::endl;
-            // Continue to resolve symbols below
-        } else {
-            std::cerr << "Stream check: failed to load from SIRIUS_STREAM_CHECK_LIB: " 
-                      << env_path << " - " << dlerror() << std::endl;
-        }
+void lazy_init() noexcept
+{
+  // Try to load the stream_check library
+  // Search in standard locations only (not build directory)
+  // This allows controlling whether it's loaded without recompiling
+  const char* lib_names[] = {
+    "libstream_check.so",    // Standard location (LD_LIBRARY_PATH, install dir)
+    "./libstream_check.so",  // Current directory
+    nullptr};
+
+  // Check for environment variable override
+  const char* env_path = std::getenv("SIRIUS_STREAM_CHECK_LIB");
+  if (env_path && env_path[0] != '\0') {
+    g_stream_check_handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
+    if (g_stream_check_handle) {
+      std::cerr << "Stream check: loaded from SIRIUS_STREAM_CHECK_LIB: " << env_path << std::endl;
+      // Continue to resolve symbols below
+    } else {
+      std::cerr << "Stream check: failed to load from SIRIUS_STREAM_CHECK_LIB: " << env_path
+                << " - " << dlerror() << std::endl;
     }
-    
-    // If not loaded from environment variable, try standard search paths
-    if (!g_stream_check_handle) {
-        for (int i = 0; lib_names[i] != nullptr; ++i) {
-            g_stream_check_handle = dlopen(lib_names[i], RTLD_LAZY | RTLD_LOCAL);
-            if (g_stream_check_handle) {
-                std::cerr << "Stream check: loaded from: " << lib_names[i] << std::endl;
-                break;
-            }
-        }
+  }
+
+  // If not loaded from environment variable, try standard search paths
+  if (!g_stream_check_handle) {
+    for (int i = 0; lib_names[i] != nullptr; ++i) {
+      g_stream_check_handle = dlopen(lib_names[i], RTLD_LAZY | RTLD_LOCAL);
+      if (g_stream_check_handle) {
+        std::cerr << "Stream check: loaded from: " << lib_names[i] << std::endl;
+        break;
+      }
     }
-    
-    if (!g_stream_check_handle) {
-        // Not an error - library is optional
-        return;
-    }
-    
-    // Clear any existing errors
-    dlerror();
-    
-    // Resolve symbols
-    g_enable_log_fn = reinterpret_cast<enable_log_fn_t>(
-        dlsym(g_stream_check_handle, "enable_log_on_default_stream"));
-    if (!g_enable_log_fn) {
-        std::cerr << "Stream check: failed to resolve enable_log_on_default_stream: " 
-                  << dlerror() << std::endl;
-        dlclose(g_stream_check_handle);
-        g_stream_check_handle = nullptr;
-        return;
-    }
-    
-    g_disable_log_fn = reinterpret_cast<disable_log_fn_t>(
-        dlsym(g_stream_check_handle, "disable_log_on_default_stream"));
-    if (!g_disable_log_fn) {
-        std::cerr << "Stream check: failed to resolve disable_log_on_default_stream: " 
-                  << dlerror() << std::endl;
-        dlclose(g_stream_check_handle);
-        g_stream_check_handle = nullptr;
-        g_enable_log_fn = nullptr;
-        return;
-    }
-    
-    g_set_log_file_fn = reinterpret_cast<set_log_file_fn_t>(
-        dlsym(g_stream_check_handle, "set_stream_check_log_file"));
-    if (!g_set_log_file_fn) {
-        std::cerr << "Stream check: failed to resolve set_stream_check_log_file: " 
-                  << dlerror() << std::endl;
-        dlclose(g_stream_check_handle);
-        g_stream_check_handle = nullptr;
-        g_enable_log_fn = nullptr;
-        g_disable_log_fn = nullptr;
-        return;
-    }
-    
-    g_init_success = true;
-    std::cerr << "Stream check: library loaded successfully" << std::endl;
+  }
+
+  if (!g_stream_check_handle) {
+    // Not an error - library is optional
+    return;
+  }
+
+  // Clear any existing errors
+  dlerror();
+
+  // Resolve symbols
+  g_enable_log_fn =
+    reinterpret_cast<enable_log_fn_t>(dlsym(g_stream_check_handle, "enable_log_on_default_stream"));
+  if (!g_enable_log_fn) {
+    std::cerr << "Stream check: failed to resolve enable_log_on_default_stream: " << dlerror()
+              << std::endl;
+    dlclose(g_stream_check_handle);
+    g_stream_check_handle = nullptr;
+    return;
+  }
+
+  g_disable_log_fn = reinterpret_cast<disable_log_fn_t>(
+    dlsym(g_stream_check_handle, "disable_log_on_default_stream"));
+  if (!g_disable_log_fn) {
+    std::cerr << "Stream check: failed to resolve disable_log_on_default_stream: " << dlerror()
+              << std::endl;
+    dlclose(g_stream_check_handle);
+    g_stream_check_handle = nullptr;
+    g_enable_log_fn       = nullptr;
+    return;
+  }
+
+  g_set_log_file_fn =
+    reinterpret_cast<set_log_file_fn_t>(dlsym(g_stream_check_handle, "set_stream_check_log_file"));
+  if (!g_set_log_file_fn) {
+    std::cerr << "Stream check: failed to resolve set_stream_check_log_file: " << dlerror()
+              << std::endl;
+    dlclose(g_stream_check_handle);
+    g_stream_check_handle = nullptr;
+    g_enable_log_fn       = nullptr;
+    g_disable_log_fn      = nullptr;
+    return;
+  }
+
+  g_init_success = true;
+  std::cerr << "Stream check: library loaded successfully" << std::endl;
 }
 
 }  // anonymous namespace
 
-void enable_log_on_default_stream() noexcept {
-    std::call_once(g_init_flag, lazy_init);
-    if (g_init_success && g_enable_log_fn) {
-        g_enable_log_fn();
-    }
+void enable_log_on_default_stream() noexcept
+{
+  std::call_once(g_init_flag, lazy_init);
+  if (g_init_success && g_enable_log_fn) { g_enable_log_fn(); }
 }
 
-void disable_log_on_default_stream() noexcept {
-    std::call_once(g_init_flag, lazy_init);
-    if (g_init_success && g_disable_log_fn) {
-        g_disable_log_fn();
-    }
+void disable_log_on_default_stream() noexcept
+{
+  std::call_once(g_init_flag, lazy_init);
+  if (g_init_success && g_disable_log_fn) { g_disable_log_fn(); }
 }
 
-void set_stream_check_log_file(const char* path) noexcept {
-    std::call_once(g_init_flag, lazy_init);
-    if (g_init_success && g_set_log_file_fn) {
-        g_set_log_file_fn(path);
-    }
+void set_stream_check_log_file(const char* path) noexcept
+{
+  std::call_once(g_init_flag, lazy_init);
+  if (g_init_success && g_set_log_file_fn) { g_set_log_file_fn(path); }
 }
 
 }  // namespace util

--- a/test/cpp/config/test_config.cpp
+++ b/test/cpp/config/test_config.cpp
@@ -171,7 +171,7 @@ TEST_CASE("use configuration basic setters with condition", "[config_opt][condit
   using namespace sirius;
   config::configuration_setter setter;
   int int_value = 0;
-  setter.add_config("int_value", int_value, sirius::config::greater_than<int>{50});
+  setter.add_config("int_value", int_value, sirius::config::greater_than<int>{150});
 
   // Create a libconfig config object
   libconfig::Config libconfig;
@@ -494,4 +494,211 @@ TEST_CASE("use nested naming with config", "[config_opt][nested_naming]")
 
   REQUIRE(int_value == 100);
   REQUIRE(favorite_color == ee::color::green);
+}
+
+// Test iterable config with element-level validation
+TEST_CASE("Iterable config validates each element", "[config_opt][validation]")
+{
+  using namespace sirius;
+  SECTION("Valid elements pass validation")
+  {
+    // Create a simple config with a vector of positive integers
+    libconfig::Config cfg;
+    cfg.getRoot().add("numbers", libconfig::Setting::TypeArray);
+    auto& numbers_setting                            = cfg.getRoot()["numbers"];
+    numbers_setting.add(libconfig::Setting::TypeInt) = 1;
+    numbers_setting.add(libconfig::Setting::TypeInt) = 5;
+    numbers_setting.add(libconfig::Setting::TypeInt) = 10;
+
+    std::vector<int> numbers;
+    config::configuration_setter setter;
+
+    // Add config with predicate that requires positive numbers
+    setter.add_config("numbers", numbers, [](const int& val) { return val > 0; });
+
+    // This should succeed
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(numbers.size() == 3);
+    REQUIRE(numbers[0] == 1);
+    REQUIRE(numbers[1] == 5);
+    REQUIRE(numbers[2] == 10);
+  }
+
+  SECTION("Invalid element fails validation")
+  {
+    // Create a config with a vector containing a negative number
+    libconfig::Config cfg;
+    cfg.getRoot().add("numbers", libconfig::Setting::TypeArray);
+    auto& numbers_setting                            = cfg.getRoot()["numbers"];
+    numbers_setting.add(libconfig::Setting::TypeInt) = 1;
+    numbers_setting.add(libconfig::Setting::TypeInt) = -5;  // Invalid
+    numbers_setting.add(libconfig::Setting::TypeInt) = 10;
+
+    std::vector<int> numbers;
+    config::configuration_setter setter;
+
+    // Add config with predicate that requires positive numbers
+    setter.add_config("numbers", numbers, [](const int& val) { return val > 0; });
+
+    // This should throw because -5 fails validation
+    REQUIRE_THROWS_AS(setter.apply(cfg.getRoot()), std::invalid_argument);
+  }
+
+  SECTION("Element validation with custom predicate")
+  {
+    // Test with greater_than validator
+    libconfig::Config cfg;
+    cfg.getRoot().add("scores", libconfig::Setting::TypeArray);
+    auto& scores_setting                            = cfg.getRoot()["scores"];
+    scores_setting.add(libconfig::Setting::TypeInt) = 50;
+    scores_setting.add(libconfig::Setting::TypeInt) = 75;
+    scores_setting.add(libconfig::Setting::TypeInt) = 100;
+
+    std::vector<int> scores;
+    config::configuration_setter setter;
+
+    // Use greater_than validator
+    setter.add_config("scores", scores, sirius::config::greater_than<int>{40});
+
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(scores.size() == 3);
+  }
+
+  SECTION("Element validation with fraction predicate on doubles")
+  {
+    // Test with fraction validator (0.0 to 1.0)
+    libconfig::Config cfg;
+    cfg.getRoot().add("fractions", libconfig::Setting::TypeArray);
+    auto& fractions_setting                              = cfg.getRoot()["fractions"];
+    fractions_setting.add(libconfig::Setting::TypeFloat) = 0.0;
+    fractions_setting.add(libconfig::Setting::TypeFloat) = 0.5;
+    fractions_setting.add(libconfig::Setting::TypeFloat) = 1.0;
+
+    std::vector<double> fractions;
+    config::configuration_setter setter;
+
+    setter.add_config("fractions", fractions, sirius::config::fraction<double>{});
+
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(fractions.size() == 3);
+    REQUIRE(fractions[0] == 0.0);
+    REQUIRE(fractions[1] == 0.5);
+    REQUIRE(fractions[2] == 1.0);
+  }
+
+  SECTION("Element validation fails for out-of-range fraction")
+  {
+    libconfig::Config cfg;
+    cfg.getRoot().add("fractions", libconfig::Setting::TypeArray);
+    auto& fractions_setting                              = cfg.getRoot()["fractions"];
+    fractions_setting.add(libconfig::Setting::TypeFloat) = 0.5;
+    fractions_setting.add(libconfig::Setting::TypeFloat) = 1.5;  // Invalid > 1.0
+
+    std::vector<double> fractions;
+    config::configuration_setter setter;
+
+    setter.add_config("fractions", fractions, sirius::config::fraction<double>{});
+
+    REQUIRE_THROWS_AS(setter.apply(cfg.getRoot()), std::invalid_argument);
+  }
+}
+
+// Test variant config with validation
+TEST_CASE("Variant config validates the value", "[config_opt][validation][variant]")
+{
+  using namespace sirius;
+  SECTION("Valid variant value passes validation")
+  {
+    // Create a config with a port number (int)
+    libconfig::Config cfg;
+    cfg.getRoot().add("port", libconfig::Setting::TypeInt) = 8080;
+
+    std::variant<int, std::string> port_or_name;
+    config::configuration_setter setter;
+
+    // Add variant config with predicate that requires valid port range
+    setter.add_variant_config<int>(
+      "port", port_or_name, [](const int& val) { return val > 0 && val <= 65535; });
+
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(std::holds_alternative<int>(port_or_name));
+    REQUIRE(std::get<int>(port_or_name) == 8080);
+  }
+
+  SECTION("Invalid variant value fails validation")
+  {
+    // Create a config with an invalid port number
+    libconfig::Config cfg;
+    cfg.getRoot().add("port", libconfig::Setting::TypeInt) = 99999;  // Invalid port > 65535
+
+    std::variant<int, std::string> port_or_name;
+    config::configuration_setter setter;
+
+    // Add variant config with predicate that requires valid port range
+    setter.add_variant_config<int>(
+      "port", port_or_name, [](const int& val) { return val > 0 && val <= 65535; });
+
+    REQUIRE_THROWS_AS(setter.apply(cfg.getRoot()), std::invalid_argument);
+  }
+
+  SECTION("Variant with string alternative and validation")
+  {
+    // Create a config with a string that must be non-empty
+    libconfig::Config cfg;
+    cfg.getRoot().add("name", libconfig::Setting::TypeString) = "localhost";
+
+    std::variant<int, std::string> port_or_name;
+    config::configuration_setter setter;
+
+    // Add variant config with predicate that requires non-empty string
+    setter.add_variant_config<std::string>(
+      "name", port_or_name, [](const std::string& val) { return !val.empty(); });
+
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(std::holds_alternative<std::string>(port_or_name));
+    REQUIRE(std::get<std::string>(port_or_name) == "localhost");
+  }
+
+  SECTION("Variant with empty string fails validation")
+  {
+    libconfig::Config cfg;
+    cfg.getRoot().add("name", libconfig::Setting::TypeString) = "";
+
+    std::variant<int, std::string> port_or_name;
+    config::configuration_setter setter;
+
+    setter.add_variant_config<std::string>(
+      "name", port_or_name, [](const std::string& val) { return !val.empty(); });
+
+    REQUIRE_THROWS_AS(setter.apply(cfg.getRoot()), std::invalid_argument);
+  }
+
+  SECTION("Variant with between validator")
+  {
+    libconfig::Config cfg;
+    cfg.getRoot().add("percentage", libconfig::Setting::TypeInt) = 75;
+
+    std::variant<int, double, std::string> value;
+    config::configuration_setter setter;
+
+    // Use between validator for percentage (0-100)
+    setter.add_variant_config<int>("percentage", value, config::between<int>{0, 100});
+
+    REQUIRE_NOTHROW(setter.apply(cfg.getRoot()));
+    REQUIRE(std::holds_alternative<int>(value));
+    REQUIRE(std::get<int>(value) == 75);
+  }
+
+  SECTION("Variant with out-of-range value fails between validator")
+  {
+    libconfig::Config cfg;
+    cfg.getRoot().add("percentage", libconfig::Setting::TypeInt) = 150;  // Invalid > 100
+
+    std::variant<int, double, std::string> value;
+    config::configuration_setter setter;
+
+    setter.add_variant_config<int>("percentage", value, config::between<int>{0, 100});
+
+    REQUIRE_THROWS_AS(setter.apply(cfg.getRoot()), std::invalid_argument);
+  }
 }

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#include <cudf/utilities/default_stream.hpp>
+
 #include <catch.hpp>
 #include <duckdb.hpp>
-
 #include <cstdlib>
 #include <filesystem>
 #include <set>
@@ -202,6 +203,7 @@ TEST_CASE("gpu_execution - filter with projection", "[integration][gpu_execution
 
 TEST_CASE("gpu_execution - ungrouped min max", "[integration][gpu_execution][aggregate]")
 {
+  StreamCheckGuard stream_guard(true);
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -18,6 +18,7 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
+
 #include <cstdlib>
 #include <filesystem>
 #include <set>

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -203,7 +203,6 @@ TEST_CASE("gpu_execution - filter with projection", "[integration][gpu_execution
 
 TEST_CASE("gpu_execution - ungrouped min max", "[integration][gpu_execution][aggregate]")
 {
-  StreamCheckGuard stream_guard(true);
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -97,7 +97,7 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = filter.execute(inputs);
+  auto outputs = filter.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
     std::move(types), std::move(limit_node), std::move(offset_node), values.size(), false);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = limiter.execute(inputs);
+  auto outputs = limiter.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto host_vals    = copy_column_to_host<typename Traits::type>(output_table.view().column(0));

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -86,7 +86,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(inputs);
+  auto outputs = projection.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(inputs);
+  auto outputs = projection.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();
@@ -175,7 +175,7 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(inputs);
+  auto outputs = projection.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->template cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -262,7 +262,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
                                                                get_test_client_context());
 
-  collector.sink({batch});
+  collector.sink({batch}, cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -330,7 +330,7 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
                                                                get_test_client_context());
 
-  collector.sink({batch});
+  collector.sink({batch}, cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -437,7 +437,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
         std::this_thread::yield();
       }
       try {
-        collector.sink({batches[static_cast<size_t>(thread_idx)]});
+        collector.sink({batches[static_cast<size_t>(thread_idx)]}, cudf::get_default_stream());
       } catch (...) {
         exceptions[static_cast<size_t>(thread_idx)] = std::current_exception();
       }

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -127,7 +127,7 @@ TEMPLATE_TEST_CASE(
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(inputs);
+  auto outputs = table_scan.execute(inputs, cudf::get_default_stream());
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto out_view     = output_table.view();
@@ -196,7 +196,7 @@ TEST_CASE("sirius_physical_table_scan with no filters passes through data", "[ph
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(inputs);
+  auto outputs = table_scan.execute(inputs, cudf::get_default_stream());
 
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -267,7 +267,7 @@ TEST_CASE("sirius_physical_table_scan with multiple filters", "[physical_table_s
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(inputs);
+  auto outputs = table_scan.execute(inputs, cudf::get_default_stream());
 
   REQUIRE(outputs.size() == 1);
   auto output_table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -336,7 +336,7 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(inputs);
+  auto outputs = table_scan.execute(inputs, cudf::get_default_stream());
 
   REQUIRE(outputs.size() == 1);
   auto table = outputs[0]->get_data()->cast<gpu_table_representation>().get_table();

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -202,8 +202,8 @@ TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_to
                                          std::move(orders),
                                          /*limit=*/0,
                                          /*offset=*/2,
-                         nullptr,
-                         0);
+                                         nullptr,
+                                         0);
 
   auto out = topn_merge.execute(batches, cudf::get_default_stream());
   REQUIRE(out.empty());

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -87,7 +87,7 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
                              nullptr,
                              0);
 
-  auto out = topn.execute({batches[0]});
+  auto out = topn.execute({batches[0]}, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -127,7 +127,7 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
                              nullptr,
                              0);
 
-  auto out = topn.execute({batches[0]});
+  auto out = topn.execute({batches[0]}, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -167,7 +167,7 @@ TEST_CASE("sirius_physical_top_n_merge applies offset and limit", "[physical_top
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(batches);
+  auto out = topn_merge.execute(batches, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table       = out[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -202,10 +202,10 @@ TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_to
                                          std::move(orders),
                                          /*limit=*/0,
                                          /*offset=*/2,
-                                         nullptr,
-                                         0);
+                         nullptr,
+                         0);
 
-  auto out = topn_merge.execute(batches);
+  auto out = topn_merge.execute(batches, cudf::get_default_stream());
   REQUIRE(out.empty());
 }
 
@@ -232,7 +232,7 @@ TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(batches);
+  auto out = topn_merge.execute(batches, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -168,8 +168,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1 = local_op.execute({b1});
-  auto local_out2 = local_op.execute({b2});
+  auto local_out1 = local_op.execute({b1}, cudf::get_default_stream());
+  auto local_out2 = local_op.execute({b2}, cudf::get_default_stream());
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1.begin()),
@@ -177,7 +177,7 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out2.begin()),
                       std::make_move_iterator(local_out2.end()));
-  auto out = merge_op.execute(merge_inputs);
+  auto out = merge_op.execute(merge_inputs, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table = out[0]->get_data()->template cast<gpu_table_representation>().get_table();
@@ -276,8 +276,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1 = local_op.execute({b1});
-  auto local_out2 = local_op.execute({b2});
+  auto local_out1 = local_op.execute({b1}, cudf::get_default_stream());
+  auto local_out2 = local_op.execute({b2}, cudf::get_default_stream());
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1.begin()),
@@ -286,7 +286,7 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
                       std::make_move_iterator(local_out2.begin()),
                       std::make_move_iterator(local_out2.end()));
 
-  auto out = merge_op.execute(merge_inputs);
+  auto out = merge_op.execute(merge_inputs, cudf::get_default_stream());
   REQUIRE(out.size() == 1);
 
   auto table = out[0]->get_data()->template cast<gpu_table_representation>().get_table();

--- a/test/cpp/parallel/test_task_executor.cpp
+++ b/test/cpp/parallel/test_task_executor.cpp
@@ -46,7 +46,7 @@ class dummy_task : public itask {
   {
   }
 
-  void execute() override
+  void execute(rmm::cuda_stream_view stream) override
   {
     auto* g = static_cast<dummy_task_global_state*>(_global_state.get());
     auto* l = static_cast<dummy_task_local_state*>(_local_state.get());

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -46,6 +46,7 @@ class test_gpu_pipeline_task_global_state
 
   void add_error(std::string message)
   {
+    std::cerr << message << std::endl;
     error_count.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lock(error_mutex);
     errors.push_back(std::move(message));
@@ -77,7 +78,7 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
   {
   }
 
-  void execute() override
+  void execute(rmm::cuda_stream_view stream) override
   {
     auto& global = _global_state->cast<test_gpu_pipeline_task_global_state>();
     auto& local  = _local_state->cast<test_gpu_pipeline_task_local_state>();
@@ -98,7 +99,6 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
       return;
     }
 
-    auto stream = mem_space.acquire_stream();
     if (!allocator->attach_reservation_to_tracker(stream, std::move(reservation))) {
       global.add_error("Failed to attach reservation to stream tracker.");
       global.executed_count.fetch_add(1, std::memory_order_relaxed);

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -148,7 +148,8 @@ TEST_CASE("GPU pipeline executor uses task requests to schedule GPU tasks",
       .track_reservation_per_stream(false)
       .set_reservation_fraction_per_host(0.75);
     auto space_configs = builder.build();
-    manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+    manager =
+      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
   } catch (const std::exception& e) {
     WARN("Skipping test due to insufficient GPUs: " << e.what());
     return;

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -139,7 +139,16 @@ TEST_CASE("GPU pipeline executor uses task requests to schedule GPU tasks",
 {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
   try {
-    manager = initialize_memory_manager(1);
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(256 * 1024 * 1024)
+      .set_reservation_fraction_per_gpu(0.75)
+      .set_per_host_capacity(1 * 1024 * 1024 * 1024)
+      .use_host_per_gpu()
+      .track_reservation_per_stream(false)
+      .set_reservation_fraction_per_host(0.75);
+    auto space_configs = builder.build();
+    manager = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
   } catch (const std::exception& e) {
     WARN("Skipping test due to insufficient GPUs: " << e.what());
     return;

--- a/test/cpp/pipeline/test_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_pipeline_executor.cpp
@@ -22,6 +22,8 @@
 #include "pipeline/task_request.hpp"
 #include "scan/test_utils.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -73,7 +75,7 @@ class mock_gpu_pipeline_task : public gpu_pipeline_task {
   {
   }
 
-  void execute() override
+  void execute(rmm::cuda_stream_view stream) override
   {
     auto& global = _global_state->cast<mock_gpu_pipeline_task_global_state>();
     auto& local  = _local_state->cast<mock_gpu_pipeline_task_local_state>();

--- a/utils/stream_check/.gitignore
+++ b/utils/stream_check/.gitignore
@@ -1,0 +1,5 @@
+*.so
+*.o
+*.a
+test_stream_check
+preload_stream_check.sh

--- a/utils/stream_check/CMakeLists.txt
+++ b/utils/stream_check/CMakeLists.txt
@@ -1,0 +1,62 @@
+# =============================================================================
+# Copyright 2025, Sirius Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+cmake_minimum_required(VERSION 3.30.4)
+
+project(stream_check LANGUAGES CXX)
+
+# Find required packages
+find_package(cudf REQUIRED CONFIG)
+find_package(absl REQUIRED CONFIG)
+
+# Create shared library for LD_PRELOAD
+add_library(stream_check SHARED
+    stream_check.cpp
+)
+
+# Set C++ standard
+set_target_properties(stream_check PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# Include directories
+target_include_directories(stream_check
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Link against RMM (cudf dependency) and absl for stack traces
+target_link_libraries(stream_check
+    PUBLIC
+        rmm::rmm
+        absl::stacktrace
+        absl::symbolize
+        absl::failure_signal_handler
+)
+
+# Install library
+install(TARGETS stream_check
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+# Install header
+install(FILES stream_check.hpp
+    DESTINATION include
+)
+

--- a/utils/stream_check/CMakeLists.txt
+++ b/utils/stream_check/CMakeLists.txt
@@ -23,40 +23,28 @@ find_package(cudf REQUIRED CONFIG)
 find_package(absl REQUIRED CONFIG)
 
 # Create shared library for LD_PRELOAD
-add_library(stream_check SHARED
-    stream_check.cpp
-)
+add_library(stream_check SHARED stream_check.cpp)
 
 # Set C++ standard
-set_target_properties(stream_check PROPERTIES
-    CXX_STANDARD 20
-    CXX_STANDARD_REQUIRED ON
-    POSITION_INDEPENDENT_CODE ON
-)
+set_target_properties(
+  stream_check
+  PROPERTIES CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             POSITION_INDEPENDENT_CODE ON)
 
 # Include directories
-target_include_directories(stream_check
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
+target_include_directories(stream_check PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Link against RMM (cudf dependency) and absl for stack traces
-target_link_libraries(stream_check
-    PUBLIC
-        rmm::rmm
-        absl::stacktrace
-        absl::symbolize
-        absl::failure_signal_handler
-)
+target_link_libraries(
+  stream_check PUBLIC rmm::rmm absl::stacktrace absl::symbolize
+                      absl::failure_signal_handler)
 
 # Install library
-install(TARGETS stream_check
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-)
+install(
+  TARGETS stream_check
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
 
 # Install header
-install(FILES stream_check.hpp
-    DESTINATION include
-)
-
+install(FILES stream_check.hpp DESTINATION include)

--- a/utils/stream_check/README.md
+++ b/utils/stream_check/README.md
@@ -1,0 +1,150 @@
+# Stream Check
+
+## 🎯 Primary Goal
+
+Create a preloadable library that intercepts `cudf::get_default_stream()` calls to detect and prevent unintended default stream usage in GPU applications.
+
+## Usage
+
+### In Code
+
+Include the header and use the API:
+
+```cpp
+#include <stream_check.hpp>
+
+// Enable logging on default stream access for this thread
+enable_log_on_default_stream();
+
+// Your code here - any call to cudf::get_default_stream() will be logged
+
+// Disable logging
+disable_log_on_default_stream();
+```
+
+### With LD_PRELOAD
+
+Use the helper script:
+
+```bash
+./preload_stream_check.sh your_application [args...]
+```
+
+Or manually:
+
+```bash
+LD_PRELOAD=/path/to/libstream_check.so your_application [args...]
+```
+
+### Example Test Program
+
+```cpp
+#include <stream_check.hpp>
+#include <cudf/types.hpp>
+#include <iostream>
+
+int main() {
+    // This works fine - returns rmm default stream (no logging)
+    auto stream1 = cudf::get_default_stream();
+    std::cout << "Got default stream (normal): " << stream1.value() << std::endl;
+    
+    // Enable logging
+    enable_log_on_default_stream();
+    
+    // This will be logged to default_stream_traces.log
+    auto stream2 = cudf::get_default_stream();
+    std::cout << "Got default stream (logged): " << stream2.value() << std::endl;
+    
+    // Disable logging
+    disable_log_on_default_stream();
+    
+    // This works again without logging
+    auto stream3 = cudf::get_default_stream();
+    std::cout << "Got default stream (normal): " << stream3.value() << std::endl;
+    
+    return 0;
+}
+```
+
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────┐
+│                Application                       │
+│  (e.g., sirius_unittest, custom tests)          │
+└─────────────────┬───────────────────────────────┘
+                  │
+                  │ calls cudf::get_default_stream()
+                  │
+                  ▼
+┌─────────────────────────────────────────────────┐
+│         libstream_check.so (LD_PRELOAD)         │
+│  ┌───────────────────────────────────────────┐  │
+│  │ cudf::get_default_stream() {              │  │
+│  │   if (g_throw_on_default_stream) {        │  │
+│  │     throw runtime_error(...);             │  │
+│  │   }                                        │  │
+│  │   return rmm::cuda_stream_view{};         │  │
+│  │ }                                          │  │
+│  └───────────────────────────────────────────┘  │
+│                                                  │
+│  thread_local atomic<bool>                      │
+│  g_throw_on_default_stream{false}               │
+└─────────────────────────────────────────────────┘
+                  │
+                  │ symbol override
+                  │
+┌─────────────────▼───────────────────────────────┐
+│           libcudf.so (original)                 │
+│  cudf::get_default_stream() { ... }             │
+│  (not called when libstream_check is preloaded) │
+└─────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+Thread A                         Thread B
+   │                               │
+   ├─ enable_log_on_default_stream()│
+   │  (sets A's flag = true)       │
+   │                               │
+   ├─ cudf::get_default_stream()   │
+   │  └─> logs stack trace         │
+   │                               ├─ cudf::get_default_stream()
+   │                               │  └─> returns stream (no log)
+   │                               │      (B's flag = false)
+   ├─ disable_log_on_default_stream()
+   │  (sets A's flag = false)      │
+   │                               │
+   ├─ cudf::get_default_stream()   │
+   │  └─> returns stream (no log)  │
+```
+
+## 🔧 Technical Details
+
+### Key Technologies
+
+- **C++20**: Thread-local storage, atomic operations
+- **CUDA/cuDF**: Stream management API
+- **RMM**: RAPIDS Memory Manager for default stream
+- **CMake**: Build system integration
+- **LD_PRELOAD**: Dynamic symbol interception
+
+### Symbol Interception Mechanism
+
+The library uses the Linux dynamic linker's symbol resolution order:
+
+1. `LD_PRELOAD` libraries are searched first
+2. Our `cudf::get_default_stream()` is found
+3. Original libcudf symbol is shadowed
+4. No source code changes needed in application
+
+### Thread Safety
+
+- ✅ **Thread-safe**: Each thread has independent state
+- ✅ **Atomic operations**: Lock-free reads/writes
+- ✅ **No synchronization**: No mutex overhead
+- ✅ **Concurrent safe**: Multiple threads can call simultaneously
+

--- a/utils/stream_check/README.md
+++ b/utils/stream_check/README.md
@@ -47,21 +47,21 @@ int main() {
     // This works fine - returns rmm default stream (no logging)
     auto stream1 = cudf::get_default_stream();
     std::cout << "Got default stream (normal): " << stream1.value() << std::endl;
-    
+
     // Enable logging
     enable_log_on_default_stream();
-    
+
     // This will be logged to default_stream_traces.log
     auto stream2 = cudf::get_default_stream();
     std::cout << "Got default stream (logged): " << stream2.value() << std::endl;
-    
+
     // Disable logging
     disable_log_on_default_stream();
-    
+
     // This works again without logging
     auto stream3 = cudf::get_default_stream();
     std::cout << "Got default stream (normal): " << stream3.value() << std::endl;
-    
+
     return 0;
 }
 ```
@@ -147,4 +147,3 @@ The library uses the Linux dynamic linker's symbol resolution order:
 - ✅ **Atomic operations**: Lock-free reads/writes
 - ✅ **No synchronization**: No mutex overhead
 - ✅ **Concurrent safe**: Multiple threads can call simultaneously
-

--- a/utils/stream_check/stream_check.cpp
+++ b/utils/stream_check/stream_check.cpp
@@ -15,17 +15,20 @@
 // =============================================================================
 
 #include "stream_check.hpp"
-#include <atomic>
-#include <fstream>
-#include <mutex>
-#include <string>
-#include <ctime>
-#include <iomanip>
-#include <sstream>
-#include <unordered_set>
+
 #include <rmm/cuda_stream_view.hpp>
+
 #include <absl/debugging/stacktrace.h>
 #include <absl/debugging/symbolize.h>
+
+#include <atomic>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_set>
 
 // Thread-local atomic boolean to control logging behavior
 thread_local std::atomic<bool> g_log_on_default_stream{false};
@@ -38,89 +41,96 @@ static bool g_symbolize_initialized = false;
 
 extern "C" {
 
-void enable_log_on_default_stream() {
-    // Initialize symbolization on first use
-    if (!g_symbolize_initialized) {
-        absl::InitializeSymbolizer(nullptr);
-        g_symbolize_initialized = true;
-    }
-    g_log_on_default_stream.store(true, std::memory_order_relaxed);
+void enable_log_on_default_stream()
+{
+  // Initialize symbolization on first use
+  if (!g_symbolize_initialized) {
+    absl::InitializeSymbolizer(nullptr);
+    g_symbolize_initialized = true;
+  }
+  g_log_on_default_stream.store(true, std::memory_order_relaxed);
 }
 
-void disable_log_on_default_stream() {
-    g_log_on_default_stream.store(false, std::memory_order_relaxed);
+void disable_log_on_default_stream()
+{
+  g_log_on_default_stream.store(false, std::memory_order_relaxed);
 }
 
-void set_stream_check_log_file(const char* path) {
-    std::lock_guard<std::mutex> lock(g_log_mutex);
-    if (path && path[0] != '\0') {
-        g_log_file_path = path;
-    } else {
-        g_log_file_path = "default_stream_traces.log";
-    }
+void set_stream_check_log_file(const char* path)
+{
+  std::lock_guard<std::mutex> lock(g_log_mutex);
+  if (path && path[0] != '\0') {
+    g_log_file_path = path;
+  } else {
+    g_log_file_path = "default_stream_traces.log";
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 // Helper function to get a string representation of a stack trace
-static std::string get_stack_trace_string() {
-    constexpr int kMaxStackDepth = 64;
-    void* stack[kMaxStackDepth];
-    
-    // Get the raw stack trace
-    int depth = absl::GetStackTrace(stack, kMaxStackDepth, 1); // Skip this function
-    
-    std::ostringstream oss;
-    char symbol_buf[1024];
-    
-    for (int i = 0; i < depth; ++i) {
-        // Try to symbolize the address
-        if (absl::Symbolize(stack[i], symbol_buf, sizeof(symbol_buf))) {
-            oss << "  [" << i << "] " << symbol_buf << " (" << stack[i] << ")\n";
-        } else {
-            oss << "  [" << i << "] " << stack[i] << "\n";
-        }
+static std::string get_stack_trace_string()
+{
+  constexpr int kMaxStackDepth = 64;
+  void* stack[kMaxStackDepth];
+
+  // Get the raw stack trace
+  int depth = absl::GetStackTrace(stack, kMaxStackDepth, 1);  // Skip this function
+
+  std::ostringstream oss;
+  char symbol_buf[1024];
+
+  for (int i = 0; i < depth; ++i) {
+    // Try to symbolize the address
+    if (absl::Symbolize(stack[i], symbol_buf, sizeof(symbol_buf))) {
+      oss << "  [" << i << "] " << symbol_buf << " (" << stack[i] << ")\n";
+    } else {
+      oss << "  [" << i << "] " << stack[i] << "\n";
     }
-    
-    return oss.str();
+  }
+
+  return oss.str();
 }
 
 // Helper function to get current timestamp
-static std::string get_timestamp() {
-    auto now = std::time(nullptr);
-    auto tm = *std::localtime(&now);
-    std::ostringstream oss;
-    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
-    return oss.str();
+static std::string get_timestamp()
+{
+  auto now = std::time(nullptr);
+  auto tm  = *std::localtime(&now);
+  std::ostringstream oss;
+  oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
+  return oss.str();
 }
 
 // Helper function to log a default stream access
-static void log_default_stream_access() {
-    std::string stack_trace = get_stack_trace_string();
-    
-    std::lock_guard<std::mutex> lock(g_log_mutex);
-    
-    // Check if we've already logged this exact stack trace
-    if (g_logged_traces.find(stack_trace) != g_logged_traces.end()) {
-        return; // Already logged, skip to avoid spam
-    }
-    
-    // Mark this trace as logged
-    g_logged_traces.insert(stack_trace);
-    
-    // Open log file in append mode
-    std::ofstream log_file(g_log_file_path, std::ios::app);
-    if (!log_file) {
-        return; // Can't log, silently continue
-    }
-    
-    // Write the log entry
-    log_file << "================================================================================\n";
-    log_file << "Default stream access detected at: " << get_timestamp() << "\n";
-    log_file << "Stack trace:\n";
-    log_file << stack_trace;
-    log_file << "================================================================================\n\n";
-    log_file.flush();
+static void log_default_stream_access()
+{
+  std::string stack_trace = get_stack_trace_string();
+
+  std::lock_guard<std::mutex> lock(g_log_mutex);
+
+  // Check if we've already logged this exact stack trace
+  if (g_logged_traces.find(stack_trace) != g_logged_traces.end()) {
+    return;  // Already logged, skip to avoid spam
+  }
+
+  // Mark this trace as logged
+  g_logged_traces.insert(stack_trace);
+
+  // Open log file in append mode
+  std::ofstream log_file(g_log_file_path, std::ios::app);
+  if (!log_file) {
+    return;  // Can't log, silently continue
+  }
+
+  // Write the log entry
+  log_file << "================================================================================\n";
+  log_file << "Default stream access detected at: " << get_timestamp() << "\n";
+  log_file << "Stack trace:\n";
+  log_file << stack_trace;
+  log_file
+    << "================================================================================\n\n";
+  log_file.flush();
 }
 
 // Namespace wrapper to match cudf's namespace structure
@@ -128,19 +138,18 @@ namespace cudf {
 
 /**
  * @brief Override of cudf::get_default_stream() that logs stack traces
- * 
+ *
  * This function intercepts calls to cudf::get_default_stream(). When
  * enable_log_on_default_stream() has been called for the current thread,
  * this will log a stack trace to the configured file. Otherwise, it returns
  * the RMM default stream without logging.
  */
-rmm::cuda_stream_view get_default_stream() {
-    if (g_log_on_default_stream.load(std::memory_order_relaxed)) {
-        log_default_stream_access();
-    }
-    
-    // Always return the RMM default stream
-    return rmm::cuda_stream_view{};
+rmm::cuda_stream_view get_default_stream()
+{
+  if (g_log_on_default_stream.load(std::memory_order_relaxed)) { log_default_stream_access(); }
+
+  // Always return the RMM default stream
+  return rmm::cuda_stream_view{};
 }
 
-} // namespace cudf
+}  // namespace cudf

--- a/utils/stream_check/stream_check.cpp
+++ b/utils/stream_check/stream_check.cpp
@@ -1,0 +1,146 @@
+// =============================================================================
+// Copyright 2025, Sirius Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+// =============================================================================
+
+#include "stream_check.hpp"
+#include <atomic>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <unordered_set>
+#include <rmm/cuda_stream_view.hpp>
+#include <absl/debugging/stacktrace.h>
+#include <absl/debugging/symbolize.h>
+
+// Thread-local atomic boolean to control logging behavior
+thread_local std::atomic<bool> g_log_on_default_stream{false};
+
+// Global state for logging
+static std::mutex g_log_mutex;
+static std::string g_log_file_path = "default_stream_traces.log";
+static std::unordered_set<std::string> g_logged_traces;
+static bool g_symbolize_initialized = false;
+
+extern "C" {
+
+void enable_log_on_default_stream() {
+    // Initialize symbolization on first use
+    if (!g_symbolize_initialized) {
+        absl::InitializeSymbolizer(nullptr);
+        g_symbolize_initialized = true;
+    }
+    g_log_on_default_stream.store(true, std::memory_order_relaxed);
+}
+
+void disable_log_on_default_stream() {
+    g_log_on_default_stream.store(false, std::memory_order_relaxed);
+}
+
+void set_stream_check_log_file(const char* path) {
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    if (path && path[0] != '\0') {
+        g_log_file_path = path;
+    } else {
+        g_log_file_path = "default_stream_traces.log";
+    }
+}
+
+} // extern "C"
+
+// Helper function to get a string representation of a stack trace
+static std::string get_stack_trace_string() {
+    constexpr int kMaxStackDepth = 64;
+    void* stack[kMaxStackDepth];
+    
+    // Get the raw stack trace
+    int depth = absl::GetStackTrace(stack, kMaxStackDepth, 1); // Skip this function
+    
+    std::ostringstream oss;
+    char symbol_buf[1024];
+    
+    for (int i = 0; i < depth; ++i) {
+        // Try to symbolize the address
+        if (absl::Symbolize(stack[i], symbol_buf, sizeof(symbol_buf))) {
+            oss << "  [" << i << "] " << symbol_buf << " (" << stack[i] << ")\n";
+        } else {
+            oss << "  [" << i << "] " << stack[i] << "\n";
+        }
+    }
+    
+    return oss.str();
+}
+
+// Helper function to get current timestamp
+static std::string get_timestamp() {
+    auto now = std::time(nullptr);
+    auto tm = *std::localtime(&now);
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
+    return oss.str();
+}
+
+// Helper function to log a default stream access
+static void log_default_stream_access() {
+    std::string stack_trace = get_stack_trace_string();
+    
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    
+    // Check if we've already logged this exact stack trace
+    if (g_logged_traces.find(stack_trace) != g_logged_traces.end()) {
+        return; // Already logged, skip to avoid spam
+    }
+    
+    // Mark this trace as logged
+    g_logged_traces.insert(stack_trace);
+    
+    // Open log file in append mode
+    std::ofstream log_file(g_log_file_path, std::ios::app);
+    if (!log_file) {
+        return; // Can't log, silently continue
+    }
+    
+    // Write the log entry
+    log_file << "================================================================================\n";
+    log_file << "Default stream access detected at: " << get_timestamp() << "\n";
+    log_file << "Stack trace:\n";
+    log_file << stack_trace;
+    log_file << "================================================================================\n\n";
+    log_file.flush();
+}
+
+// Namespace wrapper to match cudf's namespace structure
+namespace cudf {
+
+/**
+ * @brief Override of cudf::get_default_stream() that logs stack traces
+ * 
+ * This function intercepts calls to cudf::get_default_stream(). When
+ * enable_log_on_default_stream() has been called for the current thread,
+ * this will log a stack trace to the configured file. Otherwise, it returns
+ * the RMM default stream without logging.
+ */
+rmm::cuda_stream_view get_default_stream() {
+    if (g_log_on_default_stream.load(std::memory_order_relaxed)) {
+        log_default_stream_access();
+    }
+    
+    // Always return the RMM default stream
+    return rmm::cuda_stream_view{};
+}
+
+} // namespace cudf

--- a/utils/stream_check/stream_check.hpp
+++ b/utils/stream_check/stream_check.hpp
@@ -22,7 +22,7 @@ extern "C" {
 
 /**
  * @brief Enable logging on default stream access for the current thread
- * 
+ *
  * After calling this function, any call to cudf::get_default_stream() from
  * the current thread will log a stack trace to the configured file.
  */
@@ -30,7 +30,7 @@ void enable_log_on_default_stream();
 
 /**
  * @brief Disable logging on default stream access for the current thread
- * 
+ *
  * After calling this function, calls to cudf::get_default_stream() from
  * the current thread will not log stack traces.
  */
@@ -38,7 +38,7 @@ void disable_log_on_default_stream();
 
 /**
  * @brief Set the file path for logging default stream stack traces
- * 
+ *
  * @param path File path where stack traces will be logged. If NULL or empty,
  *             defaults to "default_stream_traces.log" in current directory.
  */

--- a/utils/stream_check/stream_check.hpp
+++ b/utils/stream_check/stream_check.hpp
@@ -1,0 +1,49 @@
+// =============================================================================
+// Copyright 2025, Sirius Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+// =============================================================================
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable logging on default stream access for the current thread
+ * 
+ * After calling this function, any call to cudf::get_default_stream() from
+ * the current thread will log a stack trace to the configured file.
+ */
+void enable_log_on_default_stream();
+
+/**
+ * @brief Disable logging on default stream access for the current thread
+ * 
+ * After calling this function, calls to cudf::get_default_stream() from
+ * the current thread will not log stack traces.
+ */
+void disable_log_on_default_stream();
+
+/**
+ * @brief Set the file path for logging default stream stack traces
+ * 
+ * @param path File path where stack traces will be logged. If NULL or empty,
+ *             defaults to "default_stream_traces.log" in current directory.
+ */
+void set_stream_check_log_file(const char* path);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
CHANGES:
1. acquire stream in the executor
2. pass the stream to `itask::execute` and `compute` methods
3. hold extension lock in `$HOME/.sirius`
4. fix some issues in config, allowing predicate for variants and optional and iterable to check correctness of configs


