### PR TITLE
Updated threadpool config settings

### DIFF
--- a/test/cpp/config/data/configurator.cfg
+++ b/test/cpp/config/data/configurator.cfg
@@ -27,13 +27,13 @@ sirius = {
             num_threads = 4;
             thread_name_prefix = "sirius_pipeline_executor";
         };
+        downgrade = {
+            num_threads = 1;
+            thread_name_prefix = "sirius_downgrade_executor";
+        };
         duckdb_scan = {
             num_threads = 4;
             thread_name_prefix = "sirius_scan_executor";
-        };
-        downgrade = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = false;
         };
     };
 };

--- a/test/cpp/config/data/minimal.cfg
+++ b/test/cpp/config/data/minimal.cfg
@@ -17,12 +17,16 @@ sirius = {
     };
     executor = {
         pipeline = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = true;
+            num_threads = 4;
+            thread_name_prefix = "sirius_pipeline_executor";
         };
         downgrade = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = false;
+            num_threads = 1;
+            thread_name_prefix = "sirius_downgrade_executor";
+        };
+        duckdb_scan = {
+            num_threads = 4;
+            thread_name_prefix = "sirius_scan_executor";
         };
     };
 };

--- a/test/cpp/config/data/spaces.cfg
+++ b/test/cpp/config/data/spaces.cfg
@@ -37,12 +37,16 @@ sirius = {
     };
     executor = {
         pipeline = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = true;
+            num_threads = 4;
+            thread_name_prefix = "sirius_pipeline_executor";
         };
         downgrade = {
-            max_concurrent_tasks = 4;
-            retry_on_failure = false;
+            num_threads = 1;
+            thread_name_prefix = "sirius_downgrade_executor";
+        };
+        duckdb_scan = {
+            num_threads = 4;
+            thread_name_prefix = "sirius_scan_executor";
         };
     };
 };


### PR DESCRIPTION
`max_concurrent_tasks` and `retry_on_failure` were fields in a config struct that was removed some time ago.