### PR TITLE
Retry mechanism for oom handling in tasks

### DIFF
--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -61,12 +61,14 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
    * @param batch_views Vector of data batches serving as input to the pipeline
    * @param res Memory reservation for GPU resources
    */
-  explicit gpu_pipeline_task_local_state(std::unique_ptr<op::operator_data> input_data)
-    : _input_data(std::move(input_data))
+  explicit gpu_pipeline_task_local_state(std::unique_ptr<op::operator_data> input_data,
+                                         size_t start_operator_index = 0)
+    : _input_data(std::move(input_data)), _start_operator_index(start_operator_index)
   {
   }
 
   std::unique_ptr<op::operator_data> _input_data;  ///< Input data batches for the pipeline
+  size_t _start_operator_index = 0;  ///< Operator index to resume from (0 = start of pipeline)
 
   /**
    * @brief Get a const pointer to the reservation (non-owning).
@@ -156,9 +158,57 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   /// @brief Get the output consumer operators for this task.
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 
+  /**
+   * @brief Mark this task as rescheduled due to OOM.
+   *
+   * When set, the destructor will NOT call mark_task_completed() on the pipeline,
+   * since the rescheduled replacement task will handle that instead.
+   */
+  void mark_as_rescheduled() noexcept { _oom_rescheduled = true; }
+
+  /**
+   * @brief Check if this task was rescheduled due to OOM.
+   */
+  [[nodiscard]] bool is_rescheduled() const noexcept { return _oom_rescheduled; }
+
+  /**
+   * @brief Get the data repositories for output publishing.
+   *
+   * Used by the executor to create a rescheduled task with the same output destinations.
+   */
+  [[nodiscard]] const std::vector<cucascade::shared_data_repository*>& get_data_repos()
+    const noexcept
+  {
+    return _data_repos;
+  }
+
+  /**
+   * @brief Get the shared global state.
+   *
+   * Used by the executor to create a rescheduled task sharing the same pipeline context.
+   */
+  [[nodiscard]] std::shared_ptr<sirius_pipeline_task_global_state> get_shared_global_state() const
+  {
+    return std::dynamic_pointer_cast<sirius_pipeline_task_global_state>(_global_state);
+  }
+
+  /**
+   * @brief Create a rescheduled task after an OOM event.
+   *
+   * Derived classes can override this to ensure the rescheduled task has the correct
+   * dynamic type and any additional state needed for re-execution.
+   *
+   * @param task_id The unique identifier for the new task
+   * @param local_state The local state with intermediate data and resume index
+   * @return A new task ready to be scheduled for execution
+   */
+  virtual std::unique_ptr<gpu_pipeline_task> create_rescheduled_task(
+    uint64_t task_id, std::unique_ptr<sirius_pipeline_task_local_state> local_state);
+
  private:
   uint64_t _task_id;
   std::vector<cucascade::shared_data_repository*> _data_repos;
+  bool _oom_rescheduled = false;
 };
 
 }  // namespace pipeline

--- a/src/include/pipeline/oom_reschedule_exception.hpp
+++ b/src/include/pipeline/oom_reschedule_exception.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "op/sirius_physical_operator.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace sirius::pipeline {
+
+/**
+ * @brief Exception thrown when an OOM occurs during pipeline task execution.
+ *
+ * This exception carries the intermediate operator data and the index of the
+ * operator that failed, allowing the executor to reschedule the task to resume
+ * from the point of failure.
+ */
+class oom_reschedule_exception : public std::exception {
+ public:
+  oom_reschedule_exception(std::unique_ptr<op::operator_data> intermediate_data,
+                           size_t resume_operator_index,
+                           std::string message)
+    : _intermediate_data(std::move(intermediate_data)),
+      _resume_operator_index(resume_operator_index),
+      _message(std::move(message))
+  {
+  }
+
+  /**
+   * @brief Release ownership of the intermediate data.
+   */
+  std::unique_ptr<op::operator_data> release_intermediate_data()
+  {
+    return std::move(_intermediate_data);
+  }
+
+  /**
+   * @brief Get the operator index to resume from.
+   */
+  [[nodiscard]] size_t get_resume_operator_index() const noexcept { return _resume_operator_index; }
+
+  [[nodiscard]] const char* what() const noexcept override { return _message.c_str(); }
+
+ private:
+  std::unique_ptr<op::operator_data> _intermediate_data;
+  size_t _resume_operator_index;
+  std::string _message;
+};
+
+}  // namespace sirius::pipeline

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -23,6 +23,7 @@
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_queue.hpp"
+#include "pipeline/oom_reschedule_exception.hpp"
 #include "pipeline/task_request.hpp"
 
 #include <rmm/cuda_device.hpp>
@@ -139,6 +140,50 @@ void gpu_pipeline_executor::manager_loop()
                             pipeline]() mutable {
       try {
         task->execute(exc_stream);
+      } catch (oom_reschedule_exception& oom) {
+        SIRIUS_LOG_WARN("GPU Pipeline Executor: OOM reschedule, resuming from operator index {}",
+                        oom.get_resume_operator_index());
+
+        auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
+        if (!gpu_task) {
+          SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for OOM reschedule");
+          if (_completion_handler) {
+            _completion_handler->report_error(
+              "GPU Pipeline Executor: Failed to cast task for OOM reschedule");
+          }
+          return;
+        }
+
+        // Mark old task as rescheduled so its destructor skips mark_task_completed().
+        // The rescheduled task will handle completion instead.
+        gpu_task->mark_as_rescheduled();
+
+        // Prepare intermediate data batches for re-processing.
+        // Operator outputs are in idle state; transition to task_created so
+        // lock_or_prepare_batch() can lock them for the rescheduled task.
+        auto intermediate_data = oom.release_intermediate_data();
+        if (intermediate_data) {
+          for (auto& batch : intermediate_data->get_data_batches()) {
+            if (batch) { batch->try_to_create_task(); }
+          }
+        }
+
+        // Build the rescheduled task via virtual factory (preserves derived type).
+        auto new_local_state = std::make_unique<gpu_pipeline_task_local_state>(
+          std::move(intermediate_data), oom.get_resume_operator_index());
+        auto new_task_id =
+          _task_creator ? _task_creator->get_next_task_id() : gpu_task->get_task_id();
+        auto new_task = gpu_task->create_rescheduled_task(new_task_id, std::move(new_local_state));
+
+        // Brief backoff before rescheduling to allow other tasks to complete
+        // and free memory. Without this, a rescheduled task can spin in a tight
+        // OOM → reschedule → OOM loop consuming CPU without making progress.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Schedule the rescheduled task. It goes back through manager_loop()
+        // to acquire a fresh reservation before execution.
+        this->schedule(std::move(new_task));
+        return;
       } catch (const std::exception& e) {
         SIRIUS_LOG_ERROR("GPU Pipeline Executor: Exception during task execution: {}", e.what());
         if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -178,7 +178,7 @@ void gpu_pipeline_executor::manager_loop()
         // Brief backoff before rescheduling to allow other tasks to complete
         // and free memory. Without this, a rescheduled task can spin in a tight
         // OOM → reschedule → OOM loop consuming CPU without making progress.
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
         // Schedule the rescheduled task. It goes back through manager_loop()
         // to acquire a fresh reservation before execution.

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -18,6 +18,7 @@
 
 #include "cudf/cudf_utils.hpp"
 #include "log/logging.hpp"
+#include "pipeline/oom_reschedule_exception.hpp"
 
 #include <absl/cleanup/cleanup.h>
 #include <absl/functional/any_invocable.h>
@@ -25,6 +26,7 @@
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/error.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <data/data_batch_utils.hpp>
@@ -154,6 +156,7 @@ gpu_pipeline_task::gpu_pipeline_task(
 
 gpu_pipeline_task::~gpu_pipeline_task()
 {
+  if (_oom_rescheduled) { return; }
   if (_global_state == nullptr ||
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
     return;
@@ -173,39 +176,65 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
   auto pipeline     = _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
   auto& local_state = _local_state->cast<gpu_pipeline_task_local_state>();
   auto operator_input_output_data = std::move(local_state._input_data);
-  std::string batch_sizes         = "";
+  auto operators                  = pipeline->get_operators();
+  auto start_index                = local_state._start_operator_index;
+
+  if (start_index > 0) {
+    SIRIUS_LOG_INFO("Pipeline {}: resuming task {} from operator index {} (of {})",
+                    pipeline->get_pipeline_id(),
+                    _task_id,
+                    start_index,
+                    operators.size());
+  }
+
+  std::string batch_sizes = "";
   for (auto& batch : operator_input_output_data->get_data_batches()) {
     auto view = get_cudf_table_view(*batch);
     batch_sizes += std::to_string(view.num_rows()) + "  ";
   }
-  for (auto& op : pipeline->get_operators()) {
+  for (size_t i = start_index; i < operators.size(); i++) {
+    auto& op = operators[i].get();
     SIRIUS_LOG_TRACE("Pipeline {}: operator {} (id={}) executing on {} batches with num row: {}",
                      pipeline->get_pipeline_id(),
-                     op.get().get_name(),
-                     op.get().get_operator_id(),
+                     op.get_name(),
+                     op.get_operator_id(),
                      operator_input_output_data->get_data_batches().size(),
                      batch_sizes);
-    auto start            = std::chrono::high_resolution_clock::now();
-    auto temp_output_data = op.get().execute(*operator_input_output_data, stream);
-    stream.synchronize();
-    operator_input_output_data = std::move(temp_output_data);
-    auto end                   = std::chrono::high_resolution_clock::now();
-    auto duration              = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    batch_sizes                = "";
-    for (auto& batch : operator_input_output_data->get_data_batches()) {
-      auto view = get_cudf_table_view(*batch);
-      batch_sizes += std::to_string(view.num_rows()) + "  ";
+    try {
+      auto start            = std::chrono::high_resolution_clock::now();
+      auto temp_output_data = op.execute(*operator_input_output_data, stream);
+      stream.synchronize();
+      operator_input_output_data = std::move(temp_output_data);
+      auto end                   = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+      batch_sizes   = "";
+      for (auto& batch : operator_input_output_data->get_data_batches()) {
+        auto view = get_cudf_table_view(*batch);
+        batch_sizes += std::to_string(view.num_rows()) + "  ";
+      }
+      SIRIUS_LOG_TRACE(
+        "Pipeline {}: operator {} (id={}) produced {} batches with num rows: {}, execution time: "
+        "{:.2f} ms",
+        pipeline->get_pipeline_id(),
+        op.get_name(),
+        op.get_operator_id(),
+        operator_input_output_data ? operator_input_output_data->get_data_batches().size() : 0u,
+        batch_sizes,
+        duration.count() / 1000.0);
+      validate_operator_output_types(operator_input_output_data.get(), op);
+    } catch (const rmm::out_of_memory&) {
+      SIRIUS_LOG_WARN("Pipeline {}: OOM at operator {} (id={}, index {}/{}), rescheduling task {}",
+                      pipeline->get_pipeline_id(),
+                      op.get_name(),
+                      op.get_operator_id(),
+                      i,
+                      operators.size(),
+                      _task_id);
+      throw oom_reschedule_exception(
+        std::move(operator_input_output_data),
+        i,
+        "OOM at operator " + op.get_name() + " (index " + std::to_string(i) + ")");
     }
-    SIRIUS_LOG_TRACE(
-      "Pipeline {}: operator {} (id={}) produced {} batches with num rows: {}, execution time: "
-      "{:.2f} ms",
-      pipeline->get_pipeline_id(),
-      op.get().get_name(),
-      op.get().get_operator_id(),
-      operator_input_output_data ? operator_input_output_data->get_data_batches().size() : 0u,
-      batch_sizes,
-      duration.count() / 1000.0);
-    validate_operator_output_types(operator_input_output_data.get(), op.get());
   }
   return operator_input_output_data;
 }
@@ -291,6 +320,13 @@ std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consume
   return _global_state->cast<gpu_pipeline_task_global_state>()
     .get_pipeline()
     ->get_output_consumers();
+}
+
+std::unique_ptr<gpu_pipeline_task> gpu_pipeline_task::create_rescheduled_task(
+  uint64_t task_id, std::unique_ptr<sirius_pipeline_task_local_state> local_state)
+{
+  return std::make_unique<gpu_pipeline_task>(
+    task_id, _data_repos, std::move(local_state), get_shared_global_state());
 }
 
 }  // namespace pipeline

--- a/test/cpp/pipeline/CMakeLists.txt
+++ b/test/cpp/pipeline/CMakeLists.txt
@@ -17,7 +17,9 @@
 # include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(TEST_SOURCES
-    ${TEST_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_pipeline_executor.cpp
+    ${TEST_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_pipeline_executor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_pipeline_executor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_oom_reschedule.cpp
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_modified_pipeline.cpp
     PARENT_SCOPE)

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "exec/channel.hpp"
+#include "exec/config.hpp"
+#include "pipeline/gpu_pipeline_executor.hpp"
+#include "pipeline/gpu_pipeline_task.hpp"
+#include "pipeline/oom_reschedule_exception.hpp"
+#include "pipeline/sirius_pipeline_task_states.hpp"
+#include "pipeline/task_request.hpp"
+#include "scan/test_utils.hpp"
+
+#include <rmm/mr/device_memory_resource.hpp>
+
+#include <absl/cleanup/cleanup.h>
+#include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// Memory layout:
+//   GPU capacity  = 1100 MB (software limit)
+//   Reservation   =  50 MB per task (intentionally small)
+//   Allocation    = 400 MB per task (much larger than reservation)
+//
+// With 3 threads, all 3 tasks start concurrently.
+// Accounting after 3 reservations: 150 MB
+// First  allocation (+350 MB overflow): total =  500 MB ≤ 1100 → OK
+// Second allocation (+350 MB overflow): total =  850 MB ≤ 1100 → OK
+// Third  allocation (+350 MB overflow): total = 1200 MB > 1100 → OOM!
+//
+// The OOM'd task gets rescheduled. After the first two complete, enough
+// accounting headroom is freed for the rescheduled task to succeed.
+// (Note: cucascade's cross-boundary deallocation accounting leaves some
+//  residual in _total_allocated_bytes, hence the extra capacity margin.)
+constexpr std::size_t kGpuCapacity     = 1100ULL * 1024 * 1024;  // 1100 MB
+constexpr std::size_t kReservationSize = 50ULL * 1024 * 1024;    // 50 MB
+constexpr std::size_t kAllocationBytes = 400ULL * 1024 * 1024;   // 400 MB
+constexpr auto kHoldDuration           = std::chrono::milliseconds(800);
+
+//------------------------------------------------------------------------------
+// Test global state — shared across all tasks
+//------------------------------------------------------------------------------
+class oom_test_global_state : public sirius::pipeline::sirius_pipeline_task_global_state {
+ public:
+  oom_test_global_state() : sirius_pipeline_task_global_state(nullptr) {}
+
+  void add_error(std::string message)
+  {
+    error_count.fetch_add(1, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(error_mutex);
+    errors.push_back(std::move(message));
+  }
+
+  std::atomic<int> completed_count{0};
+  std::atomic<int> oom_count{0};
+  std::atomic<int> error_count{0};
+  std::mutex error_mutex;
+  std::vector<std::string> errors;
+};
+
+//------------------------------------------------------------------------------
+// Test task — allocates kAllocationBytes of GPU memory, holds it, then frees.
+// If OOM occurs, throws oom_reschedule_exception for the executor to handle.
+//------------------------------------------------------------------------------
+class oom_test_task : public sirius::pipeline::gpu_pipeline_task {
+ public:
+  oom_test_task(uint64_t task_id,
+                std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state> local_state,
+                std::shared_ptr<oom_test_global_state> global_state)
+    : gpu_pipeline_task(task_id,
+                        std::vector<cucascade::shared_data_repository*>{},
+                        std::move(local_state),
+                        std::move(global_state))
+  {
+  }
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto& global = _global_state->cast<oom_test_global_state>();
+    auto& local  = _local_state->cast<sirius::pipeline::gpu_pipeline_task_local_state>();
+
+    auto reservation = local.release_reservation();
+    if (!reservation) {
+      global.add_error("Missing GPU memory reservation for OOM test task.");
+      global.completed_count.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+
+    auto* allocator =
+      reservation->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
+    if (!allocator) {
+      global.add_error("Missing reservation-aware allocator for OOM test task.");
+      global.completed_count.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+
+    // Attach with ignore policy — reservations are intentionally small so the
+    // actual allocation (kAllocationBytes >> kReservationSize) exceeds the
+    // reservation. The ignore policy lets the allocation proceed to the
+    // upstream pool, where it will OOM if the software capacity is exceeded.
+    if (!allocator->attach_reservation_to_tracker(
+          stream,
+          std::move(reservation),
+          std::make_unique<cucascade::memory::ignore_reservation_limit_policy>(),
+          nullptr)) {
+      global.add_error("Failed to attach reservation to stream tracker.");
+      global.completed_count.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+    absl::Cleanup cleanup = [allocator, stream]() { allocator->reset_stream_reservation(stream); };
+
+    void* allocation = nullptr;
+    try {
+      allocation = allocator->allocate(stream, kAllocationBytes);
+    } catch (const rmm::out_of_memory&) {
+      global.oom_count.fetch_add(1, std::memory_order_relaxed);
+      // Throw oom_reschedule_exception so the executor reschedules this task.
+      // Pass the input data through so the rescheduled task can use it.
+      throw sirius::pipeline::oom_reschedule_exception(
+        std::move(local._input_data), 0, "OOM in test task allocation");
+    }
+
+    // Hold the memory for a while to create pressure on concurrent tasks.
+    std::this_thread::sleep_for(kHoldDuration);
+
+    allocator->deallocate(stream, allocation, kAllocationBytes);
+    global.completed_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  std::unique_ptr<sirius::op::operator_data> compute_task(rmm::cuda_stream_view) override
+  {
+    return nullptr;
+  }
+
+  void publish_output(sirius::op::operator_data&, rmm::cuda_stream_view) override {}
+
+  std::size_t get_estimated_reservation_size() const override { return kReservationSize; }
+
+  std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
+
+  std::unique_ptr<gpu_pipeline_task> create_rescheduled_task(
+    uint64_t task_id,
+    std::unique_ptr<sirius::pipeline::sirius_pipeline_task_local_state> local_state) override
+  {
+    auto typed_local = std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state>(
+      static_cast<sirius::pipeline::gpu_pipeline_task_local_state*>(local_state.release()));
+    return std::make_unique<oom_test_task>(
+      task_id,
+      std::move(typed_local),
+      std::dynamic_pointer_cast<oom_test_global_state>(_global_state));
+  }
+};
+
+}  // namespace
+
+TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_executor][oom]")
+{
+  //--------------------------------------------------------------------------
+  // 1. Set up a constrained GPU memory environment (900 MB software limit)
+  //--------------------------------------------------------------------------
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  try {
+    cucascade::memory::reservation_manager_configurator builder;
+    builder.set_number_of_gpus(1)
+      .set_gpu_usage_limit(kGpuCapacity)
+      .set_reservation_fraction_per_gpu(0.95)
+      .set_per_host_capacity(1ULL * 1024 * 1024 * 1024)
+      .use_host_per_gpu()
+      .track_reservation_per_stream(false)
+      .set_reservation_fraction_per_host(0.75);
+    auto space_configs = builder.build();
+    manager =
+      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+  } catch (const std::exception& e) {
+    WARN("Skipping OOM reschedule test due to insufficient GPUs: " << e.what());
+    return;
+  }
+
+  auto* mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+  if (!mem_space) {
+    WARN("Skipping OOM reschedule test because no GPU memory space is available.");
+    return;
+  }
+
+  //--------------------------------------------------------------------------
+  // 2. Create the executor with 3 worker threads so all tasks run concurrently
+  //--------------------------------------------------------------------------
+  sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
+  auto request_publisher = request_channel.make_publisher();
+
+  sirius::exec::thread_pool_config config;
+  config.num_threads        = 3;
+  config.thread_name_prefix = "oom-test";
+
+  sirius::pipeline::gpu_pipeline_executor executor(config, mem_space, request_publisher);
+  auto global_state = std::make_shared<oom_test_global_state>();
+
+  //--------------------------------------------------------------------------
+  // 3. Schedule 3 tasks (total demand 3×400MB = 1.2GB > 900MB capacity)
+  //--------------------------------------------------------------------------
+  const int num_tasks = 3;
+  std::atomic<int> dispatched{0};
+
+  executor.start();
+
+  // Thread that responds to task requests from the executor's manager_loop.
+  std::thread request_handler([&]() {
+    while (dispatched.load(std::memory_order_relaxed) < num_tasks) {
+      auto request = request_channel.get();
+      if (!request) { break; }
+
+      auto local_state = std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(
+        std::make_unique<sirius::op::operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+      auto task = std::make_unique<oom_test_task>(
+        static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed)),
+        std::move(local_state),
+        global_state);
+      executor.schedule(std::move(task));
+      dispatched.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Keep consuming task requests for rescheduled tasks until completion.
+    // Rescheduled tasks are already in the executor's queue — we just drain
+    // the request channel to prevent the manager_loop from blocking.
+    while (global_state->completed_count.load(std::memory_order_relaxed) < num_tasks) {
+      auto request = request_channel.get();
+      if (!request) { break; }
+    }
+  });
+
+  //--------------------------------------------------------------------------
+  // 4. Wait for all tasks to complete (including rescheduled ones)
+  //--------------------------------------------------------------------------
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout    = std::chrono::seconds(30);
+  while (global_state->completed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    if (std::chrono::steady_clock::now() - start_time > timeout) {
+      executor.stop();
+      request_channel.close();
+      request_handler.join();
+      FAIL("Timed out waiting for OOM rescheduled tasks to complete. "
+           << "Completed: " << global_state->completed_count.load()
+           << ", OOM count: " << global_state->oom_count.load());
+    }
+  }
+
+  executor.stop();
+  request_channel.close();
+  request_handler.join();
+
+  //--------------------------------------------------------------------------
+  // 5. Validate results
+  //--------------------------------------------------------------------------
+  if (global_state->error_count.load(std::memory_order_relaxed) > 0) {
+    std::lock_guard<std::mutex> lock(global_state->error_mutex);
+    for (const auto& error : global_state->errors) {
+      INFO(error);
+    }
+  }
+
+  REQUIRE(global_state->error_count.load(std::memory_order_relaxed) == 0);
+  REQUIRE(global_state->completed_count.load(std::memory_order_relaxed) == num_tasks);
+  // At least one task should have OOM'd and been rescheduled
+  REQUIRE(global_state->oom_count.load(std::memory_order_relaxed) >= 1);
+
+  INFO("OOM reschedule test passed: " << global_state->oom_count.load() << " task(s) rescheduled, "
+                                      << num_tasks << " completed successfully");
+}


### PR DESCRIPTION
When an operator throws rmm::out_of_memory during gpu_pipeline_task execution, catch it and reschedule the task to resume from the failing operator once memory is available.

Key changes:
- Add oom_reschedule_exception to carry intermediate data and resume index from the point of OOM failure
- Modify compute_task() to catch rmm::out_of_memory per-operator and throw oom_reschedule_exception with the intermediate state
- Add _oom_rescheduled flag to gpu_pipeline_task so the destructor skips mark_task_completed() for rescheduled tasks, preventing counter imbalance and premature pipeline completion
- Add _start_operator_index to gpu_pipeline_task_local_state to support mid-pipeline resume on rescheduled tasks
- Catch oom_reschedule_exception in gpu_pipeline_executor, create a rescheduled task via virtual factory, and re-queue it with a 100ms backoff to avoid tight OOM spin loops
- Add virtual create_rescheduled_task() so derived task types are preserved through rescheduling
- Add integration test that validates OOM recovery with constrained GPU memory (3 concurrent tasks, 1100MB capacity, 400MB per task) )


Please ignore the branch name. I am sleep deprived and working on multiple things at once :s .