### PR TITLE
Fixed bug in setting partitioning keys for hash join.

### DIFF
--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -88,9 +88,9 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
         extract_bound_ref_index(*hash_join_op.conditions[cond_idx].right);
       if (left_index.has_value() && right_index.has_value()) {
         if (is_build) {
-          _partition_keys.push_back(left_index.value());
-        } else {
           _partition_keys.push_back(right_index.value());
+        } else {
+          _partition_keys.push_back(left_index.value());
         }
       }
     }

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1028,16 +1028,6 @@ TEST_CASE_METHOD(GPUExecutionFixture,
 }
 
 TEST_CASE_METHOD(GPUExecutionFixture,
-                 "gpu_execution - partitioned anti join misfit key",
-                 "[integration][gpu_execution][antijoin][partitioned_join]")
-{
-  partition_size_guard guard(1);
-  compare_gpu_vs_cpu(
-    "select n.n_nationkey, n.n_regionkey from nation n "
-    "anti join customer c on n.n_nationkey = c.c_custkey;");
-}
-
-TEST_CASE_METHOD(GPUExecutionFixture,
                  "gpu_execution - partitioned semi join (probe key not at col 0)",
                  "[integration][gpu_execution][semijoin][partitioned_join]")
 {

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1000,6 +1000,64 @@ TEST_CASE_METHOD(GPUExecutionFixture,
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// Partitioned join tests
+// ======================
+// Force _num_partitions >= 2 by setting the partition size to 1 row, so that hash partitioning
+// actually runs for all joins even with small TPC-H tables. Without this, all existing anti/semi
+// join tests use tables small enough that _num_partitions = ceil(n / 10M) = 1, which skips
+// partitioning entirely.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// RAII guard to reset partition size after each test, even on failure.
+struct partition_size_guard {
+  explicit partition_size_guard(duckdb::idx_t size)
+  {
+    sirius::op::sirius_physical_partition::set_partition_size(size);
+  }
+  ~partition_size_guard() { sirius::op::sirius_physical_partition::reset_partition_size(); }
+};
+
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - partitioned anti join (probe key not at col 0)",
+                 "[integration][gpu_execution][antijoin][partitioned_join]")
+{
+  // n.n_regionkey is not column 0 in nation — this is the index mismatch that triggered the bug.
+  partition_size_guard guard(1);
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey from nation n anti join region r on n.n_regionkey = r.r_regionkey;");
+}
+
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - partitioned anti join misfit key",
+                 "[integration][gpu_execution][antijoin][partitioned_join]")
+{
+  partition_size_guard guard(1);
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, n.n_regionkey from nation n "
+    "anti join customer c on n.n_nationkey = c.c_custkey;");
+}
+
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - partitioned semi join (probe key not at col 0)",
+                 "[integration][gpu_execution][semijoin][partitioned_join]")
+{
+  // Same shape as the anti join above — verifies the fix didn't break semi join partitioning.
+  partition_size_guard guard(1);
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey from nation n semi join region r on n.n_regionkey = r.r_regionkey;");
+}
+
+TEST_CASE_METHOD(GPUExecutionFixture,
+                 "gpu_execution - partitioned inner join (key not at col 0)",
+                 "[integration][gpu_execution][partitioned_join]")
+{
+  partition_size_guard guard(1);
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, n.n_regionkey, r.r_name "
+    "from nation n join region r on n.n_regionkey = r.r_regionkey;");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST_CASE_METHOD(GPUExecutionFixture,
                  "gpu_execution - bigger inner join",


### PR DESCRIPTION
The problem is not triggered in smaller runs (like the tests) because the 10M rows partition threshold is not reached.