### PR TITLE
CI: Improve stability with new self-hosted runners

### DIFF
--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -1,4 +1,4 @@
-name: Sirius Test
+name: Sirius GPU Test
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,8 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: [self-hosted, Linux, X64, gpu]
+  cpu_build:
+    runs-on: [self-hosted, Linux, X64, cpu-xl]
     timeout-minutes: 60
     steps:
       - name: Cleanup
@@ -25,8 +25,39 @@ jobs:
           activate-environment: true
       - name: Build
         env:
-          CUDAARCHS: native
+          CUDAARCHS: "75" # For Turing, T4 capability
         run: make -j$(nproc)
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ github.run_id }}
+          path: build/
+          retention-days: 1
+
+  gpu_test:
+    runs-on: [self-hosted, Linux, X64, gpu-t4]
+    needs: build
+    timeout-minutes: 60
+    steps:
+      - name: Cleanup
+        run: rm -rf -- * .[^.]* ..?*
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+        with:
+          pixi-version: v0.59.0
+          activate-environment: true
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ github.run_id }}
+          path: build/
+      - name: Restore executable permissions
+        run: chmod -R u+x build/
       - name: Run C++ unit tests
         run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
       - name: Prepare SQL test datasets

--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -67,7 +67,7 @@ jobs:
         run: ./setup_test_datasets.sh
       - name: Run sqllogic tests
         run: |
-          make test | tee test.log
+          ./build/release/test/unittest "$PWD/test/*" | tee test.log
           if grep -q "Error in GPUExecuteQuery" test.log; then
             echo "GPU execution errors detected!"
             exit 1

--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   cpu_build:
-    runs-on: [self-hosted, Linux, X64, cpu-xl]
+    runs-on: [self-hosted, ubuntu-22.04, cuda-13, cpu-xl]
     timeout-minutes: 60
     steps:
       - name: Cleanup
@@ -35,7 +35,7 @@ jobs:
           retention-days: 1
 
   gpu_test:
-    runs-on: [self-hosted, Linux, X64, gpu-t4]
+    runs-on: [self-hosted, ubuntu-22.04, cuda-13, gpu-t4]
     needs: cpu_build
     timeout-minutes: 60
     steps:

--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, gpu]
     timeout-minutes: 60
     steps:
       - name: Cleanup

--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -36,7 +36,7 @@ jobs:
 
   gpu_test:
     runs-on: [self-hosted, Linux, X64, gpu-t4]
-    needs: build
+    needs: cpu_build
     timeout-minutes: 60
     steps:
       - name: Cleanup

--- a/.github/workflows/sirius_test.yml
+++ b/.github/workflows/sirius_test.yml
@@ -27,11 +27,17 @@ jobs:
         env:
           CUDAARCHS: "75" # For Turing, T4 capability
         run: make -j$(nproc)
-      - name: Upload build artifacts
+      - name: Archive workspace
+        run: |
+          tar -czf /tmp/workspace.tar.gz \
+            --exclude='.git' \
+            --exclude='.pixi' \
+            .
+      - name: Upload workspace
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ github.run_id }}
-          path: build/
+          name: workspace-${{ github.run_id }}
+          path: /tmp/workspace.tar.gz
           retention-days: 1
 
   gpu_test:
@@ -41,23 +47,20 @@ jobs:
     steps:
       - name: Cleanup
         run: rm -rf -- * .[^.]* ..?*
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Download workspace
+        uses: actions/download-artifact@v4
         with:
-          submodules: recursive
-          fetch-depth: 0
+          name: workspace-${{ github.run_id }}
+          path: /tmp/
+      - name: Extract workspace
+        run: |
+          tar -xzf /tmp/workspace.tar.gz
+          rm /tmp/workspace.tar.gz
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           pixi-version: v0.59.0
           activate-environment: true
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-${{ github.run_id }}
-          path: build/
-      - name: Restore executable permissions
-        run: chmod -R u+x build/
       - name: Run C++ unit tests
         run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
       - name: Prepare SQL test datasets


### PR DESCRIPTION
Refs #155 

Improve CI uptime by switching to new self-hosted runners. One CPU node (32 cores, 128GB RAM; with 2x GHA runners) and one GPU node (T4; with one GHA runner) for PR and branch testing.

Update the `Sirius Test` to `Sirius GPU Test` which splits the builds between the two nodes to speed up the build process.

There are performance optimizations still with the runners we are using but this closes the current gap of no CI testing available. Additional work will be done to improve build/test times on the future.