### PR TITLE
Implement memory-pressure-driven downgrade execution with per-space executors

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -16,26 +16,30 @@
 
 #include "downgrade/downgrade_executor.hpp"
 
+#include "log/logging.hpp"
+
+#include <rmm/cuda_stream.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <optional>
+#include <thread>
+
 namespace sirius {
 namespace parallel {
 
 void downgrade_executor::schedule(std::unique_ptr<itask> task)
 {
-  // Downgrade-specific scheduling logic
   auto downgrade_task = cast_to_downgrade_task(task.get());
   if (!downgrade_task) {
-    // If it's not a downgrade_task, use the parent's implementation
     itask_executor::schedule(std::move(task));
     return;
   }
-
-  // Schedule the downgrade task using the parent's method
   itask_executor::schedule(std::move(task));
 }
 
 downgrade_task* downgrade_executor::cast_to_downgrade_task(itask* task)
 {
-  // Safely cast to downgrade_task
   return dynamic_cast<downgrade_task*>(task);
 }
 
@@ -44,10 +48,21 @@ void downgrade_executor::start()
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
   on_start();
+  // Tell the queue how many workers to wake on close()
+  auto* dq = dynamic_cast<downgrade_task_queue*>(_task_queue.get());
+  if (dq) { dq->set_num_workers(_config.num_threads); }
   _threads.reserve(_config.num_threads);
   for (int i = 0; i < _config.num_threads; ++i) {
     _threads.emplace_back(&downgrade_executor::worker_loop, this, i);
   }
+  _monitor_thread = std::thread(&downgrade_executor::monitor_loop, this);
+}
+
+void downgrade_executor::drain()
+{
+  // Stop then restart — ensures all in-flight tasks complete and the queue is empty
+  stop();
+  start();
 }
 
 void downgrade_executor::stop()
@@ -55,6 +70,7 @@ void downgrade_executor::stop()
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
   on_stop();
+  if (_monitor_thread.joinable()) { _monitor_thread.join(); }
   for (auto& thread : _threads) {
     if (thread.joinable()) { thread.join(); }
   }
@@ -63,22 +79,180 @@ void downgrade_executor::stop()
 
 void downgrade_executor::worker_loop(int worker_id)
 {
+  // cudaMemcpyBatchAsync requires a real (non-default) CUDA stream
+  rmm::cuda_stream stream;
+
   while (true) {
-    if (!_running.load()) {
-      // Executor is stopped.
-      break;
-    }
+    if (!_running.load()) { break; }
     auto task = _task_queue->pull();
-    if (task == nullptr) {
-      // Task queue is closed.
-      break;
-    }
+    if (task == nullptr) { break; }
     try {
-      task->execute(cudf::get_default_stream());
+      task->execute(stream);
     } catch (const std::exception& e) {
-      on_task_error(worker_id, std::move(task), e);
+      // Downgrade failures are non-fatal — log and continue to the next task.
+      // Do NOT call on_task_error() here: it calls stop() from within the worker
+      // thread, which tries to join itself and causes a deadlock.
+      SIRIUS_LOG_ERROR("[downgrade] worker {} task failed: {}", worker_id, e.what());
     }
   }
+}
+
+void downgrade_executor::monitor_loop()
+{
+  using namespace std::chrono_literals;
+
+  while (_running.load()) {
+    if (_memory_space && _memory_space->should_downgrade_memory()) {
+      size_t amount = _memory_space->get_amount_to_downgrade();
+      if (amount > 0) {
+        // Collect all repositories from the manager
+        std::vector<downgrade_repository_info> repos;
+        _data_repo_mgr.for_each_repository(
+          [&repos](cucascade::shared_data_repository* repo) { repos.push_back({repo}); });
+        if (!repos.empty()) { run_downgrade_pass(std::move(repos), amount); }
+      }
+    }
+    // Brief sleep to avoid busy-spinning; the monitor re-checks after each interval
+    std::this_thread::sleep_for(10ms);
+  }
+}
+
+// --- Static helpers ---
+
+size_t downgrade_executor::get_repo_data_size_on_tier(cucascade::shared_data_repository* repo,
+                                                      cucascade::memory::Tier tier)
+{
+  size_t total = 0;
+  for (size_t p = 0; p < repo->num_partitions(); ++p) {
+    auto batch_ids = repo->get_batch_ids(p);
+    for (auto id : batch_ids) {
+      auto batch = repo->get_data_batch_by_id(id, std::nullopt, p);
+      if (!batch || !batch->get_data()) continue;
+      auto* ms = batch->get_memory_space();
+      if (!ms) continue;
+      if (ms->get_tier() == tier) { total += batch->get_data()->get_size_in_bytes(); }
+    }
+  }
+  return total;
+}
+
+bool downgrade_executor::is_partition_active(cucascade::shared_data_repository* repo,
+                                             size_t partition_idx)
+{
+  auto batch_ids = repo->get_batch_ids(partition_idx);
+  for (auto id : batch_ids) {
+    auto batch = repo->get_data_batch_by_id(id, std::nullopt, partition_idx);
+    if (!batch) continue;
+    auto state = batch->get_state();
+    if (state == cucascade::batch_state::task_created ||
+        state == cucascade::batch_state::processing) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>>
+downgrade_executor::collect_candidates_from_partition(
+  cucascade::shared_data_repository* repo,
+  size_t partition_idx,
+  cucascade::memory::memory_space_id source_space,
+  size_t max_bytes,
+  size_t& collected_bytes)
+{
+  std::vector<std::shared_ptr<cucascade::data_batch>> candidates;
+  auto batch_ids = repo->get_batch_ids(partition_idx);
+  for (auto id : batch_ids) {
+    if (max_bytes > 0 && collected_bytes >= max_bytes) break;
+    auto batch = repo->get_data_batch_by_id(id, std::nullopt, partition_idx);
+    if (!batch || !batch->get_data()) continue;
+    if (batch->get_state() != cucascade::batch_state::idle) continue;
+    auto* ms = batch->get_memory_space();
+    if (!ms || ms->get_id() != source_space) continue;
+
+    collected_bytes += batch->get_data()->get_size_in_bytes();
+    candidates.push_back(std::move(batch));
+  }
+  return candidates;
+}
+
+// --- Main selection + scheduling logic ---
+
+size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_info> repositories,
+                                              size_t amount_to_downgrade)
+{
+  auto source_tier = _space_id.tier;
+
+  struct scored_repo {
+    cucascade::shared_data_repository* repo;
+    size_t tier_data_size;
+    bool is_partitioned;
+  };
+
+  std::vector<scored_repo> scored_repos;
+  for (auto& info : repositories) {
+    if (!info.repo) continue;
+    size_t tier_size = get_repo_data_size_on_tier(info.repo, source_tier);
+    if (tier_size == 0) continue;
+    scored_repos.push_back({info.repo, tier_size, info.repo->num_partitions() > 1});
+  }
+
+  std::sort(
+    scored_repos.begin(), scored_repos.end(), [](const scored_repo& a, const scored_repo& b) {
+      if (a.is_partitioned != b.is_partitioned) return a.is_partitioned > b.is_partitioned;
+      return a.tier_data_size > b.tier_data_size;
+    });
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> all_candidates;
+  size_t collected_bytes = 0;
+
+  // Pass 1: Non-active partitions (last to first)
+  for (auto& sr : scored_repos) {
+    if (collected_bytes >= amount_to_downgrade) break;
+    for (size_t i = sr.repo->num_partitions(); i > 0; --i) {
+      if (collected_bytes >= amount_to_downgrade) break;
+      size_t pidx = i - 1;
+      if (is_partition_active(sr.repo, pidx)) continue;
+      auto candidates = collect_candidates_from_partition(
+        sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
+      for (auto& c : candidates) {
+        all_candidates.push_back(std::move(c));
+      }
+    }
+  }
+
+  // Pass 2: Active partitions (last to first)
+  if (collected_bytes < amount_to_downgrade) {
+    for (auto& sr : scored_repos) {
+      if (collected_bytes >= amount_to_downgrade) break;
+      for (size_t i = sr.repo->num_partitions(); i > 0; --i) {
+        if (collected_bytes >= amount_to_downgrade) break;
+        size_t pidx = i - 1;
+        if (!is_partition_active(sr.repo, pidx)) continue;
+        auto candidates = collect_candidates_from_partition(
+          sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
+        for (auto& c : candidates) {
+          all_candidates.push_back(std::move(c));
+        }
+      }
+    }
+  }
+
+  if (all_candidates.empty()) return 0;
+
+  auto global_state = std::make_shared<downgrade_task_global_state>(
+    _reservation_manager, _data_repo_mgr, _message_queue);
+
+  size_t task_count = 0;
+  for (auto& batch : all_candidates) {
+    auto local_state =
+      std::make_unique<downgrade_task_local_state>(task_count, 0, std::move(batch));
+    auto task = std::make_unique<downgrade_task>(std::move(local_state), global_state);
+    schedule_downgrade_task(std::move(task));
+    ++task_count;
+  }
+
+  return task_count;
 }
 
 }  // namespace parallel

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -40,6 +40,11 @@ void downgrade_task::execute(rmm::cuda_stream_view stream)
     return;
   }
 
+  // Save the batch state so we can restore it after the in-transit conversion.
+  // The batch may be in task_created state if a pipeline task is pending for it;
+  // blindly resetting to idle would cause the pipeline task to fail with invalid_state.
+  auto prev_state = batch->get_state();
+
   // Try to acquire an in-transit lock - if batch is being processed, we can't downgrade
   if (!batch->try_to_lock_for_in_transit()) {
     // Batch is currently being processed or moving, skip downgrade for now
@@ -64,16 +69,15 @@ void downgrade_task::execute(rmm::cuda_stream_view stream)
 
     // Use the centralized converter registry to convert GPU representation to HOST
     auto& converter_registry = sirius::converter_registry::get();
-    batch->convert_to<cucascade::host_data_packed_representation>(
-      converter_registry, mem_space, stream);
+    batch->convert_to<cucascade::host_data_representation>(converter_registry, mem_space, stream);
 
-    // Release the in-transit lock once conversion finishes
-    batch->try_to_release_in_transit();
+    // Release the in-transit lock, restoring the batch to its previous state
+    batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
 
     mark_task_completion();
     return;
   } catch (...) {
-    batch->try_to_release_in_transit();
+    batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
     throw;
   }
 }
@@ -86,7 +90,7 @@ void downgrade_task::mark_task_completion()
   auto message         = std::make_unique<sirius::task_completion_message>();
   message->task_id     = task_id;
   message->pipeline_id = pipeline_id;
-  message->source      = sirius::Source::PIPELINE;
+  message->source      = sirius::Source::DOWNGRADE;
   _global_state->cast<downgrade_task_global_state>()._message_queue.EnqueueMessage(
     std::move(message));
 }

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -19,42 +19,68 @@
 #include "downgrade/downgrade_queue.hpp"
 #include "downgrade/downgrade_task.hpp"
 #include "parallel/task_executor.hpp"
+#include "task_completion.hpp"
 
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <algorithm>
+#include <thread>
+#include <vector>
 
 namespace sirius {
 namespace parallel {
 
 /**
+ * @brief Information about a repository to consider for downgrade candidate selection.
+ */
+struct downgrade_repository_info {
+  cucascade::shared_data_repository* repo;
+};
+
+/**
  * @brief Executor specialized for performing memory downgrade operations across tier hierarchies.
  *
- * The downgrade_executor inherits from itask_executor and manages a pool of threads dedicated
- * to executing downgrade tasks that move data between different memory tiers (e.g., GPU to CPU,
- * CPU to disk). It uses a downgrade_task_queue for task scheduling and coordination.
+ * Each downgrade_executor is bound to a specific memory space (e.g., GPU:0, HOST:0) and
+ * monitors it for memory pressure. When `should_downgrade_memory()` triggers, it automatically
+ * iterates all repositories in the data_repository_manager and schedules downgrade tasks.
  *
- * While similar to gpu_pipeline_executor in its threading model, it includes specialized
- * memory management logic required for efficient spilling operations and tier management.
+ * The executor runs a monitor thread that polls the memory space and a worker thread that
+ * executes the downgrade tasks (GPU→HOST copies, etc.).
  */
 class downgrade_executor : public itask_executor {
  public:
   /**
-   * @brief Constructs a new downgrade_executor with task execution configuration
+   * @brief Constructs a new downgrade_executor bound to a specific memory space.
    *
    * @param config Configuration for the task executor (thread count, retry policy, etc.)
-   * @param data_repo_mgr Reference to the data repository for accessing and storing data batches
+   * @param data_repo_mgr Reference to the data repository manager
+   * @param space_id The memory space this executor is responsible for downgrading FROM
+   * @param memory_space Pointer to the memory space (for pressure queries; nullptr disables
+   * monitor)
+   * @param reservation_manager Reference to the memory reservation manager
    */
-  explicit downgrade_executor(task_executor_config config,
-                              cucascade::shared_data_repository_manager& data_repo_mgr)
+  explicit downgrade_executor(
+    task_executor_config config,
+    cucascade::shared_data_repository_manager& data_repo_mgr,
+    cucascade::memory::memory_space_id space_id,
+    cucascade::memory::memory_space* memory_space,
+    sirius::memory::sirius_memory_reservation_manager& reservation_manager)
     : itask_executor(std::make_unique<downgrade_task_queue>(), config),
-      _data_repo_mgr(data_repo_mgr)
+      _data_repo_mgr(data_repo_mgr),
+      _space_id(space_id),
+      _memory_space(memory_space),
+      _reservation_manager(reservation_manager)
   {
   }
 
   /**
-   * @brief Destructor for the downgrade_executor.
+   * @brief Get the memory space this executor is responsible for.
    */
+  cucascade::memory::memory_space_id get_space_id() const { return _space_id; }
+
   ~downgrade_executor() override = default;
 
   // Non-copyable and non-movable
@@ -63,71 +89,75 @@ class downgrade_executor : public itask_executor {
   downgrade_executor(downgrade_executor&&)                 = delete;
   downgrade_executor& operator=(downgrade_executor&&)      = delete;
 
-  /**
-   * @brief Schedules a downgrade task for execution
-   *
-   * This is a type-safe wrapper that converts the downgrade task to the base itask
-   * interface and delegates to the parent's schedule method.
-   *
-   * @param downgrade_task The downgrade task to schedule for execution
-   */
   void schedule_downgrade_task(std::unique_ptr<downgrade_task> downgrade_task)
   {
-    // Convert to itask and use parent's schedule method
     this->schedule(std::move(downgrade_task));
   }
 
-  /**
-   * @brief Schedules a task for execution with downgrade-specific logic
-   *
-   * Overrides the base class schedule method to provide specialized scheduling
-   * behavior for downgrade operations, including memory tier validation and
-   * resource management.
-   *
-   * @param task The task to schedule (must be a downgrade_task)
-   */
   void schedule(std::unique_ptr<itask> task) override;
-
-  /**
-   * @brief Main worker loop for executing downgrade tasks
-   *
-   * Each worker thread runs this loop to continuously pull and execute downgrade
-   * tasks from the queue. Includes specialized error handling and resource cleanup
-   * for memory tier operations.
-   *
-   * @param worker_id The unique identifier for this worker thread
-   */
   void worker_loop(int worker_id) override;
-
-  /**
-   * @brief Starts the executor and initializes worker threads
-   *
-   * Initializes the thread pool and begins accepting tasks for execution.
-   */
   void start() override;
-
-  /**
-   * @brief Stops the executor and cleanly shuts down worker threads
-   *
-   * Stops accepting new tasks and waits for all worker threads to complete
-   * their current tasks before shutting down.
-   */
   void stop() override;
 
- private:
   /**
-   * @brief Safely casts itask to downgrade_task with type validation
+   * @brief Drain all pending and in-flight downgrade tasks.
    *
-   * @param task The base task pointer to cast
-   * @return downgrade_task* The casted downgrade_task pointer
-   * @throws std::bad_cast if the task is not of type downgrade_task
+   * Must be called before clearing data repositories (e.g., at QueryEnd) to ensure
+   * no downgrade tasks hold shared_ptr<data_batch> references to batches that are
+   * about to be destroyed.
+   *
+   * Closes the queue (discarding pending tasks), waits for in-flight tasks to finish,
+   * then re-opens the queue so new tasks can be scheduled for the next query.
    */
-  downgrade_task* cast_to_downgrade_task(itask* task);
+  void drain();
+
+  /**
+   * @brief Perform a downgrade pass with an explicit list of repositories.
+   *
+   * Uses this executor's bound memory space as the source tier and its stored
+   * reservation manager. Walks through the provided repositories using the
+   * prioritization rules:
+   * 1. Partitioned repos first, then by descending data size on this tier
+   * 2. Within each repo, iterate partitions from last to first
+   * 3. First pass: non-active partitions; second pass: active partitions
+   *
+   * @param repositories Vector of repository pointers to scan
+   * @param amount_to_downgrade Target bytes of data to downgrade
+   * @return size_t Number of downgrade tasks scheduled
+   */
+  size_t run_downgrade_pass(std::vector<downgrade_repository_info> repositories,
+                            size_t amount_to_downgrade);
 
  private:
-  cucascade::shared_data_repository_manager&
-    _data_repo_mgr;  ///< Reference to the data repository manager
-                     ///< for accessing data during downgrade operations
+  downgrade_task* cast_to_downgrade_task(itask* task);
+
+  /**
+   * @brief Monitor loop that polls the memory space for pressure and triggers downgrades.
+   *
+   * Iterates all repositories via data_repository_manager::for_each_repository().
+   */
+  void monitor_loop();
+
+  static size_t get_repo_data_size_on_tier(cucascade::shared_data_repository* repo,
+                                           cucascade::memory::Tier tier);
+
+  static bool is_partition_active(cucascade::shared_data_repository* repo, size_t partition_idx);
+
+  static std::vector<std::shared_ptr<cucascade::data_batch>> collect_candidates_from_partition(
+    cucascade::shared_data_repository* repo,
+    size_t partition_idx,
+    cucascade::memory::memory_space_id source_space,
+    size_t max_bytes,
+    size_t& collected_bytes);
+
+ private:
+  cucascade::shared_data_repository_manager& _data_repo_mgr;
+  cucascade::memory::memory_space_id _space_id;
+  cucascade::memory::memory_space* _memory_space;
+  sirius::memory::sirius_memory_reservation_manager& _reservation_manager;
+  task_completion_message_queue _message_queue;  ///< Owned; receives downgrade task completions
+
+  std::thread _monitor_thread;
 };
 
 }  // namespace parallel

--- a/src/include/downgrade/downgrade_queue.hpp
+++ b/src/include/downgrade/downgrade_queue.hpp
@@ -67,13 +67,18 @@ class downgrade_task_queue : public itask_queue {
    */
   void close() override
   {
-    // Wake up all waiting threads by releasing the semaphore enough times
-    for (int i = 0; i < Config::NUM_DOWNGRADE_EXECUTOR_THREADS; ++i) {
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      _is_open = false;
+    }
+    // Wake up all waiting threads by releasing the semaphore enough times.
+    // Use a generous count to cover any number of blocked workers.
+    for (int i = 0; i < _num_workers; ++i) {
       _sem.release();
     }
-    std::lock_guard<std::mutex> lock(_mutex);
-    _is_open = false;
   }
+
+  void set_num_workers(int n) { _num_workers = n; }
 
   /**
    * @brief Pushes a new task to be scheduled (base interface implementation)
@@ -181,8 +186,9 @@ class downgrade_task_queue : public itask_queue {
 
  private:
   std::queue<std::unique_ptr<downgrade_task>>
-    _task_queue;                      ///< FIFO queue storing the downgrade tasks
-  bool _is_open = false;              ///< Whether the queue is open for operations
+    _task_queue;          ///< FIFO queue storing the downgrade tasks
+  bool _is_open = false;  ///< Whether the queue is open for operations
+  int _num_workers{Config::NUM_DOWNGRADE_EXECUTOR_THREADS};  ///< Number of worker threads to wake
   mutable std::mutex _mutex;          ///< Mutex for thread-safe access (mutable for const methods)
   std::counting_semaphore<> _sem{0};  ///< Semaphore for blocking/signaling (starts with 0 permits)
 };

--- a/src/include/downgrade/downgrade_task.hpp
+++ b/src/include/downgrade/downgrade_task.hpp
@@ -74,13 +74,13 @@ class downgrade_task_local_state : public itask_local_state {
  public:
   explicit downgrade_task_local_state(uint64_t task_id,
                                       uint64_t pipeline_id,
-                                      std::unique_ptr<cucascade::data_batch> batch)
+                                      std::shared_ptr<cucascade::data_batch> batch)
     : _task_id(task_id), _pipeline_id(pipeline_id), _batch(std::move(batch))
   {
   }
   uint64_t _task_id;
   uint64_t _pipeline_id;
-  std::unique_ptr<cucascade::data_batch> _batch;
+  std::shared_ptr<cucascade::data_batch> _batch;
 };
 
 /**

--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -18,7 +18,6 @@
 
 // sirius
 #include <helper/utils.hpp>
-#include <memory/host_table_utils.hpp>
 #include <memory/multiple_blocks_allocation_accessor.hpp>
 
 // duckdb
@@ -34,6 +33,7 @@
 // cucascade
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/host_table.hpp>
 
 // standard library
 #include <memory>
@@ -46,8 +46,7 @@ namespace sirius::op::result {
 //===----------------------------------------------------------------------===//
 
 /**
- * @brief Reads chunks of data from a cucascade::host_data_packed_representation into duckdb data
- * chunkss
+ * @brief Reads chunks of data from a cucascade::host_data_representation into duckdb data chunks
  */
 class host_table_chunk_reader {
   using multiple_blocks_allocation =
@@ -79,10 +78,10 @@ class host_table_chunk_reader {
 
     /**
      * @brief Construct a new column reader object
-     * @param[in] node The metadata node for the column (via unpack proxy)
+     * @param[in] col The column metadata describing the column's buffer layout
      * @param[in] allocation The multiple blocks allocation containing the column data
      */
-    column_reader(metadata_node const& node,
+    column_reader(cucascade::memory::column_metadata const& col,
                   std::unique_ptr<multiple_blocks_allocation> const& allocation);
 
     /**
@@ -130,14 +129,14 @@ class host_table_chunk_reader {
    * @brief Construct a new host table chunk reader object
    *
    * @param[in] client_ctx The duckdb client context (for allocation)
-   * @param[in] host_table The cucascade::host_data_packed_representation to read from
+   * @param[in] host_table The cucascade::host_data_representation to read from
    * @param[in] types The duckdb logical types for the chunk columns
-   * @throw std::runtime_error If there is a mismatch in metadata and types, if the row count is
-   * negative or inconsistent across metadata_nodes, or if the duckdb output logical type for any
-   * column is HUGEINT.
+   * @throw std::runtime_error If there is a mismatch in column metadata and types, if the row count
+   * is negative or inconsistent across columns, or if the duckdb output logical type for any column
+   * is HUGEINT.
    */
   host_table_chunk_reader(duckdb::ClientContext& client_ctx,
-                          cucascade::host_data_packed_representation const& host_table,
+                          cucascade::host_data_representation const& host_table,
                           duckdb::vector<duckdb::LogicalType> const& types);
   ~host_table_chunk_reader() = default;
 

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -20,7 +20,6 @@
 #include <cudf/utilities/default_stream.hpp>
 
 #include <config.hpp>
-#include <memory/host_table_utils.hpp>
 #include <memory/multiple_blocks_allocation_accessor.hpp>
 #include <op/sirius_physical_duckdb_scan.hpp>
 #include <op/sirius_physical_table_scan.hpp>
@@ -36,6 +35,7 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/host_table.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 
@@ -272,12 +272,12 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
                         std::unique_ptr<multiple_blocks_allocation>& allocation);
 
     /**
-     * @brief Create a metadata node for this column for building a host_table_allocation.
+     * @brief Create a column_metadata for this column for building a host_table_allocation.
      *
      * @param[in] num_rows The number of rows in the column.
-     * @return metadata_node The constructed metadata node.
+     * @return cucascade::memory::column_metadata The constructed column metadata.
      */
-    [[nodiscard]] metadata_node make_metadata_node(size_t num_rows) const;
+    [[nodiscard]] cucascade::memory::column_metadata make_column_metadata(size_t num_rows) const;
   };
 
   //===----------Constructor & Destructor----------===//

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -90,8 +90,8 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
    * @throws InternalException if the memory manager is not initialized, if the reservation fails,
    * or if the memory space for the reservation is invalid
    * @note For now, we assume that the input batch, if in the HOST tier, is always in the
-   * host_data_packed_representation. If it is in the GPU tier, we convert it to the
-   * host_data_packed_representation. In the future, we should register converters for other
+   * host_data_representation. If it is in the GPU tier, we convert it to the
+   * host_data_representation. In the future, we should register converters for other
    * specialized data representations and invoke one such here.
    */
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -29,8 +29,10 @@
 #include <duckdb/main/client_context_state.hpp>
 #include <duckdb/planner/extension_callback.hpp>
 
+#include <map>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 namespace duckdb {
 
@@ -84,8 +86,15 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] sirius::pipeline::pipeline_executor& get_pipeline_executor();
   [[nodiscard]] const sirius::pipeline::pipeline_executor& get_pipeline_executor() const;
 
-  [[nodiscard]] sirius::parallel::downgrade_executor& get_downgrade_executor();
-  [[nodiscard]] const sirius::parallel::downgrade_executor& get_downgrade_executor() const;
+  /// \brief Get the downgrade executor for a specific memory space.
+  [[nodiscard]] sirius::parallel::downgrade_executor& get_downgrade_executor(
+    cucascade::memory::memory_space_id space_id);
+  [[nodiscard]] const sirius::parallel::downgrade_executor& get_downgrade_executor(
+    cucascade::memory::memory_space_id space_id) const;
+
+  /// \brief Get all downgrade executors.
+  [[nodiscard]] const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>&
+  get_downgrade_executors() const;
 
   [[nodiscard]] sirius::creator::task_creator& get_task_creator();
   [[nodiscard]] const sirius::creator::task_creator& get_task_creator() const;
@@ -113,7 +122,7 @@ class SiriusContext : public ClientContextState {
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager_;
   std::unique_ptr<cucascade::shared_data_repository_manager> data_repository_manager_;
   std::unique_ptr<sirius::pipeline::pipeline_executor> pipeline_executor_;
-  std::unique_ptr<sirius::parallel::downgrade_executor> downgrade_executor_;
+  std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;
   duckdb::shared_ptr<sirius::planner::query> query_;
 };

--- a/src/include/task_completion.hpp
+++ b/src/include/task_completion.hpp
@@ -27,8 +27,9 @@ namespace sirius {
  * @brief Enumeration of task sources for completion tracking
  */
 enum class Source {
-  SCAN,     ///< Task originated from a scan operation
-  PIPELINE  ///< Task originated from a pipeline operation
+  SCAN,      ///< Task originated from a scan operation
+  PIPELINE,  ///< Task originated from a pipeline operation
+  DOWNGRADE  ///< Task originated from a downgrade operation
 };
 
 /**

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -16,7 +16,6 @@
 
 // sirius
 #include <helper/utils.hpp>
-#include <memory/host_table_utils.hpp>
 #include <op/result/host_table_chunk_reader.hpp>
 
 // cucascade
@@ -34,34 +33,34 @@
 namespace sirius::op::result {
 
 host_table_chunk_reader::column_reader::column_reader(
-  metadata_node const& node, std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  cucascade::memory::column_metadata const& col,
+  std::unique_ptr<multiple_blocks_allocation> const& allocation)
 {
   if (allocation == nullptr || allocation->block_size() == 0) {
     throw std::runtime_error(
       "[host_table_chunk_reader::column_reader::column_reader] Invalid allocation.");
   }
-  size          = static_cast<size_t>(node.size);
-  null_count    = static_cast<size_t>(node.null_count);
-  cudf_col_type = node.type;
-  if (node.null_mask_offset < 0) { null_count = 0; }
+  size       = static_cast<size_t>(col.num_rows);
+  null_count = static_cast<size_t>(col.null_count);
+  cudf_col_type =
+    col.scale != 0 ? cudf::data_type(col.type_id, col.scale) : cudf::data_type(col.type_id);
+  if (!col.has_null_mask) { null_count = 0; }
 
-  data_accessor.initialize(static_cast<size_t>(node.data_offset), allocation);
+  data_accessor.initialize(col.data_offset, allocation);
 
-  if (null_count > 0) {
-    mask_accessor.initialize(static_cast<size_t>(node.null_mask_offset), allocation);
-  }
+  if (null_count > 0) { mask_accessor.initialize(col.null_mask_offset, allocation); }
 
-  if (node.type.id() == cudf::type_id::STRING) {
-    if (node.children.size() != 1) {
+  if (col.type_id == cudf::type_id::STRING) {
+    if (col.children.size() != 1) {
       throw std::runtime_error(
         "[host_table_chunk_reader::column_reader::initialize_accessors] STRING type must have one "
         "child node for offsets.");
     }
-    use_int64_offsets = (node.children[0].type.id() == cudf::type_id::INT64);
+    use_int64_offsets = (col.children[0].type_id == cudf::type_id::INT64);
     if (use_int64_offsets) {
-      offset_accessor_64.initialize(node.children[0].data_offset, allocation);
+      offset_accessor_64.initialize(col.children[0].data_offset, allocation);
     } else {
-      offset_accessor_32.initialize(node.children[0].data_offset, allocation);
+      offset_accessor_32.initialize(col.children[0].data_offset, allocation);
     }
   }
 }
@@ -221,7 +220,7 @@ void host_table_chunk_reader::column_reader::copy_string(
 
 host_table_chunk_reader::host_table_chunk_reader(
   duckdb::ClientContext& client_ctx,
-  cucascade::host_data_packed_representation const& host_table,
+  cucascade::host_data_representation const& host_table,
   duckdb::vector<duckdb::LogicalType> const& types_p)
   : _client_ctx(client_ctx), _allocation(host_table.get_host_table()->allocation), _types(types_p)
 {
@@ -233,14 +232,14 @@ host_table_chunk_reader::host_table_chunk_reader(
     throw std::runtime_error(
       "[host_table_chunk_reader] host_table allocation is null (cannot read column data)");
   }
-  // Unpack metadata
-  auto metadata_nodes = sirius::unpack_metadata_to_nodes(host_table.get_host_table()->metadata);
-  if (metadata_nodes.size() != _types.size()) {
+  // Access column metadata directly
+  auto const& columns = host_table.get_host_table()->columns;
+  if (columns.size() != _types.size()) {
     throw std::runtime_error(
       "[host_table_chunk_reader] Metadata column count does not match expected column count.");
   }
   if (_allocation->size_bytes() == 0) {
-    if (metadata_nodes[0].size == 0) {
+    if (columns[0].num_rows == 0) {
       // Empty result host table, return without any column readers (creating them would fail).
       // Because _row_offset and _total_rows are 0 by default, get_next_chunk() will immediately
       // return false.
@@ -251,14 +250,14 @@ host_table_chunk_reader::host_table_chunk_reader(
     }
   }
   // Initialize column readers
-  _column_readers.reserve(metadata_nodes.size());
-  for (size_t col_idx = 0; col_idx < metadata_nodes.size(); ++col_idx) {
+  _column_readers.reserve(columns.size());
+  for (size_t col_idx = 0; col_idx < columns.size(); ++col_idx) {
     if (col_idx == 0) {
-      _total_rows = static_cast<size_t>(metadata_nodes[col_idx].size);
+      _total_rows = static_cast<size_t>(columns[col_idx].num_rows);
       if (_total_rows < 0) {
         throw std::runtime_error("[host_table_chunk_reader] Negative total rows in first column.");
       }
-    } else if (metadata_nodes[col_idx].size != _total_rows) {
+    } else if (static_cast<size_t>(columns[col_idx].num_rows) != _total_rows) {
       throw std::runtime_error(
         "[host_table_chunk_reader] Metadata column size mismatch across columns.");
     }
@@ -268,7 +267,7 @@ host_table_chunk_reader::host_table_chunk_reader(
       throw std::runtime_error(
         "[host_table_chunk_reader] HUGEINT type is not currently supported.");
     }
-    _column_readers.emplace_back(metadata_nodes[col_idx], _allocation);
+    _column_readers.emplace_back(columns[col_idx], _allocation);
   }
 }
 

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -18,6 +18,7 @@
 #include "cucascade/memory/memory_space.hpp"
 #include "op/sirius_physical_operator.hpp"
 
+#include <cudf_utils.hpp>
 #include <data/data_batch_utils.hpp>
 #include <helper/utils.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
@@ -28,6 +29,9 @@
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/host_table.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
+
+// cudf
+#include <cudf/utilities/bit.hpp>
 
 // duckdb
 #include <duckdb/common/types.hpp>
@@ -256,23 +260,54 @@ void duckdb_scan_task_local_state::column_builder::process_column(
   process_mask_for_column(validity, num_rows, row_offset, allocation);
 }
 
-metadata_node duckdb_scan_task_local_state::column_builder::make_metadata_node(
-  size_t num_rows) const
+cucascade::memory::column_metadata
+duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_rows) const
 {
+  using cucascade::memory::column_metadata;
+
   if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
-    // VARCHAR column
-    return make_string_metadata_node(
-      static_cast<cudf::size_type>(num_rows),
-      static_cast<cudf::size_type>(null_count),
-      static_cast<int64_t>(data_blocks_accessor.initial_byte_offset),
-      static_cast<int64_t>(mask_blocks_accessor.initial_byte_offset),
-      static_cast<int64_t>(offset_blocks_accessor.initial_byte_offset));
+    // VARCHAR column: data buffer + offsets child
+    column_metadata offsets_child{};
+    offsets_child.type_id          = cudf::type_id::INT32;
+    offsets_child.num_rows         = static_cast<cudf::size_type>(num_rows + 1);
+    offsets_child.null_count       = 0;
+    offsets_child.scale            = 0;
+    offsets_child.has_null_mask    = false;
+    offsets_child.null_mask_offset = 0;
+    offsets_child.null_mask_size   = 0;
+    offsets_child.has_data         = true;
+    offsets_child.data_offset      = offset_blocks_accessor.initial_byte_offset;
+    offsets_child.data_size        = (num_rows + 1) * sizeof(int32_t);
+
+    column_metadata col{};
+    col.type_id          = cudf::type_id::STRING;
+    col.num_rows         = static_cast<cudf::size_type>(num_rows);
+    col.null_count       = static_cast<cudf::size_type>(null_count);
+    col.scale            = 0;
+    col.has_null_mask    = (null_count > 0);
+    col.null_mask_offset = mask_blocks_accessor.initial_byte_offset;
+    col.null_mask_size   = (null_count > 0) ? cudf::bitmask_allocation_size_bytes(num_rows) : 0;
+    col.has_data         = true;
+    col.data_offset      = data_blocks_accessor.initial_byte_offset;
+    col.data_size        = total_data_bytes;
+    col.children.push_back(std::move(offsets_child));
+    return col;
   } else {
-    return make_flat_metadata_node(type,
-                                   static_cast<cudf::size_type>(num_rows),
-                                   static_cast<cudf::size_type>(null_count),
-                                   static_cast<int64_t>(data_blocks_accessor.initial_byte_offset),
-                                   static_cast<int64_t>(mask_blocks_accessor.initial_byte_offset));
+    // Fixed-width column
+    auto cudf_type = duckdb::GetCudfType(type);
+
+    column_metadata col{};
+    col.type_id          = cudf_type.id();
+    col.num_rows         = static_cast<cudf::size_type>(num_rows);
+    col.null_count       = static_cast<cudf::size_type>(null_count);
+    col.scale            = cudf_type.scale();
+    col.has_null_mask    = (null_count > 0);
+    col.null_mask_offset = mask_blocks_accessor.initial_byte_offset;
+    col.null_mask_size   = (null_count > 0) ? cudf::bitmask_allocation_size_bytes(num_rows) : 0;
+    col.has_data         = true;
+    col.data_offset      = data_blocks_accessor.initial_byte_offset;
+    col.data_size        = type_size * num_rows;
+    return col;
   }
 }
 
@@ -411,28 +446,25 @@ void duckdb_scan_task_local_state::initialize_local_table_function_state(
 
 std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_batch()
 {
-  using data_batch                      = cucascade::data_batch;
-  using host_table_allocation           = cucascade::memory::host_table_packed_allocation;
-  using host_data_packed_representation = cucascade::host_data_packed_representation;
+  using data_batch               = cucascade::data_batch;
+  using host_table_allocation    = cucascade::memory::host_table_allocation;
+  using host_data_representation = cucascade::host_data_representation;
 
-  // Create metadata nodes for each column and assemble metadata buffer
-  std::vector<metadata_node> column_metadata;
-  column_metadata.reserve(_num_columns);
+  // Create column metadata for each column
+  std::vector<cucascade::memory::column_metadata> columns;
+  columns.reserve(_num_columns);
   for (size_t ci = 0; ci < _column_builders.size(); ci++) {
     auto& builder = _column_builders[ci];
-    column_metadata.push_back(builder.make_metadata_node(_row_offset));
+    columns.push_back(builder.make_column_metadata(_row_offset));
   }
-  auto metadata = std::make_unique<std::vector<uint8_t>>(pack_metadata_from_nodes(column_metadata));
 
   // Make the host table allocation
   auto const sz = get_tail_byte_offset();
-  // auto const sz = allocation->size_bytes();
   auto table_allocation =
-    std::make_unique<host_table_allocation>(std::move(_allocation), std::move(metadata), sz);
+    std::make_unique<host_table_allocation>(std::move(_allocation), std::move(columns), sz);
 
   // Make the host table representation
-  auto table =
-    std::make_unique<host_data_packed_representation>(std::move(table_allocation), _host_space);
+  auto table = std::make_unique<host_data_representation>(std::move(table_allocation), _host_space);
 
   // Create the data batch and return
   return std::make_shared<data_batch>(get_next_batch_id(), std::move(table));

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -153,26 +153,25 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
       clone_batch         = input_batch->clone(next_batch_id, stream);
       // todo (bobbi) pass stream to sink
-      clone_batch->convert_to<cucascade::host_data_packed_representation>(
-        registry, &mem_space, stream);
+      clone_batch->convert_to<cucascade::host_data_representation>(registry, &mem_space, stream);
       data = clone_batch->get_data();
     } else if (data->get_current_tier() != cucascade::memory::Tier::HOST) {
       // Data must be in HOST tier (i.e., cannot currently reside in DISK tier)
       throw duckdb::InvalidInputException(
-        "[GPUPhysicalMaterializedCollector] Expected host_data_packed_representation in HOST tier");
+        "[GPUPhysicalMaterializedCollector] Expected host_data_representation in HOST tier");
     }
 
-    // Only accepting host_data_packed_representation for now
-    assert(dynamic_cast<cucascade::host_data_packed_representation*>(data) != nullptr);
+    // Only accepting host_data_representation for now
+    assert(dynamic_cast<cucascade::host_data_representation*>(data) != nullptr);
 
     // Push chunks to result collection
-    auto const& host_table = data->cast<cucascade::host_data_packed_representation>();
+    auto const& host_table = data->cast<cucascade::host_data_representation>();
     // host_table_chunk_reader expects get_host_table() and ->allocation to be non-null;
     // otherwise it will dereference a null unique_ptr (e.g. in column_reader::initialize).
     auto const* ht = host_table.get_host_table().get();
     if (!ht) {
       throw duckdb::InvalidInputException(
-        "[GPUPhysicalMaterializedCollector] host_data_packed_representation has null "
+        "[GPUPhysicalMaterializedCollector] host_data_representation has null "
         "get_host_table()");
     }
     if (!ht->allocation) {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -67,8 +67,13 @@ std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
             cancel_task_if_needed();
             return std::nullopt;
           }
-          batch->convert_to<cucascade::gpu_table_representation>(
-            registry, requested_memory_space, stream);
+          try {
+            batch->convert_to<cucascade::gpu_table_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
           batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
           break;
         }
@@ -78,8 +83,13 @@ std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
             cancel_task_if_needed();
             return std::nullopt;
           }
-          batch->convert_to<cucascade::host_data_packed_representation>(
-            registry, requested_memory_space, stream);
+          try {
+            batch->convert_to<cucascade::host_data_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
           batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
           break;
         }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -24,6 +24,8 @@
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/scan/duckdb_scan_executor.hpp"
 
+#include <cuda_runtime_api.h>
+
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 
@@ -91,6 +93,12 @@ void SiriusContext::QueryEnd()
 {
   query_.reset();
 
+  // Drain all downgrade executors before clearing repositories — ensures no downgrade
+  // tasks hold shared_ptr<data_batch> references to batches we're about to destroy.
+  for (auto& executor : downgrade_executors_) {
+    executor->drain();
+  }
+
   // Clear all data repositories between queries.
   // Any batches still present are leaked — operators should have popped everything.
   if (data_repository_manager_) {
@@ -130,8 +138,25 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     *memory_manager_,
     &config_.get_hw_topology());
 
-  downgrade_executor_ = std::make_unique<sirius::parallel::downgrade_executor>(
-    sirius::parallel::task_executor_config{}, *data_repository_manager_);
+  // Create one downgrade executor per GPU memory space.
+  // HOST→DISK downgrade is not yet implemented, so we skip HOST tier for now.
+  auto create_executors_for_tier = [&](cucascade::memory::Tier tier) {
+    auto spaces        = memory_manager_->get_memory_spaces_for_tier(tier);
+    auto const& dg_cfg = config_.get_downgrade_executor_config();
+    for (auto* space : spaces) {
+      sirius::parallel::task_executor_config executor_config{
+        dg_cfg.num_threads, false, dg_cfg.cpu_affinity_list};
+      auto executor = std::make_unique<sirius::parallel::downgrade_executor>(
+        std::move(executor_config),
+        *data_repository_manager_,
+        space->get_id(),
+        const_cast<cucascade::memory::memory_space*>(space),
+        *memory_manager_);
+      executor->start();
+      downgrade_executors_.push_back(std::move(executor));
+    }
+  };
+  create_executors_for_tier(cucascade::memory::Tier::GPU);
 
   task_creator_ = std::make_unique<sirius::creator::task_creator>(config_.get_task_creator_config(),
                                                                   *memory_manager_);
@@ -154,7 +179,17 @@ void SiriusContext::terminate()
   pipeline_executor_.reset();
   task_creator_->stop_thread_pool();
   task_creator_.reset();
-  downgrade_executor_.reset();
+  for (auto& executor : downgrade_executors_) {
+    executor->stop();
+  }
+  downgrade_executors_.clear();
+
+  // Ensure all CUDA operations (including async copies from downgrade tasks)
+  // are complete before destroying pinned memory pools.  cudaStreamDestroy
+  // returns immediately even when copies are still in-flight; without this
+  // sync, the subsequent cudaFreeHost inside the memory manager destructor
+  // can deadlock against a new cudaHostAlloc from the next SiriusContext.
+  cudaDeviceSynchronize();
 
   memory_manager_->shutdown();
   memory_manager_.reset();
@@ -198,16 +233,31 @@ const sirius::pipeline::pipeline_executor& SiriusContext::get_pipeline_executor(
   return *pipeline_executor_;
 }
 
-sirius::parallel::downgrade_executor& SiriusContext::get_downgrade_executor()
+sirius::parallel::downgrade_executor& SiriusContext::get_downgrade_executor(
+  cucascade::memory::memory_space_id space_id)
 {
   throw_if_not_initialized();
-  return *downgrade_executor_;
+  for (auto& executor : downgrade_executors_) {
+    if (executor->get_space_id() == space_id) { return *executor; }
+  }
+  throw std::runtime_error("No downgrade executor for the requested memory space");
 }
 
-const sirius::parallel::downgrade_executor& SiriusContext::get_downgrade_executor() const
+const sirius::parallel::downgrade_executor& SiriusContext::get_downgrade_executor(
+  cucascade::memory::memory_space_id space_id) const
 {
   throw_if_not_initialized();
-  return *downgrade_executor_;
+  for (auto& executor : downgrade_executors_) {
+    if (executor->get_space_id() == space_id) { return *executor; }
+  }
+  throw std::runtime_error("No downgrade executor for the requested memory space");
+}
+
+const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>&
+SiriusContext::get_downgrade_executors() const
+{
+  throw_if_not_initialized();
+  return downgrade_executors_;
 }
 
 sirius::creator::task_creator& SiriusContext::get_task_creator()

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(pipeline)
 add_subdirectory(creator)
 add_subdirectory(config)
 add_subdirectory(exec)
+add_subdirectory(downgrade)
 add_subdirectory(expression_executor)
 add_subdirectory(integration)
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -39,7 +39,8 @@ struct finally {
   }
 };
 
-TEST_CASE("Sirius configuration loading from file with configurator", "[sirius][context]")
+TEST_CASE("Sirius configuration loading from file with configurator",
+          "[sirius][context][isolated_context]")
 {
   finally cleanup_env{[]() { unsetenv("SIRIUS_CONFIG_FILE"); }};
 
@@ -65,7 +66,8 @@ TEST_CASE("Sirius configuration loading from file with configurator", "[sirius][
   REQUIRE(manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).size() == 1);
 }
 
-TEST_CASE("Sirius configuration loading from file with spaces", "[sirius][context]")
+TEST_CASE("Sirius configuration loading from file with spaces",
+          "[sirius][context][isolated_context]")
 {
   finally cleanup_env{[]() { unsetenv("SIRIUS_CONFIG_FILE"); }};
 

--- a/test/cpp/downgrade/CMakeLists.txt
+++ b/test/cpp/downgrade/CMakeLists.txt
@@ -15,6 +15,5 @@
 # =============================================================================
 
 set(TEST_SOURCES
-    ${TEST_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/sirius_test_env.cpp
+    ${TEST_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/test_downgrade_executor.cpp
     PARENT_SCOPE)

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+
+// sirius
+#include "downgrade/downgrade_executor.hpp"
+#include "downgrade/downgrade_task.hpp"
+#include "memory/sirius_memory_reservation_manager.hpp"
+#include "task_completion.hpp"
+
+// data utilities
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <utils/utils.hpp>
+
+// cucascade
+#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <cucascade/data/data_repository_manager.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+
+// cudf / rmm
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/cuda_stream.hpp>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace sirius::parallel;
+using namespace std::chrono_literals;
+
+namespace {
+
+const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
+
+std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_test_memory_manager()
+{
+  sirius::converter_registry::reset_for_testing();
+
+  cucascade::memory::reservation_manager_configurator builder;
+  const size_t gpu_capacity  = 2ull << 30;
+  const double limit_ratio   = 0.75;
+  const size_t host_capacity = 4ull << 30;
+
+  builder.set_number_of_gpus(1)
+    .set_gpu_usage_limit(gpu_capacity)
+    .set_reservation_fraction_per_gpu(limit_ratio)
+    .set_per_host_capacity(host_capacity)
+    .use_host_per_gpu()
+    .set_reservation_fraction_per_host(limit_ratio);
+
+  auto space_configs = builder.build();
+  auto manager =
+    std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+
+  sirius::converter_registry::initialize();
+  return manager;
+}
+
+cucascade::memory::memory_space* get_gpu_space(
+  sirius::memory::sirius_memory_reservation_manager& mgr)
+{
+  auto* space = mgr.get_memory_space(cucascade::memory::Tier::GPU, 0);
+  if (space) return space;
+  auto spaces = mgr.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+  if (!spaces.empty()) return const_cast<cucascade::memory::memory_space*>(spaces.front());
+  return nullptr;
+}
+
+std::shared_ptr<cucascade::data_batch> make_gpu_batch(cucascade::memory::memory_space& gpu_space,
+                                                      size_t num_rows = 1000)
+{
+  auto stream = cudf::get_default_stream();
+  auto mr     = gpu_space.get_default_allocator();
+
+  std::vector<cudf::data_type> col_types                 = {cudf::data_type{cudf::type_id::INT32}};
+  std::vector<std::optional<std::pair<int, int>>> ranges = {std::make_pair(0, 100000)};
+
+  auto table = sirius::create_cudf_table_with_random_data(num_rows, col_types, ranges, stream, mr);
+
+  return sirius::make_data_batch(std::move(table), gpu_space);
+}
+
+/**
+ * @brief Helper to create a downgrade_executor for tests.
+ *
+ * Pass nullptr for memory_space when the monitor loop shouldn't trigger automatically.
+ */
+downgrade_executor make_test_executor(cucascade::shared_data_repository_manager& repo_mgr,
+                                      cucascade::memory::memory_space* gpu_space,
+                                      sirius::memory::sirius_memory_reservation_manager& mem_mgr)
+{
+  task_executor_config config{1, false};
+  return downgrade_executor(config, repo_mgr, GPU_SPACE_ID, gpu_space, mem_mgr);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Downgrade executor starts and stops cleanly", "[downgrade_executor]")
+{
+  auto mem_mgr = make_test_memory_manager();
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  // nullptr memory_space — monitor loop won't trigger, just tests lifecycle
+  auto executor = make_test_executor(repo_mgr, nullptr, *mem_mgr);
+
+  REQUIRE_NOTHROW(executor.start());
+  REQUIRE_NOTHROW(executor.stop());
+}
+
+TEST_CASE("run_downgrade_pass with empty repositories returns 0", "[downgrade_executor]")
+{
+  auto mem_mgr = make_test_memory_manager();
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  auto executor = make_test_executor(repo_mgr, nullptr, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos;
+  size_t scheduled = executor.run_downgrade_pass(repos, 1024);
+  REQUIRE(scheduled == 0);
+
+  executor.stop();
+}
+
+TEST_CASE("Single downgrade task executes correctly", "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+  sirius::task_completion_message_queue msg_queue;
+
+  auto batch = make_gpu_batch(*gpu_space);
+  REQUIRE(batch->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+
+  auto global_state = std::make_shared<downgrade_task_global_state>(*mem_mgr, repo_mgr, msg_queue);
+  auto local_state  = std::make_unique<downgrade_task_local_state>(0, 0, batch);
+  downgrade_task task(std::move(local_state), global_state);
+
+  rmm::cuda_stream stream;
+  REQUIRE_NOTHROW(task.execute(stream));
+
+  REQUIRE(batch->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+}
+
+TEST_CASE("run_downgrade_pass downgrades GPU batches from a single non-partitioned repo",
+          "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo;
+  auto batch1 = make_gpu_batch(*gpu_space);
+  auto batch2 = make_gpu_batch(*gpu_space);
+  auto batch3 = make_gpu_batch(*gpu_space);
+  repo.add_data_batch(batch1);
+  repo.add_data_batch(batch2);
+  repo.add_data_batch(batch3);
+
+  REQUIRE(batch1->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch2->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch3->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, 1ull << 30);
+  REQUIRE(scheduled == 3);
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    bool all_on_host = true;
+    if (batch1->get_memory_space()->get_tier() != cucascade::memory::Tier::HOST)
+      all_on_host = false;
+    if (batch2->get_memory_space()->get_tier() != cucascade::memory::Tier::HOST)
+      all_on_host = false;
+    if (batch3->get_memory_space()->get_tier() != cucascade::memory::Tier::HOST)
+      all_on_host = false;
+    if (all_on_host) break;
+    std::this_thread::sleep_for(50ms);
+  }
+
+  REQUIRE(batch1->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch3->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+
+  executor.stop();
+}
+
+TEST_CASE("run_downgrade_pass respects amount_to_downgrade limit", "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo;
+  std::vector<std::shared_ptr<cucascade::data_batch>> batches;
+  for (int i = 0; i < 5; ++i) {
+    auto batch = make_gpu_batch(*gpu_space);
+    batches.push_back(batch);
+    repo.add_data_batch(batch);
+  }
+
+  size_t one_batch_size = batches[0]->get_data()->get_size_in_bytes();
+  REQUIRE(one_batch_size > 0);
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, one_batch_size);
+  REQUIRE(scheduled >= 1);
+  REQUIRE(scheduled < 5);
+
+  executor.stop();
+}
+
+TEST_CASE("run_downgrade_pass prioritizes partitioned repos over non-partitioned",
+          "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo_non_partitioned;
+  auto batch_np1 = make_gpu_batch(*gpu_space);
+  auto batch_np2 = make_gpu_batch(*gpu_space);
+  repo_non_partitioned.add_data_batch(batch_np1);
+  repo_non_partitioned.add_data_batch(batch_np2);
+
+  cucascade::shared_data_repository repo_partitioned;
+  auto batch_p0 = make_gpu_batch(*gpu_space);
+  auto batch_p1 = make_gpu_batch(*gpu_space);
+  auto batch_p2 = make_gpu_batch(*gpu_space);
+  repo_partitioned.add_data_batch(batch_p0, 0);
+  repo_partitioned.add_data_batch(batch_p1, 1);
+  repo_partitioned.add_data_batch(batch_p2, 2);
+
+  size_t one_batch_size = batch_p0->get_data()->get_size_in_bytes();
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo_non_partitioned}, {&repo_partitioned}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, one_batch_size);
+  REQUIRE(scheduled >= 1);
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST) break;
+    std::this_thread::sleep_for(50ms);
+  }
+
+  REQUIRE(batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch_np1->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch_np2->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+
+  executor.stop();
+}
+
+TEST_CASE("run_downgrade_pass iterates partitions from last to first", "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo;
+  auto batch_p0 = make_gpu_batch(*gpu_space);
+  auto batch_p1 = make_gpu_batch(*gpu_space);
+  auto batch_p2 = make_gpu_batch(*gpu_space);
+  auto batch_p3 = make_gpu_batch(*gpu_space);
+  repo.add_data_batch(batch_p0, 0);
+  repo.add_data_batch(batch_p1, 1);
+  repo.add_data_batch(batch_p2, 2);
+  repo.add_data_batch(batch_p3, 3);
+
+  size_t two_batches = batch_p0->get_data()->get_size_in_bytes() * 2;
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, two_batches);
+  REQUIRE(scheduled == 2);
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (batch_p3->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST &&
+        batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST)
+      break;
+    std::this_thread::sleep_for(50ms);
+  }
+
+  REQUIRE(batch_p3->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch_p0->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch_p1->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+
+  executor.stop();
+}
+
+TEST_CASE("run_downgrade_pass skips active partitions in first pass", "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo;
+  auto batch_p0 = make_gpu_batch(*gpu_space);
+  auto batch_p1 = make_gpu_batch(*gpu_space);
+  auto batch_p2 = make_gpu_batch(*gpu_space);
+  repo.add_data_batch(batch_p0, 0);
+  repo.add_data_batch(batch_p1, 1);
+  repo.add_data_batch(batch_p2, 2);
+
+  REQUIRE(batch_p1->try_to_create_task());
+
+  size_t three_batches = batch_p0->get_data()->get_size_in_bytes() * 3;
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, three_batches);
+  REQUIRE(scheduled >= 2);
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST &&
+        batch_p0->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST)
+      break;
+    std::this_thread::sleep_for(50ms);
+  }
+
+  REQUIRE(batch_p2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch_p0->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+  REQUIRE(batch_p1->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+
+  batch_p1->try_to_cancel_task();
+  executor.stop();
+}
+
+TEST_CASE("run_downgrade_pass skips batches already on HOST", "[downgrade_executor]")
+{
+  auto mem_mgr    = make_test_memory_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  cucascade::shared_data_repository_manager repo_mgr;
+
+  cucascade::shared_data_repository repo;
+  auto gpu_batch  = make_gpu_batch(*gpu_space);
+  auto gpu_batch2 = make_gpu_batch(*gpu_space);
+  repo.add_data_batch(gpu_batch);
+  repo.add_data_batch(gpu_batch2);
+
+  // Pre-downgrade one batch to HOST manually
+  auto& registry   = sirius::converter_registry::get();
+  auto* host_space = mem_mgr->get_memory_space(cucascade::memory::Tier::HOST, 0);
+  if (!host_space) {
+    auto host_spaces = mem_mgr->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+    REQUIRE_FALSE(host_spaces.empty());
+    host_space = const_cast<cucascade::memory::memory_space*>(host_spaces.front());
+  }
+  rmm::cuda_stream conv_stream;
+  REQUIRE(gpu_batch->try_to_lock_for_in_transit());
+  gpu_batch->convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
+  gpu_batch->try_to_release_in_transit();
+  REQUIRE(gpu_batch->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+
+  auto executor = make_test_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  std::vector<downgrade_repository_info> repos = {{&repo}};
+  size_t scheduled                             = executor.run_downgrade_pass(repos, 1ull << 30);
+  REQUIRE(scheduled == 1);
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (gpu_batch2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST) break;
+    std::this_thread::sleep_for(50ms);
+  }
+  REQUIRE(gpu_batch2->get_memory_space()->get_tier() == cucascade::memory::Tier::HOST);
+
+  executor.stop();
+}

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -18,6 +18,7 @@
 
 #include <catch.hpp>
 #include <duckdb.hpp>
+#include <utils/sirius_test_env.hpp>
 
 #include <cmath>
 #include <cstdlib>
@@ -61,14 +62,19 @@ class GPUExecutionFixtureBase {
  public:
   GPUExecutionFixtureBase()
   {
-    // Set up environment variable for config file
-    auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
-    REQUIRE(fs::exists(cfg_path));
-    config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
+    if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+      // Use the shared DuckDB instance managed by the test listener
+      con =
+        std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+    } else {
+      // Fallback: create an isolated DuckDB (e.g. when running a single test directly)
+      auto cfg_path = fs::path(__FILE__).parent_path() / "integration.cfg";
+      REQUIRE(fs::exists(cfg_path));
+      config_guard = std::make_unique<sirius_config_env_guard>(cfg_path.string());
 
-    // Initialize DuckDB in-memory, then attach the TPC-H database
-    db  = std::make_unique<duckdb::DuckDB>(nullptr);
-    con = std::make_unique<duckdb::Connection>(*db);
+      db  = std::make_unique<duckdb::DuckDB>(nullptr);
+      con = std::make_unique<duckdb::Connection>(*db);
+    }
   }
 
   ~GPUExecutionFixtureBase() = default;
@@ -183,7 +189,7 @@ class GPUExecutionDuckDBFixture : public GPUExecutionFixtureBase {
   GPUExecutionDuckDBFixture()
   {
     auto db_path = get_tpch_db_path().string();
-    auto result  = con->Query("ATTACH '" + db_path + "' AS tpch (READ_ONLY);");
+    auto result  = con->Query("ATTACH IF NOT EXISTS '" + db_path + "' AS tpch (READ_ONLY);");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
@@ -204,42 +210,42 @@ class GPUExecutionParquetFixture : public GPUExecutionFixtureBase {
   GPUExecutionParquetFixture()
   {
     auto parquet_dir = fs::path(__FILE__).parent_path() / "data/parquet";
-    auto result      = con->Query("CREATE VIEW nation AS SELECT * FROM read_parquet('" +
+    auto result = con->Query("CREATE VIEW IF NOT EXISTS nation AS SELECT * FROM read_parquet('" +
                              parquet_dir.string() + "/nation.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW region AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS region AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/region.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW customer AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS customer AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/customer.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW orders AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS orders AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/orders.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW part AS SELECT * FROM read_parquet('" + parquet_dir.string() +
-                        "/part.parquet');");
+    result = con->Query("CREATE VIEW IF NOT EXISTS part AS SELECT * FROM read_parquet('" +
+                        parquet_dir.string() + "/part.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW partsupp AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS partsupp AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/partsupp.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW supplier AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS supplier AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/supplier.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());
 
-    result = con->Query("CREATE VIEW lineitem AS SELECT * FROM read_parquet('" +
+    result = con->Query("CREATE VIEW IF NOT EXISTS lineitem AS SELECT * FROM read_parquet('" +
                         parquet_dir.string() + "/lineitem.parquet');");
     REQUIRE(result);
     REQUIRE_FALSE(result->HasError());

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -48,6 +48,7 @@
 #include <cuda_runtime.h>
 
 // rmm
+#include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
@@ -327,9 +328,10 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-cucascade::host_data_packed_representation const& convert_to_host_table(
+cucascade::host_data_representation const& convert_to_host_table(
   duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
-  std::shared_ptr<cucascade::data_batch> const& batch)
+  std::shared_ptr<cucascade::data_batch> const& batch,
+  rmm::cuda_stream_view stream)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
@@ -347,29 +349,26 @@ cucascade::host_data_packed_representation const& convert_to_host_table(
   if (!host_space) { throw std::runtime_error("Invalid host memory space in test"); }
 
   auto& registry = sirius::converter_registry::get();
-  batch->convert_to<cucascade::host_data_packed_representation>(
-    registry, host_space, rmm::cuda_stream_default);
+  batch->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
 
   data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data after conversion"); }
-  return data->cast<cucascade::host_data_packed_representation>();
+  return data->cast<cucascade::host_data_representation>();
 }
 
 }  // namespace
 
 TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
-          "[memory][host_table_utils]")
+          "[memory][host_table_utils][shared_context]")
 {
-  using metadata_node = sirius::metadata_node;
-
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
 
   auto* host_space = get_memory_space(sirius_ctx, Tier::HOST, 0);
   REQUIRE(host_space != nullptr);
   auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   auto* allocator = host_space->get_memory_resource_as<fixed_size_host_memory_resource>();
   REQUIRE(allocator != nullptr);
@@ -464,24 +463,22 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
     str_builder.data_blocks_accessor.initial_byte_offset + str_builder.total_data_bytes;
   REQUIRE(str_end < big_builder.data_blocks_accessor.initial_byte_offset);
 
-  std::vector<metadata_node> column_metadata;
-  column_metadata.reserve(3);
-  column_metadata.push_back(int_builder.make_metadata_node(num_rows));
-  column_metadata.push_back(str_builder.make_metadata_node(num_rows));
-  column_metadata.push_back(big_builder.make_metadata_node(num_rows));
-  auto metadata = std::make_unique<std::vector<uint8_t>>(pack_metadata_from_nodes(column_metadata));
+  std::vector<cucascade::memory::column_metadata> columns;
+  columns.reserve(3);
+  columns.push_back(int_builder.make_column_metadata(num_rows));
+  columns.push_back(str_builder.make_column_metadata(num_rows));
+  columns.push_back(big_builder.make_column_metadata(num_rows));
 
   auto const sz         = allocation->size_bytes();
-  auto table_allocation = std::make_unique<cucascade::memory::host_table_packed_allocation>(
-    std::move(allocation), std::move(metadata), sz);
-  auto host_table = std::make_unique<cucascade::host_data_packed_representation>(
-    std::move(table_allocation), host_space);
+  auto table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
+    std::move(allocation), std::move(columns), sz);
+  auto host_table =
+    std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =
     std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
-  batch->convert_to<cucascade::gpu_table_representation>(
-    registry, gpu_space, cudf::get_default_stream());
+  batch->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);
   REQUIRE(table_view.num_rows() == static_cast<cudf::size_type>(num_rows));
@@ -496,18 +493,16 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
 }
 
 TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
-          "[memory][host_table_utils]")
+          "[memory][host_table_utils][shared_context]")
 {
-  using metadata_node = sirius::metadata_node;
-
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
 
   auto* host_space = get_memory_space(sirius_ctx, Tier::HOST, 0);
   REQUIRE(host_space != nullptr);
   auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   auto* allocator = host_space->get_memory_resource_as<fixed_size_host_memory_resource>();
   REQUIRE(allocator != nullptr);
@@ -594,23 +589,21 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
     expected_str_valid[i] = all_str_valid[i];
   }
 
-  std::vector<metadata_node> column_metadata;
-  column_metadata.reserve(2);
-  column_metadata.push_back(int_builder.make_metadata_node(rows_fit));
-  column_metadata.push_back(str_builder.make_metadata_node(rows_fit));
-  auto metadata = std::make_unique<std::vector<uint8_t>>(pack_metadata_from_nodes(column_metadata));
+  std::vector<cucascade::memory::column_metadata> columns;
+  columns.reserve(2);
+  columns.push_back(int_builder.make_column_metadata(rows_fit));
+  columns.push_back(str_builder.make_column_metadata(rows_fit));
 
   auto const sz         = allocation->size_bytes();
-  auto table_allocation = std::make_unique<cucascade::memory::host_table_packed_allocation>(
-    std::move(allocation), std::move(metadata), sz);
-  auto host_table = std::make_unique<cucascade::host_data_packed_representation>(
-    std::move(table_allocation), host_space);
+  auto table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
+    std::move(allocation), std::move(columns), sz);
+  auto host_table =
+    std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =
     std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
-  batch->convert_to<cucascade::gpu_table_representation>(
-    registry, gpu_space, cudf::get_default_stream());
+  batch->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);
   REQUIRE(table_view.num_rows() == static_cast<cudf::size_type>(rows_fit));
@@ -622,17 +615,17 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
   verify_string_column(table_view.column(1), expected_str, expected_str_valid);
 }
 
-TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][host_table_utils]")
+TEST_CASE("host_table_utils - metadata offsets match packed data",
+          "[memory][host_table_utils][shared_context]")
 {
   constexpr size_t num_rows = 257;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con]      = sirius::make_test_db_and_connection();
+  auto sirius_ctx           = sirius::get_sirius_context(con, get_test_config_path());
 
   auto* gpu_space = get_memory_space(sirius_ctx, Tier::GPU, 0);
   REQUIRE(gpu_space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = gpu_space->get_default_allocator();
+  rmm::cuda_stream stream;
+  auto mr = gpu_space->get_default_allocator();
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
                                             cudf::data_type{cudf::type_id::INT64},
@@ -663,22 +656,22 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
     expected_string_mask = extract_mask_bytes(gpu_view.column(2));
   }
 
-  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch, stream);
   auto const& host_alloc = host_table.get_host_table();
   auto const& allocation = host_alloc->allocation;
 
-  auto metadata_nodes = sirius::unpack_metadata_to_nodes(host_alloc->metadata);
-  REQUIRE(metadata_nodes.size() == column_types.size());
+  auto const& cols = host_alloc->columns;
+  REQUIRE(cols.size() == column_types.size());
 
-  REQUIRE(metadata_nodes[0].null_count == 0);
-  REQUIRE(metadata_nodes[0].null_mask_offset < 0);
-  REQUIRE(metadata_nodes[1].null_count == static_cast<cudf::size_type>(int64_nulls.size()));
-  REQUIRE(metadata_nodes[1].null_mask_offset >= 0);
-  REQUIRE(metadata_nodes[2].null_count == static_cast<cudf::size_type>(string_nulls.size()));
-  REQUIRE(metadata_nodes[2].null_mask_offset >= 0);
+  REQUIRE(cols[0].null_count == 0);
+  REQUIRE(!cols[0].has_null_mask);
+  REQUIRE(cols[1].null_count == static_cast<cudf::size_type>(int64_nulls.size()));
+  REQUIRE(cols[1].has_null_mask);
+  REQUIRE(cols[2].null_count == static_cast<cudf::size_type>(string_nulls.size()));
+  REQUIRE(cols[2].has_null_mask);
 
   sirius::memory::multiple_blocks_allocation_accessor<int32_t> int32_accessor;
-  int32_accessor.initialize(static_cast<size_t>(metadata_nodes[0].data_offset), allocation);
+  int32_accessor.initialize(cols[0].data_offset, allocation);
   std::vector<int32_t> actual_int32(num_rows);
   if (num_rows > 0) {
     int32_accessor.memcpy_to(allocation, actual_int32.data(), sizeof(int32_t) * num_rows);
@@ -686,7 +679,7 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
   REQUIRE(actual_int32 == expected.int32_values);
 
   sirius::memory::multiple_blocks_allocation_accessor<int64_t> int64_accessor;
-  int64_accessor.initialize(static_cast<size_t>(metadata_nodes[1].data_offset), allocation);
+  int64_accessor.initialize(cols[1].data_offset, allocation);
   std::vector<int64_t> actual_int64(num_rows);
   if (num_rows > 0) {
     int64_accessor.memcpy_to(allocation, actual_int64.data(), sizeof(int64_t) * num_rows);
@@ -696,18 +689,18 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
   sirius::memory::multiple_blocks_allocation_accessor<uint8_t> mask_accessor;
   if (!expected_int64_mask.empty()) {
     std::vector<uint8_t> actual_int64_mask(expected_int64_mask.size(), 0);
-    mask_accessor.initialize(static_cast<size_t>(metadata_nodes[1].null_mask_offset), allocation);
+    mask_accessor.initialize(cols[1].null_mask_offset, allocation);
     mask_accessor.memcpy_to(allocation, actual_int64_mask.data(), actual_int64_mask.size());
     mask_unused_bits(actual_int64_mask, num_rows);
     REQUIRE(actual_int64_mask == expected_int64_mask);
   }
 
-  auto const& string_node = metadata_nodes[2];
-  REQUIRE(string_node.children.size() == 1);
-  REQUIRE(string_node.children[0].type.id() == cudf::type_id::INT64);
+  auto const& string_col = cols[2];
+  REQUIRE(string_col.children.size() == 1);
+  REQUIRE(string_col.children[0].type_id == cudf::type_id::INT64);
 
   sirius::memory::multiple_blocks_allocation_accessor<int64_t> offset_accessor;
-  offset_accessor.initialize(static_cast<size_t>(string_node.children[0].data_offset), allocation);
+  offset_accessor.initialize(string_col.children[0].data_offset, allocation);
   std::vector<int64_t> actual_offsets(num_rows + 1);
   if (num_rows > 0) {
     offset_accessor.memcpy_to(allocation, actual_offsets.data(), sizeof(int64_t) * (num_rows + 1));
@@ -715,7 +708,7 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
   REQUIRE(actual_offsets == expected.string_offsets);
 
   sirius::memory::multiple_blocks_allocation_accessor<uint8_t> chars_accessor;
-  chars_accessor.initialize(static_cast<size_t>(string_node.data_offset), allocation);
+  chars_accessor.initialize(string_col.data_offset, allocation);
   std::vector<char> actual_chars(expected.string_chars.size());
   if (!actual_chars.empty()) {
     chars_accessor.memcpy_to(allocation, actual_chars.data(), actual_chars.size());
@@ -724,7 +717,7 @@ TEST_CASE("host_table_utils - metadata offsets match packed data", "[memory][hos
 
   if (!expected_string_mask.empty()) {
     std::vector<uint8_t> actual_string_mask(expected_string_mask.size(), 0);
-    mask_accessor.initialize(static_cast<size_t>(string_node.null_mask_offset), allocation);
+    mask_accessor.initialize(string_col.null_mask_offset, allocation);
     mask_accessor.memcpy_to(allocation, actual_string_mask.data(), actual_string_mask.size());
     mask_unused_bits(actual_string_mask, num_rows);
     REQUIRE(actual_string_mask == expected_string_mask);

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -32,6 +32,7 @@
 #include <cudf/utilities/default_stream.hpp>
 
 // rmm
+#include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 // standard library
@@ -209,8 +210,10 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
   return total_bytes;
 }
 
-host_data_packed_representation const& convert_to_host_table(
-  duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx, std::shared_ptr<data_batch> const& batch)
+host_data_representation const& convert_to_host_table(
+  duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
+  std::shared_ptr<data_batch> const& batch,
+  rmm::cuda_stream_view stream)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
@@ -228,25 +231,24 @@ host_data_packed_representation const& convert_to_host_table(
   if (!host_space) { throw std::runtime_error("Invalid host memory space in test"); }
 
   auto& registry = sirius::converter_registry::get();
-  batch->convert_to<host_data_packed_representation>(
-    registry, host_space, rmm::cuda_stream_default);
+  batch->convert_to<host_data_representation>(registry, host_space, stream);
 
   data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data after conversion"); }
-  return data->cast<host_data_packed_representation>();
+  return data->cast<host_data_representation>();
 }
 
 }  // namespace
 
 TEST_CASE("host_table_chunk_reader produces correct DataChunks",
-          "[operator][result_collector][host_table_chunk_reader]")
+          "[operator][result_collector][host_table_chunk_reader][shared_context]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE + 5;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* gpu_space = get_default_gpu_space(sirius_ctx);
+  auto [db_owner, con]      = sirius::make_test_db_and_connection();
+  auto sirius_ctx           = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space           = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
                                             cudf::data_type{cudf::type_id::INT64},
@@ -254,12 +256,8 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
   std::vector<std::optional<std::pair<int, int>>> ranges{
     std::make_pair(0, 100), std::make_pair(1000, 2000), std::make_pair(0, 100)};
 
-  auto table = sirius::create_cudf_table_with_random_data(num_rows,
-                                                          column_types,
-                                                          ranges,
-                                                          cudf::get_default_stream(),
-                                                          gpu_space->get_default_allocator(),
-                                                          true);
+  auto table = sirius::create_cudf_table_with_random_data(
+    num_rows, column_types, ranges, stream, gpu_space->get_default_allocator(), true);
   auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
 
   expected_table_data expected;
@@ -275,7 +273,7 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
     expected_strings    = build_expected_strings(expected);
   }
 
-  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch, stream);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
@@ -317,16 +315,15 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
 }
 
 TEST_CASE("host_table_chunk_reader handles null masks",
-          "[operator][result_collector][host_table_chunk_reader]")
+          "[operator][result_collector][host_table_chunk_reader][shared_context]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE * 2 + 3;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* gpu_space = get_default_gpu_space(sirius_ctx);
+  auto [db_owner, con]      = sirius::make_test_db_and_connection();
+  auto sirius_ctx           = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space           = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = gpu_space->get_default_allocator();
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
+  auto mr = gpu_space->get_default_allocator();
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
                                             cudf::data_type{cudf::type_id::INT64},
@@ -363,7 +360,7 @@ TEST_CASE("host_table_chunk_reader handles null masks",
     expected_string_valid = extract_validity(gpu_view.column(2));
   }
 
-  auto const& host_table = convert_to_host_table(sirius_ctx, batch);
+  auto const& host_table = convert_to_host_table(sirius_ctx, batch, stream);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -37,6 +37,7 @@
 #include <cudf/utilities/default_stream.hpp>
 
 // rmm
+#include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 // duckdb
@@ -177,7 +178,8 @@ size_t estimate_packed_data_bytes(cudf::table_view const& view)
 }
 
 void convert_batch_to_host(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
-                           std::shared_ptr<data_batch> const& batch)
+                           std::shared_ptr<data_batch> const& batch,
+                           rmm::cuda_stream_view stream)
 {
   auto* data = batch->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data representation"); }
@@ -194,21 +196,20 @@ void convert_batch_to_host(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
   if (!host_space) { throw std::runtime_error("Invalid host memory space for test"); }
 
   auto& registry = sirius::converter_registry::get();
-  batch->convert_to<cucascade::host_data_packed_representation>(
-    registry, host_space, rmm::cuda_stream_default);
+  batch->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
 }
 
 }  // namespace
 
 TEST_CASE("sirius_physical_materialized_collector sink with host input",
-          "[operator][physical_result_collector]")
+          "[operator][physical_result_collector][shared_context]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE + 7;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* gpu_space = get_default_gpu_space(sirius_ctx);
+  auto [db_owner, con]      = sirius::make_test_db_and_connection();
+  auto sirius_ctx           = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space           = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
                                             cudf::data_type{cudf::type_id::INT64},
@@ -216,12 +217,8 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
   std::vector<std::optional<std::pair<int, int>>> ranges{
     std::make_pair(0, 100), std::make_pair(1000, 2000), std::make_pair(0, 100)};
 
-  auto table = sirius::create_cudf_table_with_random_data(num_rows,
-                                                          column_types,
-                                                          ranges,
-                                                          cudf::get_default_stream(),
-                                                          gpu_space->get_default_allocator(),
-                                                          true);
+  auto table = sirius::create_cudf_table_with_random_data(
+    num_rows, column_types, ranges, stream, gpu_space->get_default_allocator(), true);
   auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
 
   expected_table_data expected;
@@ -237,7 +234,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
     expected_strings    = build_expected_strings(expected);
   }
 
-  convert_batch_to_host(sirius_ctx, batch);
+  convert_batch_to_host(sirius_ctx, batch, stream);
 
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
@@ -277,26 +274,22 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
 }
 
 TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
-          "[operator][physical_result_collector]")
+          "[operator][physical_result_collector][shared_context]")
 {
   constexpr size_t num_rows = STANDARD_VECTOR_SIZE * 2 + 3;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* gpu_space = get_default_gpu_space(sirius_ctx);
+  auto [db_owner, con]      = sirius::make_test_db_and_connection();
+  auto sirius_ctx           = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space           = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   std::vector<cudf::data_type> column_types{cudf::data_type{cudf::type_id::INT32},
                                             cudf::data_type{cudf::type_id::INT64}};
   std::vector<std::optional<std::pair<int, int>>> ranges{std::make_pair(0, 100),
                                                          std::make_pair(1000, 2000)};
 
-  auto table = sirius::create_cudf_table_with_random_data(num_rows,
-                                                          column_types,
-                                                          ranges,
-                                                          cudf::get_default_stream(),
-                                                          gpu_space->get_default_allocator(),
-                                                          false);
+  auto table = sirius::create_cudf_table_with_random_data(
+    num_rows, column_types, ranges, stream, gpu_space->get_default_allocator(), false);
   auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
 
   expected_table_data expected;
@@ -321,7 +314,7 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
-  collector.sink(operator_data({batch}), cudf::get_default_stream());
+  collector.sink(operator_data({batch}), stream);
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -344,15 +337,15 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
 }
 
 TEST_CASE("sirius_physical_materialized_collector sink supports concurrent append",
-          "[operator][physical_result_collector][concurrent]")
+          "[operator][physical_result_collector][concurrent][shared_context]")
 {
   constexpr int num_threads       = 4;
   constexpr size_t rows_per_batch = STANDARD_VECTOR_SIZE * 3 + 13;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* gpu_space = get_default_gpu_space(sirius_ctx);
+  auto [db_owner, con]            = sirius::make_test_db_and_connection();
+  auto sirius_ctx                 = sirius::get_sirius_context(con, get_test_config_path());
+  auto* gpu_space                 = get_default_gpu_space(sirius_ctx);
   REQUIRE(gpu_space != nullptr);
+  rmm::cuda_stream stream;  // Must outlive data_batch for cudaMemcpyBatchAsync
 
   using row_t = std::pair<int32_t, int64_t>;
   std::vector<row_t> expected_rows;
@@ -360,9 +353,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
 
   std::vector<std::shared_ptr<data_batch>> batches;
   batches.reserve(num_threads);
-
-  auto stream = cudf::get_default_stream();
-  auto mr     = gpu_space->get_default_allocator();
+  auto mr = gpu_space->get_default_allocator();
 
   for (int thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
     std::vector<int32_t> col0_values(rows_per_batch, thread_idx);
@@ -401,7 +392,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
 
     auto table = std::make_unique<cudf::table>(std::move(cols));
     auto batch = sirius::make_data_batch(std::move(table), *gpu_space);
-    convert_batch_to_host(sirius_ctx, batch);
+    convert_batch_to_host(sirius_ctx, batch, stream);
     batches.emplace_back(std::move(batch));
   }
 

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -79,7 +79,7 @@ create_test_allocation(duckdb::SiriusContext& sirius_ctx, size_t total_size)
 //===----------------------------------------------------------------------===//
 // Test: column_builder - Construction
 //===----------------------------------------------------------------------===//
-TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder][shared_context]")
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
 
@@ -128,14 +128,14 @@ TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder]")
 //===----------------------------------------------------------------------===//
 // Test: column_builder - Accessor Initialization with Shared Allocation
 //===----------------------------------------------------------------------===//
-TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - accessor initialization",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
 
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* mem_space = get_host_space(*sirius_ctx);
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
+  auto* mem_space      = get_host_space(*sirius_ctx);
   REQUIRE(mem_space != nullptr);
   auto* allocator = mem_space->template get_memory_resource_as<fixed_size_host_memory_resource>();
   REQUIRE(allocator != nullptr);
@@ -194,14 +194,14 @@ TEST_CASE("column_builder - accessor initialization", "[duckdb_scan_task][column
 //===----------------------------------------------------------------------===//
 // Test: column_builder - sufficient_space_for_column
 //===----------------------------------------------------------------------===//
-TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - sufficient_space_for_column",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
 
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
-  auto* mem_space = get_host_space(*sirius_ctx);
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
+  auto* mem_space      = get_host_space(*sirius_ctx);
   REQUIRE(mem_space != nullptr);
   auto* allocator = mem_space->template get_memory_resource_as<fixed_size_host_memory_resource>();
   REQUIRE(allocator != nullptr);
@@ -277,11 +277,11 @@ TEST_CASE("column_builder - sufficient_space_for_column", "[duckdb_scan_task][co
 //===----------------------------------------------------------------------===//
 // Test: column_builder - process_mask_for_column
 //===----------------------------------------------------------------------===//
-TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - process_mask_for_column",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
 
   SECTION("byte-aligned mask processing")
   {
@@ -423,11 +423,10 @@ TEST_CASE("column_builder - process_mask_for_column", "[duckdb_scan_task][column
 //===----------------------------------------------------------------------===//
 
 TEST_CASE("column_builder - process_column for fixed-width types",
-          "[duckdb_scan_task][column_builder]")
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("INTEGER column processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -538,12 +537,12 @@ TEST_CASE("column_builder - process_column for fixed-width types",
 // Test: column_builder - process_column (VARCHAR)
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - process_column for VARCHAR",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
   constexpr size_t DEFAULT_VARCHAR_SIZE = 256;
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con]                  = sirius::make_test_db_and_connection();
+  auto sirius_ctx                       = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("VARCHAR column processing with all valid rows")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
@@ -642,11 +641,11 @@ TEST_CASE("column_builder - process_column for VARCHAR", "[duckdb_scan_task][col
 // Test: column_builder - Multiple batch processing
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - multiple batch processing",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("process multiple batches of INTEGER data")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -787,11 +786,10 @@ TEST_CASE("column_builder - multiple batch processing", "[duckdb_scan_task][colu
 // Test: column_builder - Edge Cases
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("empty vector (0 rows)")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
@@ -985,11 +983,10 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder]")
 //===----------------------------------------------------------------------===//
 
 TEST_CASE("column_builder - packed allocation multiple columns",
-          "[duckdb_scan_task][column_builder]")
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("two fixed-width columns in packed allocation")
   {
     // Simulate layout: [INT column data][INT column mask][BIGINT column data][BIGINT column mask]
@@ -1236,11 +1233,10 @@ TEST_CASE("column_builder - packed allocation multiple columns",
 //===----------------------------------------------------------------------===//
 
 TEST_CASE("column_builder - VARCHAR space checking edge cases",
-          "[duckdb_scan_task][column_builder]")
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("sufficient_space_for_column returns false when space exceeded")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
@@ -1365,11 +1361,11 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
 // Test: NULL handling at block boundaries
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("column_builder - NULL handling at boundaries", "[duckdb_scan_task][column_builder]")
+TEST_CASE("column_builder - NULL handling at boundaries",
+          "[duckdb_scan_task][column_builder][shared_context]")
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
-  auto sirius_ctx = sirius::get_sirius_context(con, get_test_config_path());
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto sirius_ctx      = sirius::get_sirius_context(con, get_test_config_path());
   SECTION("NULLs at byte boundaries in mask")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);

--- a/test/cpp/scan/test_parquet_scan_task.cpp
+++ b/test/cpp/scan/test_parquet_scan_task.cpp
@@ -29,6 +29,9 @@
 // cucascade
 #include <cucascade/memory/memory_reservation_manager.hpp>
 
+// rmm
+#include <rmm/cuda_stream.hpp>
+
 // cudf
 #include <cudf/logger.hpp>
 
@@ -58,7 +61,8 @@ using table_creator_t = void (*)(duckdb::Connection&,
 
 using batch_validator_t = void (*)(const std::vector<std::shared_ptr<cucascade::data_batch>>&,
                                    size_t,
-                                   cucascade::memory::memory_reservation_manager&);
+                                   cucascade::memory::memory_reservation_manager&,
+                                   rmm::cuda_stream_view);
 
 static std::unique_ptr<sirius::op::sirius_physical_parquet_scan> make_parquet_scan(
   duckdb::ClientContext& ctx,
@@ -166,10 +170,11 @@ static std::filesystem::path write_parquet_from_table(duckdb::Connection& con,
 static void validate_scanned_batches_suppress_cudf(
   const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
   size_t expected_rows,
-  cucascade::memory::memory_reservation_manager& mem_mgr)
+  cucascade::memory::memory_reservation_manager& mem_mgr,
+  rmm::cuda_stream_view stream)
 {
   rapids_logger::log_level_setter guard(cudf::default_logger(), rapids_logger::level_enum::error);
-  validate_scanned_batches(batches, expected_rows, mem_mgr);
+  validate_scanned_batches(batches, expected_rows, mem_mgr, stream);
 }
 
 static void create_synthetic_table_with_nested_list(duckdb::Connection& con,
@@ -258,8 +263,7 @@ static void run_parquet_scan_test(std::string const& table_name,
                                   batch_validator_t validator   = validate_scanned_batches,
                                   table_creator_t table_creator = create_synthetic_table)
 {
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
 
   table_creator(con, table_name, num_rows);
   auto parquet_path = write_parquet_from_table(con, table_name, row_group_size);
@@ -317,8 +321,10 @@ static void run_parquet_scan_test(std::string const& table_name,
     return batches;
   };
 
+  // The stream must be declared before batches so it outlives GPU data allocated on it.
+  rmm::cuda_stream stream;
   auto batches = run_scan();
-  validator(batches, num_rows, mem_mgr);
+  validator(batches, num_rows, mem_mgr, stream);
 
   // End the transaction.
   auto commit_result = con.Query("COMMIT");
@@ -341,8 +347,7 @@ static void run_multi_file_parquet_scan_test(std::string const& table_prefix,
 {
   REQUIRE(!file_row_counts.empty());
 
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
 
   auto parquet_dir = std::filesystem::temp_directory_path() / (table_prefix + "_multi_file");
   std::filesystem::remove_all(parquet_dir);
@@ -415,8 +420,10 @@ static void run_multi_file_parquet_scan_test(std::string const& table_prefix,
     return batches;
   };
 
+  // The stream must be declared before batches so it outlives GPU data allocated on it.
+  rmm::cuda_stream stream;
   auto batches = run_scan();
-  validator(batches, total_rows, mem_mgr);
+  validator(batches, total_rows, mem_mgr, stream);
 
   auto commit_result = con.Query("COMMIT");
   REQUIRE(commit_result);
@@ -430,32 +437,37 @@ static void run_multi_file_parquet_scan_test(std::string const& table_prefix,
   std::filesystem::remove_all(parquet_dir);
 }
 
-TEST_CASE("parquet_scan_task - single threaded small table", "[parquet_scan_task][single_thread]")
+TEST_CASE("parquet_scan_task - single threaded small table",
+          "[parquet_scan_task][single_thread][shared_context]")
 {
   run_parquet_scan_test("parquet_small", 2000, 1, 200000, 500);
 }
 
-TEST_CASE("parquet_scan_task - single threaded small batches", "[parquet_scan_task][single_thread]")
+TEST_CASE("parquet_scan_task - single threaded small batches",
+          "[parquet_scan_task][single_thread][shared_context]")
 {
   run_parquet_scan_test("parquet_medium", 10000, 1, 150000, 500);
 }
 
-TEST_CASE("parquet_scan_task - multi threaded medium table", "[parquet_scan_task][multi_thread]")
+TEST_CASE("parquet_scan_task - multi threaded medium table",
+          "[parquet_scan_task][multi_thread][shared_context]")
 {
   run_parquet_scan_test("parquet_mt", 100000, 4, 1000000, 0);
 }
 
-TEST_CASE("parquet_scan_task - multi threaded large table", "[parquet_scan_task][multi_thread]")
+TEST_CASE("parquet_scan_task - multi threaded large table",
+          "[parquet_scan_task][multi_thread][shared_context]")
 {
   run_parquet_scan_test("parquet_mt_large", 500000, 8, 10000000, 0);
 }
 
-TEST_CASE("parquet_scan_task - single partition row group", "[parquet_scan_task][edge_case]")
+TEST_CASE("parquet_scan_task - single partition row group",
+          "[parquet_scan_task][edge_case][shared_context]")
 {
   run_parquet_scan_test("parquet_single_partition", 5000, 2, 5000000, 100000);
 }
 
-TEST_CASE("parquet_scan_task - projected subset", "[parquet_scan_task][projection]")
+TEST_CASE("parquet_scan_task - projected subset", "[parquet_scan_task][projection][shared_context]")
 {
   duckdb::vector<duckdb::idx_t> projection_ids{0, 2};  // id, price
   run_parquet_scan_test("parquet_projected",
@@ -468,7 +480,7 @@ TEST_CASE("parquet_scan_task - projected subset", "[parquet_scan_task][projectio
 }
 
 TEST_CASE("parquet_scan_task - projected flat columns with nested schema",
-          "[parquet_scan_task][projection][nested_schema]")
+          "[parquet_scan_task][projection][nested_schema][shared_context]")
 {
   duckdb::vector<duckdb::idx_t> projection_ids{0, 2};  // id, price
   run_parquet_scan_test("parquet_projected_nested_schema",
@@ -481,12 +493,12 @@ TEST_CASE("parquet_scan_task - projected flat columns with nested schema",
                         create_synthetic_table_with_nested_list);
 }
 
-TEST_CASE("parquet_scan_task - empty table", "[parquet_scan_task][edge_case]")
+TEST_CASE("parquet_scan_task - empty table", "[parquet_scan_task][edge_case][shared_context]")
 {
   run_parquet_scan_test("parquet_empty", 0, 1, 200000, 500);
 }
 
-TEST_CASE("parquet_scan_task - single row table", "[parquet_scan_task][edge_case]")
+TEST_CASE("parquet_scan_task - single row table", "[parquet_scan_task][edge_case][shared_context]")
 {
   // Suppress cudf warnings about single-row parquet files
   run_parquet_scan_test("parquet_single_row",
@@ -498,13 +510,14 @@ TEST_CASE("parquet_scan_task - single row table", "[parquet_scan_task][edge_case
                         validate_scanned_batches_suppress_cudf);
 }
 
-TEST_CASE("parquet_scan_task - multi file full scan", "[parquet_scan_task][multi_file]")
+TEST_CASE("parquet_scan_task - multi file full scan",
+          "[parquet_scan_task][multi_file][shared_context]")
 {
   run_multi_file_parquet_scan_test("parquet_multi_file", {3000, 4200}, 4, 200000, 500);
 }
 
 TEST_CASE("parquet_scan_task - multi file projected subset",
-          "[parquet_scan_task][multi_file][projection]")
+          "[parquet_scan_task][multi_file][projection][shared_context]")
 {
   duckdb::vector<duckdb::idx_t> projection_ids{0, 2};  // id, price
   run_multi_file_parquet_scan_test("parquet_multi_file_projected",
@@ -517,7 +530,7 @@ TEST_CASE("parquet_scan_task - multi file projected subset",
 }
 
 TEST_CASE("parquet_scan_task - multi file full scan five files mixed sizes",
-          "[parquet_scan_task][multi_file]")
+          "[parquet_scan_task][multi_file][shared_context]")
 {
   run_multi_file_parquet_scan_test(
     "parquet_multi_file_five", {1400, 2600, 0, 3100, 900}, 6, 150000, 300);

--- a/test/cpp/scan/test_scan_executor.cpp
+++ b/test/cpp/scan/test_scan_executor.cpp
@@ -28,6 +28,9 @@
 // cucascade
 #include <cucascade/data/data_repository.hpp>
 
+// rmm
+#include <rmm/cuda_stream.hpp>
+
 // duckdb
 #include <duckdb.hpp>
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
@@ -117,9 +120,8 @@ static void run_scan_test(std::string const& table_name,
                           int num_threads,
                           size_t batch_size)
 {
-  // Setup DuckDB database
-  duckdb::DuckDB db(nullptr);
-  duckdb::Connection con(db);
+  // Use shared DuckDB when available, otherwise create standalone
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
 
   // Create and populate table
   create_synthetic_table(con, table_name, num_rows);
@@ -158,8 +160,12 @@ static void run_scan_test(std::string const& table_name,
   auto execution_context =
     std::make_unique<duckdb::ExecutionContext>(client_ctx, *thread_context, nullptr);
 
-  // Run tasks
-  pipeline_executor.start();
+  // Only start/stop the pipeline executor when NOT using the shared test env.
+  // The shared env's SiriusContext already started it, and stopping it would
+  // permanently break the interruptible_mpmc queue (no reset on restart).
+  bool const manage_executor = !sirius::test::g_shared_env;
+  if (manage_executor) { pipeline_executor.start(); }
+
   for (int i = 0; i < scan_executor.get_num_threads(); ++i) {
     auto local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
       *global_state, *execution_context, batch_size);
@@ -171,11 +177,13 @@ static void run_scan_test(std::string const& table_name,
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
-  pipeline_executor.stop();
+  if (manage_executor) { pipeline_executor.stop(); }
 
-  // Validate repository data batches
+  // Validate repository data batches.
+  // The stream must be declared before batches so it outlives GPU data allocated on it.
+  rmm::cuda_stream stream;
   auto batches = drain_data_repo(data_repo);
-  validate_scanned_batches(batches, num_rows, mem_mgr);
+  validate_scanned_batches(batches, num_rows, mem_mgr, stream);
 
   // End the transaction
   auto commit_result = con.Query("COMMIT");
@@ -190,13 +198,15 @@ static void run_scan_test(std::string const& table_name,
 // Test: Single-threaded scan executor
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("scan_executor - single threaded small table", "[scan_executor][single_thread]")
+TEST_CASE("scan_executor - single threaded small table",
+          "[scan_executor][single_thread][shared_context]")
 {
   // Use 10MB batch size to ensure multiple 1MB blocks are allocated
   run_scan_test("test_small", 100, 1, 10000000);
 }
 
-TEST_CASE("scan_executor - single threaded with small batches", "[scan_executor][single_thread]")
+TEST_CASE("scan_executor - single threaded with small batches",
+          "[scan_executor][single_thread][shared_context]")
 {
   // Use a small batch size to force multiple batches
   // With 4 columns (INT + BIGINT + DOUBLE + VARCHAR(256)) = 4 + 8 + 8 + 256 = 276 bytes per row
@@ -208,17 +218,20 @@ TEST_CASE("scan_executor - single threaded with small batches", "[scan_executor]
 // Test: Multi-threaded scan executor
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("scan_executor - multi threaded small table", "[scan_executor][multi_thread]")
+TEST_CASE("scan_executor - multi threaded small table",
+          "[scan_executor][multi_thread][shared_context]")
 {
   run_scan_test("test_mt_small", 1000, 4, 1000000);
 }
 
-TEST_CASE("scan_executor - multi threaded medium table", "[scan_executor][multi_thread]")
+TEST_CASE("scan_executor - multi threaded medium table",
+          "[scan_executor][multi_thread][shared_context]")
 {
   run_scan_test("test_mt_medium", 100000, 4, 1000000);
 }
 
-TEST_CASE("scan_executor - multi threaded large table", "[scan_executor][multi_thread]")
+TEST_CASE("scan_executor - multi threaded large table",
+          "[scan_executor][multi_thread][shared_context]")
 {
   run_scan_test("test_mt_large", 500000, 8, 10000000);
 }
@@ -227,12 +240,12 @@ TEST_CASE("scan_executor - multi threaded large table", "[scan_executor][multi_t
 // Test: Edge cases
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("scan_executor - empty table", "[scan_executor][edge_case]")
+TEST_CASE("scan_executor - empty table", "[scan_executor][edge_case][shared_context]")
 {
   run_scan_test("test_empty", 0, 1, 1000000);
 }
 
-TEST_CASE("scan_executor - single row table", "[scan_executor][edge_case]")
+TEST_CASE("scan_executor - single row table", "[scan_executor][edge_case][shared_context]")
 {
   run_scan_test("test_single_row", 1, 1, 1000000);
 }

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -36,6 +36,9 @@
 // cudf
 #include <cudf/strings/strings_column_view.hpp>
 
+// rmm
+#include <rmm/cuda_stream.hpp>
+
 // duckdb
 #include <duckdb.hpp>
 
@@ -186,7 +189,8 @@ inline std::vector<int64_t> copy_string_offsets(const cudf::column_view& offsets
 inline void validate_scanned_batches(
   const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
   size_t expected_rows,
-  cucascade::memory::memory_reservation_manager& mem_mgr)
+  cucascade::memory::memory_reservation_manager& mem_mgr,
+  rmm::cuda_stream_view stream)
 {
   auto* gpu_space = get_space(mem_mgr, cucascade::memory::Tier::GPU);
   REQUIRE(gpu_space != nullptr);
@@ -199,8 +203,7 @@ inline void validate_scanned_batches(
 
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
-    batch->convert_to<cucascade::gpu_table_representation>(
-      registry, gpu_space, cudf::get_default_stream());
+    batch->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     auto table_view = sirius::get_cudf_table_view(*batch);
 
     REQUIRE(table_view.num_columns() == 4);
@@ -272,7 +275,8 @@ inline void validate_scanned_batches(
 inline void validate_projected_id_price_batches(
   const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
   size_t expected_rows,
-  cucascade::memory::memory_reservation_manager& mem_mgr)
+  cucascade::memory::memory_reservation_manager& mem_mgr,
+  rmm::cuda_stream_view stream)
 {
   auto* gpu_space = get_space(mem_mgr, cucascade::memory::Tier::GPU);
   REQUIRE(gpu_space != nullptr);
@@ -285,8 +289,7 @@ inline void validate_projected_id_price_batches(
 
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
-    batch->convert_to<cucascade::gpu_table_representation>(
-      registry, gpu_space, cudf::get_default_stream());
+    batch->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     auto table_view = sirius::get_cudf_table_view(*batch);
 
     REQUIRE(table_view.num_columns() == 2);

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -18,10 +18,54 @@
 
 #include "catch.hpp"
 #include "log/logging.hpp"
+#include "utils/sirius_test_env.hpp"
 
+#include <algorithm>
 #include <cstdlib>
+#include <filesystem>
+#include <string>
 
 using namespace duckdb;
+
+/**
+ * @brief Catch2 listener that activates/deactivates the shared test environment
+ * based on test tags.
+ *
+ * The shared SiriusContext's GPU memory pools cannot coexist with the separate
+ * memory managers used by operator tests (both reserve GPU memory, causing
+ * exhaustion or corruption). Therefore the shared environment starts PAUSED
+ * and is only activated for tests tagged [shared_context] that explicitly
+ * need it. Tests tagged [isolated_context] or [integration] create their
+ * own DuckDB/SiriusContext, so the shared env must be paused for those too.
+ */
+struct shared_env_listener : Catch::TestEventListenerBase {
+  using TestEventListenerBase::TestEventListenerBase;
+
+  static bool wants_shared_env(Catch::TestCaseInfo const& info)
+  {
+    return std::any_of(info.tags.begin(), info.tags.end(), [](std::string const& tag) {
+      return tag == "shared_context";
+    });
+  }
+
+  void testCaseStarting(Catch::TestCaseInfo const& info) override
+  {
+    if (wants_shared_env(info) && sirius::test::g_shared_env &&
+        !sirius::test::g_shared_env->is_active()) {
+      sirius::test::g_shared_env->resume();
+    }
+  }
+
+  void testCaseEnded(Catch::TestCaseStats const& stats) override
+  {
+    if (wants_shared_env(stats.testInfo) && sirius::test::g_shared_env &&
+        sirius::test::g_shared_env->is_active()) {
+      sirius::test::g_shared_env->pause();
+    }
+  }
+};
+
+CATCH_REGISTER_LISTENER(shared_env_listener)
 
 int main(int argc, char* argv[])
 {
@@ -29,9 +73,23 @@ int main(int argc, char* argv[])
   std::string log_dir = SIRIUS_UNITTEST_LOG_DIR;
   InitGlobalLogger(log_dir + "/sirius_unittest.log");
 
-  // Run tests
-  int code = Catch::Session().run(argc, argv);
+  // Create a shared test environment. It starts PAUSED and is only activated
+  // by the listener for tests tagged [shared_context]. This avoids GPU memory
+  // conflicts with operator tests that use their own memory managers.
+  auto config_path =
+    std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "scan" / "memory.cfg";
+  sirius::test::shared_test_env env(config_path);
+  // Immediately pause — the listener will resume for [shared_context] tests
+  env.pause();
+  sirius::test::g_shared_env = &env;
+
+  Catch::Session session;
+  session.applyCommandLine(argc, argv);
+  int result = session.run();
+
+  sirius::test::g_shared_env = nullptr;
+
   std::fflush(stdout);
   std::fflush(stderr);
-  std::quick_exit(code);
+  std::quick_exit(result);
 }

--- a/test/cpp/unittest.cpp
+++ b/test/cpp/unittest.cpp
@@ -28,39 +28,55 @@
 using namespace duckdb;
 
 /**
- * @brief Catch2 listener that activates/deactivates the shared test environment
+ * @brief Catch2 listener that activates/deactivates shared test environments
  * based on test tags.
  *
- * The shared SiriusContext's GPU memory pools cannot coexist with the separate
- * memory managers used by operator tests (both reserve GPU memory, causing
- * exhaustion or corruption). Therefore the shared environment starts PAUSED
- * and is only activated for tests tagged [shared_context] that explicitly
- * need it. Tests tagged [isolated_context] or [integration] create their
- * own DuckDB/SiriusContext, so the shared env must be paused for those too.
+ * Only one shared environment can be active at a time (each owns the extension
+ * lock).  The listener uses a transition-based design: it pauses the wrong
+ * environment and resumes the right one in testCaseStarting, so consecutive
+ * tests of the same type share a single DuckDB/SiriusContext instance without
+ * any intermediate teardown.
+ *
+ *   [shared_context]  → g_shared_env      (scan/operator unit tests)
+ *   [integration]     → g_integration_env (GPU execution integration tests)
+ *   anything else     → no env active     (isolated / standalone tests)
  */
 struct shared_env_listener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;
 
-  static bool wants_shared_env(Catch::TestCaseInfo const& info)
+  enum class env_need { NONE, SHARED, INTEGRATION };
+
+  static env_need classify(Catch::TestCaseInfo const& info)
   {
-    return std::any_of(info.tags.begin(), info.tags.end(), [](std::string const& tag) {
-      return tag == "shared_context";
-    });
+    for (auto const& tag : info.tags) {
+      if (tag == "shared_context") return env_need::SHARED;
+      if (tag == "integration") return env_need::INTEGRATION;
+    }
+    return env_need::NONE;
   }
 
   void testCaseStarting(Catch::TestCaseInfo const& info) override
   {
-    if (wants_shared_env(info) && sirius::test::g_shared_env &&
+    auto needs = classify(info);
+
+    // Pause environments that should not be active for this test
+    if (needs != env_need::SHARED && sirius::test::g_shared_env &&
+        sirius::test::g_shared_env->is_active()) {
+      sirius::test::g_shared_env->pause();
+    }
+    if (needs != env_need::INTEGRATION && sirius::test::g_integration_env &&
+        sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->pause();
+    }
+
+    // Resume the environment this test needs
+    if (needs == env_need::SHARED && sirius::test::g_shared_env &&
         !sirius::test::g_shared_env->is_active()) {
       sirius::test::g_shared_env->resume();
     }
-  }
-
-  void testCaseEnded(Catch::TestCaseStats const& stats) override
-  {
-    if (wants_shared_env(stats.testInfo) && sirius::test::g_shared_env &&
-        sirius::test::g_shared_env->is_active()) {
-      sirius::test::g_shared_env->pause();
+    if (needs == env_need::INTEGRATION && sirius::test::g_integration_env &&
+        !sirius::test::g_integration_env->is_active()) {
+      sirius::test::g_integration_env->resume();
     }
   }
 };
@@ -73,21 +89,28 @@ int main(int argc, char* argv[])
   std::string log_dir = SIRIUS_UNITTEST_LOG_DIR;
   InitGlobalLogger(log_dir + "/sirius_unittest.log");
 
-  // Create a shared test environment. It starts PAUSED and is only activated
-  // by the listener for tests tagged [shared_context]. This avoids GPU memory
+  // Create shared test environments. Both start PAUSED and are only activated
+  // by the listener for tests with the matching tag. This avoids GPU memory
   // conflicts with operator tests that use their own memory managers.
-  auto config_path =
+  // Only one environment can be active at a time (each owns the extension lock).
+  auto scan_config_path =
     std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "scan" / "memory.cfg";
-  sirius::test::shared_test_env env(config_path);
-  // Immediately pause — the listener will resume for [shared_context] tests
-  env.pause();
-  sirius::test::g_shared_env = &env;
+  sirius::test::shared_test_env scan_env(scan_config_path);
+  scan_env.pause();
+  sirius::test::g_shared_env = &scan_env;
+
+  auto integration_config_path =
+    std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "integration" / "integration.cfg";
+  sirius::test::shared_test_env integration_env(integration_config_path);
+  integration_env.pause();
+  sirius::test::g_integration_env = &integration_env;
 
   Catch::Session session;
   session.applyCommandLine(argc, argv);
   int result = session.run();
 
-  sirius::test::g_shared_env = nullptr;
+  sirius::test::g_integration_env = nullptr;
+  sirius::test::g_shared_env      = nullptr;
 
   std::fflush(stdout);
   std::fflush(stderr);

--- a/test/cpp/utils/sirius_test_env.cpp
+++ b/test/cpp/utils/sirius_test_env.cpp
@@ -18,7 +18,8 @@
 
 namespace sirius::test {
 
-shared_test_env* g_shared_env = nullptr;
+shared_test_env* g_shared_env      = nullptr;
+shared_test_env* g_integration_env = nullptr;
 
 shared_test_env::shared_test_env(const std::filesystem::path& config_path)
   : config_path_(config_path)

--- a/test/cpp/utils/sirius_test_env.cpp
+++ b/test/cpp/utils/sirius_test_env.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sirius_test_env.hpp"
+
+namespace sirius::test {
+
+shared_test_env* g_shared_env = nullptr;
+
+shared_test_env::shared_test_env(const std::filesystem::path& config_path)
+  : config_path_(config_path)
+{
+  // Save the current SIRIUS_CONFIG_FILE value so we can restore it on destruction
+  const char* current = std::getenv("SIRIUS_CONFIG_FILE");
+  if (current) {
+    had_original_config_env_ = true;
+    original_config_env_     = current;
+  }
+
+  create_db();
+}
+
+shared_test_env::~shared_test_env()
+{
+  // Destroy DuckDB — this releases the SiriusContext and the extension lock
+  db_.reset();
+
+  // Restore original environment
+  if (had_original_config_env_) {
+    setenv("SIRIUS_CONFIG_FILE", original_config_env_.c_str(), 1);
+  } else {
+    unsetenv("SIRIUS_CONFIG_FILE");
+  }
+}
+
+void shared_test_env::create_db()
+{
+  // Point the extension callback at our test config
+  setenv("SIRIUS_CONFIG_FILE", config_path_.string().c_str(), 1);
+
+  // Creating DuckDB triggers the extension load callback, which reads the config,
+  // acquires the extension lock, and creates + initializes the SiriusContext.
+  db_ = std::make_unique<duckdb::DuckDB>(nullptr);
+
+  // Point SIRIUS_CONFIG_FILE to a non-existent path so that any other DuckDB
+  // instances created by tests (e.g. operator tests that use their own memory
+  // manager) will NOT attempt to acquire the lock or create a SiriusContext.
+  // The extension callback's read_config_file_if_exists() returns early when
+  // the config file doesn't exist.
+  setenv("SIRIUS_CONFIG_FILE", "/nonexistent/sirius_test_shared_env_active.cfg", 1);
+}
+
+duckdb::Connection shared_test_env::make_connection() { return duckdb::Connection(*db_); }
+
+duckdb::DuckDB& shared_test_env::database() { return *db_; }
+
+void shared_test_env::pause()
+{
+  // Destroy DuckDB — releases SiriusContext and extension lock so isolated tests
+  // can create their own DuckDB with a different config.
+  db_.reset();
+}
+
+void shared_test_env::resume()
+{
+  // Recreate DuckDB with the shared config — reacquires lock and SiriusContext.
+  create_db();
+}
+
+}  // namespace sirius::test

--- a/test/cpp/utils/sirius_test_env.hpp
+++ b/test/cpp/utils/sirius_test_env.hpp
@@ -96,5 +96,6 @@ class shared_test_env {
  * Check is_active() before using — it may be temporarily paused for isolated tests.
  */
 extern shared_test_env* g_shared_env;
+extern shared_test_env* g_integration_env;
 
 }  // namespace sirius::test

--- a/test/cpp/utils/sirius_test_env.hpp
+++ b/test/cpp/utils/sirius_test_env.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace sirius::test {
+
+/**
+ * @brief Shared test environment that holds a single DuckDB instance and SiriusContext.
+ *
+ * The constructor sets SIRIUS_CONFIG_FILE and creates a DuckDB instance, which triggers
+ * the extension callback to create a SiriusContext and acquire the extension lock.
+ * All tests in the "shared" phase get connections to this DuckDB instance, avoiding
+ * the overhead of repeated SiriusContext creation/destruction.
+ *
+ * For tests tagged [isolated_context] or [integration] that need their own SiriusContext,
+ * the environment is temporarily paused (DuckDB destroyed, lock released) via a Catch2
+ * listener, then resumed after the isolated test completes.
+ */
+class shared_test_env {
+ public:
+  explicit shared_test_env(const std::filesystem::path& config_path);
+  ~shared_test_env();
+
+  shared_test_env(const shared_test_env&)            = delete;
+  shared_test_env& operator=(const shared_test_env&) = delete;
+  shared_test_env(shared_test_env&&)                 = delete;
+  shared_test_env& operator=(shared_test_env&&)      = delete;
+
+  /**
+   * @brief Create a new connection to the shared DuckDB instance.
+   *
+   * The extension callback's OnConnectionOpened automatically registers
+   * the shared SiriusContext into the new connection's registered_state.
+   */
+  duckdb::Connection make_connection();
+
+  /**
+   * @brief Get a reference to the shared DuckDB instance.
+   */
+  duckdb::DuckDB& database();
+
+  /**
+   * @brief Returns true if the environment is active (DuckDB instance exists).
+   */
+  bool is_active() const { return db_ != nullptr; }
+
+  /**
+   * @brief Temporarily destroy the DuckDB instance and release the extension lock.
+   *
+   * Called by the Catch2 listener before an isolated test runs, allowing
+   * the test to create its own DuckDB with a different config.
+   */
+  void pause();
+
+  /**
+   * @brief Recreate the DuckDB instance and reacquire the extension lock.
+   *
+   * Called by the Catch2 listener after an isolated test completes.
+   */
+  void resume();
+
+ private:
+  void create_db();
+
+  std::filesystem::path config_path_;
+  std::string original_config_env_;
+  bool had_original_config_env_{false};
+  std::unique_ptr<duckdb::DuckDB> db_;
+};
+
+/**
+ * @brief Non-owning pointer to the shared test environment.
+ *
+ * Managed by main() in unittest.cpp. Non-null for the entire test run.
+ * Check is_active() before using — it may be temporarily paused for isolated tests.
+ */
+extern shared_test_env* g_shared_env;
+
+}  // namespace sirius::test

--- a/test/cpp/utils/utils.hpp
+++ b/test/cpp/utils/utils.hpp
@@ -20,6 +20,7 @@
 #include "gpu_buffer_manager.hpp"
 #include "gpu_columns.hpp"
 #include "sirius_context.hpp"
+#include "sirius_test_env.hpp"
 
 #include <data/sirius_converter_registry.hpp>
 #include <duckdb.hpp>
@@ -28,6 +29,7 @@
 #include <memory>
 #include <optional>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace duckdb {
@@ -86,6 +88,34 @@ std::unique_ptr<cudf::table> create_cudf_table_with_random_data(
   rmm::device_async_resource_ref mr,
   bool use_int64_string_offsets = false);
 
+/**
+ * @brief Get a DuckDB database and connection for testing.
+ *
+ * When a shared test environment is active (g_shared_env != nullptr), returns a
+ * connection to the shared DuckDB instance (db_owner will be null).
+ * Otherwise, creates a standalone DuckDB instance and connection (db_owner will
+ * own the DuckDB instance and must outlive the connection).
+ */
+inline std::pair<std::unique_ptr<duckdb::DuckDB>, duckdb::Connection> make_test_db_and_connection()
+{
+  if (sirius::test::g_shared_env && sirius::test::g_shared_env->is_active()) {
+    return {nullptr, sirius::test::g_shared_env->make_connection()};
+  }
+  auto db  = std::make_unique<duckdb::DuckDB>(nullptr);
+  auto con = duckdb::Connection(*db);
+  return {std::move(db), std::move(con)};
+}
+
+/**
+ * @brief Get or create a SiriusContext for the given connection.
+ *
+ * When a shared test environment is active, the SiriusContext is already registered
+ * in the connection by the extension callback's OnConnectionOpened. In that case,
+ * the config_path is ignored.
+ *
+ * When no shared environment is active (isolated tests), creates and initializes
+ * a new SiriusContext from the given config file.
+ */
 inline duckdb::shared_ptr<duckdb::SiriusContext> get_sirius_context(
   duckdb::Connection& con, const std::filesystem::path& config_path)
 {


### PR DESCRIPTION


Overhaul the downgrade subsystem to automatically spill GPU data to HOST
when memory pressure is detected, replacing the previous stub executor.

Key changes:
- Bind each downgrade_executor to a specific memory space (GPU:0, etc.)
  with a monitor thread that polls should_downgrade_memory() and triggers
  downgrade passes automatically
- Implement two-pass candidate selection: prioritize partitioned repos
  over non-partitioned, iterate partitions last-to-first, prefer
  non-active partitions before active ones
- Use shared_ptr<data_batch> instead of unique_ptr in downgrade tasks so
  batches remain accessible in repositories during async downgrade
- Preserve batch state across in-transit conversion to avoid invalidating
  pending pipeline tasks
- Convert from host_data_packed_representation to host_data_representation
  and replace metadata_node packing with structured column_metadata
- Add drain() to flush in-flight downgrade tasks at QueryEnd before
  destroying repositories
- Add cudaDeviceSynchronize() in terminate() to prevent deadlocks between
  async copies and pinned memory pool teardown
- Fix in-transit lock leak in gpu_pipeline_task by adding try/catch
  around convert_to calls
- Add Source::DOWNGRADE to task completion message tracking
- Add shared_test_env with Catch2 listener for pause/resume lifecycle,
  avoiding GPU memory conflicts between shared and isolated tests
- Add comprehensive downgrade_executor unit tests covering lifecycle,
  candidate selection, partition ordering, and amount limiting

Fixes #358.
