### PR TITLE
 Fix ORDER BY merge sort producing incorrect results (query 09 validation)

### DIFF
--- a/src/include/op/sirius_physical_merge_sort.hpp
+++ b/src/include/op/sirius_physical_merge_sort.hpp
@@ -20,6 +20,8 @@
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_order.hpp"
 
+#include <mutex>
+
 namespace sirius {
 namespace op {
 
@@ -59,6 +61,8 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
   bool sink_order_dependent() const override { return false; }
 
  public:
+  std::unique_ptr<operator_data> get_next_task_input_data() override;
+
   std::unique_ptr<operator_data> execute(
     const operator_data& input_data,
     rmm::cuda_stream_view stream = cudf::get_default_stream()) override;
@@ -74,6 +78,10 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
  private:
   //! Final projection to apply after merge (empty = no extra projection)
   duckdb::vector<duckdb::idx_t> _final_projections;
+  //! Guards concurrent calls to get_next_task_input_data().
+  std::mutex _drain_mutex;
+  //! Tracks which partition to drain next (one task per partition).
+  size_t _current_partition_index{0};
 };
 
 }  // namespace op

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -51,12 +51,36 @@ sirius_physical_merge_sort::sirius_physical_merge_sort(
 {
 }
 
+std::unique_ptr<operator_data> sirius_physical_merge_sort::get_next_task_input_data()
+{
+  // Drain all batches from one partition per call (one merge task per partition).
+  // Follows the same pattern as sirius_physical_grouped_aggregate_merge.
+  std::lock_guard<std::mutex> lg(_drain_mutex);
+
+  auto* repo = ports.begin()->second->repo;
+  if (_current_partition_index < repo->num_partitions()) {
+    std::vector<std::shared_ptr<cucascade::data_batch>> all_batches;
+    while (true) {
+      auto batch =
+        repo->pop_data_batch(cucascade::batch_state::task_created, _current_partition_index);
+      if (!batch) { break; }
+      all_batches.push_back(std::move(batch));
+    }
+    _current_partition_index++;
+    SIRIUS_LOG_DEBUG("merge_sort: drained {} batches for partition {}",
+                     all_batches.size(),
+                     _current_partition_index - 1);
+    return std::make_unique<operator_data>(all_batches);
+  }
+  return nullptr;
+}
+
 std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operator_data& input_data,
                                                                    rmm::cuda_stream_view stream)
 {
   const auto& input_batches = input_data.get_data_batches();
 
-  SIRIUS_LOG_DEBUG("Executing merge sort");
+  SIRIUS_LOG_DEBUG("Executing merge sort with {} input batches", input_batches.size());
   auto start = std::chrono::high_resolution_clock::now();
 
   // Collect valid batches and find memory space
@@ -120,7 +144,9 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
 
   auto end      = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  SIRIUS_LOG_DEBUG("Merge sort time: {:.2f} ms", duration.count() / 1000.0);
+  SIRIUS_LOG_DEBUG("Merge sort time: {:.2f} ms ({} batches merged)",
+                   duration.count() / 1000.0,
+                   valid_batches.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   if (merged_batch) { outputs.push_back(apply_final_projection(std::move(merged_batch))); }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -872,14 +872,14 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
                  new_scheduled[i]->sink->type ==
                    op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE ||
                  new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::TOP_N ||
-                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT) {
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT ||
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_PARTITION) {
         // Full barrier operators — wait for upstream to finish before processing
         for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {
           insert_repository("default", new_scheduled[i], dependent_pipeline);
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
-                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE ||
-                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_PARTITION) {
+                 new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE) {
         // Pipeline barrier — sort operators process batches as they arrive
         // (sort_sample overrides get_next_task_hint to wait for N batches)
         for (auto dependent_pipeline : source_to_pipelines[new_scheduled[i]->get_sink().get()]) {


### PR DESCRIPTION
## Fix ORDER BY merge sort producing incorrect results
fixes #279 
### Problem

TPC-H Q9 (and any query with `ORDER BY`) returned rows with correct values but wrong ordering at SF≥10 where multiple batches are produced. The `cudf::merge()` call that should k-way merge the presorted batches was never actually executing.

### Root cause

Two bugs combined to cause this:

1. **Wrong barrier type for `SORT_PARTITION` → `MERGE_SORT` port** (`sirius_engine.cpp`): `SORT_PARTITION` was grouped with `ORDER_BY` and `SORT_SAMPLE` as a `PIPELINE` barrier operator. This meant merge_sort's input port received a streaming barrier, so the task creator would trigger merge_sort as soon as *any* batch arrived — before all upstream sort_partition tasks had completed and pushed their output.

2. **Default per-batch task creation** (`sirius_physical_merge_sort.cpp`): The base `get_next_task_input_data()` pops one batch per task. With only 1 batch per task, `execute()` always hit the `valid_batches.size() == 1` early return, so `cudf::merge()` was never called — each batch was passed through unmerged, producing arbitrarily ordered output.

### Fix

- **Move `SORT_PARTITION` to the `FULL` barrier group** in `sirius_engine.cpp` so that merge_sort's input port uses a `FULL` barrier. This ensures merge_sort is only scheduled after *all* upstream sort_partition tasks have completed and pushed their data to the repo.

- **Override `get_next_task_input_data()` in merge_sort** to drain all batches from one partition per call (following the same pattern as `sirius_physical_grouped_aggregate_merge`). This creates one merge task per partition with all batches, so `cudf::merge()` performs the actual k-way merge.

### Validation

- TPC-H Q9 at SF=10: 10/10 runs produce identical output matching DuckDB exactly (175 rows, correct `ORDER BY nation, o_year DESC`).
- TPC-H Q9 at SF=1: also verified correct.
