### PR TITLE
Partition operator: use grandparent join when feeding directly into a concat

### DIFF
--- a/src/include/op/sirius_physical_nested_loop_join.hpp
+++ b/src/include/op/sirius_physical_nested_loop_join.hpp
@@ -24,7 +24,7 @@
 #include "duckdb/execution/operator/join/physical_join.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
-#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_partition_consumer_operator.hpp"
 
 namespace sirius {
 
@@ -36,7 +36,7 @@ class sirius_meta_pipeline;
 namespace op {
 
 //! sirius_physical_nested_loop_join represents a nested loop join between two tables
-class sirius_physical_nested_loop_join : public sirius_physical_operator {
+class sirius_physical_nested_loop_join : public sirius_physical_partition_consumer_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE =
     SiriusPhysicalOperatorType::NESTED_LOOP_JOIN;

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -18,7 +18,6 @@
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
-#include "log/logging.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 #include "op/sirius_physical_grouped_aggregate.hpp"
 #include "op/sirius_physical_hash_join.hpp"
@@ -159,7 +158,13 @@ void sirius_physical_concat::sink(const operator_data& output_data, rmm::cuda_st
     for (auto& [next_op, port_id] : next_port_after_sink) {
       auto partition_consumer_op =
         dynamic_cast<sirius_physical_partition_consumer_operator*>(next_op);
-      partition_consumer_op->push_data_batch_partitioned(port_id, batch, partition_idx);
+      if (partition_consumer_op) {
+        partition_consumer_op->push_data_batch_partitioned(port_id, batch, partition_idx);
+      } else {
+        throw std::runtime_error(
+          "sirius_physical_concat::sink(): Next operator is not a partition consumer operator: " +
+          SiriusPhysicalOperatorToString(next_op->type));
+      }
     }
   }
 }

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -59,10 +59,14 @@ sirius_physical_concat::sirius_physical_concat(duckdb::vector<duckdb::LogicalTyp
     } else if (hash_join->join_type == duckdb::JoinType::OUTER) {
       _concat_all = true;
     } else {
-      throw std::runtime_error("sirius_physical_concat: unsupported join type");
+      throw std::runtime_error("sirius_physical_concat: unsupported join type: " +
+                               duckdb::JoinTypeToString(hash_join->join_type));
     }
+  } else if (parent_op->type == SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
+    _concat_all = false;
   } else {
-    throw std::runtime_error("sirius_physical_concat: parent_op is not a hash join");
+    throw std::runtime_error("sirius_physical_concat: parent_op is not a hash join: " +
+                             SiriusPhysicalOperatorToString(parent_op->type));
   }
 }
 

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -78,7 +78,7 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   duckdb::vector<duckdb::JoinCondition> cond,
   duckdb::JoinType join_type,
   duckdb::idx_t estimated_cardinality)
-  : sirius_physical_operator(
+  : sirius_physical_partition_consumer_operator(
       SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, op.types, estimated_cardinality),
     join_type(join_type),
     conditions(std::move(cond))
@@ -110,7 +110,7 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   duckdb::JoinType join_type,
   duckdb::idx_t estimated_cardinality,
   duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p)
-  : sirius_physical_operator(
+  : sirius_physical_partition_consumer_operator(
       SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, op.types, estimated_cardinality),
     join_type(join_type),
     conditions(std::move(cond))

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -113,7 +113,19 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
       }
     }
   } else if (op->type == SiriusPhysicalOperatorType::CONCAT) {
-    _partition_type = PartitionType::EVENLY;
+    auto& parent_concat_op = op->Cast<sirius_physical_concat>();
+    if (parent_concat_op.get_parent_op()->type == SiriusPhysicalOperatorType::HASH_JOIN) {
+      auto& grandparent_join_op =
+        parent_concat_op.get_parent_op()->Cast<sirius_physical_hash_join>();
+      bool is_build       = parent_concat_op.is_build_concat();
+      auto num_conditions = grandparent_join_op.conditions.size();
+      _is_build           = is_build;
+      _num_partitions     = num_conditions;
+      get_partition_keys_and_type(&grandparent_join_op, is_build);
+    } else {
+      throw std::runtime_error("Unsupported operator following partition->concat: " +
+                               op->get_name());
+    }
   } else {
     throw std::runtime_error("Unsupported operator type for partition: " + op->get_name());
   }

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -24,6 +24,7 @@
 #include "op/sirius_physical_concat.hpp"
 #include "op/sirius_physical_grouped_aggregate_merge.hpp"
 #include "op/sirius_physical_hash_join.hpp"
+#include "op/sirius_physical_nested_loop_join.hpp"
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_top_n.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -122,9 +123,18 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
       _is_build           = is_build;
       _num_partitions     = num_conditions;
       get_partition_keys_and_type(&grandparent_join_op, is_build);
+    } else if (parent_concat_op.get_parent_op()->type ==
+               SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
+      auto& grandparent_join_op =
+        parent_concat_op.get_parent_op()->Cast<sirius_physical_nested_loop_join>();
+      bool is_build       = parent_concat_op.is_build_concat();
+      auto num_conditions = grandparent_join_op.conditions.size();
+      _is_build           = is_build;
+      _num_partitions     = num_conditions;
+      get_partition_keys_and_type(&grandparent_join_op, is_build);
     } else {
       throw std::runtime_error("Unsupported operator following partition->concat: " +
-                               op->get_name());
+                               parent_concat_op.get_parent_op()->get_name());
     }
   } else {
     throw std::runtime_error("Unsupported operator type for partition: " + op->get_name());

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -73,7 +73,25 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
         }
       }
     }
-
+  } else if (op->type == SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
+    _partition_type      = PartitionType::NONE;
+    auto& nested_join_op = op->Cast<sirius_physical_nested_loop_join>();
+    if (is_build) {
+      for (duckdb::idx_t cond_idx = 0; cond_idx < nested_join_op.conditions.size(); cond_idx++) {
+        auto& condition = nested_join_op.conditions[cond_idx];
+        if (condition.right->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+          _partition_keys.push_back(
+            condition.right->Cast<duckdb::BoundReferenceExpression>().index);
+        }
+      }
+    } else {
+      for (duckdb::idx_t cond_idx = 0; cond_idx < nested_join_op.conditions.size(); cond_idx++) {
+        auto& condition = nested_join_op.conditions[cond_idx];
+        if (condition.left->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+          _partition_keys.push_back(condition.left->Cast<duckdb::BoundReferenceExpression>().index);
+        }
+      }
+    }
   } else if (op->type == SiriusPhysicalOperatorType::HASH_GROUP_BY) {
     _partition_type            = PartitionType::HASH;
     auto& grouped_aggregate_op = op->Cast<sirius_physical_grouped_aggregate>();
@@ -115,21 +133,19 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
     }
   } else if (op->type == SiriusPhysicalOperatorType::CONCAT) {
     auto& parent_concat_op = op->Cast<sirius_physical_concat>();
+    bool is_build          = parent_concat_op.is_build_concat();
+    _is_build              = is_build;
     if (parent_concat_op.get_parent_op()->type == SiriusPhysicalOperatorType::HASH_JOIN) {
       auto& grandparent_join_op =
         parent_concat_op.get_parent_op()->Cast<sirius_physical_hash_join>();
-      bool is_build       = parent_concat_op.is_build_concat();
       auto num_conditions = grandparent_join_op.conditions.size();
-      _is_build           = is_build;
       _num_partitions     = num_conditions;
       get_partition_keys_and_type(&grandparent_join_op, is_build);
     } else if (parent_concat_op.get_parent_op()->type ==
                SiriusPhysicalOperatorType::NESTED_LOOP_JOIN) {
       auto& grandparent_join_op =
         parent_concat_op.get_parent_op()->Cast<sirius_physical_nested_loop_join>();
-      bool is_build       = parent_concat_op.is_build_concat();
       auto num_conditions = grandparent_join_op.conditions.size();
-      _is_build           = is_build;
       _num_partitions     = num_conditions;
       get_partition_keys_and_type(&grandparent_join_op, is_build);
     } else {

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -112,6 +112,10 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
         _partition_keys.push_back(expr->Cast<duckdb::BoundReferenceExpression>().index);
       }
     }
+  } else if (op->type == SiriusPhysicalOperatorType::CONCAT) {
+    _partition_type = PartitionType::EVENLY;
+  } else {
+    throw std::runtime_error("Unsupported operator type for partition: " + op->get_name());
   }
 }
 
@@ -140,6 +144,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
       partitioned_results = gpu_partition_impl::evenly_partition(
         input_batch, _num_partitions, stream, *input_batch->get_memory_space());
       break;
+    case PartitionType::NONE: partitioned_results = {input_batch}; break;
     case PartitionType::CUSTOM:
       throw std::runtime_error("Custom partitioning is not implemented yet");
     default:

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -357,10 +357,13 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
           } else {
             agg_op = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
           }
-          // For AVG, the SUM reduction must use the input column type (cudf requires
-          // output type == input type for fixed-point reductions). The final AVG return
-          // type is applied later in the merge step when dividing SUM / COUNT.
-          if (spec.kind == aggregate_kind::AVG) { out_type = col.type(); }
+          // cuDF requires output type == input type for fixed-point (decimal) reductions.
+          // For AVG we use input type and apply return type in the merge step (SUM/COUNT).
+          // For SUM/MIN/MAX on decimals we must also use input column type.
+          bool is_decimal = (col.type().id() == cudf::type_id::DECIMAL32 ||
+                             col.type().id() == cudf::type_id::DECIMAL64 ||
+                             col.type().id() == cudf::type_id::DECIMAL128);
+          if (spec.kind == aggregate_kind::AVG || is_decimal) { out_type = col.type(); }
           auto scalar = cudf::reduce(col, *agg_op, out_type, std::nullopt, stream);
           cols.push_back(cudf::make_column_from_scalar(*scalar, 1, stream));
           if (spec.kind == aggregate_kind::AVG) {


### PR DESCRIPTION
There's a number of query plans in TPC-H where a partition operator feeds directly into a concat. Usually after that concat there's a join. To make these queries works this PR looks at the grandparent (the join) to configure the partition. Normally the number of partitions is set using the cardinality estimation, but in case of a join the data is partitioned using the number of join conditions.