### PR TITLE
Adds sort, fixes large strings

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -39,4 +39,6 @@ bool Config::MODIFIED_PIPELINE = false;
 uint64_t Config::DEFAULT_SCAN_TASK_BATCH_SIZE   = 2ULL * 1024 * 1024 * 1024;  ///< 2 GB
 uint64_t Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256ULL;
 
+uint64_t Config::MAX_SORT_PARTITION_BYTES = 0;  ///< 0 = auto (33% of available GPU memory)
+
 }  // namespace duckdb

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -56,6 +56,10 @@ struct Config {
   //  - the default varchar size for estimating rows per batch
   static uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE;
   static uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE;
+
+  // For sort partitioning:
+  //  - max bytes per sort partition (0 = auto based on 33% GPU memory)
+  static uint64_t MAX_SORT_PARTITION_BYTES;
 };
 
 }  // namespace duckdb

--- a/src/include/memory/host_table_utils.hpp
+++ b/src/include/memory/host_table_utils.hpp
@@ -101,7 +101,7 @@ inline metadata_node make_string_metadata_node(cudf::size_type size,
     null_count,
     data_offset,
     null_mask_offset,
-    {metadata_node{cudf::data_type(cudf::type_id::INT64), size + 1, 0, offsets_offset, -1, {}}}};
+    {metadata_node{cudf::data_type(cudf::type_id::INT32), size + 1, 0, offsets_offset, -1, {}}}};
 }
 
 namespace detail {

--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -66,8 +66,13 @@ class host_table_chunk_reader {
       data_accessor;  ///< Accessor to the column data in the multiple blocks allocation
     memory::multiple_blocks_allocation_accessor<uint8_t>
       mask_accessor;  ///< Accessor to the null mask data in the multiple blocks allocation
+    memory::multiple_blocks_allocation_accessor<int32_t>
+      offset_accessor_32;  ///< Accessor to the STRING offsets (INT32) in the multiple blocks
+                           ///< allocation
     memory::multiple_blocks_allocation_accessor<int64_t>
-      offset_accessor;  ///< Accessor to the STRING offsets in the multiple blocks allocation
+      offset_accessor_64;  ///< Accessor to the STRING offsets (INT64) in the multiple blocks
+                           ///< allocation
+    bool use_int64_offsets{false};  ///< Whether the offset column uses INT64 (from cudf::pack)
 
     /**
      * @brief Construct a new column reader object

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -199,7 +199,7 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_it
     // The allocation accessors for the column data, mask, and offsets
     memory::multiple_blocks_allocation_accessor<uint8_t> data_blocks_accessor;
     memory::multiple_blocks_allocation_accessor<uint8_t> mask_blocks_accessor;
-    memory::multiple_blocks_allocation_accessor<int64_t> offset_blocks_accessor;
+    memory::multiple_blocks_allocation_accessor<int32_t> offset_blocks_accessor;
 
     //===----------Constructors & Destructor----------===//
     column_builder() = default;

--- a/src/include/op/sirius_physical_operator_type.hpp
+++ b/src/include/op/sirius_physical_operator_type.hpp
@@ -142,6 +142,8 @@ enum class SiriusPhysicalOperatorType : uint8_t {
   MERGE_GROUP_BY,
   MERGE_TOP_N,
   MERGE_AGGREGATE,
+  SORT_PARTITION,
+  SORT_SAMPLE,
   DUCKDB_SCAN
 };
 

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -22,6 +22,18 @@
 namespace sirius {
 namespace op {
 
+// Helper to deep copy BoundOrderByNode vector (contains unique_ptr<Expression>)
+inline duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
+  const duckdb::vector<duckdb::BoundOrderByNode>& src)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> result;
+  result.reserve(src.size());
+  for (const auto& order : src) {
+    result.push_back(order.Copy());
+  }
+  return result;
+}
+
 class sirius_physical_order : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::ORDER_BY;

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -51,6 +51,11 @@ class sirius_physical_order : public sirius_physical_operator {
   // Sink interface
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }
+
+ public:
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -23,26 +23,24 @@
 namespace sirius {
 namespace op {
 
-class sirius_physical_merge_sort : public sirius_physical_operator {
+class sirius_physical_sort_sample;
+
+class sirius_physical_sort_partition : public sirius_physical_operator {
  public:
-  static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::MERGE_SORT;
+  static constexpr const SiriusPhysicalOperatorType TYPE =
+    SiriusPhysicalOperatorType::SORT_PARTITION;
 
  public:
-  sirius_physical_merge_sort(sirius_physical_order* order_by);
+  sirius_physical_sort_partition(sirius_physical_order* order_by);
 
-  sirius_physical_merge_sort(duckdb::vector<duckdb::LogicalType> types,
-                             duckdb::vector<duckdb::BoundOrderByNode> orders,
-                             duckdb::vector<duckdb::idx_t> projections_p,
-                             duckdb::idx_t estimated_cardinality,
-                             bool is_index_sort_p = false);
+  sirius_physical_sort_partition(duckdb::vector<duckdb::LogicalType> types,
+                                 duckdb::vector<duckdb::BoundOrderByNode> orders,
+                                 duckdb::vector<duckdb::idx_t> projections_p,
+                                 duckdb::idx_t estimated_cardinality);
 
-  //! Input data
+  //! Order specification (copied from ORDER_BY)
   duckdb::vector<duckdb::BoundOrderByNode> orders;
   duckdb::vector<duckdb::idx_t> projections;
-  bool is_index_sort;
-
-  sirius_physical_operator* child_op;
-  sirius_physical_operator* get_child_op() const { return child_op; }
 
  public:
   // Source interface
@@ -63,17 +61,14 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
     rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
-  //! Set the final output projection (applied after merge, to remove sort-key-only columns)
-  void set_final_projections(duckdb::vector<duckdb::idx_t> proj,
-                             duckdb::vector<duckdb::LogicalType> output_types)
-  {
-    _final_projections = std::move(proj);
-    types              = std::move(output_types);
-  }
+  //! Set the sample operator to read partition boundaries from
+  void set_sample_op(sirius_physical_sort_sample* sample) { _sample_op = sample; }
+
+  //! Get the sample operator
+  sirius_physical_sort_sample* get_sample_op() const { return _sample_op; }
 
  private:
-  //! Final projection to apply after merge (empty = no extra projection)
-  duckdb::vector<duckdb::idx_t> _final_projections;
+  sirius_physical_sort_sample* _sample_op = nullptr;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -82,9 +82,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Whether boundaries have been computed
   bool boundaries_computed() const { return _boundaries_computed.load(); }
 
-  //! Set the total number of scan batches expected in this pipeline
-  void set_total_scan_batches(size_t n) { _total_scan_batches = n; }
-
   //! Override the maximum bytes per partition (0 = use default GPU memory-based calculation)
   void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
 
@@ -97,9 +94,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
 
   //! Whether partition boundaries have been computed
   std::atomic<bool> _boundaries_computed{false};
-
-  //! Total number of scan batches expected (set by engine during init)
-  size_t _total_scan_batches = 0;
 
   //! Override for max partition bytes (0 = use default GPU memory-based calculation)
   size_t _max_partition_bytes_override = 0;

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/planner/bound_query_node.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_order.hpp"
+
+#include <cudf/table/table.hpp>
+
+#include <atomic>
+
+namespace sirius {
+namespace op {
+
+class sirius_physical_sort_sample : public sirius_physical_operator {
+ public:
+  static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::SORT_SAMPLE;
+
+  static constexpr duckdb::idx_t DEFAULT_NUM_SAMPLE_BATCHES = 5;
+
+  //! Maximum fraction of available GPU memory per partition (33%)
+  static constexpr double MAX_PARTITION_MEMORY_FRACTION = 0.33;
+
+ public:
+  sirius_physical_sort_sample(sirius_physical_order* order_by);
+
+  sirius_physical_sort_sample(duckdb::vector<duckdb::LogicalType> types,
+                              duckdb::vector<duckdb::BoundOrderByNode> orders,
+                              duckdb::idx_t estimated_cardinality,
+                              duckdb::idx_t num_sample_batches = DEFAULT_NUM_SAMPLE_BATCHES);
+
+  //! Order specification (copied from ORDER_BY) — determines which columns to sample
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+
+  //! Number of batches to sample before computing partition boundaries
+  duckdb::idx_t num_sample_batches;
+
+ public:
+  // Source interface
+  bool is_source() const override { return true; }
+
+  duckdb::OrderPreservationType source_order() const override
+  {
+    return duckdb::OrderPreservationType::FIXED_ORDER;
+  }
+
+ public:
+  // Sink interface
+  bool is_sink() const override { return true; }
+  bool sink_order_dependent() const override { return false; }
+
+ public:
+  std::vector<std::shared_ptr<cucascade::data_batch>> execute(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+
+  //! Override to wait for N batches before returning READY
+  std::optional<task_creation_hint> get_next_task_hint() override;
+
+ public:
+  //! Get the computed partition boundaries (P-1 rows, sort key columns only)
+  const cudf::table& get_partition_boundaries() const { return *_partition_boundaries; }
+
+  //! Get the computed number of partitions
+  size_t get_num_partitions() const { return _num_partitions; }
+
+  //! Whether boundaries have been computed
+  bool boundaries_computed() const { return _boundaries_computed.load(); }
+
+  //! Set the total number of scan batches expected in this pipeline
+  void set_total_scan_batches(size_t n) { _total_scan_batches = n; }
+
+  //! Override the maximum bytes per partition (0 = use default GPU memory-based calculation)
+  void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
+
+ private:
+  //! Partition boundary rows (P-1 rows containing sort key column values)
+  std::unique_ptr<cudf::table> _partition_boundaries;
+
+  //! Number of partitions computed from the sample
+  size_t _num_partitions = 1;
+
+  //! Whether partition boundaries have been computed
+  std::atomic<bool> _boundaries_computed{false};
+
+  //! Total number of scan batches expected (set by engine during init)
+  size_t _total_scan_batches = 0;
+
+  //! Override for max partition bytes (0 = use default GPU memory-based calculation)
+  size_t _max_partition_bytes_override = 0;
+};
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/CMakeLists.txt
+++ b/src/op/CMakeLists.txt
@@ -43,6 +43,8 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sirius_physical_duckdb_scan.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sirius_physical_grouped_aggregate_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sirius_physical_merge_sort.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sirius_physical_sort_partition.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sirius_physical_sort_sample.cpp
     # # Below is for the new execution model, and we are gradually migrating #
     # operators above to the new execution model.
     ${CMAKE_CURRENT_SOURCE_DIR}/aggregate/aggregate_op_util.cpp

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -52,7 +52,12 @@ host_table_chunk_reader::column_reader::column_reader(
         "[host_table_chunk_reader::column_reader::initialize_accessors] STRING type must have one "
         "child node for offsets.");
     }
-    offset_accessor.initialize(node.children[0].data_offset, allocation);
+    use_int64_offsets = (node.children[0].type.id() == cudf::type_id::INT64);
+    if (use_int64_offsets) {
+      offset_accessor_64.initialize(node.children[0].data_offset, allocation);
+    } else {
+      offset_accessor_32.initialize(node.children[0].data_offset, allocation);
+    }
   }
 }
 
@@ -100,9 +105,9 @@ void host_table_chunk_reader::column_reader::copy_fixed_width(
 
 namespace detail {
 // Helper template function for constructing duckdb strings from offsets
-template <bool HasNulls>
+template <bool HasNulls, typename OffsetType>
 void make_duckdb_strings(
-  memory::multiple_blocks_allocation_accessor<int64_t>& offset_accessor,
+  memory::multiple_blocks_allocation_accessor<OffsetType>& offset_accessor,
   std::unique_ptr<
     cucascade::memory::fixed_size_host_memory_resource::multiple_blocks_allocation> const&
     allocation,
@@ -119,11 +124,11 @@ void make_duckdb_strings(
   while (offset_counter < count) {
     auto const offsets_in_block =
       std::min(count - offset_counter,
-               (allocation->block_size() - offset_accessor.offset_in_block) / sizeof(int64_t));
-    auto* src = reinterpret_cast<int64_t*>(allocation->get_blocks()[offset_accessor.block_index] +
-                                           offset_accessor.offset_in_block);
+               (allocation->block_size() - offset_accessor.offset_in_block) / sizeof(OffsetType));
+    auto* src = reinterpret_cast<OffsetType*>(
+      allocation->get_blocks()[offset_accessor.block_index] + offset_accessor.offset_in_block);
     for (size_t i = 0; i < offsets_in_block; ++i) {
-      auto const end = src[i];
+      auto const end = static_cast<size_t>(src[i]);
       if constexpr (HasNulls) {
         if (!duckdb::FlatVector::IsNull(vector, offset_counter + i)) {
           auto const d_ptr   = str_buffer_ptr + (start - start_offset);
@@ -140,8 +145,8 @@ void make_duckdb_strings(
       start = end;
     }
     offset_counter += offsets_in_block;
-    offset_accessor.offset_in_block += offsets_in_block * sizeof(int64_t);
-    if (offset_counter == count) { offset_accessor.offset_in_block -= sizeof(int64_t); }
+    offset_accessor.offset_in_block += offsets_in_block * sizeof(OffsetType);
+    if (offset_counter == count) { offset_accessor.offset_in_block -= sizeof(OffsetType); }
     if (offset_accessor.offset_in_block == allocation->block_size()) {
       offset_accessor.block_index++;
       offset_accessor.offset_in_block = 0;
@@ -164,27 +169,39 @@ void host_table_chunk_reader::column_reader::copy_string(
   // We are copying into a flat vector
   vector.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
 
-  // Allocate duckdb buffer and bulk copy data into it
-  auto start_offset           = offset_accessor.get_current(allocation);
-  auto end_offset             = offset_accessor.get(row_offset + count, allocation);
-  auto const total_data_bytes = end_offset - start_offset;
-  auto str_buffer             = duckdb::make_buffer<duckdb::VectorBuffer>(total_data_bytes);
-  auto str_buffer_ptr         = str_buffer->GetData();
-  data_accessor.memcpy_to(allocation, str_buffer_ptr, total_data_bytes);
+  if (use_int64_offsets) {
+    // INT64 offsets (from cudf::pack after GPU roundtrip)
+    auto start_offset           = offset_accessor_64.get_current(allocation);
+    auto end_offset             = offset_accessor_64.get(row_offset + count, allocation);
+    auto const total_data_bytes = end_offset - start_offset;
+    auto str_buffer             = duckdb::make_buffer<duckdb::VectorBuffer>(total_data_bytes);
+    auto str_buffer_ptr         = str_buffer->GetData();
+    data_accessor.memcpy_to(allocation, str_buffer_ptr, total_data_bytes);
 
-  if (null_count != 0) {
-    // Set the null mask
-    auto& validity = duckdb::FlatVector::Validity(vector);
-    copy_mask_to_validity(validity, row_offset, count, allocation);
+    if (null_count != 0) {
+      auto& validity = duckdb::FlatVector::Validity(vector);
+      copy_mask_to_validity(validity, row_offset, count, allocation);
+    }
     detail::make_duckdb_strings<false>(
-      offset_accessor, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
+      offset_accessor_64, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
+    duckdb::StringVector::AddBuffer(vector, str_buffer);
   } else {
-    detail::make_duckdb_strings<false>(
-      offset_accessor, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
-  }
+    // INT32 offsets (from scan task)
+    auto start_offset = static_cast<size_t>(offset_accessor_32.get_current(allocation));
+    auto end_offset   = static_cast<size_t>(offset_accessor_32.get(row_offset + count, allocation));
+    auto const total_data_bytes = end_offset - start_offset;
+    auto str_buffer             = duckdb::make_buffer<duckdb::VectorBuffer>(total_data_bytes);
+    auto str_buffer_ptr         = str_buffer->GetData();
+    data_accessor.memcpy_to(allocation, str_buffer_ptr, total_data_bytes);
 
-  // Move the buffer into the string vector
-  duckdb::StringVector::AddBuffer(vector, str_buffer);
+    if (null_count != 0) {
+      auto& validity = duckdb::FlatVector::Validity(vector);
+      copy_mask_to_validity(validity, row_offset, count, allocation);
+    }
+    detail::make_duckdb_strings<false>(
+      offset_accessor_32, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
+    duckdb::StringVector::AddBuffer(vector, str_buffer);
+  }
 }
 
 host_table_chunk_reader::host_table_chunk_reader(

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -102,7 +102,7 @@ void duckdb_scan_task_local_state::column_builder::initialize_accessors(
     offset_blocks_accessor.set_current(0, allocation);
     // Initialize data accessor
     total_data_bytes_allocated = estimated_num_rows * type_size;
-    size_t data_byte_offset    = byte_offset + (estimated_num_rows + 1) * sizeof(int64_t);
+    size_t data_byte_offset    = byte_offset + (estimated_num_rows + 1) * sizeof(int32_t);
     data_blocks_accessor.initialize(data_byte_offset, allocation);
     // Initialize mask accessor
     size_t mask_byte_offset = data_byte_offset + total_data_bytes_allocated;
@@ -346,7 +346,7 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_duckd
     _column_builders.emplace_back(col_type, _default_varchar_size);
     if (col_type.InternalType() == duckdb::PhysicalType::VARCHAR) {
       _varchar_indices.push_back(i);
-      estimated_row_bytes += (sizeof(int64_t) + _default_varchar_size);  // offset + data + mask
+      estimated_row_bytes += (sizeof(int32_t) + _default_varchar_size);  // offset + data + mask
     } else {
       estimated_row_bytes += duckdb::GetTypeIdSize(col_type.InternalType());  // data + mask
     }
@@ -358,7 +358,7 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_duckd
   estimated_row_bytes += mask_bytes_per_row;
 
   // For VARCHAR columns, add space for the extra offset at the end
-  size_t extra_varchar_offset_bytes = _varchar_indices.size() * sizeof(int64_t);
+  size_t extra_varchar_offset_bytes = _varchar_indices.size() * sizeof(int32_t);
 
   // Calculate rows that fit in the batch
   _estimated_rows_per_batch =
@@ -372,11 +372,14 @@ void duckdb_scan_task_local_state::initialize_builders()
 {
   size_t byte_offset = 0;
   for (size_t i = 0; i < _num_columns; ++i) {
+    // Align byte_offset to 8 bytes before each column to ensure proper alignment
+    // for offset arrays (int32/int64) and data types
+    byte_offset = (byte_offset + 7) & ~size_t{7};
     _column_builders[i].initialize_accessors(_estimated_rows_per_batch, byte_offset, _allocation);
     // Update byte_offset for next column
     if (_column_builders[i].type.InternalType() == duckdb::PhysicalType::VARCHAR) {
       // VARCHAR column (offsets + data + mask)
-      byte_offset += (_estimated_rows_per_batch + 1) * sizeof(int64_t) +
+      byte_offset += (_estimated_rows_per_batch + 1) * sizeof(int32_t) +
                      _estimated_rows_per_batch * _default_varchar_size +
                      utils::ceil_div_8(_estimated_rows_per_batch);
     } else {
@@ -414,7 +417,8 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   // Create metadata nodes for each column and assemble metadata buffer
   std::vector<metadata_node> column_metadata;
   column_metadata.reserve(_num_columns);
-  for (auto const& builder : _column_builders) {
+  for (size_t ci = 0; ci < _column_builders.size(); ci++) {
+    auto& builder = _column_builders[ci];
     column_metadata.push_back(builder.make_metadata_node(_row_offset));
   }
   auto metadata = std::make_unique<std::vector<uint8_t>>(pack_metadata_from_nodes(column_metadata));

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -26,18 +26,6 @@
 namespace sirius {
 namespace op {
 
-// Helper to deep copy BoundOrderByNode vector
-static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
-  const duckdb::vector<duckdb::BoundOrderByNode>& src)
-{
-  duckdb::vector<duckdb::BoundOrderByNode> result;
-  result.reserve(src.size());
-  for (const auto& order : src) {
-    result.push_back(order.Copy());
-  }
-  return result;
-}
-
 sirius_physical_merge_sort::sirius_physical_merge_sort(sirius_physical_order* order_by)
   : sirius_physical_merge_sort(
       order_by->types,                // copied by value

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -16,9 +16,12 @@
 
 #include "op/sirius_physical_merge_sort.hpp"
 
+#include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
-#include "operator/gpu_materialize.hpp"
+#include "op/merge/gpu_merge_impl.hpp"
+
+#include <cudf/cudf_utils.hpp>
 
 namespace sirius {
 namespace op {
@@ -58,6 +61,79 @@ sirius_physical_merge_sort::sirius_physical_merge_sort(
     projections(std::move(projections_p)),
     is_index_sort(is_index_sort_p)
 {
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_merge_sort::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+  rmm::cuda_stream_view stream)
+{
+  SIRIUS_LOG_DEBUG("Executing merge sort");
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // Collect valid batches and find memory space
+  std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
+  cucascade::memory::memory_space* space = nullptr;
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    if (!space) { space = batch->get_memory_space(); }
+    valid_batches.push_back(batch);
+  }
+
+  if (valid_batches.empty() || !space) { return {}; }
+
+  // Helper lambda to apply final projection to a batch (removes sort-key-only columns)
+  auto apply_final_projection =
+    [this, stream, space](
+      std::shared_ptr<cucascade::data_batch> batch) -> std::shared_ptr<cucascade::data_batch> {
+    if (_final_projections.empty() || !batch) { return batch; }
+    auto table_view = sirius::get_cudf_table_view(*batch);
+    std::vector<cudf::column_view> projected_cols;
+    for (auto idx : _final_projections) {
+      projected_cols.push_back(table_view.column(static_cast<cudf::size_type>(idx)));
+    }
+    auto projected_table = std::make_unique<cudf::table>(
+      cudf::table_view(projected_cols), stream, space->get_default_allocator());
+    return sirius::make_data_batch(std::move(projected_table), *space);
+  };
+
+  // Single batch: no merge needed
+  if (valid_batches.size() == 1) {
+    std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
+    outputs.push_back(apply_final_projection(valid_batches[0]));
+    return outputs;
+  }
+
+  // Build cudf order vectors from BoundOrderByNode
+  std::vector<int> order_key_idx;
+  std::vector<cudf::order> column_order;
+  std::vector<cudf::null_order> null_precedence;
+  order_key_idx.reserve(orders.size());
+  column_order.reserve(orders.size());
+  null_precedence.reserve(orders.size());
+
+  for (auto const& ord : orders) {
+    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      throw duckdb::NotImplementedException("Merge sort only supports bound reference expressions");
+    }
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    order_key_idx.push_back(idx);
+    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                    : cudf::order::DESCENDING);
+    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                                ? cudf::null_order::BEFORE
+                                : cudf::null_order::AFTER);
+  }
+
+  auto merged_batch = gpu_merge_impl::merge_order_by(
+    valid_batches, order_key_idx, column_order, null_precedence, stream, *space);
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG("Merge sort time: {:.2f} ms", duration.count() / 1000.0);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
+  if (merged_batch) { outputs.push_back(apply_final_projection(std::move(merged_batch))); }
+  return outputs;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_operator_type.cpp
+++ b/src/op/sirius_physical_operator_type.cpp
@@ -109,6 +109,8 @@ std::string SiriusPhysicalOperatorToString(SiriusPhysicalOperatorType type)
     case SiriusPhysicalOperatorType::MERGE_GROUP_BY: return "MERGE_GROUP_BY";
     case SiriusPhysicalOperatorType::MERGE_TOP_N: return "MERGE_TOP_N";
     case SiriusPhysicalOperatorType::MERGE_AGGREGATE: return "MERGE_AGGREGATE";
+    case SiriusPhysicalOperatorType::SORT_PARTITION: return "SORT_PARTITION";
+    case SiriusPhysicalOperatorType::SORT_SAMPLE: return "SORT_SAMPLE";
     case SiriusPhysicalOperatorType::DUCKDB_SCAN: return "DUCKDB_SCAN";
     case SiriusPhysicalOperatorType::INVALID: break;
   }

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -18,7 +18,7 @@
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
-#include "operator/gpu_materialize.hpp"
+#include "op/order/gpu_order_impl.hpp"
 
 namespace sirius {
 namespace op {
@@ -34,10 +34,56 @@ sirius_physical_order::sirius_physical_order(duckdb::vector<duckdb::LogicalType>
     projections(std::move(projections_p)),
     is_index_sort(is_index_sort_p)
 {
-  // sort_result = duckdb::make_shared_ptr<GPUIntermediateRelation>(projections.size());
-  // for (int col = 0; col < projections.size(); col++) {
-  //   sort_result->columns[col] = nullptr;
-  // }
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_order::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+  rmm::cuda_stream_view stream)
+{
+  SIRIUS_LOG_DEBUG("Executing order by");
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // Build cudf order vectors from BoundOrderByNode
+  std::vector<int> order_key_idx;
+  std::vector<cudf::order> column_order;
+  std::vector<cudf::null_order> null_precedence;
+  order_key_idx.reserve(orders.size());
+  column_order.reserve(orders.size());
+  null_precedence.reserve(orders.size());
+
+  for (auto const& ord : orders) {
+    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      throw duckdb::NotImplementedException("Order by only supports bound reference expressions");
+    }
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    order_key_idx.push_back(idx);
+    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                    : cudf::order::DESCENDING);
+    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                                ? cudf::null_order::BEFORE
+                                : cudf::null_order::AFTER);
+  }
+
+  std::vector<int> proj_idx(projections.begin(), projections.end());
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(input_batches.size());
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto* space = batch->get_memory_space();
+    if (!space) { continue; }
+
+    auto sorted_batch = gpu_order_impl::local_order_by(
+      batch, order_key_idx, column_order, null_precedence, proj_idx, stream, *space);
+    if (sorted_batch) { output_batches.push_back(std::move(sorted_batch)); }
+  }
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG("Order by time: {:.2f} ms", duration.count() / 1000.0);
+
+  return output_batches;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -27,18 +27,6 @@
 namespace sirius {
 namespace op {
 
-// Helper to deep copy BoundOrderByNode vector
-static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
-  const duckdb::vector<duckdb::BoundOrderByNode>& src)
-{
-  duckdb::vector<duckdb::BoundOrderByNode> result;
-  result.reserve(src.size());
-  for (const auto& order : src) {
-    result.push_back(order.Copy());
-  }
-  return result;
-}
-
 sirius_physical_sort_partition::sirius_physical_sort_partition(sirius_physical_order* order_by)
   : sirius_physical_sort_partition(order_by->types,
                                    copy_orders(order_by->orders),

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_sort_partition.hpp"
+
+#include "cudf/cudf_utils.hpp"
+#include "data/data_batch_utils.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "log/logging.hpp"
+#include "op/sirius_physical_sort_sample.hpp"
+
+#include <cudf/search.hpp>
+
+namespace sirius {
+namespace op {
+
+// Helper to deep copy BoundOrderByNode vector
+static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
+  const duckdb::vector<duckdb::BoundOrderByNode>& src)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> result;
+  result.reserve(src.size());
+  for (const auto& order : src) {
+    result.push_back(order.Copy());
+  }
+  return result;
+}
+
+sirius_physical_sort_partition::sirius_physical_sort_partition(sirius_physical_order* order_by)
+  : sirius_physical_sort_partition(order_by->types,
+                                   copy_orders(order_by->orders),
+                                   order_by->projections,
+                                   order_by->estimated_cardinality)
+{
+}
+
+sirius_physical_sort_partition::sirius_physical_sort_partition(
+  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<duckdb::BoundOrderByNode> orders,
+  duckdb::vector<duckdb::idx_t> projections_p,
+  duckdb::idx_t estimated_cardinality)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::SORT_PARTITION, std::move(types), estimated_cardinality),
+    orders(std::move(orders)),
+    projections(std::move(projections_p))
+{
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_sort_partition::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+  rmm::cuda_stream_view stream)
+{
+  // If no sample operator or only 1 partition, pass through
+  if (!_sample_op || !_sample_op->boundaries_computed() || _sample_op->get_num_partitions() <= 1) {
+    SIRIUS_LOG_DEBUG("Sort partition: passthrough ({} batches, {} partitions)",
+                     input_batches.size(),
+                     _sample_op ? _sample_op->get_num_partitions() : 1);
+    return input_batches;
+  }
+
+  auto start           = std::chrono::high_resolution_clock::now();
+  size_t num_parts     = _sample_op->get_num_partitions();
+  auto& boundaries     = _sample_op->get_partition_boundaries();
+  auto boundaries_view = boundaries.view();
+
+  // Build cudf order vectors from BoundOrderByNode
+  std::vector<int> order_key_idx;
+  std::vector<cudf::order> column_order;
+  std::vector<cudf::null_order> null_precedence;
+  order_key_idx.reserve(orders.size());
+  column_order.reserve(orders.size());
+  null_precedence.reserve(orders.size());
+
+  for (auto const& ord : orders) {
+    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      throw duckdb::NotImplementedException(
+        "Sort partition only supports bound reference expressions");
+    }
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    order_key_idx.push_back(idx);
+    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                    : cudf::order::DESCENDING);
+    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                                ? cudf::null_order::BEFORE
+                                : cudf::null_order::AFTER);
+  }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    auto* space = batch->get_memory_space();
+    if (!space) { continue; }
+    auto input_table = get_cudf_table_view(*batch);
+    auto num_rows    = input_table.num_rows();
+
+    if (num_rows == 0) { continue; }
+
+    // Extract sort key columns from the input batch
+    std::vector<cudf::column_view> sort_key_cols;
+    for (int idx : order_key_idx) {
+      sort_key_cols.push_back(input_table.column(idx));
+    }
+    cudf::table_view batch_sort_keys(sort_key_cols);
+
+    // Use lower_bound: haystack=batch (sorted), needles=boundaries
+    // Returns P-1 split positions in the batch
+    auto split_positions_col = cudf::lower_bound(batch_sort_keys,
+                                                 boundaries_view,
+                                                 column_order,
+                                                 null_precedence,
+                                                 stream,
+                                                 space->get_default_allocator());
+
+    // Copy split positions to host (only P-1 values)
+    size_t num_splits = static_cast<size_t>(split_positions_col->size());
+    std::vector<int32_t> splits_host(num_splits);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(splits_host.data(),
+                                  split_positions_col->view().data<int32_t>(),
+                                  num_splits * sizeof(int32_t),
+                                  cudaMemcpyDeviceToHost,
+                                  stream.value()));
+    CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+
+    // Build slice indices: [0, split[0], split[0], split[1], ..., split[P-2], num_rows]
+    std::vector<cudf::size_type> slice_indices;
+    slice_indices.reserve(num_parts * 2);
+    cudf::size_type prev = 0;
+    for (size_t i = 0; i < num_splits; i++) {
+      slice_indices.push_back(prev);
+      slice_indices.push_back(splits_host[i]);
+      prev = splits_host[i];
+    }
+    // Last partition: from last split to end
+    slice_indices.push_back(prev);
+    slice_indices.push_back(num_rows);
+
+    // Slice into partitions
+    auto partition_views = cudf::slice(input_table, slice_indices, stream);
+
+    // Create data_batches for non-empty partitions
+    for (size_t i = 0; i < partition_views.size(); i++) {
+      if (partition_views[i].num_rows() == 0) { continue; }
+      auto partition_table =
+        std::make_unique<cudf::table>(partition_views[i], stream, space->get_default_allocator());
+      output_batches.push_back(make_data_batch(std::move(partition_table), *space));
+    }
+  }
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG(
+    "Sort partition: {} input batches → {} output batches ({} partitions) in {:.2f} ms",
+    input_batches.size(),
+    output_batches.size(),
+    num_parts,
+    duration.count() / 1000.0);
+
+  return output_batches;
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_physical_sort_sample.hpp"
+
+#include "cudf/cudf_utils.hpp"
+#include "data/data_batch_utils.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "log/logging.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
+#include <cudf/concatenate.hpp>
+
+namespace sirius {
+namespace op {
+
+// Helper to deep copy BoundOrderByNode vector
+static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
+  const duckdb::vector<duckdb::BoundOrderByNode>& src)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> result;
+  result.reserve(src.size());
+  for (const auto& order : src) {
+    result.push_back(order.Copy());
+  }
+  return result;
+}
+
+sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* order_by)
+  : sirius_physical_sort_sample(
+      order_by->types, copy_orders(order_by->orders), order_by->estimated_cardinality)
+{
+}
+
+sirius_physical_sort_sample::sirius_physical_sort_sample(
+  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<duckdb::BoundOrderByNode> orders,
+  duckdb::idx_t estimated_cardinality,
+  duckdb::idx_t num_sample_batches)
+  : sirius_physical_operator(
+      SiriusPhysicalOperatorType::SORT_SAMPLE, std::move(types), estimated_cardinality),
+    orders(std::move(orders)),
+    num_sample_batches(num_sample_batches)
+{
+}
+
+std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hint()
+{
+  // If boundaries already computed, use default behavior (process batches as they arrive)
+  if (_boundaries_computed.load()) { return sirius_physical_operator::get_next_task_hint(); }
+
+  // Need to wait for N batches before computing boundaries
+  auto port_ids = get_port_ids();
+  if (port_ids.empty()) { return std::nullopt; }
+
+  auto* p = get_port(port_ids[0]);
+  if (!p) { return std::nullopt; }
+
+  bool upstream_finished = p->src_pipeline && p->src_pipeline->is_pipeline_finished();
+  bool has_enough        = p->repo->size() >= static_cast<size_t>(num_sample_batches);
+
+  if (has_enough || (upstream_finished && p->repo->size() > 0)) {
+    return task_creation_hint{TaskCreationHint::READY, this};
+  }
+
+  if (p->src_pipeline && !upstream_finished) {
+    auto* producer = &(p->src_pipeline->get_operators()[0].get());
+    return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
+  }
+
+  return std::nullopt;
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_sort_sample::execute(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
+  rmm::cuda_stream_view stream)
+{
+  // After boundaries are computed, just pass through
+  if (_boundaries_computed.load()) {
+    SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
+    return input_batches;
+  }
+
+  SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches",
+                   input_batches.size());
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // 1. Collect valid batches and find memory space
+  std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
+  cucascade::memory::memory_space* space = nullptr;
+  for (auto const& batch : input_batches) {
+    if (!batch) { continue; }
+    if (!space) { space = batch->get_memory_space(); }
+    valid_batches.push_back(batch);
+  }
+
+  if (valid_batches.empty() || !space) {
+    _boundaries_computed.store(true);
+    return input_batches;
+  }
+
+  // 2. Concatenate all sample batches into one table
+  std::vector<cudf::table_view> sample_views;
+  size_t total_sample_bytes = 0;
+  sample_views.reserve(valid_batches.size());
+  for (auto const& batch : valid_batches) {
+    auto view = get_cudf_table_view(*batch);
+    sample_views.push_back(view);
+    total_sample_bytes += batch->get_data()->get_size_in_bytes();
+  }
+
+  auto concat_table = cudf::concatenate(sample_views, stream, space->get_default_allocator());
+
+  // 3. Build cudf order vectors from BoundOrderByNode
+  std::vector<int> order_key_idx;
+  std::vector<cudf::order> column_order;
+  std::vector<cudf::null_order> null_precedence;
+  order_key_idx.reserve(orders.size());
+  column_order.reserve(orders.size());
+  null_precedence.reserve(orders.size());
+
+  for (auto const& ord : orders) {
+    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+      throw duckdb::NotImplementedException(
+        "Sort sample only supports bound reference expressions");
+    }
+    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+    order_key_idx.push_back(idx);
+    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                    : cudf::order::DESCENDING);
+    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                                ? cudf::null_order::BEFORE
+                                : cudf::null_order::AFTER);
+  }
+
+  // 4. Sort the concatenated sample by sort keys
+  std::vector<cudf::column_view> sort_cols;
+  for (int idx : order_key_idx) {
+    sort_cols.push_back(concat_table->view().column(idx));
+  }
+  auto sorted_indices = cudf::sorted_order(cudf::table_view(sort_cols),
+                                           column_order,
+                                           null_precedence,
+                                           stream,
+                                           space->get_default_allocator());
+
+  auto sorted_table = cudf::gather(concat_table->view(),
+                                   sorted_indices->view(),
+                                   cudf::out_of_bounds_policy::DONT_CHECK,
+                                   stream,
+                                   space->get_default_allocator());
+
+  // 5. Compute number of partitions
+  size_t total_rows        = static_cast<size_t>(sorted_table->num_rows());
+  size_t avg_batch_bytes   = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
+  size_t total_batch_count = _total_scan_batches > 0 ? _total_scan_batches : valid_batches.size();
+  size_t estimated_total_bytes = avg_batch_bytes * total_batch_count;
+  size_t available_memory      = space->get_available_memory(stream);
+  size_t max_partition_bytes =
+    _max_partition_bytes_override > 0
+      ? _max_partition_bytes_override
+      : static_cast<size_t>(static_cast<double>(available_memory) * MAX_PARTITION_MEMORY_FRACTION);
+
+  size_t num_parts = 1;
+  if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
+    num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;
+  }
+
+  SIRIUS_LOG_DEBUG(
+    "Sort sample: total_rows={}, avg_batch_bytes={}, total_batch_count={}, "
+    "estimated_total_bytes={}, available_memory={}, max_partition_bytes={}, num_partitions={}",
+    total_rows,
+    avg_batch_bytes,
+    total_batch_count,
+    estimated_total_bytes,
+    available_memory,
+    max_partition_bytes,
+    num_parts);
+
+  // 6. Pick P-1 evenly-spaced boundary rows from the sorted sample (sort key columns only)
+  if (num_parts <= 1 || total_rows == 0) {
+    // Single partition — no boundaries needed
+    _num_partitions = 1;
+    _partition_boundaries.reset();
+  } else {
+    // Compute boundary row indices: [total_rows/P, 2*total_rows/P, ..., (P-1)*total_rows/P]
+    size_t num_boundaries = num_parts - 1;
+    std::vector<int32_t> boundary_indices_host;
+    boundary_indices_host.reserve(num_boundaries);
+    for (size_t i = 1; i <= num_boundaries; i++) {
+      auto idx = static_cast<int32_t>((i * total_rows) / num_parts);
+      if (idx >= static_cast<int32_t>(total_rows)) { idx = static_cast<int32_t>(total_rows) - 1; }
+      boundary_indices_host.push_back(idx);
+    }
+
+    // Create a device column with the boundary indices
+    auto indices_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                                 static_cast<cudf::size_type>(num_boundaries),
+                                                 cudf::mask_state::UNALLOCATED,
+                                                 stream,
+                                                 space->get_default_allocator());
+    CUDF_CUDA_TRY(cudaMemcpyAsync(indices_col->mutable_view().data<int32_t>(),
+                                  boundary_indices_host.data(),
+                                  num_boundaries * sizeof(int32_t),
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+
+    // Extract only the sort key columns from sorted table for the boundaries
+    std::vector<cudf::column_view> sort_key_cols;
+    for (int idx : order_key_idx) {
+      sort_key_cols.push_back(sorted_table->view().column(idx));
+    }
+    cudf::table_view sort_keys_view(sort_key_cols);
+
+    // Gather boundary rows
+    _partition_boundaries = cudf::gather(sort_keys_view,
+                                         indices_col->view(),
+                                         cudf::out_of_bounds_policy::DONT_CHECK,
+                                         stream,
+                                         space->get_default_allocator());
+    _num_partitions       = num_parts;
+  }
+
+  _boundaries_computed.store(true);
+
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  SIRIUS_LOG_DEBUG("Sort sample: computed {} partitions with {} boundaries in {:.2f} ms",
+                   _num_partitions,
+                   _partition_boundaries ? _partition_boundaries->num_rows() : 0,
+                   duration.count() / 1000.0);
+
+  return input_batches;
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -152,31 +152,44 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_sort_sample:
                                    space->get_default_allocator());
 
   // 5. Compute number of partitions
-  size_t total_rows        = static_cast<size_t>(sorted_table->num_rows());
-  size_t avg_batch_bytes   = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
-  size_t total_batch_count = _total_scan_batches > 0 ? _total_scan_batches : valid_batches.size();
-  size_t estimated_total_bytes = avg_batch_bytes * total_batch_count;
-  size_t available_memory      = space->get_available_memory(stream);
-  size_t max_partition_bytes =
-    _max_partition_bytes_override > 0
-      ? _max_partition_bytes_override
-      : static_cast<size_t>(static_cast<double>(available_memory) * MAX_PARTITION_MEMORY_FRACTION);
+  size_t total_rows         = static_cast<size_t>(sorted_table->num_rows());
+  size_t avg_batch_bytes    = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
+  size_t avg_rows_per_batch = valid_batches.empty() ? 0 : total_rows / valid_batches.size();
+  size_t num_parts          = 1;
+  if (estimated_cardinality == 0 || avg_rows_per_batch == 0) {
+    SIRIUS_LOG_WARN(
+      "Sort sample: estimated_cardinality={} or avg_rows_per_batch={} is zero, "
+      "defaulting to 1 partition",
+      estimated_cardinality,
+      avg_rows_per_batch);
+  } else {
+    size_t total_batch_count =
+      (estimated_cardinality + avg_rows_per_batch - 1) / avg_rows_per_batch;
+    size_t estimated_total_bytes = avg_batch_bytes * total_batch_count;
+    size_t available_memory      = space->get_available_memory(stream);
+    size_t max_partition_bytes   = _max_partition_bytes_override > 0
+                                     ? _max_partition_bytes_override
+                                     : static_cast<size_t>(static_cast<double>(available_memory) *
+                                                         MAX_PARTITION_MEMORY_FRACTION);
 
-  size_t num_parts = 1;
-  if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
-    num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;
+    if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
+      num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;
+    }
+
+    SIRIUS_LOG_DEBUG(
+      "Sort sample: estimated_cardinality={}, total_rows={}, avg_rows_per_batch={}, "
+      "avg_batch_bytes={}, total_batch_count={}, "
+      "estimated_total_bytes={}, available_memory={}, max_partition_bytes={}, num_partitions={}",
+      estimated_cardinality,
+      total_rows,
+      avg_rows_per_batch,
+      avg_batch_bytes,
+      total_batch_count,
+      estimated_total_bytes,
+      available_memory,
+      max_partition_bytes,
+      num_parts);
   }
-
-  SIRIUS_LOG_DEBUG(
-    "Sort sample: total_rows={}, avg_batch_bytes={}, total_batch_count={}, "
-    "estimated_total_bytes={}, available_memory={}, max_partition_bytes={}, num_partitions={}",
-    total_rows,
-    avg_batch_bytes,
-    total_batch_count,
-    estimated_total_bytes,
-    available_memory,
-    max_partition_bytes,
-    num_parts);
 
   // 6. Pick P-1 evenly-spaced boundary rows from the sorted sample (sort key columns only)
   if (num_parts <= 1 || total_rows == 0) {

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -27,18 +27,6 @@
 namespace sirius {
 namespace op {
 
-// Helper to deep copy BoundOrderByNode vector
-static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
-  const duckdb::vector<duckdb::BoundOrderByNode>& src)
-{
-  duckdb::vector<duckdb::BoundOrderByNode> result;
-  result.reserve(src.size());
-  for (const auto& order : src) {
-    result.push_back(order.Copy());
-  }
-  return result;
-}
-
 sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* order_by)
   : sirius_physical_sort_sample(
       order_by->types, copy_orders(order_by->orders), order_by->estimated_cardinality)

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -174,17 +174,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> sirius_physical_top_n::execu
   return outputs;
 }
 
-static duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
-  const duckdb::vector<duckdb::BoundOrderByNode>& src)
-{
-  duckdb::vector<duckdb::BoundOrderByNode> result;
-  result.reserve(src.size());
-  for (const auto& order : src) {
-    result.push_back(order.Copy());
-  }
-  return result;
-}
-
 sirius_physical_top_n_merge::sirius_physical_top_n_merge(sirius_physical_top_n* top_n)
   : sirius_physical_top_n_merge(
       top_n->types,                // copied by value

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -35,6 +35,8 @@
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_result_collector.hpp"
+#include "op/sirius_physical_sort_partition.hpp"
+#include "op/sirius_physical_sort_sample.hpp"
 #include "op/sirius_physical_table_scan.hpp"
 #include "op/sirius_physical_top_n.hpp"
 #include "op/sirius_physical_top_n_merge.hpp"
@@ -365,11 +367,14 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 
       bool group_agg_sort_topn_sink = false;
       if (current_pipeline->sink->type == op::SiriusPhysicalOperatorType::HASH_GROUP_BY ||
-          current_pipeline->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
-          current_pipeline->sink->type == op::SiriusPhysicalOperatorType::TOP_N ||
           current_pipeline->sink->type == op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE) {
         group_agg_sort_topn_sink = true;
       }
+
+      bool order_by_sink =
+        (current_pipeline->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY);
+
+      bool top_n_sink = (current_pipeline->sink->type == op::SiriusPhysicalOperatorType::TOP_N);
 
       bool join_sink = false;
       if (current_pipeline->sink->type == op::SiriusPhysicalOperatorType::HASH_JOIN ||
@@ -548,6 +553,135 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
         new_pipeline_breakers.push_back(std::move(merge_op));
       }
 
+      if (order_by_sink) {
+        auto order_op   = current_pipeline->sink;
+        auto* order_ptr = static_cast<op::sirius_physical_order*>(order_op.get());
+
+        // Save the original projection and replace with identity so ORDER outputs all columns.
+        // Sort keys must remain in the output for SORT_SAMPLE and SORT_PARTITION to reference.
+        // MERGE_SORT will apply the final projection.
+        auto original_projections = order_ptr->projections;
+        {
+          auto& child_types = current_pipeline->operators.size() > 0
+                                ? current_pipeline->operators.back().get().types
+                                : current_pipeline->source->types;
+          duckdb::vector<duckdb::idx_t> identity_proj;
+          for (duckdb::idx_t i = 0; i < child_types.size(); i++) {
+            identity_proj.push_back(i);
+          }
+          order_ptr->projections = std::move(identity_proj);
+          order_ptr->types       = child_types;
+        }
+
+        // Pipeline A: current pipeline keeps ORDER as sink (local sort per batch)
+        new_scheduled.push_back(current_pipeline);
+
+        // Create SORT_SAMPLE operator
+        auto sample_op = duckdb::unique_ptr<op::sirius_physical_sort_sample>(
+          new op::sirius_physical_sort_sample(order_ptr));
+        auto* sample_ptr = sample_op.get();
+        if (duckdb::Config::MAX_SORT_PARTITION_BYTES > 0) {
+          sample_ptr->set_max_partition_bytes(duckdb::Config::MAX_SORT_PARTITION_BYTES);
+        }
+
+        // Pipeline B: ORDER (source) → SORT_SAMPLE (sink)
+        auto sample_pipeline    = duckdb::make_shared_ptr<pipeline::sirius_pipeline>(*this);
+        sample_pipeline->source = order_op.get();
+        sample_pipeline->sink   = sample_ptr;
+        sample_pipeline->dependencies.push_back(current_pipeline);
+        new_scheduled.push_back(sample_pipeline);
+
+        // Create SORT_PARTITION operator
+        auto partition_op = duckdb::unique_ptr<op::sirius_physical_sort_partition>(
+          new op::sirius_physical_sort_partition(order_ptr));
+        auto* partition_ptr = partition_op.get();
+
+        // Wire sort_partition to read boundaries from sort_sample
+        partition_ptr->set_sample_op(sample_ptr);
+
+        // Pipeline C: SORT_SAMPLE (source) → SORT_PARTITION (sink)
+        auto partition_pipeline    = duckdb::make_shared_ptr<pipeline::sirius_pipeline>(*this);
+        partition_pipeline->source = sample_ptr;
+        partition_pipeline->sink   = partition_ptr;
+        partition_pipeline->dependencies.push_back(sample_pipeline);
+        new_scheduled.push_back(partition_pipeline);
+
+        // Create MERGE_SORT operator
+        auto merge_op = duckdb::unique_ptr<op::sirius_physical_merge_sort>(
+          new op::sirius_physical_merge_sort(order_ptr));
+        auto* merge_ptr = merge_op.get();
+
+        // If ORDER had a non-identity projection, set it as MERGE_SORT's final projection
+        {
+          bool is_identity = (original_projections.size() == order_ptr->types.size());
+          if (is_identity) {
+            for (duckdb::idx_t i = 0; i < original_projections.size(); i++) {
+              if (original_projections[i] != i) {
+                is_identity = false;
+                break;
+              }
+            }
+          }
+          if (!is_identity) {
+            duckdb::vector<duckdb::LogicalType> output_types;
+            for (auto idx : original_projections) {
+              output_types.push_back(order_ptr->types[idx]);
+            }
+            merge_ptr->set_final_projections(std::move(original_projections),
+                                             std::move(output_types));
+          }
+        }
+
+        // Pipeline D: SORT_PARTITION (source) → MERGE_SORT (sink)
+        auto merge_pipeline    = duckdb::make_shared_ptr<pipeline::sirius_pipeline>(*this);
+        merge_pipeline->source = partition_ptr;
+        merge_pipeline->sink   = merge_ptr;
+        merge_pipeline->dependencies.push_back(partition_pipeline);
+        new_scheduled.push_back(merge_pipeline);
+
+        // Update downstream pipelines to use MERGE_SORT as source
+        for (size_t j = i + 1; j < copied_scheduled.size(); j++) {
+          if (copied_scheduled[j]->source.get() == order_op.get()) {
+            copied_scheduled[j]->source = merge_ptr;
+          }
+        }
+
+        // Store ownership
+        new_pipeline_breakers.push_back(std::move(sample_op));
+        new_pipeline_breakers.push_back(std::move(partition_op));
+        new_pipeline_breakers.push_back(std::move(merge_op));
+      }
+
+      if (top_n_sink) {
+        auto top_n_op  = current_pipeline->sink;
+        auto* topn_ptr = static_cast<op::sirius_physical_top_n*>(top_n_op.get());
+
+        // Pipeline A: current pipeline keeps TOP_N as sink
+        new_scheduled.push_back(current_pipeline);
+
+        // Create MERGE_TOP_N operator
+        auto merge_op = duckdb::unique_ptr<op::sirius_physical_top_n_merge>(
+          new op::sirius_physical_top_n_merge(topn_ptr));
+        auto* merge_ptr = merge_op.get();
+
+        // Pipeline B: TOP_N (source) → MERGE_TOP_N (sink)
+        auto merge_pipeline    = duckdb::make_shared_ptr<pipeline::sirius_pipeline>(*this);
+        merge_pipeline->source = top_n_op.get();
+        merge_pipeline->sink   = merge_ptr;
+        merge_pipeline->dependencies.push_back(current_pipeline);
+        new_scheduled.push_back(merge_pipeline);
+
+        // Update downstream pipelines to use MERGE_TOP_N as source
+        for (size_t j = i + 1; j < copied_scheduled.size(); j++) {
+          if (copied_scheduled[j]->source.get() == top_n_op.get()) {
+            copied_scheduled[j]->source = merge_ptr;
+          }
+        }
+
+        // Store ownership
+        new_pipeline_breakers.push_back(std::move(merge_op));
+      }
+
       if (right_left_delim_join_sink) {
         auto delim_join   = current_pipeline->get_sink();
         auto& join_op     = delim_join->Cast<op::sirius_physical_delim_join>().join;
@@ -621,7 +755,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
         new_scheduled.push_back(new_pipeline);
       }
 
-      if (!group_agg_sort_topn_sink && !right_left_delim_join_sink && !join_sink) {
+      if (!group_agg_sort_topn_sink && !right_left_delim_join_sink && !join_sink &&
+          !order_by_sink && !top_n_sink) {
         new_scheduled.push_back(current_pipeline);
       }
     }
@@ -707,10 +842,32 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::PARTITION ||
                  new_scheduled[i]->sink->type ==
                    op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE ||
-                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::TOP_N) {
-        // Partition operators have dependent pipelines in source_to_pipelines
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::TOP_N ||
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT) {
+        // Full barrier operators — wait for upstream to finish before processing
         for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {
           insert_repository("default", new_scheduled[i], dependent_pipeline);
+        }
+      } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE ||
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_PARTITION) {
+        // Pipeline barrier — sort operators process batches as they arrive
+        // (sort_sample overrides get_next_task_hint to wait for N batches)
+        for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {
+          auto next_op             = dependent_pipeline->get_operators().size() == 0
+                                       ? dependent_pipeline->get_sink().get()
+                                       : &dependent_pipeline->get_operators()[0].get();
+          size_t op_id             = next_op->operator_id;
+          std::string_view port_id = "default";
+          data_repo_manager.add_new_repository(
+            op_id, port_id, std::make_unique<::cucascade::shared_data_repository>());
+          next_op->add_port(port_id,
+                            std::make_unique<op::sirius_physical_operator::port>(
+                              op::MemoryBarrierType::PIPELINE,
+                              data_repo_manager.get_repository(op_id, port_id).get(),
+                              new_scheduled[i],
+                              dependent_pipeline));
+          new_scheduled[i]->get_sink()->add_next_port_after_sink(std::make_pair(next_op, port_id));
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
         for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -427,10 +427,13 @@ void SiriusExtension::GPUExecutionFunction(ClientContext& context,
         data.sirius_iface->sirius_execute_query(context, data.query, data.gpu_prepared, {});
       if (data.res->HasError()) {
         SIRIUS_LOG_ERROR("SiriusExecuteQuery error: {}", data.res->GetError());
-        printf(
-          "=============================================\nError in SiriusExecuteQuery, fallback to "
-          "DuckDB\n=============================================\n");
-        data.res = data.conn->Query(data.query);
+        if (!Config::ENABLE_FALLBACK_CHECK) {
+          printf(
+            "=============================================\nError in SiriusExecuteQuery, fallback "
+            "to DuckDB\n=============================================\n");
+          data.res = data.conn->Query(data.query);
+        }
+        // When ENABLE_FALLBACK_CHECK is true, the error propagates (no silent fallback)
       }
     }
     auto end      = std::chrono::high_resolution_clock::now();
@@ -685,6 +688,13 @@ static void SetDefaultScanTaskVarcharSize(ClientContext& context, SetScope scope
                    Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE);
 }
 
+static void SetMaxSortPartitionBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  Config::MAX_SORT_PARTITION_BYTES = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_BYTES to {}",
+                   Config::MAX_SORT_PARTITION_BYTES);
+}
+
 void SiriusExtension::InitialGPUConfigs(DBConfig& config)
 {
   // Add in config option for gpu buffer manager
@@ -768,6 +778,13 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
     LogicalType::UBIGINT,
     Value::UBIGINT(Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE),
     SetDefaultScanTaskVarcharSize);
+
+  // Add in config option for sort partition size
+  config.AddExtensionOption("max_sort_partition_bytes",
+                            "Maximum bytes per sort partition (0 = auto based on 33% GPU memory)",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(Config::MAX_SORT_PARTITION_BYTES),
+                            SetMaxSortPartitionBytes);
 }
 
 static void LoadInternal(ExtensionLoader& loader)

--- a/test/cpp/integration/integration.cfg
+++ b/test/cpp/integration/integration.cfg
@@ -4,7 +4,7 @@ sirius = {
     };
     memory = {
         gpu = {
-            usage_limit_fraction = 0.2;
+            usage_limit_fraction = 0.8;
             reservation_limit_fraction = 1.0;
         }
         host = {

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <set>
 #include <string>
 
@@ -61,6 +62,9 @@ struct config_env_guard {
  */
 static void compare_gpu_vs_cpu(duckdb::Connection& con, const std::string& query)
 {
+  // Disable fallback so GPU errors are not silently hidden
+  con.Query("SET enable_fallback_check = true;");
+
   // Run on GPU
   auto gpu_sql    = "CALL gpu_execution('" + query + "')";
   auto gpu_result = con.Query(gpu_sql);
@@ -279,7 +283,16 @@ TEST_CASE("gpu_execution - group by", "[.][integration_disabled][gpu_execution]"
   compare_gpu_vs_cpu(con, "select n_regionkey, count(*) from nation group by n_regionkey;");
 }
 
-TEST_CASE("gpu_execution - order by", "[.][integration_disabled][gpu_execution]")
+TEST_CASE("gpu_execution - order by", "[integration][gpu_execution][order_by]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select n_nationkey, n_regionkey from nation order by n_regionkey;");
+}
+
+TEST_CASE("gpu_execution - order by column not in select",
+          "[integration][gpu_execution][order_by][order_by_proj]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
@@ -287,12 +300,187 @@ TEST_CASE("gpu_execution - order by", "[.][integration_disabled][gpu_execution]"
   compare_gpu_vs_cpu(con, "select n_nationkey from nation order by n_regionkey;");
 }
 
-TEST_CASE("gpu_execution - top n", "[.][integration_disabled][gpu_execution]")
+TEST_CASE("gpu_execution - order by column not in select lineitem",
+          "[integration][gpu_execution][order_by][order_by_proj]")
 {
   config_env_guard env;
   duckdb::DuckDB db(get_tpch_db_path().string());
   duckdb::Connection con(db);
-  compare_gpu_vs_cpu(con, "select n_nationkey from nation order by n_regionkey desc limit 5;");
+  compare_gpu_vs_cpu(con, "select l_orderkey from lineitem order by l_linenumber;");
+}
+
+TEST_CASE("gpu_execution - order by multipartition", "[integration][gpu_execution][order_by]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+
+  // Force small partition size (1 KB) so lineitem data is split into multiple partitions
+  con.Query("SET max_sort_partition_bytes = 1024;");
+
+  std::string query = "select l_orderkey, l_partkey from lineitem order by l_orderkey";
+
+  // Run on GPU
+  auto gpu_result = con.Query("CALL gpu_execution('" + query + "')");
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) { UNSCOPED_INFO("gpu error: " << gpu_result->GetError()); }
+  REQUIRE_FALSE(gpu_result->HasError());
+
+  // Run on CPU
+  auto cpu_result = con.Query(query + ";");
+  REQUIRE(cpu_result);
+  REQUIRE_FALSE(cpu_result->HasError());
+
+  // Verify dimensions match
+  REQUIRE(gpu_result->ColumnCount() == cpu_result->ColumnCount());
+  REQUIRE(gpu_result->RowCount() == cpu_result->RowCount());
+
+  // With 600K rows and 1KB max partition, we must have many partitions.
+  // Verify the data is non-trivially large (ensures partitioning actually happened).
+  REQUIRE(gpu_result->RowCount() > 1000);
+  // Sort both result sets for deterministic comparison
+  auto gpu_sorted = con.Query("SELECT * FROM gpu_execution('" + query + "') ORDER BY 1, 2");
+  auto cpu_sorted = con.Query("SELECT * FROM (" + query + ") t ORDER BY 1, 2");
+  REQUIRE(gpu_sorted);
+  REQUIRE_FALSE(gpu_sorted->HasError());
+  REQUIRE(cpu_sorted);
+  REQUIRE_FALSE(cpu_sorted->HasError());
+
+  // Compare every cell
+  duckdb::idx_t mismatches = 0;
+  for (duckdb::idx_t r = 0; r < gpu_sorted->RowCount(); r++) {
+    for (duckdb::idx_t c = 0; c < gpu_sorted->ColumnCount(); c++) {
+      auto gpu_val = gpu_sorted->GetValue(c, r).ToString();
+      auto cpu_val = cpu_sorted->GetValue(c, r).ToString();
+      if (gpu_val != cpu_val) {
+        if (mismatches < 5) {
+          UNSCOPED_INFO("Row " << r << " Col " << c << " mismatch: GPU=[" << gpu_val << "] CPU=["
+                               << cpu_val << "]");
+        }
+        mismatches++;
+      }
+      REQUIRE(gpu_val == cpu_val);
+    }
+  }
+
+  // Reset to auto
+  con.Query("SET max_sort_partition_bytes = 0;");
+}
+
+TEST_CASE("gpu_execution - order by multiple columns", "[integration][gpu_execution][order_by]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  con.Query("SET max_sort_partition_bytes = 1024;");
+  compare_gpu_vs_cpu(
+    con,
+    "select l_orderkey, l_linenumber, l_quantity from lineitem order by l_orderkey, l_linenumber;");
+  con.Query("SET max_sort_partition_bytes = 0;");
+}
+
+TEST_CASE("gpu_execution - order by desc", "[integration][gpu_execution][order_by]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  con.Query("SET max_sort_partition_bytes = 1024;");
+  compare_gpu_vs_cpu(
+    con, "select l_orderkey, l_partkey, l_suppkey from lineitem order by l_partkey desc;");
+  con.Query("SET max_sort_partition_bytes = 0;");
+}
+
+TEST_CASE("gpu_execution - order by many selected columns",
+          "[integration][gpu_execution][order_by]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  con.Query("SET max_sort_partition_bytes = 1024;");
+  compare_gpu_vs_cpu(con,
+                     "select l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity "
+                     "from lineitem order by l_suppkey;");
+  con.Query("SET max_sort_partition_bytes = 0;");
+}
+
+TEST_CASE("gpu_execution - order by with decimal column",
+          "[integration][gpu_execution][order_by][order_by_types]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  auto gpu_result = con.Query(
+    "CALL gpu_execution('select o_orderkey, o_totalprice from orders order by o_orderkey')");
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) {
+    std::cerr << "DECIMAL error: " << gpu_result->GetError() << std::endl;
+  }
+  REQUIRE_FALSE(gpu_result->HasError());
+  REQUIRE(gpu_result->RowCount() > 0);
+}
+
+TEST_CASE("gpu_execution - scan lineitem with varchar column",
+          "[integration][gpu_execution][varchar_scan_lineitem]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select l_orderkey, l_shipinstruct from lineitem;");
+}
+
+TEST_CASE("gpu_execution - order by lineitem with short varchar column",
+          "[integration][gpu_execution][order_by][varchar_order]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(
+    con, "select l_orderkey, l_shipinstruct, l_linenumber from lineitem order by l_orderkey;");
+}
+
+TEST_CASE("gpu_execution - order by lineitem with long varchar column",
+          "[integration][gpu_execution][order_by][varchar_order]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(
+    con, "select l_orderkey, l_comment, l_linenumber from lineitem order by l_orderkey;");
+}
+
+TEST_CASE("gpu_execution - scan with varchar column",
+          "[integration][gpu_execution][order_by_types][varchar]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(con, "select n_nationkey, n_name from nation;");
+}
+
+TEST_CASE("gpu_execution - order by with varchar column",
+          "[integration][gpu_execution][order_by][order_by_types]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  auto gpu_result =
+    con.Query("CALL gpu_execution('select n_nationkey, n_name from nation order by n_nationkey')");
+  REQUIRE(gpu_result);
+  if (gpu_result->HasError()) {
+    std::cerr << "VARCHAR order by error: " << gpu_result->GetError() << std::endl;
+  }
+  REQUIRE_FALSE(gpu_result->HasError());
+  REQUIRE(gpu_result->RowCount() > 0);
+  std::cerr << "VARCHAR order by: " << gpu_result->RowCount() << " rows OK" << std::endl;
+}
+
+TEST_CASE("gpu_execution - top n", "[.][integration_disabled][gpu_execution][top_n]")
+{
+  config_env_guard env;
+  duckdb::DuckDB db(get_tpch_db_path().string());
+  duckdb::Connection con(db);
+  compare_gpu_vs_cpu(
+    con, "select n_nationkey, n_regionkey from nation order by n_regionkey desc limit 5;");
 }
 
 TEST_CASE("gpu_execution - join", "[.][integration_disabled][gpu_execution]")

--- a/test/cpp/operator/CMakeLists.txt
+++ b/test/cpp/operator/CMakeLists.txt
@@ -23,6 +23,8 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_filter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_limit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_top_n.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_order.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_merge_sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_projection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_ungrouped_aggregate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_table_scan.cpp

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <duckdb/planner/bound_query_node.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_merge_sort.hpp>
+#include <op/sirius_physical_order.hpp>
+
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::test::operator_utils;
+
+namespace {
+
+duckdb::BoundOrderByNode make_order(
+  duckdb::idx_t col_idx,
+  duckdb::LogicalType type,
+  duckdb::OrderType dir         = duckdb::OrderType::ASCENDING,
+  duckdb::OrderByNullType nulls = duckdb::OrderByNullType::NULLS_LAST)
+{
+  return duckdb::BoundOrderByNode(
+    dir, nulls, duckdb::make_uniq<duckdb::BoundReferenceExpression>(std::move(type), col_idx));
+}
+
+// Deep copy orders (contains unique_ptr<Expression>)
+duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
+  const duckdb::vector<duckdb::BoundOrderByNode>& src)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> result;
+  result.reserve(src.size());
+  for (const auto& order : src) {
+    result.push_back(order.Copy());
+  }
+  return result;
+}
+
+std::shared_ptr<data_batch> make_1col_batch(memory_space& space, const std::vector<int64_t>& vals)
+{
+  return make_numeric_batch<int64_t>(space, vals, cudf::type_id::INT64);
+}
+
+std::shared_ptr<data_batch> make_2col_batch(memory_space& space,
+                                            const std::vector<int64_t>& col0,
+                                            const std::vector<int64_t>& col1)
+{
+  return make_two_column_batch<int64_t, int64_t>(
+    space, col0, col1, cudf::type_id::INT64, std::nullopt);
+}
+
+std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
+                                            const std::vector<int64_t>& col0,
+                                            const std::vector<int64_t>& col1,
+                                            const std::vector<int64_t>& col2)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(col0.size());
+
+  auto make_col = [&](const std::vector<int64_t>& vals) {
+    auto col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT64}, size, cudf::mask_state::UNALLOCATED, stream, mr);
+    cudaMemcpy(col->mutable_view().data<int64_t>(),
+               vals.data(),
+               sizeof(int64_t) * vals.size(),
+               cudaMemcpyHostToDevice);
+    return col;
+  };
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_col(col0));
+  cols.push_back(make_col(col1));
+  cols.push_back(make_col(col2));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
+  auto batch_id = ::sirius::get_next_batch_id();
+  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+}
+
+// Helper: sort a batch using sirius_physical_order so it can be used as merge input
+std::shared_ptr<data_batch> sort_batch(const std::shared_ptr<data_batch>& batch,
+                                       const duckdb::vector<duckdb::BoundOrderByNode>& orders,
+                                       const duckdb::vector<duckdb::idx_t>& projections,
+                                       const duckdb::vector<duckdb::LogicalType>& types)
+{
+  sirius_physical_order order_op(duckdb::vector<duckdb::LogicalType>(types),
+                                 copy_orders(orders),
+                                 duckdb::vector<duckdb::idx_t>(projections),
+                                 0);
+  auto result = order_op.execute({batch});
+  REQUIRE(result.size() == 1);
+  return result[0];
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_merge_sort merges 2 sorted 1-column batches ascending",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  // Two pre-sorted ascending batches
+  auto batch1 = make_1col_batch(*space, {1, 3, 5, 7});
+  auto batch2 = make_1col_batch(*space, {2, 4, 6, 8});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch1, batch2});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+
+  std::vector<int64_t> expected{1, 2, 3, 4, 5, 6, 7, 8};
+  REQUIRE(col0 == expected);
+}
+
+TEST_CASE("sirius_physical_merge_sort merges 3 sorted 1-column batches descending",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch1 = make_1col_batch(*space, {9, 6, 3});
+  auto batch2 = make_1col_batch(*space, {8, 5, 2});
+  auto batch3 = make_1col_batch(*space, {7, 4, 1});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::DESCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch1, batch2, batch3});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+
+  std::vector<int64_t> expected{9, 8, 7, 6, 5, 4, 3, 2, 1};
+  REQUIRE(col0 == expected);
+}
+
+// ---------------------------------------------------------------------------
+// 2-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_merge_sort merges 2 sorted 2-column batches by col0 asc",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  // Pre-sorted by col0 ascending
+  auto batch1 = make_2col_batch(*space, {1, 3, 5}, {10, 30, 50});
+  auto batch2 = make_2col_batch(*space, {2, 4, 6}, {20, 40, 60});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch1, batch2});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
+  REQUIRE(out_c1 == std::vector<int64_t>{10, 20, 30, 40, 50, 60});
+}
+
+TEST_CASE("sirius_physical_merge_sort merges 2-column batches sorted by 2 keys",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+  orders.push_back(make_order(
+    1, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1};
+
+  // Pre-sort batches using the order operator
+  auto raw1    = make_2col_batch(*space, {2, 1, 1, 3}, {20, 10, 5, 30});
+  auto sorted1 = sort_batch(raw1, orders, projections, types);
+  // sorted1: (1,5), (1,10), (2,20), (3,30)
+
+  auto raw2    = make_2col_batch(*space, {1, 2, 3, 2}, {15, 25, 35, 1});
+  auto sorted2 = sort_batch(raw2, orders, projections, types);
+  // sorted2: (1,15), (2,1), (2,25), (3,35)
+
+  sirius_physical_merge_sort op(duckdb::vector<duckdb::LogicalType>(types),
+                                copy_orders(orders),
+                                duckdb::vector<duckdb::idx_t>(projections),
+                                0);
+
+  auto out = op.execute({sorted1, sorted2});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+
+  // Merged: (1,5), (1,10), (1,15), (2,1), (2,20), (2,25), (3,30), (3,35)
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 1, 1, 2, 2, 2, 3, 3});
+  REQUIRE(out_c1 == std::vector<int64_t>{5, 10, 15, 1, 20, 25, 30, 35});
+}
+
+// ---------------------------------------------------------------------------
+// 3-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_merge_sort merges 3-column batches sorted by col0, returns all",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  // Pre-sorted by col0 ascending
+  auto batch1 = make_3col_batch(*space, {1, 3, 5}, {10, 30, 50}, {100, 300, 500});
+  auto batch2 = make_3col_batch(*space, {2, 4, 6}, {20, 40, 60}, {200, 400, 600});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch1, batch2});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+  auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
+
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
+  REQUIRE(out_c1 == std::vector<int64_t>{10, 20, 30, 40, 50, 60});
+  REQUIRE(out_c2 == std::vector<int64_t>{100, 200, 300, 400, 500, 600});
+}
+
+TEST_CASE("sirius_physical_merge_sort 3 columns sorted by col0 asc + col1 desc",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+  orders.push_back(make_order(
+    1, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::DESCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
+
+  // Pre-sort using the order operator
+  auto raw1    = make_3col_batch(*space, {1, 2, 1}, {20, 10, 30}, {100, 200, 300});
+  auto sorted1 = sort_batch(raw1, orders, projections, types);
+  // sorted1: (1,30,300), (1,20,100), (2,10,200)
+
+  auto raw2    = make_3col_batch(*space, {2, 1, 2}, {40, 25, 5}, {400, 500, 600});
+  auto sorted2 = sort_batch(raw2, orders, projections, types);
+  // sorted2: (1,25,500), (2,40,400), (2,5,600)
+
+  sirius_physical_merge_sort op(duckdb::vector<duckdb::LogicalType>(types),
+                                copy_orders(orders),
+                                duckdb::vector<duckdb::idx_t>(projections),
+                                0);
+
+  auto out = op.execute({sorted1, sorted2});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+  auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
+
+  // Merged by (col0 asc, col1 desc):
+  // (1,30,300), (1,25,500), (1,20,100), (2,40,400), (2,10,200), (2,5,600)
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 1, 1, 2, 2, 2});
+  REQUIRE(out_c1 == std::vector<int64_t>{30, 25, 20, 40, 10, 5});
+  REQUIRE(out_c2 == std::vector<int64_t>{300, 500, 100, 400, 200, 600});
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_merge_sort single batch passthrough", "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_1col_batch(*space, {1, 2, 3});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  REQUIRE(col0 == std::vector<int64_t>{1, 2, 3});
+}
+
+TEST_CASE("sirius_physical_merge_sort skips null batches", "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch1 = make_1col_batch(*space, {1, 3, 5});
+  auto batch2 = make_1col_batch(*space, {2, 4, 6});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch1, nullptr, batch2, nullptr};
+  auto out = op.execute(inputs);
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  REQUIRE(col0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
+}
+
+TEST_CASE("sirius_physical_merge_sort returns empty for all-null inputs", "[physical_merge_sort]")
+{
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
+  auto out = op.execute(inputs);
+  REQUIRE(out.empty());
+}
+
+TEST_CASE("sirius_physical_merge_sort constructed from sirius_physical_order",
+          "[physical_merge_sort]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch1 = make_1col_batch(*space, {1, 3, 5});
+  auto batch2 = make_1col_batch(*space, {2, 4, 6});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order order_op(duckdb::vector<duckdb::LogicalType>(types),
+                                 copy_orders(orders),
+                                 duckdb::vector<duckdb::idx_t>(projections),
+                                 0);
+
+  sirius_physical_merge_sort op(&order_op);
+
+  auto out = op.execute({batch1, batch2});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  REQUIRE(col0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
+}

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -39,18 +39,6 @@ duckdb::BoundOrderByNode make_order(
     dir, nulls, duckdb::make_uniq<duckdb::BoundReferenceExpression>(std::move(type), col_idx));
 }
 
-// Deep copy orders (contains unique_ptr<Expression>)
-duckdb::vector<duckdb::BoundOrderByNode> copy_orders(
-  const duckdb::vector<duckdb::BoundOrderByNode>& src)
-{
-  duckdb::vector<duckdb::BoundOrderByNode> result;
-  result.reserve(src.size());
-  for (const auto& order : src) {
-    result.push_back(order.Copy());
-  }
-  return result;
-}
-
 std::shared_ptr<data_batch> make_1col_batch(memory_space& space, const std::vector<int64_t>& vals)
 {
   return make_numeric_batch<int64_t>(space, vals, cudf::type_id::INT64);

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <duckdb/planner/bound_query_node.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_order.hpp>
+
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::test::operator_utils;
+
+namespace {
+
+duckdb::BoundOrderByNode make_order(
+  duckdb::idx_t col_idx,
+  duckdb::LogicalType type,
+  duckdb::OrderType dir         = duckdb::OrderType::ASCENDING,
+  duckdb::OrderByNullType nulls = duckdb::OrderByNullType::NULLS_LAST)
+{
+  return duckdb::BoundOrderByNode(
+    dir, nulls, duckdb::make_uniq<duckdb::BoundReferenceExpression>(std::move(type), col_idx));
+}
+
+std::shared_ptr<data_batch> make_1col_batch(memory_space& space, const std::vector<int64_t>& vals)
+{
+  return make_numeric_batch<int64_t>(space, vals, cudf::type_id::INT64);
+}
+
+std::shared_ptr<data_batch> make_2col_batch(memory_space& space,
+                                            const std::vector<int64_t>& col0,
+                                            const std::vector<int64_t>& col1)
+{
+  return make_two_column_batch<int64_t, int64_t>(
+    space, col0, col1, cudf::type_id::INT64, std::nullopt);
+}
+
+std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
+                                            const std::vector<int64_t>& col0,
+                                            const std::vector<int64_t>& col1,
+                                            const std::vector<int64_t>& col2)
+{
+  auto mr     = get_resource_ref(space);
+  auto stream = default_stream();
+  auto size   = static_cast<cudf::size_type>(col0.size());
+
+  auto make_col = [&](const std::vector<int64_t>& vals) {
+    auto col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT64}, size, cudf::mask_state::UNALLOCATED, stream, mr);
+    cudaMemcpy(col->mutable_view().data<int64_t>(),
+               vals.data(),
+               sizeof(int64_t) * vals.size(),
+               cudaMemcpyHostToDevice);
+    return col;
+  };
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(make_col(col0));
+  cols.push_back(make_col(col1));
+  cols.push_back(make_col(col2));
+  auto table = std::make_unique<cudf::table>(std::move(cols));
+
+  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
+  auto batch_id = ::sirius::get_next_batch_id();
+  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_order sorts 1 column ascending", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_1col_batch(*space, {5, 1, 9, 3, 7, 2, 8});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+
+  std::vector<int64_t> expected{1, 2, 3, 5, 7, 8, 9};
+  REQUIRE(col0 == expected);
+}
+
+TEST_CASE("sirius_physical_order sorts 1 column descending", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_1col_batch(*space, {5, 1, 9, 3, 7, 2, 8});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::DESCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+
+  std::vector<int64_t> expected{9, 8, 7, 5, 3, 2, 1};
+  REQUIRE(col0 == expected);
+}
+
+// ---------------------------------------------------------------------------
+// 2-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_order sorts by col0, returns both columns", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  //                          col0           col1 (payload)
+  auto batch = make_2col_batch(*space, {3, 1, 4, 1, 5}, {30, 10, 40, 11, 50});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+
+  // Stable sort not guaranteed — only check order keys are sorted
+  REQUIRE(std::is_sorted(out_c0.begin(), out_c0.end()));
+  REQUIRE(out_c0.size() == 5);
+  REQUIRE(out_c1.size() == 5);
+}
+
+TEST_CASE("sirius_physical_order sorts by 2 keys (asc, desc)", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  //                          col0           col1
+  auto batch = make_2col_batch(*space, {2, 2, 1, 1, 3}, {10, 20, 30, 40, 50});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+  orders.push_back(make_order(
+    1, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::DESCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+
+  // Expected: (1,40), (1,30), (2,20), (2,10), (3,50)
+  std::vector<int64_t> expected_c0{1, 1, 2, 2, 3};
+  std::vector<int64_t> expected_c1{40, 30, 20, 10, 50};
+  REQUIRE(out_c0 == expected_c0);
+  REQUIRE(out_c1 == expected_c1);
+}
+
+TEST_CASE("sirius_physical_order projects only col1 when sorting by col0", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_2col_batch(*space, {3, 1, 2}, {30, 10, 20});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  // Only project col1 (payload), not col0 (sort key)
+  duckdb::vector<duckdb::idx_t> projections{1};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
+  REQUIRE(view.num_columns() == 1);
+
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  std::vector<int64_t> expected{10, 20, 30};
+  REQUIRE(out_c0 == expected);
+}
+
+// ---------------------------------------------------------------------------
+// 3-column tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc, return all", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_3col_batch(*space, {3, 1, 2}, {30, 10, 20}, {300, 100, 200});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+  auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
+
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 2, 3});
+  REQUIRE(out_c1 == std::vector<int64_t>{10, 20, 30});
+  REQUIRE(out_c2 == std::vector<int64_t>{100, 200, 300});
+}
+
+TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc + col1 desc, return all",
+          "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  //  col0  col1  col2
+  //   1     20   100
+  //   1     10   200
+  //   2     30   300
+  //   2     40   400
+  //   3     50   500
+  auto batch =
+    make_3col_batch(*space, {1, 1, 2, 2, 3}, {20, 10, 30, 40, 50}, {100, 200, 300, 400, 500});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+  orders.push_back(make_order(
+    1, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::DESCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table  = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view   = table.view();
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+  auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
+
+  // Expected: (1,20,100), (1,10,200), (2,40,400), (2,30,300), (3,50,500)
+  REQUIRE(out_c0 == std::vector<int64_t>{1, 1, 2, 2, 3});
+  REQUIRE(out_c1 == std::vector<int64_t>{20, 10, 40, 30, 50});
+  REQUIRE(out_c2 == std::vector<int64_t>{100, 200, 400, 300, 500});
+}
+
+TEST_CASE("sirius_physical_order 3 columns, sort by col0, project col1 and col2 only",
+          "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_3col_batch(*space, {3, 1, 2}, {30, 10, 20}, {300, 100, 200});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{1, 2};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch});
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
+  REQUIRE(view.num_columns() == 2);
+
+  auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
+  auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
+
+  REQUIRE(out_c0 == std::vector<int64_t>{10, 20, 30});
+  REQUIRE(out_c1 == std::vector<int64_t>{100, 200, 300});
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+TEST_CASE("sirius_physical_order handles multiple batches", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch1 = make_1col_batch(*space, {5, 3, 1});
+  auto batch2 = make_1col_batch(*space, {4, 2, 6});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  auto out = op.execute({batch1, batch2});
+  REQUIRE(out.size() == 2);
+
+  // Each batch is independently sorted
+  auto t1   = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col1 = copy_column_to_host<int64_t>(t1.view().column(0));
+  REQUIRE(col1 == std::vector<int64_t>{1, 3, 5});
+
+  auto t2   = out[1]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col2 = copy_column_to_host<int64_t>(t2.view().column(0));
+  REQUIRE(col2 == std::vector<int64_t>{2, 4, 6});
+}
+
+TEST_CASE("sirius_physical_order handles null input batches", "[physical_order]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space);
+
+  auto batch = make_1col_batch(*space, {3, 1, 2});
+
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch, nullptr};
+  auto out = op.execute(inputs);
+  REQUIRE(out.size() == 1);
+
+  auto table = out[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  REQUIRE(col0 == std::vector<int64_t>{1, 2, 3});
+}
+
+TEST_CASE("sirius_physical_order returns empty for all-null inputs", "[physical_order]")
+{
+  duckdb::vector<duckdb::LogicalType> types;
+  types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(
+    0, duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT), duckdb::OrderType::ASCENDING));
+
+  duckdb::vector<duckdb::idx_t> projections{0};
+
+  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+
+  std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
+  auto out = op.execute(inputs);
+  REQUIRE(out.empty());
+}

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -1128,7 +1128,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     size_t int_size    = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
     size_t double_size = sizeof(double) * num_rows + sirius::utils::ceil_div_8(num_rows);
     size_t varchar_size =
-      (num_rows + 1) * sizeof(int64_t) + 256 * num_rows + sirius::utils::ceil_div_8(num_rows);
+      (num_rows + 1) * sizeof(int32_t) + 256 * num_rows + sirius::utils::ceil_div_8(num_rows);
     size_t total_size = int_size + double_size + varchar_size;
 
     auto allocation = create_test_allocation(total_size);
@@ -1199,7 +1199,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     // Verify VARCHAR NULLs
     // For VARCHAR, the mask is initialized at: data_offset + total_data_bytes_allocated
     // Where total_data_bytes_allocated = num_rows * default_varchar_size = 8 * 256 = 2048
-    size_t varchar_data_offset = int_size + double_size + (num_rows + 1) * sizeof(int64_t);
+    size_t varchar_data_offset = int_size + double_size + (num_rows + 1) * sizeof(int32_t);
     size_t varchar_mask_offset =
       varchar_data_offset + (num_rows * 256);  // 256 is default_varchar_size
     varchar_builder.mask_blocks_accessor.set_cursor(varchar_mask_offset);


### PR DESCRIPTION
This PR

Implements the sort operators.
Added two new operators. 
Sample for Sort (samples data to notify downstream of data distribution)
Sort Partition (partitions data specifically for sort)

Large string fixes
Had to deal with 32bit offsets for cudf and 64bit offsets for duckdb. This fix is temporary and we need to revisit this later to handle both types of offsets.