### PR TITLE
Fix loadable extension build by adding EXTENSION_STATIC_BUILD

### DIFF
--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -36,7 +36,8 @@
         "CMAKE_CUDA_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_C_COMPILER_LAUNCHER": "sccache",
-        "DUCKDB_EXTENSION_CONFIGS": "${sourceDir}/../extension_config.cmake"
+        "DUCKDB_EXTENSION_CONFIGS": "${sourceDir}/../extension_config.cmake",
+        "EXTENSION_STATIC_BUILD": "ON"
       },
       "generator": "Ninja",
       "hidden": true,


### PR DESCRIPTION
PR #286 replaced the extension-ci-tools Makefile with CMake presets but dropped the EXTENSION_STATIC_BUILD=1 flag. This flag is required on Linux to link duckdb_static into the loadable extension, without which DuckDB symbols are left unresolved causing missing symbol errors.