### PR TITLE
Fix empty set aggregation: COUNT returns NULL instead of 0

### DIFF
--- a/src/cuda/cudf/cudf_aggregate.cu
+++ b/src/cuda/cudf/cudf_aggregate.cu
@@ -55,7 +55,8 @@ void cudf_aggregate(vector<shared_ptr<GPUColumn>>& column,
           agg_mode[agg_idx] == AggregationType::COUNT_DISTINCT) {
         uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(1, 0, 0);
         cudaMemset(temp, 0, sizeof(uint64_t));
-        auto validity_mask = createNullMask(1, cudf::mask_state::ALL_NULL);
+        // COUNT on empty set should return 0 (valid), not NULL (SQL standard)
+        auto validity_mask = createNullMask(1, cudf::mask_state::ALL_VALID);
         column[agg_idx]    = make_shared_ptr<GPUColumn>(1,
                                                      GPUColumnType(GPUColumnTypeId::INT64),
                                                      reinterpret_cast<uint8_t*>(temp),


### PR DESCRIPTION
<html><head></head><body><h2>Problem</h2>
<p>When aggregating over an empty result set (e.g., <code>WHERE</code> clause filters all rows), <code>COUNT(*)</code> / <code>COUNT(col)</code> returned NULL instead of 0. Per SQL standard, COUNT on empty sets should return 0.</p>
<h2>Root Cause</h2>
<p>In the empty input early-return path of <code>cudf_aggregate.cu</code>, COUNT used <code>ALL_NULL</code> validity mask, making the 0 value appear as NULL.</p>
<h2>Solution</h2>
<p>Use <code>ALL_VALID</code> mask for COUNT so the 0 value is returned as valid.</p>
<p><strong>Note:</strong> The SUM/AVG empty-set fix (returning 1 row with NULL instead of 0 rows) is deferred to a separate PR — it triggers a GPU fallback in TPC-H CI tests because downstream pipeline operators don't yet handle 1-row NULL results from the empty-set path.</p>
<h2>Testing</h2>

Query | CPU | GPU Before | GPU After
-- | -- | -- | --
SELECT COUNT(val) WHERE val > 9999 | 0 | NULL | 0 ✅


<p>Tested on Tesla T4</p></body></html>