### PR TITLE
added first implementation of count distinct by group. 

### DIFF
--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -27,6 +27,7 @@
 #include "log/logging.hpp"
 
 #include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/datetime.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/attributes.hpp>
@@ -747,6 +748,20 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
   else if (func_str == REGEXP_REPLACE_FUNC_STR) {
     RegexFunctionDispatcher dispatcher(*this);
     return dispatcher(expr, state);
+  }
+
+  //----------Struct Functions----------//
+  // row() and struct_pack() both construct a struct column from their child expressions.
+  // row() is used by DuckDB for tuple constructors like (col1, col2).
+  if (func_str == "row" || func_str == "struct_pack") {
+    D_ASSERT(!expr.children.empty());
+    std::vector<std::unique_ptr<cudf::column>> child_cols;
+    for (size_t i = 0; i < expr.children.size(); ++i) {
+      child_cols.push_back(Execute(*expr.children[i], state->child_states[i].get()));
+    }
+    cudf::size_type num_rows = child_cols[0]->size();
+    return cudf::make_structs_column(
+      num_rows, std::move(child_cols), 0, rmm::device_buffer{}, execution_stream, resource_ref);
   }
 
   // If we've gotten this far, we've encountered a unimplemented function type

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -100,6 +100,7 @@ inline cudf::data_type GetCudfType(const LogicalType& logical_type)
     case LogicalTypeId::TIMESTAMP: return cudf::data_type(cudf::type_id::TIMESTAMP_MICROSECONDS);
     case LogicalTypeId::TIMESTAMP_NS: return cudf::data_type(cudf::type_id::TIMESTAMP_NANOSECONDS);
     case LogicalTypeId::VARCHAR: return cudf::data_type(cudf::type_id::STRING);
+    case LogicalTypeId::STRUCT: return cudf::data_type(cudf::type_id::STRUCT);
     case LogicalTypeId::DECIMAL: {
       switch (logical_type.InternalType()) {
         case PhysicalType::INT32:

--- a/src/include/op/aggregate/aggregate_op_util.hpp
+++ b/src/include/op/aggregate/aggregate_op_util.hpp
@@ -49,6 +49,11 @@ struct CudfAggregateDefinitions {
                                                          ///< entries per AVG)
   std::vector<int> cudf_aggregate_idx;  ///< Column indices for aggregation inputs (expanded)
 
+  /// For COLLECT_SET aggregates only: when non-empty, the aggregate input is a struct column
+  /// synthesized from these column indices (multi-column COUNT DISTINCT). Parallel to
+  /// cudf_aggregates; empty entries mean single-column (use cudf_aggregate_idx directly).
+  std::vector<std::vector<int>> cudf_aggregate_struct_col_indices;
+
   /// One entry per original DuckDB aggregate expression, mapping to cudf_aggregates positions.
   std::vector<AggregateSlot> aggregate_slots;
   bool has_avg            = false;  ///< True if any aggregate is AVG

--- a/src/include/op/aggregate/aggregate_op_util.hpp
+++ b/src/include/op/aggregate/aggregate_op_util.hpp
@@ -29,9 +29,11 @@ namespace op {
 /**
  * @brief Mapping from one original DuckDB aggregate expression to its position(s) in the expanded
  * cudf_aggregates vector. AVG is decomposed into SUM + COUNT_VALID (two slots), all others use one.
+ * COUNT DISTINCT uses COLLECT_SET locally and MERGE_SETS during merge, then counts list elements.
  */
 struct AggregateSlot {
-  bool is_avg = false;
+  bool is_avg            = false;
+  bool is_count_distinct = false;  ///< True if this is a COUNT(DISTINCT col) aggregate
   size_t cudf_idx;  ///< Index in cudf_aggregates. For AVG, this is the SUM slot; cudf_idx+1 is
                     ///< COUNT_VALID.
   cudf::data_type output_type{cudf::type_id::EMPTY};  ///< For AVG: the desired output cudf type
@@ -49,7 +51,8 @@ struct CudfAggregateDefinitions {
 
   /// One entry per original DuckDB aggregate expression, mapping to cudf_aggregates positions.
   std::vector<AggregateSlot> aggregate_slots;
-  bool has_avg = false;  ///< True if any aggregate is AVG
+  bool has_avg            = false;  ///< True if any aggregate is AVG
+  bool has_count_distinct = false;  ///< True if any aggregate is COUNT(DISTINCT col)
 };
 
 /**

--- a/src/include/op/aggregate/gpu_aggregate_impl.hpp
+++ b/src/include/op/aggregate/gpu_aggregate_impl.hpp
@@ -63,6 +63,11 @@ class gpu_aggregate_impl {
    * @param group_idx The group columns.
    * @param aggregates The aggregate functions.
    * @param aggregate_idx The aggregate columns, should have the same size as `aggregates`.
+   *        For multi-column COUNT DISTINCT (COLLECT_SET), the entry is -1 (sentinel) and
+   *        the actual column indices are provided in `aggregate_struct_col_indices`.
+   * @param aggregate_struct_col_indices Parallel to `aggregates`. Non-empty entries indicate
+   *        a multi-column COLLECT_SET where a struct column is synthesized from those column
+   *        indices. Empty entries (or an empty outer vector) use `aggregate_idx` directly.
    * @param stream CUDA stream used for device memory operations and kernel launches.
    * @param memory_space The memory space used to allocate memory for the output data batch.
    *
@@ -73,6 +78,7 @@ class gpu_aggregate_impl {
     const std::vector<int>& group_idx,
     const std::vector<cudf::aggregation::Kind>& aggregates,
     const std::vector<int>& aggregate_idx,
+    const std::vector<std::vector<int>>& aggregate_struct_col_indices,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space);
 };

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -81,7 +81,8 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
 
   // AVG decomposition metadata
   std::vector<AggregateSlot> aggregate_slots;
-  bool has_avg = false;
+  bool has_avg            = false;
+  bool has_count_distinct = false;
 
  public:
   // Source interface

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -78,6 +78,7 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
   std::vector<int> group_idx;
   std::vector<cudf::aggregation::Kind> cudf_aggregates;
   std::vector<int> cudf_aggregate_idx;
+  std::vector<std::vector<int>> cudf_aggregate_struct_col_indices;
 
   // AVG decomposition metadata
   std::vector<AggregateSlot> aggregate_slots;

--- a/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
@@ -47,6 +47,7 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
                                           std::vector<int> cudf_aggregate_idx,
                                           std::vector<AggregateSlot> aggregate_slots,
                                           bool has_avg,
+                                          bool has_count_distinct,
                                           duckdb::idx_t estimated_cardinality);
 
   sirius_physical_grouped_aggregate_merge(
@@ -91,9 +92,10 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
   std::vector<cudf::aggregation::Kind> cudf_aggregates;
   std::vector<int> cudf_aggregate_idx;
 
-  // AVG decomposition metadata
+  // AVG and COUNT DISTINCT decomposition metadata
   std::vector<AggregateSlot> aggregate_slots;
-  bool has_avg = false;
+  bool has_avg            = false;
+  bool has_count_distinct = false;
 
   std::size_t current_partition_index = 0;
 

--- a/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
@@ -41,14 +41,16 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
  public:
   sirius_physical_grouped_aggregate_merge(sirius_physical_grouped_aggregate* grouped_aggregate);
 
-  sirius_physical_grouped_aggregate_merge(duckdb::vector<duckdb::LogicalType> types,
-                                          std::vector<int> group_idx,
-                                          std::vector<cudf::aggregation::Kind> cudf_aggregates,
-                                          std::vector<int> cudf_aggregate_idx,
-                                          std::vector<AggregateSlot> aggregate_slots,
-                                          bool has_avg,
-                                          bool has_count_distinct,
-                                          duckdb::idx_t estimated_cardinality);
+  sirius_physical_grouped_aggregate_merge(
+    duckdb::vector<duckdb::LogicalType> types,
+    std::vector<int> group_idx,
+    std::vector<cudf::aggregation::Kind> cudf_aggregates,
+    std::vector<int> cudf_aggregate_idx,
+    std::vector<std::vector<int>> cudf_aggregate_struct_col_indices,
+    std::vector<AggregateSlot> aggregate_slots,
+    bool has_avg,
+    bool has_count_distinct,
+    duckdb::idx_t estimated_cardinality);
 
   sirius_physical_grouped_aggregate_merge(
     duckdb::ClientContext& context,
@@ -91,6 +93,7 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
   std::vector<int> group_idx;
   std::vector<cudf::aggregation::Kind> cudf_aggregates;
   std::vector<int> cudf_aggregate_idx;
+  std::vector<std::vector<int>> cudf_aggregate_struct_col_indices;
 
   // AVG and COUNT DISTINCT decomposition metadata
   std::vector<AggregateSlot> aggregate_slots;

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -25,8 +25,6 @@
 #include "op/sirius_physical_partition_consumer_operator.hpp"
 #include "op/sirius_physical_top_n.hpp"
 
-#define PARTITION_SIZE 10000000
-
 namespace sirius {
 namespace op {
 
@@ -48,6 +46,11 @@ inline std::string partition_type_to_string(PartitionType type)
 class sirius_physical_partition : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::PARTITION;
+  static constexpr duckdb::idx_t DEFAULT_PARTITION_SIZE  = 10000000;
+
+  // Override the rows-per-partition threshold. Intended for tests only.
+  static void set_partition_size(duckdb::idx_t size) { s_partition_size = size; }
+  static void reset_partition_size() { s_partition_size = DEFAULT_PARTITION_SIZE; }
 
   explicit sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
                                      duckdb::idx_t estimated_cardinality,
@@ -77,6 +80,8 @@ class sirius_physical_partition : public sirius_physical_operator {
   int _num_partitions;
   bool _is_build;
   PartitionType _partition_type;
+
+  static duckdb::idx_t s_partition_size;
 };
 
 }  // namespace op

--- a/src/op/aggregate/aggregate_op_util.cpp
+++ b/src/op/aggregate/aggregate_op_util.cpp
@@ -57,8 +57,23 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::COUNT_VALID);
       result.cudf_aggregate_idx.push_back(col_idx);
       result.aggregate_slots.push_back(
-        AggregateSlot{true, sum_position, duckdb::GetCudfType(aggr.return_type)});
+        AggregateSlot{true, false, sum_position, duckdb::GetCudfType(aggr.return_type)});
       result.has_avg = true;
+      continue;
+    }
+
+    // Handle COUNT(DISTINCT col): use COLLECT_SET locally; merge via MERGE_SETS; then count list
+    // elements to produce the final distinct count.
+    if (aggr.IsDistinct() && aggr.function.name == "count") {
+      D_ASSERT(aggr.children.size() == 1);
+      D_ASSERT(aggr.children[0]->type == duckdb::ExpressionType::BOUND_REF);
+      auto& bound_ref = aggr.children[0]->Cast<duckdb::BoundReferenceExpression>();
+      auto col_idx    = static_cast<int>(bound_ref.index);
+      size_t position = result.cudf_aggregates.size();
+      result.cudf_aggregates.push_back(cudf::aggregation::Kind::COLLECT_SET);
+      result.cudf_aggregate_idx.push_back(col_idx);
+      result.aggregate_slots.push_back(AggregateSlot{false, true, position});
+      result.has_count_distinct = true;
       continue;
     }
 
@@ -100,7 +115,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
                                  " with " + std::to_string(aggr.children.size()) + " children");
       }
     }
-    result.aggregate_slots.push_back(AggregateSlot{false, current_position});
+    result.aggregate_slots.push_back(AggregateSlot{false, false, current_position});
   }
 
   return result;

--- a/src/op/aggregate/aggregate_op_util.cpp
+++ b/src/op/aggregate/aggregate_op_util.cpp
@@ -19,6 +19,7 @@
 #include "cudf/cudf_utils.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 #include <stdexcept>
@@ -54,24 +55,45 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       size_t sum_position = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::SUM);
       result.cudf_aggregate_idx.push_back(col_idx);
+      result.cudf_aggregate_struct_col_indices.push_back({});
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::COUNT_VALID);
       result.cudf_aggregate_idx.push_back(col_idx);
+      result.cudf_aggregate_struct_col_indices.push_back({});
       result.aggregate_slots.push_back(
         AggregateSlot{true, false, sum_position, duckdb::GetCudfType(aggr.return_type)});
       result.has_avg = true;
       continue;
     }
 
-    // Handle COUNT(DISTINCT col): use COLLECT_SET locally; merge via MERGE_SETS; then count list
-    // elements to produce the final distinct count.
+    // Handle COUNT(DISTINCT col) and COUNT(DISTINCT (col1, col2, ...)):
+    // Use COLLECT_SET locally; merge via MERGE_SETS; then count list elements.
+    // For multi-column, a struct column is synthesized from the component columns.
     if (aggr.IsDistinct() && aggr.function.name == "count") {
       D_ASSERT(aggr.children.size() == 1);
-      D_ASSERT(aggr.children[0]->type == duckdb::ExpressionType::BOUND_REF);
-      auto& bound_ref = aggr.children[0]->Cast<duckdb::BoundReferenceExpression>();
-      auto col_idx    = static_cast<int>(bound_ref.index);
+      auto& child     = *aggr.children[0];
       size_t position = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::COLLECT_SET);
-      result.cudf_aggregate_idx.push_back(col_idx);
+
+      if (child.type == duckdb::ExpressionType::BOUND_REF) {
+        // Single-column case: COUNT(DISTINCT col)
+        auto& bound_ref = child.Cast<duckdb::BoundReferenceExpression>();
+        result.cudf_aggregate_idx.push_back(static_cast<int>(bound_ref.index));
+        result.cudf_aggregate_struct_col_indices.push_back({});
+      } else {
+        // Multi-column case: COUNT(DISTINCT (col1, col2, ...)) — child is a struct_pack expression
+        D_ASSERT(child.type == duckdb::ExpressionType::BOUND_FUNCTION);
+        auto& func_expr = child.Cast<duckdb::BoundFunctionExpression>();
+        std::vector<int> struct_indices;
+        for (auto& arg : func_expr.children) {
+          D_ASSERT(arg->type == duckdb::ExpressionType::BOUND_REF);
+          auto& br = arg->Cast<duckdb::BoundReferenceExpression>();
+          struct_indices.push_back(static_cast<int>(br.index));
+        }
+        D_ASSERT(!struct_indices.empty());
+        result.cudf_aggregate_idx.push_back(-1);  // sentinel: struct column, see gpu_aggregate_impl
+        result.cudf_aggregate_struct_col_indices.push_back(std::move(struct_indices));
+      }
+
       result.aggregate_slots.push_back(AggregateSlot{false, true, position});
       result.has_count_distinct = true;
       continue;
@@ -115,6 +137,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
                                  " with " + std::to_string(aggr.children.size()) + " children");
       }
     }
+    result.cudf_aggregate_struct_col_indices.push_back({});
     result.aggregate_slots.push_back(AggregateSlot{false, false, current_position});
   }
 

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -18,6 +18,8 @@
 
 #include "data/data_batch_utils.hpp"
 
+#include <cudf/column/column_factories.hpp>
+
 namespace sirius {
 namespace op {
 
@@ -98,6 +100,7 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   const std::vector<int>& group_idx,
   const std::vector<cudf::aggregation::Kind>& aggregates,
   const std::vector<int>& aggregate_idx,
+  const std::vector<std::vector<int>>& aggregate_struct_col_indices,
   rmm::cuda_stream_view stream,
   cucascade::memory::memory_space& memory_space)
 {
@@ -108,6 +111,8 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
       "`local_grouped_aggregate()`");
   }
 
+  const bool has_struct_col_indices = !aggregate_struct_col_indices.empty();
+
   // Create cudf groupby
   auto input_table = get_cudf_table_view(*input);
   std::vector<cudf::column_view> group_cols;
@@ -117,12 +122,20 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
   cudf::groupby::groupby grpby_obj(cudf::table_view(group_cols), cudf::null_policy::INCLUDE);
 
   // Make aggregation requests, group aggregations on the same column in the single request.
+  // For multi-column COLLECT_SET, a synthetic negative key -(i+1) is used so that each such
+  // aggregate gets its own request with a freshly synthesized struct column.
   std::unordered_map<int, std::vector<std::unique_ptr<cudf::groupby_aggregation>>> input_col_to_agg;
   std::unordered_map<int, std::vector<size_t>> input_col_to_output_idx;
   std::vector<int> input_col_order;
   for (size_t i = 0; i < aggregates.size(); ++i) {
     const auto& aggregate_kind = aggregates[i];
-    int aggregate_col_id       = aggregate_idx[i];
+    int aggregate_col_id;
+    if (has_struct_col_indices && !aggregate_struct_col_indices[i].empty()) {
+      // Multi-column COLLECT_SET: use a unique synthetic negative key for this slot.
+      aggregate_col_id = -(static_cast<int>(i) + 1);
+    } else {
+      aggregate_col_id = aggregate_idx[i];
+    }
     if (!input_col_to_agg.contains(aggregate_col_id)) {
       input_col_order.push_back(aggregate_col_id);
     }
@@ -137,10 +150,33 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
     input_col_to_output_idx[aggregate_col_id].push_back(i);
   }
 
+  // Temp struct columns for multi-col COLLECT_SET; must outlive the groupby call.
+  std::vector<std::unique_ptr<cudf::column>> temp_struct_cols;
+
   std::vector<cudf::groupby::aggregation_request> requests;
   for (int aggregate_col_id : input_col_order) {
     cudf::groupby::aggregation_request request;
-    request.values       = input_table.column(aggregate_col_id);
+    if (aggregate_col_id < 0) {
+      // Multi-col COLLECT_SET: synthesize a struct column from the component columns.
+      // The synthetic key is -(slot_index + 1), so slot_index = -aggregate_col_id - 1.
+      size_t slot_idx            = static_cast<size_t>(-aggregate_col_id - 1);
+      const auto& struct_indices = aggregate_struct_col_indices[slot_idx];
+      std::vector<std::unique_ptr<cudf::column>> struct_children;
+      for (int col_idx : struct_indices) {
+        struct_children.push_back(std::make_unique<cudf::column>(
+          input_table.column(col_idx), stream, memory_space.get_default_allocator()));
+      }
+      auto struct_col = cudf::make_structs_column(input_table.num_rows(),
+                                                  std::move(struct_children),
+                                                  0,
+                                                  rmm::device_buffer{},
+                                                  stream,
+                                                  memory_space.get_default_allocator());
+      request.values  = struct_col->view();
+      temp_struct_cols.push_back(std::move(struct_col));
+    } else {
+      request.values = input_table.column(aggregate_col_id);
+    }
     request.aggregations = std::move(input_col_to_agg[aggregate_col_id]);
     requests.push_back(std::move(request));
   }

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -126,7 +126,13 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
     if (!input_col_to_agg.contains(aggregate_col_id)) {
       input_col_order.push_back(aggregate_col_id);
     }
-    auto groupby_aggregation = get_local_aggregation<cudf::groupby_aggregation>(aggregate_kind);
+    std::unique_ptr<cudf::groupby_aggregation> groupby_aggregation;
+    if (aggregate_kind == cudf::aggregation::Kind::COLLECT_SET) {
+      groupby_aggregation =
+        cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE);
+    } else {
+      groupby_aggregation = get_local_aggregation<cudf::groupby_aggregation>(aggregate_kind);
+    }
     input_col_to_agg[aggregate_col_id].push_back(std::move(groupby_aggregation));
     input_col_to_output_idx[aggregate_col_id].push_back(i);
   }
@@ -147,8 +153,9 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
     int aggregate_col_id     = input_col_order[i];
     auto& aggregation_result = groupby_result.second[i];
 
-    // need to cast count aggregation result to int64
+    // need to cast count aggregation result to int64 (not applicable for COLLECT_SET)
     if (requests[i].aggregations.size() == 1 &&
+        requests[i].aggregations[0]->kind != cudf::aggregation::Kind::COLLECT_SET &&
         (requests[i].aggregations[0]->kind == cudf::aggregation::Kind::COUNT_VALID ||
          requests[i].aggregations[0]->kind == cudf::aggregation::Kind::COUNT_ALL)) {
       if (aggregation_result.results.size() != 1) {

--- a/src/op/merge/gpu_merge_impl.cpp
+++ b/src/op/merge/gpu_merge_impl.cpp
@@ -201,6 +201,13 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
         request.aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
         break;
       }
+      case cudf::aggregation::Kind::COLLECT_SET: {
+        // Intermediate column is a LIST produced by local COLLECT_SET. MERGE_SETS unions the
+        // per-partition lists and drops duplicates, producing a deduplicated LIST per group.
+        request.aggregations.push_back(
+          cudf::make_merge_sets_aggregation<cudf::groupby_aggregation>());
+        break;
+      }
       default:
         throw std::runtime_error(
           "Unsupported cudf aggregate kind in `merge_grouped_aggregate()`: " +

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -156,13 +156,14 @@ sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   // }
   // total_output_columns += grouped_aggregate_data.GroupCount();
 
-  auto cudf_defs     = convert_duckdb_aggregates_to_cudf(groups_p, expressions);
-  group_idx          = std::move(cudf_defs.group_idx);
-  cudf_aggregates    = std::move(cudf_defs.cudf_aggregates);
-  cudf_aggregate_idx = std::move(cudf_defs.cudf_aggregate_idx);
-  aggregate_slots    = std::move(cudf_defs.aggregate_slots);
-  has_avg            = cudf_defs.has_avg;
-  has_count_distinct = cudf_defs.has_count_distinct;
+  auto cudf_defs                    = convert_duckdb_aggregates_to_cudf(groups_p, expressions);
+  group_idx                         = std::move(cudf_defs.group_idx);
+  cudf_aggregates                   = std::move(cudf_defs.cudf_aggregates);
+  cudf_aggregate_idx                = std::move(cudf_defs.cudf_aggregate_idx);
+  cudf_aggregate_struct_col_indices = std::move(cudf_defs.cudf_aggregate_struct_col_indices);
+  aggregate_slots                   = std::move(cudf_defs.aggregate_slots);
+  has_avg                           = cudf_defs.has_avg;
+  has_count_distinct                = cudf_defs.has_count_distinct;
 }
 
 std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
@@ -175,6 +176,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
                                                               group_idx,
                                                               cudf_aggregates,
                                                               cudf_aggregate_idx,
+                                                              cudf_aggregate_struct_col_indices,
                                                               stream,
                                                               *input_batch->get_memory_space());
     results.push_back(std::move(result));

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -162,6 +162,7 @@ sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   cudf_aggregate_idx = std::move(cudf_defs.cudf_aggregate_idx);
   aggregate_slots    = std::move(cudf_defs.aggregate_slots);
   has_avg            = cudf_defs.has_avg;
+  has_count_distinct = cudf_defs.has_count_distinct;
 }
 
 std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -22,6 +22,7 @@
 #include "op/merge/gpu_merge_impl.hpp"
 
 #include <cudf/binaryop.hpp>
+#include <cudf/lists/count_elements.hpp>
 #include <cudf/unary.hpp>
 
 namespace sirius {
@@ -84,6 +85,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
                                             grouped_aggregate->cudf_aggregate_idx,
                                             grouped_aggregate->aggregate_slots,
                                             grouped_aggregate->has_avg,
+                                            grouped_aggregate->has_count_distinct,
                                             grouped_aggregate->estimated_cardinality)
 {
   child_op = grouped_aggregate;
@@ -96,6 +98,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
   std::vector<int> cudf_aggregate_idx,
   std::vector<AggregateSlot> aggregate_slots,
   bool has_avg,
+  bool has_count_distinct,
   duckdb::idx_t estimated_cardinality)
   : sirius_physical_partition_consumer_operator(
       SiriusPhysicalOperatorType::MERGE_GROUP_BY, std::move(types), estimated_cardinality),
@@ -103,7 +106,8 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
     cudf_aggregates(std::move(cudf_aggregates)),
     cudf_aggregate_idx(std::move(cudf_aggregate_idx)),
     aggregate_slots(std::move(aggregate_slots)),
-    has_avg(has_avg)
+    has_avg(has_avg),
+    has_count_distinct(has_count_distinct)
 {
 }
 
@@ -153,6 +157,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
   cudf_aggregate_idx = std::move(cudf_defs.cudf_aggregate_idx);
   aggregate_slots    = std::move(cudf_defs.aggregate_slots);
   has_avg            = cudf_defs.has_avg;
+  has_count_distinct = cudf_defs.has_count_distinct;
 }
 
 std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::get_next_task_input_data()
@@ -188,8 +193,10 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       "We expect at least one input batch for grouped aggregate merge operator");
   }
 
-  // Fast path: single batch with no AVG needs no processing
-  if (input_batches.size() == 1 && !has_avg) { return std::make_unique<operator_data>(input_data); }
+  // Fast path: single batch with no post-processing needed
+  if (input_batches.size() == 1 && !has_avg && !has_count_distinct) {
+    return std::make_unique<operator_data>(input_data);
+  }
 
   // Merge multiple batches, or use single batch directly if only one
   std::shared_ptr<::cucascade::data_batch> merged;
@@ -203,13 +210,13 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
                                                      *input_batches[0]->get_memory_space());
   }
 
-  // If no AVG, return merged result directly
-  if (!has_avg) {
+  // If no post-processing needed, return merged result directly
+  if (!has_avg && !has_count_distinct) {
     return std::make_unique<operator_data>(
       std::vector<std::shared_ptr<::cucascade::data_batch>>{merged});
   }
 
-  // Post-merge AVG projection: compute SUM/COUNT for each AVG aggregate.
+  // Post-merge projection: handle AVG (SUM/COUNT) and COUNT DISTINCT (list element count).
   // Release ownership of the merged table's columns so we can move (not copy) them.
   auto* space        = merged->get_memory_space();
   auto mr            = space->get_default_allocator();
@@ -255,8 +262,17 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       }
 
       output_cols.push_back(std::move(avg_col));
+    } else if (slot.is_count_distinct) {
+      // The merged column is a LIST column (output of MERGE_SETS). Count elements per row to
+      // produce the final distinct count, then cast to INT64.
+      int col_idx      = num_group_cols + static_cast<int>(slot.cudf_idx);
+      auto list_view   = cudf::lists_column_view(merged_cols[col_idx]->view());
+      auto count_int32 = cudf::lists::count_elements(list_view, stream, mr);
+      auto count_int64 =
+        cudf::cast(count_int32->view(), cudf::data_type{cudf::type_id::INT64}, stream, mr);
+      output_cols.push_back(std::move(count_int64));
     } else {
-      // Move non-AVG aggregate columns directly (zero-copy)
+      // Move non-AVG, non-count-distinct aggregate columns directly (zero-copy)
       int col_idx = num_group_cols + static_cast<int>(slot.cudf_idx);
       output_cols.push_back(std::move(merged_cols[col_idx]));
     }

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -83,6 +83,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
                                             grouped_aggregate->group_idx,
                                             grouped_aggregate->cudf_aggregates,
                                             grouped_aggregate->cudf_aggregate_idx,
+                                            grouped_aggregate->cudf_aggregate_struct_col_indices,
                                             grouped_aggregate->aggregate_slots,
                                             grouped_aggregate->has_avg,
                                             grouped_aggregate->has_count_distinct,
@@ -96,6 +97,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
   std::vector<int> group_idx,
   std::vector<cudf::aggregation::Kind> cudf_aggregates,
   std::vector<int> cudf_aggregate_idx,
+  std::vector<std::vector<int>> cudf_aggregate_struct_col_indices,
   std::vector<AggregateSlot> aggregate_slots,
   bool has_avg,
   bool has_count_distinct,
@@ -105,6 +107,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
     group_idx(std::move(group_idx)),
     cudf_aggregates(std::move(cudf_aggregates)),
     cudf_aggregate_idx(std::move(cudf_aggregate_idx)),
+    cudf_aggregate_struct_col_indices(std::move(cudf_aggregate_struct_col_indices)),
     aggregate_slots(std::move(aggregate_slots)),
     has_avg(has_avg),
     has_count_distinct(has_count_distinct)
@@ -151,13 +154,14 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
     grouping_sets(std::move(grouping_sets_p))
 {
   // Convert input parameters to cudf compute definitions BEFORE moving them
-  auto cudf_defs     = convert_duckdb_aggregates_to_cudf(groups_p, expressions);
-  group_idx          = std::move(cudf_defs.group_idx);
-  cudf_aggregates    = std::move(cudf_defs.cudf_aggregates);
-  cudf_aggregate_idx = std::move(cudf_defs.cudf_aggregate_idx);
-  aggregate_slots    = std::move(cudf_defs.aggregate_slots);
-  has_avg            = cudf_defs.has_avg;
-  has_count_distinct = cudf_defs.has_count_distinct;
+  auto cudf_defs                    = convert_duckdb_aggregates_to_cudf(groups_p, expressions);
+  group_idx                         = std::move(cudf_defs.group_idx);
+  cudf_aggregates                   = std::move(cudf_defs.cudf_aggregates);
+  cudf_aggregate_idx                = std::move(cudf_defs.cudf_aggregate_idx);
+  cudf_aggregate_struct_col_indices = std::move(cudf_defs.cudf_aggregate_struct_col_indices);
+  aggregate_slots                   = std::move(cudf_defs.aggregate_slots);
+  has_avg                           = cudf_defs.has_avg;
+  has_count_distinct                = cudf_defs.has_count_distinct;
 }
 
 std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::get_next_task_input_data()

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -32,6 +32,9 @@
 namespace sirius {
 namespace op {
 
+duckdb::idx_t sirius_physical_partition::s_partition_size =
+  sirius_physical_partition::DEFAULT_PARTITION_SIZE;
+
 sirius_physical_partition::sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
                                                      duckdb::idx_t estimated_cardinality,
                                                      sirius_physical_operator* parent_op,
@@ -39,9 +42,10 @@ sirius_physical_partition::sirius_physical_partition(duckdb::vector<duckdb::Logi
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::PARTITION, std::move(types), estimated_cardinality)
 {
-  _num_partitions = (estimated_cardinality + PARTITION_SIZE - 1) / PARTITION_SIZE;
-  _parent_op      = parent_op;
-  _is_build       = is_build;
+  _num_partitions =
+    static_cast<int>((estimated_cardinality + s_partition_size - 1) / s_partition_size);
+  _parent_op = parent_op;
+  _is_build  = is_build;
   get_partition_keys_and_type(parent_op, is_build);
 }
 

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -59,13 +59,6 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
                                           duckdb::vector<duckdb::column_t>& partition_columns)
 {
   if (op.grouping_sets.size() > 1 || !op.grouping_functions.empty()) { return false; }
-  for (auto& expression : op.expressions) {
-    auto& aggregate = expression->Cast<duckdb::BoundAggregateExpression>();
-    if (aggregate.IsDistinct()) {
-      // distinct aggregates are not supported in partitioned hash aggregates
-      return false;
-    }
-  }
   // check if the source is partitioned by the aggregate columns
   // figure out the columns we are grouping by
   for (auto& group_expr : op.groups) {

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "op/sirius_physical_partition.hpp"
+
 #include <cudf/utilities/default_stream.hpp>
 
 #include <catch.hpp>
@@ -1129,6 +1131,96 @@ TEST_CASE_METHOD(GPUExecutionFixture,
     "select avg(n_regionkey), avg(n_nationkey), n_name, "
     "max(cast(n_nationkey as Decimal(18,2))) "
     "from nation group by n_regionkey, n_name;");
+}
+
+//===----------------------------------------------------------------------===//
+// Count distinct tests
+//===----------------------------------------------------------------------===//
+
+// nation: 25 rows, n_regionkey in {0..4} with exactly 5 nations per region.
+// count(distinct n_nationkey) per region must equal 5.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: single group key",
+                 "[integration][gpu_execution][group_by][count_distinct]")
+{
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct n_nationkey) from nation group by n_regionkey;");
+}
+
+// count(distinct n_name): n_name is unique per nation, so same result as above.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: string column",
+                 "[integration][gpu_execution][group_by][count_distinct]")
+{
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct n_name) from nation group by n_regionkey;");
+}
+
+// count(distinct) mixed with other aggregations in the same grouped aggregate.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: mixed with min and count",
+                 "[integration][gpu_execution][group_by][count_distinct]")
+{
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct n_nationkey), min(n_nationkey), count(*) "
+    "from nation group by n_regionkey;");
+}
+
+// Larger table: customer (15000 rows), two group-by keys.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: larger table two group keys",
+                 "[integration][gpu_execution][group_by][count_distinct]")
+{
+  compare_gpu_vs_cpu(
+    "select c_nationkey, count(distinct c_mktsegment) from customer group by c_nationkey;");
+}
+
+// ---------------------------------------------------------------------------
+// Multi-partition count distinct tests
+//
+// PARTITION_SIZE is temporarily lowered so the engine creates multiple
+// partitions even with the small TPC-H test tables.  A RAII guard restores
+// the original value after each test regardless of pass/fail.
+// ---------------------------------------------------------------------------
+
+struct PartitionSizeGuard {
+  explicit PartitionSizeGuard(duckdb::idx_t override_size)
+  {
+    sirius::op::sirius_physical_partition::set_partition_size(override_size);
+  }
+  ~PartitionSizeGuard() { sirius::op::sirius_physical_partition::reset_partition_size(); }
+};
+
+// nation (25 rows) with partition_size=5 → ceil(25/5) = 5 partitions.
+// count(distinct n_nationkey) per region must still equal 5.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: multi-partition forced, single group key",
+                 "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
+{
+  PartitionSizeGuard guard(5);
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct n_nationkey) from nation group by n_regionkey;");
+}
+
+// customer (15000 rows) with partition_size=1000 → 15 partitions.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: multi-partition forced, customer table",
+                 "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
+{
+  PartitionSizeGuard guard(1000);
+  compare_gpu_vs_cpu(
+    "select c_nationkey, count(distinct c_mktsegment) from customer group by c_nationkey;");
+}
+
+// Mixed aggregations across multiple forced partitions.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: multi-partition forced, mixed aggregations",
+                 "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
+{
+  PartitionSizeGuard guard(1000);
+  compare_gpu_vs_cpu(
+    "select c_nationkey, count(distinct c_mktsegment), min(c_custkey), count(*) "
+    "from customer group by c_nationkey;");
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1223,6 +1223,30 @@ TEST_CASE_METHOD(GPUExecutionFixture,
     "from customer group by c_nationkey;");
 }
 
+// ---------------------------------------------------------------------------
+// Multi-column COUNT(DISTINCT) integration tests
+// count(distinct (col1, col2)) counts distinct combinations, not individual values.
+// ---------------------------------------------------------------------------
+
+// nation: 25 rows, 5 unique (n_nationkey, n_name) combos per region.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: multi-column struct",
+                 "[integration][gpu_execution][group_by][count_distinct]")
+{
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct (n_nationkey, n_name)) from nation group by n_regionkey;");
+}
+
+// Multi-column count distinct with a forced multi-partition execution.
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - count distinct: multi-column struct, multi-partition forced",
+                 "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
+{
+  PartitionSizeGuard guard(5);
+  compare_gpu_vs_cpu(
+    "select n_regionkey, count(distinct (n_nationkey, n_name)) from nation group by n_regionkey;");
+}
+
 //===----------------------------------------------------------------------===//
 // Top N / Join tests (disabled)
 //===----------------------------------------------------------------------===//

--- a/test/cpp/operator/CMakeLists.txt
+++ b/test/cpp/operator/CMakeLists.txt
@@ -32,4 +32,5 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_physical_concat.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/aggregate/test_physical_grouped_aggregate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/aggregate/test_physical_grouped_aggregate_merge.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
     PARENT_SCOPE)

--- a/test/cpp/operator/aggregate/aggregate_test_utils.hpp
+++ b/test/cpp/operator/aggregate/aggregate_test_utils.hpp
@@ -22,7 +22,9 @@
 #include <cudf/table/table.hpp>
 
 #include <duckdb.hpp>
+#include <duckdb/function/scalar_function.hpp>
 #include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 #include <algorithm>
@@ -451,6 +453,64 @@ AggregateExpressionResult create_count_distinct_expressions(
                                                         duckdb::AggregateType::DISTINCT);
 
   result.aggregates.push_back(std::move(agg_expr));
+  return result;
+}
+
+/**
+ * @brief Create DuckDB aggregate expressions for COUNT(DISTINCT (col1, col2, ...)) testing.
+ *
+ * Builds a COUNT DISTINCT aggregate where the child is a struct_pack BoundFunctionExpression
+ * wrapping the specified columns. This mirrors the expression tree produced by DuckDB for
+ * `count(distinct (col_a, col_b))`.
+ *
+ * @param key_col_infos  {LogicalType, col_idx} pairs for GROUP BY key columns
+ * @param struct_col_infos  {LogicalType, col_idx} pairs for the struct_pack children
+ * @return AggregateExpressionResult with output types, groups, and aggregate expressions
+ */
+inline AggregateExpressionResult create_count_distinct_struct_col_expressions(
+  const std::vector<std::pair<duckdb::LogicalType, std::size_t>>& key_col_infos,
+  const std::vector<std::pair<duckdb::LogicalType, std::size_t>>& struct_col_infos)
+{
+  AggregateExpressionResult result;
+
+  // Output types: one BIGINT count distinct result per group key
+  for (const auto& [type, idx] : key_col_infos) {
+    result.output_types.push_back(type);
+  }
+  result.output_types.push_back(duckdb::LogicalType::BIGINT);
+
+  // Group expressions
+  for (const auto& [type, idx] : key_col_infos) {
+    result.groups.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(type, idx));
+  }
+
+  // Build struct_pack(col1, col2, ...) as a BoundFunctionExpression
+  duckdb::vector<duckdb::LogicalType> struct_arg_types;
+  duckdb::child_list_t<duckdb::LogicalType> struct_fields;
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> struct_children;
+  for (std::size_t i = 0; i < struct_col_infos.size(); ++i) {
+    const auto& [type, col_idx] = struct_col_infos[i];
+    struct_arg_types.push_back(type);
+    struct_fields.emplace_back("v" + std::to_string(i), type);
+    struct_children.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(type, col_idx));
+  }
+  auto struct_return_type = duckdb::LogicalType::STRUCT(struct_fields);
+
+  duckdb::ScalarFunction struct_fn("struct_pack", struct_arg_types, struct_return_type, nullptr);
+  auto struct_expr = duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    struct_return_type, std::move(struct_fn), std::move(struct_children), nullptr);
+
+  // COUNT(DISTINCT struct_expr) aggregate expression
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_children;
+  agg_children.push_back(std::move(struct_expr));
+
+  auto agg_fn = MakeDummyAggregate("count", {struct_return_type}, duckdb::LogicalType::BIGINT);
+  result.aggregates.push_back(
+    duckdb::make_uniq<duckdb::BoundAggregateExpression>(agg_fn,
+                                                        std::move(agg_children),
+                                                        nullptr,  // filter
+                                                        nullptr,  // bind_info
+                                                        duckdb::AggregateType::DISTINCT));
   return result;
 }
 

--- a/test/cpp/operator/aggregate/aggregate_test_utils.hpp
+++ b/test/cpp/operator/aggregate/aggregate_test_utils.hpp
@@ -405,5 +405,54 @@ make_test_data_for_grouped_aggregate_with_avg(std::size_t num_groups,
   return {std::move(input_table), std::move(expected_table)};
 }
 
+/**
+ * @brief Create DuckDB aggregate expressions for COUNT(DISTINCT col) testing.
+ *
+ * Produces a single DISTINCT count aggregate expression referencing `agg_col_idx`,
+ * grouped by the columns at `group_indexes`. The count result type is BIGINT.
+ *
+ * @tparam KeyTraits Type traits for the GROUP BY key column(s)
+ * @tparam ValTraits Type traits for the column whose distinct values are counted
+ * @param group_indexes Column indices for GROUP BY expressions
+ * @param agg_col_idx Column index of the value column for COUNT(DISTINCT ...)
+ * @return AggregateExpressionResult containing output types, group, and aggregate expressions
+ */
+template <typename KeyTraits, typename ValTraits = KeyTraits>
+AggregateExpressionResult create_count_distinct_expressions(
+  const std::vector<std::size_t>& group_indexes, std::size_t agg_col_idx)
+{
+  AggregateExpressionResult result;
+
+  // Output types: one per group key column, then BIGINT for the distinct count
+  for (std::size_t i = 0; i < group_indexes.size(); ++i) {
+    result.output_types.push_back(KeyTraits::logical_type());
+  }
+  result.output_types.push_back(duckdb::LogicalType::BIGINT);
+
+  // Group expressions
+  for (std::size_t group_idx : group_indexes) {
+    result.groups.push_back(
+      duckdb::make_uniq<duckdb::BoundReferenceExpression>(KeyTraits::logical_type(), group_idx));
+  }
+
+  // COUNT(DISTINCT agg_col_idx) aggregate expression
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_children;
+  agg_children.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(ValTraits::logical_type(), agg_col_idx));
+
+  duckdb::AggregateFunction agg_function =
+    MakeDummyAggregate("count", {ValTraits::logical_type()}, duckdb::LogicalType::BIGINT);
+
+  auto agg_expr =
+    duckdb::make_uniq<duckdb::BoundAggregateExpression>(agg_function,
+                                                        std::move(agg_children),
+                                                        nullptr,  // filter
+                                                        nullptr,  // bind_info
+                                                        duckdb::AggregateType::DISTINCT);
+
+  result.aggregates.push_back(std::move(agg_expr));
+  return result;
+}
+
 }  // namespace test
 }  // namespace sirius

--- a/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
@@ -527,6 +527,7 @@ batches_with_handles create_batches_with_local_grouped_agg_result(
                                                              group_idx,
                                                              aggregates,
                                                              aggregate_idx,
+                                                             {},
                                                              cudf::get_default_stream(),
                                                              mem_space);
     REQUIRE(batch->try_to_create_task());

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
@@ -529,3 +529,79 @@ TEST_CASE("count distinct: multiple partitions with multiple batches per partiti
   REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
     result_p1->get_data_batches()[0], expected_p1->view(), true /*sort*/));
 }
+
+// ===========================================================================
+// TEST 6: Multi-column COUNT(DISTINCT (col_a, col_b))
+//
+// Distinct counts are over COMBINATIONS of (col_a, col_b), not individual cols.
+//
+// Input (col0=key, col1=val_a, col2=val_b):
+//   key=0: (10,1),(10,2),(10,1),(20,1)  → {(10,1),(10,2),(20,1)} → 3
+//   key=1: (30,3),(30,3),(40,3)          → {(30,3),(40,3)}         → 2
+//
+// Exercises:
+//   - (10,1) appearing twice counts once (intra-batch dedup).
+//   - (10,1) and (10,2) are different combos and both counted.
+//   - Multiple batches per partition: same combo in different batches counts once.
+// ===========================================================================
+TEST_CASE("count distinct: multi-column struct expression",
+          "[physical_grouped_aggregate_count_distinct]")
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<int32_t>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  // Input table: 3 columns — key (col0), val_a (col1), val_b (col2)
+  auto make_3col_input = [&](const std::vector<int32_t>& keys,
+                             const std::vector<int32_t>& val_a,
+                             const std::vector<int32_t>& val_b) {
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(vector_to_cudf_column<KeyTraits>(keys, stream, mr));
+    cols.push_back(vector_to_cudf_column<ValTraits>(val_a, stream, mr));
+    cols.push_back(vector_to_cudf_column<ValTraits>(val_b, stream, mr));
+    return std::make_unique<cudf::table>(std::move(cols));
+  };
+
+  // Batch 1
+  auto batch1 =
+    sirius::make_data_batch(make_3col_input({0, 0, 1, 1}, {10, 10, 30, 30}, {1, 1, 3, 3}), *space);
+
+  // Batch 2 — introduces new combos and cross-batch dups
+  auto batch2 =
+    sirius::make_data_batch(make_3col_input({0, 0, 0, 1}, {10, 10, 20, 40}, {2, 1, 1, 3}), *space);
+
+  // Expected: key=0 → 3 (combos: (10,1),(10,2),(20,1)), key=1 → 2 (combos: (30,3),(40,3))
+  auto expected_table = make_count_distinct_expected({0, 1}, {3, 2}, stream, mr);
+
+  // Build COUNT(DISTINCT (col1, col2)) grouped by col0
+  auto agg_spec = sirius::test::create_count_distinct_struct_col_expressions(
+    {{duckdb::LogicalType::INTEGER, 0}},  // GROUP BY col0
+    {{duckdb::LogicalType::INTEGER, 1},   // struct_pack(col1, col2)
+     {duckdb::LogicalType::INTEGER, 2}});
+
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(agg_spec.output_types),
+                                             std::move(agg_spec.aggregates),
+                                             std::move(agg_spec.groups),
+                                             2 /*estimated_cardinality*/);
+  sirius_physical_grouped_aggregate_merge merge_op(&local_op);
+
+  auto local1 = run_local(local_op, batch1);
+  auto local2 = run_local(local_op, batch2);
+
+  auto final_out = merge_op.execute(
+    operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}), default_stream());
+  REQUIRE(final_out->get_data_batches().size() == 1);
+
+  REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
+    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/));
+}

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
@@ -1,0 +1,531 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for COUNT(DISTINCT col) via sirius_physical_grouped_aggregate +
+// sirius_physical_grouped_aggregate_merge.  Scenarios exercised:
+//
+//   1. Single batch: verifies the local COLLECT_SET → merge count_elements pipeline.
+//   2. Multiple batches (randomly striped): verifies correctness when a group's rows
+//      are spread across several input batches within a partition.
+//   3. Cross-batch duplicates within a partition: the critical test that the same
+//      (key, value) pair appearing in multiple local aggregate outputs is counted
+//      only once after MERGE_SETS. Partitions are mutually exclusive by group key,
+//      but a partition receives multiple batches each processed independently.
+//   4. Mixed count(distinct) + other aggregations.
+//   5. Multiple partitions: verifies that separate execute() calls per partition
+//      (as done by the real pipeline) each produce correct results.
+
+#include "../operator_test_utils.hpp"
+#include "../operator_type_traits.hpp"
+#include "aggregate_test_utils.hpp"
+#include "data/data_batch_utils.hpp"
+#include "op/sirius_physical_grouped_aggregate.hpp"
+#include "op/sirius_physical_grouped_aggregate_merge.hpp"
+#include "utils/data_utils.hpp"
+#include "utils/test_validation_utility.hpp"
+
+#include <cudf/table/table.hpp>
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+#include <memory>
+#include <numeric>
+#include <vector>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using namespace sirius::test::operator_utils;
+using sirius::test::vector_to_cudf_column;
+
+// ---------------------------------------------------------------------------
+// Helper: build input table [key_col (int32), val_col (T)]
+// ---------------------------------------------------------------------------
+template <typename ValTraits>
+std::unique_ptr<cudf::table> make_count_distinct_input(
+  const std::vector<int32_t>& keys,
+  const std::vector<typename ValTraits::type>& values,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(vector_to_cudf_column<gpu_type_traits<int32_t>>(keys, stream, mr));
+  cols.push_back(vector_to_cudf_column<ValTraits>(values, stream, mr));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build expected output table [key (int32), count_distinct (int64)]
+// ---------------------------------------------------------------------------
+std::unique_ptr<cudf::table> make_count_distinct_expected(const std::vector<int32_t>& exp_keys,
+                                                          const std::vector<int64_t>& exp_counts,
+                                                          rmm::cuda_stream_view stream,
+                                                          rmm::device_async_resource_ref mr)
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(vector_to_cudf_column<gpu_type_traits<int32_t>>(exp_keys, stream, mr));
+  cols.push_back(vector_to_cudf_column<gpu_type_traits<int64_t>>(exp_counts, stream, mr));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run local aggregate on one batch and return the output data_batch
+// ---------------------------------------------------------------------------
+std::shared_ptr<data_batch> run_local(sirius_physical_grouped_aggregate& local_op,
+                                      std::shared_ptr<data_batch> input)
+{
+  auto out = local_op.execute(operator_data(std::vector<std::shared_ptr<data_batch>>{input}),
+                              default_stream());
+  REQUIRE(out->get_data_batches().size() == 1);
+  return out->get_data_batches()[0];
+}
+
+}  // namespace
+
+// ===========================================================================
+// TEST 1: Single batch - basic correctness
+//
+// Data layout: col0=key (int32), col1=value (int32)
+//   key=0 → values [10, 20, 10, 30, 20]  → distinct: {10,20,30} → count=3
+//   key=1 → values [40, 50, 40]           → distinct: {40,50}    → count=2
+//   key=2 → values [60, 60, 60]           → distinct: {60}       → count=1
+// ===========================================================================
+TEST_CASE("count distinct: single batch, basic correctness",
+          "[physical_grouped_aggregate_count_distinct]")
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<int32_t>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  std::vector<int32_t> keys   = {0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2};
+  std::vector<int32_t> values = {10, 20, 10, 30, 20, 40, 50, 40, 60, 60, 60};
+
+  auto input_batch =
+    sirius::make_data_batch(make_count_distinct_input<ValTraits>(keys, values, stream, mr), *space);
+
+  auto expected_table = make_count_distinct_expected({0, 1, 2}, {3, 2, 1}, stream, mr);
+
+  // Local operator
+  auto agg1 = sirius::test::create_count_distinct_expressions<KeyTraits, ValTraits>({0}, 1);
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(agg1.output_types),
+                                             std::move(agg1.aggregates),
+                                             std::move(agg1.groups),
+                                             3 /*estimated_cardinality*/);
+
+  // Merge operator (copies metadata from local_op)
+  sirius_physical_grouped_aggregate_merge merge_op(&local_op);
+
+  auto local_out = run_local(local_op, input_batch);
+
+  // Merge post-processes LIST → INT64 count, even for a single batch
+  auto final_out = merge_op.execute(
+    operator_data(std::vector<std::shared_ptr<data_batch>>{local_out}), default_stream());
+  REQUIRE(final_out->get_data_batches().size() == 1);
+
+  bool match = sirius::test::expect_data_batch_equivalent_to_table(
+    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+  REQUIRE(match);
+}
+
+// ===========================================================================
+// TEST 2: Multiple batches - randomly striped split
+//
+// The full dataset is randomly shuffled and split into 5 batches, ensuring
+// that most groups have rows spread across multiple partitions (and therefore
+// the same value may appear in several batches). MERGE_SETS must deduplicate.
+//
+// Data design: 30 groups, each group g contains values
+//   [g*100, g*100, g*100+1, g*100+1, g*100+2, g*100+2]
+// so exactly 3 distinct values per group.
+// ===========================================================================
+TEMPLATE_TEST_CASE("count distinct: multiple batches, randomly striped",
+                   "[physical_grouped_aggregate_count_distinct]",
+                   int32_t,
+                   int64_t)
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<TestType>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  constexpr int num_groups = 30;
+
+  // Build input: each group has 6 rows, 3 distinct values (each repeated twice)
+  std::vector<int32_t> keys;
+  std::vector<typename ValTraits::type> values;
+  keys.reserve(num_groups * 6);
+  values.reserve(num_groups * 6);
+
+  for (int g = 0; g < num_groups; ++g) {
+    auto base = static_cast<typename ValTraits::type>(g * 100);
+    for (int rep = 0; rep < 2; ++rep) {
+      keys.push_back(g);
+      values.push_back(base);
+      keys.push_back(g);
+      values.push_back(base + static_cast<typename ValTraits::type>(1));
+      keys.push_back(g);
+      values.push_back(base + static_cast<typename ValTraits::type>(2));
+    }
+  }
+
+  auto full_table = make_count_distinct_input<ValTraits>(keys, values, stream, mr);
+
+  // Split into 5 random, non-contiguous partitions
+  auto splits = sirius::test::make_random_striped_split(std::move(full_table), 5, stream, mr);
+
+  // Build expected: all groups have count_distinct == 3
+  std::vector<int32_t> exp_keys(num_groups);
+  std::iota(exp_keys.begin(), exp_keys.end(), 0);
+  std::vector<int64_t> exp_counts(num_groups, 3);
+  auto expected_table = make_count_distinct_expected(exp_keys, exp_counts, stream, mr);
+
+  // Local operator
+  auto agg1 = sirius::test::create_count_distinct_expressions<KeyTraits, ValTraits>({0}, 1);
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(agg1.output_types),
+                                             std::move(agg1.aggregates),
+                                             std::move(agg1.groups),
+                                             num_groups);
+
+  // Merge operator
+  sirius_physical_grouped_aggregate_merge merge_op(&local_op);
+
+  // Run local aggregate on each split
+  std::vector<std::shared_ptr<data_batch>> local_results;
+  for (auto& split : splits) {
+    auto input_batch = sirius::make_data_batch(std::move(split), *space);
+    local_results.push_back(run_local(local_op, input_batch));
+  }
+
+  // Merge all local results
+  auto final_out = merge_op.execute(operator_data(local_results), default_stream());
+  REQUIRE(final_out->get_data_batches().size() == 1);
+
+  bool match = sirius::test::expect_data_batch_equivalent_to_table(
+    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+  REQUIRE(match);
+}
+
+// ===========================================================================
+// TEST 3: Cross-batch duplicate deduplication within a partition
+//
+// Partitions are mutually exclusive by group key hash, but a single partition
+// receives multiple input batches processed independently by the local aggregate.
+// Each batch produces its own COLLECT_SET, so the same (key, value) pair can
+// appear in multiple local outputs for the same partition. MERGE_SETS must
+// union and deduplicate them.
+//
+// Batch 1: key=[0,0,1,2], val=[10,20,40,60]
+// Batch 2: key=[0,1,1,2], val=[10,50,40,60]  ← (0,10),(1,40),(2,60) are cross-batch dups
+// Batch 3: key=[0,1,2],   val=[30,40,60]     ← (1,40),(2,60) are cross-batch dups
+//
+// Expected:
+//   key=0 → distinct {10,20,30} → 3
+//   key=1 → distinct {40,50}    → 2
+//   key=2 → distinct {60}       → 1
+// ===========================================================================
+TEST_CASE("count distinct: cross-batch duplicate deduplication within a partition",
+          "[physical_grouped_aggregate_count_distinct]")
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<int32_t>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  // Batch 1
+  auto batch1 = sirius::make_data_batch(
+    make_count_distinct_input<ValTraits>({0, 0, 1, 2}, {10, 20, 40, 60}, stream, mr), *space);
+
+  // Batch 2 — intentional cross-batch dups: (0,10), (1,40), (2,60)
+  auto batch2 = sirius::make_data_batch(
+    make_count_distinct_input<ValTraits>({0, 1, 1, 2}, {10, 50, 40, 60}, stream, mr), *space);
+
+  // Batch 3 — further cross-batch dups: (1,40), (2,60)
+  auto batch3 = sirius::make_data_batch(
+    make_count_distinct_input<ValTraits>({0, 1, 2}, {30, 40, 60}, stream, mr), *space);
+
+  auto expected_table = make_count_distinct_expected({0, 1, 2}, {3, 2, 1}, stream, mr);
+
+  // Local operator (shared across all batches)
+  auto agg1 = sirius::test::create_count_distinct_expressions<KeyTraits, ValTraits>({0}, 1);
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(agg1.output_types),
+                                             std::move(agg1.aggregates),
+                                             std::move(agg1.groups),
+                                             3 /*estimated_cardinality*/);
+
+  sirius_physical_grouped_aggregate_merge merge_op(&local_op);
+
+  std::vector<std::shared_ptr<data_batch>> local_results;
+  local_results.push_back(run_local(local_op, batch1));
+  local_results.push_back(run_local(local_op, batch2));
+  local_results.push_back(run_local(local_op, batch3));
+
+  auto final_out = merge_op.execute(operator_data(local_results), default_stream());
+  REQUIRE(final_out->get_data_batches().size() == 1);
+
+  bool match = sirius::test::expect_data_batch_equivalent_to_table(
+    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+  REQUIRE(match);
+}
+
+// ===========================================================================
+// TEST 4: Count distinct mixed with regular aggregations
+//
+// Verifies that count(distinct val) coexists correctly with count(val) and
+// min(val) in the same grouped aggregate.
+//
+// Input (col0=key, col1=val):
+//   key=0: val=[10,10,20,20,30] → count_distinct=3, min=10, count=5
+//   key=1: val=[40,40,50]       → count_distinct=2, min=40, count=3
+//
+// The expression order is: [count(distinct val), min(val), count(val)]
+// so the output columns are: [key, count_distinct(int64), min(int32), count(int64)]
+// ===========================================================================
+TEST_CASE("count distinct: mixed with regular aggregations, multiple batches",
+          "[physical_grouped_aggregate_count_distinct]")
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<int32_t>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  // Batch 1 and Batch 2 together form the full dataset:
+  // key=0: [10,10,20] ++ [20,30]  → {10,20,30} → count_distinct=3, min=10, count=5
+  // key=1: [40,40]    ++ [50]     → {40,50}    → count_distinct=2, min=40, count=3
+  auto batch1 = sirius::make_data_batch(
+    make_count_distinct_input<ValTraits>({0, 0, 0, 1, 1}, {10, 10, 20, 40, 40}, stream, mr),
+    *space);
+
+  auto batch2 = sirius::make_data_batch(
+    make_count_distinct_input<ValTraits>({0, 0, 1}, {20, 30, 50}, stream, mr), *space);
+
+  // Build expected: [key(int32) | count_distinct(int64) | min(int32) | count(int64)]
+  std::vector<std::unique_ptr<cudf::column>> exp_cols;
+  exp_cols.push_back(vector_to_cudf_column<KeyTraits>({0, 1}, stream, mr));
+  exp_cols.push_back(
+    vector_to_cudf_column<gpu_type_traits<int64_t>>({3, 2}, stream, mr));      // count distinct
+  exp_cols.push_back(vector_to_cudf_column<ValTraits>({10, 40}, stream, mr));  // min
+  exp_cols.push_back(vector_to_cudf_column<gpu_type_traits<int64_t>>({5, 3}, stream, mr));  // count
+  auto expected_table = std::make_unique<cudf::table>(std::move(exp_cols));
+
+  // Build expressions: [count(distinct col1), min(col1), count(col1)]
+  duckdb::vector<duckdb::LogicalType> output_types;
+  output_types.push_back(KeyTraits::logical_type());    // group key
+  output_types.push_back(duckdb::LogicalType::BIGINT);  // count distinct
+  output_types.push_back(ValTraits::logical_type());    // min
+  output_types.push_back(duckdb::LogicalType::BIGINT);  // count
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups;
+  groups.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(KeyTraits::logical_type(), 0));
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
+
+  // count(distinct col1)
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> ch;
+    ch.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(ValTraits::logical_type(), 1));
+    auto fn = sirius::test::MakeDummyAggregate(
+      "count", {ValTraits::logical_type()}, duckdb::LogicalType::BIGINT);
+    aggregates.push_back(duckdb::make_uniq<duckdb::BoundAggregateExpression>(
+      fn, std::move(ch), nullptr, nullptr, duckdb::AggregateType::DISTINCT));
+  }
+  // min(col1)
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> ch;
+    ch.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(ValTraits::logical_type(), 1));
+    auto fn = sirius::test::MakeDummyAggregate(
+      "min", {ValTraits::logical_type()}, ValTraits::logical_type());
+    aggregates.push_back(duckdb::make_uniq<duckdb::BoundAggregateExpression>(
+      fn, std::move(ch), nullptr, nullptr, duckdb::AggregateType::NON_DISTINCT));
+  }
+  // count(col1)
+  {
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> ch;
+    ch.push_back(duckdb::make_uniq<duckdb::BoundReferenceExpression>(ValTraits::logical_type(), 1));
+    auto fn = sirius::test::MakeDummyAggregate(
+      "count", {ValTraits::logical_type()}, ValTraits::logical_type());
+    aggregates.push_back(duckdb::make_uniq<duckdb::BoundAggregateExpression>(
+      fn, std::move(ch), nullptr, nullptr, duckdb::AggregateType::NON_DISTINCT));
+  }
+
+  // Clone expressions for merge operator (it takes the same spec)
+  duckdb::vector<duckdb::LogicalType> output_types2 = output_types;
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups2;
+  groups2.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(KeyTraits::logical_type(), 0));
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates2;
+  for (auto& agg : aggregates) {
+    aggregates2.push_back(agg->Copy());
+  }
+
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(output_types),
+                                             std::move(aggregates),
+                                             std::move(groups),
+                                             2 /*estimated_cardinality*/);
+
+  sirius_physical_grouped_aggregate_merge merge_op(context,
+                                                   std::move(output_types2),
+                                                   std::move(aggregates2),
+                                                   std::move(groups2),
+                                                   2 /*estimated_cardinality*/);
+
+  auto local1 = run_local(local_op, batch1);
+  auto local2 = run_local(local_op, batch2);
+
+  auto final_out = merge_op.execute(
+    operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}), default_stream());
+  REQUIRE(final_out->get_data_batches().size() == 1);
+
+  bool match = sirius::test::expect_data_batch_equivalent_to_table(
+    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+  REQUIRE(match);
+}
+
+// ===========================================================================
+// TEST 5: Multiple partitions - separate execute() calls per partition
+//
+// In the real pipeline, sirius_physical_partition distributes rows by group-key
+// hash so each group belongs to exactly ONE partition.  The merge operator's
+// execute() is then called once per partition with ALL of that partition's local
+// aggregate outputs.  This test replicates that structure:
+//
+//   Partition 0 owns keys {0, 1, 2}  – 3 batches each
+//   Partition 1 owns keys {3, 4}     – 3 batches each
+//
+// Each batch is a random stripe of its partition's rows, so the same value can
+// appear in multiple batches (cross-batch dedup must work within a partition).
+//
+// Expected per group: exactly 4 distinct values (val = key*10 + {0,1,2,3}).
+// The merge operator is called independently for each partition and the per-
+// partition result is verified separately — exactly as the real engine does it.
+// ===========================================================================
+TEST_CASE("count distinct: multiple partitions with multiple batches per partition",
+          "[physical_grouped_aggregate_count_distinct]")
+{
+  using KeyTraits = gpu_type_traits<int32_t>;
+  using ValTraits = gpu_type_traits<int32_t>;
+
+  auto memory_manager = sirius::test::operator_utils::initialize_memory_manager();
+  auto* space         = memory_manager->get_memory_space(Tier::GPU, 0);
+  REQUIRE(space != nullptr);
+  auto mr     = get_resource_ref(*space);
+  auto stream = default_stream();
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+  auto& context = *con.context;
+
+  // Helper: build [key_col, val_col] where each group g gets values
+  //   {g*10+0, g*10+1, g*10+2, g*10+3} each repeated twice (8 rows per group)
+  auto make_partition_table = [&](const std::vector<int32_t>& group_keys) {
+    std::vector<int32_t> keys, values;
+    for (int g : group_keys) {
+      for (int v = 0; v < 4; ++v) {
+        // Repeat each distinct value twice so dedup is exercised within a batch
+        keys.push_back(g);
+        values.push_back(g * 10 + v);
+        keys.push_back(g);
+        values.push_back(g * 10 + v);
+      }
+    }
+    return make_count_distinct_input<ValTraits>(keys, values, stream, mr);
+  };
+
+  // Partition 0: keys 0, 1, 2
+  auto table0  = make_partition_table({0, 1, 2});
+  auto splits0 = sirius::test::make_random_striped_split(std::move(table0), 3, stream, mr);
+
+  // Partition 1: keys 3, 4
+  auto table1  = make_partition_table({3, 4});
+  auto splits1 = sirius::test::make_random_striped_split(std::move(table1), 3, stream, mr);
+
+  // Shared local + merge operators
+  auto agg_spec = sirius::test::create_count_distinct_expressions<KeyTraits, ValTraits>({0}, 1);
+  sirius_physical_grouped_aggregate local_op(context,
+                                             std::move(agg_spec.output_types),
+                                             std::move(agg_spec.aggregates),
+                                             std::move(agg_spec.groups),
+                                             5 /*estimated_cardinality*/);
+  sirius_physical_grouped_aggregate_merge merge_op(&local_op);
+
+  // --- Process partition 0 (separate execute() call, as the real pipeline does) ---
+  std::vector<std::shared_ptr<data_batch>> local_p0;
+  for (auto& split : splits0) {
+    local_p0.push_back(run_local(local_op, sirius::make_data_batch(std::move(split), *space)));
+  }
+  auto result_p0 = merge_op.execute(operator_data(local_p0), default_stream());
+  REQUIRE(result_p0->get_data_batches().size() == 1);
+
+  auto expected_p0 = make_count_distinct_expected({0, 1, 2}, {4, 4, 4}, stream, mr);
+  REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
+    result_p0->get_data_batches()[0], expected_p0->view(), true /*sort*/));
+
+  // --- Process partition 1 (separate execute() call) ---
+  std::vector<std::shared_ptr<data_batch>> local_p1;
+  for (auto& split : splits1) {
+    local_p1.push_back(run_local(local_op, sirius::make_data_batch(std::move(split), *space)));
+  }
+  auto result_p1 = merge_op.execute(operator_data(local_p1), default_stream());
+  REQUIRE(result_p1->get_data_batches().size() == 1);
+
+  auto expected_p1 = make_count_distinct_expected({3, 4}, {4, 4}, stream, mr);
+  REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
+    result_p1->get_data_batches()[0], expected_p1->view(), true /*sort*/));
+}


### PR DESCRIPTION
## Summary

Adds `COUNT(DISTINCT col)` support to the grouped aggregation pipeline using cuDF's `collect_set` / `merge_sets` aggregations.

### How it works

The implementation uses a three-phase pipeline:

1. **Local phase** — `COLLECT_SET` groups rows by key and collects distinct values into a LIST column per group per batch
2. **Merge phase** — `MERGE_SETS` unions the per-batch LIST columns and deduplicates across all batches in a partition, producing one deduplicated LIST per group
3. **Post-processing** — `cudf::lists::count_elements` counts the list length per row and casts to INT64 to produce the final count

This follows the same decomposition pattern already used for AVG (SUM+COUNT), extended via the `AggregateSlot` struct.

### Changes

**Core aggregation logic**
- `aggregate_op_util`: Added `is_count_distinct` to `AggregateSlot` and `has_count_distinct` to `CudfAggregateDefinitions`. Detection: `aggr.IsDistinct() && aggr.function.name == "count"` maps to `COLLECT_SET`
- `gpu_aggregate_impl`: `COLLECT_SET` is handled with an explicit branch before the generic `get_local_aggregation<>` template — necessary because that template is also instantiated with `cudf::reduce_aggregation` for ungrouped aggregates, where `make_collect_set_aggregation` does not exist. The INT64 cast guard (COUNT_VALID/COUNT_ALL) also skips `COLLECT_SET` since its output is a LIST
- `gpu_merge_impl`: Added `COLLECT_SET → MERGE_SETS` case in `merge_grouped_aggregate`
- `sirius_physical_grouped_aggregate_merge`: Added `count_elements` + INT64 cast post-processing step. Fast path (`return input unchanged`) is now also bypassed when `has_count_distinct` is set

**Planner**
- Removed the `IsDistinct()` rejection from `can_use_partitioned_aggregate`. It was a no-op: all three planner paths (partitioned, perfect-hash, default) create the same `sirius_physical_grouped_aggregate` operator

**Test infrastructure**
- Replaced `#define PARTITION_SIZE 10000000` in `sirius_physical_partition` with a static member and `set_partition_size()` / `reset_partition_size()` methods, so integration tests can force multiple partitions without changing the production default

### Tests

**Unit tests** (`test_physical_grouped_aggregate_count_distinct.cpp`)
1. Single batch, basic correctness — hand-verified expected counts
2. Multiple batches, randomly striped — `int32` and `int64` value columns (TEMPLATE_TEST_CASE), 30 groups × 3 distinct values split into 5 random batches
3. Cross-batch duplicate deduplication — same `(key, value)` intentionally appears in multiple batches; `MERGE_SETS` must count it once
4. Mixed `count(distinct)` + `min` + `count(*)` in the same grouped aggregate
5. Multiple partitions — two independent groups of keys, each split into 3 random batches; `execute()` called separately per group of batches, exactly as the real engine does

**Integration tests** (`test_gpu_execution_tpch.cpp`) — all compare GPU vs CPU results:
- `count(distinct n_nationkey)` grouped by region key on `nation`
- `count(distinct n_name)` (string column) grouped by region key on `nation`
- Mixed `count(distinct)` + `min` + `count(*)` on `nation`
- Two group keys on `customer` (15k rows)
- Three multi-partition variants using a `PartitionSizeGuard` RAII helper that lowers `PARTITION_SIZE` to force 5 partitions (`nation`) and 15 partitions (`customer`) through the real pipeline

fixes #225 