### PR TITLE
Bug fixes on streams

### DIFF
--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -141,6 +141,7 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_gpu(
   for (auto const& span : column_chunk_spans_d) {
     column_chunk_buffers.emplace_back(span.data(), span.size(), stream, mr_ref);
   }
+  stream.synchronize();
   auto result = reader.materialize_all_columns(
     host_src.get_rg_span(), std::move(column_chunk_buffers), host_src.get_reader_options(), stream);
 #endif

--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_gpu(
   for (auto const& span : column_chunk_spans_d) {
     column_chunk_buffers.emplace_back(span.data(), span.size(), stream, mr_ref);
   }
-  stream.synchronize();
+
   auto result = reader.materialize_all_columns(
     host_src.get_rg_span(), std::move(column_chunk_buffers), host_src.get_reader_options(), stream);
 #endif

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -171,7 +171,7 @@ void sirius_physical_right_delim_join::sink(const operator_data& input_data,
   auto distinct_output = distinct->execute(input_data, stream);
 
   stream.synchronize();
-  
+
   partition_join->sink(*partition_join_output, stream);
   // partition_distinct is external — push distinct output via distinct's next_port_after_sink
   distinct->sink(*distinct_output, stream);

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -167,11 +167,12 @@ void sirius_physical_right_delim_join::sink(const operator_data& input_data,
   nvtx3::scoped_range nvtx_range{"sirius_physical_right_delim_join::sink"};
   // partition_join stays inline (still part of the delim join)
   auto partition_join_output = partition_join->execute(input_data, stream);
-  partition_join->sink(*partition_join_output, stream);
-
   // distinct stays inline (still part of the delim join)
   auto distinct_output = distinct->execute(input_data, stream);
 
+  stream.synchronize();
+  
+  partition_join->sink(*partition_join_output, stream);
   // partition_distinct is external — push distinct output via distinct's next_port_after_sink
   distinct->sink(*distinct_output, stream);
 }
@@ -194,11 +195,12 @@ void sirius_physical_left_delim_join::sink(const operator_data& input_data,
   nvtx3::scoped_range nvtx_range{"sirius_physical_left_delim_join::sink"};
   // column_data_scan stays inline (still part of the delim join)
   auto column_data_scan_output = column_data_scan->execute(input_data, stream);
-  column_data_scan->sink(*column_data_scan_output, stream);
-
   // distinct stays inline (still part of the delim join)
   auto distinct_output = distinct->execute(input_data, stream);
 
+  stream.synchronize();
+
+  column_data_scan->sink(*column_data_scan_output, stream);
   // partition_distinct is external — push distinct output via distinct's next_port_after_sink
   distinct->sink(*distinct_output, stream);
 }

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -91,8 +91,8 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
     if (_remaining_limit.load(std::memory_order_acquire) <= 0) { break; }
 
     auto& input_table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
-    auto view        = input_table.view();
-    auto num_rows    = static_cast<int64_t>(view.num_rows());
+    auto view         = input_table.view();
+    auto num_rows     = static_cast<int64_t>(view.num_rows());
 
     if (num_rows == 0) { continue; }
 

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
     // Check if limit is already exhausted
     if (_remaining_limit.load(std::memory_order_acquire) <= 0) { break; }
 
-    auto input_table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+    auto& input_table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
     auto view        = input_table.view();
     auto num_rows    = static_cast<int64_t>(view.num_rows());
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -237,10 +237,6 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   std::vector<cudf::table_view> concat_views;
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
-    // auto table = std::make_unique<cudf::table>(
-    //   batch->get_data()->cast<cucascade::gpu_table_representation>().get_table(),
-    //   stream,
-    //   space->get_default_allocator());
     concat_views.push_back(
       batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
     // owned_tables.push_back(std::move(table));

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -241,7 +241,8 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     //   batch->get_data()->cast<cucascade::gpu_table_representation>().get_table(),
     //   stream,
     //   space->get_default_allocator());
-    concat_views.push_back(batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
+    concat_views.push_back(
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
     // owned_tables.push_back(std::move(table));
   }
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -239,7 +239,6 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     if (!batch) { continue; }
     concat_views.push_back(
       batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
-    // owned_tables.push_back(std::move(table));
   }
 
   if (concat_views.empty()) {

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
-  auto input_table =
+  auto& input_table =
     input_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
   auto output_table =
     compute_top_n_table(input_table, orders, limit, offset, stream, space->get_default_allocator());
@@ -233,16 +233,16 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
-  std::vector<std::unique_ptr<cudf::table>> owned_tables;
+  // std::vector<std::unique_ptr<cudf::table>> owned_tables;
   std::vector<cudf::table_view> concat_views;
   for (auto const& batch : input_batches) {
     if (!batch) { continue; }
-    auto table = std::make_unique<cudf::table>(
-      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table(),
-      stream,
-      space->get_default_allocator());
-    concat_views.push_back(table->view());
-    owned_tables.push_back(std::move(table));
+    // auto table = std::make_unique<cudf::table>(
+    //   batch->get_data()->cast<cucascade::gpu_table_representation>().get_table(),
+    //   stream,
+    //   space->get_default_allocator());
+    concat_views.push_back(batch->get_data()->cast<cucascade::gpu_table_representation>().get_table().view());
+    // owned_tables.push_back(std::move(table));
   }
 
   if (concat_views.empty()) {

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -342,7 +342,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
     auto* space = batch->get_memory_space();
     if (!space) { continue; }
 
-    auto table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
+    auto& table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
     auto view  = table.view();
 
     std::vector<std::unique_ptr<cudf::column>> cols;
@@ -524,7 +524,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
       std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(merged_batch)});
   }
 
-  auto merged_table =
+  auto& merged_table =
     merged_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
   auto merged_view = merged_table.view();
 

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -343,7 +343,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
     if (!space) { continue; }
 
     auto& table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();
-    auto view  = table.view();
+    auto view   = table.view();
 
     std::vector<std::unique_ptr<cudf::column>> cols;
     cols.reserve(layout.local_types.size());

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -257,6 +257,7 @@ void gpu_pipeline_task::publish_output(op::operator_data& output_data, rmm::cuda
     _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_sink();
   if (sink_operators) {
     sink_operators.get()->sink(output_data, stream);
+    stream.synchronize();
   } else {
     throw std::runtime_error("Sink operator not found");
   }
@@ -289,6 +290,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     }
     processing_handles.emplace_back(std::move(*handle));
   }
+  stream.synchronize();  // ensure all conversions are done before we proceed with execution
 
   // At this point, all input batches are locked for processing.
   // They will remain locked until the processing_handles go out of scope.

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -257,7 +257,6 @@ void gpu_pipeline_task::publish_output(op::operator_data& output_data, rmm::cuda
     _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->get_sink();
   if (sink_operators) {
     sink_operators.get()->sink(output_data, stream);
-    stream.synchronize();
   } else {
     throw std::runtime_error("Sink operator not found");
   }
@@ -290,7 +289,6 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     }
     processing_handles.emplace_back(std::move(*handle));
   }
-  stream.synchronize();  // ensure all conversions are done before we proceed with execution
 
   // At this point, all input batches are locked for processing.
   // They will remain locked until the processing_handles go out of scope.
@@ -298,7 +296,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   // 2. Set reservation_aware_memory_resource_ref as the default cudf allocator
   // 3. Execute cudf operators on the pipeline
   auto output_data = compute_task(stream);
-  stream.synchronize();
+
   if (output_data) { publish_output(*output_data, stream); }
   // 4. After each cudf operator, get peak total bytes to collect statistics
   // 5. Push output batches to the data repository

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -81,7 +81,7 @@ void SiriusContext::QueryBegin(ClientContext& context)
 {
   // Reset operator ID counter so each query starts from 0
   sirius::op::sirius_physical_operator::next_operator_id.store(0);
-  
+
   auto query = context.GetCurrentQuery();
   if (config_.is_scan_caching_enabled()) {
     pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -79,6 +79,9 @@ SiriusContext::~SiriusContext() noexcept
 
 void SiriusContext::QueryBegin(ClientContext& context)
 {
+  // Reset operator ID counter so each query starts from 0
+  sirius::op::sirius_physical_operator::next_operator_id.store(0);
+  
   auto query = context.GetCurrentQuery();
   if (config_.is_scan_caching_enabled()) {
     pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
@@ -148,7 +148,7 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate grouped aggregates with AV
 
   // The local operator outputs expanded columns: group_key, min, max, count, sum, count_valid
   // (AVG decomposed into SUM + COUNT_VALID). Verify column count = 1 group + 5 aggregates.
-  auto output_table = outputs->get_data_batches()[0]
+  auto& output_table = outputs->get_data_batches()[0]
                         ->get_data()
                         ->cast<cucascade::gpu_table_representation>()
                         .get_table();

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
@@ -149,9 +149,9 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate grouped aggregates with AV
   // The local operator outputs expanded columns: group_key, min, max, count, sum, count_valid
   // (AVG decomposed into SUM + COUNT_VALID). Verify column count = 1 group + 5 aggregates.
   auto& output_table = outputs->get_data_batches()[0]
-                        ->get_data()
-                        ->cast<cucascade::gpu_table_representation>()
-                        .get_table();
+                         ->get_data()
+                         ->cast<cucascade::gpu_table_representation>()
+                         .get_table();
   REQUIRE(output_table.view().num_columns() == 6);  // 1 group + 3 non-avg + 2 (sum+count for avg)
 }
 


### PR DESCRIPTION
Currently cudf::default_stream() is still used in several places such as in
`auto table = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table();`

This will trigger a deep copy of `cudf::table` on the `cudf::default_stream`. This causes a bunch of validation error in larger scale factor, because even though Sirius is calling `stream.synchronize()`, it won't `synchronize()` against `cudf::default_stream`