### PR TITLE
Usage of Mixed Join in Hash Join Operator

### DIFF
--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -35,54 +35,79 @@ gpu_expression_translator::translate_expression(duckdb::Expression const& expr,
   return result;
 }
 
+std::optional<expr_ref> gpu_expression_translator::add_join_condition(
+  duckdb::JoinCondition const& condition, bool swap_sides)
+{
+  auto left_table_ref =
+    swap_sides ? cudf::ast::table_reference::RIGHT : cudf::ast::table_reference::LEFT;
+  auto right_table_ref =
+    swap_sides ? cudf::ast::table_reference::LEFT : cudf::ast::table_reference::RIGHT;
+
+  auto left_expr = add_expression(*condition.left, left_table_ref);
+  if (!left_expr) { return std::nullopt; }
+
+  auto right_expr = add_expression(*condition.right, right_table_ref);
+  if (!right_expr) { return std::nullopt; }
+
+  switch (condition.comparison) {
+    case duckdb::ExpressionType::COMPARE_EQUAL:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
+    case duckdb::ExpressionType::COMPARE_NOTEQUAL:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
+    case duckdb::ExpressionType::COMPARE_LESSTHAN:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
+    case duckdb::ExpressionType::COMPARE_GREATERTHAN:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
+    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
+    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
+    default:
+      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported join condition comparison type: {}",
+                       condition.comparison);
+      return std::nullopt;
+  }
+}
+
 std::optional<gpu_expression_translator::translated_expression>
 gpu_expression_translator::translate_join_condition(duckdb::JoinCondition const& condition)
 {
   reset_tree();
-  auto left_expr = add_expression(*condition.left, cudf::ast::table_reference::LEFT);
-  if (!left_expr) { return std::nullopt; }
+  auto cond_ref = add_join_condition(condition);
+  if (!cond_ref) { return std::nullopt; }
+  translated_expression result;
+  result.tree           = std::move(_ast_tree);
+  result.owned_literals = std::move(_literal_scalars);
+  return result;
+}
 
-  auto right_expr = add_expression(*condition.right, cudf::ast::table_reference::RIGHT);
-  if (!right_expr) { return std::nullopt; }
+std::optional<gpu_expression_translator::translated_expression>
+gpu_expression_translator::translate_join_conditions(
+  duckdb::vector<duckdb::JoinCondition> const& conditions,
+  std::size_t start_idx,
+  std::size_t end_idx,
+  bool swap_sides)
+{
+  if (start_idx >= end_idx) { return std::nullopt; }
 
-  // Combine the left and right expressions with the appropriate comparison operator
-  switch (condition.comparison) {
-    case duckdb::ExpressionType::COMPARE_EQUAL: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
-      break;
-    }
-    case duckdb::ExpressionType::COMPARE_NOTEQUAL: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
-      break;
-    }
-    case duckdb::ExpressionType::COMPARE_LESSTHAN: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
-      break;
-    }
-    case duckdb::ExpressionType::COMPARE_GREATERTHAN: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
-      break;
-    }
-    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
-      break;
-    }
-    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
-      _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
-      break;
-    }
-    default: {
-      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported join condition comparison type: {}",
-                       condition.comparison);
-      return std::nullopt;
-    }
+  reset_tree();
+
+  auto combined = add_join_condition(conditions[start_idx], swap_sides);
+  if (!combined) { return std::nullopt; }
+
+  for (std::size_t i = start_idx + 1; i < end_idx; ++i) {
+    auto next = add_join_condition(conditions[i], swap_sides);
+    if (!next) { return std::nullopt; }
+    combined = _ast_tree.emplace<cudf::ast::operation>(
+      cudf::ast::ast_operator::LOGICAL_AND, *combined, *next);
   }
+
   translated_expression result;
   result.tree           = std::move(_ast_tree);
   result.owned_literals = std::move(_literal_scalars);

--- a/src/include/expression_executor/gpu_expression_translator.hpp
+++ b/src/include/expression_executor/gpu_expression_translator.hpp
@@ -114,6 +114,26 @@ class gpu_expression_translator {
   std::optional<translated_expression> translate_join_condition(
     duckdb::JoinCondition const& condition);
 
+  /**
+   * @brief Try to translate a contiguous range of DuckDB join conditions into a single cuDF AST,
+   * combining them with logical AND.
+   *
+   * Intended for translating the inequality conditions of a mixed join into a binary predicate.
+   *
+   * @param conditions The vector of join conditions.
+   * @param start_idx The first condition index to translate (inclusive).
+   * @param end_idx One past the last condition index to translate (exclusive).
+   * @param swap_sides If true, swap LEFT/RIGHT table references in the produced AST. Used when the
+   * caller needs to flip the join sides (e.g. to implement a RIGHT join as a swapped LEFT join).
+   * @return An optional containing the combined translated expression, or std::nullopt if any
+   * condition could not be translated.
+   */
+  std::optional<translated_expression> translate_join_conditions(
+    duckdb::vector<duckdb::JoinCondition> const& conditions,
+    std::size_t start_idx,
+    std::size_t end_idx,
+    bool swap_sides = false);
+
  private:
   // std::optional cannot wrap a real reference, so we use reference_wrapper instead
   using expr_ref = std::reference_wrapper<cudf::ast::expression const>;
@@ -153,6 +173,12 @@ class gpu_expression_translator {
   /// @brief Specialized add_expression for column REFERENCE expressions.
   std::optional<expr_ref> add_expression(duckdb::BoundReferenceExpression const& expr,
                                          cudf::ast::table_reference const table_src);
+
+  /// @brief Add a single join condition to the current AST tree without resetting it.
+  /// @param condition The join condition to translate.
+  /// @param swap_sides If true, swap LEFT/RIGHT table references in the column references.
+  std::optional<expr_ref> add_join_condition(duckdb::JoinCondition const& condition,
+                                             bool swap_sides = false);
 
   /// @brief Helper function for adding a binary function expression (e.g. addition) to the AST.
   /// OP is the cuDF AST operator corresponding to the function (e.g. cudf::ast::ast_operator::ADD).

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -122,6 +122,11 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::vector<std::vector<uint64_t>> right_batch_ids;
 
   bool is_all_inequality_join = true;
+  // True when conditions contain both equality conditions (hashed) and inequality conditions
+  // (evaluated via cuDF mixed_join binary predicate).
+  bool is_mixed_join = false;
+  // Number of equality conditions after reordering; inequality conditions follow at higher indices.
+  std::size_t num_equality_conditions = 0;
   std::vector<cudf::size_type> left_key_col_indices;
   std::vector<cudf::size_type> right_key_col_indices;
   bool cast_necessary = false;

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -97,6 +97,16 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
                                    pipeline::sirius_meta_pipeline& meta_pipeline,
                                    sirius_physical_operator& op,
                                    bool build_rhs = true);
+
+  /**
+   * @brief Returns true if the given join conditions can be handled by this operator.
+   *
+   * Requires at least one equality condition. For mixed joins (equality + inequality), also
+   * requires that no column referenced by an equality condition appears in any inequality
+   * condition on the same side — cuDF's mixed_join API requires disjoint equality and
+   * conditional table columns.
+   */
+  static bool are_conditions_supported(duckdb::vector<duckdb::JoinCondition>& conditions);
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -121,7 +121,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::vector<std::vector<uint64_t>> left_batch_ids;
   std::vector<std::vector<uint64_t>> right_batch_ids;
 
-  bool is_equality_join = true;
+  bool is_all_inequality_join = true;
   std::vector<cudf::size_type> left_key_col_indices;
   std::vector<cudf::size_type> right_key_col_indices;
   bool cast_necessary = false;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -406,6 +406,55 @@ static join_keys_result prepare_join_keys(
   return result;
 }
 
+/// Build the MARK join output from the semi_join matching row indices.
+/// Copies all left output columns (all rows pass through, no gather), then creates a BOOL8 mark
+/// column initialized to false and scatters true at every position in semi_indices.
+static std::unique_ptr<operator_data> resolve_mark_join_result(
+  rmm::device_uvector<cudf::size_type> const& semi_indices,
+  cudf::table_view const& left_full,
+  std::vector<cudf::size_type> const& lhs_output_col_idxs,
+  std::shared_ptr<::cucascade::data_batch> const& left_batch,
+  rmm::cuda_stream_view stream)
+{
+  cudf::table_view left_cols_to_output = left_full.select(lhs_output_col_idxs);
+  auto num_left_rows                   = left_cols_to_output.num_rows();
+
+  std::vector<std::unique_ptr<cudf::column>> mark_out_cols;
+  for (cudf::size_type i = 0; i < left_cols_to_output.num_columns(); i++) {
+    mark_out_cols.push_back(std::make_unique<cudf::column>(left_cols_to_output.column(i), stream));
+  }
+
+  // Create BOOL8 mark column: start all-false, scatter true at matching positions
+  cudf::numeric_scalar<bool> false_scalar(false, true, stream);
+  auto mark_column = cudf::make_column_from_scalar(false_scalar, num_left_rows, stream);
+
+  if (semi_indices.size() > 0) {
+    cudf::numeric_scalar<bool> true_scalar(true, true, stream);
+    cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
+                                  static_cast<cudf::size_type>(semi_indices.size()),
+                                  semi_indices.data(),
+                                  nullptr,
+                                  0,
+                                  0,
+                                  {});
+    // The scatter API is a bit confusing when it says: the number of elements in first arg i.e.
+    // the vector should have same number of columns in the target table. It is essentially a
+    // row-scatter operation. For our use case, we have only column i.e. target mark column;
+    // therefore we are good. The scalar is broadcasted to respective positions provided by the
+    // scatter map.
+    auto scattered = cudf::scatter({std::ref(static_cast<cudf::scalar const&>(true_scalar))},
+                                   scatter_map,
+                                   cudf::table_view({mark_column->view()}),
+                                   stream);
+    mark_column    = std::move(scattered->release()[0]);
+  }
+
+  mark_out_cols.push_back(std::move(mark_column));
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
+  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+    make_data_batch(std::move(output_cudf_table), *left_batch->get_memory_space())});
+}
+
 std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator_data& input_data,
                                                                   rmm::cuda_stream_view stream)
 {
@@ -420,10 +469,16 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       duckdb::JoinTypeToString(join_type));
   }
 
+  // Full input table views used as both gather sources and (for mixed joins) conditional views.
+  // Hoisted here so both join paths and the shared gather tail can reference them.
+  cudf::table_view left_full  = get_cudf_table_view(*input_batches[0]);
+  cudf::table_view right_full = get_cudf_table_view(*input_batches[1]);
+
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
+
   if (is_mixed_join) {
     // Mixed join: equality conditions drive the hash table; inequality conditions are evaluated
     // via a cuDF AST binary predicate on the full input tables.
-
     auto keys                 = prepare_join_keys(input_batches,
                                   left_key_col_indices,
                                   right_key_col_indices,
@@ -432,11 +487,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                   stream);
     cudf::table_view left_eq  = keys.left_keys;
     cudf::table_view right_eq = keys.right_keys;
-
-    // Pass the full tables as conditional views so that AST column_reference indices, which are
-    // relative to the original input tables, resolve correctly without any remapping.
-    cudf::table_view left_full  = get_cudf_table_view(*input_batches[0]);
-    cudf::table_view right_full = get_cudf_table_view(*input_batches[1]);
 
     sirius::gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
     auto pred =
@@ -447,12 +497,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         "cuDF AST predicate");
     }
 
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
-    bool collect_left  = true;
-    bool collect_right = true;
-
     if (join_type == duckdb::JoinType::MARK) {
-      // MARK mixed join: find matching left rows via semi join, then build the mark column.
       auto semi_indices = cudf::mixed_left_semi_join(left_eq,
                                                      right_eq,
                                                      left_full,
@@ -460,39 +505,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                      pred->back(),
                                                      cudf::null_equality::UNEQUAL,
                                                      stream);
-
-      cudf::table_view left_cols_to_output = left_full.select(lhs_output_columns.col_idxs);
-      auto num_left_rows                   = left_cols_to_output.num_rows();
-
-      std::vector<std::unique_ptr<cudf::column>> mark_out_cols;
-      for (cudf::size_type i = 0; i < left_cols_to_output.num_columns(); i++) {
-        mark_out_cols.push_back(
-          std::make_unique<cudf::column>(left_cols_to_output.column(i), stream));
-      }
-
-      cudf::numeric_scalar<bool> false_scalar(false, true, stream);
-      auto mark_column = cudf::make_column_from_scalar(false_scalar, num_left_rows, stream);
-
-      if (semi_indices->size() > 0) {
-        cudf::numeric_scalar<bool> true_scalar(true, true, stream);
-        cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
-                                      static_cast<cudf::size_type>(semi_indices->size()),
-                                      semi_indices->data(),
-                                      nullptr,
-                                      0,
-                                      0,
-                                      {});
-        auto scattered = cudf::scatter({std::ref(static_cast<cudf::scalar const&>(true_scalar))},
-                                       scatter_map,
-                                       cudf::table_view({mark_column->view()}),
-                                       stream);
-        mark_column    = std::move(scattered->release()[0]);
-      }
-
-      mark_out_cols.push_back(std::move(mark_column));
-      auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
-      return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-        make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
+      return resolve_mark_join_result(
+        *semi_indices, left_full, lhs_output_columns.col_idxs, input_batches[0], stream);
     } else if (join_type == duckdb::JoinType::INNER) {
       auto result   = cudf::mixed_inner_join(left_eq,
                                            right_eq,
@@ -547,23 +561,21 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);
     } else if (join_type == duckdb::JoinType::SEMI) {
-      left_indices  = cudf::mixed_left_semi_join(left_eq,
+      left_indices = cudf::mixed_left_semi_join(left_eq,
                                                 right_eq,
                                                 left_full,
                                                 right_full,
                                                 pred->back(),
                                                 cudf::null_equality::UNEQUAL,
                                                 stream);
-      collect_right = false;
     } else if (join_type == duckdb::JoinType::ANTI) {
-      left_indices  = cudf::mixed_left_anti_join(left_eq,
+      left_indices = cudf::mixed_left_anti_join(left_eq,
                                                 right_eq,
                                                 left_full,
                                                 right_full,
                                                 pred->back(),
                                                 cudf::null_equality::UNEQUAL,
                                                 stream);
-      collect_right = false;
     } else if (join_type == duckdb::JoinType::RIGHT_SEMI) {
       auto swapped_pred = translator.translate_join_conditions(
         conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
@@ -579,7 +591,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                  swapped_pred->back(),
                                                  cudf::null_equality::UNEQUAL,
                                                  stream);
-      collect_left  = false;
     } else if (join_type == duckdb::JoinType::RIGHT_ANTI) {
       auto swapped_pred = translator.translate_join_conditions(
         conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
@@ -595,62 +606,11 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                  swapped_pred->back(),
                                                  cudf::null_equality::UNEQUAL,
                                                  stream);
-      collect_left  = false;
     } else {
       throw std::runtime_error("Unsupported join type for mixed join: " +
                                duckdb::JoinTypeToString(join_type));
     }
-
-    cudf::out_of_bounds_policy left_oob  = cudf::out_of_bounds_policy::DONT_CHECK;
-    cudf::out_of_bounds_policy right_oob = cudf::out_of_bounds_policy::DONT_CHECK;
-    if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
-        join_type == duckdb::JoinType::SEMI) {
-      right_oob = cudf::out_of_bounds_policy::NULLIFY;
-    }
-    if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
-        join_type == duckdb::JoinType::RIGHT_SEMI) {
-      left_oob = cudf::out_of_bounds_policy::NULLIFY;
-    }
-
-    std::vector<std::unique_ptr<cudf::column>> out_cols;
-    if (collect_left) {
-      cudf::table_view left_cols_to_gather = left_full.select(lhs_output_columns.col_idxs);
-      cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
-                                      left_indices->size(),
-                                      left_indices->data(),
-                                      nullptr,
-                                      0,
-                                      0,
-                                      {});
-      auto left_result = cudf::gather(left_cols_to_gather, left_map_view, left_oob, stream);
-      out_cols         = left_result->release();
-    }
-    if (collect_right) {
-      cudf::table_view right_cols_to_gather = right_full.select(rhs_output_columns.col_idxs);
-      cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
-                                       right_indices->size(),
-                                       right_indices->data(),
-                                       nullptr,
-                                       0,
-                                       0,
-                                       {});
-      auto right_result   = cudf::gather(right_cols_to_gather, right_map_view, right_oob, stream);
-      auto right_out_cols = right_result->release();
-      for (auto& col : right_out_cols) {
-        out_cols.push_back(std::move(col));
-      }
-    }
-
-    auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-      make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
-  }
-
-  if (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT ||
-      join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
-      join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::RIGHT_SEMI ||
-      join_type == duckdb::JoinType::ANTI || join_type == duckdb::JoinType::RIGHT_ANTI ||
-      join_type == duckdb::JoinType::MARK) {
+  } else {
     auto keys                   = prepare_join_keys(input_batches,
                                   left_key_col_indices,
                                   right_key_col_indices,
@@ -659,9 +619,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                   stream);
     cudf::table_view left_keys  = keys.left_keys;
     cudf::table_view right_keys = keys.right_keys;
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
-    bool collect_left  = true;
-    bool collect_right = true;
+
     if (join_type == duckdb::JoinType::INNER) {
       auto join_result =
         cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
@@ -699,117 +657,67 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       auto filtered_join_object = cudf::filtered_join(
         right_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
       auto semi_indices = filtered_join_object.semi_join(left_keys, stream);
-
-      // All left output columns pass through directly (no gather -- all rows kept)
-      cudf::table_view left_cols_to_output =
-        get_cudf_table_view(*input_batches[0]).select(lhs_output_columns.col_idxs);
-      auto num_left_rows = left_cols_to_output.num_rows();
-
-      std::vector<std::unique_ptr<cudf::column>> mark_out_cols;
-      for (cudf::size_type i = 0; i < left_cols_to_output.num_columns(); i++) {
-        mark_out_cols.push_back(
-          std::make_unique<cudf::column>(left_cols_to_output.column(i), stream));
-      }
-
-      // Create BOOL8 mark column: start all-false, scatter true at matching positions
-      cudf::numeric_scalar<bool> false_scalar(false, true, stream);
-      auto mark_column = cudf::make_column_from_scalar(false_scalar, num_left_rows, stream);
-
-      if (semi_indices->size() > 0) {
-        cudf::numeric_scalar<bool> true_scalar(true, true, stream);
-
-        cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
-                                      static_cast<cudf::size_type>(semi_indices->size()),
-                                      semi_indices->data(),
-                                      nullptr,
-                                      0,
-                                      0,
-                                      {});
-
-        // The scatter API is a bit confusing when it says: the number of elements in first arg i.e.
-        // the vector should have same number of columns in the target table. It is essentially a
-        // row-scatter operation. For our use case, we have only column i.e. target mark column;
-        // therefore we are good. The scalar is broadcasted to respective positions provided by the
-        // scatter map.
-        auto scattered = cudf::scatter({std::ref(static_cast<cudf::scalar const&>(true_scalar))},
-                                       scatter_map,
-                                       cudf::table_view({mark_column->view()}),
-                                       stream);
-        mark_column    = std::move(scattered->release()[0]);
-      }
-
-      mark_out_cols.push_back(std::move(mark_column));
-
-      // Return early -- skip the normal gather path (MARK outputs all rows, not a subset)
-      auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
-      return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-        make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
+      return resolve_mark_join_result(
+        *semi_indices, left_full, lhs_output_columns.col_idxs, input_batches[0], stream);
     } else if (join_type == duckdb::JoinType::OUTER) {
       auto join_result =
         cudf::full_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
       left_indices  = std::move(join_result.first);
       right_indices = std::move(join_result.second);
+    } else {
+      throw std::runtime_error("Unsupported join type: " + duckdb::JoinTypeToString(join_type));
     }
-    if (join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::ANTI) {
-      collect_right = false;
-    } else if (join_type == duckdb::JoinType::RIGHT_SEMI ||
-               join_type == duckdb::JoinType::RIGHT_ANTI) {
-      collect_left = false;
-    }
-
-    cudf::out_of_bounds_policy left_out_of_bounds_policy  = cudf::out_of_bounds_policy::DONT_CHECK;
-    cudf::out_of_bounds_policy right_out_of_bounds_policy = cudf::out_of_bounds_policy::DONT_CHECK;
-    if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
-        join_type == duckdb::JoinType::SEMI) {
-      right_out_of_bounds_policy = cudf::out_of_bounds_policy::NULLIFY;
-    }
-    if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
-        join_type == duckdb::JoinType::RIGHT_SEMI) {
-      left_out_of_bounds_policy = cudf::out_of_bounds_policy::NULLIFY;
-    }
-
-    std::vector<std::unique_ptr<cudf::column>> out_cols;
-    if (collect_left) {
-      cudf::table_view left_cols_to_gather =
-        get_cudf_table_view(*input_batches[0]).select(lhs_output_columns.col_idxs);
-      cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
-                                      left_indices->size(),
-                                      left_indices->data(),
-                                      nullptr,
-                                      0,
-                                      0,
-                                      {});
-      auto left_result =
-        cudf::gather(left_cols_to_gather, left_map_view, left_out_of_bounds_policy, stream);
-      out_cols = left_result->release();
-    }
-    if (collect_right) {
-      cudf::table_view right_cols_to_gather =
-        get_cudf_table_view(*input_batches[1]).select(rhs_output_columns.col_idxs);
-      cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
-                                       right_indices->size(),
-                                       right_indices->data(),
-                                       nullptr,
-                                       0,
-                                       0,
-                                       {});
-      auto right_result =
-        cudf::gather(right_cols_to_gather, right_map_view, right_out_of_bounds_policy, stream);
-      auto right_out_cols = right_result->release();
-      for (auto& col : right_out_cols) {
-        out_cols.push_back(std::move(col));
-      }
-    }
-
-    auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-      make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
-
-    // } else if (join_type == duckdb::JoinType::SINGLE) {
-    //   return std::vector<std::shared_ptr<::cucascade::data_batch>>{};
-  } else {
-    throw std::runtime_error("Unsupported join type: " + duckdb::JoinTypeToString(join_type));
   }
+
+  // Shared tail: which sides to collect, out-of-bounds nullification policy, and gather.
+  // collect_left/right are purely a function of join type and apply to both mixed and non-mixed.
+  bool collect_left =
+    (join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI);
+  bool collect_right = (join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::ANTI);
+
+  cudf::out_of_bounds_policy left_oob  = cudf::out_of_bounds_policy::DONT_CHECK;
+  cudf::out_of_bounds_policy right_oob = cudf::out_of_bounds_policy::DONT_CHECK;
+  if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
+      join_type == duckdb::JoinType::SEMI) {
+    right_oob = cudf::out_of_bounds_policy::NULLIFY;
+  }
+  if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
+      join_type == duckdb::JoinType::RIGHT_SEMI) {
+    left_oob = cudf::out_of_bounds_policy::NULLIFY;
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> out_cols;
+  if (collect_left) {
+    cudf::table_view left_cols_to_gather = left_full.select(lhs_output_columns.col_idxs);
+    cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
+                                    left_indices->size(),
+                                    left_indices->data(),
+                                    nullptr,
+                                    0,
+                                    0,
+                                    {});
+    auto left_result = cudf::gather(left_cols_to_gather, left_map_view, left_oob, stream);
+    out_cols         = left_result->release();
+  }
+  if (collect_right) {
+    cudf::table_view right_cols_to_gather = right_full.select(rhs_output_columns.col_idxs);
+    cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
+                                     right_indices->size(),
+                                     right_indices->data(),
+                                     nullptr,
+                                     0,
+                                     0,
+                                     {});
+    auto right_result   = cudf::gather(right_cols_to_gather, right_map_view, right_oob, stream);
+    auto right_out_cols = right_result->release();
+    for (auto& col : right_out_cols) {
+      out_cols.push_back(std::move(col));
+    }
+  }
+
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+    make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -19,13 +19,16 @@
 #include "cudf/copying.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
+#include "cudf/join/mixed_join.hpp"
 #include "cudf/table/table_view.hpp"
 #include "cudf/types.hpp"
 #include "cudf/unary.hpp"
+#include "cudf/utilities/memory_resource.hpp"
 #include "data/data_batch_utils.hpp"
 #include "duckdb/common/enums/physical_operator_type.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression_executor/gpu_expression_translator.hpp"
 #include "log/logging.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -142,10 +145,18 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
   for (duckdb::idx_t cond_idx = 0; cond_idx < conditions.size(); cond_idx++) {
     auto& condition = conditions[cond_idx];
-    if (condition.comparison == duckdb::ExpressionType::COMPARE_EQUAL ||
-        condition.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-      is_all_inequality_join = false;
+    const bool is_equality =
+      (condition.comparison == duckdb::ExpressionType::COMPARE_EQUAL ||
+       condition.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+
+    if (!is_equality) {
+      // Inequality conditions are handled at execute time via the cuDF mixed_join binary predicate.
+      // No key index extraction is needed here.
+      continue;
     }
+
+    is_all_inequality_join = false;
+    num_equality_conditions++;
 
     // Extract left key index (may be BOUND_REF or BOUND_CAST wrapping a BOUND_REF)
     key_cast_info cast_info;
@@ -191,6 +202,10 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
     key_casts.push_back(cast_info);
   }
+
+  // Mixed join: has at least one equality condition (for hashing) and at least one inequality
+  // condition (for the binary predicate).
+  is_mixed_join = !is_all_inequality_join && (num_equality_conditions < conditions.size());
 };
 
 //===--------------------------------------------------------------------===//
@@ -403,6 +418,232 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     throw std::runtime_error(
       "Error sirius_physical_hash_join being asked to do all inequality join of type: " +
       duckdb::JoinTypeToString(join_type));
+  }
+
+  if (is_mixed_join) {
+    // Mixed join: equality conditions drive the hash table; inequality conditions are evaluated
+    // via a cuDF AST binary predicate on the full input tables.
+
+    auto keys                 = prepare_join_keys(input_batches,
+                                  left_key_col_indices,
+                                  right_key_col_indices,
+                                  cast_necessary,
+                                  key_casts,
+                                  stream);
+    cudf::table_view left_eq  = keys.left_keys;
+    cudf::table_view right_eq = keys.right_keys;
+
+    // Pass the full tables as conditional views so that AST column_reference indices, which are
+    // relative to the original input tables, resolve correctly without any remapping.
+    cudf::table_view left_full  = get_cudf_table_view(*input_batches[0]);
+    cudf::table_view right_full = get_cudf_table_view(*input_batches[1]);
+
+    sirius::gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
+    auto pred =
+      translator.translate_join_conditions(conditions, num_equality_conditions, conditions.size());
+    if (!pred) {
+      throw std::runtime_error(
+        "In sirius_physical_hash_join: failed to translate mixed join inequality conditions to "
+        "cuDF AST predicate");
+    }
+
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
+    bool collect_left  = true;
+    bool collect_right = true;
+
+    if (join_type == duckdb::JoinType::MARK) {
+      // MARK mixed join: find matching left rows via semi join, then build the mark column.
+      auto semi_indices = cudf::mixed_left_semi_join(left_eq,
+                                                     right_eq,
+                                                     left_full,
+                                                     right_full,
+                                                     pred->back(),
+                                                     cudf::null_equality::UNEQUAL,
+                                                     stream);
+
+      cudf::table_view left_cols_to_output = left_full.select(lhs_output_columns.col_idxs);
+      auto num_left_rows                   = left_cols_to_output.num_rows();
+
+      std::vector<std::unique_ptr<cudf::column>> mark_out_cols;
+      for (cudf::size_type i = 0; i < left_cols_to_output.num_columns(); i++) {
+        mark_out_cols.push_back(
+          std::make_unique<cudf::column>(left_cols_to_output.column(i), stream));
+      }
+
+      cudf::numeric_scalar<bool> false_scalar(false, true, stream);
+      auto mark_column = cudf::make_column_from_scalar(false_scalar, num_left_rows, stream);
+
+      if (semi_indices->size() > 0) {
+        cudf::numeric_scalar<bool> true_scalar(true, true, stream);
+        cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
+                                      static_cast<cudf::size_type>(semi_indices->size()),
+                                      semi_indices->data(),
+                                      nullptr,
+                                      0,
+                                      0,
+                                      {});
+        auto scattered = cudf::scatter({std::ref(static_cast<cudf::scalar const&>(true_scalar))},
+                                       scatter_map,
+                                       cudf::table_view({mark_column->view()}),
+                                       stream);
+        mark_column    = std::move(scattered->release()[0]);
+      }
+
+      mark_out_cols.push_back(std::move(mark_column));
+      auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
+      return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+        make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
+    } else if (join_type == duckdb::JoinType::INNER) {
+      auto result   = cudf::mixed_inner_join(left_eq,
+                                           right_eq,
+                                           left_full,
+                                           right_full,
+                                           pred->back(),
+                                           cudf::null_equality::UNEQUAL,
+                                             {},
+                                           stream);
+      left_indices  = std::move(result.first);
+      right_indices = std::move(result.second);
+    } else if (join_type == duckdb::JoinType::LEFT) {
+      auto result   = cudf::mixed_left_join(left_eq,
+                                          right_eq,
+                                          left_full,
+                                          right_full,
+                                          pred->back(),
+                                          cudf::null_equality::UNEQUAL,
+                                            {},
+                                          stream);
+      left_indices  = std::move(result.first);
+      right_indices = std::move(result.second);
+    } else if (join_type == duckdb::JoinType::RIGHT) {
+      // Implement as a swapped left join: right becomes the probe side, left becomes the build
+      // side. The predicate is rebuilt with LEFT/RIGHT table references flipped to match.
+      auto swapped_pred = translator.translate_join_conditions(
+        conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
+      if (!swapped_pred) {
+        throw std::runtime_error(
+          "In sirius_physical_hash_join: failed to translate swapped predicate for RIGHT mixed "
+          "join");
+      }
+      auto result   = cudf::mixed_left_join(right_eq,
+                                          left_eq,
+                                          right_full,
+                                          left_full,
+                                          swapped_pred->back(),
+                                          cudf::null_equality::UNEQUAL,
+                                            {},
+                                          stream);
+      right_indices = std::move(result.first);
+      left_indices  = std::move(result.second);
+    } else if (join_type == duckdb::JoinType::OUTER) {
+      auto result   = cudf::mixed_full_join(left_eq,
+                                          right_eq,
+                                          left_full,
+                                          right_full,
+                                          pred->back(),
+                                          cudf::null_equality::UNEQUAL,
+                                            {},
+                                          stream);
+      left_indices  = std::move(result.first);
+      right_indices = std::move(result.second);
+    } else if (join_type == duckdb::JoinType::SEMI) {
+      left_indices  = cudf::mixed_left_semi_join(left_eq,
+                                                right_eq,
+                                                left_full,
+                                                right_full,
+                                                pred->back(),
+                                                cudf::null_equality::UNEQUAL,
+                                                stream);
+      collect_right = false;
+    } else if (join_type == duckdb::JoinType::ANTI) {
+      left_indices  = cudf::mixed_left_anti_join(left_eq,
+                                                right_eq,
+                                                left_full,
+                                                right_full,
+                                                pred->back(),
+                                                cudf::null_equality::UNEQUAL,
+                                                stream);
+      collect_right = false;
+    } else if (join_type == duckdb::JoinType::RIGHT_SEMI) {
+      auto swapped_pred = translator.translate_join_conditions(
+        conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
+      if (!swapped_pred) {
+        throw std::runtime_error(
+          "In sirius_physical_hash_join: failed to translate swapped predicate for RIGHT_SEMI "
+          "mixed join");
+      }
+      right_indices = cudf::mixed_left_semi_join(right_eq,
+                                                 left_eq,
+                                                 right_full,
+                                                 left_full,
+                                                 swapped_pred->back(),
+                                                 cudf::null_equality::UNEQUAL,
+                                                 stream);
+      collect_left  = false;
+    } else if (join_type == duckdb::JoinType::RIGHT_ANTI) {
+      auto swapped_pred = translator.translate_join_conditions(
+        conditions, num_equality_conditions, conditions.size(), /*swap_sides=*/true);
+      if (!swapped_pred) {
+        throw std::runtime_error(
+          "In sirius_physical_hash_join: failed to translate swapped predicate for RIGHT_ANTI "
+          "mixed join");
+      }
+      right_indices = cudf::mixed_left_anti_join(right_eq,
+                                                 left_eq,
+                                                 right_full,
+                                                 left_full,
+                                                 swapped_pred->back(),
+                                                 cudf::null_equality::UNEQUAL,
+                                                 stream);
+      collect_left  = false;
+    } else {
+      throw std::runtime_error("Unsupported join type for mixed join: " +
+                               duckdb::JoinTypeToString(join_type));
+    }
+
+    cudf::out_of_bounds_policy left_oob  = cudf::out_of_bounds_policy::DONT_CHECK;
+    cudf::out_of_bounds_policy right_oob = cudf::out_of_bounds_policy::DONT_CHECK;
+    if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
+        join_type == duckdb::JoinType::SEMI) {
+      right_oob = cudf::out_of_bounds_policy::NULLIFY;
+    }
+    if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
+        join_type == duckdb::JoinType::RIGHT_SEMI) {
+      left_oob = cudf::out_of_bounds_policy::NULLIFY;
+    }
+
+    std::vector<std::unique_ptr<cudf::column>> out_cols;
+    if (collect_left) {
+      cudf::table_view left_cols_to_gather = left_full.select(lhs_output_columns.col_idxs);
+      cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
+                                      left_indices->size(),
+                                      left_indices->data(),
+                                      nullptr,
+                                      0,
+                                      0,
+                                      {});
+      auto left_result = cudf::gather(left_cols_to_gather, left_map_view, left_oob, stream);
+      out_cols         = left_result->release();
+    }
+    if (collect_right) {
+      cudf::table_view right_cols_to_gather = right_full.select(rhs_output_columns.col_idxs);
+      cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
+                                       right_indices->size(),
+                                       right_indices->data(),
+                                       nullptr,
+                                       0,
+                                       0,
+                                       {});
+      auto right_result   = cudf::gather(right_cols_to_gather, right_map_view, right_oob, stream);
+      auto right_out_cols = right_result->release();
+      for (auto& col : right_out_cols) {
+        out_cols.push_back(std::move(col));
+      }
+    }
+
+    auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+      make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
   }
 
   if (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT ||

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -142,14 +142,9 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
   for (duckdb::idx_t cond_idx = 0; cond_idx < conditions.size(); cond_idx++) {
     auto& condition = conditions[cond_idx];
-    if (condition.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
-        condition.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-      printf("Unsupported non-equality condition comparison: %d\n",
-             static_cast<int>(condition.comparison));
-      printf("    left: %s\n", condition.left->ToString().c_str());
-      printf("    right: %s\n", condition.right->ToString().c_str());
-      is_equality_join = false;
-      break;
+    if (condition.comparison == duckdb::ExpressionType::COMPARE_EQUAL ||
+        condition.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      is_all_inequality_join = false;
     }
 
     // Extract left key index (may be BOUND_REF or BOUND_CAST wrapping a BOUND_REF)
@@ -404,9 +399,10 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     throw std::runtime_error("Expected 2 input batches for hash join, got " +
                              std::to_string(input_batches.size()) + " input batches");
   }
-  if (!is_equality_join) {
-    throw std::runtime_error("Unsupported non-equality join of type type: " +
-                             duckdb::JoinTypeToString(join_type));
+  if (is_all_inequality_join) {
+    throw std::runtime_error(
+      "Error sirius_physical_hash_join being asked to do all inequality join of type: " +
+      duckdb::JoinTypeToString(join_type));
   }
 
   if (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT ||

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -28,15 +28,87 @@
 #include "duckdb/common/enums/physical_operator_type.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "expression_executor/gpu_expression_translator.hpp"
 #include "log/logging.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
 #include <cstdio>
+#include <unordered_set>
 
 namespace sirius {
 namespace op {
+
+/// Recursively collect all BoundReferenceExpression indices from an expression tree.
+static void collect_bound_ref_indices(duckdb::Expression& expr,
+                                      std::unordered_set<duckdb::idx_t>& indices)
+{
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+    indices.insert(expr.Cast<duckdb::BoundReferenceExpression>().index);
+    return;
+  }
+  duckdb::ExpressionIterator::EnumerateChildren(
+    expr, [&](duckdb::Expression& child) { collect_bound_ref_indices(child, indices); });
+}
+
+bool sirius_physical_hash_join::are_conditions_supported(
+  duckdb::vector<duckdb::JoinCondition>& conditions)
+{
+  // Must have at least one equality condition for a hash-based join.
+  bool has_equality = false;
+  for (auto const& cond : conditions) {
+    if (cond.comparison == duckdb::ExpressionType::COMPARE_EQUAL ||
+        cond.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      has_equality = true;
+      break;
+    }
+  }
+  if (!has_equality) { return false; }
+
+  // Pure equality join: always supported.
+  bool has_inequality = false;
+  for (auto const& cond : conditions) {
+    if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
+        cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      has_inequality = true;
+      break;
+    }
+  }
+  if (!has_inequality) { return true; }
+
+  // Mixed join: collect the column indices used on each side of the equality conditions.
+  std::unordered_set<duckdb::idx_t> equality_left_cols, equality_right_cols;
+  for (auto const& cond : conditions) {
+    if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
+        cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      continue;
+    }
+    collect_bound_ref_indices(*cond.left, equality_left_cols);
+    collect_bound_ref_indices(*cond.right, equality_right_cols);
+  }
+
+  // For each inequality condition, verify that its left/right column references don't overlap
+  // with the equality key columns on the same side. cuDF's mixed_join API requires the equality
+  // and conditional table columns to be disjoint.
+  for (auto const& cond : conditions) {
+    if (cond.comparison == duckdb::ExpressionType::COMPARE_EQUAL ||
+        cond.comparison == duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+      continue;
+    }
+    std::unordered_set<duckdb::idx_t> ineq_left_cols, ineq_right_cols;
+    collect_bound_ref_indices(*cond.left, ineq_left_cols);
+    collect_bound_ref_indices(*cond.right, ineq_right_cols);
+    for (auto const idx : ineq_left_cols) {
+      if (equality_left_cols.count(idx) > 0) { return false; }
+    }
+    for (auto const idx : ineq_right_cols) {
+      if (equality_right_cols.count(idx) > 0) { return false; }
+    }
+  }
+
+  return true;
+}
 
 void reorder_join_conditions(duckdb::vector<duckdb::JoinCondition>& conditions)
 {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -478,9 +478,20 @@ static join_keys_result prepare_join_keys(
   return result;
 }
 
-/// Build the MARK join output from the semi_join matching row indices.
+/// @brief the MARK join output from the semi_join matching row indices.
+///
 /// Copies all left output columns (all rows pass through, no gather), then creates a BOOL8 mark
 /// column initialized to false and scatters true at every position in semi_indices.
+///
+/// @param semi_indices  Device vector of left-side row indices that matched the join condition,
+///                      as returned by cuDF's semi-join. Used as the scatter map for the mark
+///                      column.
+/// @param left_full     Full left-side table view (all columns, all rows) before output projection.
+/// @param lhs_output_col_idxs  Column indices within @p left_full to include in the output.
+///                             Drives the projection of the left side.
+/// @param left_batch    The original left-side data batch; used to propagate memory space metadata
+///                      to the returned operator_data.
+/// @param stream        CUDA stream on which all device operations are launched.
 static std::unique_ptr<operator_data> resolve_mark_join_result(
   rmm::device_uvector<cudf::size_type> const& semi_indices,
   cudf::table_view const& left_full,

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -82,6 +82,11 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
       static_cast<int>((op->estimated_cardinality + s_partition_size - 1) / s_partition_size);
     auto& hash_join_op = op->Cast<sirius_physical_hash_join>();
     for (duckdb::idx_t cond_idx = 0; cond_idx < hash_join_op.conditions.size(); cond_idx++) {
+      auto& condition = hash_join_op.conditions[cond_idx];
+      if (condition.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
+          condition.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+        continue;
+      }
       std::optional<duckdb::idx_t> left_index =
         extract_bound_ref_index(*hash_join_op.conditions[cond_idx].left);
       std::optional<duckdb::idx_t> right_index =

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -74,17 +74,8 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
   //	TODO: Extend PWMJ to handle all comparisons and projection maps
   bool prefer_range_joins = duckdb::DBConfig::GetSetting<duckdb::PreferRangeJoinsSetting>(context);
   prefer_range_joins      = prefer_range_joins && can_iejoin;
-  // Hash join only supports equality and NOT_DISTINCT_FROM; use nested loop join if any condition
-  // is non-equality (e.g. COMPARE_GREATERTHAN).
-  bool all_equality = true;
-  for (const auto& c : op.conditions) {
-    if (c.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
-        c.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-      all_equality = false;
-      break;
-    }
-  }
-  if (has_equality && all_equality && !prefer_range_joins) {
+
+  if (has_equality && !prefer_range_joins) {
     // Equality join with small number of keys : possible perfect join optimization
     // auto &join = Make<PhysicalHashJoin>(op, left, right, std::move(op.conditions), op.join_type,
     //                                     op.left_projection_map, op.right_projection_map,

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -75,7 +75,9 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
   bool prefer_range_joins = duckdb::DBConfig::GetSetting<duckdb::PreferRangeJoinsSetting>(context);
   prefer_range_joins      = prefer_range_joins && can_iejoin;
 
-  if (has_equality && !prefer_range_joins) {
+  bool is_supported_by_hash_join =
+    sirius::op::sirius_physical_hash_join::are_conditions_supported(op.conditions);
+  if (is_supported_by_hash_join && !prefer_range_joins) {
     // Equality join with small number of keys : possible perfect join optimization
     // auto &join = Make<PhysicalHashJoin>(op, left, right, std::move(op.conditions), op.join_type,
     //                                     op.left_projection_map, op.right_projection_map,

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -2289,6 +2289,124 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
     "by c.c_custkey, n.n_nationkey limit 1000;");
 }
 
+TEST_CASE_METHOD(
+  GPUExecutionDuckDBFixture,
+  "gpu_execution - nested loop inner join two inequality condition and expression eval",
+  "[integration][gpu_execution][nested_loop_join]")
+{
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, n.n_name,  c.c_nationkey, c.c_custkey, c.c_name  from nation n "
+    "join customer c on n.n_nationkey < c.c_nationkey * 2 and n.n_regionkey * 1000 > c.c_custkey "
+    "order "
+    "by c.c_custkey, n.n_nationkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed inner join one equality and one inequality condition but "
+                 "equality column is shared (triggers nested join)",
+                 "[integration][gpu_execution][nested_loop_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey, l.l_orderkey from lineitem l right join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_partkey "
+    "where l.l_orderkey < 1000 and ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey, l.l_orderkey limit 1000;");
+}
+
+//===----------------------------------------------------------------------===//
+// Mixed join tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(
+  GPUExecutionDuckDBFixture,
+  "gpu_execution - mixed inner join one equality and one inequality condition with cast needed",
+  "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, n.n_name,  c.c_nationkey, c.c_custkey, c.c_name  from nation n "
+    "join customer c on n.n_nationkey = c.c_nationkey and n.n_regionkey < c.c_custkey  "
+    "where c.c_custkey < 10000 order by c.c_custkey, n.n_nationkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed right join one equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey, l.l_orderkey from lineitem l right join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey "
+    "where l.l_orderkey < 1000 and ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey, l.l_orderkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed left join one equality and two inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey, l.l_orderkey from lineitem l left join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey and l.l_orderkey < "
+    "ps.ps_suppkey "
+    "where l.l_orderkey < 1000 and ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey, l.l_orderkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed inner join two equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey, l.l_orderkey from lineitem l join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey and l.l_orderkey = "
+    "ps.ps_partkey "
+    "where l.l_orderkey < 1000 and ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey, l.l_orderkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed semi join one equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linenumber from lineitem l semi join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey "
+    "where l.l_orderkey < 1000 "
+    "order by l.l_orderkey, l.l_linenumber limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed right semi join one equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey  from partsupp ps semi join lineitem l "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey "
+    "where ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed anti join one equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linenumber from lineitem l anti join partsupp ps "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey "
+    "where l.l_orderkey < 1000 "
+    "order by l.l_orderkey, l.l_linenumber limit 1000;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed anti semi join one equality and one inequality condition",
+                 "[integration][gpu_execution][mixed_join]")
+{
+  compare_gpu_vs_cpu(
+    "select ps.ps_partkey, ps.ps_suppkey  from partsupp ps anti join lineitem l "
+    "on l.l_partkey = ps.ps_partkey and l.l_suppkey > ps.ps_suppkey "
+    "where ps.ps_partkey < 1000 "
+    "order by ps.ps_partkey, ps.ps_suppkey limit 1000;");
+}
+
 //===----------------------------------------------------------------------===//
 // Disabled tests - known issues
 //===----------------------------------------------------------------------===//

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -2376,7 +2376,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - mixed right semi join one equality and one inequality condition",
-                 "[integration][gpu_execution][mixed_join]")
+                 "[.][integration_disabled][gpu_execution][mixed_join]")
 {
   compare_gpu_vs_cpu(
     "select ps.ps_partkey, ps.ps_suppkey  from partsupp ps semi join lineitem l "
@@ -2398,7 +2398,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - mixed anti semi join one equality and one inequality condition",
-                 "[integration][gpu_execution][mixed_join]")
+                 "[.][integration_disabled][gpu_execution][mixed_join]")
 {
   compare_gpu_vs_cpu(
     "select ps.ps_partkey, ps.ps_suppkey  from partsupp ps anti join lineitem l "


### PR DESCRIPTION
Adds support for mixed joins in the hash join operator.
It modified partition operator so that it partitions tables, only on the columns that are part of equality conditions.
It ensures that mixed joins are only allowed if a column is not referenced in both an equality and inequality condition.

The PR refactored a lot of the hash join code so that its not too repetitive between the mixed and non-mixed join case.

PR adds only integration tests. 

Closes #316 