### PR TITLE
Added operator parameter Sirius Configuration parameters

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ libabseil = ">=20260107.0"
 duckdb = ">=1.4.4,<2"
 clang-tools = ">=21.1.8,<22"
 spdlog = "1.8.*"
+pyarrow = "*"
 
 [tasks]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,6 @@ libabseil = ">=20260107.0"
 duckdb = ">=1.4.4,<2"
 clang-tools = ">=21.1.8,<22"
 spdlog = "1.8.*"
-pyarrow = "*"
 
 [tasks]
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -38,9 +38,4 @@ bool Config::ENABLE_REGEX_JIT_IMPL = true;
 
 bool Config::MODIFIED_PIPELINE = false;
 
-uint64_t Config::DEFAULT_SCAN_TASK_BATCH_SIZE   = 512ULL * 1024 * 1024;  ///< 50 MB
-uint64_t Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256ULL;
-
-uint64_t Config::MAX_SORT_PARTITION_BYTES = 0;  ///< 0 = auto (33% of available GPU memory)
-
 }  // namespace duckdb

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -29,6 +29,7 @@
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/pipeline_executor.hpp"
 #include "planner/query.hpp"
+#include "sirius_context.hpp"
 
 #include <duckdb/execution/execution_context.hpp>
 #include <duckdb/parallel/thread_context.hpp>
@@ -91,10 +92,16 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
+      const auto& op_params =
+        _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
+          ->get_config()
+          .get_operator_params();
       _parquet_scan_operator_global_state_map.emplace(
         operator_id,
         std::make_shared<op::scan::parquet_scan_task_global_state>(
-          pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>()));
+          pipeline,
+          &source_operator->Cast<op::sirius_physical_parquet_scan>(),
+          op_params.default_scan_task_batch_size));
     } else {
       _gpu_operator_global_state_map.emplace(
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
@@ -254,8 +261,15 @@ void task_creator::manager_loop()
           size_t operator_id          = node->get_operator_id();
           auto scan_task_global_state = _scan_operator_global_state_map.at(operator_id);
 
+          const auto& op_params =
+            _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
+              ->get_config()
+              .get_operator_params();
           auto scan_task_local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
-            *scan_task_global_state, *_execution_context);
+            *scan_task_global_state,
+            *_execution_context,
+            op_params.default_scan_task_batch_size,
+            op_params.default_scan_task_varchar_size);
           if (destination_data_repositories.empty()) {
             throw std::runtime_error(
               "No destination data repositories provided for scan task creation.");

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -101,7 +101,7 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
         std::make_shared<op::scan::parquet_scan_task_global_state>(
           pipeline,
           &source_operator->Cast<op::sirius_physical_parquet_scan>(),
-          op_params.default_scan_task_batch_size));
+          op_params.scan_task_batch_size));
     } else {
       _gpu_operator_global_state_map.emplace(
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
@@ -268,7 +268,7 @@ void task_creator::manager_loop()
           auto scan_task_local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
             *scan_task_global_state,
             *_execution_context,
-            op_params.default_scan_task_batch_size,
+            op_params.scan_task_batch_size,
             op_params.default_scan_task_varchar_size);
           if (destination_data_repositories.empty()) {
             throw std::runtime_error(

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -53,17 +53,6 @@ struct Config {
 
   // Whether to fall back to duckdb execution after an error is detected
   static bool ENABLE_DUCKDB_FALLBACK;
-
-  // For duckdb scan task:
-  //  - the default batch size
-  //  - the default varchar size for estimating rows per batch
-  // TODO: probably want to use sirius config for these two values
-  static uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE;
-  static uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE;
-
-  // For sort partitioning:
-  //  - max bytes per sort partition (0 = auto based on 33% GPU memory)
-  static uint64_t MAX_SORT_PARTITION_BYTES;
 };
 
 }  // namespace duckdb

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -29,6 +29,7 @@
 #include <pipeline/sirius_pipeline.hpp>
 #include <pipeline/sirius_pipeline_itask.hpp>
 #include <pipeline/sirius_pipeline_task_states.hpp>
+#include <sirius_config.hpp>
 #include <sirius_context.hpp>
 
 // cucascade
@@ -294,8 +295,8 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
   duckdb_scan_task_local_state(
     duckdb_scan_task_global_state& g_state,
     duckdb::ExecutionContext& exec_ctx,
-    size_t approximate_batch_size = duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE,
-    size_t default_varchar_size   = duckdb::Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE,
+    size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE,
+    size_t default_varchar_size   = sirius::config::DEFAULT_SCAN_TASK_VARCHAR_SIZE,
     std::unique_ptr<duckdb::LocalTableFunctionState> existing_local_tf_state = nullptr);
 
   [[nodiscard]] std::size_t get_estimated_reservation_size() const noexcept

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -23,6 +23,7 @@
 #include <op/sirius_physical_table_scan.hpp>
 #include <pipeline/sirius_pipeline_itask.hpp>
 #include <pipeline/sirius_pipeline_task_states.hpp>
+#include <sirius_config.hpp>
 #include <sirius_context.hpp>
 
 // cucascade
@@ -89,7 +90,7 @@ class parquet_scan_task_global_state : public pipeline::sirius_pipeline_task_glo
   parquet_scan_task_global_state(
     duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
     sirius_physical_parquet_scan* scan_op,
-    size_t approximate_batch_size = duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE);
+    size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE);
 
   //===----------Methods----------===//
   /**

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -24,6 +24,7 @@
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_partition_consumer_operator.hpp"
 #include "op/sirius_physical_top_n.hpp"
+#include "sirius_config.hpp"
 
 namespace sirius {
 namespace op {
@@ -32,10 +33,12 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::CONCAT;
 
-  explicit sirius_physical_concat(duckdb::vector<duckdb::LogicalType> types,
-                                  duckdb::idx_t estimated_cardinality,
-                                  sirius_physical_operator* parent_op,
-                                  bool is_build);
+  explicit sirius_physical_concat(
+    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::idx_t estimated_cardinality,
+    sirius_physical_operator* parent_op,
+    bool is_build,
+    uint64_t concat_batch_bytes = sirius::config::DEFAULT_CONCAT_BATCH_BYTES);
 
   std::string get_name() const override;
 
@@ -59,6 +62,7 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   sirius_physical_operator* _parent_op;
   bool _is_build;
   bool _concat_all;
+  uint64_t _concat_batch_bytes;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -24,6 +24,7 @@
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_partition_consumer_operator.hpp"
 #include "op/sirius_physical_top_n.hpp"
+#include "sirius_config.hpp"
 
 namespace sirius {
 namespace op {
@@ -46,16 +47,13 @@ inline std::string partition_type_to_string(PartitionType type)
 class sirius_physical_partition : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::PARTITION;
-  static constexpr duckdb::idx_t DEFAULT_PARTITION_SIZE  = 10000000;
 
-  // Override the rows-per-partition threshold. Intended for tests only.
-  static void set_partition_size(duckdb::idx_t size) { s_partition_size = size; }
-  static void reset_partition_size() { s_partition_size = DEFAULT_PARTITION_SIZE; }
-
-  explicit sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
-                                     duckdb::idx_t estimated_cardinality,
-                                     sirius_physical_operator* parent_op,
-                                     bool is_build = false);
+  explicit sirius_physical_partition(
+    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::idx_t estimated_cardinality,
+    sirius_physical_operator* parent_op,
+    bool is_build                 = false,
+    uint64_t hash_partition_bytes = sirius::config::DEFAULT_HASH_PARTITION_BYTES);
 
   std::string get_name() const override;
 
@@ -84,8 +82,7 @@ class sirius_physical_partition : public sirius_physical_operator {
   int _num_partitions;
   bool _is_build;
   PartitionType _partition_type;
-
-  static duckdb::idx_t s_partition_size;
+  uint64_t s_partition_size;
 };
 
 }  // namespace op

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -29,7 +29,33 @@ namespace sirius {
 
 namespace config {
 struct configuration_setter;
+
+constexpr uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE   = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256LL;
+constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES   = 100ULL * 1024 * 1024;  // 100 MB
+constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES     = 100ULL * 1024 * 1024;  // 100 MB
+
 }  // namespace config
+
+/// Parameters controlling operator-level resource sizing.
+/// These can be set via the .cfg file under the [sirius.operator_params] section
+/// or overridden at runtime using DuckDB SET commands.
+struct operator_params {
+  /// Target batch size (bytes) for DuckDB scan tasks.
+  uint64_t default_scan_task_batch_size = config::DEFAULT_SCAN_TASK_BATCH_SIZE;
+
+  /// Default size estimate (bytes) for VARCHAR columns when computing rows per batch.
+  uint64_t default_scan_task_varchar_size = config::DEFAULT_SCAN_TASK_VARCHAR_SIZE;
+
+  /// Maximum bytes per sort partition (0 = auto: 33% of available GPU memory).
+  uint64_t max_sort_partition_bytes = 0;
+
+  /// Target size (bytes) per hash partition for joins and group-bys.
+  uint64_t hash_partition_bytes = config::DEFAULT_HASH_PARTITION_BYTES;
+
+  /// Target size (bytes) for the concat operator output batch.
+  uint64_t concat_batch_bytes = config::DEFAULT_CONCAT_BATCH_BYTES;
+};
 
 struct sirius_config {
   sirius_config();
@@ -55,6 +81,13 @@ struct sirius_config {
 
   [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return _enable_scan_caching; }
 
+  [[nodiscard]] const operator_params& get_operator_params() const noexcept
+  {
+    return _operator_params;
+  }
+
+  [[nodiscard]] operator_params& get_operator_params() noexcept { return _operator_params; }
+
  private:
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
@@ -67,6 +100,7 @@ struct sirius_config {
   exec::thread_pool_config _duckdb_scan_executor_config{.num_threads        = 4,
                                                         .thread_name_prefix = "duckdb_scan"};
   bool _enable_scan_caching = false;
+  operator_params _operator_params;
 };
 
 }  // namespace sirius

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -42,7 +42,7 @@ constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES     = 100ULL * 1024 * 1024;  // 10
 /// or overridden at runtime using DuckDB SET commands.
 struct operator_params {
   /// Target batch size (bytes) for DuckDB scan tasks.
-  uint64_t default_scan_task_batch_size = config::DEFAULT_SCAN_TASK_BATCH_SIZE;
+  uint64_t scan_task_batch_size = config::DEFAULT_SCAN_TASK_BATCH_SIZE;
 
   /// Default size estimate (bytes) for VARCHAR columns when computing rows per batch.
   uint64_t default_scan_task_varchar_size = config::DEFAULT_SCAN_TASK_VARCHAR_SIZE;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -98,8 +98,11 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] duckdb::shared_ptr<sirius::planner::query> get_query();
   [[nodiscard]] duckdb::shared_ptr<const sirius::planner::query> get_query() const;
 
-  /// \brief Get the current Sirius configuration.
+  /// \brief Get the current Sirius configuration (const).
   [[nodiscard]] const sirius::sirius_config& get_config() const noexcept { return config_; }
+
+  /// \brief Get the current Sirius configuration (mutable, e.g. for SET command callbacks).
+  [[nodiscard]] sirius::sirius_config& get_config() noexcept { return config_; }
 
  private:
   void throw_if_not_initialized() const;

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -17,6 +17,7 @@
 #include "op/partition/gpu_partition_impl.hpp"
 
 #include "data/data_batch_utils.hpp"
+#include "log/logging.hpp"
 
 #include <cudf/partitioning.hpp>
 #include <cudf/unary.hpp>

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -33,12 +33,14 @@ namespace op {
 sirius_physical_concat::sirius_physical_concat(duckdb::vector<duckdb::LogicalType> types,
                                                duckdb::idx_t estimated_cardinality,
                                                sirius_physical_operator* parent_op,
-                                               bool is_build)
+                                               bool is_build,
+                                               uint64_t concat_batch_bytes)
   : sirius_physical_partition_consumer_operator(
       SiriusPhysicalOperatorType::CONCAT, std::move(types), estimated_cardinality)
 {
-  _parent_op = parent_op;
-  _is_build  = is_build;
+  _parent_op          = parent_op;
+  _is_build           = is_build;
+  _concat_batch_bytes = concat_batch_bytes;
   // check if parent_op is a hash join
   if (parent_op->type == SiriusPhysicalOperatorType::HASH_JOIN) {
     auto hash_join = dynamic_cast<sirius_physical_hash_join*>(parent_op);
@@ -92,7 +94,7 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
       auto batch_size = batch->get_data()->get_size_in_bytes();
       total_batch_size += batch_size;
       // Check if the batch size is already exceed the threshold
-      if (!_concat_all && total_batch_size > duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE) {
+      if (!_concat_all && total_batch_size > _concat_batch_bytes) {
         // if the batch size is already exceed the threshold, then we need to return the batch right
         // away
         if (input_batch.size() == 0) {

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -35,8 +35,6 @@
 namespace sirius {
 namespace op {
 
-duckdb::idx_t sirius_physical_partition::s_partition_size =
-  sirius_physical_partition::DEFAULT_PARTITION_SIZE;
 namespace {
 
 std::optional<duckdb::idx_t> extract_bound_ref_index(const duckdb::Expression& expr)
@@ -58,10 +56,12 @@ std::optional<duckdb::idx_t> extract_bound_ref_index(const duckdb::Expression& e
 sirius_physical_partition::sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
                                                      duckdb::idx_t estimated_cardinality,
                                                      sirius_physical_operator* parent_op,
-                                                     bool is_build)
+                                                     bool is_build,
+                                                     uint64_t hash_partition_bytes)
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::PARTITION, std::move(types), estimated_cardinality)
 {
+  s_partition_size = hash_partition_bytes;
   _num_partitions =
     static_cast<int>((estimated_cardinality + s_partition_size - 1) / s_partition_size);
   _parent_op = parent_op;

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -212,6 +212,18 @@ struct sirius::config::custom_config_registrar<sirius::disk_mem_config> {
   }
 };
 
+template <>
+struct sirius::config::custom_config_registrar<sirius::operator_params> {
+  static void config(sirius::config::configuration_setter& setter, sirius::operator_params& opt)
+  {
+    setter.add_config("default_scan_task_batch_size", opt.default_scan_task_batch_size);
+    setter.add_config("default_scan_task_varchar_size", opt.default_scan_task_varchar_size);
+    setter.add_config("max_sort_partition_bytes", opt.max_sort_partition_bytes);
+    setter.add_config("hash_partition_bytes", opt.hash_partition_bytes);
+    setter.add_config("concat_batch_bytes", opt.concat_batch_bytes);
+  }
+};
+
 sirius_config::sirius_config()
 {
   cucascade::memory::topology_discovery discovery;
@@ -243,6 +255,7 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
   config_setter.add_config("sirius.executor.downgrade", _downgrade_executor_config);
   config_setter.add_config("sirius.executor.duckdb_scan", _duckdb_scan_executor_config);
   config_setter.add_config("sirius.executor.duckdb_scan.cache", _enable_scan_caching);
+  config_setter.add_config("sirius.operator_params", _operator_params);
 
   config_setter.add_config("sirius.space.gpu", gpu_memory_space_configs);
   config_setter.add_config("sirius.space.host", host_memory_space_configs);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -216,7 +216,7 @@ template <>
 struct sirius::config::custom_config_registrar<sirius::operator_params> {
   static void config(sirius::config::configuration_setter& setter, sirius::operator_params& opt)
   {
-    setter.add_config("default_scan_task_batch_size", opt.default_scan_task_batch_size);
+    setter.add_config("scan_task_batch_size", opt.scan_task_batch_size);
     setter.add_config("default_scan_task_varchar_size", opt.default_scan_task_varchar_size);
     setter.add_config("max_sort_partition_bytes", opt.max_sort_partition_bytes);
     setter.add_config("hash_partition_bytes", opt.hash_partition_bytes);

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -44,6 +44,7 @@
 #include "op/sirius_physical_top_n_merge.hpp"
 #include "op/sirius_physical_ungrouped_aggregate.hpp"
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
+#include "sirius_context.hpp"
 
 #include <cucascade/data/data_repository_manager.hpp>
 
@@ -220,6 +221,10 @@ duckdb::unique_ptr<op::sirius_physical_operator> sirius_engine::construct_sirius
 void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 {
   // auto &scheduler = TaskScheduler::GetScheduler(context);
+  const sirius::operator_params& op_params =
+    context.registered_state->Get<duckdb::SiriusContext>("sirius_state")
+      ->get_config()
+      .get_operator_params();
   {
     // lock_guard<mutex> elock(executor_lock);
     sirius_physical_plan = &plan;
@@ -412,24 +417,28 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
               current_pipeline->get_source()->types,
               current_pipeline->get_source()->estimated_cardinality,
               &current_pipeline->operators[join_pos].get(),
-              false);
+              false,
+              op_params.concat_batch_bytes);
             auto partition_op = make_uniq<op::sirius_physical_partition>(
               current_pipeline->get_source()->types,
               current_pipeline->get_source()->estimated_cardinality,
               concat_op.get(),
-              false);
+              false,
+              op_params.hash_partition_bytes);
             new_pipeline_breakers.push_back(std::move(partition_op));
           } else {
             concat_op = make_uniq<op::sirius_physical_concat>(
               current_pipeline->operators[join_pos - 1].get().types,
               current_pipeline->operators[join_pos - 1].get().estimated_cardinality,
               &current_pipeline->operators[join_pos].get(),
-              false);
+              false,
+              op_params.concat_batch_bytes);
             auto partition_op = make_uniq<op::sirius_physical_partition>(
               current_pipeline->operators[join_pos - 1].get().types,
               current_pipeline->operators[join_pos - 1].get().estimated_cardinality,
               concat_op.get(),
-              false);
+              false,
+              op_params.hash_partition_bytes);
             new_pipeline_breakers.push_back(std::move(partition_op));
           }
 
@@ -497,12 +506,14 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             current_pipeline->get_source()->types,
             current_pipeline->get_source()->estimated_cardinality,
             hash_join_op.get(),
-            true);
+            true,
+            op_params.concat_batch_bytes);
           partition_op = make_uniq<op::sirius_physical_partition>(
             current_pipeline->get_source()->types,
             current_pipeline->get_source()->estimated_cardinality,
             concat_op.get(),
-            true);
+            true,
+            op_params.hash_partition_bytes);
         } else {
           concat_op = make_uniq<op::sirius_physical_concat>(
             current_pipeline->operators[current_pipeline->operators.size() - 1].get().types,
@@ -510,14 +521,16 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
               .get()
               .estimated_cardinality,
             hash_join_op.get(),
-            true);
+            true,
+            op_params.concat_batch_bytes);
           partition_op = make_uniq<op::sirius_physical_partition>(
             current_pipeline->operators[current_pipeline->operators.size() - 1].get().types,
             current_pipeline->operators[current_pipeline->operators.size() - 1]
               .get()
               .estimated_cardinality,
             concat_op.get(),
-            true);
+            true,
+            op_params.hash_partition_bytes);
         }
 
         // replace sink with partition_op
@@ -548,7 +561,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             current_pipeline->get_sink()->types,
             current_pipeline->get_sink()->estimated_cardinality,
             current_pipeline->get_sink().get(),
-            false);
+            false,
+            op_params.hash_partition_bytes);
           new_pipeline_breakers.push_back(std::move(partition_op));
 
           op::sirius_physical_partition* partition_ptr =
@@ -608,8 +622,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
         // Create SORT_SAMPLE operator
         auto sample_op   = duckdb::make_uniq<op::sirius_physical_sort_sample>(order_ptr);
         auto* sample_ptr = sample_op.get();
-        if (duckdb::Config::MAX_SORT_PARTITION_BYTES > 0) {
-          sample_ptr->set_max_partition_bytes(duckdb::Config::MAX_SORT_PARTITION_BYTES);
+        if (op_params.max_sort_partition_bytes > 0) {
+          sample_ptr->set_max_partition_bytes(op_params.max_sort_partition_bytes);
         }
 
         // Pipeline B: ORDER (source) → SORT_SAMPLE (sink)
@@ -721,7 +735,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
               current_pipeline->get_source()->types,
               current_pipeline->get_source()->estimated_cardinality,
               join_op.get(),
-              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN);
+              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN,
+              op_params.hash_partition_bytes);
           } else {
             partition_join = make_uniq<op::sirius_physical_partition>(
               current_pipeline->operators[current_pipeline->operators.size() - 1].get().types,
@@ -729,7 +744,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
                 .get()
                 .estimated_cardinality,
               join_op.get(),
-              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN);
+              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN,
+              op_params.hash_partition_bytes);
           }
           delim_join->Cast<op::sirius_physical_right_delim_join>().partition_join =
             static_cast<op::sirius_physical_partition*>(partition_join.get());
@@ -738,8 +754,12 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             static_cast<op::sirius_physical_column_data_scan*>(join_op->children[0].get());
         }
 
-        auto partition_distinct = make_uniq<op::sirius_physical_partition>(
-          distinct_op->types, distinct_op->estimated_cardinality, distinct_op.get(), false);
+        auto partition_distinct =
+          make_uniq<op::sirius_physical_partition>(distinct_op->types,
+                                                   distinct_op->estimated_cardinality,
+                                                   distinct_op.get(),
+                                                   false,
+                                                   op_params.hash_partition_bytes);
 
         delim_join->Cast<op::sirius_physical_delim_join>().partition_distinct =
           static_cast<op::sirius_physical_partition*>(partition_distinct.get());
@@ -754,7 +774,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
               partition_join.get()->types,
               partition_join.get()->estimated_cardinality,
               join_op.get(),
-              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN);
+              delim_join->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN,
+              op_params.concat_batch_bytes);
           new_pipeline->source = partition_join.get();
           new_pipeline->sink   = concat_op.get();
           new_pipeline->dependencies.push_back(current_pipeline);

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -691,25 +691,57 @@ static void SetModifiedPipeline(ClientContext& context, SetScope scope, Value& p
   SIRIUS_LOG_DEBUG("Updated config MODIFIED_PIPELINE to {}", Config::MODIFIED_PIPELINE);
 }
 
+static sirius::operator_params* get_operator_params(ClientContext& context)
+{
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (sirius_ctx == nullptr) {
+    SIRIUS_LOG_DEBUG("SiriusContext not available; operator_params SET ignored");
+    return nullptr;
+  }
+  return &sirius_ctx->get_config().get_operator_params();
+}
+
 static void SetDefaultScanTaskBatchSize(ClientContext& context, SetScope scope, Value& parameter)
 {
-  Config::DEFAULT_SCAN_TASK_BATCH_SIZE = UBigIntValue::Get(parameter);
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->default_scan_task_batch_size = UBigIntValue::Get(parameter);
   SIRIUS_LOG_DEBUG("Updated config DEFAULT_SCAN_TASK_BATCH_SIZE to {}",
-                   Config::DEFAULT_SCAN_TASK_BATCH_SIZE);
+                   params->default_scan_task_batch_size);
 }
 
 static void SetDefaultScanTaskVarcharSize(ClientContext& context, SetScope scope, Value& parameter)
 {
-  Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = UBigIntValue::Get(parameter);
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->default_scan_task_varchar_size = UBigIntValue::Get(parameter);
   SIRIUS_LOG_DEBUG("Updated config DEFAULT_SCAN_TASK_VARCHAR_SIZE to {}",
-                   Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE);
+                   params->default_scan_task_varchar_size);
 }
 
 static void SetMaxSortPartitionBytes(ClientContext& context, SetScope scope, Value& parameter)
 {
-  Config::MAX_SORT_PARTITION_BYTES = UBigIntValue::Get(parameter);
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->max_sort_partition_bytes = UBigIntValue::Get(parameter);
   SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_BYTES to {}",
-                   Config::MAX_SORT_PARTITION_BYTES);
+                   params->max_sort_partition_bytes);
+}
+
+static void SetHashPartitionBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->hash_partition_bytes = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config HASH_PARTITION_BYTES to {}", params->hash_partition_bytes);
+}
+
+static void SetConcatBatchBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->concat_batch_bytes = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config CONCAT_BATCH_BYTES to {}", params->concat_batch_bytes);
 }
 
 void SiriusExtension::InitialGPUConfigs(DBConfig& config)
@@ -793,22 +825,34 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
   config.AddExtensionOption("default_scan_task_batch_size",
                             "The default batch size for a duckdb scan task",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(Config::DEFAULT_SCAN_TASK_BATCH_SIZE),
+                            Value::UBIGINT(sirius::operator_params{}.default_scan_task_batch_size),
                             SetDefaultScanTaskBatchSize);
   // Default varchar size for estimating rows per batch
   config.AddExtensionOption(
     "default_scan_task_varchar_size",
     "The default varchar size for estimating rows per batch in a duckdb scan task",
     LogicalType::UBIGINT,
-    Value::UBIGINT(Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE),
+    Value::UBIGINT(sirius::operator_params{}.default_scan_task_varchar_size),
     SetDefaultScanTaskVarcharSize);
 
   // Add in config option for sort partition size
   config.AddExtensionOption("max_sort_partition_bytes",
                             "Maximum bytes per sort partition (0 = auto based on 33% GPU memory)",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(Config::MAX_SORT_PARTITION_BYTES),
+                            Value::UBIGINT(sirius::operator_params{}.max_sort_partition_bytes),
                             SetMaxSortPartitionBytes);
+
+  config.AddExtensionOption("hash_partition_bytes",
+                            "Target size in bytes per hash partition",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(sirius::operator_params{}.hash_partition_bytes),
+                            SetHashPartitionBytes);
+
+  config.AddExtensionOption("concat_batch_bytes",
+                            "Target size for concat operator",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(sirius::operator_params{}.concat_batch_bytes),
+                            SetConcatBatchBytes);
 }
 
 static void LoadInternal(ExtensionLoader& loader)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -705,9 +705,8 @@ static void SetDefaultScanTaskBatchSize(ClientContext& context, SetScope scope, 
 {
   auto* params = get_operator_params(context);
   if (!params) { return; }
-  params->default_scan_task_batch_size = UBigIntValue::Get(parameter);
-  SIRIUS_LOG_DEBUG("Updated config DEFAULT_SCAN_TASK_BATCH_SIZE to {}",
-                   params->default_scan_task_batch_size);
+  params->scan_task_batch_size = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config SCAN_TASK_BATCH_SIZE to {}", params->scan_task_batch_size);
 }
 
 static void SetDefaultScanTaskVarcharSize(ClientContext& context, SetScope scope, Value& parameter)
@@ -822,10 +821,10 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
 
   // Add in config options for duckdb scan task
   // Default batch size
-  config.AddExtensionOption("default_scan_task_batch_size",
+  config.AddExtensionOption("scan_task_batch_size",
                             "The default batch size for a duckdb scan task",
                             LogicalType::UBIGINT,
-                            Value::UBIGINT(sirius::operator_params{}.default_scan_task_batch_size),
+                            Value::UBIGINT(sirius::operator_params{}.scan_task_batch_size),
                             SetDefaultScanTaskBatchSize);
   // Default varchar size for estimating rows per batch
   config.AddExtensionOption(

--- a/test/cpp/config/data/single_node.cfg
+++ b/test/cpp/config/data/single_node.cfg
@@ -24,10 +24,10 @@ sirius = {
         };
     };
     operator_params = {
-        scan_task_batch_size = 536870;   // 512 MB
+        scan_task_batch_size = 536870912;   // 512 MB
         default_scan_task_varchar_size = 256;
         max_sort_partition_bytes = 0;               // 0 = auto (33% GPU memory)
-        hash_partition_bytes = 104850;           // 100 MB
+        hash_partition_bytes = 104857600;           // 100 MB
         concat_batch_bytes = 104857600;             // 100 MB
     };
 };

--- a/test/cpp/config/data/single_node.cfg
+++ b/test/cpp/config/data/single_node.cfg
@@ -24,10 +24,10 @@ sirius = {
         };
     };
     operator_params = {
-        default_scan_task_batch_size = 536870912;   // 512 MB
+        scan_task_batch_size = 536870;   // 512 MB
         default_scan_task_varchar_size = 256;
         max_sort_partition_bytes = 0;               // 0 = auto (33% GPU memory)
-        hash_partition_bytes = 104857600;           // 100 MB
+        hash_partition_bytes = 104850;           // 100 MB
         concat_batch_bytes = 104857600;             // 100 MB
     };
 };

--- a/test/cpp/config/data/single_node.cfg
+++ b/test/cpp/config/data/single_node.cfg
@@ -23,4 +23,11 @@ sirius = {
             num_threads = 5;
         };
     };
+    operator_params = {
+        default_scan_task_batch_size = 536870912;   // 512 MB
+        default_scan_task_varchar_size = 256;
+        max_sort_partition_bytes = 0;               // 0 = auto (33% GPU memory)
+        hash_partition_bytes = 104857600;           // 100 MB
+        concat_batch_bytes = 104857600;             // 100 MB
+    };
 };

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -62,9 +62,9 @@ class GPUExecutionFixtureBase {
   GPUExecutionFixtureBase()
   {
     // Set up environment variable for config file
-    // auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
-    // REQUIRE(fs::exists(cfg_path));
-    // config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
+    auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
+    REQUIRE(fs::exists(cfg_path));
+    config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
 
     // Initialize DuckDB in-memory, then attach the TPC-H database
     db  = std::make_unique<duckdb::DuckDB>(nullptr);

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -62,9 +62,9 @@ class GPUExecutionFixtureBase {
   GPUExecutionFixtureBase()
   {
     // Set up environment variable for config file
-    auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
-    REQUIRE(fs::exists(cfg_path));
-    config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
+    // auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
+    // REQUIRE(fs::exists(cfg_path));
+    // config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
 
     // Initialize DuckDB in-memory, then attach the TPC-H database
     db  = std::make_unique<duckdb::DuckDB>(nullptr);

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "op/sirius_physical_partition.hpp"
-
 #include <cudf/utilities/default_stream.hpp>
 
 #include <catch.hpp>
@@ -1827,11 +1825,12 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
 
 // RAII guard to reset partition size after each test, even on failure.
 struct partition_size_guard {
-  explicit partition_size_guard(duckdb::idx_t size)
+  duckdb::Connection& con;
+  explicit partition_size_guard(duckdb::Connection& con, duckdb::idx_t size) : con(con)
   {
-    sirius::op::sirius_physical_partition::set_partition_size(size);
+    con.Query("SET hash_partition_bytes = " + std::to_string(size));
   }
-  ~partition_size_guard() { sirius::op::sirius_physical_partition::reset_partition_size(); }
+  ~partition_size_guard() { con.Query("RESET hash_partition_bytes"); }
 };
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
@@ -1839,7 +1838,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "[integration][gpu_execution][antijoin][partitioned_join]")
 {
   // n.n_regionkey is not column 0 in nation — this is the index mismatch that triggered the bug.
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey from nation n anti join region r on n.n_regionkey = r.r_regionkey;");
 }
@@ -1849,7 +1848,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "[integration][gpu_execution][parquet][antijoin][partitioned_join]")
 {
   // n.n_regionkey is not column 0 in nation — this is the index mismatch that triggered the bug.
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey from nation n anti join region r on n.n_regionkey = r.r_regionkey;");
 }
@@ -1859,7 +1858,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "[integration][gpu_execution][semijoin][partitioned_join]")
 {
   // Same shape as the anti join above — verifies the fix didn't break semi join partitioning.
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey from nation n semi join region r on n.n_regionkey = r.r_regionkey;");
 }
@@ -1869,7 +1868,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "[integration][gpu_execution][parquet][semijoin][partitioned_join]")
 {
   // Same shape as the anti join above — verifies the fix didn't break semi join partitioning.
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey from nation n semi join region r on n.n_regionkey = r.r_regionkey;");
 }
@@ -1878,7 +1877,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - partitioned inner join (key not at col 0)",
                  "[integration][gpu_execution][partitioned_join]")
 {
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey, n.n_regionkey, r.r_name "
     "from nation n join region r on n.n_regionkey = r.r_regionkey;");
@@ -1888,7 +1887,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - partitioned inner join (key not at col 0) parquet",
                  "[integration][gpu_execution][parquet][partitioned_join]")
 {
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey, n.n_regionkey, r.r_name "
     "from nation n join region r on n.n_regionkey = r.r_regionkey;");
@@ -3094,21 +3093,13 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
 // the original value after each test regardless of pass/fail.
 // ---------------------------------------------------------------------------
 
-struct PartitionSizeGuard {
-  explicit PartitionSizeGuard(duckdb::idx_t override_size)
-  {
-    sirius::op::sirius_physical_partition::set_partition_size(override_size);
-  }
-  ~PartitionSizeGuard() { sirius::op::sirius_physical_partition::reset_partition_size(); }
-};
-
 // nation (25 rows) with partition_size=5 → ceil(25/5) = 5 partitions.
 // count(distinct n_nationkey) per region must still equal 5.
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - count distinct: multi-partition forced, single group key",
                  "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(5);
+  partition_size_guard guard(*con, 5);
   compare_gpu_vs_cpu(
     "select n_regionkey, count(distinct n_nationkey) from nation group by n_regionkey;");
 }
@@ -3117,7 +3108,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - count distinct: multi-partition forced, single group key parquet",
                  "[integration][gpu_execution][parquet][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(5);
+  partition_size_guard guard(*con, 5);
   compare_gpu_vs_cpu(
     "select n_regionkey, count(distinct n_nationkey) from nation group by n_regionkey;");
 }
@@ -3127,7 +3118,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - count distinct: multi-partition forced, customer table",
                  "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(1000);
+  partition_size_guard guard(*con, 1000);
   compare_gpu_vs_cpu(
     "select c_nationkey, count(distinct c_mktsegment) from customer group by c_nationkey;");
 }
@@ -3136,7 +3127,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - count distinct: multi-partition forced, customer table parquet",
                  "[integration][gpu_execution][parquet][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(1000);
+  partition_size_guard guard(*con, 1000);
   compare_gpu_vs_cpu(
     "select c_nationkey, count(distinct c_mktsegment) from customer group by c_nationkey;");
 }
@@ -3146,7 +3137,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - count distinct: multi-partition forced, mixed aggregations",
                  "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(1000);
+  partition_size_guard guard(*con, 1000);
   compare_gpu_vs_cpu(
     "select c_nationkey, count(distinct c_mktsegment), min(c_custkey), count(*) "
     "from customer group by c_nationkey;");
@@ -3157,7 +3148,7 @@ TEST_CASE_METHOD(
   "gpu_execution - count distinct: multi-partition forced, mixed aggregations parquet",
   "[integration][gpu_execution][parquet][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(1000);
+  partition_size_guard guard(*con, 1000);
   compare_gpu_vs_cpu(
     "select c_nationkey, count(distinct c_mktsegment), min(c_custkey), count(*) "
     "from customer group by c_nationkey;");
@@ -3190,7 +3181,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - count distinct: multi-column struct, multi-partition forced",
                  "[integration][gpu_execution][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(5);
+  partition_size_guard guard(*con, 5);
   compare_gpu_vs_cpu(
     "select n_regionkey, count(distinct (n_nationkey, n_name)) from nation group by n_regionkey;");
 }
@@ -3200,7 +3191,7 @@ TEST_CASE_METHOD(
   "gpu_execution - count distinct: multi-column struct, multi-partition forced parquet",
   "[integration][gpu_execution][parquet][group_by][count_distinct][multi_partition]")
 {
-  PartitionSizeGuard guard(5);
+  partition_size_guard guard(*con, 5);
   compare_gpu_vs_cpu(
     "select n_regionkey, count(distinct (n_nationkey, n_name)) from nation group by n_regionkey;");
 }

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1901,7 +1901,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   // Regression test for the bug where n_nationkey (INT32) and c_custkey (INT64) were hashed
   // using different physical types: cuDF murmur3 produces different hash values for the same
   // integer in INT32 vs INT64, so matching keys landed in different partitions.
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey, n.n_regionkey from nation n "
     "anti join customer c on n.n_nationkey = c.c_custkey;");
@@ -1911,7 +1911,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
                  "gpu_execution - partitioned anti join (misfit key) parquet",
                  "[integration][gpu_execution][antijoin][partitioned_join]")
 {
-  partition_size_guard guard(1);
+  partition_size_guard guard(*con, 1);
   compare_gpu_vs_cpu(
     "select n.n_nationkey, n.n_regionkey from nation n "
     "anti join customer c on n.n_nationkey = c.c_custkey;");

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -390,19 +390,18 @@ TEST_CASE("sirius_physical_concat sink forwards to multiple downstream operators
 // 3. get_next_task_input_batch threshold tests
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("sirius_physical_concat stops concatenating at DEFAULT_SCAN_TASK_BATCH_SIZE threshold",
+TEST_CASE("sirius_physical_concat stops concatenating at concat_batch_bytes threshold",
           "[physical_concat]")
 {
   auto* space = get_shared_mem_space();
   REQUIRE(space != nullptr);
 
-  // Save and set a small threshold so our test batches exceed it
-  auto original_threshold                      = duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE;
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = 1024;  // 1 KB
+  // Use a small threshold so our test batches exceed it
+  constexpr uint64_t threshold = 1024;  // 1 KB
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false, threshold);
 
   // Set up a port with a data repository
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -441,9 +440,6 @@ TEST_CASE("sirius_physical_concat stops concatenating at DEFAULT_SCAN_TASK_BATCH
 
   // All batches should eventually be consumed
   REQUIRE(total_batches_returned == static_cast<std::size_t>(num_batches));
-
-  // Restore threshold
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = original_threshold;
 }
 
 TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[physical_concat]")
@@ -451,14 +447,13 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   auto* space = get_shared_mem_space();
   REQUIRE(space != nullptr);
 
-  // Save and set a small threshold
-  auto original_threshold                      = duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE;
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = 1024;  // 1 KB
+  // Use a small threshold (ignored when concat_all=true)
+  constexpr uint64_t threshold = 1024;  // 1 KB
 
   // LEFT join + is_build=true -> _concat_all = true
   auto fixture = create_test_hash_join(duckdb::JoinType::LEFT, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true);
+    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true, threshold);
 
   // Set up a port with a data repository
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -488,9 +483,6 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   // No more batches remaining
   auto result2 = concat_op.get_next_task_input_data();
   REQUIRE(result2 == nullptr);
-
-  // Restore threshold
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = original_threshold;
 }
 
 //===----------------------------------------------------------------------===//
@@ -568,13 +560,12 @@ TEST_CASE("sirius_physical_concat get_next_task_input_batch is thread-safe", "[p
   auto* space = get_shared_mem_space();
   REQUIRE(space != nullptr);
 
-  // Save and set a small threshold to force multiple get_next_task_input_batch calls
-  auto original_threshold                      = duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE;
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = 1024;  // 1 KB
+  // Use a small threshold to force multiple get_next_task_input_batch calls
+  constexpr uint64_t threshold = 1024;  // 1 KB
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false, threshold);
 
   // Set up a port with a data repository containing many batches across partitions
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -640,9 +631,6 @@ TEST_CASE("sirius_physical_concat get_next_task_input_batch is thread-safe", "[p
 
   // Check all expected IDs are present
   REQUIRE(collected_set == expected_batch_ids);
-
-  // Restore threshold
-  duckdb::Config::DEFAULT_SCAN_TASK_BATCH_SIZE = original_threshold;
 }
 
 TEST_CASE("sirius_physical_concat execute is thread-safe with independent streams",

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -61,6 +61,8 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
 
   std::size_t num_values = 10000;
 
+  std::size_t partition_size = 10000000;
+
   std::vector<typename Traits::type> values(num_values);
   if constexpr (Traits::is_string) {
     std::vector<std::string> string_values = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"};
@@ -133,12 +135,13 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
                                                              std::move(agg_result.groups),
                                                              estimated_cardinality);
 
-  sirius_physical_partition partitioner(
-    std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
+  sirius_physical_partition partitioner(std::move(partitioner_types),
+                                        estimated_cardinality,
+                                        &grouped_aggregator,
+                                        false,
+                                        partition_size);
 
   auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
-
-  std::size_t partition_size = 10000000;  // from sirius_physical_partition.hpp
 
   std::size_t expected_num_partitions =
     (estimated_cardinality + partition_size - 1) / partition_size;
@@ -229,6 +232,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
   auto input_batch =
     std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
+  std::size_t partition_size = 10000000;
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
   std::size_t estimated_cardinality = 100000000;  // 100 million rows = PARTITION_SIZE x 10
@@ -255,12 +259,13 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
                                                              std::move(agg_result.groups),
                                                              estimated_cardinality);
 
-  sirius_physical_partition partitioner(
-    std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
+  sirius_physical_partition partitioner(std::move(partitioner_types),
+                                        estimated_cardinality,
+                                        &grouped_aggregator,
+                                        false,
+                                        partition_size);
 
   auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
-
-  std::size_t partition_size = 10000000;  // from sirius_physical_partition.hpp
 
   std::size_t expected_num_partitions =
     (estimated_cardinality + partition_size - 1) / partition_size;


### PR DESCRIPTION
Moved DEFAULT_SCAN_TASK_BATCH_SIZE,  DEFAULT_SCAN_TASK_VARCHAR_SIZE and MAX_SORT_PARTITION_BYTES from DuckDB configuration to Sirius Config. 

Also added hash_partition_bytes and concat_batch_bytes.

These now all can be set from the config file under operator_params: e.g.:
```
operator_params = {
        default_scan_task_batch_size = 536870912;   // 512 MB
        default_scan_task_varchar_size = 256;
        max_sort_partition_bytes = 0;               // 0 = auto (33% GPU memory)
        hash_partition_bytes = 104857600;           // 100 MB
        concat_batch_bytes = 104857600;             // 100 MB
    };
```

CLoses #285 