### PR TITLE
operator_data polymorphism

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -221,8 +221,8 @@ void task_creator::manager_loop()
                 }
               }
 
-              auto local_state =
-                std::make_unique<pipeline::gpu_pipeline_task_local_state>(input_data.value());
+              auto local_state = std::make_unique<pipeline::gpu_pipeline_task_local_state>(
+                std::move(input_data.value()));
               auto task = std::make_unique<pipeline::gpu_pipeline_task>(
                 get_next_task_id(),
                 destination_data_repositories,

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -179,7 +179,8 @@ class duckdb_scan_executor {
    */
   void submit_scan_request();
 
-  op::operator_data get_scan_output(op::scan::duckdb_scan_task* task, rmm::cuda_stream_view stream);
+  std::unique_ptr<op::operator_data> get_scan_output(op::scan::duckdb_scan_task* task,
+                                                     rmm::cuda_stream_view stream);
 
   struct cache_entry {
     std::vector<std::vector<std::shared_ptr<cucascade::data_batch>>> batches;

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -469,7 +469,8 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
-  op::operator_data compute_task([[maybe_unused]] rmm::cuda_stream_view stream) override;
+  std::unique_ptr<op::operator_data> compute_task(
+    [[maybe_unused]] rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Publish the computed output batches to the data repository.
@@ -479,7 +480,8 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
+  void publish_output(std::unique_ptr<op::operator_data> output_data,
+                      rmm::cuda_stream_view stream) override;
 
   std::size_t get_estimated_reservation_size() const override
   {

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -480,7 +480,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(std::unique_ptr<op::operator_data> output_data,
+  void publish_output(std::shared_ptr<op::operator_data> output_data,
                       rmm::cuda_stream_view stream) override;
 
   std::size_t get_estimated_reservation_size() const override

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -323,7 +323,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
    * @param[in] output_batches The data batches produced by this task to be published.
    * @param[in] stream The CUDA stream on which to perform memory operations (ignored in this task).
    */
-  void publish_output(std::unique_ptr<op::operator_data> output_data,
+  void publish_output(std::shared_ptr<op::operator_data> output_data,
                       rmm::cuda_stream_view stream) override;
 
   /**

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -315,7 +315,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
    * @param[in] stream The CUDA stream on which to perform memory operations.
    * @return A vector of shared pointers to data batches produced by this task.
    */
-  op::operator_data compute_task(rmm::cuda_stream_view stream) override;
+  std::unique_ptr<op::operator_data> compute_task(rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Publish the output data batches produced by this task to the shared data repository.
@@ -323,7 +323,8 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
    * @param[in] output_batches The data batches produced by this task to be published.
    * @param[in] stream The CUDA stream on which to perform memory operations (ignored in this task).
    */
-  void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
+  void publish_output(std::unique_ptr<op::operator_data> output_data,
+                      rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Get the estimated reservation size for this task, which is the number of compressed

--- a/src/include/op/sirius_physical_column_data_scan.hpp
+++ b/src/include/op/sirius_physical_column_data_scan.hpp
@@ -54,7 +54,8 @@ class sirius_physical_column_data_scan : public sirius_physical_operator {
 
   duckdb::optional_idx delim_index;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
  public:
   bool is_source() const override { return true; }

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -50,7 +50,7 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  void sink(std::unique_ptr<operator_data> output_data, rmm::cuda_stream_view stream) override;
+  void sink(std::shared_ptr<operator_data> output_data, rmm::cuda_stream_view stream) override;
 
   //! Get the parent operator (e.g., HASH_JOIN for build concat)
   sirius_physical_operator* get_parent_op() const { return _parent_op; }

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -45,11 +45,12 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
 
   bool is_build_concat();
 
-  std::optional<operator_data> get_next_task_input_data() override;
+  std::optional<std::unique_ptr<operator_data>> get_next_task_input_data() override;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
-  void sink(const operator_data& output_data, rmm::cuda_stream_view stream) override;
+  void sink(std::unique_ptr<operator_data> output_data, rmm::cuda_stream_view stream) override;
 
   //! Get the parent operator (e.g., HASH_JOIN for build concat)
   sirius_physical_operator* get_parent_op() const { return _parent_op; }

--- a/src/include/op/sirius_physical_cte.hpp
+++ b/src/include/op/sirius_physical_cte.hpp
@@ -51,7 +51,8 @@ class sirius_physical_cte : public sirius_physical_operator {
   duckdb::idx_t table_index;
   std::string ctename;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
  public:
   // Sink interface

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -87,7 +87,7 @@ class sirius_physical_right_delim_join : public sirius_physical_delim_join {
   std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::shared_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 };
 
 class sirius_physical_left_delim_join : public sirius_physical_delim_join {
@@ -111,7 +111,7 @@ class sirius_physical_left_delim_join : public sirius_physical_delim_join {
   std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::shared_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -84,9 +84,10 @@ class sirius_physical_right_delim_join : public sirius_physical_delim_join {
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 };
 
 class sirius_physical_left_delim_join : public sirius_physical_delim_join {
@@ -107,9 +108,10 @@ class sirius_physical_left_delim_join : public sirius_physical_delim_join {
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_filter.hpp
+++ b/src/include/op/sirius_physical_filter.hpp
@@ -36,7 +36,8 @@ class sirius_physical_filter : public sirius_physical_operator {
   //! The filter expression
   duckdb::unique_ptr<duckdb::Expression> expression;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
   // sirius_expression_executor* sirius_expression_executor;
 

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -97,7 +97,8 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
 
   bool sink_order_dependent() const override { return false; }
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
@@ -111,9 +111,10 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
 
   bool sink_order_dependent() const override { return false; }
 
-  std::optional<operator_data> get_next_task_input_data() override;
+  std::optional<std::unique_ptr<operator_data>> get_next_task_input_data() override;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -40,7 +40,8 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
   duckdb::BoundLimitNode offset_val;
   bool parallel;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_merge_sort.hpp
+++ b/src/include/op/sirius_physical_merge_sort.hpp
@@ -59,8 +59,9 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
   bool sink_order_dependent() const override { return false; }
 
  public:
-  operator_data execute(const operator_data& input_data,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  std::unique_ptr<operator_data> execute(
+    std::unique_ptr<operator_data> input_data,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   //! Set the final output projection (applied after merge, to remove sort-key-only columns)
   void set_final_projections(duckdb::vector<duckdb::idx_t> proj,

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -180,7 +180,8 @@ class sirius_physical_operator {
   virtual duckdb::unique_ptr<duckdb::GlobalOperatorState> get_global_operator_state(
     duckdb::ClientContext& context) const;
 
-  virtual operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream);
+  virtual std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                                 rmm::cuda_stream_view stream);
 
   //! The influence the operator has on order (insertion order means no influence)
   virtual duckdb::OrderPreservationType operator_order() const
@@ -212,7 +213,7 @@ class sirius_physical_operator {
   virtual duckdb::unique_ptr<duckdb::GlobalSinkState> get_global_sink_state(
     duckdb::ClientContext& context) const;
 
-  virtual void sink(const operator_data& input_data, rmm::cuda_stream_view stream);
+  virtual void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream);
 
   virtual bool is_sink() const { return false; }
 
@@ -295,7 +296,7 @@ class sirius_physical_operator {
   }
 
   //! Get the input batch
-  virtual std::optional<operator_data> get_next_task_input_data();
+  virtual std::optional<std::unique_ptr<operator_data>> get_next_task_input_data();
   //! Check if all ports are empty
   bool all_ports_empty();
   //! Check if the pipeline is finished

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -213,7 +213,7 @@ class sirius_physical_operator {
   virtual duckdb::unique_ptr<duckdb::GlobalSinkState> get_global_sink_state(
     duckdb::ClientContext& context) const;
 
-  virtual void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream);
+  virtual void sink(std::shared_ptr<operator_data> input_data, rmm::cuda_stream_view stream);
 
   virtual bool is_sink() const { return false; }
 

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -58,8 +58,9 @@ class sirius_physical_order : public sirius_physical_operator {
     return duckdb::OrderPreservationType::FIXED_ORDER;
   }
 
-  operator_data execute(const operator_data& input_data,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  std::unique_ptr<operator_data> execute(
+    std::unique_ptr<operator_data> input_data,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -65,9 +65,10 @@ class sirius_physical_partition : public sirius_physical_operator {
   //! Get the parent operator (e.g., HASH_JOIN for build partition)
   [[nodiscard]] sirius_physical_operator* get_parent_op() const { return _parent_op; }
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 
  private:
   void get_partition_keys_and_type(sirius_physical_operator* op, bool is_build = false);

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -68,7 +68,7 @@ class sirius_physical_partition : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::shared_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 
  private:
   void get_partition_keys_and_type(sirius_physical_operator* op, bool is_build = false);

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -31,7 +31,8 @@ class sirius_physical_projection : public sirius_physical_operator {
                              duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
                              duckdb::idx_t estimated_cardinality);
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
 };

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -44,7 +44,8 @@ class sirius_physical_result_collector : public sirius_physical_operator {
  public:
   explicit sirius_physical_result_collector(::sirius::sirius_prepared_statement_data& data);
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
   duckdb::StatementType statement_type;
   duckdb::StatementProperties properties;
@@ -93,7 +94,7 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
    * host_table_representation. In the future, we should register converters for other specialized
    * data representations and invoke one such here.
    */
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 
  private:
   duckdb::ClientContext& _client_ctx;

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -94,7 +94,7 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
    * host_table_representation. In the future, we should register converters for other specialized
    * data representations and invoke one such here.
    */
-  void sink(std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
+  void sink(std::shared_ptr<operator_data> input_data, rmm::cuda_stream_view stream) override;
 
  private:
   duckdb::ClientContext& _client_ctx;

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -57,8 +57,9 @@ class sirius_physical_sort_partition : public sirius_physical_operator {
   bool sink_order_dependent() const override { return false; }
 
  public:
-  operator_data execute(const operator_data& input_data,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  std::unique_ptr<operator_data> execute(
+    std::unique_ptr<operator_data> input_data,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   //! Set the sample operator to read partition boundaries from
   void set_sample_op(sirius_physical_sort_sample* sample) { _sample_op = sample; }

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -58,8 +58,9 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
     return duckdb::OrderPreservationType::FIXED_ORDER;
   }
 
-  operator_data execute(const operator_data& input_data,
-                        rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
+  std::unique_ptr<operator_data> execute(
+    std::unique_ptr<operator_data> input_data,
+    rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
 
   //! Override to wait for N batches before returning READY
   std::optional<task_creation_hint> get_next_task_hint() override;

--- a/src/include/op/sirius_physical_table_scan.hpp
+++ b/src/include/op/sirius_physical_table_scan.hpp
@@ -118,7 +118,8 @@ class sirius_physical_table_scan : public sirius_physical_operator {
   //! Only used in optimized table scan
   bool exhausted = false;
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 
  public:
   bool is_source() const override { return true; }

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -60,7 +60,8 @@ class sirius_physical_top_n : public sirius_physical_operator {
 
  public:
   bool is_sink() const override { return true; }
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_top_n_merge.hpp
+++ b/src/include/op/sirius_physical_top_n_merge.hpp
@@ -62,7 +62,8 @@ class sirius_physical_top_n_merge : public sirius_physical_operator {
  public:
   bool is_sink() const override { return true; }
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -47,7 +47,8 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
 
  public:
   bool is_sink() const override { return true; }
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
@@ -55,7 +55,8 @@ class sirius_physical_ungrouped_aggregate_merge : public sirius_physical_operato
  public:
   bool is_sink() const override { return true; }
 
-  operator_data execute(const operator_data& input_data, rmm::cuda_stream_view stream) override;
+  std::unique_ptr<operator_data> execute(std::unique_ptr<operator_data> input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -72,15 +72,14 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_itask_local_state {
   /**
    * @brief Construct a new gpu_pipeline_task_local_state object
    *
-   * @param batch_views Vector of data batches serving as input to the pipeline
-   * @param res Memory reservation for GPU resources
+   * @param input_data Input data (can be operator_data or partitioned_operator_data)
    */
-  explicit gpu_pipeline_task_local_state(op::operator_data input_data)
+  explicit gpu_pipeline_task_local_state(std::unique_ptr<op::operator_data> input_data)
     : _input_data(std::move(input_data))
   {
   }
 
-  op::operator_data _input_data;  ///< Input data batches for the pipeline
+  std::unique_ptr<op::operator_data> _input_data;  ///< Input data for the pipeline
 
   /**
    * @brief Get a const pointer to the reservation (non-owning).
@@ -147,7 +146,7 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output batches
    */
-  op::operator_data compute_task(rmm::cuda_stream_view stream) override;
+  std::unique_ptr<op::operator_data> compute_task(rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Publish the computed output batches to data repositories.
@@ -156,7 +155,8 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(op::operator_data& output_batches, rmm::cuda_stream_view stream) override;
+  void publish_output(std::unique_ptr<op::operator_data> output_data,
+                      rmm::cuda_stream_view stream) override;
 
   /**
    * @brief Get the input size for this task

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -155,7 +155,7 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    *
    * @param output_batches The data batches to publish
    */
-  void publish_output(std::unique_ptr<op::operator_data> output_data,
+  void publish_output(std::shared_ptr<op::operator_data> output_data,
                       rmm::cuda_stream_view stream) override;
 
   /**

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -59,7 +59,7 @@ class sirius_pipeline_itask : public parallel::itask {
    * @return std::vector<std::shared_ptr<cucascade::data_batch>> The computed output
    *         data batches, which may be empty if no output is produced.
    */
-  virtual op::operator_data compute_task(rmm::cuda_stream_view stream) = 0;
+  virtual std::unique_ptr<op::operator_data> compute_task(rmm::cuda_stream_view stream) = 0;
 
   /**
    * @brief Publish the computed output batches to appropriate destinations.
@@ -70,7 +70,8 @@ class sirius_pipeline_itask : public parallel::itask {
    *
    * @param output_batches The data batches to publish (typically the result of compute_task())
    */
-  virtual void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) = 0;
+  virtual void publish_output(std::unique_ptr<op::operator_data> output_data,
+                              rmm::cuda_stream_view stream) = 0;
 
   /**
    * @brief Get the estimated reservation memory size needed for this task.
@@ -86,8 +87,8 @@ class sirius_pipeline_itask : public parallel::itask {
 
   void execute(rmm::cuda_stream_view stream) override
   {
-    auto output_batches = compute_task(stream);
-    publish_output(output_batches, stream);
+    auto output_data = compute_task(stream);
+    publish_output(std::move(output_data), stream);
   }
 
  protected:

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -70,7 +70,7 @@ class sirius_pipeline_itask : public parallel::itask {
    *
    * @param output_batches The data batches to publish (typically the result of compute_task())
    */
-  virtual void publish_output(std::unique_ptr<op::operator_data> output_data,
+  virtual void publish_output(std::shared_ptr<op::operator_data> output_data,
                               rmm::cuda_stream_view stream) = 0;
 
   /**

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -133,8 +133,8 @@ void duckdb_scan_executor::submit_scan_request()
     _task_request_publisher.send(std::make_unique<sirius::pipeline::task_request>(0, true));
 }
 
-op::operator_data duckdb_scan_executor::get_scan_output(op::scan::duckdb_scan_task* task,
-                                                        rmm::cuda_stream_view stream)
+std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
+  op::scan::duckdb_scan_task* task, rmm::cuda_stream_view stream)
 {
   if (!_caching_enabled) {
     return task->compute_task(stream);
@@ -148,10 +148,10 @@ op::operator_data duckdb_scan_executor::get_scan_output(op::scan::duckdb_scan_ta
       if (entry->batch_index >= entry->batches.size()) {
         throw std::runtime_error("Scan results for query not cached");
       }
-      return op::operator_data(entry->batches[entry->batch_index++]);
+      return std::make_unique<op::operator_data>(entry->batches[entry->batch_index++]);
     } else {
       auto scan_output = task->compute_task(stream);
-      entry->batches.push_back(scan_output.get_data_batches());
+      entry->batches.push_back(scan_output->get_data_batches());
       return scan_output;
     }
   }
@@ -209,7 +209,7 @@ void duckdb_scan_executor::manager_loop()
       try {
         auto consumers   = scan_task->get_output_consumers();
         auto output_data = get_scan_output(scan_task, stream);
-        scan_task->publish_output(output_data, stream);
+        scan_task->publish_output(std::move(output_data), stream);
         t.reset();
         if (_task_creator && !(_completion_handler && _completion_handler->is_completed())) {
           for (auto* consumer : consumers) {

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -501,10 +501,10 @@ void duckdb_scan_task::process_chunk(duckdb_scan_task_local_state& l_state)
 void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
 {
   auto output_data = compute_task(stream);
-  publish_output(output_data, stream);
+  publish_output(std::move(output_data), stream);
 }
 
-op::operator_data duckdb_scan_task::compute_task(rmm::cuda_stream_view stream)
+std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stream_view stream)
 {
   // Cast base task states to DuckDB scan task states
   auto& l_state = this->_local_state->cast<duckdb_scan_task_local_state>();
@@ -556,17 +556,18 @@ op::operator_data duckdb_scan_task::compute_task(rmm::cuda_stream_view stream)
 
   // Make data batch and push to repository
   if (l_state._row_offset > 0) {
-    return op::operator_data(
+    return std::make_unique<op::operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{l_state.make_data_batch()});
   }
 
-  return op::operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+  return std::make_unique<op::operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
 }
 
-void duckdb_scan_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
+void duckdb_scan_task::publish_output(std::unique_ptr<op::operator_data> output_data,
+                                      rmm::cuda_stream_view stream)
 {
-  std::for_each(std::make_move_iterator(output_data.get_data_batches().begin()),
-                std::make_move_iterator(output_data.get_data_batches().end()),
+  std::for_each(std::make_move_iterator(output_data->get_data_batches().begin()),
+                std::make_move_iterator(output_data->get_data_batches().end()),
                 [this](auto batch) { this->_data_repo->add_data_batch(std::move(batch)); });
 }
 

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -563,12 +563,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   return std::make_unique<op::operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
 }
 
-void duckdb_scan_task::publish_output(std::unique_ptr<op::operator_data> output_data,
+void duckdb_scan_task::publish_output(std::shared_ptr<op::operator_data> output_data,
                                       rmm::cuda_stream_view stream)
 {
-  std::for_each(std::make_move_iterator(output_data->get_data_batches().begin()),
-                std::make_move_iterator(output_data->get_data_batches().end()),
-                [this](auto batch) { this->_data_repo->add_data_batch(std::move(batch)); });
+  for (const auto& batch : output_data->get_data_batches()) {
+    this->_data_repo->add_data_batch(batch);
+  }
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -306,7 +306,8 @@ parquet_scan_task_local_state::make_allocation()
 //===----------------------------------------------------------------------===//
 // Parquet Scan Task
 //===----------------------------------------------------------------------===//
-op::operator_data parquet_scan_task::compute_task(rmm::cuda_stream_view /* stream */)
+std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
+  rmm::cuda_stream_view /* stream */)
 {
   auto& l_state = this->_local_state->cast<parquet_scan_task_local_state>();
   auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
@@ -347,13 +348,14 @@ op::operator_data parquet_scan_task::compute_task(rmm::cuda_stream_view /* strea
                                                   l_state.get_reserved_uncompressed_bytes());
   auto data_batch =
     std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(parquet_representation));
-  return op::operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{data_batch});
+  return std::make_unique<op::operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{data_batch});
 }
 
-void parquet_scan_task::publish_output(op::operator_data& output_data,
+void parquet_scan_task::publish_output(std::unique_ptr<op::operator_data> output_data,
                                        rmm::cuda_stream_view /* stream */)
 {
-  for (auto& batch : output_data.get_data_batches()) {
+  for (auto& batch : output_data->get_data_batches()) {
     _data_repo->add_data_batch(std::move(batch));
   }
 }

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -352,11 +352,11 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
     std::vector<std::shared_ptr<cucascade::data_batch>>{data_batch});
 }
 
-void parquet_scan_task::publish_output(std::unique_ptr<op::operator_data> output_data,
+void parquet_scan_task::publish_output(std::shared_ptr<op::operator_data> output_data,
                                        rmm::cuda_stream_view /* stream */)
 {
-  for (auto& batch : output_data->get_data_batches()) {
-    _data_repo->add_data_batch(std::move(batch));
+  for (const auto& batch : output_data->get_data_batches()) {
+    _data_repo->add_data_batch(batch);
   }
 }
 

--- a/src/op/sirius_physical_column_data_scan.cpp
+++ b/src/op/sirius_physical_column_data_scan.cpp
@@ -99,8 +99,8 @@ void sirius_physical_column_data_scan::build_pipelines(
   state.set_pipeline_source(current, *this);
 }
 
-operator_data sirius_physical_column_data_scan::execute(const operator_data& input_data,
-                                                        rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_column_data_scan::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   return input_data;
 }

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -147,7 +147,7 @@ std::unique_ptr<operator_data> sirius_physical_concat::execute(
   return std::make_unique<partitioned_operator_data>(output_batches, partition_idx);
 }
 
-void sirius_physical_concat::sink(std::unique_ptr<operator_data> output_data,
+void sirius_physical_concat::sink(std::shared_ptr<operator_data> output_data,
                                   rmm::cuda_stream_view stream)
 {
   auto partitioned_output_data = dynamic_cast<const partitioned_operator_data*>(output_data.get());

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -65,7 +65,7 @@ sirius_physical_concat::sirius_physical_concat(duckdb::vector<duckdb::LogicalTyp
   }
 }
 
-std::optional<operator_data> sirius_physical_concat::get_next_task_input_data()
+std::optional<std::unique_ptr<operator_data>> sirius_physical_concat::get_next_task_input_data()
 {
   // iterate through all the partition and pull the
   std::lock_guard<std::mutex> lg(lock);
@@ -106,15 +106,17 @@ std::optional<operator_data> sirius_physical_concat::get_next_task_input_data()
         input_batch.push_back(std::move(popped_batch));
       }
     }
-    if (input_batch.size() != 0) { return partitioned_operator_data(std::move(input_batch), i); }
+    if (input_batch.size() != 0) {
+      return std::make_unique<partitioned_operator_data>(std::move(input_batch), i);
+    }
   }
   return std::nullopt;
 }
 
-operator_data sirius_physical_concat::execute(const operator_data& input_data,
-                                              rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_concat::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  auto partitioned_input_data = dynamic_cast<const partitioned_operator_data*>(&input_data);
+  auto partitioned_input_data = dynamic_cast<const partitioned_operator_data*>(input_data.get());
   if (partitioned_input_data == nullptr) {
     throw std::runtime_error(
       "sirius_physical_concat: input_data is not a partitioned_operator_data");
@@ -127,8 +129,8 @@ operator_data sirius_physical_concat::execute(const operator_data& input_data,
     if (batch) { valid_batches.push_back(batch); }
   }
   if (valid_batches.empty()) {
-    return partitioned_operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{},
-                                     partition_idx);
+    return std::make_unique<partitioned_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{}, partition_idx);
   }
 
   cucascade::memory::memory_space* space = valid_batches[0]->get_memory_space();
@@ -142,12 +144,13 @@ operator_data sirius_physical_concat::execute(const operator_data& input_data,
     auto merged_batch = gpu_merge_impl::concat(valid_batches, stream, *space);
     output_batches.push_back(std::move(merged_batch));
   }
-  return partitioned_operator_data(output_batches, partition_idx);
+  return std::make_unique<partitioned_operator_data>(output_batches, partition_idx);
 }
 
-void sirius_physical_concat::sink(const operator_data& output_data, rmm::cuda_stream_view stream)
+void sirius_physical_concat::sink(std::unique_ptr<operator_data> output_data,
+                                  rmm::cuda_stream_view stream)
 {
-  auto partitioned_output_data = dynamic_cast<const partitioned_operator_data*>(&output_data);
+  auto partitioned_output_data = dynamic_cast<const partitioned_operator_data*>(output_data.get());
   auto partition_idx           = partitioned_output_data->get_partition_idx();
   for (auto& batch : partitioned_output_data->get_data_batches()) {
     for (auto& [next_op, port_id] : next_port_after_sink) {

--- a/src/op/sirius_physical_cte.cpp
+++ b/src/op/sirius_physical_cte.cpp
@@ -77,8 +77,8 @@ duckdb::vector<duckdb::const_reference<sirius_physical_operator>> sirius_physica
   return children[1]->get_sources();
 }
 
-operator_data sirius_physical_cte::execute(const operator_data& input_data,
-                                           rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_cte::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   return input_data;
 }

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -158,20 +158,18 @@ std::unique_ptr<operator_data> sirius_physical_right_delim_join::execute(
   return input_data;
 }
 
-void sirius_physical_right_delim_join::sink(std::unique_ptr<operator_data> input_data,
+void sirius_physical_right_delim_join::sink(std::shared_ptr<operator_data> input_data,
                                             rmm::cuda_stream_view stream)
 {
-  // call partition join execute
+  // Copy data for each consumer (execute takes unique_ptr)
   auto partition_join_output = partition_join->execute(
     std::make_unique<operator_data>(input_data->get_data_batches()), stream);
-  // call distinct execute
-  auto distinct_output = distinct->execute(std::move(input_data), stream);
-  // call partition distinct execute
+  auto distinct_output =
+    distinct->execute(std::make_unique<operator_data>(input_data->get_data_batches()), stream);
   auto partition_distinct_output = partition_distinct->execute(std::move(distinct_output), stream);
-  // call partition join sink
-  partition_join->sink(std::move(partition_join_output), stream);
-  // call partition distinct sink
-  partition_distinct->sink(std::move(partition_distinct_output), stream);
+  partition_join->sink(std::shared_ptr<operator_data>(std::move(partition_join_output)), stream);
+  partition_distinct->sink(std::shared_ptr<operator_data>(std::move(partition_distinct_output)),
+                           stream);
 }
 
 std::unique_ptr<operator_data> sirius_physical_left_delim_join::execute(
@@ -180,19 +178,18 @@ std::unique_ptr<operator_data> sirius_physical_left_delim_join::execute(
   return input_data;
 }
 
-void sirius_physical_left_delim_join::sink(std::unique_ptr<operator_data> input_data,
+void sirius_physical_left_delim_join::sink(std::shared_ptr<operator_data> input_data,
                                            rmm::cuda_stream_view stream)
 {
-  // call distinct execute
-  auto distinct_output = distinct->execute(std::move(input_data), stream);
-  // call column data scan execute
-  auto column_data_scan_output = column_data_scan->execute(std::move(distinct_output), stream);
-  // call partition distinct execute
-  auto partition_distinct_output = partition_distinct->execute(std::move(distinct_output), stream);
-  // call partition join sink
-  column_data_scan->sink(std::move(column_data_scan_output), stream);
-  // call partition distinct sink
-  partition_distinct->sink(std::move(partition_distinct_output), stream);
+  auto distinct_output =
+    distinct->execute(std::make_unique<operator_data>(input_data->get_data_batches()), stream);
+  auto column_data_scan_output   = column_data_scan->execute(std::move(distinct_output), stream);
+  auto partition_distinct_output = partition_distinct->execute(
+    std::make_unique<operator_data>(input_data->get_data_batches()), stream);
+  column_data_scan->sink(std::shared_ptr<operator_data>(std::move(column_data_scan_output)),
+                         stream);
+  partition_distinct->sink(std::shared_ptr<operator_data>(std::move(partition_distinct_output)),
+                           stream);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -152,46 +152,47 @@ void sirius_physical_right_delim_join::build_pipelines(
   sirius_physical_hash_join::build_join_pipelines(current, meta_pipeline, *join, false);
 }
 
-operator_data sirius_physical_right_delim_join::execute(const operator_data& input_data,
-                                                        rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_right_delim_join::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   return input_data;
 }
 
-void sirius_physical_right_delim_join::sink(const operator_data& input_data,
+void sirius_physical_right_delim_join::sink(std::unique_ptr<operator_data> input_data,
                                             rmm::cuda_stream_view stream)
 {
   // call partition join execute
-  auto partition_join_output = partition_join->execute(input_data, stream);
+  auto partition_join_output = partition_join->execute(
+    std::make_unique<operator_data>(input_data->get_data_batches()), stream);
   // call distinct execute
-  auto distinct_output = distinct->execute(input_data, stream);
+  auto distinct_output = distinct->execute(std::move(input_data), stream);
   // call partition distinct execute
-  auto partition_distinct_output = partition_distinct->execute(distinct_output, stream);
+  auto partition_distinct_output = partition_distinct->execute(std::move(distinct_output), stream);
   // call partition join sink
-  partition_join->sink(partition_join_output, stream);
+  partition_join->sink(std::move(partition_join_output), stream);
   // call partition distinct sink
-  partition_distinct->sink(partition_distinct_output, stream);
+  partition_distinct->sink(std::move(partition_distinct_output), stream);
 }
 
-operator_data sirius_physical_left_delim_join::execute(const operator_data& input_data,
-                                                       rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_left_delim_join::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   return input_data;
 }
 
-void sirius_physical_left_delim_join::sink(const operator_data& input_data,
+void sirius_physical_left_delim_join::sink(std::unique_ptr<operator_data> input_data,
                                            rmm::cuda_stream_view stream)
 {
   // call distinct execute
-  auto distinct_output = distinct->execute(input_data, stream);
+  auto distinct_output = distinct->execute(std::move(input_data), stream);
   // call column data scan execute
-  auto column_data_scan_output = column_data_scan->execute(distinct_output, stream);
+  auto column_data_scan_output = column_data_scan->execute(std::move(distinct_output), stream);
   // call partition distinct execute
-  auto partition_distinct_output = partition_distinct->execute(distinct_output, stream);
+  auto partition_distinct_output = partition_distinct->execute(std::move(distinct_output), stream);
   // call partition join sink
-  column_data_scan->sink(column_data_scan_output, stream);
+  column_data_scan->sink(std::move(column_data_scan_output), stream);
   // call partition distinct sink
-  partition_distinct->sink(partition_distinct_output, stream);
+  partition_distinct->sink(std::move(partition_distinct_output), stream);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -55,13 +55,13 @@ sirius_physical_filter::sirius_physical_filter(
   }
 }
 
-operator_data sirius_physical_filter::execute(const operator_data& input_data,
-                                              rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_filter::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   SIRIUS_LOG_DEBUG("Executing expression {}", expression->ToString());
   auto start = std::chrono::high_resolution_clock::now();
 
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
 
   // The executor uses the data_batch API to filter rows according to `expression`.
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*expression.get());
@@ -79,7 +79,7 @@ operator_data sirius_physical_filter::execute(const operator_data& input_data,
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
   SIRIUS_LOG_DEBUG("Filter time: {:.2f} ms", duration.count() / 1000.0);
 
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -164,10 +164,10 @@ sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   has_avg            = cudf_defs.has_avg;
 }
 
-operator_data sirius_physical_grouped_aggregate::execute(const operator_data& input_data,
-                                                         rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   std::vector<std::shared_ptr<::cucascade::data_batch>> results;
   for (auto& input_batch : input_batches) {
     auto result = gpu_aggregate_impl::local_grouped_aggregate(input_batch,
@@ -178,7 +178,7 @@ operator_data sirius_physical_grouped_aggregate::execute(const operator_data& in
                                                               *input_batch->get_memory_space());
     results.push_back(std::move(result));
   }
-  return operator_data(results);
+  return std::make_unique<operator_data>(results);
 }
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -155,7 +155,8 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
   has_avg            = cudf_defs.has_avg;
 }
 
-std::optional<operator_data> sirius_physical_grouped_aggregate_merge::get_next_task_input_data()
+std::optional<std::unique_ptr<operator_data>>
+sirius_physical_grouped_aggregate_merge::get_next_task_input_data()
 {
   // we need to lock, then pull all the batches from one partition and return them, and increment
   // the partition index
@@ -173,16 +174,16 @@ std::optional<operator_data> sirius_physical_grouped_aggregate_merge::get_next_t
       }
     }
     current_partition_index++;
-    return operator_data(input_batch);
+    return std::make_unique<operator_data>(input_batch);
   } else {
     return std::nullopt;
   }
 }
 
-operator_data sirius_physical_grouped_aggregate_merge::execute(const operator_data& input_data,
-                                                               rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   if (input_batches.size() == 0) {
     throw std::runtime_error(
       "We expect at least one input batch for grouped aggregate merge operator");
@@ -204,7 +205,10 @@ operator_data sirius_physical_grouped_aggregate_merge::execute(const operator_da
   }
 
   // If no AVG, return merged result directly
-  if (!has_avg) { return operator_data({merged}); }
+  if (!has_avg) {
+    return std::make_unique<operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{merged});
+  }
 
   // Post-merge AVG projection: compute SUM/COUNT for each AVG aggregate.
   // Release ownership of the merged table's columns so we can move (not copy) them.
@@ -261,7 +265,8 @@ operator_data sirius_physical_grouped_aggregate_merge::execute(const operator_da
 
   auto output_table = std::make_unique<cudf::table>(std::move(output_cols), stream, mr);
   auto result       = sirius::make_data_batch(std::move(output_table), *space);
-  return operator_data({result});
+  return std::make_unique<operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{result});
 }
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -42,10 +42,10 @@ sirius_physical_streaming_limit::sirius_physical_streaming_limit(
 {
 }
 
-operator_data sirius_physical_streaming_limit::execute(const operator_data& input_data,
-                                                       rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   SIRIUS_LOG_DEBUG("Executing streaming limit");
 
   if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
@@ -96,7 +96,7 @@ operator_data sirius_physical_streaming_limit::execute(const operator_data& inpu
     offset_const = 0;  // offset only applies to the first batch with rows
   }
 
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -51,10 +51,10 @@ sirius_physical_merge_sort::sirius_physical_merge_sort(
 {
 }
 
-operator_data sirius_physical_merge_sort::execute(const operator_data& input_data,
-                                                  rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
 
   SIRIUS_LOG_DEBUG("Executing merge sort");
   auto start = std::chrono::high_resolution_clock::now();
@@ -69,7 +69,7 @@ operator_data sirius_physical_merge_sort::execute(const operator_data& input_dat
   }
 
   if (valid_batches.empty() || !space) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   // Helper lambda to apply final projection to a batch (removes sort-key-only columns)
@@ -91,7 +91,7 @@ operator_data sirius_physical_merge_sort::execute(const operator_data& input_dat
   if (valid_batches.size() == 1) {
     std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
     outputs.push_back(apply_final_projection(valid_batches[0]));
-    return operator_data(outputs);
+    return std::make_unique<operator_data>(outputs);
   }
 
   // Build cudf order vectors from BoundOrderByNode
@@ -124,7 +124,7 @@ operator_data sirius_physical_merge_sort::execute(const operator_data& input_dat
 
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   if (merged_batch) { outputs.push_back(apply_final_projection(std::move(merged_batch))); }
-  return operator_data(outputs);
+  return std::make_unique<operator_data>(outputs);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -17,6 +17,7 @@
 #include "op/sirius_physical_operator.hpp"
 
 #include "gpu_executor.hpp"
+#include "log/logging.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
@@ -178,20 +179,22 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
   return it->second.get();
 }
 
-void sirius_physical_operator::sink(const operator_data& output_data, rmm::cuda_stream_view stream)
+void sirius_physical_operator::sink(std::unique_ptr<operator_data> output_data,
+                                    rmm::cuda_stream_view stream)
 {
-  for (auto& batch : output_data.get_data_batches()) {
+  for (auto& batch : output_data->get_data_batches()) {
     for (auto& [next_op, port_id] : next_port_after_sink) {
       next_op->push_data_batch(port_id, batch);
     }
   }
 }
 
-operator_data sirius_physical_operator::execute(const operator_data& input_data,
-                                                rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_operator::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  // not doing anything for now
-  return operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>>{});
+  // Passthrough the input data. Creating a new (empty) operator_data object could lead to problems
+  // if the input was a partitioned_operator_data.
+  return input_data;
 }
 
 void sirius_physical_operator::push_data_batch(std::string_view port_id,
@@ -254,7 +257,7 @@ std::optional<task_creation_hint> sirius_physical_operator::get_next_task_hint()
   return std::nullopt;
 }
 
-std::optional<operator_data> sirius_physical_operator::get_next_task_input_data()
+std::optional<std::unique_ptr<operator_data>> sirius_physical_operator::get_next_task_input_data()
 {
   // take one data batch from each port and schedule a task (a task takes one data batch from each
   // port), do this repeatedly until all ports are empty
@@ -263,12 +266,17 @@ std::optional<operator_data> sirius_physical_operator::get_next_task_input_data(
     // For Pipeline barrier: need at least one data batch in the port's repository
     // TODO: later on we will adjust to the new data repository interface in cuCascade
     auto batch_and_handle = port_ptr->repo->pop_data_batch(::cucascade::batch_state::task_created);
-    if (batch_and_handle) { input_batch.push_back(std::move(batch_and_handle)); }
+    if (batch_and_handle) {
+      SIRIUS_LOG_DEBUG(
+        "sirius_physical_operator::get_next_task_input_data(): popping batch from port {}",
+        port_name);
+      input_batch.push_back(std::move(batch_and_handle));
+    }
   }
   if (input_batch.empty()) {
-    return operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{});
   }
-  return operator_data(input_batch);
+  return std::make_unique<operator_data>(input_batch);
 }
 
 bool sirius_physical_operator::all_ports_empty()

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -179,7 +179,7 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
   return it->second.get();
 }
 
-void sirius_physical_operator::sink(std::unique_ptr<operator_data> output_data,
+void sirius_physical_operator::sink(std::shared_ptr<operator_data> output_data,
                                     rmm::cuda_stream_view stream)
 {
   for (auto& batch : output_data->get_data_batches()) {

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -36,10 +36,10 @@ sirius_physical_order::sirius_physical_order(duckdb::vector<duckdb::LogicalType>
 {
 }
 
-operator_data sirius_physical_order::execute(const operator_data& input_data,
-                                             rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_order::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   SIRIUS_LOG_DEBUG("Executing order by");
   auto start = std::chrono::high_resolution_clock::now();
 
@@ -83,7 +83,7 @@ operator_data sirius_physical_order::execute(const operator_data& input_data,
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
   SIRIUS_LOG_DEBUG("Order by time: {:.2f} ms", duration.count() / 1000.0);
 
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -117,10 +117,10 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
 
 bool sirius_physical_partition::is_build_partition() { return _is_build; }
 
-operator_data sirius_physical_partition::execute(const operator_data& input_data,
-                                                 rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_partition::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   if (input_batches.size() != 1) {
     throw std::runtime_error("We expect only one input batch for partition operator");
   }
@@ -146,12 +146,15 @@ operator_data sirius_physical_partition::execute(const operator_data& input_data
       throw std::runtime_error("Unsupported partition type: " +
                                partition_type_to_string(_partition_type));
   }
-  return operator_data(partitioned_results);
+  return std::make_unique<operator_data>(partitioned_results);
 }
 
-void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_stream_view stream)
+void sirius_physical_partition::sink(std::unique_ptr<operator_data> input_data,
+                                     rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
+  SIRIUS_LOG_DEBUG("sirius_physical_partition::sink(): input_batches.size() = {}",
+                   input_batches.size());
   (void)stream;  // sink does not use stream for push_data_batch_partitioned
   int partition_id = 0;
   for (auto& batch : input_batches) {
@@ -161,6 +164,8 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
       auto partition_consumer_op =
         dynamic_cast<sirius_physical_partition_consumer_operator*>(next_op);
       if (partition_consumer_op) {
+        SIRIUS_LOG_DEBUG("sirius_physical_partition::sink(): pushing batch to partition {}",
+                         partition_id);
         partition_consumer_op->push_data_batch_partitioned(port_id, batch, partition_id);
       } else {
         throw std::runtime_error("Next operator is not a partition consumer operator");

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(
   return std::make_unique<operator_data>(partitioned_results);
 }
 
-void sirius_physical_partition::sink(std::unique_ptr<operator_data> input_data,
+void sirius_physical_partition::sink(std::shared_ptr<operator_data> input_data,
                                      rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data->get_data_batches();

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -41,10 +41,10 @@ sirius_physical_projection::sirius_physical_projection(
 {
 }
 
-operator_data sirius_physical_projection::execute(const operator_data& input_data,
-                                                  rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_projection::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   SIRIUS_LOG_DEBUG("Executing projection");
   auto start = std::chrono::high_resolution_clock::now();
 
@@ -63,7 +63,7 @@ operator_data sirius_physical_projection::execute(const operator_data& input_dat
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
   SIRIUS_LOG_DEBUG("Projection time: {:.2f} ms", duration.count() / 1000.0);
 
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -107,7 +107,7 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_physical_materialized_collector::
     statement_type, properties, names, std::move(result_collection), props);
 }
 
-void sirius_physical_materialized_collector::sink(std::unique_ptr<operator_data> input_data,
+void sirius_physical_materialized_collector::sink(std::shared_ptr<operator_data> input_data,
                                                   rmm::cuda_stream_view stream)
 {
   const auto& input_batches     = input_data->get_data_batches();

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -53,8 +53,8 @@ sirius_physical_result_collector::sirius_physical_result_collector(
   this->types = data.prepared->types;
 }
 
-operator_data sirius_physical_result_collector::execute(const operator_data& input_data,
-                                                        rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_result_collector::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
   return input_data;
 }
@@ -107,10 +107,10 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_physical_materialized_collector::
     statement_type, properties, names, std::move(result_collection), props);
 }
 
-void sirius_physical_materialized_collector::sink(const operator_data& input_data,
+void sirius_physical_materialized_collector::sink(std::unique_ptr<operator_data> input_data,
                                                   rmm::cuda_stream_view stream)
 {
-  const auto& input_batches     = input_data.get_data_batches();
+  const auto& input_batches     = input_data->get_data_batches();
   using host_table_chunk_reader = ::sirius::op::result::host_table_chunk_reader;
 
   if (input_batches.empty()) {

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -47,10 +47,10 @@ sirius_physical_sort_partition::sirius_physical_sort_partition(
 {
 }
 
-operator_data sirius_physical_sort_partition::execute(const operator_data& input_data,
-                                                      rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
 
   // If no sample operator or only 1 partition, pass through
   if (!_sample_op || !_sample_op->boundaries_computed() || _sample_op->get_num_partitions() <= 1) {
@@ -158,7 +158,7 @@ operator_data sirius_physical_sort_partition::execute(const operator_data& input
     num_parts,
     duration.count() / 1000.0);
 
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -72,10 +72,10 @@ std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hin
   return std::nullopt;
 }
 
-operator_data sirius_physical_sort_sample::execute(const operator_data& input_data,
-                                                   rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
 
   // After boundaries are computed, just pass through
   if (_boundaries_computed.load()) {

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -128,10 +128,10 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   return conjunction;
 }
 
-operator_data sirius_physical_table_scan::execute(const operator_data& input_data,
-                                                  rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_table_scan::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   auto start                = std::chrono::high_resolution_clock::now();
 
   duckdb::unique_ptr<duckdb::Expression> filter_expr;
@@ -209,7 +209,7 @@ operator_data sirius_physical_table_scan::execute(const operator_data& input_dat
   auto end      = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
   SIRIUS_LOG_DEBUG("Filter time: {:.2f} ms", duration.count() / 1000.0);
-  return operator_data(output_batches);
+  return std::make_unique<operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -141,11 +141,13 @@ sirius_physical_top_n::sirius_physical_top_n(
 
 sirius_physical_top_n::~sirius_physical_top_n() {}
 
-operator_data sirius_physical_top_n::execute(const operator_data& input_data,
-                                             rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_top_n::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
-  if (limit == 0) { return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}); }
+  const auto& input_batches = input_data->get_data_batches();
+  if (limit == 0) {
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+  }
 
   std::shared_ptr<cucascade::data_batch> input_batch;
   for (auto const& batch : input_batches) {
@@ -156,11 +158,13 @@ operator_data sirius_physical_top_n::execute(const operator_data& input_data,
       input_batch = batch;
     }
   }
-  if (!input_batch) { return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}); }
+  if (!input_batch) {
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+  }
 
   auto* space = input_batch->get_memory_space();
   if (space == nullptr) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto input_table =
@@ -173,7 +177,7 @@ operator_data sirius_physical_top_n::execute(const operator_data& input_data,
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
     std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
-  return operator_data(outputs);
+  return std::make_unique<operator_data>(outputs);
 }
 
 sirius_physical_top_n_merge::sirius_physical_top_n_merge(sirius_physical_top_n* top_n)
@@ -204,11 +208,13 @@ sirius_physical_top_n_merge::sirius_physical_top_n_merge(
 {
 }
 
-operator_data sirius_physical_top_n_merge::execute(const operator_data& input_data,
-                                                   rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
-  if (limit == 0) { return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}); }
+  const auto& input_batches = input_data->get_data_batches();
+  if (limit == 0) {
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+  }
 
   // Use the memory space from the first valid batch (all batches are expected to share the same
   // space in practice).
@@ -220,7 +226,7 @@ operator_data sirius_physical_top_n_merge::execute(const operator_data& input_da
     }
   }
   if (space == nullptr) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::vector<std::unique_ptr<cudf::table>> owned_tables;
@@ -236,7 +242,7 @@ operator_data sirius_physical_top_n_merge::execute(const operator_data& input_da
   }
 
   if (concat_views.empty()) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::unique_ptr<cudf::table> combined;
@@ -264,7 +270,7 @@ operator_data sirius_physical_top_n_merge::execute(const operator_data& input_da
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
     std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
-  return operator_data(outputs);
+  return std::make_unique<operator_data>(outputs);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -304,12 +304,12 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
 
 }  // namespace
 
-operator_data sirius_physical_ungrouped_aggregate::execute(const operator_data& input_data,
-                                                           rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   if (aggregates.empty()) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto layout = build_aggregate_layout(aggregates);
@@ -380,7 +380,7 @@ operator_data sirius_physical_ungrouped_aggregate::execute(const operator_data& 
     outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
   }
 
-  return operator_data(outputs);
+  return std::make_unique<operator_data>(outputs);
 }
 
 // Helper to deep copy Expression vector (same as in grouped_aggregate)
@@ -422,12 +422,12 @@ sirius_physical_ungrouped_aggregate_merge::sirius_physical_ungrouped_aggregate_m
     duckdb::make_uniq<duckdb::DistinctAggregateData>(*distinct_collection_info, distinct_validity);
 }
 
-operator_data sirius_physical_ungrouped_aggregate_merge::execute(const operator_data& input_data,
-                                                                 rmm::cuda_stream_view stream)
+std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execute(
+  std::unique_ptr<operator_data> input_data, rmm::cuda_stream_view stream)
 {
-  const auto& input_batches = input_data.get_data_batches();
+  const auto& input_batches = input_data->get_data_batches();
   if (aggregates.empty()) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
@@ -436,12 +436,12 @@ operator_data sirius_physical_ungrouped_aggregate_merge::execute(const operator_
     if (batch) { valid_batches.push_back(batch); }
   }
   if (valid_batches.empty()) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   cucascade::memory::memory_space* space = valid_batches[0]->get_memory_space();
   if (space == nullptr) {
-    return operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto layout = build_aggregate_layout(aggregates);
@@ -454,7 +454,7 @@ operator_data sirius_physical_ungrouped_aggregate_merge::execute(const operator_
   }
 
   if (!layout.has_avg) {
-    return operator_data(
+    return std::make_unique<operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(merged_batch)});
   }
 
@@ -483,7 +483,7 @@ operator_data sirius_physical_ungrouped_aggregate_merge::execute(const operator_
   auto const batch_id = ::sirius::get_next_batch_id();
   auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
 
-  return operator_data(
+  return std::make_unique<operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(output_batch)});
 }
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -125,8 +125,18 @@ const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
 
 std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_stream_view stream)
 {
-  auto& local_state               = _local_state->cast<gpu_pipeline_task_local_state>();
-  auto operator_input_output_data = std::move(local_state._input_data);
+  auto& local_state                       = _local_state->cast<gpu_pipeline_task_local_state>();
+  auto operator_input_output_data_batches = local_state._input_data->get_data_batches();
+  std::unique_ptr<op::operator_data> operator_input_output_data;
+  if (dynamic_cast<op::partitioned_operator_data*>(local_state._input_data.get())) {
+    auto partition_idx = dynamic_cast<op::partitioned_operator_data*>(local_state._input_data.get())
+                           ->get_partition_idx();
+    operator_input_output_data = std::make_unique<op::partitioned_operator_data>(
+      std::move(operator_input_output_data_batches), partition_idx);
+  } else {
+    operator_input_output_data =
+      std::make_unique<op::operator_data>(std::move(operator_input_output_data_batches));
+  }
 
   for (auto& op :
        _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_operators()) {
@@ -142,13 +152,13 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
   return std::move(operator_input_output_data);
 }
 
-void gpu_pipeline_task::publish_output(std::unique_ptr<op::operator_data> output_data,
+void gpu_pipeline_task::publish_output(std::shared_ptr<op::operator_data> output_data,
                                        rmm::cuda_stream_view stream)
 {
   auto sink_operators =
     _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_sink();
   if (sink_operators) {
-    sink_operators.get()->sink(std::move(output_data), stream);
+    sink_operators.get()->sink(output_data, stream);
   } else {
     throw std::runtime_error("Sink operator not found");
   }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -16,6 +16,8 @@
 
 #include "pipeline/gpu_pipeline_task.hpp"
 
+#include "log/logging.hpp"
+
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
@@ -121,23 +123,32 @@ const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
   return _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get();
 }
 
-op::operator_data gpu_pipeline_task::compute_task(rmm::cuda_stream_view stream)
+std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_stream_view stream)
 {
   auto& local_state               = _local_state->cast<gpu_pipeline_task_local_state>();
-  auto operator_input_output_data = local_state._input_data;
+  auto operator_input_output_data = std::move(local_state._input_data);
+
   for (auto& op :
        _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_operators()) {
-    operator_input_output_data = op.get().execute(operator_input_output_data, stream);
+    SIRIUS_LOG_DEBUG(
+      "Pipeline {} executing operator {} on {} batches ({} input)",
+      _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_pipeline_id(),
+      op.get().get_name(),
+      operator_input_output_data->get_data_batches().size(),
+      dynamic_cast<op::partitioned_operator_data*>(operator_input_output_data.get()) ? "partitioned"
+                                                                                     : "regular");
+    operator_input_output_data = op.get().execute(std::move(operator_input_output_data), stream);
   }
-  return operator_input_output_data;
+  return std::move(operator_input_output_data);
 }
 
-void gpu_pipeline_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
+void gpu_pipeline_task::publish_output(std::unique_ptr<op::operator_data> output_data,
+                                       rmm::cuda_stream_view stream)
 {
   auto sink_operators =
     _global_state->cast<gpu_pipeline_task_global_state>()._pipeline.get()->get_sink();
   if (sink_operators) {
-    sink_operators.get()->sink(output_data, stream);
+    sink_operators.get()->sink(std::move(output_data), stream);
   } else {
     throw std::runtime_error("Sink operator not found");
   }
@@ -160,9 +171,9 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   const auto* requested_memory_space =
     reservation != nullptr ? &reservation->get_memory_space() : nullptr;
   std::vector<cucascade::data_batch_processing_handle> processing_handles;
-  processing_handles.reserve(local_state._input_data.get_data_batches().size());
+  processing_handles.reserve(local_state._input_data->get_data_batches().size());
 
-  for (const auto& batch : local_state._input_data.get_data_batches()) {
+  for (const auto& batch : local_state._input_data->get_data_batches()) {
     auto handle = lock_or_prepare_batch(batch, requested_memory_space, stream);
     if (!handle) {
       // Failed to lock (or convert) one of the batches. Caller can retry later.
@@ -176,7 +187,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   // TODO: Implement actual pipeline execution:
   // 1. Transfer data batch to GPU memory if not already there
-  for (auto& batch : local_state._input_data.get_data_batches()) {
+  for (auto& batch : local_state._input_data->get_data_batches()) {
     // 1. Transfer data batch to GPU memory if not already there
     // for now assuming that local_state._batches will continue to hold the data and now in GPU
     // memory
@@ -186,7 +197,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   // 3. Execute cudf operators on the pipeline
   auto output_data = compute_task(stream);
   stream.synchronize();
-  publish_output(output_data, stream);
+  publish_output(std::move(output_data), stream);
   // 4. After each cudf operator, get peak total bytes to collect statistics
   // 5. Push output batches to the data repository
 
@@ -197,7 +208,7 @@ std::size_t gpu_pipeline_task::get_input_size() const
 {
   auto& local_state      = _local_state->cast<gpu_pipeline_task_local_state>();
   std::size_t input_size = 0;
-  for (const auto& batch : local_state._input_data.get_data_batches()) {
+  for (const auto& batch : local_state._input_data->get_data_batches()) {
     input_size += batch->get_data()->get_size_in_bytes();
   }
   return input_size;

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
@@ -90,15 +90,17 @@ TEMPLATE_TEST_CASE(
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+  auto outputs = grouped_aggregator.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs.get_data_batches()[0], expected_table->view(), true);
+    outputs->get_data_batches()[0], expected_table->view(), true);
   REQUIRE(tables_match);
 }
 
@@ -143,12 +145,14 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate grouped aggregates with AV
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  auto outputs = grouped_aggregator.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // The local operator outputs expanded columns: group_key, min, max, count, sum, count_valid
   // (AVG decomposed into SUM + COUNT_VALID). Verify column count = 1 group + 5 aggregates.
-  auto output_table = outputs.get_data_batches()[0]
+  auto output_table = outputs->get_data_batches()[0]
                         ->get_data()
                         ->cast<cucascade::gpu_table_representation>()
                         .get_table();
@@ -204,14 +208,16 @@ TEMPLATE_TEST_CASE(
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+  auto outputs = grouped_aggregator.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs.get_data_batches()[0], expected_table->view(), true);
+    outputs->get_data_batches()[0], expected_table->view(), true);
   REQUIRE(tables_match);
 }

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_merge.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_merge.cpp
@@ -90,16 +90,18 @@ TEST_CASE("sirius_physical_grouped_aggregate_merge grouped aggregates single dat
   auto input_table = std::make_unique<cudf::table>(expected_table->view());
   auto input_batch = sirius::make_data_batch(std::move(input_table), *space);
 
-  auto outputs =
-    grouped_aggregate_merger.execute(operator_data({std::move(input_batch)}), default_stream());
+  auto outputs = grouped_aggregate_merger.execute(
+    std::make_unique<operator_data>(
+      std::vector<std::shared_ptr<data_batch>>({std::move(input_batch)})),
+    default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Dont Sort both tables before comparison since they should be identical
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs.get_data_batches()[0], expected_table->view(), false);
+    outputs->get_data_batches()[0], expected_table->view(), false);
   REQUIRE(tables_match);
 }
 
@@ -174,15 +176,20 @@ TEMPLATE_TEST_CASE(
     std::shared_ptr<data_batch> input_batch =
       sirius::make_data_batch(std::move(input_table), *space);
 
-    auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+    auto outputs = grouped_aggregator.execute(
+      std::make_unique<operator_data>(
+        std::vector<std::shared_ptr<data_batch>>({std::move(input_batch)})),
+      default_stream());
 
     // Verify we got one output batch
-    REQUIRE(outputs.get_data_batches().size() == 1);
-    agg_outputs.push_back(outputs.get_data_batches()[0]);
+    REQUIRE(outputs->get_data_batches().size() == 1);
+    agg_outputs.push_back(outputs->get_data_batches()[0]);
   }
 
-  auto outputs = grouped_aggregate_merger.execute(operator_data(agg_outputs), default_stream());
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  auto outputs = grouped_aggregate_merger.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({agg_outputs})),
+    default_stream());
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // need to cast the expected table column 4 (which is the count column) to int64_t since at the
   // merge stage, we end up doing a sum of int32_t which becomes an int64_t
@@ -204,7 +211,7 @@ TEMPLATE_TEST_CASE(
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs.get_data_batches()[0], expected_table->view(), true);
+    outputs->get_data_batches()[0], expected_table->view(), true);
   REQUIRE(tables_match);
 }
 
@@ -263,14 +270,19 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate_merge end-to-end with AVG"
   std::vector<std::shared_ptr<data_batch>> agg_outputs;
   for (auto& split_table : input_tables) {
     auto input_batch = sirius::make_data_batch(std::move(split_table), *space);
-    auto outputs     = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
-    REQUIRE(outputs.get_data_batches().size() == 1);
-    agg_outputs.push_back(outputs.get_data_batches()[0]);
+    auto outputs     = grouped_aggregator.execute(
+      std::make_unique<operator_data>(
+        std::vector<std::shared_ptr<data_batch>>({std::move(input_batch)})),
+      default_stream());
+    REQUIRE(outputs->get_data_batches().size() == 1);
+    agg_outputs.push_back(outputs->get_data_batches()[0]);
   }
 
   // Run merge with AVG projection
-  auto outputs = grouped_aggregate_merger.execute(operator_data(agg_outputs), default_stream());
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  auto outputs = grouped_aggregate_merger.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({agg_outputs})),
+    default_stream());
+  REQUIRE(outputs->get_data_batches().size() == 1);
 
   // Cast expected count column from int32 to int64 (merge sums int32 counts -> int64)
   auto expected_columns = expected_table->release();
@@ -281,6 +293,6 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate_merge end-to-end with AVG"
   expected_table = std::make_unique<cudf::table>(std::move(expected_columns));
 
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs.get_data_batches()[0], expected_table->view(), true);
+    outputs->get_data_batches()[0], expected_table->view(), true);
   REQUIRE(tables_match);
 }

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -195,7 +195,8 @@ TEMPLATE_TEST_CASE("sirius_physical_concat concatenates multiple data_batches",
   sirius_physical_concat concat_op({Traits::logical_type()}, 1000, fixture.hash_join.get(), false);
 
   // Execute
-  auto outputs = concat_op.execute(partitioned_operator_data(input_batches, 0), default_stream());
+  auto outputs = *concat_op.execute(std::make_unique<partitioned_operator_data>(input_batches, 0),
+                                    default_stream());
 
   // Verify: single output batch with correct total rows
   REQUIRE(outputs.get_data_batches().size() == 1);
@@ -228,11 +229,13 @@ TEST_CASE("sirius_physical_concat returns single batch as-is", "[physical_concat
   sirius_physical_concat concat_op(
     {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
 
-  auto outputs = concat_op.execute(partitioned_operator_data({input_batch}, 0), default_stream());
+  auto outputs = concat_op.execute(std::make_unique<partitioned_operator_data>(
+                                     std::vector<std::shared_ptr<data_batch>>({input_batch}), 0),
+                                   default_stream());
 
-  REQUIRE(outputs.get_data_batches().size() == 1);
+  REQUIRE(outputs->get_data_batches().size() == 1);
   // Single batch should be the same pointer (passthrough)
-  REQUIRE(outputs.get_data_batches()[0].get() == input_batch.get());
+  REQUIRE(outputs->get_data_batches()[0].get() == input_batch.get());
 }
 
 TEST_CASE("sirius_physical_concat handles empty input", "[physical_concat]")
@@ -241,11 +244,11 @@ TEST_CASE("sirius_physical_concat handles empty input", "[physical_concat]")
   sirius_physical_concat concat_op(
     {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
 
-  auto outputs = concat_op.execute(
-    partitioned_operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}, 0),
-    default_stream());
+  auto outputs = concat_op.execute(std::make_unique<partitioned_operator_data>(
+                                     std::vector<std::shared_ptr<cucascade::data_batch>>{}, 0),
+                                   default_stream());
 
-  REQUIRE(outputs.get_data_batches().empty());
+  REQUIRE(outputs->get_data_batches().empty());
 }
 
 TEST_CASE("sirius_physical_concat filters null batches", "[physical_concat]")
@@ -264,7 +267,8 @@ TEST_CASE("sirius_physical_concat filters null batches", "[physical_concat]")
 
   // Mix valid and null batches
   std::vector<std::shared_ptr<data_batch>> input = {batch1, nullptr, batch2, nullptr};
-  auto outputs = concat_op.execute(partitioned_operator_data(input, 0), default_stream());
+  auto outputs =
+    *concat_op.execute(std::make_unique<partitioned_operator_data>(input, 0), default_stream());
 
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto& out_table = outputs.get_data_batches()[0]
@@ -320,8 +324,9 @@ TEST_CASE(
 
   // Sink partitioned data with partition_idx = 3
   constexpr std::size_t partition_idx = 3;
-  partitioned_operator_data sink_data({batch1, batch2}, partition_idx);
-  concat_op.sink(sink_data, default_stream());
+  concat_op.sink(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})),
+    default_stream());
 
   // Verify: downstream repo should have both batches in partition 3
   auto batch_ids = downstream_repo->get_batch_ids(partition_idx);
@@ -373,8 +378,8 @@ TEST_CASE("sirius_physical_concat sink forwards to multiple downstream operators
   concat_op.add_next_port_after_sink({&downstream2, "input"});
 
   constexpr std::size_t partition_idx = 1;
-  partitioned_operator_data sink_data({batch}, partition_idx);
-  concat_op.sink(sink_data, default_stream());
+  concat_op.sink(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})),
+                 default_stream());
 
   // Both downstream repos should have the batch in partition 1
   auto ids1 = repo1->get_batch_ids(partition_idx);
@@ -428,15 +433,15 @@ TEST_CASE("sirius_physical_concat stops concatenating at DEFAULT_SCAN_TASK_BATCH
   // First call: should return some batches but not all (threshold exceeded)
   auto result1 = concat_op.get_next_task_input_data();
   REQUIRE(result1.has_value());
-  REQUIRE(result1->get_data_batches().size() < static_cast<std::size_t>(num_batches));
-  REQUIRE(result1->get_data_batches().size() >= 1);
+  REQUIRE(result1.value()->get_data_batches().size() < static_cast<std::size_t>(num_batches));
+  REQUIRE(result1.value()->get_data_batches().size() >= 1);
 
   // Collect total batches returned across multiple calls
-  std::size_t total_batches_returned = result1->get_data_batches().size();
+  std::size_t total_batches_returned = result1.value()->get_data_batches().size();
   while (true) {
     auto result = concat_op.get_next_task_input_data();
     if (!result.has_value()) { break; }
-    total_batches_returned += result->get_data_batches().size();
+    total_batches_returned += result.value()->get_data_batches().size();
   }
 
   // All batches should eventually be consumed
@@ -483,7 +488,7 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   // With concat_all=true, all batches in the partition should be returned in one call
   auto result = concat_op.get_next_task_input_data();
   REQUIRE(result.has_value());
-  REQUIRE(result->get_data_batches().size() == static_cast<std::size_t>(num_batches));
+  REQUIRE(result.value()->get_data_batches().size() == static_cast<std::size_t>(num_batches));
 
   // No more batches remaining
   auto result2 = concat_op.get_next_task_input_data();
@@ -617,7 +622,7 @@ TEST_CASE("sirius_physical_concat get_next_task_input_batch is thread-safe", "[p
       if (!result.has_value()) { break; }
       total_calls.fetch_add(1, std::memory_order_relaxed);
       std::lock_guard<std::mutex> lg(collected_mutex);
-      for (auto& batch : result->get_data_batches()) {
+      for (auto& batch : result.value()->get_data_batches()) {
         if (batch) { collected_batch_ids.push_back(batch->get_batch_id()); }
       }
     }
@@ -686,13 +691,13 @@ TEST_CASE("sirius_physical_concat execute is thread-safe with independent stream
       cudaStreamCreate(&raw_stream);
       rmm::cuda_stream_view stream(raw_stream);
 
-      auto outputs =
-        concat_op.execute(partitioned_operator_data(thread_inputs[thread_id], 0), default_stream());
+      auto outputs = concat_op.execute(
+        std::make_unique<partitioned_operator_data>(thread_inputs[thread_id], 0), default_stream());
 
       // Synchronize the stream before accessing results
       cudaStreamSynchronize(raw_stream);
 
-      thread_outputs[thread_id] = std::move(outputs.get_data_batches());
+      thread_outputs[thread_id] = std::move(outputs->get_data_batches());
 
       cudaStreamDestroy(raw_stream);
     } catch (const std::exception& e) {

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -97,7 +97,8 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = filter.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *filter.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
     outputs.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -98,7 +98,8 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
     std::move(types), std::move(limit_node), std::move(offset_node), values.size(), false);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = limiter.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *limiter.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
     outputs.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -93,9 +93,10 @@ std::shared_ptr<data_batch> sort_batch(const std::shared_ptr<data_batch>& batch,
                                  copy_orders(orders),
                                  duckdb::vector<duckdb::idx_t>(projections),
                                  0);
-  auto result = order_op.execute(operator_data({batch}));
-  REQUIRE(result.get_data_batches().size() == 1);
-  return result.get_data_batches()[0];
+  auto result = order_op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(result->get_data_batches().size() == 1);
+  return result->get_data_batches()[0];
 }
 
 }  // namespace
@@ -125,10 +126,11 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 1-column batches ascending
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{1, 2, 3, 4, 5, 6, 7, 8};
@@ -156,10 +158,11 @@ TEST_CASE("sirius_physical_merge_sort merges 3 sorted 1-column batches descendin
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2, batch3}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(std::make_unique<operator_data>(
+    std::vector<std::shared_ptr<data_batch>>({batch1, batch2, batch3})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{9, 8, 7, 6, 5, 4, 3, 2, 1};
@@ -192,11 +195,12 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 2-column batches by col0 a
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -236,11 +240,12 @@ TEST_CASE("sirius_physical_merge_sort merges 2-column batches sorted by 2 keys",
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
 
-  auto out = op.execute(operator_data({sorted1, sorted2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({sorted1, sorted2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -276,11 +281,12 @@ TEST_CASE("sirius_physical_merge_sort merges 3-column batches sorted by col0, re
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -323,11 +329,12 @@ TEST_CASE("sirius_physical_merge_sort 3 columns sorted by col0 asc + col1 desc",
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
 
-  auto out = op.execute(operator_data({sorted1, sorted2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({sorted1, sorted2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -361,10 +368,11 @@ TEST_CASE("sirius_physical_merge_sort single batch passthrough", "[physical_merg
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3});
 }
@@ -389,7 +397,7 @@ TEST_CASE("sirius_physical_merge_sort skips null batches", "[physical_merge_sort
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch1, nullptr, batch2, nullptr};
-  auto out = op.execute(operator_data(inputs));
+  auto out = *op.execute(std::make_unique<operator_data>(inputs));
   REQUIRE(out.get_data_batches().size() == 1);
 
   auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -411,7 +419,7 @@ TEST_CASE("sirius_physical_merge_sort returns empty for all-null inputs", "[phys
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
-  auto out = op.execute(operator_data(inputs));
+  auto out = *op.execute(std::make_unique<operator_data>(inputs));
   REQUIRE(out.get_data_batches().empty());
 }
 
@@ -440,10 +448,11 @@ TEST_CASE("sirius_physical_merge_sort constructed from sirius_physical_order",
 
   sirius_physical_merge_sort op(&order_op);
 
-  auto out = op.execute(operator_data({batch1, batch2}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
 }

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -106,10 +106,11 @@ TEST_CASE("sirius_physical_order sorts 1 column ascending", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{1, 2, 3, 5, 7, 8, 9};
@@ -134,10 +135,11 @@ TEST_CASE("sirius_physical_order sorts 1 column descending", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{9, 8, 7, 5, 3, 2, 1};
@@ -168,11 +170,12 @@ TEST_CASE("sirius_physical_order sorts by col0, returns both columns", "[physica
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -204,11 +207,12 @@ TEST_CASE("sirius_physical_order sorts by 2 keys (asc, desc)", "[physical_order]
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -238,10 +242,11 @@ TEST_CASE("sirius_physical_order projects only col1 when sorting by col0", "[phy
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view  = table.view();
   REQUIRE(view.num_columns() == 1);
 
@@ -274,11 +279,12 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc, return all", "[phy
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -318,11 +324,12 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc + col1 desc, return
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table  = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view   = table.view();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto view  = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -353,10 +360,11 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0, project col1 and col2 
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}));
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    op.execute(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})));
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view  = table.view();
   REQUIRE(view.num_columns() == 2);
 
@@ -390,15 +398,16 @@ TEST_CASE("sirius_physical_order handles multiple batches", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}));
-  REQUIRE(out.get_data_batches().size() == 2);
+  auto out = op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch1, batch2})));
+  REQUIRE(out->get_data_batches().size() == 2);
 
   // Each batch is independently sorted
-  auto t1   = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto t1   = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto col1 = copy_column_to_host<int64_t>(t1.view().column(0));
   REQUIRE(col1 == std::vector<int64_t>{1, 3, 5});
 
-  auto t2   = out.get_data_batches()[1]->get_data()->cast<gpu_table_representation>().get_table();
+  auto t2   = out->get_data_batches()[1]->get_data()->cast<gpu_table_representation>().get_table();
   auto col2 = copy_column_to_host<int64_t>(t2.view().column(0));
   REQUIRE(col2 == std::vector<int64_t>{2, 4, 6});
 }
@@ -422,7 +431,7 @@ TEST_CASE("sirius_physical_order handles null input batches", "[physical_order]"
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch, nullptr};
-  auto out = op.execute(operator_data(inputs));
+  auto out = *op.execute(std::make_unique<operator_data>(inputs));
   REQUIRE(out.get_data_batches().size() == 1);
 
   auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -444,6 +453,6 @@ TEST_CASE("sirius_physical_order returns empty for all-null inputs", "[physical_
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
-  auto out = op.execute(operator_data(inputs));
+  auto out = *op.execute(std::make_unique<operator_data>(inputs));
   REQUIRE(out.get_data_batches().empty());
 }

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -136,18 +136,20 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
   sirius_physical_partition partitioner(
     std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
+  auto outputs = partitioner.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
 
   std::size_t partition_size = 10000000;  // from sirius_physical_partition.hpp
 
   std::size_t expected_num_partitions =
     (estimated_cardinality + partition_size - 1) / partition_size;
 
-  REQUIRE(outputs.get_data_batches().size() == expected_num_partitions);
+  REQUIRE(outputs->get_data_batches().size() == expected_num_partitions);
 
   // count the number of rows in each output and make sure it's the same and the initial inputs
   std::size_t total_num_rows = 0;
-  for (auto& output : outputs.get_data_batches()) {
+  for (auto& output : outputs->get_data_batches()) {
     total_num_rows += output->get_data()->cast<gpu_table_representation>().get_table().num_rows();
   }
   REQUIRE(total_num_rows == num_values);
@@ -259,18 +261,20 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
   sirius_physical_partition partitioner(
     std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
+  auto outputs = partitioner.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
 
   std::size_t partition_size = 10000000;  // from sirius_physical_partition.hpp
 
   std::size_t expected_num_partitions =
     (estimated_cardinality + partition_size - 1) / partition_size;
 
-  REQUIRE(outputs.get_data_batches().size() == expected_num_partitions);
+  REQUIRE(outputs->get_data_batches().size() == expected_num_partitions);
 
   // count the number of rows in each output and make sure it's the same and the initial inputs
   std::size_t total_num_rows = 0;
-  for (auto& output : outputs.get_data_batches()) {
+  for (auto& output : outputs->get_data_batches()) {
     std::size_t num_rows_out =
       output->get_data()->cast<gpu_table_representation>().get_table().num_rows();
     REQUIRE(num_rows_out % prime_repeater ==
@@ -330,9 +334,11 @@ TEST_CASE(
   sirius_physical_partition partitioner(
     std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
-  REQUIRE(outputs.get_data_batches().size() == 1);
-  REQUIRE(outputs.get_data_batches()[0]
+  auto outputs = partitioner.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({input_batch})),
+    default_stream());
+  REQUIRE(outputs->get_data_batches().size() == 1);
+  REQUIRE(outputs->get_data_batches()[0]
             ->get_data()
             ->cast<gpu_table_representation>()
             .get_table()

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -86,7 +86,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *projection.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
     outputs.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -131,7 +132,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *projection.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table = outputs.get_data_batches()[0]
                         ->get_data()
@@ -179,7 +181,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *projection.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table = outputs.get_data_batches()[0]
                         ->get_data()

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -263,7 +263,8 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
                                                                get_test_client_context());
 
-  collector.sink(operator_data({batch}), cudf::get_default_stream());
+  collector.sink(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})),
+                 cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -331,7 +332,8 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
                                                                get_test_client_context());
 
-  collector.sink(operator_data({batch}), cudf::get_default_stream());
+  collector.sink(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batch})),
+                 cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -438,7 +440,8 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
         std::this_thread::yield();
       }
       try {
-        collector.sink(operator_data({batches[static_cast<size_t>(thread_idx)]}),
+        collector.sink(std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>(
+                         {batches[static_cast<size_t>(thread_idx)]})),
                        cudf::get_default_stream());
       } catch (...) {
         exceptions[static_cast<size_t>(thread_idx)] = std::current_exception();

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -127,7 +127,8 @@ TEMPLATE_TEST_CASE(
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *table_scan.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
     outputs.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
@@ -197,7 +198,8 @@ TEST_CASE("sirius_physical_table_scan with no filters passes through data", "[ph
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *table_scan.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
 
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
@@ -269,7 +271,8 @@ TEST_CASE("sirius_physical_table_scan with multiple filters", "[physical_table_s
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *table_scan.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
 
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto output_table =
@@ -339,7 +342,8 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    *table_scan.execute(std::make_unique<operator_data>(inputs), cudf::get_default_stream());
 
   REQUIRE(outputs.get_data_batches().size() == 1);
   auto table =

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -88,10 +88,12 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
                              nullptr,
                              0);
 
-  auto out = topn.execute(operator_data({batches[0]}), cudf::get_default_stream());
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = topn.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batches[0]})),
+    cudf::get_default_stream());
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view  = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
@@ -128,10 +130,12 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
                              nullptr,
                              0);
 
-  auto out = topn.execute(operator_data({batches[0]}), cudf::get_default_stream());
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = topn.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batches[0]})),
+    cudf::get_default_stream());
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view  = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
@@ -168,10 +172,12 @@ TEST_CASE("sirius_physical_top_n_merge applies offset and limit", "[physical_top
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out = topn_merge.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batches})),
+    cudf::get_default_stream());
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   auto view  = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
@@ -206,8 +212,10 @@ TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_to
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out.get_data_batches().empty());
+  auto out = topn_merge.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({batches})),
+    cudf::get_default_stream());
+  REQUIRE(out->get_data_batches().empty());
 }
 
 TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_merge]")
@@ -233,9 +241,10 @@ TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out.get_data_batches().size() == 1);
+  auto out =
+    topn_merge.execute(std::make_unique<operator_data>(batches), cudf::get_default_stream());
+  REQUIRE(out->get_data_batches().size() == 1);
 
-  auto table = out.get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
   REQUIRE(table.num_rows() == 0);
 }

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -168,10 +168,14 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1         = local_op.execute(operator_data({b1}), cudf::get_default_stream());
-  auto local_out2         = local_op.execute(operator_data({b2}), cudf::get_default_stream());
-  auto local_out1_batches = local_out1.get_data_batches();
-  auto local_out2_batches = local_out2.get_data_batches();
+  auto local_out1 = local_op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({b1})),
+    cudf::get_default_stream());
+  auto local_out2 = local_op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({b2})),
+    cudf::get_default_stream());
+  auto local_out1_batches = local_out1->get_data_batches();
+  auto local_out2_batches = local_out2->get_data_batches();
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1_batches.begin()),
@@ -179,7 +183,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out2_batches.begin()),
                       std::make_move_iterator(local_out2_batches.end()));
-  auto out = merge_op.execute(operator_data(merge_inputs), cudf::get_default_stream());
+  auto out =
+    *merge_op.execute(std::make_unique<operator_data>(merge_inputs), cudf::get_default_stream());
   REQUIRE(out.get_data_batches().size() == 1);
 
   auto table =
@@ -279,10 +284,14 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1         = local_op.execute(operator_data({b1}), cudf::get_default_stream());
-  auto local_out2         = local_op.execute(operator_data({b2}), cudf::get_default_stream());
-  auto local_out1_batches = local_out1.get_data_batches();
-  auto local_out2_batches = local_out2.get_data_batches();
+  auto local_out1 = local_op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({b1})),
+    cudf::get_default_stream());
+  auto local_out2 = local_op.execute(
+    std::make_unique<operator_data>(std::vector<std::shared_ptr<data_batch>>({b2})),
+    cudf::get_default_stream());
+  auto local_out1_batches = local_out1->get_data_batches();
+  auto local_out2_batches = local_out2->get_data_batches();
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1_batches.begin()),
@@ -291,7 +300,8 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
                       std::make_move_iterator(local_out2_batches.begin()),
                       std::make_move_iterator(local_out2_batches.end()));
 
-  auto out = merge_op.execute(operator_data(merge_inputs), cudf::get_default_stream());
+  auto out =
+    *merge_op.execute(std::make_unique<operator_data>(merge_inputs), cudf::get_default_stream());
   REQUIRE(out.get_data_batches().size() == 1);
 
   auto table =

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -182,7 +182,8 @@ TEST_CASE("GPU pipeline executor uses task requests to schedule GPU tasks",
       if (!request) { break; }
 
       auto local_state = std::make_unique<test_gpu_pipeline_task_local_state>(
-        sirius::op::operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+        std::make_unique<sirius::op::operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{}));
       auto task = std::make_unique<sirius_pipeline_task>(
         static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed)),
         std::move(local_state),

--- a/test/cpp/pipeline/test_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_pipeline_executor.cpp
@@ -56,7 +56,7 @@ class mock_gpu_pipeline_task_local_state : public gpu_pipeline_task_local_state 
  public:
   mock_gpu_pipeline_task_local_state(int task_id, int expected_gpu_id)
     : gpu_pipeline_task_local_state(
-        operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{})),
+        std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{})),
       _task_id(task_id),
       _expected_gpu_id(expected_gpu_id)
   {


### PR DESCRIPTION
Changed parameter and return types of functions passing around `operator_data` to ptr. This prevents object slicing when trying to pass `partitioned_operator_data` which is a subclass.
This code builds but the engine hangs, so I have to debug this solution.