### PR TITLE
Fix NVCC warning #117-D in cudaAssert macro

### DIFF
--- a/src/cuda/operator/cuda_helper.cuh
+++ b/src/cuda/operator/cuda_helper.cuh
@@ -41,11 +41,9 @@
 #define CUB_STDERR
 
 // clang-format off
-// FIXME: handle error message from kernel to log file
 #define cudaAssert( X ) { \
     if ( !(X) ) { \
-        /* printf( "Thread %d:%d failed assert at %s:%d!\n", blockIdx.x, threadIdx.x, __FILE__, __LINE__ ); */ \
-        return; \
+        __trap(); \
     } \
 }
 


### PR DESCRIPTION
Replace bare `return;` with `__trap()` in the cudaAssert device macro. The bare return triggered "non-void function should return a value" warnings in non-void __device__ functions (e.g. device_comparison_null).