### PR TITLE
Fix Q12 output datatypes by enabling hugeints

### DIFF
--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -262,11 +262,6 @@ host_table_chunk_reader::host_table_chunk_reader(
         "[host_table_chunk_reader] Metadata column size mismatch across columns.");
     }
 
-    // For the time being, we do not handle HUGEINT, as cudf does not support it
-    if (_types[col_idx] == duckdb::LogicalType::HUGEINT) {
-      throw std::runtime_error(
-        "[host_table_chunk_reader] HUGEINT type is not currently supported.");
-    }
     _column_readers.emplace_back(columns[col_idx], _allocation);
   }
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -372,7 +372,6 @@ unique_ptr<FunctionData> SiriusExtension::GPUExecutionBind(ClientContext& contex
   planner.CreatePlan(std::move(parser.statements[0]));
   D_ASSERT(planner.plan);
 
-
   auto prepared       = make_shared_ptr<PreparedStatementData>(statement_type);
   prepared->names     = planner.names;
   prepared->types     = planner.types;

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -372,11 +372,6 @@ unique_ptr<FunctionData> SiriusExtension::GPUExecutionBind(ClientContext& contex
   planner.CreatePlan(std::move(parser.statements[0]));
   D_ASSERT(planner.plan);
 
-  // cuDF does not support HUGEINT (int128). DuckDB widens aggregates like sum(int32) to HUGEINT.
-  // Downcast to BIGINT so all downstream operators and the result collector use a supported type.
-  for (auto& type : planner.types) {
-    if (type == LogicalType::HUGEINT) { type = LogicalType::BIGINT; }
-  }
 
   auto prepared       = make_shared_ptr<PreparedStatementData>(statement_type);
   prepared->names     = planner.names;


### PR DESCRIPTION
Remove some temporary hugeint provisions that disable them in the engine, these work now due to some casting mechanisms that are already in place. This allows Q12 to return the results in the same datatypes as duckdb.