### PR TITLE
Casting aggregate output columns to their expected types

### DIFF
--- a/src/include/data/data_batch_utils.hpp
+++ b/src/include/data/data_batch_utils.hpp
@@ -16,15 +16,22 @@
 
 #pragma once
 
+#include "cudf/cudf_utils.hpp"
+#include "log/logging.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
 
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
+#include <duckdb/common/types.hpp>
 
 #include <atomic>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace sirius {
@@ -85,6 +92,56 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), memory_space);
   return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
+}
+
+/**
+ * @brief Cast batch columns to match expected DuckDB LogicalTypes (e.g. decimal64 -> decimal128).
+ *
+ * If the batch has a different number of columns than expected_types, or all columns already
+ * match their expected type, returns the original batch. Otherwise returns a new batch with
+ * columns cast to their expected type.
+ *
+ * @param batch The data batch to cast (may be null).
+ * @param expected_types Expected output types (one per column).
+ * @param stream CUDA stream for allocations and casts.
+ * @return The original batch if no casts needed or on error; otherwise a new batch.
+ */
+inline std::shared_ptr<cucascade::data_batch> cast_batch_to_expected_types(
+  const std::shared_ptr<cucascade::data_batch>& batch,
+  const duckdb::vector<duckdb::LogicalType>& expected_types,
+  rmm::cuda_stream_view stream)
+{
+  if (!batch || !batch->get_data()) { return batch; }
+  cudf::table_view tbl = get_cudf_table_view(*batch);
+  if (static_cast<size_t>(tbl.num_columns()) != expected_types.size()) {
+    SIRIUS_LOG_ERROR(
+      "cast_batch_to_expected_types: batch column count mismatch: got {}, expected {}",
+      tbl.num_columns(),
+      expected_types.size());
+    return batch;
+  }
+  auto* space = batch->get_memory_space();
+  if (!space) {
+    SIRIUS_LOG_ERROR("cast_batch_to_expected_types: Could not get memory space from batch");
+    return batch;
+  }
+  auto mr = space->get_default_allocator();
+  std::vector<std::unique_ptr<cudf::column>> out_cols;
+  out_cols.reserve(tbl.num_columns());
+  bool any_cast = false;
+  for (cudf::size_type c = 0; c < tbl.num_columns(); c++) {
+    cudf::data_type expected = duckdb::GetCudfType(expected_types[c]);
+    cudf::column_view col    = tbl.column(c);
+    if (col.type() != expected) {
+      out_cols.push_back(cudf::cast(col, expected, stream, mr));
+      any_cast = true;
+    } else {
+      out_cols.push_back(std::make_unique<cudf::column>(col, stream, mr));
+    }
+  }
+  if (!any_cast) { return batch; }
+  auto out_table = std::make_unique<cudf::table>(std::move(out_cols), stream, mr);
+  return make_data_batch(std::move(out_table), *space);
 }
 
 }  // namespace sirius

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -16,8 +16,7 @@
 
 #include "op/sirius_physical_grouped_aggregate.hpp"
 
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "log/logging.hpp"
+#include "data/data_batch_utils.hpp"
 #include "op/aggregate/aggregate_op_util.hpp"
 #include "op/aggregate/gpu_aggregate_impl.hpp"
 
@@ -176,7 +175,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
                                                               cudf_aggregate_idx,
                                                               stream,
                                                               *input_batch->get_memory_space());
-    results.push_back(std::move(result));
+    results.push_back(sirius::cast_batch_to_expected_types(result, get_types(), stream));
   }
   return std::make_unique<operator_data>(results);
 }

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -17,7 +17,6 @@
 
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "log/logging.hpp"
 #include "op/aggregate/aggregate_op_util.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 
@@ -189,7 +188,11 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   }
 
   // Fast path: single batch with no AVG needs no processing
-  if (input_batches.size() == 1 && !has_avg) { return std::make_unique<operator_data>(input_data); }
+  if (input_batches.size() == 1 && !has_avg) {
+    auto cast_batch = sirius::cast_batch_to_expected_types(input_batches[0], get_types(), stream);
+    return std::make_unique<operator_data>(
+      std::vector<std::shared_ptr<::cucascade::data_batch>>{cast_batch});
+  }
 
   // Merge multiple batches, or use single batch directly if only one
   std::shared_ptr<::cucascade::data_batch> merged;
@@ -203,10 +206,11 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
                                                      *input_batches[0]->get_memory_space());
   }
 
-  // If no AVG, return merged result directly
+  // If no AVG, return merged result directly (cast to expected types if needed)
   if (!has_avg) {
+    auto cast_batch = sirius::cast_batch_to_expected_types(merged, get_types(), stream);
     return std::make_unique<operator_data>(
-      std::vector<std::shared_ptr<::cucascade::data_batch>>{merged});
+      std::vector<std::shared_ptr<::cucascade::data_batch>>{cast_batch});
   }
 
   // Post-merge AVG projection: compute SUM/COUNT for each AVG aggregate.
@@ -264,8 +268,9 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 
   auto output_table = std::make_unique<cudf::table>(std::move(output_cols), stream, mr);
   auto result       = sirius::make_data_batch(std::move(output_table), *space);
+  auto cast_batch   = sirius::cast_batch_to_expected_types(result, get_types(), stream);
   return std::make_unique<operator_data>(
-    std::vector<std::shared_ptr<::cucascade::data_batch>>{result});
+    std::vector<std::shared_ptr<::cucascade::data_batch>>{cast_batch});
 }
 }  // namespace op
 }  // namespace sirius


### PR DESCRIPTION
To fix a type mismatch error downstream, this PR adds a casting step at the end of aggregation that checks the types of the output columns and casts them to the expected types (set during plan creation) if needed.