### PR TITLE
Set `release/26.02` branch for `cucascade` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "cucascade"]
 	path = cucascade
 	url = https://github.com/NVIDIA/cuCascade.git
-	branch = main
+	branch = release/26.02
 [submodule "duckdb-python"]
 	path = duckdb-python
 	url = https://github.com/duckdb/duckdb-python.git


### PR DESCRIPTION
Forget to set this in #347.