### PR TITLE
Improvement/benchmarking

### DIFF
--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -85,6 +85,61 @@ struct ComparisonDispatcher {
                                       executor.execution_stream,
                                       executor.resource_ref);
       }
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      // For int64_t, check at runtime if this is a timestamp comparison
+      switch (left.type().id()) {
+        case cudf::type_id::TIMESTAMP_SECONDS: {
+          auto ts_scalar = cudf::timestamp_scalar<cudf::timestamp_s>(
+            cudf::duration_s{right_value}, true, executor.execution_stream, executor.resource_ref);
+          return cudf::binary_operation(left,
+                                        ts_scalar,
+                                        ComparisonOp,
+                                        return_type,
+                                        executor.execution_stream,
+                                        executor.resource_ref);
+        }
+        case cudf::type_id::TIMESTAMP_MILLISECONDS: {
+          auto ts_scalar = cudf::timestamp_scalar<cudf::timestamp_ms>(
+            cudf::duration_ms{right_value}, true, executor.execution_stream, executor.resource_ref);
+          return cudf::binary_operation(left,
+                                        ts_scalar,
+                                        ComparisonOp,
+                                        return_type,
+                                        executor.execution_stream,
+                                        executor.resource_ref);
+        }
+        case cudf::type_id::TIMESTAMP_MICROSECONDS: {
+          auto ts_scalar = cudf::timestamp_scalar<cudf::timestamp_us>(
+            cudf::duration_us{right_value}, true, executor.execution_stream, executor.resource_ref);
+          return cudf::binary_operation(left,
+                                        ts_scalar,
+                                        ComparisonOp,
+                                        return_type,
+                                        executor.execution_stream,
+                                        executor.resource_ref);
+        }
+        case cudf::type_id::TIMESTAMP_NANOSECONDS: {
+          auto ts_scalar = cudf::timestamp_scalar<cudf::timestamp_ns>(
+            cudf::duration_ns{right_value}, true, executor.execution_stream, executor.resource_ref);
+          return cudf::binary_operation(left,
+                                        ts_scalar,
+                                        ComparisonOp,
+                                        return_type,
+                                        executor.execution_stream,
+                                        executor.resource_ref);
+        }
+        default: {
+          // Regular int64_t comparison
+          auto numeric_scalar = cudf::numeric_scalar(
+            right_value, true, executor.execution_stream, executor.resource_ref);
+          return cudf::binary_operation(left,
+                                        numeric_scalar,
+                                        ComparisonOp,
+                                        return_type,
+                                        executor.execution_stream,
+                                        executor.resource_ref);
+        }
+      }
     } else {
       // Create a numeric scalar from the constant value
       auto numeric_scalar =
@@ -197,9 +252,15 @@ struct ComparisonDispatcher {
             left->view(), right_value.GetValue<std::string>(), return_type);
         case cudf::type_id::TIMESTAMP_DAYS:
           // DuckDB DATE is int32_t (days since epoch), same as cuDF TIMESTAMP_DAYS
-          // Use numeric_scalar<int32_t> for the comparison
           return DoScalarComparison<int32_t>(
             left->view(), right_value.GetValue<int32_t>(), return_type);
+        case cudf::type_id::TIMESTAMP_SECONDS:
+        case cudf::type_id::TIMESTAMP_MILLISECONDS:
+        case cudf::type_id::TIMESTAMP_MICROSECONDS:
+        case cudf::type_id::TIMESTAMP_NANOSECONDS:
+          // DuckDB timestamps are int64_t internally
+          return DoScalarComparison<int64_t>(
+            left->view(), right_value.GetValue<int64_t>(), return_type);
         case cudf::type_id::DECIMAL32:
           // cudf decimal type uses negative scale, same for below
           return DoScalarComparison<numeric::decimal32>(

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -1,0 +1,148 @@
+# TPC-H Performance Testing
+
+This directory contains benchmarking and performance testing tools for comparing DuckDB (CPU) vs Sirius (GPU) on TPC-H queries at various scale factors.
+
+## Prerequisites
+
+- Sirius must be built: `pixi run make -j12` (from project root)
+- Binary: `build/release/duckdb` with Sirius extension at `build/release/extension/sirius/sirius.duckdb_extension`
+- Sirius config: `test/cpp/integration/integration.cfg` (set `SIRIUS_CONFIG_FILE` env var)
+- Parquet data must exist in `test_datasets/tpch_parquet_sf<N>/`
+
+## Generating Test Data
+
+### From DuckDB's built-in TPC-H generator (simplest)
+
+```bash
+# From project root - generates parquet files with DuckDB's default row groups (122K rows)
+./build/release/duckdb -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=100); EXPORT DATABASE 'test_datasets/tpch_parquet_sf100' (FORMAT PARQUET);"
+```
+
+### Rewriting parquet with GPU-optimized settings
+
+The `rewrite_parquet.py` script reads existing parquet files via cudf and rewrites them with larger row groups, snappy compression, and V2 page headers. Requires the pixi environment in this directory (`pixi install`).
+
+```bash
+cd test/tpch_performance
+
+# Rewrite with 10M-row row groups (recommended for GPU workloads)
+pixi run python rewrite_parquet.py ../../test_datasets/tpch_parquet_sf100 ../../test_datasets/tpch_parquet_sf100_optimized 10000000
+
+# Rewrite with 2M-row row groups
+pixi run python rewrite_parquet.py ../../test_datasets/tpch_parquet_sf100 ../../test_datasets/tpch_parquet_sf100_rg2m 2000000
+```
+
+The rewriter reads with cudf (GPU), casts back to the original parquet schema (preserving date32 and decimal types), and writes single-file output via pyarrow ParquetWriter. Large tables are processed in batches by row group to stay within GPU memory.
+
+### From tpchgen-rs (alternative, supports partitioned output)
+
+```bash
+cd test/tpch_performance
+pixi run python generate_test_data_tpchgen-rs.py <SF> <partitions> <format>
+```
+
+## Running Benchmarks
+
+All commands run from the **project root** directory.
+
+### Full DuckDB vs Sirius benchmark (cold + warm per query)
+
+Runs each TPC-H query (1-20, 22, skipping 21) twice in the same DuckDB session for both DuckDB and Sirius. Uses DuckDB's `.timer on` for timing. Produces a comparison table with speedup ratios.
+
+```bash
+export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.cfg
+
+# Against original parquet (122K row groups)
+bash test/tpch_performance/benchmark_tpch.sh 100
+
+# Against optimized parquet (10M row groups)
+bash test/tpch_performance/benchmark_tpch.sh 100_optimized
+
+# Against 2M row group parquet
+bash test/tpch_performance/benchmark_tpch.sh 100_rg2m
+```
+
+The scale factor argument maps to the directory name: `test_datasets/tpch_parquet_sf<arg>/`. Results are saved to `benchmark_results_sf<arg>/` as CSV files.
+
+### Sirius-only individual queries
+
+Run a single query cold+warm to quickly test:
+
+```bash
+export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.cfg
+
+# Create a temp SQL with views + query (run twice for cold+warm)
+PARQUET_DIR="test_datasets/tpch_parquet_sf100_optimized"
+# ... create views, .timer on, query, query in temp file ...
+./build/release/duckdb -f /tmp/test.sql
+```
+
+### DuckDB-only baseline
+
+```bash
+bash test/tpch_performance/run_tpch_parquet_duckdb.sh <scale_factor> <query_numbers...>
+# Example: bash test/tpch_performance/run_tpch_parquet_duckdb.sh 100 1 3 6 9
+```
+
+### Sirius-only run
+
+```bash
+export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.cfg
+bash test/tpch_performance/run_tpch_parquet.sh <scale_factor> <query_numbers...>
+```
+
+Both scripts accept `TIMING_CSV` env var to write per-query timing to a CSV file.
+
+### Thread configuration sweep
+
+Runs Sirius-only across multiple thread configurations (pipeline, scan, task_creator threads) to find optimal settings. Modifies `integration.cfg` during the run and restores baseline when done.
+
+```bash
+bash test/tpch_performance/sweep_threads.sh
+```
+
+Results are saved to `benchmark_results_thread_sweep/` as CSV files per configuration.
+
+### Python-based performance test (in-memory database)
+
+Loads data into a DuckDB database, runs all 22 queries with both CPU and GPU, verifies results match:
+
+```bash
+pixi run python test/tpch_performance/performance_test.py <scale_factor>
+```
+
+## Query Files
+
+- `tpch_queries/orig/q*.sql` - Plain SQL queries
+- `tpch_queries/gpu/q*.sql` - Queries wrapped in `call gpu_execution('...');` for Sirius
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `benchmark_tpch.sh` | Full DuckDB vs Sirius benchmark with cold/warm timing |
+| `sweep_threads.sh` | Thread configuration sweep (Sirius-only) |
+| `run_tpch_parquet.sh` | Run Sirius queries on parquet files |
+| `run_tpch_parquet_duckdb.sh` | Run DuckDB queries on parquet files |
+| `rewrite_parquet.py` | Rewrite parquet with GPU-optimized row groups |
+| `performance_test.py` | Python-based benchmark with result verification |
+| `queries.py` | TPC-H query definitions (base SQL) |
+| `generate_test_data.py` | Generate test data via dbgen |
+| `generate_test_data_tpchgen-rs.py` | Generate test data via tpchgen-rs + query files |
+| `pixi.toml` | Python environment with cudf for parquet rewriting |
+
+## Sirius Configuration
+
+The Sirius config file (`test/cpp/integration/integration.cfg`) controls:
+- **GPU memory**: `usage_limit_fraction`, `reservation_limit_fraction`
+- **Host memory**: `capacity_bytes`, `initial_number_pools`, `pool_size`, `block_size`
+  - Initial allocation = `initial_number_pools * pool_size * block_size`
+- **Thread pools**: `pipeline`, `duckdb_scan`, `task_creator`, `downgrade` thread counts
+- **Scan cache**: `duckdb_scan.cache = true` enables caching
+
+## Parquet Format Notes
+
+- DuckDB's default export creates 122,880-row row groups (its internal vector size)
+- For GPU workloads, 2M-10M row groups perform significantly better
+- The `rewrite_parquet.py` script preserves the original schema (date32, decimal128) to avoid type mismatch issues with Sirius
+- cudf internally promotes date32 to timestamp; the rewriter casts back before writing

--- a/test/tpch_performance/benchmark_tpch.sh
+++ b/test/tpch_performance/benchmark_tpch.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# =============================================================================
+# TPC-H Benchmark: DuckDB vs Sirius
+#
+# For each query, runs it twice within the SAME DuckDB session (cold then
+# warm) so the warm run benefits from internal caches.  Does this for both
+# plain DuckDB and Sirius, then prints a comparison table.
+#
+# Usage:
+#   export SIRIUS_CONFIG_FILE=/path/to/integration.cfg
+#   ./test/tpch_performance/benchmark_tpch.sh [scale_factor]
+#
+# Default scale factor is 100.
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="$PROJECT_DIR/build/release/duckdb"
+QUERY_DIR="$PROJECT_DIR/test/tpch_performance/tpch_queries/gpu"
+
+SF="${1:-100}"
+QUERIES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 22)
+
+PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+
+if [ ! -d "$PARQUET_DIR" ]; then
+    echo "ERROR: Parquet directory not found: $PARQUET_DIR"
+    exit 1
+fi
+
+# Output directory
+OUTPUT_DIR="$PROJECT_DIR/benchmark_results_sf${SF}"
+mkdir -p "$OUTPUT_DIR"
+
+echo "============================================================"
+echo "  TPC-H Benchmark: DuckDB vs Sirius  (SF${SF})"
+echo "============================================================"
+echo "Queries: ${QUERIES[*]}"
+echo "Output dir: $OUTPUT_DIR"
+echo ""
+
+# Build CREATE VIEW statements
+TPCH_TABLES=(customer lineitem nation orders part partsupp region supplier)
+VIEW_SQL=""
+for TABLE_NAME in "${TPCH_TABLES[@]}"; do
+    FILES=()
+    for f in "$PARQUET_DIR/${TABLE_NAME}.parquet" "$PARQUET_DIR/${TABLE_NAME}_"*.parquet; do
+        [ -f "$f" ] && FILES+=("'$f'")
+    done
+    FILE_LIST=$(IFS=,; echo "${FILES[*]}")
+    VIEW_SQL+="CREATE VIEW ${TABLE_NAME} AS SELECT * FROM read_parquet([${FILE_LIST}]);"$'\n'
+done
+
+# Initialize timing CSVs
+for name in duckdb_cold duckdb_warm sirius_cold sirius_warm; do
+    echo "query,seconds" > "$OUTPUT_DIR/${name}.csv"
+done
+
+# parse_timer_output <output_text>
+# Extracts real (wall clock) times from DuckDB .timer on output.
+# Format: "Run Time (s): real 5.419 user 20.134 sys 0.512"
+# Prints one time per line (first = cold, second = warm).
+parse_timer_output() {
+    echo "$1" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+'
+}
+
+# run_duckdb_query <query_num>
+# Runs the query twice in a single DuckDB session with .timer on.
+# Prints two lines: cold_seconds warm_seconds
+run_duckdb_query() {
+    local q=$1
+    local QUERY_FILE="$QUERY_DIR/q${q}.sql"
+    local INNER_SQL
+    INNER_SQL=$(sed -n "s/call gpu_execution('//; s/');//; p" "$QUERY_FILE" | sed "s/''/'/g")
+
+    local TEMP_SQL
+    TEMP_SQL=$(mktemp /tmp/tpch_bench_duckdb_q${q}_XXXXXX.sql)
+    {
+        printf '%s\n' "$VIEW_SQL"
+        echo ".timer on"
+        printf '%s;\n' "$INNER_SQL"
+        printf '%s;\n' "$INNER_SQL"
+    } > "$TEMP_SQL"
+
+    local OUTPUT
+    OUTPUT=$("$DUCKDB" -f "$TEMP_SQL" 2>&1)
+    rm -f "$TEMP_SQL"
+
+    parse_timer_output "$OUTPUT"
+}
+
+# run_sirius_query <query_num>
+# Runs the gpu_execution query twice in a single DuckDB session with .timer on.
+# Prints two lines: cold_seconds warm_seconds
+run_sirius_query() {
+    local q=$1
+    local QUERY_FILE="$QUERY_DIR/q${q}.sql"
+    local GPU_SQL
+    GPU_SQL=$(cat "$QUERY_FILE")
+
+    local TEMP_SQL
+    TEMP_SQL=$(mktemp /tmp/tpch_bench_sirius_q${q}_XXXXXX.sql)
+    {
+        printf '%s\n' "$VIEW_SQL"
+        echo ".timer on"
+        printf '%s\n' "$GPU_SQL"
+        printf '%s\n' "$GPU_SQL"
+    } > "$TEMP_SQL"
+
+    local OUTPUT
+    OUTPUT=$("$DUCKDB" -f "$TEMP_SQL" 2>&1)
+    rm -f "$TEMP_SQL"
+
+    parse_timer_output "$OUTPUT"
+}
+
+# Declare timing arrays
+declare -A DC DW SC SW
+
+for q in "${QUERIES[@]}"; do
+    QUERY_FILE="$QUERY_DIR/q${q}.sql"
+    if [ ! -f "$QUERY_FILE" ]; then
+        echo "WARNING: Query file not found: $QUERY_FILE, skipping Q${q}"
+        continue
+    fi
+
+    echo "========== Q${q} =========="
+
+    # DuckDB: cold + warm in same session
+    readarray -t DUCKDB_TIMES < <(run_duckdb_query "$q")
+    dc="${DUCKDB_TIMES[0]:-N/A}"
+    dw="${DUCKDB_TIMES[1]:-N/A}"
+    DC[$q]="$dc"
+    DW[$q]="$dw"
+    echo "${q},${dc}" >> "$OUTPUT_DIR/duckdb_cold.csv"
+    echo "${q},${dw}" >> "$OUTPUT_DIR/duckdb_warm.csv"
+    echo "  DuckDB cold: ${dc}s  warm: ${dw}s"
+
+    # Sirius: cold + warm in same session
+    readarray -t SIRIUS_TIMES < <(run_sirius_query "$q")
+    sc="${SIRIUS_TIMES[0]:-N/A}"
+    sw="${SIRIUS_TIMES[1]:-N/A}"
+    SC[$q]="$sc"
+    SW[$q]="$sw"
+    echo "${q},${sc}" >> "$OUTPUT_DIR/sirius_cold.csv"
+    echo "${q},${sw}" >> "$OUTPUT_DIR/sirius_warm.csv"
+    echo "  Sirius cold: ${sc}s  warm: ${sw}s"
+
+    echo ""
+done
+
+# ---------- Print comparison table ----------
+echo "============================================================"
+echo "  Results Summary  (SF${SF})"
+echo "============================================================"
+echo ""
+
+# Print header
+printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+    "Query" "DuckDB Cold" "DuckDB Warm" "Sirius Cold" "Sirius Warm" "Speedup (warm)"
+printf "%-7s-+-%13s-+-%13s-+-%13s-+-%13s-+-%14s\n" \
+    "-------" "-------------" "-------------" "-------------" "-------------" "--------------"
+
+TOTAL_DC=0
+TOTAL_DW=0
+TOTAL_SC=0
+TOTAL_SW=0
+
+for q in "${QUERIES[@]}"; do
+    dc="${DC[$q]:-N/A}"
+    dw="${DW[$q]:-N/A}"
+    sc="${SC[$q]:-N/A}"
+    sw="${SW[$q]:-N/A}"
+
+    # Compute speedup (DuckDB warm / Sirius warm)
+    speedup="N/A"
+    if [ "$dw" != "N/A" ] && [ "$sw" != "N/A" ]; then
+        speedup=$(echo "scale=2; $dw / $sw" | bc 2>/dev/null || echo "N/A")
+        if [ "$speedup" != "N/A" ]; then
+            speedup="${speedup}x"
+        fi
+    fi
+
+    # Format seconds
+    fmt_dc="N/A"
+    fmt_dw="N/A"
+    fmt_sc="N/A"
+    fmt_sw="N/A"
+    [ "$dc" != "N/A" ] && fmt_dc=$(printf "%.2fs" "$dc")
+    [ "$dw" != "N/A" ] && fmt_dw=$(printf "%.2fs" "$dw")
+    [ "$sc" != "N/A" ] && fmt_sc=$(printf "%.2fs" "$sc")
+    [ "$sw" != "N/A" ] && fmt_sw=$(printf "%.2fs" "$sw")
+
+    printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+        "Q${q}" "$fmt_dc" "$fmt_dw" "$fmt_sc" "$fmt_sw" "$speedup"
+
+    # Accumulate totals
+    [ "$dc" != "N/A" ] && TOTAL_DC=$(echo "$TOTAL_DC + $dc" | bc)
+    [ "$dw" != "N/A" ] && TOTAL_DW=$(echo "$TOTAL_DW + $dw" | bc)
+    [ "$sc" != "N/A" ] && TOTAL_SC=$(echo "$TOTAL_SC + $sc" | bc)
+    [ "$sw" != "N/A" ] && TOTAL_SW=$(echo "$TOTAL_SW + $sw" | bc)
+done
+
+# Total row
+total_speedup="N/A"
+if [ "$(echo "$TOTAL_SW > 0" | bc)" -eq 1 ]; then
+    total_speedup=$(echo "scale=2; $TOTAL_DW / $TOTAL_SW" | bc 2>/dev/null || echo "N/A")
+    [ "$total_speedup" != "N/A" ] && total_speedup="${total_speedup}x"
+fi
+
+printf "%-7s-+-%13s-+-%13s-+-%13s-+-%13s-+-%14s\n" \
+    "-------" "-------------" "-------------" "-------------" "-------------" "--------------"
+printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+    "TOTAL" "$(printf '%.2fs' "$TOTAL_DC")" "$(printf '%.2fs' "$TOTAL_DW")" \
+    "$(printf '%.2fs' "$TOTAL_SC")" "$(printf '%.2fs' "$TOTAL_SW")" "$total_speedup"
+
+echo ""
+echo "Timing CSVs saved to: $OUTPUT_DIR/"
+echo "============================================================"

--- a/test/tpch_performance/pixi.toml
+++ b/test/tpch_performance/pixi.toml
@@ -1,0 +1,12 @@
+[workspace]
+name = "tpch-parquet-tools"
+channels = ["rapidsai-nightly", "conda-forge", "nvidia"]
+platforms = ["linux-64"]
+
+[dependencies]
+cudf = "26.04.*"
+python = ">=3.11"
+cuda-version = "13.*"
+
+[system-requirements]
+cuda = "13"

--- a/test/tpch_performance/rewrite_parquet.py
+++ b/test/tpch_performance/rewrite_parquet.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Rewrite TPC-H parquet files with GPU-optimized settings using cudf.
+
+Reads each table from the source directory and writes it back with:
+  - Snappy compression
+  - Parquet V2 page headers
+  - Configurable row group size (default 10M rows)
+  - 8 MiB max page size
+  - Statistics at ROWGROUP level
+  - Dictionary encoding enabled
+
+Large tables are processed by reading row groups in batches via cudf,
+then writing via pyarrow ParquetWriter (single output file with append).
+The original parquet schema is preserved (dates stay as dates, etc.).
+
+Usage:
+  pixi run python rewrite_parquet.py <source_dir> <dest_dir> [row_group_rows]
+
+Example:
+  pixi run python rewrite_parquet.py \
+      ../../test_datasets/tpch_parquet_sf100 \
+      ../../test_datasets/tpch_parquet_sf100_optimized \
+      10000000
+"""
+
+import os
+import sys
+import time
+import glob
+
+import cudf
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+TPCH_TABLES = [
+    "customer",
+    "lineitem",
+    "nation",
+    "orders",
+    "part",
+    "partsupp",
+    "region",
+    "supplier",
+]
+
+MAX_PAGE_SIZE_BYTES = 8 * 1024 * 1024  # 8 MiB
+
+# Tables with fewer rows than this are read in one shot with cudf
+SMALL_TABLE_THRESHOLD = 50_000_000
+
+
+def cudf_write_kwargs(row_group_size_rows):
+    return dict(
+        compression="snappy",
+        header_version="2.0",
+        row_group_size_rows=row_group_size_rows,
+        max_page_size_bytes=MAX_PAGE_SIZE_BYTES,
+        statistics="ROWGROUP",
+        use_dictionary=True,
+        index=False,
+    )
+
+
+def cast_to_schema(arrow_table, target_schema):
+    """Cast an arrow table to match the target schema types."""
+    arrays = []
+    for i, field in enumerate(target_schema):
+        col = arrow_table.column(i)
+        if col.type != field.type:
+            col = col.cast(field.type)
+        arrays.append(col)
+    return pa.table(arrays, schema=target_schema)
+
+
+def rewrite_table(table_name, source_dir, dest_dir, row_group_size_rows):
+    """Read a table's parquet file(s) with cudf and write back optimized."""
+    single = os.path.join(source_dir, f"{table_name}.parquet")
+    partitioned = sorted(glob.glob(os.path.join(source_dir, f"{table_name}_*.parquet")))
+
+    source_files = []
+    if os.path.isfile(single):
+        source_files.append(single)
+    source_files.extend(partitioned)
+
+    if not source_files:
+        print(f"  WARNING: No parquet files found for {table_name}, skipping")
+        return
+
+    # Get metadata and original schema
+    orig_schema = pq.read_schema(source_files[0])
+    total_rows = 0
+    for f in source_files:
+        total_rows += pq.read_metadata(f).num_rows
+    src_size = sum(os.path.getsize(f) for f in source_files)
+    print(f"  {table_name}: {total_rows:,} rows, {src_size / 1e9:.2f} GB on disk")
+
+    dest_path = os.path.join(dest_dir, f"{table_name}.parquet")
+    t0 = time.time()
+
+    if total_rows <= SMALL_TABLE_THRESHOLD:
+        # Small enough — read with cudf, cast back to original schema, write with pyarrow
+        df = cudf.read_parquet(source_files)
+        arrow_table = cast_to_schema(df.to_arrow(), orig_schema)
+        del df
+        pq.write_table(
+            arrow_table,
+            dest_path,
+            compression="snappy",
+            version="2.6",
+            data_page_version="2.0",
+            write_statistics=True,
+            use_dictionary=True,
+            data_page_size=MAX_PAGE_SIZE_BYTES,
+            row_group_size=row_group_size_rows,
+        )
+        total_written = len(arrow_table)
+        del arrow_table
+    else:
+        # Large table — read row groups in batches with cudf,
+        # cast to original schema, write with pyarrow ParquetWriter
+        meta = pq.read_metadata(source_files[0])
+        num_rgs = meta.num_row_groups
+        rows_per_src_rg = meta.row_group(0).num_rows
+
+        rgs_per_batch = max(1, row_group_size_rows // rows_per_src_rg)
+        print(f"    {num_rgs} source row groups of {rows_per_src_rg:,} rows each")
+        print(
+            f"    Reading {rgs_per_batch} source RGs per batch -> ~{rgs_per_batch * rows_per_src_rg:,} rows/batch"
+        )
+
+        writer = pq.ParquetWriter(
+            dest_path,
+            orig_schema,
+            compression="snappy",
+            version="2.6",
+            data_page_version="2.0",
+            write_statistics=True,
+            use_dictionary=True,
+            data_page_size=MAX_PAGE_SIZE_BYTES,
+        )
+        total_written = 0
+
+        for batch_start in range(0, num_rgs, rgs_per_batch):
+            batch_end = min(batch_start + rgs_per_batch, num_rgs)
+            rg_indices = list(range(batch_start, batch_end))
+
+            df = cudf.read_parquet(source_files[0], row_groups=[rg_indices])
+            arrow_table = cast_to_schema(df.to_arrow(), orig_schema)
+            del df
+
+            writer.write_table(arrow_table)
+            total_written += len(arrow_table)
+            del arrow_table
+
+            pct = total_written * 100 // total_rows
+            print(
+                f"    Wrote row group: {total_written:,} / {total_rows:,} rows ({pct}%)"
+            )
+
+        writer.close()
+
+    elapsed = time.time() - t0
+    dst_size = os.path.getsize(dest_path)
+    print(
+        f"    Wrote {total_written:,} rows in {elapsed:.1f}s  "
+        f"({src_size / 1e9:.2f} GB -> {dst_size / 1e9:.2f} GB, "
+        f"{dst_size / src_size:.1%})"
+    )
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <source_dir> <dest_dir> [row_group_rows]")
+        sys.exit(1)
+
+    source_dir = sys.argv[1]
+    dest_dir = sys.argv[2]
+    row_group_size_rows = int(sys.argv[3]) if len(sys.argv) > 3 else 10_000_000
+
+    if not os.path.isdir(source_dir):
+        print(f"ERROR: Source directory not found: {source_dir}")
+        sys.exit(1)
+
+    os.makedirs(dest_dir, exist_ok=True)
+    print(f"Rewriting TPC-H parquet: {source_dir} -> {dest_dir}")
+    print(f"  Row group size: {row_group_size_rows:,} rows")
+    print(f"  Max page size: {MAX_PAGE_SIZE_BYTES // (1024*1024)} MiB")
+    print(f"  Compression: snappy")
+    print(f"  Header version: 2.0 (V2 pages)")
+    print()
+
+    t_total = time.time()
+    for table in TPCH_TABLES:
+        rewrite_table(table, source_dir, dest_dir, row_group_size_rows)
+        print()
+
+    elapsed = time.time() - t_total
+    print(f"Done. Total time: {elapsed:.1f}s")
+    print(f"Output: {dest_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tpch_performance/run_tpch_parquet_duckdb.sh
+++ b/test/tpch_performance/run_tpch_parquet_duckdb.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
-# Run TPC-H GPU queries against Parquet files
-#
-# Creates views from parquet files found in the dataset directory,
-# then runs the standard GPU query files unchanged.
+# Run TPC-H queries against Parquet files using plain DuckDB (no Sirius)
+# Used as a baseline for validating Sirius results.
 #
 # Usage:
-#   export SIRIUS_CONFIG_FILE=/home/felipe/sirius/test/cpp/integration/integration.cfg
-#   ./test/tpch_performance/run_tpch_parquet.sh <scale_factor> <query_numbers...>
-#
-# Example:
-#   ./test/tpch_performance/run_tpch_parquet.sh 100 1 3 4 5 6 7 8 9 10 12 13 14 18 19
+#   ./test/tpch_performance/run_tpch_parquet_duckdb.sh <scale_factor> <query_numbers...>
 #
 # Environment variables:
-#   SIRIUS_CONFIG_FILE - path to Sirius config file (required)
-#   TIMING_CSV         - path to write per-query timing CSV (optional)
+#   TIMING_CSV  - path to write per-query timing CSV (optional)
 
 set -uo pipefail
 
@@ -24,7 +17,6 @@ QUERY_DIR="$PROJECT_DIR/test/tpch_performance/tpch_queries/gpu"
 
 if [ $# -lt 2 ]; then
     echo "Usage: $0 <scale_factor> <query_numbers...>"
-    echo "Example: $0 100 1 3 4 5 6 7 8 9 10 12 13 14 18 19"
     exit 1
 fi
 
@@ -36,15 +28,10 @@ PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
 
 if [ ! -d "$PARQUET_DIR" ]; then
     echo "ERROR: Parquet directory not found: $PARQUET_DIR"
-    echo "Generate it first with:"
-    echo "  ./build/release/duckdb -c \"INSTALL tpch; LOAD tpch; CALL dbgen(sf=${SF}); EXPORT DATABASE '${PARQUET_DIR}' (FORMAT PARQUET);\""
     exit 1
 fi
 
-# Build CREATE VIEW statements for the TPC-H tables.
-# Match both single files (table.parquet) and partitioned files (table_0.parquet, table_1.parquet, ...).
-# A plain glob like part*.parquet would also match partsupp.parquet, so we collect
-# matching files with bash globs and pass an explicit list to read_parquet().
+# Build CREATE VIEW statements
 TPCH_TABLES=(customer lineitem nation orders part partsupp region supplier)
 VIEW_SQL=""
 for TABLE_NAME in "${TPCH_TABLES[@]}"; do
@@ -61,14 +48,12 @@ if [ -n "${TIMING_CSV:-}" ]; then
     echo "query,seconds" > "$TIMING_CSV"
 fi
 
-echo "Running TPC-H queries against SF${SF} parquet data"
-echo "Parquet dir: $PARQUET_DIR"
-echo "Queries: ${QUERIES[*]}"
+echo "Running TPC-H DuckDB baseline queries against SF${SF} parquet data"
 echo "=========================================="
 
 for q in "${QUERIES[@]}"; do
     QUERY_FILE="$QUERY_DIR/q${q}.sql"
-    RESULT_FILE="$PROJECT_DIR/result_sirius_sf${SF}_q${q}.txt"
+    RESULT_FILE="$PROJECT_DIR/result_duckdb_sf${SF}_q${q}.txt"
 
     if [ ! -f "$QUERY_FILE" ]; then
         echo "WARNING: Query file not found: $QUERY_FILE, skipping Q${q}"
@@ -78,9 +63,12 @@ for q in "${QUERIES[@]}"; do
     echo ""
     echo "========== Q${q} =========="
 
-    TEMP_SQL=$(mktemp /tmp/tpch_q${q}_XXXXXX.sql)
+    # Extract SQL from inside gpu_execution('...')
+    INNER_SQL=$(sed -n "s/call gpu_execution('//; s/');//; p" "$QUERY_FILE" | sed "s/''/'/g")
+
+    TEMP_SQL=$(mktemp /tmp/tpch_duckdb_q${q}_XXXXXX.sql)
     printf '%s\n' "$VIEW_SQL" > "$TEMP_SQL"
-    cat "$QUERY_FILE" >> "$TEMP_SQL"
+    printf '%s\n' "$INNER_SQL" >> "$TEMP_SQL"
 
     START_TIME=$(date +%s.%N)
     "$DUCKDB" -f "$TEMP_SQL" 2>&1 | tee "$RESULT_FILE"
@@ -98,4 +86,4 @@ done
 
 echo ""
 echo "=========================================="
-echo "All queries complete. Results saved as result_sirius_sf${SF}_q*.txt"
+echo "All DuckDB baseline queries complete."

--- a/test/tpch_performance/sweep_threads.sh
+++ b/test/tpch_performance/sweep_threads.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# =============================================================================
+# Thread sweep benchmark: Sirius-only on 2M RG parquet
+#
+# Runs the Sirius queries with different thread configurations to find
+# the optimal settings. Only runs Sirius (no DuckDB).
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="$PROJECT_DIR/build/release/duckdb"
+QUERY_DIR="$PROJECT_DIR/test/tpch_performance/tpch_queries/gpu"
+CONFIG_FILE="$PROJECT_DIR/test/cpp/integration/integration.cfg"
+
+export SIRIUS_CONFIG_FILE="$CONFIG_FILE"
+
+SF="100_rg2m"
+QUERIES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 22)
+PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+OUTPUT_DIR="$PROJECT_DIR/benchmark_results_thread_sweep"
+mkdir -p "$OUTPUT_DIR"
+
+# Build view SQL
+TPCH_TABLES=(customer lineitem nation orders part partsupp region supplier)
+VIEW_SQL=""
+for T in "${TPCH_TABLES[@]}"; do
+    FILES=()
+    for f in "$PARQUET_DIR/${T}.parquet" "$PARQUET_DIR/${T}_"*.parquet; do
+        [ -f "$f" ] && FILES+=("'$f'")
+    done
+    FILE_LIST=$(IFS=,; echo "${FILES[*]}")
+    VIEW_SQL+="CREATE VIEW ${T} AS SELECT * FROM read_parquet([${FILE_LIST}]);"$'\n'
+done
+
+# update_config <pipeline> <scan> <task_creator>
+update_config() {
+    local pipeline=$1 scan=$2 task_creator=$3
+    cat > "$CONFIG_FILE" << EOF
+sirius = {
+    topology = {
+        num_gpus = 1;
+    };
+    memory = {
+        gpu = {
+            usage_limit_fraction = 0.9;
+            reservation_limit_fraction = 1.0;
+        }
+        host = {
+            capacity_bytes = 50000000000;
+            initial_number_pools = 80;
+            pool_size = 512;
+            block_size = 1048576;
+        };
+    };
+    executor = {
+        pipeline = {
+            num_threads = ${pipeline};
+        };
+        duckdb_scan = {
+            num_threads = ${scan};
+            cache = true;
+        };
+        task_creator = {
+            num_threads = ${task_creator};
+        };
+        downgrade = {
+            num_threads = 4;
+        };
+    };
+};
+EOF
+}
+
+# run_sirius_sweep <label> <pipeline> <scan> <task_creator>
+run_sirius_sweep() {
+    local label=$1 pipeline=$2 scan=$3 task_creator=$4
+    local csv="$OUTPUT_DIR/${label}.csv"
+
+    update_config "$pipeline" "$scan" "$task_creator"
+
+    echo ""
+    echo "============================================================"
+    echo "  $label: pipeline=$pipeline scan=$scan task_creator=$task_creator"
+    echo "============================================================"
+
+    echo "query,cold,warm" > "$csv"
+
+    for q in "${QUERIES[@]}"; do
+        QUERY_FILE="$QUERY_DIR/q${q}.sql"
+        [ ! -f "$QUERY_FILE" ] && continue
+
+        TEMP_SQL=$(mktemp /tmp/tpch_sweep_q${q}_XXXXXX.sql)
+        {
+            printf '%s\n' "$VIEW_SQL"
+            echo ".timer on"
+            cat "$QUERY_FILE"
+            cat "$QUERY_FILE"
+        } > "$TEMP_SQL"
+
+        OUTPUT=$("$DUCKDB" -f "$TEMP_SQL" 2>&1)
+        rm -f "$TEMP_SQL"
+
+        readarray -t TIMES < <(echo "$OUTPUT" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+')
+        cold="${TIMES[0]:-N/A}"
+        warm="${TIMES[1]:-N/A}"
+        echo "  Q${q}: cold=${cold}s warm=${warm}s"
+        echo "${q},${cold},${warm}" >> "$csv"
+    done
+}
+
+echo "============================================================"
+echo "  Thread Sweep Benchmark (SF${SF}, Sirius-only)"
+echo "============================================================"
+
+# Baseline: pipeline=8, scan=4, task_creator=4
+run_sirius_sweep "baseline_p8_s4_t4" 8 4 4
+
+# Vary pipeline threads (scan=4, task_creator=4)
+run_sirius_sweep "pipeline_p4_s4_t4" 4 4 4
+run_sirius_sweep "pipeline_p12_s4_t4" 12 4 4
+run_sirius_sweep "pipeline_p16_s4_t4" 16 4 4
+
+# Vary scan threads (pipeline=8, task_creator=4)
+run_sirius_sweep "scan_p8_s2_t4" 8 2 4
+run_sirius_sweep "scan_p8_s8_t4" 8 8 4
+
+# Vary task creator threads (pipeline=8, scan=4)
+run_sirius_sweep "taskcreator_p8_s4_t2" 8 4 2
+run_sirius_sweep "taskcreator_p8_s4_t8" 8 4 8
+
+# Restore baseline config
+update_config 8 4 4
+
+# ---- Print comparison table ----
+echo ""
+echo "============================================================"
+echo "  Thread Sweep Summary (Sirius cold times)"
+echo "============================================================"
+echo ""
+
+LABELS=(
+    "baseline_p8_s4_t4"
+    "pipeline_p4_s4_t4"
+    "pipeline_p12_s4_t4"
+    "pipeline_p16_s4_t4"
+    "scan_p8_s2_t4"
+    "scan_p8_s8_t4"
+    "taskcreator_p8_s4_t2"
+    "taskcreator_p8_s4_t8"
+)
+SHORT_NAMES=(
+    "p8/s4/t4"
+    "p4/s4/t4"
+    "p12/s4/t4"
+    "p16/s4/t4"
+    "p8/s2/t4"
+    "p8/s8/t4"
+    "p8/s4/t2"
+    "p8/s4/t8"
+)
+
+# Header
+printf "%-5s" "Query"
+for name in "${SHORT_NAMES[@]}"; do
+    printf " | %11s" "$name"
+done
+echo ""
+
+printf "%-5s" "-----"
+for name in "${SHORT_NAMES[@]}"; do
+    printf "-+-%-11s" "-----------"
+done
+echo ""
+
+# Data rows
+for q in "${QUERIES[@]}"; do
+    printf "%-5s" "Q${q}"
+    for label in "${LABELS[@]}"; do
+        csv="$OUTPUT_DIR/${label}.csv"
+        val=$(grep "^${q}," "$csv" 2>/dev/null | cut -d, -f2)
+        if [ -n "$val" ] && [ "$val" != "N/A" ]; then
+            printf " | %10ss" "$val"
+        else
+            printf " | %11s" "N/A"
+        fi
+    done
+    echo ""
+done
+
+# Totals
+printf "%-5s" "TOTAL"
+for label in "${LABELS[@]}"; do
+    csv="$OUTPUT_DIR/${label}.csv"
+    total=$(tail -n +2 "$csv" 2>/dev/null | cut -d, -f2 | grep -v N/A | paste -sd+ | bc 2>/dev/null || echo "N/A")
+    if [ -n "$total" ] && [ "$total" != "N/A" ]; then
+        printf " | %10ss" "$(printf '%.1f' "$total")"
+    else
+        printf " | %11s" "N/A"
+    fi
+done
+echo ""
+
+echo ""
+echo "CSVs saved to: $OUTPUT_DIR/"
+echo "============================================================"


### PR DESCRIPTION
## Summary

- **Add timestamp comparison support to Sirius GPU expression executor** — Handles `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLISECONDS`, `TIMESTAMP_MICROSECONDS`, and `TIMESTAMP_NANOSECONDS` constant types in scalar comparisons, in addition to the existing `TIMESTAMP_DAYS` (DATE) support. This fixes crashes when running queries against parquet files that store dates as timestamps.

- **Add TPC-H benchmarking tooling** — New scripts for benchmarking DuckDB vs Sirius on TPC-H queries off parquet files:
  - `benchmark_tpch.sh` — Full cold+warm benchmark comparing DuckDB and Sirius within the same session, with per-query timing and summary table
  - `sweep_threads.sh` — Sirius-only thread configuration sweep (pipeline, scan, task creator threads)
  - `run_tpch_parquet_duckdb.sh` — DuckDB baseline runner with timing support
  - `rewrite_parquet.py` — Rewrites parquet files via cudf with GPU-optimized row group sizes (2M-10M rows), snappy compression, and V2 page headers while preserving the original schema
  - `pixi.toml` — Separate pixi environment with cudf for parquet rewriting
  - `CLAUDE.md` — Documentation for running all benchmarks

- **Updated `run_tpch_parquet.sh`** with per-query wall-clock timing and optional CSV output

