### PR TITLE
Getting rid of usage of static DuckDB in unit tests

### DIFF
--- a/src/data/host_parquet_representation.cpp
+++ b/src/data/host_parquet_representation.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<cucascade::idata_representation> host_parquet_representation::cl
   // Get the host memory resource from the memory space
   auto* host_mr = get_memory_space().get_memory_resource_of<cucascade::memory::Tier::HOST>();
   if (!host_mr) {
-    throw std::runtime_error("Cannot clone host_table_representation: no host memory resource");
+    throw std::runtime_error("Cannot clone host_parquet_representation: no host memory resource");
   }
 
   // Allocate new blocks for the copy

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -90,9 +90,9 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
    * @throws InternalException if the memory manager is not initialized, if the reservation fails,
    * or if the memory space for the reservation is invalid
    * @note For now, we assume that the input batch, if in the HOST tier, is always in the
-   * host_table_representation. If it is in the GPU tier, we convert it to the
-   * host_table_representation. In the future, we should register converters for other specialized
-   * data representations and invoke one such here.
+   * host_data_packed_representation. If it is in the GPU tier, we convert it to the
+   * host_data_packed_representation. In the future, we should register converters for other
+   * specialized data representations and invoke one such here.
    */
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -411,9 +411,9 @@ void duckdb_scan_task_local_state::initialize_local_table_function_state(
 
 std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_batch()
 {
-  using data_batch                = cucascade::data_batch;
-  using host_table_allocation     = cucascade::memory::host_table_packed_allocation;
-  using host_table_representation = cucascade::host_data_packed_representation;
+  using data_batch                      = cucascade::data_batch;
+  using host_table_allocation           = cucascade::memory::host_table_packed_allocation;
+  using host_data_packed_representation = cucascade::host_data_packed_representation;
 
   // Create metadata nodes for each column and assemble metadata buffer
   std::vector<metadata_node> column_metadata;
@@ -432,7 +432,7 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
 
   // Make the host table representation
   auto table =
-    std::make_unique<host_table_representation>(std::move(table_allocation), _host_space);
+    std::make_unique<host_data_packed_representation>(std::move(table_allocation), _host_space);
 
   // Create the data batch and return
   return std::make_shared<data_batch>(get_next_batch_id(), std::move(table));

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -155,10 +155,10 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
     } else if (data->get_current_tier() != cucascade::memory::Tier::HOST) {
       // Data must be in HOST tier (i.e., cannot currently reside in DISK tier)
       throw duckdb::InvalidInputException(
-        "[GPUPhysicalMaterializedCollector] Expected host_table_representation in HOST tier");
+        "[GPUPhysicalMaterializedCollector] Expected host_data_packed_representation in HOST tier");
     }
 
-    // Only accepting host_table_representations for now
+    // Only accepting host_data_packed_representation for now
     assert(dynamic_cast<cucascade::host_data_packed_representation*>(data) != nullptr);
 
     // Push chunks to result collection
@@ -168,7 +168,8 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
     auto const* ht = host_table.get_host_table().get();
     if (!ht) {
       throw duckdb::InvalidInputException(
-        "[GPUPhysicalMaterializedCollector] host_table_representation has null get_host_table()");
+        "[GPUPhysicalMaterializedCollector] host_data_packed_representation has null "
+        "get_host_table()");
     }
     if (!ht->allocation) {
       throw duckdb::InvalidInputException(

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -70,11 +70,12 @@ std::filesystem::path get_test_config_path()
   return std::filesystem::path(__FILE__).parent_path() / "memory.cfg";
 }
 
-memory_space* get_memory_space(cucascade::memory::Tier tier, int device_id)
+memory_space* get_memory_space(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
+                               cucascade::memory::Tier tier,
+                               int device_id)
 {
-  auto sirius_ctx = sirius::get_sirius_context(get_test_config_path());
-  auto& manager   = sirius_ctx->get_memory_manager();
-  auto* space     = manager.get_memory_space(tier, device_id);
+  auto& manager = sirius_ctx->get_memory_manager();
+  auto* space   = manager.get_memory_space(tier, device_id);
   if (space) { return space; }
   auto spaces = manager.get_memory_spaces_for_tier(tier);
   if (!spaces.empty()) { return const_cast<memory_space*>(spaces.front()); }
@@ -326,14 +327,14 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-cucascade::host_data_packed_representation const& convert_to_host_table(
+cucascade::host_table_representation const& convert_to_host_table(
+  duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
   std::shared_ptr<cucascade::data_batch> const& batch)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
 
-  auto sirius_ctx = sirius::get_sirius_context(get_test_config_path());
-  auto& manager   = sirius_ctx->get_memory_manager();
+  auto& manager = sirius_ctx->get_memory_manager();
 
   auto reservation =
     manager.request_reservation(any_memory_space_in_tier{Tier::HOST},
@@ -361,9 +362,13 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
 {
   using metadata_node = sirius::metadata_node;
 
-  auto* host_space = get_memory_space(Tier::HOST, 0);
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+
+  auto* host_space = get_memory_space(sirius_ctx, Tier::HOST, 0);
   REQUIRE(host_space != nullptr);
-  auto* gpu_space = get_memory_space(Tier::GPU, 0);
+  auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
 
   auto* allocator = host_space->get_memory_resource_as<fixed_size_host_memory_resource>();
@@ -495,9 +500,13 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
 {
   using metadata_node = sirius::metadata_node;
 
-  auto* host_space = get_memory_space(Tier::HOST, 0);
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+
+  auto* host_space = get_memory_space(sirius_ctx, Tier::HOST, 0);
   REQUIRE(host_space != nullptr);
-  auto* gpu_space = get_memory_space(Tier::GPU, 0);
+  auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
 
   auto* allocator = host_space->get_memory_resource_as<fixed_size_host_memory_resource>();
@@ -616,7 +625,11 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
 TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][host_table_utils]")
 {
   constexpr size_t num_rows = 257;
-  auto* gpu_space           = get_memory_space(Tier::GPU, 0);
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+
+  auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
   auto stream = cudf::get_default_stream();
   auto mr     = gpu_space->get_default_allocator();
@@ -650,7 +663,7 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
     expected_string_mask = extract_mask_bytes(gpu_view.column(2));
   }
 
-  auto const& host_table = convert_to_host_table(batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
   auto const& host_alloc = host_table.get_host_table();
   auto const& allocation = host_alloc->allocation;
 

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -327,7 +327,7 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-cucascade::host_table_representation const& convert_to_host_table(
+cucascade::host_data_packed_representation const& convert_to_host_table(
   duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
   std::shared_ptr<cucascade::data_batch> const& batch)
 {

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -209,7 +209,7 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-host_table_representation const& convert_to_host_table(
+host_data_packed_representation const& convert_to_host_table(
   duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx, std::shared_ptr<data_batch> const& batch)
 {
   auto* data = batch->get_data();

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -59,25 +59,10 @@ std::filesystem::path get_test_config_path()
   return std::filesystem::path(__FILE__).parent_path() / "result.cfg";
 }
 
-duckdb::Connection& get_test_connection()
+memory_space* get_default_gpu_space(duckdb::shared_ptr<duckdb::SiriusContext>& sirius_ctx)
 {
-  static duckdb::DuckDB db(nullptr);
-  static duckdb::Connection con(db);
-  return con;
-}
-
-duckdb::ClientContext& get_test_client_context() { return *get_test_connection().context; }
-
-duckdb::shared_ptr<duckdb::SiriusContext> get_test_sirius_context()
-{
-  return sirius::get_sirius_context(get_test_connection(), get_test_config_path());
-}
-
-memory_space* get_default_gpu_space()
-{
-  auto sirius_ctx = get_test_sirius_context();
-  auto& manager   = sirius_ctx->get_memory_manager();
-  auto* space     = manager.get_memory_space(Tier::GPU, 0);
+  auto& manager = sirius_ctx->get_memory_manager();
+  auto* space   = manager.get_memory_space(Tier::GPU, 0);
   if (space) { return space; }
   auto spaces = manager.get_memory_spaces_for_tier(Tier::GPU);
   if (!spaces.empty()) { return const_cast<memory_space*>(spaces.front()); }
@@ -224,14 +209,13 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-host_data_packed_representation const& convert_to_host_table(
-  std::shared_ptr<data_batch> const& batch)
+host_table_representation const& convert_to_host_table(
+  duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx, std::shared_ptr<data_batch> const& batch)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
 
-  auto sirius_ctx = get_test_sirius_context();
-  auto& manager   = sirius_ctx->get_memory_manager();
+  auto& manager = sirius_ctx->get_memory_manager();
 
   auto reservation =
     manager.request_reservation(any_memory_space_in_tier{Tier::HOST},
@@ -258,7 +242,10 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
           "[operator][result_collector][host_table_chunk_reader]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE + 5;
-  auto* gpu_space           = get_default_gpu_space();
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
@@ -288,12 +275,12 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
     expected_strings    = build_expected_strings(expected);
   }
 
-  auto const& host_table = convert_to_host_table(batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
-  sirius::op::result::host_table_chunk_reader reader(get_test_client_context(), host_table, types);
+  sirius::op::result::host_table_chunk_reader reader(*con.context, host_table, types);
 
   size_t row_base       = 0;
   auto const num_chunks = reader.calculate_num_chunks();
@@ -333,7 +320,10 @@ TEST_CASE("host_table_chunk_reader handles null masks",
           "[operator][result_collector][host_table_chunk_reader]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE * 2 + 3;
-  auto* gpu_space           = get_default_gpu_space();
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
   auto stream = cudf::get_default_stream();
   auto mr     = gpu_space->get_default_allocator();
@@ -373,12 +363,12 @@ TEST_CASE("host_table_chunk_reader handles null masks",
     expected_string_valid = extract_validity(gpu_view.column(2));
   }
 
-  auto const& host_table = convert_to_host_table(batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
-  sirius::op::result::host_table_chunk_reader reader(get_test_client_context(), host_table, types);
+  sirius::op::result::host_table_chunk_reader reader(*con.context, host_table, types);
 
   size_t row_base       = 0;
   auto const num_chunks = reader.calculate_num_chunks();

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -18,6 +18,7 @@
 #include "operator/aggregate/aggregate_test_utils.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
+#include "utils/data_utils.hpp"
 
 #include <catch.hpp>
 #include <duckdb.hpp>
@@ -72,7 +73,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
     }
   } else if constexpr (Traits::is_ts) {
     for (int i = 0; i < num_values; ++i) {
-      values[i] = static_cast<typename Traits::type>(i * 1'000'000);
+      values[i] = static_cast<typename Traits::type>(i * 100'000);
     }
   } else if constexpr (std::is_same_v<typename Traits::type, int32_t> ||
                        std::is_same_v<typename Traits::type, int64_t> ||
@@ -88,24 +89,23 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
       values[i] = (i % 2 == 0);
     }
   }
-  std::shared_ptr<data_batch> input_batch0;  // batch for the aggregation key
-  if constexpr (Traits::is_string) {
-    input_batch0 = make_string_batch(*space, values);
-  } else if constexpr (Traits::is_decimal) {
-    input_batch0 = make_decimal64_batch(*space, values, Traits::scale);
-  } else if constexpr (Traits::is_ts) {
-    input_batch0 = make_timestamp_batch(*space, values, Traits::cudf_type);
-  } else {
-    input_batch0 = make_numeric_batch<typename Traits::type>(*space, values, Traits::cudf_type);
-  }
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
 
-  // create a batch for the aggregation value to just be a int32_t
-  std::shared_ptr<data_batch> input_batch1;
-  input_batch1 =
-    make_numeric_batch<int32_t>(*space, std::vector<int32_t>(num_values, 1), cudf::type_id::INT32);
+  // Column 0: aggregation key
+  auto col0 = sirius::test::vector_to_cudf_column<Traits>(values, stream, mr);
+  // Column 1: aggregation value (all ones)
+  auto col1 = sirius::test::vector_to_cudf_column<gpu_type_traits<int32_t>>(
+    std::vector<int32_t>(num_values, 1), stream, mr);
 
-  // Concatenate the two batches horizontally (side by side columns)
-  auto input_batch = concatenate_batches_horizontal({input_batch0, input_batch1}, *space);
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(col0));
+  columns.push_back(std::move(col1));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
+  auto input_batch =
+    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
@@ -209,26 +209,25 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
       }
     }
   }
-  std::shared_ptr<data_batch> input_batch0;  // batch for the aggregation key0 and 1
-  if constexpr (Traits::is_string) {
-    input_batch0 = make_string_batch(*space, values0);
-  } else if constexpr (Traits::is_decimal) {
-    input_batch0 = make_decimal64_batch(*space, values0, Traits::scale);
-  } else if constexpr (Traits::is_ts) {
-    input_batch0 = make_timestamp_batch(*space, values0, Traits::cudf_type);
-  } else {
-    input_batch0 = make_numeric_batch<typename Traits::type>(*space, values0, Traits::cudf_type);
-  }
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
 
-  std::shared_ptr<data_batch> input_batch1 =
-    make_numeric_batch<int32_t>(*space, values1, cudf::type_id::INT32);
+  // Column 0: aggregation key0
+  auto col0 = sirius::test::vector_to_cudf_column<Traits>(values0, stream, mr);
+  // Column 1: aggregation key1
+  auto col1 = sirius::test::vector_to_cudf_column<gpu_type_traits<int32_t>>(values1, stream, mr);
+  // Column 2: aggregation value (same as column 1; values won't matter)
+  auto col2 = sirius::test::vector_to_cudf_column<gpu_type_traits<int32_t>>(values1, stream, mr);
 
-  // we can make the third column which is for aggregation the same as the second column because the
-  // values won't matter
-  std::shared_ptr<data_batch> input_batch2 =
-    make_numeric_batch<int32_t>(*space, values1, cudf::type_id::INT32);
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(col0));
+  columns.push_back(std::move(col1));
+  columns.push_back(std::move(col2));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
   auto input_batch =
-    concatenate_batches_horizontal({input_batch0, input_batch1, input_batch2}, *space);
+    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
@@ -293,15 +292,24 @@ TEST_CASE(
 
   std::vector<int32_t> values(num_values);
   std::iota(values.begin(), values.end(), 0);
-  std::shared_ptr<data_batch> input_batch0 =
-    make_numeric_batch<int32_t>(*space, values, cudf::type_id::INT32);
 
-  // create a batch for the aggregation value to just be a int32_t
-  std::shared_ptr<data_batch> input_batch1 =
-    make_numeric_batch<int32_t>(*space, std::vector<int32_t>(num_values, 1), cudf::type_id::INT32);
+  auto stream = default_stream();
+  auto mr     = get_resource_ref(*space);
 
-  // Concatenate the two batches horizontally (side by side columns)
-  auto input_batch = concatenate_batches_horizontal({input_batch0, input_batch1}, *space);
+  // Column 0: partition key
+  auto col0 = sirius::test::vector_to_cudf_column<gpu_type_traits<int32_t>>(values, stream, mr);
+  // Column 1: aggregation value (all ones)
+  auto col1 = sirius::test::vector_to_cudf_column<gpu_type_traits<int32_t>>(
+    std::vector<int32_t>(num_values, 1), stream, mr);
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(col0));
+  columns.push_back(std::move(col1));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
+  auto input_batch =
+    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t estimated_cardinality = num_values;
 

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -72,25 +72,10 @@ std::filesystem::path get_test_config_path()
   return std::filesystem::path(__FILE__).parent_path() / "result.cfg";
 }
 
-duckdb::Connection& get_test_connection()
+memory_space* get_default_gpu_space(duckdb::shared_ptr<duckdb::SiriusContext>& sirius_ctx)
 {
-  static duckdb::DuckDB db(nullptr);
-  static duckdb::Connection con(db);
-  return con;
-}
-
-duckdb::ClientContext& get_test_client_context() { return *get_test_connection().context; }
-
-duckdb::shared_ptr<duckdb::SiriusContext> get_test_sirius_context()
-{
-  return sirius::get_sirius_context(get_test_connection(), get_test_config_path());
-}
-
-memory_space* get_default_gpu_space()
-{
-  auto sirius_ctx = get_test_sirius_context();
-  auto& manager   = sirius_ctx->get_memory_manager();
-  auto* space     = manager.get_memory_space(Tier::GPU, 0);
+  auto& manager = sirius_ctx->get_memory_manager();
+  auto* space   = manager.get_memory_space(Tier::GPU, 0);
   if (space) { return space; }
   auto spaces = manager.get_memory_spaces_for_tier(Tier::GPU);
   if (!spaces.empty()) { return const_cast<memory_space*>(spaces.front()); }
@@ -191,7 +176,8 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-void convert_batch_to_host(std::shared_ptr<data_batch> const& batch)
+void convert_batch_to_host(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
+                           std::shared_ptr<data_batch> const& batch)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
@@ -199,8 +185,7 @@ void convert_batch_to_host(std::shared_ptr<data_batch> const& batch)
   auto const view       = sirius::get_cudf_table_view(*batch);
   auto const data_bytes = estimate_packed_data_bytes(view);
 
-  auto sirius_ctx = get_test_sirius_context();
-  auto& manager   = sirius_ctx->get_memory_manager();
+  auto& manager = sirius_ctx->get_memory_manager();
 
   auto reservation = manager.request_reservation(any_memory_space_in_tier{Tier::HOST}, data_bytes);
   if (!reservation) { throw std::runtime_error("Failed to reserve host memory for test"); }
@@ -219,7 +204,10 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
           "[operator][physical_result_collector]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE + 7;
-  auto* gpu_space           = get_default_gpu_space();
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
@@ -249,7 +237,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
     expected_strings    = build_expected_strings(expected);
   }
 
-  convert_batch_to_host(batch);
+  convert_batch_to_host(sirius_ctx, batch);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
@@ -261,8 +249,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
   auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
-  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
-                                                               get_test_client_context());
+  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
   collector.sink(operator_data({batch}), cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
@@ -293,7 +280,10 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
           "[operator][physical_result_collector]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE * 2 + 3;
-  auto* gpu_space           = get_default_gpu_space();
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
@@ -329,8 +319,7 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
   auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
-  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
-                                                               get_test_client_context());
+  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
   collector.sink(operator_data({batch}), cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
@@ -359,8 +348,10 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
 {
   constexpr int num_threads       = 4;
   constexpr size_t rows_per_batch = STANDARD_VECTOR_SIZE * 3 + 13;
-
-  auto* gpu_space = get_default_gpu_space();
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
 
   using row_t = std::pair<int32_t, int64_t>;
@@ -410,7 +401,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
 
     auto table = std::make_unique<cudf::table>(std::move(cols));
     auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
-    convert_batch_to_host(batch);
+    convert_batch_to_host(sirius_ctx, batch);
     batches.emplace_back(std::move(batch));
   }
 
@@ -423,8 +414,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
   auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
-  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared,
-                                                               get_test_client_context());
+  sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
   std::atomic<int> ready{0};
   std::atomic<bool> go{false};

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -65,10 +65,9 @@ static memory_space* get_host_space(duckdb::SiriusContext& sirius_ctx)
  * @return unique_ptr to the allocation
  */
 static std::unique_ptr<fixed_size_host_memory_resource::multiple_blocks_allocation>
-create_test_allocation(size_t total_size)
+create_test_allocation(duckdb::SiriusContext& sirius_ctx, size_t total_size)
 {
-  auto sirius_ctx = sirius::get_sirius_context(get_test_config_path());
-  auto* mem_space = get_host_space(*sirius_ctx);
+  auto* mem_space = get_host_space(sirius_ctx);
   REQUIRE(mem_space != nullptr);
   auto* allocator = mem_space->template get_memory_resource_as<fixed_size_host_memory_resource>();
   REQUIRE(allocator != nullptr);
@@ -133,7 +132,9 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
 
-  auto sirius_ctx = sirius::get_sirius_context(get_test_config_path());
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   auto* mem_space = get_host_space(*sirius_ctx);
   REQUIRE(mem_space != nullptr);
   auto* allocator = mem_space->template get_memory_resource_as<fixed_size_host_memory_resource>();
@@ -148,7 +149,7 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
     // Calculate total size needed: data + mask
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
 
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     // Initialize the accessors at byte offset 0
     builder.initialize_accessors(num_rows, 0, allocation);
@@ -175,7 +176,7 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
                         sirius::utils::ceil_div_8(num_rows);  // mask
 
     // Use the helper to create the allocation
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     // Initialize the accessors at byte offset 0
     builder.initialize_accessors(num_rows, 0, allocation);
@@ -197,7 +198,9 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
 
-  auto sirius_ctx = sirius::get_sirius_context(get_test_config_path());
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   auto* mem_space = get_host_space(*sirius_ctx);
   REQUIRE(mem_space != nullptr);
   auto* allocator = mem_space->template get_memory_resource_as<fixed_size_host_memory_resource>();
@@ -215,7 +218,7 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
                         sirius::utils::ceil_div_8(num_rows);  // mask
 
     // Use the helper to create the allocation
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -248,7 +251,7 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
                         sirius::utils::ceil_div_8(num_rows);  // mask
 
     // Use the helper to create the allocation
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     builder.initialize_accessors(num_rows, 0, allocation);
 
@@ -276,6 +279,10 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
 //===----------------------------------------------------------------------===//
 TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+
   SECTION("byte-aligned mask processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -283,7 +290,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a validity mask with some NULLs
@@ -318,7 +325,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // First, add 3 rows (to create a 3-bit offset)
@@ -349,7 +356,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Initially, null_count should be 0
@@ -373,7 +380,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Initially, null_count should be 0
@@ -396,7 +403,7 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Initially, null_count should be 0
@@ -418,6 +425,9 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 TEST_CASE("column_builder - process_column for fixed-width types",
           "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("INTEGER column processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -425,7 +435,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with integer data
@@ -464,7 +474,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int64_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with bigint data
@@ -501,7 +511,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(double) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with double data
@@ -531,7 +541,9 @@ TEST_CASE("column_builder - process_column for fixed-width types",
 TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][column_builder]")
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
-
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("VARCHAR column processing with all valid rows")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
@@ -541,7 +553,7 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
                         DEFAULT_VARCHAR_SIZE * num_rows +     // data
                         sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with string data
@@ -587,7 +599,7 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
                         DEFAULT_VARCHAR_SIZE * num_rows +     // data
                         sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create a DuckDB vector with string data
@@ -632,6 +644,9 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
 
 TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("process multiple batches of INTEGER data")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -639,7 +654,7 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Process first batch
@@ -677,7 +692,7 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
                         256 * num_rows +                      // data
                         sirius::utils::ceil_div_8(num_rows);  // mask
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Process first batch
@@ -720,7 +735,7 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // First batch: some NULLs
@@ -774,6 +789,9 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
 
 TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("empty vector (0 rows)")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -781,7 +799,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Process empty vector
@@ -802,7 +820,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create vector with all NULLs
@@ -846,7 +864,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     size_t max_data_size = 1024;
     size_t total_size =
       max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create vector with empty strings
@@ -890,7 +908,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
     size_t max_data_size = 1024;
     size_t total_size =
       max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Mix of empty and non-empty strings
@@ -937,7 +955,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 
     size_t num_rows   = 10;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Process single row
@@ -969,6 +987,9 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 TEST_CASE("column_builder - packed allocation multiple columns",
           "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("two fixed-width columns in packed allocation")
   {
     // Simulate layout: [INT column data][INT column mask][BIGINT column data][BIGINT column mask]
@@ -985,7 +1006,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     size_t bigint_mask_size = sirius::utils::ceil_div_8(num_rows);
     size_t total_size       = int_data_size + int_mask_size + bigint_data_size + bigint_mask_size;
 
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     // Initialize INT column at offset 0
     size_t int_byte_offset = 0;
@@ -1052,7 +1073,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     size_t total_size =
       int_data_size + int_mask_size + varchar_offset_size + varchar_data_size + varchar_mask_size;
 
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     // Initialize INT column at offset 0
     size_t int_byte_offset = 0;
@@ -1131,7 +1152,7 @@ TEST_CASE("column_builder - packed allocation multiple columns",
       (num_rows + 1) * sizeof(int32_t) + 256 * num_rows + sirius::utils::ceil_div_8(num_rows);
     size_t total_size = int_size + double_size + varchar_size;
 
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
 
     int_builder.initialize_accessors(num_rows, 0, allocation);
     double_builder.initialize_accessors(num_rows, int_size, allocation);
@@ -1217,6 +1238,9 @@ TEST_CASE("column_builder - packed allocation multiple columns",
 TEST_CASE("column_builder - VARCHAR space checking edge cases",
           "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("sufficient_space_for_column returns false when space exceeded")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
@@ -1227,7 +1251,7 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
     size_t max_data_size = 20;  // Only 20 bytes of data space
     size_t total_size =
       max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // Create vector with strings that exceed allocated space
@@ -1263,7 +1287,7 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
     size_t max_data_size = 1024;
     size_t total_size =
       max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     // All NULLs - strings don't matter
@@ -1300,7 +1324,7 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
     size_t max_data_size = 1024;
     size_t total_size =
       max_data_size + (num_rows + 1) * sizeof(int64_t) + sirius::utils::ceil_div_8(num_rows);
-    auto allocation = create_test_allocation(total_size);
+    auto allocation = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     duckdb::Vector vec(varchar_type, 10);
@@ -1343,6 +1367,9 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
 
 TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][column_builder]")
 {
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("NULLs at byte boundaries in mask")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -1351,7 +1378,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     // Test with exactly 16 rows (2 mask bytes)
     size_t num_rows   = 16;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     duckdb::Vector vec(int_type, 16);
@@ -1396,7 +1423,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     // Test with 24 rows (3 mask bytes)
     size_t num_rows   = 24;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     duckdb::Vector vec(int_type, 24);
@@ -1425,7 +1452,7 @@ TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][co
     // Test with 20 rows (3 mask bytes, last one partial)
     size_t num_rows   = 20;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
-    auto allocation   = create_test_allocation(total_size);
+    auto allocation   = create_test_allocation(*sirius_ctx, total_size);
     builder.initialize_accessors(num_rows, 0, allocation);
 
     duckdb::Vector vec(int_type, 20);

--- a/test/cpp/utils/utils.hpp
+++ b/test/cpp/utils/utils.hpp
@@ -104,12 +104,4 @@ inline duckdb::shared_ptr<duckdb::SiriusContext> get_sirius_context(
   return sirius_ctx;
 }
 
-inline duckdb::shared_ptr<duckdb::SiriusContext> get_sirius_context(
-  const std::filesystem::path& config_path)
-{
-  static duckdb::DuckDB db(nullptr);
-  static duckdb::Connection con(db);
-  return get_sirius_context(con, config_path);
-}
-
 }  // namespace sirius


### PR DESCRIPTION
The usage of static for a DuckDB context in unit tests, although convenient, when running unit tests in debug mode, results in multiple errors of the extension context file being locked. 

This PR also fixes the physical_paritition tests