### PR TITLE
Use `cucascade` `main` branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 [submodule "cucascade"]
 	path = cucascade
 	url = https://github.com/NVIDIA/cuCascade.git
-	branch = release/26.02
+	branch = main
 [submodule "duckdb-python"]
 	path = duckdb-python
 	url = https://github.com/duckdb/duckdb-python.git


### PR DESCRIPTION
It seems we can just use the `main` branch. I propose adding cudf stable checks in https://github.com/NVIDIA/cuCascade/pull/80.