### PR TITLE
Interpret string offsets as int32

### DIFF
--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -66,7 +66,7 @@ class host_table_chunk_reader {
       data_accessor;  ///< Accessor to the column data in the multiple blocks allocation
     memory::multiple_blocks_allocation_accessor<uint8_t>
       mask_accessor;  ///< Accessor to the null mask data in the multiple blocks allocation
-    memory::multiple_blocks_allocation_accessor<int64_t>
+    memory::multiple_blocks_allocation_accessor<int32_t>
       offset_accessor;  ///< Accessor to the STRING offsets in the multiple blocks allocation
 
     /**

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -102,7 +102,7 @@ namespace detail {
 // Helper template function for constructing duckdb strings from offsets
 template <bool HasNulls>
 void make_duckdb_strings(
-  memory::multiple_blocks_allocation_accessor<int64_t>& offset_accessor,
+  memory::multiple_blocks_allocation_accessor<int32_t>& offset_accessor,
   std::unique_ptr<
     cucascade::memory::fixed_size_host_memory_resource::multiple_blocks_allocation> const&
     allocation,
@@ -119,8 +119,8 @@ void make_duckdb_strings(
   while (offset_counter < count) {
     auto const offsets_in_block =
       std::min(count - offset_counter,
-               (allocation->block_size() - offset_accessor.offset_in_block) / sizeof(int64_t));
-    auto* src = reinterpret_cast<int64_t*>(allocation->get_blocks()[offset_accessor.block_index] +
+               (allocation->block_size() - offset_accessor.offset_in_block) / sizeof(int32_t));
+    auto* src = reinterpret_cast<int32_t*>(allocation->get_blocks()[offset_accessor.block_index] +
                                            offset_accessor.offset_in_block);
     for (size_t i = 0; i < offsets_in_block; ++i) {
       auto const end = src[i];
@@ -140,8 +140,8 @@ void make_duckdb_strings(
       start = end;
     }
     offset_counter += offsets_in_block;
-    offset_accessor.offset_in_block += offsets_in_block * sizeof(int64_t);
-    if (offset_counter == count) { offset_accessor.offset_in_block -= sizeof(int64_t); }
+    offset_accessor.offset_in_block += offsets_in_block * sizeof(int32_t);
+    if (offset_counter == count) { offset_accessor.offset_in_block -= sizeof(int32_t); }
     if (offset_accessor.offset_in_block == allocation->block_size()) {
       offset_accessor.block_index++;
       offset_accessor.offset_in_block = 0;
@@ -202,6 +202,7 @@ host_table_chunk_reader::host_table_chunk_reader(
   }
 
   // Initialize column readers
+  _column_readers.reserve(metadata_nodes.size());
   for (size_t col_idx = 0; col_idx < metadata_nodes.size(); ++col_idx) {
     if (col_idx == 0) {
       _total_rows = static_cast<size_t>(metadata_nodes[col_idx].size);

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -270,7 +270,7 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
                                                           ranges,
                                                           cudf::get_default_stream(),
                                                           gpu_space->get_default_allocator(),
-                                                          true);
+                                                          false);
   auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
 
   expected_table_data expected;
@@ -343,7 +343,7 @@ TEST_CASE("host_table_chunk_reader handles null masks",
     std::make_pair(0, 100), std::make_pair(1000, 2000), std::make_pair(0, 100)};
 
   auto table =
-    sirius::create_cudf_table_with_random_data(num_rows, column_types, ranges, stream, mr, true);
+    sirius::create_cudf_table_with_random_data(num_rows, column_types, ranges, stream, mr, false);
   auto int64_nulls = build_null_indices(
     num_rows,
     {0, 5, STANDARD_VECTOR_SIZE - 1, STANDARD_VECTOR_SIZE, STANDARD_VECTOR_SIZE + 1, num_rows - 1});


### PR DESCRIPTION
As in https://github.com/felipeblazing/sirius/pull/2.
We'll use int32 for string offsets for now, as it seems to be the default in libcudf. Here's an issue for tracking future efforts to add support for int64: #213 