### PR TITLE
CI: Add permissions policy details to GHA workflow files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,17 @@
+# NOTICE - Actions permissions policy (Settings > Actions > General):
+#   - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
+#   - Allow actions created by GitHub: YES (covers actions/*)
+#   - Allow actions by Marketplace verified creators: NO
+#   - Explicitly allowed third-party actions:
+#       prefix-dev/setup-pixi@*
+#       mozilla-actions/sccache-action@*
+#       pre-commit/action@*
+#   - Require actions to be pinned to a full-length commit SHA: YES
+#
+# Adding a new action? You must:
+#   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
+#   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
+#      project-level allowlist above before merging
 name: Check
 
 on:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,12 +1,12 @@
 # NOTICE - Actions permissions policy (Settings > Actions > General):
 #   - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
-#   - Allow actions created by GitHub: YES (covers actions/*)
-#   - Allow actions by Marketplace verified creators: NO
-#   - Explicitly allowed third-party actions:
+#     - Allow actions created by GitHub: YES (covers actions/*)
+#     - Allow actions by Marketplace verified creators: NO
+#     - Explicitly allowed third-party actions:
 #       prefix-dev/setup-pixi@*
 #       mozilla-actions/sccache-action@*
 #       pre-commit/action@*
-#   - Require actions to be pinned to a full-length commit SHA: YES
+#     - Require actions to be pinned to a full-length commit SHA: NO
 #
 # Adding a new action? You must:
 #   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@
 #       prefix-dev/setup-pixi@*
 #       mozilla-actions/sccache-action@*
 #       pre-commit/action@*
-#     - Require actions to be pinned to a full-length commit SHA: YES
+#     - Require actions to be pinned to a full-length commit SHA: NO
 #
 # Adding a new action? You must:
 #   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,17 @@
+# NOTICE - Actions permissions policy (Settings > Actions > General):
+#   - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
+#     - Allow actions created by GitHub: YES (covers actions/*)
+#     - Allow actions by Marketplace verified creators: NO
+#     - Explicitly allowed third-party actions:
+#       prefix-dev/setup-pixi@*
+#       mozilla-actions/sccache-action@*
+#       pre-commit/action@*
+#     - Require actions to be pinned to a full-length commit SHA: YES
+#
+# Adding a new action? You must:
+#   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
+#   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
+#      project-level allowlist above before merging
 name: Test
 
 on:


### PR DESCRIPTION
## Description
Documenting the recent Actions permission policy change in the repo for additional security for our self-hosted runners in the headers of the GHA workflow files for developers that modify these workflows.

## Policy changes

### Old policy
- "Allow all actions and reusable workflows"
  >Any action or reusable workflow can be used, regardless of who authored it or where it is defined.

### New policy
Actions permissions policy (Settings > Actions > General):
  - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
    >Any action or reusable workflow that matches the specified criteria, plus those defined in a repository within sirius-db, can be used. [Learn more about allowing specific actions and reusable workflows to run.](https://docs.github.com/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run)
    - Allow actions created by GitHub: **YES** (covers `actions/*`)
    - Allow actions by Marketplace verified creators: **NO**
    - Explicitly allowed third-party actions:
       ```
       prefix-dev/setup-pixi@*
       mozilla-actions/sccache-action@*
       pre-commit/action@*
       ```
    - Require actions to be pinned to a full-length commit SHA: **NO**

## Developer actions
Adding a new action? You must:
  1. Pin it to a full-length commit SHA (e.g. uses: `owner/repo@<40-char-sha> # vX.Y.Z`)
    - While not required, it is best practice to protect from malicious updates to actions
  2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the project-level allowlist above before merging