### PR TITLE
issue with tpch queries after scan changes

### DIFF
--- a/src/op/sirius_physical_duckdb_scan.cpp
+++ b/src/op/sirius_physical_duckdb_scan.cpp
@@ -85,21 +85,14 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
     virtual_columns(std::move(virtual_columns_p)),
     gen_row_id_column(column_ids.back().GetPrimaryIndex() == duckdb::DConstants::INVALID_INDEX)
 {
-  // Build scanned_types: the types DuckDB will output after applying projection_ids.
-  // This includes virtual ROW_ID columns (typed as BIGINT) when the plan requires them.
-  auto get_projected_columns = [&]() {
-    if (!projection_ids.empty()) { return projection_ids; }
-    // When projection_ids is empty, DuckDB projects all column_ids
-    duckdb::vector<duckdb::idx_t> all;
-    for (duckdb::idx_t i = 0; i < column_ids.size(); i++) {
-      all.push_back(i);
-    }
-    return all;
-  };
-
-  auto effective_projection = get_projected_columns();
-  for (auto proj_id : effective_projection) {
-    auto col_idx = column_ids[proj_id].GetPrimaryIndex();
+  // Build scanned_types: the types of ALL columns DuckDB will output, in column_ids order.
+  // DuckDB's table function fills the DataChunk with columns in column_ids order, regardless
+  // of projection_ids. projection_ids only control which columns the PhysicalTableScan keeps
+  // after the scan function returns. Since Sirius handles projection at the TABLE_SCAN level,
+  // we must initialize the DataChunk with ALL column_ids types in their original order.
+  auto num_cols = column_ids.size();
+  for (duckdb::idx_t i = 0; i < num_cols; i++) {
+    auto col_idx = column_ids[i].GetPrimaryIndex();
     if (col_idx == duckdb::DConstants::INVALID_INDEX) {
       // ROW_ID virtual column
       scanned_types.push_back(duckdb::LogicalType::BIGINT);
@@ -113,7 +106,22 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
   }
 
   fake_table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  SIRIUS_LOG_DEBUG("Table scan column ids: {}", column_ids.size());
+
+  // Log column mapping for debugging scan-related issues
+  SIRIUS_LOG_DEBUG(
+    "DUCKDB_SCAN column_ids.size()={}, projection_ids.size()={}, "
+    "scanned_types.size()={}, types.size()={}, gen_row_id={}",
+    column_ids.size(),
+    projection_ids.size(),
+    scanned_types.size(),
+    types.size(),
+    gen_row_id_column);
+  for (size_t i = 0; i < scanned_types.size(); i++) {
+    SIRIUS_LOG_DEBUG("  DUCKDB_SCAN scanned_types[{}] = {}", i, scanned_types[i].ToString());
+  }
+  for (size_t i = 0; i < types.size(); i++) {
+    SIRIUS_LOG_DEBUG("  DUCKDB_SCAN types[{}] = {}", i, types[i].ToString());
+  }
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_duckdb_scan.cpp
+++ b/src/op/sirius_physical_duckdb_scan.cpp
@@ -106,22 +106,7 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
   }
 
   fake_table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-
-  // Log column mapping for debugging scan-related issues
-  SIRIUS_LOG_DEBUG(
-    "DUCKDB_SCAN column_ids.size()={}, projection_ids.size()={}, "
-    "scanned_types.size()={}, types.size()={}, gen_row_id={}",
-    column_ids.size(),
-    projection_ids.size(),
-    scanned_types.size(),
-    types.size(),
-    gen_row_id_column);
-  for (size_t i = 0; i < scanned_types.size(); i++) {
-    SIRIUS_LOG_DEBUG("  DUCKDB_SCAN scanned_types[{}] = {}", i, scanned_types[i].ToString());
-  }
-  for (size_t i = 0; i < types.size(); i++) {
-    SIRIUS_LOG_DEBUG("  DUCKDB_SCAN types[{}] = {}", i, types[i].ToString());
-  }
+  SIRIUS_LOG_DEBUG("Table scan column ids: {}", column_ids.size());
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -100,8 +100,8 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
     auto primary_idx = column_ids[column_index].GetPrimaryIndex();
     auto col_type    = returned_types[primary_idx];
 
-    // The batch columns are produced by DuckDB scan in the same order as column_ids.
-    // So the batch column index is just the column_index itself.
+    // The batch columns are produced by DUCKDB_SCAN in column_ids order.
+    // So the batch column index is just the column_index itself (an index into column_ids).
     duckdb::idx_t batch_column_index = column_index;
 
     // Create column reference for this filter - uses the batch column index
@@ -168,13 +168,19 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto& first_batch_rep =
       output_batches[0]->get_data()->cast<cucascade::gpu_table_representation>();
     auto& first_table = first_batch_rep.get_table();
+    SIRIUS_LOG_DEBUG(
+      "TABLE_SCAN: batch has {} columns, expected output {} columns, "
+      "projection_ids.size()={}",
+      first_table.num_columns(),
+      expected_output_columns,
+      projection_ids.size());
     if (first_table.num_columns() > expected_output_columns) { needs_projection = true; }
   }
 
   if (needs_projection) {
-    // The batch columns are in the same order as column_ids.
-    // projection_ids tells us which column_ids indices to select for output.
-    // We want the first expected_output_columns elements from projection_ids.
+    // The batch columns are in column_ids order (as produced by DUCKDB_SCAN).
+    // projection_ids are indices into column_ids that specify which columns to keep.
+    // We select the first expected_output_columns entries from projection_ids.
     std::vector<std::shared_ptr<cucascade::data_batch>> projected_batches;
     projected_batches.reserve(output_batches.size());
 
@@ -186,7 +192,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
       auto table    = gpu_rep.release_table();
       auto columns  = table->release();
 
-      // Select only the output columns by moving ownership
+      // Select only the output columns by using projection_ids as indices
       std::vector<std::unique_ptr<cudf::column>> selected;
       selected.reserve(expected_output_columns);
       for (duckdb::idx_t i = 0; i < expected_output_columns; i++) {

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -168,12 +168,6 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto& first_batch_rep =
       output_batches[0]->get_data()->cast<cucascade::gpu_table_representation>();
     auto& first_table = first_batch_rep.get_table();
-    SIRIUS_LOG_DEBUG(
-      "TABLE_SCAN: batch has {} columns, expected output {} columns, "
-      "projection_ids.size()={}",
-      first_table.num_columns(),
-      expected_output_columns,
-      projection_ids.size());
     if (first_table.num_columns() > expected_output_columns) { needs_projection = true; }
   }
 

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -113,8 +113,24 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalOperator& op)
 {
-  SIRIUS_LOG_DEBUG("Creating sirius physical plan for logical operator type: {}",
-                   duckdb::LogicalOperatorToString(op.type));
+  SIRIUS_LOG_DEBUG(
+    "Creating sirius physical plan for logical operator type: {}, "
+    "num_children={}, types.size()={}",
+    duckdb::LogicalOperatorToString(op.type),
+    op.children.size(),
+    op.types.size());
+  for (size_t i = 0; i < op.types.size(); i++) {
+    SIRIUS_LOG_DEBUG("  Logical op {} types[{}] = {}",
+                     duckdb::LogicalOperatorToString(op.type),
+                     i,
+                     op.types[i].ToString());
+  }
+  if (op.type == duckdb::LogicalOperatorType::LOGICAL_PROJECTION) {
+    auto& proj = op.Cast<duckdb::LogicalProjection>();
+    for (size_t i = 0; i < proj.expressions.size(); i++) {
+      SIRIUS_LOG_DEBUG("  LOGICAL_PROJECTION expr[{}] = {}", i, proj.expressions[i]->ToString());
+    }
+  }
   op.estimated_cardinality                                      = op.EstimateCardinality(context);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> plan = nullptr;
 

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -113,24 +113,8 @@ sirius_physical_plan_generator::create_plan(duckdb::unique_ptr<duckdb::LogicalOp
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalOperator& op)
 {
-  SIRIUS_LOG_DEBUG(
-    "Creating sirius physical plan for logical operator type: {}, "
-    "num_children={}, types.size()={}",
-    duckdb::LogicalOperatorToString(op.type),
-    op.children.size(),
-    op.types.size());
-  for (size_t i = 0; i < op.types.size(); i++) {
-    SIRIUS_LOG_DEBUG("  Logical op {} types[{}] = {}",
-                     duckdb::LogicalOperatorToString(op.type),
-                     i,
-                     op.types[i].ToString());
-  }
-  if (op.type == duckdb::LogicalOperatorType::LOGICAL_PROJECTION) {
-    auto& proj = op.Cast<duckdb::LogicalProjection>();
-    for (size_t i = 0; i < proj.expressions.size(); i++) {
-      SIRIUS_LOG_DEBUG("  LOGICAL_PROJECTION expr[{}] = {}", i, proj.expressions[i]->ToString());
-    }
-  }
+  SIRIUS_LOG_DEBUG("Creating sirius physical plan for logical operator type: {}",
+                   duckdb::LogicalOperatorToString(op.type));
   op.estimated_cardinality                                      = op.EstimateCardinality(context);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> plan = nullptr;
 

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -18,7 +18,6 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
-#include "log/logging.hpp"
 #include "op/sirius_physical_filter.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_table_scan.hpp"
@@ -53,26 +52,6 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 {
   auto column_ids = op.GetColumnIds();
-
-  SIRIUS_LOG_DEBUG(
-    "LogicalGet: column_ids.size()={}, projection_ids.size()={}, "
-    "returned_types.size()={}, types.size()={}, "
-    "table_filters.size()={}, projection_pushdown={}",
-    column_ids.size(),
-    op.projection_ids.size(),
-    op.returned_types.size(),
-    op.types.size(),
-    op.table_filters.filters.size(),
-    op.function.projection_pushdown);
-  for (size_t i = 0; i < column_ids.size(); i++) {
-    SIRIUS_LOG_DEBUG("  LogicalGet column_ids[{}] = {}", i, column_ids[i].GetPrimaryIndex());
-  }
-  for (size_t i = 0; i < op.projection_ids.size(); i++) {
-    SIRIUS_LOG_DEBUG("  LogicalGet projection_ids[{}] = {}", i, op.projection_ids[i]);
-  }
-  for (size_t i = 0; i < op.types.size(); i++) {
-    SIRIUS_LOG_DEBUG("  LogicalGet types[{}] = {}", i, op.types[i].ToString());
-  }
 
   if (!op.children.empty()) {
     throw duckdb::NotImplementedException("Table Input Output functions are not supported yet");

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "log/logging.hpp"
 #include "op/sirius_physical_filter.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_table_scan.hpp"
@@ -52,6 +53,27 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 {
   auto column_ids = op.GetColumnIds();
+
+  SIRIUS_LOG_DEBUG(
+    "LogicalGet: column_ids.size()={}, projection_ids.size()={}, "
+    "returned_types.size()={}, types.size()={}, "
+    "table_filters.size()={}, projection_pushdown={}",
+    column_ids.size(),
+    op.projection_ids.size(),
+    op.returned_types.size(),
+    op.types.size(),
+    op.table_filters.filters.size(),
+    op.function.projection_pushdown);
+  for (size_t i = 0; i < column_ids.size(); i++) {
+    SIRIUS_LOG_DEBUG("  LogicalGet column_ids[{}] = {}", i, column_ids[i].GetPrimaryIndex());
+  }
+  for (size_t i = 0; i < op.projection_ids.size(); i++) {
+    SIRIUS_LOG_DEBUG("  LogicalGet projection_ids[{}] = {}", i, op.projection_ids[i]);
+  }
+  for (size_t i = 0; i < op.types.size(); i++) {
+    SIRIUS_LOG_DEBUG("  LogicalGet types[{}] = {}", i, op.types[i].ToString());
+  }
+
   if (!op.children.empty()) {
     throw duckdb::NotImplementedException("Table Input Output functions are not supported yet");
   }


### PR DESCRIPTION
Changed scanned_types computation to iterate over ALL column_ids in order (ignoring projection_ids), matching how DuckDB actually fills the DataChunk.