### PR TITLE
Misc task scheduling improvements

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -152,7 +152,10 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
     // task creator should never schedule additional scans from downstream.
     // (Parquet scans are fine — they use partition indices that self-limit.)
     if (producer != nullptr && producer->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
-      return nullptr;
+      auto& global_state = _scan_operator_global_state_map.at(producer->get_operator_id());
+      if (global_state->is_source_drained() || !global_state->can_create_more_tasks()) {
+        return nullptr;
+      }
     }
     return get_operator_for_next_task(producer);
   }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -313,7 +313,6 @@ void task_creator::manager_loop()
                                                             std::move(parquet_task_local_state),
                                                             parquet_task_global_state);
             _pipeline_executor->schedule(std::move(parquet_task));
-            // scheduling pipeline task
           }
         } else {
           // need to exhaust input batches until all ports are empty

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -139,7 +139,13 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
     return output_consumers;
   }
 
+  std::size_t can_create_more_tasks() const noexcept
+  {
+    return _total_task_count.load(std::memory_order_acquire) < _max_threads;
+  }
+
  private:
+  std::atomic<std::size_t> _total_task_count{0};
   //===----------Fields----------===//
   duckdb::SiriusContext* _sirius_ctx;  ///< The Sirius context
   std::unique_ptr<duckdb::GlobalTableFunctionState>
@@ -403,10 +409,13 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
                    std::shared_ptr<duckdb_scan_task_global_state> g_state)
     : sirius::pipeline::sirius_pipeline_itask(std::move(l_state), g_state),
       _task_id(task_id),
-      _data_repo(data_repo) {};
+      _data_repo(data_repo)
+  {
+    g_state->_total_task_count.fetch_add(1);
+  };
 
   //===----------Destructor----------===//
-  ~duckdb_scan_task();
+  ~duckdb_scan_task() override;
 
   void execute(rmm::cuda_stream_view stream) override;
 

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -34,6 +34,7 @@
 #include <cucascade/data/data_repository.hpp>
 
 #include <atomic>
+#include <list>
 #include <memory>
 #include <optional>
 #include <string_view>
@@ -313,8 +314,12 @@ class sirius_physical_operator {
 
  protected:
   duckdb::shared_ptr<pipeline::sirius_pipeline> _pipeline;
-  //! The ports of the operator
-  std::unordered_map<std::string, std::unique_ptr<port>> ports;
+  //! Lookup map: port name -> raw pointer into _ports_list (never owns)
+  std::unordered_map<std::string, port*> ports;
+  //! Ownership container for ports, kept sorted by src_pipeline->get_pipeline_id().
+  //! std::list is used intentionally: its nodes have stable addresses, so raw pointers
+  //! in `ports` are never invalidated by insertions.
+  std::list<std::unique_ptr<port>> _ports_list;
   //! The next operators to be executed after this operator when it is used as a sink
   std::vector<std::pair<sirius_physical_operator*, std::string_view>> next_port_after_sink;
 };

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -270,6 +270,8 @@ class sirius_physical_operator {
   std::vector<std::string_view> get_port_ids();
   //! Check if the source pipeline is finished
   bool is_source_pipeline_finished();
+  //! Returns true if any FULL-barrier port has src_pipeline == src
+  bool has_full_barrier_from(const pipeline::sirius_pipeline* src) const;
   //! Add a next port after sink
   void add_next_port_after_sink(
     std::pair<sirius_physical_operator*, std::string_view> port_locator);

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -83,6 +83,8 @@ class sirius_physical_partition : public sirius_physical_operator {
 
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
+  std::optional<task_creation_hint> get_next_task_hint() override;
+
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
   void set_num_partitions(int num_partitions);

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
     throw std::runtime_error("sirius_physical_concat: there should be only one port");
   }
 
-  auto port_ptr = ports.begin()->second.get();
+  auto port_ptr = ports.begin()->second;
   for (size_t i = 0; i < port_ptr->repo->num_partitions(); i++) {
     std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
     // get all the batch ids from the partition

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -296,6 +296,14 @@ bool sirius_physical_operator::is_source_pipeline_finished()
   return true;
 }
 
+bool sirius_physical_operator::has_full_barrier_from(const pipeline::sirius_pipeline* src) const
+{
+  for (auto& p : _ports_list) {
+    if (p->src_pipeline.get() == src && p->type == MemoryBarrierType::FULL) { return true; }
+  }
+  return false;
+}
+
 duckdb::shared_ptr<pipeline::sirius_pipeline> sirius_physical_operator::get_pipeline()
   const noexcept
 {

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -160,7 +160,20 @@ void sirius_physical_operator::verify()
 
 void sirius_physical_operator::add_port(std::string_view port_id, std::unique_ptr<port> p)
 {
-  ports[std::string(port_id)] = std::move(p);
+  // Insert into _ports_list in sorted order by src_pipeline->get_pipeline_id().
+  // Using std::list so that all previously stored raw pointers remain valid.
+  port* raw = p.get();
+  auto insert_pos =
+    std::lower_bound(_ports_list.begin(),
+                     _ports_list.end(),
+                     p,
+                     [](const std::unique_ptr<port>& a, const std::unique_ptr<port>& b) {
+                       size_t id_a = (a->src_pipeline) ? a->src_pipeline->get_pipeline_id() : 0;
+                       size_t id_b = (b->src_pipeline) ? b->src_pipeline->get_pipeline_id() : 0;
+                       return id_a < id_b;
+                     });
+  _ports_list.insert(insert_pos, std::move(p));
+  ports[std::string(port_id)] = raw;
 }
 
 sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_view port_id)
@@ -174,7 +187,7 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
     throw duckdb::InternalException("Port " + std::string(port_id) + " not found in operator " +
                                     get_name() + " existing ports are: " + ports_string);
   }
-  return it->second.get();
+  return it->second;
 }
 
 void sirius_physical_operator::sink(const operator_data& output_data, rmm::cuda_stream_view stream)
@@ -217,35 +230,34 @@ std::optional<task_creation_hint> sirius_physical_operator::get_next_task_hint()
   if (ports.empty()) { return std::nullopt; }
 
   // look at the input ports and see if there are any unfinished hard barriers
-  auto unfinished_barrier = std::find_if(ports.begin(), ports.end(), [](const auto& port_pair) {
-    return port_pair.second->type == MemoryBarrierType::FULL && port_pair.second->src_pipeline &&
-           !port_pair.second->src_pipeline->is_pipeline_finished();
+  auto unfinished_barrier = std::find_if(_ports_list.begin(), _ports_list.end(), [](const auto& p) {
+    return p->type == MemoryBarrierType::FULL && p->src_pipeline &&
+           !p->src_pipeline->is_pipeline_finished();
   });
 
-  if (unfinished_barrier != ports.end()) {
-    auto* producer = &(unfinished_barrier->second->src_pipeline->get_operators()[0].get());
+  if (unfinished_barrier != _ports_list.end()) {
+    auto* producer = &((*unfinished_barrier)->src_pipeline->get_operators()[0].get());
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
   }
 
   // if no unfinished barriers, then is this operator ready to create a task?
-  if (std::all_of(ports.begin(), ports.end(), [](const auto& port_pair) {
-        return (port_pair.second->type != MemoryBarrierType::FULL &&
-                port_pair.second->repo->total_size() > 0) ||
-               (port_pair.second->type == MemoryBarrierType::FULL &&
-                port_pair.second->repo->total_size() > 0 && port_pair.second->src_pipeline &&
-                port_pair.second->src_pipeline->is_pipeline_finished());
+  if (std::all_of(_ports_list.begin(), _ports_list.end(), [](const auto& p) {
+        return (p->type != MemoryBarrierType::FULL && p->repo->total_size() > 0) ||
+               (p->type == MemoryBarrierType::FULL && p->repo->total_size() > 0 &&
+                p->src_pipeline && p->src_pipeline->is_pipeline_finished());
       })) {
     return task_creation_hint{TaskCreationHint::READY, this};
   }
 
   // if not scan from dependent pipelines
-  auto unfinished_pipeline = std::find_if(ports.begin(), ports.end(), [](const auto& port_pair) {
-    return port_pair.second->type != MemoryBarrierType::FULL && port_pair.second->src_pipeline &&
-           !port_pair.second->src_pipeline->is_pipeline_finished();
-  });
+  auto unfinished_pipeline =
+    std::find_if(_ports_list.begin(), _ports_list.end(), [](const auto& p) {
+      return p->type != MemoryBarrierType::FULL && p->src_pipeline &&
+             !p->src_pipeline->is_pipeline_finished();
+    });
 
-  if (unfinished_pipeline != ports.end()) {
-    auto* producer = &(unfinished_pipeline->second->src_pipeline->get_operators()[0].get());
+  if (unfinished_pipeline != _ports_list.end()) {
+    auto* producer = &((*unfinished_pipeline)->src_pipeline->get_operators()[0].get());
     return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
   }
 

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -216,12 +216,7 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
 
 int sirius_physical_partition::determine_num_partitions()
 {
-  SIRIUS_LOG_DEBUG("sirius_physical_partition::determine_num_partitions() start for id {}",
-                   this->get_operator_id());
   if (ports.find("default") == ports.end()) {
-    SIRIUS_LOG_WARN(
-      "sirius_physical_partition::determine_num_partitions() did not find default repo for id {}",
-      this->get_operator_id());
     throw std::runtime_error(
       "sirius_physical_partition::determine_num_partitions() did not find default repo for id " +
       std::to_string(this->get_operator_id()));
@@ -240,6 +235,20 @@ void sirius_physical_partition::set_num_partitions(int num_partitions)
 {
   std::lock_guard<std::mutex> guard(lock);
   _num_partitions = num_partitions;
+}
+
+std::optional<task_creation_hint> sirius_physical_partition::get_next_task_hint()
+{
+  std::lock_guard<std::mutex> guard(lock);
+  if (!_num_partitions.has_value() && !_is_build && _sibling_partition_op != nullptr) {
+    // If this is a probe partition and we haven't determined the number of partitions yet, we
+    // should wait for the build sibling to determine it. This is because the build side will drive
+    // the partitioning and the probe side needs to know the number of partitions to create the
+    // correct number of tasks.
+    return _sibling_partition_op->get_next_task_hint();
+  } else {
+    return sirius_physical_operator::get_next_task_hint();
+  }
 }
 
 std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_data()

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -19,6 +19,7 @@
 #include "creator/task_creator.hpp"
 #include "cucascade/memory/stream_pool.hpp"
 #include "cuda_runtime_api.h"
+#include "log/logging.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/completion_handler.hpp"
@@ -205,7 +206,11 @@ void gpu_pipeline_executor::manager_loop()
       }
 
       if (!query_complete && _task_creator) {
+        bool pipeline_done = pipeline && pipeline->is_pipeline_finished();
         for (auto* consumer : consumers) {
+          // Don't wake up FULL-barrier consumers until the pipeline is completely
+          // done — doing so just causes repeated no-op dependency walks (spin loop).
+          if (consumer && !pipeline_done && consumer->has_full_barrier_from(pipeline)) { continue; }
           _task_creator->schedule(consumer);
         }
       }

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -188,8 +188,9 @@ void pipeline_executor::management_eventloop()
       }
       _gpu_executors.at(request->device_id)->schedule(std::move(task));
     } else {
-      // TODO: implement scan task scheduling when state is owned in the operator itself
-      schedule_next_scan_tasks();
+      // TODO(amin): think about eager scheduling again when state of next tasks are stored in the
+      // operator
+      // schedule_next_scan_tasks();
     }
   }
 }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -1051,7 +1051,6 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 
     // Set pipeline IDs, parents, and operator children (before finalization)
     for (size_t i = 0; i < new_scheduled.size(); i++) {
-      new_scheduled[i]->set_pipeline_id(i);
       new_scheduled[i]->parents.clear();
       new_scheduled[i]->dependencies.clear();
 

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -898,6 +898,13 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
       source_to_pipelines[new_scheduled[i]->source.get()].push_back(new_scheduled[i]);
     }
 
+    // Assign pipeline IDs before adding ports so that add_port can sort _ports_list
+    // correctly by pipeline ID. (set_pipeline_id was previously called only after
+    // insert_repository, meaning all pipelines had id=0 at port-insertion time.)
+    for (size_t i = 0; i < new_scheduled.size(); i++) {
+      new_scheduled[i]->set_pipeline_id(i);
+    }
+
     // add data repositories and ports
     for (size_t i = 0; i < new_scheduled.size(); i++) {
       if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_GROUP_BY ||


### PR DESCRIPTION
1. dont eagerly scheudle scan tasks in pipeline executor
2. schedule all the scan tasks from pipelines
3. Ensure that task scheduling runs partition tasks on the build side of a join first to result in better number of partitions