### PR TITLE
Validate output datatypes

### DIFF
--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -153,12 +153,23 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
   pipeline::sirius_pipeline_itask* task, rmm::cuda_stream_view stream)
 {
   if (!_caching_enabled) {
-    return task->compute_task(stream);
+    SIRIUS_LOG_TRACE("Pipeline {}: cache disabled, scanning...", task->get_pipeline_id());
+    auto start    = std::chrono::high_resolution_clock::now();
+    auto data     = task->compute_task(stream);
+    auto end      = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    SIRIUS_LOG_TRACE("Pipeline {}: scan finished in {:.2f} ms",
+                     task->get_pipeline_id(),
+                     duration.count() / 1000.0);
+    return data;
   } else {
     auto pipe_id = task->get_pipeline_id();
     std::lock_guard<std::mutex> lock(_cache_mutex);
     auto& entry = _cache.at(pipe_id);
-    if (!entry) { throw std::runtime_error("Scan results for query not cached"); }
+    if (!entry) {
+      throw std::runtime_error("Could not find cache entry for pipeline " +
+                               std::to_string(pipe_id));
+    }
     if (_preload_mode) {
       if (entry->batch_index >= entry->batches.size()) {
         throw std::runtime_error("Scan results for query not cached");
@@ -171,7 +182,15 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
       }
       return std::make_unique<op::operator_data>(std::move(cloned_batches));
     } else {
+      SIRIUS_LOG_TRACE("Pipeline {}: data not found in cache, scanning...",
+                       task->get_pipeline_id());
+      auto start       = std::chrono::high_resolution_clock::now();
       auto scan_output = task->compute_task(stream);
+      auto end         = std::chrono::high_resolution_clock::now();
+      auto duration    = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+      SIRIUS_LOG_TRACE("Pipeline {}: scan finished in {:.2f} ms",
+                       task->get_pipeline_id(),
+                       duration.count() / 1000.0);
       std::vector<std::shared_ptr<cucascade::data_batch>> cloned_batches;
       cloned_batches.reserve(scan_output->get_data_batches().size());
       for (auto& b : scan_output->get_data_batches()) {

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -153,23 +153,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
   pipeline::sirius_pipeline_itask* task, rmm::cuda_stream_view stream)
 {
   if (!_caching_enabled) {
-    SIRIUS_LOG_TRACE("Pipeline {}: cache disabled, scanning...", task->get_pipeline_id());
-    auto start    = std::chrono::high_resolution_clock::now();
-    auto data     = task->compute_task(stream);
-    auto end      = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    SIRIUS_LOG_TRACE("Pipeline {}: scan finished in {:.2f} ms",
-                     task->get_pipeline_id(),
-                     duration.count() / 1000.0);
-    return data;
+    return task->compute_task(stream);
   } else {
     auto pipe_id = task->get_pipeline_id();
     std::lock_guard<std::mutex> lock(_cache_mutex);
     auto& entry = _cache.at(pipe_id);
-    if (!entry) {
-      throw std::runtime_error("Could not find cache entry for pipeline " +
-                               std::to_string(pipe_id));
-    }
+    if (!entry) { throw std::runtime_error("Scan results for query not cached"); }
     if (_preload_mode) {
       if (entry->batch_index >= entry->batches.size()) {
         throw std::runtime_error("Scan results for query not cached");
@@ -182,15 +171,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
       }
       return std::make_unique<op::operator_data>(std::move(cloned_batches));
     } else {
-      SIRIUS_LOG_TRACE("Pipeline {}: data not found in cache, scanning...",
-                       task->get_pipeline_id());
-      auto start       = std::chrono::high_resolution_clock::now();
       auto scan_output = task->compute_task(stream);
-      auto end         = std::chrono::high_resolution_clock::now();
-      auto duration    = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-      SIRIUS_LOG_TRACE("Pipeline {}: scan finished in {:.2f} ms",
-                       task->get_pipeline_id(),
-                       duration.count() / 1000.0);
       std::vector<std::shared_ptr<cucascade::data_batch>> cloned_batches;
       cloned_batches.reserve(scan_output->get_data_batches().size());
       for (auto& b : scan_output->get_data_batches()) {

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -58,9 +58,6 @@ sirius_physical_filter::sirius_physical_filter(
 std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_data& input_data,
                                                                rmm::cuda_stream_view stream)
 {
-  SIRIUS_LOG_DEBUG("Executing expression {}", expression->ToString());
-  auto start = std::chrono::high_resolution_clock::now();
-
   const auto& input_batches = input_data.get_data_batches();
 
   // The executor uses the data_batch API to filter rows according to `expression`.
@@ -74,11 +71,6 @@ std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_da
     auto filtered_batch = gpu_expression_executor.select(batch, stream);
     if (filtered_batch) { output_batches.push_back(std::move(filtered_batch)); }
   }
-
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Filter time: {:.2f} ms", duration.count() / 1000.0);
-
   return std::make_unique<operator_data>(output_batches);
 }
 

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -69,7 +69,6 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data.get_data_batches();
-  SIRIUS_LOG_DEBUG("Executing streaming limit");
 
   if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
     throw duckdb::NotImplementedException("Streaming limit with non-constant limit value");

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -80,9 +80,6 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
 {
   const auto& input_batches = input_data.get_data_batches();
 
-  SIRIUS_LOG_DEBUG("Executing merge sort with {} input batches", input_batches.size());
-  auto start = std::chrono::high_resolution_clock::now();
-
   // Collect valid batches and find memory space
   std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
   cucascade::memory::memory_space* space = nullptr;
@@ -141,12 +138,6 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
 
   auto merged_batch = gpu_merge_impl::merge_order_by(
     valid_batches, order_key_idx, column_order, null_precedence, stream, *space);
-
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Merge sort time: {:.2f} ms ({} batches merged)",
-                   duration.count() / 1000.0,
-                   valid_batches.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   if (merged_batch) { outputs.push_back(apply_final_projection(std::move(merged_batch))); }

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -40,8 +40,6 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
                                                               rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data.get_data_batches();
-  SIRIUS_LOG_DEBUG("Executing order by");
-  auto start = std::chrono::high_resolution_clock::now();
 
   // Build cudf order vectors from BoundOrderByNode
   std::vector<int> order_key_idx;
@@ -78,10 +76,6 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
       batch, order_key_idx, column_order, null_precedence, proj_idx, stream, *space);
     if (sorted_batch) { output_batches.push_back(std::move(sorted_batch)); }
   }
-
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Order by time: {:.2f} ms", duration.count() / 1000.0);
 
   return std::make_unique<operator_data>(output_batches);
 }

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -45,8 +45,6 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data.get_data_batches();
-  SIRIUS_LOG_DEBUG("Executing projection");
-  auto start = std::chrono::high_resolution_clock::now();
 
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(select_list);
 
@@ -58,11 +56,6 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
     auto projected_batch = gpu_expression_executor.execute(batch, stream);
     if (projected_batch) { output_batches.push_back(std::move(projected_batch)); }
   }
-
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Projection time: {:.2f} ms", duration.count() / 1000.0);
-
   return std::make_unique<operator_data>(output_batches);
 }
 

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -132,7 +132,6 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data.get_data_batches();
-  auto start                = std::chrono::high_resolution_clock::now();
 
   duckdb::unique_ptr<duckdb::Expression> filter_expr;
   if (table_filters) {
@@ -206,9 +205,6 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     output_batches = std::move(projected_batches);
   }
 
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Filter time: {:.2f} ms", duration.count() / 1000.0);
   return std::make_unique<operator_data>(output_batches);
 }
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -137,7 +137,12 @@ void gpu_pipeline_executor::manager_loop()
                             pipeline]() mutable {
       try {
         task->execute(exc_stream);
+      } catch (const std::exception& e) {
+        SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
+        if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
+        return;
       } catch (...) {
+        SIRIUS_LOG_ERROR("GPU Pipeline Executor: unknown error during task execution");
         if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         return;
       }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -16,6 +16,8 @@
 
 #include "pipeline/gpu_pipeline_task.hpp"
 
+#include "cudf/cudf_utils.hpp"
+
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
@@ -92,6 +94,36 @@ std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
   return std::move(lock_result.handle);
 }
 
+void validate_operator_output_types(const op::operator_data* data,
+                                    const op::sirius_physical_operator& op)
+{
+  if (data == nullptr) { return; }
+  const auto& expected_types = op.get_types();
+  const auto& batches        = data->get_data_batches();
+  for (size_t batch_index = 0; batch_index < batches.size(); batch_index++) {
+    const auto& batch = batches[batch_index];
+    if (!batch) { continue; }
+    cudf::table_view tbl = get_cudf_table_view(*batch);
+    if (static_cast<size_t>(tbl.num_columns()) != expected_types.size()) {
+      throw std::runtime_error("gpu_pipeline_task: operator '" + op.get_name() + "' output batch " +
+                               std::to_string(batch_index) + " column count mismatch: got " +
+                               std::to_string(tbl.num_columns()) + ", expected " +
+                               std::to_string(expected_types.size()));
+    }
+    for (cudf::size_type c = 0; c < tbl.num_columns(); c++) {
+      cudf::data_type expected_cudf = duckdb::GetCudfType(expected_types[c]);
+      cudf::data_type actual        = tbl.column(c).type();
+      if (actual != expected_cudf) {
+        throw std::runtime_error("gpu_pipeline_task: operator '" + op.get_name() +
+                                 "' output batch " + std::to_string(batch_index) + " column " +
+                                 std::to_string(c) + " datatype mismatch: got " +
+                                 cudf::type_to_name(actual) + ", expected " +
+                                 cudf::type_to_name(expected_cudf));
+      }
+    }
+  }
+}
+
 }  // namespace
 
 gpu_pipeline_task::gpu_pipeline_task(
@@ -125,10 +157,10 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
 {
   auto& local_state               = _local_state->cast<gpu_pipeline_task_local_state>();
   auto operator_input_output_data = std::move(local_state._input_data);
-
   for (auto& op :
        _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_operators()) {
     operator_input_output_data = op.get().execute(*operator_input_output_data, stream);
+    validate_operator_output_types(operator_input_output_data.get(), op.get());
   }
   return operator_input_output_data;
 }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -17,6 +17,7 @@
 #include "pipeline/gpu_pipeline_task.hpp"
 
 #include "cudf/cudf_utils.hpp"
+#include "log/logging.hpp"
 
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
@@ -105,20 +106,28 @@ void validate_operator_output_types(const op::operator_data* data,
     if (!batch) { continue; }
     cudf::table_view tbl = get_cudf_table_view(*batch);
     if (static_cast<size_t>(tbl.num_columns()) != expected_types.size()) {
-      throw std::runtime_error("gpu_pipeline_task: operator '" + op.get_name() + "' output batch " +
-                               std::to_string(batch_index) + " column count mismatch: got " +
-                               std::to_string(tbl.num_columns()) + ", expected " +
-                               std::to_string(expected_types.size()));
+      SIRIUS_LOG_WARN(
+        "gpu_pipeline_task: operator '{}' output batch {} column count mismatch: got "
+        "{}, expected {}",
+        op.get_name(),
+        batch_index,
+        tbl.num_columns(),
+        expected_types.size());
+      return;
     }
     for (cudf::size_type c = 0; c < tbl.num_columns(); c++) {
       cudf::data_type expected_cudf = duckdb::GetCudfType(expected_types[c]);
       cudf::data_type actual        = tbl.column(c).type();
       if (actual != expected_cudf) {
-        throw std::runtime_error("gpu_pipeline_task: operator '" + op.get_name() +
-                                 "' output batch " + std::to_string(batch_index) + " column " +
-                                 std::to_string(c) + " datatype mismatch: got " +
-                                 cudf::type_to_name(actual) + ", expected " +
-                                 cudf::type_to_name(expected_cudf));
+        SIRIUS_LOG_WARN(
+          "gpu_pipeline_task: operator '{}' output batch {} column {} datatype "
+          "mismatch: got {}, expected {}",
+          op.get_name(),
+          batch_index,
+          c,
+          cudf::type_to_name(actual),
+          cudf::type_to_name(expected_cudf));
+        return;
       }
     }
   }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -107,9 +107,10 @@ void validate_operator_output_types(const op::operator_data* data,
     cudf::table_view tbl = get_cudf_table_view(*batch);
     if (static_cast<size_t>(tbl.num_columns()) != expected_types.size()) {
       SIRIUS_LOG_WARN(
-        "gpu_pipeline_task: operator '{}' output batch {} column count mismatch: got "
+        "gpu_pipeline_task: operator '{}' (id={}) output batch {} column count mismatch: got "
         "{}, expected {}",
         op.get_name(),
+        op.get_operator_id(),
         batch_index,
         tbl.num_columns(),
         expected_types.size());
@@ -120,9 +121,10 @@ void validate_operator_output_types(const op::operator_data* data,
       cudf::data_type actual        = tbl.column(c).type();
       if (actual != expected_cudf) {
         SIRIUS_LOG_WARN(
-          "gpu_pipeline_task: operator '{}' output batch {} column {} datatype "
+          "gpu_pipeline_task: operator '{}' (id={}) output batch {} column {} datatype "
           "mismatch: got {}, expected {}",
           op.get_name(),
+          op.get_operator_id(),
           batch_index,
           c,
           cudf::type_to_name(actual),
@@ -168,18 +170,20 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
   auto& local_state = _local_state->cast<gpu_pipeline_task_local_state>();
   auto operator_input_output_data = std::move(local_state._input_data);
   for (auto& op : pipeline->get_operators()) {
-    SIRIUS_LOG_TRACE("Pipeline {}: operator {} executing on {} batches",
+    SIRIUS_LOG_TRACE("Pipeline {}: operator {} (id={}) executing on {} batches",
                      pipeline->get_pipeline_id(),
                      op.get().get_name(),
+                     op.get().get_operator_id(),
                      operator_input_output_data->get_data_batches().size());
     auto start                 = std::chrono::high_resolution_clock::now();
     operator_input_output_data = op.get().execute(*operator_input_output_data, stream);
     auto end                   = std::chrono::high_resolution_clock::now();
     auto duration              = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
     SIRIUS_LOG_TRACE(
-      "Pipeline {}: operator {} produced {} batches, execution time: {:.2f} ms",
+      "Pipeline {}: operator {} (id={}) produced {} batches, execution time: {:.2f} ms",
       pipeline->get_pipeline_id(),
       op.get().get_name(),
+      op.get().get_operator_id(),
       operator_input_output_data ? operator_input_output_data->get_data_batches().size() : 0u,
       duration.count() / 1000.0);
     validate_operator_output_types(operator_input_output_data.get(), op.get());

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -164,11 +164,24 @@ const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
 
 std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_stream_view stream)
 {
-  auto& local_state               = _local_state->cast<gpu_pipeline_task_local_state>();
+  auto pipeline     = _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
+  auto& local_state = _local_state->cast<gpu_pipeline_task_local_state>();
   auto operator_input_output_data = std::move(local_state._input_data);
-  for (auto& op :
-       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_operators()) {
+  for (auto& op : pipeline->get_operators()) {
+    SIRIUS_LOG_TRACE("Pipeline {}: operator {} executing on {} batches",
+                     pipeline->get_pipeline_id(),
+                     op.get().get_name(),
+                     operator_input_output_data->get_data_batches().size());
+    auto start                 = std::chrono::high_resolution_clock::now();
     operator_input_output_data = op.get().execute(*operator_input_output_data, stream);
+    auto end                   = std::chrono::high_resolution_clock::now();
+    auto duration              = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    SIRIUS_LOG_TRACE(
+      "Pipeline {}: operator {} produced {} batches, execution time: {:.2f} ms",
+      pipeline->get_pipeline_id(),
+      op.get().get_name(),
+      operator_input_output_data ? operator_input_output_data->get_data_batches().size() : 0u,
+      duration.count() / 1000.0);
     validate_operator_output_types(operator_input_output_data.get(), op.get());
   }
   return operator_input_output_data;

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -946,19 +946,23 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
     for (size_t i = 0; i < new_scheduled.size(); i++) {
       auto pipeline = new_scheduled[i];
       SIRIUS_LOG_INFO("Pipeline #{}", i);
-      SIRIUS_LOG_INFO("  Source: {}", pipeline->source->get_name());
+      SIRIUS_LOG_INFO(
+        "  Source: {} (id={})", pipeline->source->get_name(), pipeline->source->get_operator_id());
 
       // Print operators
       for (size_t j = 0; j < pipeline->operators.size(); j++) {
-        SIRIUS_LOG_INFO("    Operator[{}]: {}", j, pipeline->operators[j].get().get_name());
+        auto& op = pipeline->operators[j].get();
+        SIRIUS_LOG_INFO("    Operator[{}]: {} (id={})", j, op.get_name(), op.get_operator_id());
       }
 
-      SIRIUS_LOG_INFO("  Sink: {}", pipeline->sink->get_name());
+      SIRIUS_LOG_INFO(
+        "  Sink: {} (id={})", pipeline->sink->get_name(), pipeline->sink->get_operator_id());
 
       // Print ports at operator[0] (beginning of pipeline)
       if (pipeline->operators.size() > 0) {
         auto& first_op = pipeline->operators[0].get();
-        SIRIUS_LOG_INFO("  Ports at Operator[0] ({}):", first_op.get_name());
+        SIRIUS_LOG_INFO(
+          "  Ports at Operator[0] ({}, id={}):", first_op.get_name(), first_op.get_operator_id());
 
         // Check for different port types based on operator type
         if (first_op.type == op::SiriusPhysicalOperatorType::HASH_JOIN ||
@@ -1044,7 +1048,10 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
       for (auto& next_port : pipeline->sink->get_next_port_after_sink()) {
         auto next_op = next_port.first;
         auto port_id = next_port.second;
-        SIRIUS_LOG_INFO("    Next Op: {}, Port: '{}'", next_op->get_name(), port_id.data());
+        SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}'",
+                        next_op->get_name(),
+                        next_op->get_operator_id(),
+                        port_id.data());
 
         // Print the port details if it exists
         auto* port = next_op->get_port(port_id);
@@ -1065,8 +1072,9 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             delim_join->Cast<op::sirius_physical_right_delim_join>().partition_join;
           SIRIUS_LOG_INFO("  Partition Join next operators:");
           for (auto& next_port : partition_join->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {}, Port: '{}' Repo:'{}'",
+            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
                             next_port.first->get_name(),
+                            next_port.first->get_operator_id(),
                             next_port.second.data(),
                             static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
           }
@@ -1076,8 +1084,9 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
           delim_join->Cast<op::sirius_physical_right_delim_join>().partition_distinct;
         SIRIUS_LOG_INFO("  Partition Distinct next operators:");
         for (auto& next_port : partition_distinct->get_next_port_after_sink()) {
-          SIRIUS_LOG_INFO("    Next Op: {}, Port: '{}' Repo:'{}'",
+          SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
                           next_port.first->get_name(),
+                          next_port.first->get_operator_id(),
                           next_port.second.data(),
                           static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
         }
@@ -1087,8 +1096,9 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             delim_join->Cast<op::sirius_physical_left_delim_join>().column_data_scan;
           SIRIUS_LOG_INFO("  Column Data Scan next operators:");
           for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {}, Port: '{}' Repo:'{}'",
+            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
                             next_port.first->get_name(),
+                            next_port.first->get_operator_id(),
                             next_port.second.data(),
                             static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
           }


### PR DESCRIPTION
Adds a check after each operator's execute() function that compares the datatypes of the output columns to the vector (that was set during planning). If it doesn't match, it writes a warning in the log.