### PR TITLE
Handle empty result tables

### DIFF
--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -38,7 +38,6 @@ class sirius_physical_order : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::ORDER_BY;
 
- public:
   sirius_physical_order(duckdb::vector<duckdb::LogicalType> types,
                         duckdb::vector<duckdb::BoundOrderByNode> orders,
                         duckdb::vector<duckdb::idx_t> projections_p,
@@ -50,21 +49,15 @@ class sirius_physical_order : public sirius_physical_operator {
   duckdb::vector<duckdb::idx_t> projections;
   bool is_index_sort;
 
- public:
-  // Source interface
   bool is_source() const override { return true; }
+  bool is_sink() const override { return true; }
+  bool sink_order_dependent() const override { return false; }
 
   duckdb::OrderPreservationType source_order() const override
   {
     return duckdb::OrderPreservationType::FIXED_ORDER;
   }
 
- public:
-  // Sink interface
-  bool is_sink() const override { return true; }
-  bool sink_order_dependent() const override { return false; }
-
- public:
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
     rmm::cuda_stream_view stream = cudf::get_default_stream()) override;

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "duckdb/planner/bound_query_node.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_order.hpp"
 
@@ -36,7 +35,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Maximum fraction of available GPU memory per partition (33%)
   static constexpr double MAX_PARTITION_MEMORY_FRACTION = 0.33;
 
- public:
   sirius_physical_sort_sample(sirius_physical_order* order_by);
 
   sirius_physical_sort_sample(duckdb::vector<duckdb::LogicalType> types,
@@ -51,20 +49,15 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   duckdb::idx_t num_sample_batches;
 
  public:
-  // Source interface
   bool is_source() const override { return true; }
+  bool is_sink() const override { return true; }
+  bool sink_order_dependent() const override { return false; }
 
   duckdb::OrderPreservationType source_order() const override
   {
     return duckdb::OrderPreservationType::FIXED_ORDER;
   }
 
- public:
-  // Sink interface
-  bool is_sink() const override { return true; }
-  bool sink_order_dependent() const override { return false; }
-
- public:
   std::vector<std::shared_ptr<cucascade::data_batch>> execute(
     const std::vector<std::shared_ptr<cucascade::data_batch>>& input_batches,
     rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
@@ -72,7 +65,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Override to wait for N batches before returning READY
   std::optional<task_creation_hint> get_next_task_hint() override;
 
- public:
   //! Get the computed partition boundaries (P-1 rows, sort key columns only)
   const cudf::table& get_partition_boundaries() const { return *_partition_boundaries; }
 

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -180,7 +180,7 @@ void host_table_chunk_reader::column_reader::copy_string(
     // Set the null mask
     auto& validity = duckdb::FlatVector::Validity(vector);
     copy_mask_to_validity(validity, row_offset, count, allocation);
-    detail::make_duckdb_strings<false>(
+    detail::make_duckdb_strings<true>(
       offset_accessor, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
   } else {
     detail::make_duckdb_strings<false>(

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -238,7 +238,7 @@ host_table_chunk_reader::host_table_chunk_reader(
   }
   if (_allocation->size_bytes() == 0) {
     if (metadata_nodes[0].size == 0) {
-      // empty result host table, return without any column readers (creating them would fail).
+      // Empty result host table, return without any column readers (creating them would fail).
       // Because _row_offset and _total_rows are 0 by default, get_next_chunk() will immediately
       // return false.
       return;

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -185,11 +185,11 @@ void host_table_chunk_reader::column_reader::copy_string(
     if (null_count != 0) {
       auto& validity = duckdb::FlatVector::Validity(vector);
       copy_mask_to_validity(validity, row_offset, count, allocation);
-      detail::make_duckdb_strings<true>(
+      detail::make_duckdb_strings<true, int64_t>(
         offset_accessor_64, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
       duckdb::StringVector::AddBuffer(vector, str_buffer);
     } else {
-      detail::make_duckdb_strings<false>(
+      detail::make_duckdb_strings<false, int64_t>(
         offset_accessor_64, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
       duckdb::StringVector::AddBuffer(vector, str_buffer);
     }
@@ -205,11 +205,11 @@ void host_table_chunk_reader::column_reader::copy_string(
     if (null_count != 0) {
       auto& validity = duckdb::FlatVector::Validity(vector);
       copy_mask_to_validity(validity, row_offset, count, allocation);
-      detail::make_duckdb_strings<true>(
+      detail::make_duckdb_strings<true, int32_t>(
         offset_accessor_32, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
       duckdb::StringVector::AddBuffer(vector, str_buffer);
     } else {
-      detail::make_duckdb_strings<false>(
+      detail::make_duckdb_strings<false, int32_t>(
         offset_accessor_32, allocation, vector, count, start_offset, end_offset, str_buffer_ptr);
       duckdb::StringVector::AddBuffer(vector, str_buffer);
     }

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -212,6 +212,7 @@ host_table_chunk_reader::host_table_chunk_reader(
       "[host_table_chunk_reader] Metadata column count does not match expected column count.");
   }
   // Initialize column readers
+  _column_readers.reserve(metadata_nodes.size());
   for (size_t col_idx = 0; col_idx < metadata_nodes.size(); ++col_idx) {
     if (col_idx == 0) {
       _total_rows = static_cast<size_t>(metadata_nodes[col_idx].size);

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -211,6 +211,17 @@ host_table_chunk_reader::host_table_chunk_reader(
     throw std::runtime_error(
       "[host_table_chunk_reader] Metadata column count does not match expected column count.");
   }
+  if (_allocation->size_bytes() == 0) {
+    if (metadata_nodes[0].size == 0) {
+      // empty result host table, return without any column readers (creating them would fail).
+      // Because _row_offset and _total_rows are 0 by default, get_next_chunk() will immediately
+      // return false.
+      return;
+    } else {
+      throw duckdb::InvalidInputException(
+        "[GPUPhysicalMaterializedCollector] host_table has rows but a zero-sized allocation");
+    }
+  }
   // Initialize column readers
   _column_readers.reserve(metadata_nodes.size());
   for (size_t col_idx = 0; col_idx < metadata_nodes.size(); ++col_idx) {

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -36,6 +36,10 @@ namespace sirius::op::result {
 host_table_chunk_reader::column_reader::column_reader(
   metadata_node const& node, std::unique_ptr<multiple_blocks_allocation> const& allocation)
 {
+  if (allocation == nullptr || allocation->block_size() == 0) {
+    throw std::runtime_error(
+      "[host_table_chunk_reader::column_reader::column_reader] Invalid allocation.");
+  }
   size       = static_cast<size_t>(node.size);
   null_count = static_cast<size_t>(node.null_count);
   if (node.null_mask_offset < 0) { null_count = 0; }


### PR DESCRIPTION
We could also just check if the allocation is zero in the result collector and then skip it, but in this PR I also check the metadata to see if that agrees that the table should be empty.
This PR includes some cosmetic changes and a fix as follow-up for #217 