### PR TITLE
Cast sum result from decimal64 to decimal128

### DIFF
--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -222,29 +222,29 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
       auto result_view = aggregation_result.results[j]->view();
       // Widen decimal result for SUM (expected by duckdb)
       if (requests[i].aggregations[j]->kind == cudf::aggregation::Kind::SUM) {
-        if (requests[i].values.type().id() == cudf::type_id::DECIMAL64 &&
-        aggregation_result.results[j] =
-        cudf::cast(result_view,
-          cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale());,
-                   stream,
-                   memory_space.get_default_allocator());
-        } else if (requests[i].values.type().id() == cudf::type_id::DECIMAL32 &&
-        aggregation_result.results[j] =
-        cudf::cast(result_view,
-          cudf::data_type(cudf::type_id::DECIMAL64, result_view.type().scale());,
-                   stream,
-                   memory_space.get_default_allocator());
+        if (requests[i].values.type().id() == cudf::type_id::DECIMAL64) {
+          aggregation_result.results[j] =
+            cudf::cast(result_view,
+                       cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale()),
+                       stream,
+                       memory_space.get_default_allocator());
+        } else if (requests[i].values.type().id() == cudf::type_id::DECIMAL32) {
+          aggregation_result.results[j] =
+            cudf::cast(result_view,
+                       cudf::data_type(cudf::type_id::DECIMAL64, result_view.type().scale()),
+                       stream,
+                       memory_space.get_default_allocator());
+        }
+      }
+      size_t output_col_id       = group_idx.size() + output_idx[j];
+      output_cols[output_col_id] = std::move(aggregation_result.results[j]);
     }
   }
-  size_t output_col_id       = group_idx.size() + output_idx[j];
-  output_cols[output_col_id] = std::move(aggregation_result.results[j]);
-}
-}
 
-// Create the output data batch
-auto output_table = std::make_unique<cudf::table>(
-  std::move(output_cols), stream, memory_space.get_default_allocator());
-return make_data_batch(std::move(output_table), memory_space);
+  // Create the output data batch
+  auto output_table = std::make_unique<cudf::table>(
+    std::move(output_cols), stream, memory_space.get_default_allocator());
+  return make_data_batch(std::move(output_table), memory_space);
 }
 
 }  // namespace op

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -219,23 +219,6 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
 
     const auto& output_idx = input_col_to_output_idx[aggregate_col_id];
     for (size_t j = 0; j < output_idx.size(); ++j) {
-      auto result_view = aggregation_result.results[j]->view();
-      // Widen decimal result for SUM (expected by duckdb)
-      if (requests[i].aggregations[j]->kind == cudf::aggregation::Kind::SUM) {
-        if (requests[i].values.type().id() == cudf::type_id::DECIMAL64) {
-          aggregation_result.results[j] =
-            cudf::cast(result_view,
-                       cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale()),
-                       stream,
-                       memory_space.get_default_allocator());
-        } else if (requests[i].values.type().id() == cudf::type_id::DECIMAL32) {
-          aggregation_result.results[j] =
-            cudf::cast(result_view,
-                       cudf::data_type(cudf::type_id::DECIMAL64, result_view.type().scale()),
-                       stream,
-                       memory_space.get_default_allocator());
-        }
-      }
       size_t output_col_id       = group_idx.size() + output_idx[j];
       output_cols[output_col_id] = std::move(aggregation_result.results[j]);
     }

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -209,6 +209,17 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
 
     const auto& output_idx = input_col_to_output_idx[aggregate_col_id];
     for (size_t j = 0; j < output_idx.size(); ++j) {
+      auto result_view = aggregation_result.results[j]->view();
+      // Cast result to DECIMAL128 when input and output are DECIMAL64 (expected by duckdb)
+      if (requests[i].aggregations[j]->kind == cudf::aggregation::Kind::SUM &&
+          requests[i].values.type().id() == cudf::type_id::DECIMAL64 &&
+          result_view.type().id() == cudf::type_id::DECIMAL64) {
+        aggregation_result.results[j] =
+          cudf::cast(result_view,
+                     cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale()),
+                     stream,
+                     memory_space.get_default_allocator());
+      }
       size_t output_col_id       = group_idx.size() + output_idx[j];
       output_cols[output_col_id] = std::move(aggregation_result.results[j]);
     }

--- a/src/op/aggregate/gpu_aggregate_impl.cpp
+++ b/src/op/aggregate/gpu_aggregate_impl.cpp
@@ -74,6 +74,16 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_ungrouped_aggre
             break;
           }
           default: break;
+          case cudf::type_id::DECIMAL64:
+            if (input_col.type().id() == cudf::type_id::DECIMAL64) {
+              output_type = cudf::data_type(cudf::type_id::DECIMAL128, output_type.scale());
+            }
+            break;
+          case cudf::type_id::DECIMAL32:
+            if (input_col.type().id() == cudf::type_id::DECIMAL32) {
+              output_type = cudf::data_type(cudf::type_id::DECIMAL64, output_type.scale());
+            }
+            break;
         }
         break;
       }
@@ -210,25 +220,31 @@ std::shared_ptr<cucascade::data_batch> gpu_aggregate_impl::local_grouped_aggrega
     const auto& output_idx = input_col_to_output_idx[aggregate_col_id];
     for (size_t j = 0; j < output_idx.size(); ++j) {
       auto result_view = aggregation_result.results[j]->view();
-      // Cast result to DECIMAL128 when input and output are DECIMAL64 (expected by duckdb)
-      if (requests[i].aggregations[j]->kind == cudf::aggregation::Kind::SUM &&
-          requests[i].values.type().id() == cudf::type_id::DECIMAL64 &&
-          result_view.type().id() == cudf::type_id::DECIMAL64) {
+      // Widen decimal result for SUM (expected by duckdb)
+      if (requests[i].aggregations[j]->kind == cudf::aggregation::Kind::SUM) {
+        if (requests[i].values.type().id() == cudf::type_id::DECIMAL64 &&
         aggregation_result.results[j] =
-          cudf::cast(result_view,
-                     cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale()),
-                     stream,
-                     memory_space.get_default_allocator());
-      }
-      size_t output_col_id       = group_idx.size() + output_idx[j];
-      output_cols[output_col_id] = std::move(aggregation_result.results[j]);
+        cudf::cast(result_view,
+          cudf::data_type(cudf::type_id::DECIMAL128, result_view.type().scale());,
+                   stream,
+                   memory_space.get_default_allocator());
+        } else if (requests[i].values.type().id() == cudf::type_id::DECIMAL32 &&
+        aggregation_result.results[j] =
+        cudf::cast(result_view,
+          cudf::data_type(cudf::type_id::DECIMAL64, result_view.type().scale());,
+                   stream,
+                   memory_space.get_default_allocator());
     }
   }
+  size_t output_col_id       = group_idx.size() + output_idx[j];
+  output_cols[output_col_id] = std::move(aggregation_result.results[j]);
+}
+}
 
-  // Create the output data batch
-  auto output_table = std::make_unique<cudf::table>(
-    std::move(output_cols), stream, memory_space.get_default_allocator());
-  return make_data_batch(std::move(output_table), memory_space);
+// Create the output data batch
+auto output_table = std::make_unique<cudf::table>(
+  std::move(output_cols), stream, memory_space.get_default_allocator());
+return make_data_batch(std::move(output_table), memory_space);
 }
 
 }  // namespace op

--- a/src/op/merge/gpu_merge_impl.cpp
+++ b/src/op/merge/gpu_merge_impl.cpp
@@ -175,6 +175,28 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
   auto concatenated =
     cudf::concatenate(input_cudf_table_views, stream, memory_space.get_default_allocator());
 
+  // Upcast decimal aggregate columns for SUM (DECIMAL32 -> DECIMAL64, DECIMAL64 -> DECIMAL128).
+  std::vector<std::unique_ptr<cudf::column>> upcasted_agg_cols(aggregates.size());
+  for (size_t i = 0; i < aggregates.size(); ++i) {
+    if (aggregates[i] == cudf::aggregation::Kind::SUM) {
+      int aggregate_col_id = num_group_cols + static_cast<int>(i);
+      auto col_view        = concatenated->get_column(aggregate_col_id).view();
+      if (col_view.type().id() == cudf::type_id::DECIMAL64) {
+        upcasted_agg_cols[i] =
+          cudf::cast(col_view,
+                     cudf::data_type(cudf::type_id::DECIMAL128, col_view.type().scale()),
+                     stream,
+                     memory_space.get_default_allocator());
+      } else if (col_view.type().id() == cudf::type_id::DECIMAL32) {
+        upcasted_agg_cols[i] =
+          cudf::cast(col_view,
+                     cudf::data_type(cudf::type_id::DECIMAL64, col_view.type().scale()),
+                     stream,
+                     memory_space.get_default_allocator());
+      }
+    }
+  }
+
   // Create cudf groupby and make aggregation requests.
   std::vector<cudf::column_view> group_cols;
   for (int c = 0; c < num_group_cols; ++c) {
@@ -185,7 +207,8 @@ std::shared_ptr<cucascade::data_batch> gpu_merge_impl::merge_grouped_aggregate(
   for (size_t i = 0; i < aggregates.size(); ++i) {
     int aggregate_col_id = num_group_cols + static_cast<int>(i);
     cudf::groupby::aggregation_request request;
-    request.values = concatenated->get_column(aggregate_col_id).view();
+    request.values = upcasted_agg_cols[i] ? upcasted_agg_cols[i]->view()
+                                          : concatenated->get_column(aggregate_col_id).view();
     switch (aggregates[i]) {
       case cudf::aggregation::Kind::MIN: {
         request.aggregations.push_back(cudf::make_min_aggregation<cudf::groupby_aggregation>());

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -197,11 +197,6 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       "We expect at least one input batch for grouped aggregate merge operator");
   }
 
-  // Fast path: single batch with no post-processing needed
-  if (input_batches.size() == 1 && !has_avg && !has_count_distinct) {
-    return std::make_unique<operator_data>(input_data);
-  }
-
   // Merge multiple batches, or use single batch directly if only one
   std::shared_ptr<::cucascade::data_batch> merged;
   if (input_batches.size() == 1) {
@@ -212,12 +207,6 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
                                                      cudf_aggregates,
                                                      stream,
                                                      *input_batches[0]->get_memory_space());
-  }
-
-  // If no post-processing needed, return merged result directly
-  if (!has_avg && !has_count_distinct) {
-    return std::make_unique<operator_data>(
-      std::vector<std::shared_ptr<::cucascade::data_batch>>{merged});
   }
 
   // Post-merge projection: handle AVG (SUM/COUNT) and COUNT DISTINCT (list element count).
@@ -276,8 +265,20 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
         cudf::cast(count_int32->view(), cudf::data_type{cudf::type_id::INT64}, stream, mr);
       output_cols.push_back(std::move(count_int64));
     } else {
-      // Move non-AVG, non-count-distinct aggregate columns directly (zero-copy)
+      // Move non-AVG aggregate columns, upcasting DECIMAL SUM columns if needed.
+      // In the single-batch fast path, merge_grouped_aggregate is skipped, so the upcast
+      // (DECIMAL32→DECIMAL64, DECIMAL64→DECIMAL128) that normally happens there must be applied
+      // here instead.
       int col_idx = num_group_cols + static_cast<int>(slot.cudf_idx);
+      if (cudf_aggregates[slot.cudf_idx] == cudf::aggregation::Kind::SUM) {
+        auto col_view = merged_cols[col_idx]->view();
+        if (col_view.type() != slot.output_type) {
+          merged_cols[col_idx] =
+            cudf::cast(col_view,                       slot.output_type,
+                       stream,
+                       mr);
+        } 
+      }
       output_cols.push_back(std::move(merged_cols[col_idx]));
     }
   }

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -273,11 +273,8 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       if (cudf_aggregates[slot.cudf_idx] == cudf::aggregation::Kind::SUM) {
         auto col_view = merged_cols[col_idx]->view();
         if (col_view.type() != slot.output_type) {
-          merged_cols[col_idx] =
-            cudf::cast(col_view,                       slot.output_type,
-                       stream,
-                       mr);
-        } 
+          merged_cols[col_idx] = cudf::cast(col_view, slot.output_type, stream, mr);
+        }
       }
       output_cols.push_back(std::move(merged_cols[col_idx]));
     }

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -272,8 +272,18 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       int col_idx = num_group_cols + static_cast<int>(slot.cudf_idx);
       if (cudf_aggregates[slot.cudf_idx] == cudf::aggregation::Kind::SUM) {
         auto col_view = merged_cols[col_idx]->view();
-        if (col_view.type() != slot.output_type) {
-          merged_cols[col_idx] = cudf::cast(col_view, slot.output_type, stream, mr);
+        if (col_view.type().id() == cudf::type_id::DECIMAL64) {
+          merged_cols[col_idx] =
+            cudf::cast(col_view,
+                       cudf::data_type(cudf::type_id::DECIMAL128, col_view.type().scale()),
+                       stream,
+                       mr);
+        } else if (col_view.type().id() == cudf::type_id::DECIMAL32) {
+          merged_cols[col_idx] =
+            cudf::cast(col_view,
+                       cudf::data_type(cudf::type_id::DECIMAL64, col_view.type().scale()),
+                       stream,
+                       mr);
         }
       }
       output_cols.push_back(std::move(merged_cols[col_idx]));


### PR DESCRIPTION
A more targeted approach than #270. The source of of the type mismatch is in the expected widening of decimal64 to decimal128 which duckdb expects but libcudf does not perform implicitly.