### PR TITLE
Don't cache pixi envs in ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
+          cache: false
           pixi-version: v0.65.0
           activate-environment: true
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,7 @@
 	path = duckdb
 	url = https://github.com/duckdb/duckdb
 	branch = main
+	ignore = dirty
 [submodule "extension-ci-tools"]
 	path = extension-ci-tools
 	url = https://github.com/duckdb/extension-ci-tools

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,22 @@ TEST_BUILD_TARGET ?= unittest
 	clang-release clang-debug clang-relwithdebinfo \
 	test test_release test_debug test_reldebug clean list-presets
 
+PRESETS_LINK := $(DUCKDB_DIR)/CMakePresets.json
+
 all: release
 
-release:
+$(PRESETS_LINK): cmake/CMakePresets.json
+	rm -f $(DUCKDB_DIR)/CMakeUserPresets.json
+	ln -sf ../cmake/CMakePresets.json $@
+
+release: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset release
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset release
 ifneq ($(TEST_BUILD_TARGET),)
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset release --target $(TEST_BUILD_TARGET)
 endif
 
-debug:
+debug: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset debug
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset debug
 ifneq ($(TEST_BUILD_TARGET),)
@@ -43,22 +49,22 @@ reldebug: relwithdebinfo
 
 debug-release: relwithdebinfo
 
-relwithdebinfo:
+relwithdebinfo: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset relwithdebinfo
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset relwithdebinfo
 ifneq ($(TEST_BUILD_TARGET),)
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset relwithdebinfo --target $(TEST_BUILD_TARGET)
 endif
 
-clang-release:
+clang-release: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset clang-release
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset clang-release
 
-clang-debug:
+clang-debug: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset clang-debug
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset clang-debug
 
-clang-relwithdebinfo:
+clang-relwithdebinfo: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --preset clang-relwithdebinfo
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset clang-relwithdebinfo
 
@@ -76,5 +82,5 @@ test_reldebug: relwithdebinfo
 clean:
 	rm -rf build
 
-list-presets:
+list-presets: $(PRESETS_LINK)
 	cd $(DUCKDB_DIR) && $(CMAKE) --list-presets

--- a/scripts/pixi_activate.sh
+++ b/scripts/pixi_activate.sh
@@ -14,8 +14,9 @@ fi
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cmake_presets_src="$project_root/cmake/CMakePresets.json"
-cmake_presets_dst="$project_root/duckdb/CMakeUserPresets.json"
+cmake_presets_dst="$project_root/duckdb/CMakePresets.json"
 
+rm -f "$project_root/duckdb/CMakeUserPresets.json"
 if [[ ! -e "$cmake_presets_dst" ]]; then
   ln -s "$cmake_presets_src" "$cmake_presets_dst"
 fi


### PR DESCRIPTION
Because we currently don't run CI on `dev` we should skip this cache because it will generate a cache entry per PR, using cache space that we can better use for `sccache`.