### PR TITLE
Match test config files to struct types of thread_pool_config

### DIFF
--- a/test/cpp/config/data/configurator.cfg
+++ b/test/cpp/config/data/configurator.cfg
@@ -24,8 +24,12 @@ sirius = {
     };
     executor = {
         pipeline = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = true;
+            num_threads = 4;
+            thread_name_prefix = "sirius_pipeline_executor";
+        };
+        duckdb_scan = {
+            num_threads = 4;
+            thread_name_prefix = "sirius_scan_executor";
         };
         downgrade = {
             max_concurrent_tasks = 4;


### PR DESCRIPTION
The pipeline executor config struct is slightly different that than that of the downgrade executor. 
The config files in the test dir were not setting them properly. Most users including me probably use these as examples for their own config file, so these will also have some wrong values in them. They cause a bunch of exceptions being thrown by libconfig, but these are ignored (you will only see them in gdb when running with `catch throw`).
Maybe we should merge them:

```
struct thread_pool_config {
  int num_threads{0};
  std::string thread_name_prefix{"thread"};
  std::vector<int> cpu_affinity_list;
};
```

```
struct task_executor_config {
  int num_threads{0};
  bool retry_on_error{false};
  std::vector<int> cpu_affinity_list;
};
```
