### PR TITLE
fix q5 sf100 inconsistent results

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -301,10 +301,20 @@ void task_creator::manager_loop()
         } else {
           // need to exhaust input batches until all ports are empty
           while (!node->all_ports_empty()) {
+            // Mark task created BEFORE popping data from ports to prevent a race
+            // condition where update_pipeline_status() sees empty ports and matching
+            // task counters, prematurely marking the pipeline as finished.
+            pipeline->mark_task_created();
+
             auto input_data = node->get_next_task_input_data();
-            if (!input_data) { break; }
-            pipeline->mark_task_created();  // WSM TODO: this needs to be done atomically with the
-                                            // task creation
+            if (!input_data || input_data->get_data_batches().empty()) {
+              // No data was available (e.g., another thread already consumed it).
+              // Balance the counter. mark_task_completed() calls update_pipeline_status()
+              // which is correct: if all ports are truly empty and all real tasks have
+              // completed, the pipeline should finish.
+              pipeline->mark_task_completed();
+              break;
+            }
 
             // Check to see if you need to create a new global state for this operator
             size_t operator_id                  = node->get_operator_id();

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -278,6 +278,12 @@ void task_creator::manager_loop()
           auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
           if (!partition_idx.has_value()) {
             pipeline->mark_task_completed();
+            if (pipeline->is_pipeline_finished()) {
+              auto output_consumers = pipeline->get_output_consumers();
+              for (auto& output_consumer : output_consumers) {
+                schedule(output_consumer);
+              }
+            }
             return;
           }
           if (!parquet_task_global_state->has_more_partitions()) {
@@ -313,6 +319,12 @@ void task_creator::manager_loop()
               // which is correct: if all ports are truly empty and all real tasks have
               // completed, the pipeline should finish.
               pipeline->mark_task_completed();
+              if (pipeline->is_pipeline_finished()) {
+                auto output_consumers = pipeline->get_output_consumers();
+                for (auto& output_consumer : output_consumers) {
+                  this->schedule(output_consumer);
+                }
+              }
               break;
             }
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -123,7 +123,7 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Get the pipeline ID
   size_t get_pipeline_id() const { return pipeline_id; }
   //! Returns the parent pipelines (pipelines that depend on this pipeline)
-  std::vector<sirius_pipeline*> get_parents() const; 
+  std::vector<sirius_pipeline*> get_parents() const;
 
   std::vector<op::sirius_physical_operator*> get_output_consumers() const;
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -123,7 +123,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Get the pipeline ID
   size_t get_pipeline_id() const { return pipeline_id; }
   //! Returns the parent pipelines (pipelines that depend on this pipeline)
-  std::vector<sirius_pipeline*> get_parents();
+  std::vector<sirius_pipeline*> get_parents() const; 
+
+  std::vector<op::sirius_physical_operator*> get_output_consumers() const;
 
   //! Returns whether any of the operators in the pipeline care about preserving order
   bool is_order_dependent() const;

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -184,6 +184,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::get_next
       }
     }
     current_partition_index++;
+    if (input_batch.empty()) { return nullptr; }
     return std::make_unique<operator_data>(input_batch);
   } else {
     return nullptr;

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -72,6 +72,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::get_next_task_input_d
     SIRIUS_LOG_DEBUG("merge_sort: drained {} batches for partition {}",
                      all_batches.size(),
                      _current_partition_index - 1);
+    if (all_batches.empty()) { return nullptr; }
     return std::make_unique<operator_data>(all_batches);
   }
   return nullptr;

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -264,9 +264,7 @@ std::unique_ptr<operator_data> sirius_physical_operator::get_next_task_input_dat
     auto batch_and_handle = port_ptr->repo->pop_data_batch(::cucascade::batch_state::task_created);
     if (batch_and_handle) { input_batch.push_back(std::move(batch_and_handle)); }
   }
-  if (input_batch.empty()) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{});
-  }
+  if (input_batch.empty()) { return nullptr; }
   return std::make_unique<operator_data>(input_batch);
 }
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -293,6 +293,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::get_next_task_input_
       found_batch = false;
     }
   }
+  if (input_batch.empty()) { return nullptr; }
   return std::make_unique<operator_data>(input_batch);
 }
 

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -569,6 +569,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::get_ne
       found_batch = false;
     }
   }
+  if (input_batch.empty()) { return nullptr; }
   return std::make_unique<operator_data>(input_batch);
 }
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -185,8 +185,10 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
                      op.get().get_operator_id(),
                      operator_input_output_data->get_data_batches().size(),
                      batch_sizes);
-    auto start                 = std::chrono::high_resolution_clock::now();
-    operator_input_output_data = op.get().execute(*operator_input_output_data, stream);
+    auto start            = std::chrono::high_resolution_clock::now();
+    auto temp_output_data = op.get().execute(*operator_input_output_data, stream);
+    stream.synchronize();
+    operator_input_output_data = std::move(temp_output_data);
     auto end                   = std::chrono::high_resolution_clock::now();
     auto duration              = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
     batch_sizes                = "";

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -285,12 +285,7 @@ std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consume
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
     return output_consumers;
   }
-  auto parents =
-    _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_parents();
-  for (auto& parent : parents) {
-    output_consumers.push_back(&parent->get_operators()[0].get());
-  }
-  return output_consumers;
+  return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_output_consumers();
 }
 
 }  // namespace pipeline

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -285,7 +285,9 @@ std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consume
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
     return output_consumers;
   }
-  return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_output_consumers();
+  return _global_state->cast<gpu_pipeline_task_global_state>()
+    .get_pipeline()
+    ->get_output_consumers();
 }
 
 }  // namespace pipeline

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -172,7 +172,7 @@ sirius_pipeline::get_operators() const
   return result;
 }
 
-std::vector<sirius_pipeline*> sirius_pipeline::get_parents()
+std::vector<sirius_pipeline*> sirius_pipeline::get_parents() const
 {
   std::vector<sirius_pipeline*> result;
   for (auto& weak_parent : parents) {
@@ -331,5 +331,16 @@ void sirius_pipeline::mark_task_completed()
   update_pipeline_status();
 }
 
+std::vector<op::sirius_physical_operator*> sirius_pipeline::get_output_consumers() const
+{
+  auto parents = get_parents();
+  std::vector<op::sirius_physical_operator*> result;
+  for (auto& parent : parents) {
+    if (auto src = parent->get_source(); src) {
+      result.push_back(src.get());
+    }
+    }
+    return result;
+  }
 }  // namespace pipeline
 }  // namespace sirius

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -336,11 +336,9 @@ std::vector<op::sirius_physical_operator*> sirius_pipeline::get_output_consumers
   auto parents = get_parents();
   std::vector<op::sirius_physical_operator*> result;
   for (auto& parent : parents) {
-    if (auto src = parent->get_source(); src) {
-      result.push_back(src.get());
-    }
-    }
-    return result;
+    if (auto src = parent->get_source(); src) { result.push_back(src.get()); }
   }
+  return result;
+}
 }  // namespace pipeline
 }  // namespace sirius


### PR DESCRIPTION
fixed issue where we had a race condition where an operator could end early if we pulled a batch and created = completed before we marked created