### PR TITLE
Clickbench optimization for gpu_processing path port to dev branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,8 @@ set(CUDA_SOURCES
     src/cuda/operator/nested_loop_join.cu
     src/cuda/operator/strings_matching.cu
     src/cuda/operator/substring.cu
+    src/cuda/operator/strlen_from_offsets.cu
+    src/cuda/operator/empty_str_check.cu
     src/cuda/print.cu
     src/cuda/utils.cu)
 # cmake-format: on

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,7 +22,7 @@ bool Config::USE_PIN_MEM_FOR_CPU_PROCESSING = true;
 
 bool Config::USE_CUDF_EXPR = true;
 
-bool Config::USE_CUSTOM_TOP_N = false;
+bool Config::USE_CUSTOM_TOP_N = true;
 
 bool Config::USE_OPT_TABLE_SCAN                  = true;
 int Config::OPT_TABLE_SCAN_NUM_CUDA_STREAMS      = 8;

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -231,61 +231,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     if (num_cd == num_aggregates && num_cd > 0) {
       SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} aggregates", num_cd);
 
-      // --- SIRIUS_P1_STRATEGY=nunique: use native cudf nunique instead of two-phase distinct ---
-      const char* p1_strategy_env = std::getenv("SIRIUS_P1_STRATEGY");
-      if (p1_strategy_env && std::string(p1_strategy_env) == "nunique") {
-        SIRIUS_LOG_INFO("[INVESTIGATE] P1 strategy: native nunique, input={}", size);
-
-        cudaEvent_t nu_start, nu_stop;
-        cudaEventCreate(&nu_start);
-        cudaEventCreate(&nu_stop);
-
-        cudf::groupby::groupby grpby_nu(
-          keys_table,
-          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
-
-        std::vector<cudf::groupby::aggregation_request> nu_requests;
-        for (int agg = 0; agg < num_aggregates; agg++) {
-          auto value_view = aggregate_keys[agg]->convertToCudfColumn();
-          nu_requests.emplace_back();
-          nu_requests[agg].values = value_view;
-          nu_requests[agg].aggregations.push_back(
-            cudf::make_nunique_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
-        }
-
-        cudaEventRecord(nu_start, 0);
-        cudaEventSynchronize(nu_start);
-        auto nu_result = grpby_nu.aggregate(nu_requests);
-        cudaEventRecord(nu_stop, 0);
-        cudaEventSynchronize(nu_stop);
-        float nu_ms = 0;
-        cudaEventElapsedTime(&nu_ms, nu_start, nu_stop);
-        SIRIUS_LOG_INFO("[INVESTIGATE] P1-nunique groupby.aggregate: {:.3f} ms", nu_ms);
-        cudaEventDestroy(nu_start);
-        cudaEventDestroy(nu_stop);
-
-        auto nu_result_keys = std::move(nu_result.first);
-        for (int key = 0; key < num_keys; key++) {
-          cudf::column group_key = nu_result_keys->get_column(key);
-          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
-        }
-        for (int agg = 0; agg < num_aggregates; agg++) {
-          auto agg_val      = std::move(nu_result.second[agg].results[0]);
-          auto agg_val_view = agg_val->view();
-          auto temp_data    = convertInt32ToUInt64(
-            const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
-          auto validity_mask = createNullMask(agg_val_view.size());
-          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
-                                                           GPUColumnType(GPUColumnTypeId::INT64),
-                                                           reinterpret_cast<uint8_t*>(temp_data),
-                                                           validity_mask);
-        }
-        STOP_TIMER();
-        SIRIUS_LOG_DEBUG("CUDF Groupby (P1-nunique) result count: {}", keys[0]->column_length);
-        return;
-      }
-      // --- End SIRIUS_P1_STRATEGY=nunique ---
-
       for (int agg = 0; agg < num_aggregates; agg++) {
         auto value_view = aggregate_keys[agg]->convertToCudfColumn();
 
@@ -311,12 +256,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           all_key_indices.push_back(k);
         }
 
-        cudaEvent_t p1_start, p1_stop;
-        cudaEventCreate(&p1_start);
-        cudaEventCreate(&p1_stop);
-
-        cudaEventRecord(p1_start, 0);
-        cudaEventSynchronize(p1_start);
         auto distinct_result = cudf::distinct(
           effective_dedup_table, all_key_indices,
           cudf::duplicate_keep_option::KEEP_ANY,
@@ -324,13 +263,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudf::nan_equality::ALL_EQUAL,
           rmm::cuda_stream_default,
           gpuBufferManager->mr);
-        cudaEventRecord(p1_stop, 0);
-        cudaEventSynchronize(p1_stop);
-        float p1_distinct_ms = 0;
-        cudaEventElapsedTime(&p1_distinct_ms, p1_start, p1_stop);
-        SIRIUS_LOG_INFO("[INVESTIGATE] P1 cudf::distinct: {:.3f} ms, {} -> {} rows",
-                        p1_distinct_ms, size, distinct_result->num_rows());
-
         SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
 
         std::vector<cudf::column_view> dedup_keys_views;
@@ -348,16 +280,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
         phase2_requests[0].values = distinct_result->get_column(num_keys);
 
-        cudaEventRecord(p1_start, 0);
-        cudaEventSynchronize(p1_start);
         auto phase2_result = grpby_phase2.aggregate(phase2_requests);
-        cudaEventRecord(p1_stop, 0);
-        cudaEventSynchronize(p1_stop);
-        float p1_phase2_ms = 0;
-        cudaEventElapsedTime(&p1_phase2_ms, p1_start, p1_stop);
-        SIRIUS_LOG_INFO("[INVESTIGATE] P1 phase2 groupby: {:.3f} ms", p1_phase2_ms);
-        cudaEventDestroy(p1_start);
-        cudaEventDestroy(p1_stop);
 
         auto result_key = std::move(phase2_result.first);
         for (int key = 0; key < num_keys; key++) {

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -221,6 +221,33 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
   auto keys_table = cudf::table_view(keys_cudf);
 
+  // cudf::distinct uses a hash function that reads STRING offset children as INT32.
+  // Sirius stores offsets as INT64 (non-standard). Passing an INT64-offset STRING
+  // column to cudf::distinct produces wrong hashes — all strings hash as if empty,
+  // so dedup collapses every group to 1 row and COUNT DISTINCT returns 1 everywhere.
+  // Fix: convert any VARCHAR column_view to standard INT32-offset format before
+  // calling cudf::distinct. The INT32 buffer is allocated via customCudaMalloc and
+  // is persistent for the query lifetime, so the returned column_view is safe to use.
+  auto to_distinct_view = [](cudf::column_view const& cv) -> cudf::column_view {
+    if (cv.type().id() != cudf::type_id::STRING) return cv;
+    if (cv.num_children() == 0 || cv.child(0).type().id() == cudf::type_id::INT32) return cv;
+    int32_t* int32_offs = convertUInt64ToInt32(
+      const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(cv.child(0).data<int64_t>())),
+      static_cast<size_t>(cv.size()) + 1);
+    auto offsets_cv = cudf::column_view(
+      cudf::data_type{cudf::type_id::INT32}, cv.size() + 1, int32_offs, nullptr, 0);
+    return cudf::column_view(
+      cv.type(), cv.size(), cv.data<uint8_t>(), cv.null_mask(), cv.null_count(), 0, {offsets_cv});
+  };
+
+  // Pre-compute INT32-offset versions of group key columns once (they're shared across all
+  // COUNT DISTINCT aggregates in P1 and P1b, so we avoid redundant conversions per aggregate).
+  std::vector<cudf::column_view> keys_cudf_for_distinct;
+  keys_cudf_for_distinct.reserve(num_keys);
+  for (const auto& kcv : keys_cudf) {
+    keys_cudf_for_distinct.push_back(to_distinct_view(kcv));
+  }
+
   // --- Two-phase COUNT DISTINCT optimization (P1) ---
   // When ALL aggregates are COUNT_DISTINCT, use distinct(keys+value) → count_star groupby
   // instead of cudf's sort-based nunique. Avoids materializing sorted order.
@@ -238,9 +265,9 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
         std::vector<cudf::column_view> dedup_columns;
         for (int key = 0; key < num_keys; key++) {
-          dedup_columns.push_back(keys_cudf[key]);
+          dedup_columns.push_back(keys_cudf_for_distinct[key]);
         }
-        dedup_columns.push_back(value_view);
+        dedup_columns.push_back(to_distinct_view(value_view));
 
         auto dedup_table = cudf::table_view(dedup_columns);
 
@@ -255,6 +282,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           effective_dedup_table = null_filtered_owner->view();
         }
 
+        // All columns are keys for deduplication
         std::vector<cudf::size_type> all_key_indices;
         for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
           all_key_indices.push_back(k);
@@ -489,10 +517,10 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         // Phase 1: distinct(group_keys + value), excluding NULL values
         std::vector<cudf::column_view> dedup_columns;
         for (int key = 0; key < num_keys; key++) {
-          dedup_columns.push_back(keys_cudf[key]);
+          dedup_columns.push_back(keys_cudf_for_distinct[key]);
         }
         auto value_view = aggregate_keys[agg]->convertToCudfColumn();
-        dedup_columns.push_back(value_view);
+        dedup_columns.push_back(to_distinct_view(value_view));
 
         auto dedup_table = cudf::table_view(dedup_columns);
 

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -19,7 +19,9 @@
 #include "gpu_buffer_manager.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_physical_grouped_aggregate.hpp"
+
 #include <cudf/stream_compaction.hpp>
+
 #include <cstdlib>
 
 namespace duckdb {
@@ -246,8 +248,10 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         std::unique_ptr<cudf::table> null_filtered_owner;
         cudf::table_view effective_dedup_table = dedup_table;
         if (value_view.nullable() && value_view.null_count() > 0) {
-          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
-                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
+          null_filtered_owner   = cudf::drop_nulls(dedup_table,
+                                                   {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default,
+                                                 gpuBufferManager->mr);
           effective_dedup_table = null_filtered_owner->view();
         }
 
@@ -256,14 +260,15 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           all_key_indices.push_back(k);
         }
 
-        auto distinct_result = cudf::distinct(
-          effective_dedup_table, all_key_indices,
-          cudf::duplicate_keep_option::KEEP_ANY,
-          cudf::null_equality::EQUAL,
-          cudf::nan_equality::ALL_EQUAL,
-          rmm::cuda_stream_default,
-          gpuBufferManager->mr);
-        SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
+        auto distinct_result = cudf::distinct(effective_dedup_table,
+                                              all_key_indices,
+                                              cudf::duplicate_keep_option::KEEP_ANY,
+                                              cudf::null_equality::EQUAL,
+                                              cudf::nan_equality::ALL_EQUAL,
+                                              rmm::cuda_stream_default,
+                                              gpuBufferManager->mr);
+        SIRIUS_LOG_DEBUG(
+          "Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
 
         std::vector<cudf::column_view> dedup_keys_views;
         for (int key = 0; key < num_keys; key++) {
@@ -272,7 +277,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto dedup_keys_table = cudf::table_view(dedup_keys_views);
 
         cudf::groupby::groupby grpby_phase2(
-          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+          dedup_keys_table,
+          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 
         std::vector<cudf::groupby::aggregation_request> phase2_requests;
         phase2_requests.emplace_back();
@@ -285,13 +291,15 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto result_key = std::move(phase2_result.first);
         for (int key = 0; key < num_keys; key++) {
           cudf::column group_key = result_key->get_column(key);
-          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+          keys[key]->setFromCudfColumn(
+            group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
         }
 
         auto agg_val      = std::move(phase2_result.second[0].results[0]);
         auto agg_val_view = agg_val->view();
-        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
-        auto validity_mask = createNullMask(agg_val_view.size());
+        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
+                                              agg_val_view.size());
+        auto validity_mask  = createNullMask(agg_val_view.size());
         aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
                                                          GPUColumnType(GPUColumnTypeId::INT64),
                                                          reinterpret_cast<uint8_t*>(temp_data),
@@ -299,7 +307,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       }
 
       STOP_TIMER();
-      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}", keys[0]->column_length);
+      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}",
+                       keys[0]->column_length);
       return;
     }
   }
@@ -335,12 +344,16 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       if (size > size_threshold) {
         skip_p1b = true;
         SIRIUS_LOG_DEBUG("P1b guard: skip (size={} > K={} * groups={} = {})",
-                         size, p1b_K, estimated_output_groups, size_threshold);
+                         size,
+                         p1b_K,
+                         estimated_output_groups,
+                         size_threshold);
       }
     }
 
     if (num_cd > 0 && num_cd < num_aggregates && !skip_p1b) {
-      SIRIUS_LOG_DEBUG("Mixed aggregate: {} COUNT_DISTINCT + {} other", num_cd, num_aggregates - num_cd);
+      SIRIUS_LOG_DEBUG(
+        "Mixed aggregate: {} COUNT_DISTINCT + {} other", num_cd, num_aggregates - num_cd);
 
       // Step 1: Normal groupby with COUNT placeholder for CD aggregates
       cudf::groupby::groupby grpby_normal(
@@ -364,8 +377,10 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size);
           shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
+            make_shared_ptr<GPUColumn>(size,
+                                       GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp),
+                                       validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
         } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
                    agg_mode[agg] == AggregationType::SUM &&
@@ -376,42 +391,54 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size, cudf::mask_state::ALL_NULL);
           shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
+            make_shared_ptr<GPUColumn>(size,
+                                       GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp),
+                                       validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
         } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
                    agg_mode[agg] == AggregationType::COUNT_STAR &&
                    aggregate_keys[agg]->column_length != 0) {
-          auto aggregate = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
+          auto aggregate =
+            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
           normal_requests[agg].aggregations.push_back(std::move(aggregate));
           uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size);
           shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
+            make_shared_ptr<GPUColumn>(size,
+                                       GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp),
+                                       validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::SUM) {
-          normal_requests[agg].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
           normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::AVERAGE) {
-          normal_requests[agg].aggregations.push_back(cudf::make_mean_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_mean_aggregation<cudf::groupby_aggregation>());
           if (aggregate_keys[agg]->data_wrapper.type.id() == GPUColumnTypeId::DECIMAL) {
             if (aggregate_keys[agg]->data_wrapper.getColumnTypeSize() != sizeof(int64_t)) {
               throw NotImplementedException("Only support decimal64 for decimal AVG group-by");
             }
             auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
-            auto to_cudf_type = cudf::data_type(cudf::type_id::FLOAT64);
-            auto to_cudf_column = cudf::cast(
-              from_cudf_column_view, to_cudf_type, rmm::cuda_stream_default, GPUBufferManager::GetInstance().mr);
-            aggregate_keys[agg]->setFromCudfColumn(*to_cudf_column, false, nullptr, 0, gpuBufferManager);
+            auto to_cudf_type          = cudf::data_type(cudf::type_id::FLOAT64);
+            auto to_cudf_column        = cudf::cast(from_cudf_column_view,
+                                             to_cudf_type,
+                                             rmm::cuda_stream_default,
+                                             GPUBufferManager::GetInstance().mr);
+            aggregate_keys[agg]->setFromCudfColumn(
+              *to_cudf_column, false, nullptr, 0, gpuBufferManager);
           }
           normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::MIN) {
-          normal_requests[agg].aggregations.push_back(cudf::make_min_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_min_aggregation<cudf::groupby_aggregation>());
           normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::MAX) {
-          normal_requests[agg].aggregations.push_back(cudf::make_max_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_max_aggregation<cudf::groupby_aggregation>());
           normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::COUNT) {
           normal_requests[agg].aggregations.push_back(
@@ -440,10 +467,12 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       for (int agg = 0; agg < num_aggregates; agg++) {
         if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) continue;
         auto agg_val = std::move(normal_result.second[agg].results[0]);
-        if (agg_mode[agg] == AggregationType::COUNT || agg_mode[agg] == AggregationType::COUNT_STAR) {
-          auto agg_val_view  = agg_val->view();
-          auto temp_data     = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
-          auto validity_mask = createNullMask(agg_val_view.size());
+        if (agg_mode[agg] == AggregationType::COUNT ||
+            agg_mode[agg] == AggregationType::COUNT_STAR) {
+          auto agg_val_view = agg_val->view();
+          auto temp_data = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
+                                                agg_val_view.size());
+          auto validity_mask  = createNullMask(agg_val_view.size());
           aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
                                                            GPUColumnType(GPUColumnTypeId::INT64),
                                                            reinterpret_cast<uint8_t*>(temp_data),
@@ -471,8 +500,10 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         std::unique_ptr<cudf::table> null_filtered_owner;
         cudf::table_view effective_dedup_table = dedup_table;
         if (value_view.nullable() && value_view.null_count() > 0) {
-          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
-                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
+          null_filtered_owner   = cudf::drop_nulls(dedup_table,
+                                                   {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default,
+                                                 gpuBufferManager->mr);
           effective_dedup_table = null_filtered_owner->view();
         }
 
@@ -481,15 +512,16 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           all_key_indices.push_back(k);
         }
 
-        auto distinct_result = cudf::distinct(
-          effective_dedup_table, all_key_indices,
-          cudf::duplicate_keep_option::KEEP_ANY,
-          cudf::null_equality::EQUAL,
-          cudf::nan_equality::ALL_EQUAL,
-          rmm::cuda_stream_default,
-          gpuBufferManager->mr);
+        auto distinct_result = cudf::distinct(effective_dedup_table,
+                                              all_key_indices,
+                                              cudf::duplicate_keep_option::KEEP_ANY,
+                                              cudf::null_equality::EQUAL,
+                                              cudf::nan_equality::ALL_EQUAL,
+                                              rmm::cuda_stream_default,
+                                              gpuBufferManager->mr);
 
-        SIRIUS_LOG_DEBUG("Mixed two-phase: {} -> {} after distinct", size, distinct_result->num_rows());
+        SIRIUS_LOG_DEBUG(
+          "Mixed two-phase: {} -> {} after distinct", size, distinct_result->num_rows());
 
         // Phase 2: groupby COUNT_STAR on deduplicated table
         std::vector<cudf::column_view> dedup_keys_views;
@@ -499,7 +531,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto dedup_keys_table = cudf::table_view(dedup_keys_views);
 
         cudf::groupby::groupby grpby_phase2(
-          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+          dedup_keys_table,
+          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 
         std::vector<cudf::groupby::aggregation_request> phase2_requests;
         phase2_requests.emplace_back();
@@ -512,17 +545,20 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         // Both the normal groupby (step 1) and this phase2 groupby sort their output by the
         // same key columns and operate on the same key domain, so results are positionally
         // aligned — no join needed.
-        auto cd_count_col  = std::move(phase2_result.second[0].results[0]);
-        auto cd_view       = cd_count_col->view();
-        auto temp_data     = convertInt32ToUInt64(const_cast<int32_t*>(cd_view.data<int32_t>()), cd_view.size());
-        auto validity_mask = createNullMask(cd_view.size());
-        aggregate_keys[agg] = make_shared_ptr<GPUColumn>(
-          cd_view.size(), GPUColumnType(GPUColumnTypeId::INT64),
-          reinterpret_cast<uint8_t*>(temp_data), validity_mask);
+        auto cd_count_col = std::move(phase2_result.second[0].results[0]);
+        auto cd_view      = cd_count_col->view();
+        auto temp_data =
+          convertInt32ToUInt64(const_cast<int32_t*>(cd_view.data<int32_t>()), cd_view.size());
+        auto validity_mask  = createNullMask(cd_view.size());
+        aggregate_keys[agg] = make_shared_ptr<GPUColumn>(cd_view.size(),
+                                                         GPUColumnType(GPUColumnTypeId::INT64),
+                                                         reinterpret_cast<uint8_t*>(temp_data),
+                                                         validity_mask);
       }
 
       STOP_TIMER();
-      SIRIUS_LOG_DEBUG("CUDF Groupby (mixed COUNT DISTINCT) result count: {}", keys[0]->column_length);
+      SIRIUS_LOG_DEBUG("CUDF Groupby (mixed COUNT DISTINCT) result count: {}",
+                       keys[0]->column_length);
       return;
     }
   }

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -231,6 +231,61 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     if (num_cd == num_aggregates && num_cd > 0) {
       SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} aggregates", num_cd);
 
+      // --- SIRIUS_P1_STRATEGY=nunique: use native cudf nunique instead of two-phase distinct ---
+      const char* p1_strategy_env = std::getenv("SIRIUS_P1_STRATEGY");
+      if (p1_strategy_env && std::string(p1_strategy_env) == "nunique") {
+        SIRIUS_LOG_INFO("[INVESTIGATE] P1 strategy: native nunique, input={}", size);
+
+        cudaEvent_t nu_start, nu_stop;
+        cudaEventCreate(&nu_start);
+        cudaEventCreate(&nu_stop);
+
+        cudf::groupby::groupby grpby_nu(
+          keys_table,
+          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+
+        std::vector<cudf::groupby::aggregation_request> nu_requests;
+        for (int agg = 0; agg < num_aggregates; agg++) {
+          auto value_view = aggregate_keys[agg]->convertToCudfColumn();
+          nu_requests.emplace_back();
+          nu_requests[agg].values = value_view;
+          nu_requests[agg].aggregations.push_back(
+            cudf::make_nunique_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
+        }
+
+        cudaEventRecord(nu_start, 0);
+        cudaEventSynchronize(nu_start);
+        auto nu_result = grpby_nu.aggregate(nu_requests);
+        cudaEventRecord(nu_stop, 0);
+        cudaEventSynchronize(nu_stop);
+        float nu_ms = 0;
+        cudaEventElapsedTime(&nu_ms, nu_start, nu_stop);
+        SIRIUS_LOG_INFO("[INVESTIGATE] P1-nunique groupby.aggregate: {:.3f} ms", nu_ms);
+        cudaEventDestroy(nu_start);
+        cudaEventDestroy(nu_stop);
+
+        auto nu_result_keys = std::move(nu_result.first);
+        for (int key = 0; key < num_keys; key++) {
+          cudf::column group_key = nu_result_keys->get_column(key);
+          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+        }
+        for (int agg = 0; agg < num_aggregates; agg++) {
+          auto agg_val      = std::move(nu_result.second[agg].results[0]);
+          auto agg_val_view = agg_val->view();
+          auto temp_data    = convertInt32ToUInt64(
+            const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+          auto validity_mask = createNullMask(agg_val_view.size());
+          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
+                                                           GPUColumnType(GPUColumnTypeId::INT64),
+                                                           reinterpret_cast<uint8_t*>(temp_data),
+                                                           validity_mask);
+        }
+        STOP_TIMER();
+        SIRIUS_LOG_DEBUG("CUDF Groupby (P1-nunique) result count: {}", keys[0]->column_length);
+        return;
+      }
+      // --- End SIRIUS_P1_STRATEGY=nunique ---
+
       for (int agg = 0; agg < num_aggregates; agg++) {
         auto value_view = aggregate_keys[agg]->convertToCudfColumn();
 
@@ -256,6 +311,12 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           all_key_indices.push_back(k);
         }
 
+        cudaEvent_t p1_start, p1_stop;
+        cudaEventCreate(&p1_start);
+        cudaEventCreate(&p1_stop);
+
+        cudaEventRecord(p1_start, 0);
+        cudaEventSynchronize(p1_start);
         auto distinct_result = cudf::distinct(
           effective_dedup_table, all_key_indices,
           cudf::duplicate_keep_option::KEEP_ANY,
@@ -263,6 +324,12 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudf::nan_equality::ALL_EQUAL,
           rmm::cuda_stream_default,
           gpuBufferManager->mr);
+        cudaEventRecord(p1_stop, 0);
+        cudaEventSynchronize(p1_stop);
+        float p1_distinct_ms = 0;
+        cudaEventElapsedTime(&p1_distinct_ms, p1_start, p1_stop);
+        SIRIUS_LOG_INFO("[INVESTIGATE] P1 cudf::distinct: {:.3f} ms, {} -> {} rows",
+                        p1_distinct_ms, size, distinct_result->num_rows());
 
         SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
 
@@ -281,7 +348,16 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
         phase2_requests[0].values = distinct_result->get_column(num_keys);
 
+        cudaEventRecord(p1_start, 0);
+        cudaEventSynchronize(p1_start);
         auto phase2_result = grpby_phase2.aggregate(phase2_requests);
+        cudaEventRecord(p1_stop, 0);
+        cudaEventSynchronize(p1_stop);
+        float p1_phase2_ms = 0;
+        cudaEventElapsedTime(&p1_phase2_ms, p1_start, p1_stop);
+        SIRIUS_LOG_INFO("[INVESTIGATE] P1 phase2 groupby: {:.3f} ms", p1_phase2_ms);
+        cudaEventDestroy(p1_start);
+        cudaEventDestroy(p1_stop);
 
         auto result_key = std::move(phase2_result.first);
         for (int key = 0; key < num_keys; key++) {

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -19,7 +19,9 @@
 #include "gpu_buffer_manager.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_physical_grouped_aggregate.hpp"
+
 #include <cudf/stream_compaction.hpp>
+
 #include <cstdlib>
 
 namespace duckdb {
@@ -35,8 +37,10 @@ void combineColumns(T* a, T* b, T*& c, uint64_t N_a, uint64_t N_b)
   SIRIUS_LOG_DEBUG("Launching Combine Columns Kernel");
   GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
   c                                  = gpuBufferManager->customCudaMalloc<T>(N_a + N_b, 0, 0);
-  cudaMemcpyAsync(c, a, N_a * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
-  cudaMemcpyAsync(c + N_a, b, N_b * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(
+    c, a, N_a * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(
+    c + N_a, b, N_b * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(a), 0);
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(b), 0);
   CHECK_ERROR();
@@ -72,25 +76,32 @@ void combineMasks(
   auto size_a                        = getMaskBytesSize(N_a) / sizeof(cudf::bitmask_type);
   auto size_c                        = getMaskBytesSize(N_a + N_b) / sizeof(cudf::bitmask_type);
   c                                  = gpuBufferManager->customCudaMalloc<uint32_t>(size_c, 0, 0);
-  cudaMemcpyAsync(c, a, size_a * sizeof(uint32_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(
+    c, a, size_a * sizeof(uint32_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
 
   if (N_a % 32 == 0) {
     auto offset_after_a        = (N_a + 31) / 32;
     auto offset_remain_after_a = 0;
     auto N                     = N_b - offset_remain_after_a;
-    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
+    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS,
+                BLOCK_THREADS,
+                0,
+                rmm::cuda_stream_default.value()>>>(
       b, c + offset_after_a, offset_remain_after_a, N);
     CHECK_ERROR();
   } else {
     auto offset_after_a        = (N_a + 31) / 32;
     auto offset_remain_after_a = 32 - (N_a % 32);
     auto N                     = N_b - offset_remain_after_a;
-    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
+    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS,
+                BLOCK_THREADS,
+                0,
+                rmm::cuda_stream_default.value()>>>(
       b, c + offset_after_a, offset_remain_after_a, N);
     CHECK_ERROR();
     uint32_t temp  = 0;
     uint32_t temp2 = 0;
-    cudaDeviceSynchronize(); // Need sync before Host memory copy
+    cudaDeviceSynchronize();  // Need sync before Host memory copy
     cudaMemcpy(&temp, c + offset_after_a - 1, sizeof(uint32_t), cudaMemcpyDeviceToHost);
     cudaMemcpy(&temp2, b, sizeof(uint32_t), cudaMemcpyDeviceToHost);
     temp  = (temp << offset_remain_after_a) >> offset_remain_after_a;
@@ -130,11 +141,25 @@ void combineStrings(uint8_t* a,
   GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
   c        = gpuBufferManager->customCudaMalloc<uint8_t>(num_bytes_a + num_bytes_b, 0, 0);
   offset_c = gpuBufferManager->customCudaMalloc<uint64_t>(N_a + N_b + 1, 0, 0);
-  cudaMemcpyAsync(c, a, num_bytes_a * sizeof(uint8_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
-  cudaMemcpyAsync(c + num_bytes_a, b, num_bytes_b * sizeof(uint8_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
-  cudaMemcpyAsync(offset_c, offset_a, N_a * sizeof(uint64_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
-  add_offset<<<((N_b + 1) + BLOCK_THREADS - 1) / (BLOCK_THREADS), BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
-    offset_c + N_a, offset_b, num_bytes_a, N_b + 1);
+  cudaMemcpyAsync(c,
+                  a,
+                  num_bytes_a * sizeof(uint8_t),
+                  cudaMemcpyDeviceToDevice,
+                  rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(c + num_bytes_a,
+                  b,
+                  num_bytes_b * sizeof(uint8_t),
+                  cudaMemcpyDeviceToDevice,
+                  rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(offset_c,
+                  offset_a,
+                  N_a * sizeof(uint64_t),
+                  cudaMemcpyDeviceToDevice,
+                  rmm::cuda_stream_default.value());
+  add_offset<<<((N_b + 1) + BLOCK_THREADS - 1) / (BLOCK_THREADS),
+               BLOCK_THREADS,
+               0,
+               rmm::cuda_stream_default.value()>>>(offset_c + N_a, offset_b, num_bytes_a, N_b + 1);
   CHECK_ERROR();
   cudaDeviceSynchronize();
 }
@@ -236,8 +261,10 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         std::unique_ptr<cudf::table> null_filtered_owner;
         cudf::table_view effective_dedup_table = dedup_table;
         if (value_view.nullable() && value_view.null_count() > 0) {
-          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
-                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
+          null_filtered_owner   = cudf::drop_nulls(dedup_table,
+                                                   {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default,
+                                                 gpuBufferManager->mr);
           effective_dedup_table = null_filtered_owner->view();
         }
 
@@ -245,15 +272,16 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
           all_key_indices.push_back(k);
         }
-        auto distinct_result = cudf::distinct(
-          effective_dedup_table, all_key_indices,
-          cudf::duplicate_keep_option::KEEP_ANY,
-          cudf::null_equality::EQUAL,
-          cudf::nan_equality::ALL_EQUAL,
-          rmm::cuda_stream_default,
-          gpuBufferManager->mr);
+        auto distinct_result = cudf::distinct(effective_dedup_table,
+                                              all_key_indices,
+                                              cudf::duplicate_keep_option::KEEP_ANY,
+                                              cudf::null_equality::EQUAL,
+                                              cudf::nan_equality::ALL_EQUAL,
+                                              rmm::cuda_stream_default,
+                                              gpuBufferManager->mr);
 
-        SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
+        SIRIUS_LOG_DEBUG(
+          "Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
 
         std::vector<cudf::column_view> dedup_keys_views;
         for (int key = 0; key < num_keys; key++) {
@@ -262,7 +290,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto dedup_keys_table = cudf::table_view(dedup_keys_views);
 
         cudf::groupby::groupby grpby_phase2(
-          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+          dedup_keys_table,
+          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 
         std::vector<cudf::groupby::aggregation_request> phase2_requests;
         phase2_requests.emplace_back();
@@ -271,16 +300,18 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         phase2_requests[0].values = distinct_result->get_column(num_keys);
 
         auto phase2_result = grpby_phase2.aggregate(phase2_requests);
-        auto result_key = std::move(phase2_result.first);
+        auto result_key    = std::move(phase2_result.first);
 
         for (int key = 0; key < num_keys; key++) {
           cudf::column group_key = result_key->get_column(key);
-          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+          keys[key]->setFromCudfColumn(
+            group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
         }
 
         auto agg_val      = std::move(phase2_result.second[0].results[0]);
         auto agg_val_view = agg_val->view();
-        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
+                                              agg_val_view.size());
         auto validity_mask = createNullMask(agg_val_view.size());
 
         aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
@@ -289,7 +320,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                                                          validity_mask);
       }
       STOP_TIMER();
-      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}", keys[0]->column_length);
+      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}",
+                       keys[0]->column_length);
       return;
     }
   }
@@ -357,9 +389,9 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
         auto to_cudf_type          = cudf::data_type(cudf::type_id::FLOAT64);
         auto to_cudf_column        = cudf::cast(from_cudf_column_view,
-                                                to_cudf_type,
-                                                rmm::cuda_stream_default,
-                                                GPUBufferManager::GetInstance().mr);
+                                         to_cudf_type,
+                                         rmm::cuda_stream_default,
+                                         GPUBufferManager::GetInstance().mr);
         aggregate_keys[agg]->setFromCudfColumn(
           *to_cudf_column, false, nullptr, 0, gpuBufferManager);
       }
@@ -388,7 +420,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     }
   }
 
-  auto result = grpby_obj.aggregate(requests);
+  auto result     = grpby_obj.aggregate(requests);
   auto result_key = std::move(result.first);
   for (int key = 0; key < num_keys; key++) {
     cudf::column group_key = result_key->get_column(key);
@@ -401,7 +433,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         agg_mode[agg] == AggregationType::COUNT_DISTINCT) {
       auto agg_val_view   = agg_val->view();
       auto temp_data      = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
-                                                 agg_val_view.size());
+                                            agg_val_view.size());
       auto validity_mask  = createNullMask(agg_val_view.size());
       aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
                                                        GPUColumnType(GPUColumnTypeId::INT64),

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,7 @@
 #include "gpu_buffer_manager.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_physical_grouped_aggregate.hpp"
-
 #include <cudf/stream_compaction.hpp>
-
 #include <cstdlib>
 
 namespace duckdb {
@@ -37,8 +35,8 @@ void combineColumns(T* a, T* b, T*& c, uint64_t N_a, uint64_t N_b)
   SIRIUS_LOG_DEBUG("Launching Combine Columns Kernel");
   GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
   c                                  = gpuBufferManager->customCudaMalloc<T>(N_a + N_b, 0, 0);
-  cudaMemcpy(c, a, N_a * sizeof(T), cudaMemcpyDeviceToDevice);
-  cudaMemcpy(c + N_a, b, N_b * sizeof(T), cudaMemcpyDeviceToDevice);
+  cudaMemcpyAsync(c, a, N_a * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(c + N_a, b, N_b * sizeof(T), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(a), 0);
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(b), 0);
   CHECK_ERROR();
@@ -52,7 +50,6 @@ __global__ void copy_mask(uint32_t* b, uint32_t* c, uint64_t offset, uint64_t N)
   uint64_t bit_idx = (idx + offset) % 32;
   uint32_t mask    = 0;
   if (idx < N) { mask = (b[int_idx] >> bit_idx) & 1; }
-
   uint32_t lane_id = threadIdx.x % 32;
   uint32_t set     = (mask << lane_id);
   for (int lane = 16; lane >= 1; lane /= 2) {
@@ -75,25 +72,25 @@ void combineMasks(
   auto size_a                        = getMaskBytesSize(N_a) / sizeof(cudf::bitmask_type);
   auto size_c                        = getMaskBytesSize(N_a + N_b) / sizeof(cudf::bitmask_type);
   c                                  = gpuBufferManager->customCudaMalloc<uint32_t>(size_c, 0, 0);
-  cudaMemcpy(c, a, size_a * sizeof(uint32_t), cudaMemcpyDeviceToDevice);
+  cudaMemcpyAsync(c, a, size_a * sizeof(uint32_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
 
   if (N_a % 32 == 0) {
     auto offset_after_a        = (N_a + 31) / 32;
     auto offset_remain_after_a = 0;
     auto N                     = N_b - offset_remain_after_a;
-    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS>>>(
+    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
       b, c + offset_after_a, offset_remain_after_a, N);
     CHECK_ERROR();
   } else {
     auto offset_after_a        = (N_a + 31) / 32;
     auto offset_remain_after_a = 32 - (N_a % 32);
     auto N                     = N_b - offset_remain_after_a;
-    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS>>>(
+    copy_mask<<<(N + BLOCK_THREADS - 1) / BLOCK_THREADS, BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
       b, c + offset_after_a, offset_remain_after_a, N);
     CHECK_ERROR();
-
     uint32_t temp  = 0;
     uint32_t temp2 = 0;
+    cudaDeviceSynchronize(); // Need sync before Host memory copy
     cudaMemcpy(&temp, c + offset_after_a - 1, sizeof(uint32_t), cudaMemcpyDeviceToHost);
     cudaMemcpy(&temp2, b, sizeof(uint32_t), cudaMemcpyDeviceToHost);
     temp  = (temp << offset_remain_after_a) >> offset_remain_after_a;
@@ -102,7 +99,6 @@ void combineMasks(
     cudaMemcpy(c + offset_after_a - 1, &temp, sizeof(uint32_t), cudaMemcpyHostToDevice);
     CHECK_ERROR();
   }
-
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(a), 0);
   gpuBufferManager->customCudaFree(reinterpret_cast<uint8_t*>(b), 0);
   CHECK_ERROR();
@@ -134,11 +130,10 @@ void combineStrings(uint8_t* a,
   GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
   c        = gpuBufferManager->customCudaMalloc<uint8_t>(num_bytes_a + num_bytes_b, 0, 0);
   offset_c = gpuBufferManager->customCudaMalloc<uint64_t>(N_a + N_b + 1, 0, 0);
-  cudaMemcpy(c, a, num_bytes_a * sizeof(uint8_t), cudaMemcpyDeviceToDevice);
-  cudaMemcpy(c + num_bytes_a, b, num_bytes_b * sizeof(uint8_t), cudaMemcpyDeviceToDevice);
-
-  cudaMemcpy(offset_c, offset_a, N_a * sizeof(uint64_t), cudaMemcpyDeviceToDevice);
-  add_offset<<<((N_b + 1) + BLOCK_THREADS - 1) / (BLOCK_THREADS), BLOCK_THREADS>>>(
+  cudaMemcpyAsync(c, a, num_bytes_a * sizeof(uint8_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(c + num_bytes_a, b, num_bytes_b * sizeof(uint8_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  cudaMemcpyAsync(offset_c, offset_a, N_a * sizeof(uint64_t), cudaMemcpyDeviceToDevice, rmm::cuda_stream_default.value());
+  add_offset<<<((N_b + 1) + BLOCK_THREADS - 1) / (BLOCK_THREADS), BLOCK_THREADS, 0, rmm::cuda_stream_default.value()>>>(
     offset_c + N_a, offset_b, num_bytes_a, N_b + 1);
   CHECK_ERROR();
   cudaDeviceSynchronize();
@@ -169,7 +164,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       }
       keys[group]->is_unique = old_unique;
     }
-
     for (int agg_idx = 0; agg_idx < num_aggregates; agg_idx++) {
       if (agg_mode[agg_idx] == AggregationType::COUNT_STAR ||
           agg_mode[agg_idx] == AggregationType::COUNT) {
@@ -188,9 +182,9 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     }
     return;
   }
-
   SIRIUS_LOG_DEBUG("CUDF Group By");
   SIRIUS_LOG_DEBUG("Input size: {}", keys[0]->column_length);
+
   SETUP_TIMING();
   START_TIMER();
 
@@ -206,9 +200,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     }
   }
 
-  // TODO: This is a hack to get the size of the keys
   size_t size = 0;
-
   for (int key = 0; key < num_keys; key++) {
     if (keys[key]->data_wrapper.data != nullptr) {
       auto cudf_column = keys[key]->convertToCudfColumn();
@@ -221,36 +213,9 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
   auto keys_table = cudf::table_view(keys_cudf);
 
-  // cudf::distinct uses a hash function that reads STRING offset children as INT32.
-  // Sirius stores offsets as INT64 (non-standard). Passing an INT64-offset STRING
-  // column to cudf::distinct produces wrong hashes — all strings hash as if empty,
-  // so dedup collapses every group to 1 row and COUNT DISTINCT returns 1 everywhere.
-  // Fix: convert any VARCHAR column_view to standard INT32-offset format before
-  // calling cudf::distinct. The INT32 buffer is allocated via customCudaMalloc and
-  // is persistent for the query lifetime, so the returned column_view is safe to use.
-  auto to_distinct_view = [](cudf::column_view const& cv) -> cudf::column_view {
-    if (cv.type().id() != cudf::type_id::STRING) return cv;
-    if (cv.num_children() == 0 || cv.child(0).type().id() == cudf::type_id::INT32) return cv;
-    int32_t* int32_offs = convertUInt64ToInt32(
-      const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(cv.child(0).data<int64_t>())),
-      static_cast<size_t>(cv.size()) + 1);
-    auto offsets_cv = cudf::column_view(
-      cudf::data_type{cudf::type_id::INT32}, cv.size() + 1, int32_offs, nullptr, 0);
-    return cudf::column_view(
-      cv.type(), cv.size(), cv.data<uint8_t>(), cv.null_mask(), cv.null_count(), 0, {offsets_cv});
-  };
-
-  // Pre-compute INT32-offset versions of group key columns once (they're shared across all
-  // COUNT DISTINCT aggregates in P1 and P1b, so we avoid redundant conversions per aggregate).
-  std::vector<cudf::column_view> keys_cudf_for_distinct;
-  keys_cudf_for_distinct.reserve(num_keys);
-  for (const auto& kcv : keys_cudf) {
-    keys_cudf_for_distinct.push_back(to_distinct_view(kcv));
-  }
-
-  // --- Two-phase COUNT DISTINCT optimization (P1) ---
-  // When ALL aggregates are COUNT_DISTINCT, use distinct(keys+value) → count_star groupby
-  // instead of cudf's sort-based nunique. Avoids materializing sorted order.
+  // --- Two-phase COUNT DISTINCT optimization (P1a) ---
+  // When ALL aggregates are COUNT_DISTINCT, use global distinct(keys+value) -> count_star groupby.
+  // This bypasses the cuDF 26 per-group hash-map fragmentation penalty.
   {
     int num_cd = 0;
     for (int agg = 0; agg < num_aggregates; agg++) {
@@ -259,44 +224,36 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
     if (num_cd == num_aggregates && num_cd > 0) {
       SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} aggregates", num_cd);
-
       for (int agg = 0; agg < num_aggregates; agg++) {
         auto value_view = aggregate_keys[agg]->convertToCudfColumn();
-
         std::vector<cudf::column_view> dedup_columns;
         for (int key = 0; key < num_keys; key++) {
-          dedup_columns.push_back(keys_cudf_for_distinct[key]);
+          dedup_columns.push_back(keys_cudf[key]);
         }
-        dedup_columns.push_back(to_distinct_view(value_view));
-
+        dedup_columns.push_back(value_view);
         auto dedup_table = cudf::table_view(dedup_columns);
 
-        // COUNT DISTINCT must not count NULLs — drop rows where value is NULL
         std::unique_ptr<cudf::table> null_filtered_owner;
         cudf::table_view effective_dedup_table = dedup_table;
         if (value_view.nullable() && value_view.null_count() > 0) {
-          null_filtered_owner   = cudf::drop_nulls(dedup_table,
-                                                   {static_cast<cudf::size_type>(num_keys)},
-                                                 rmm::cuda_stream_default,
-                                                 gpuBufferManager->mr);
+          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
           effective_dedup_table = null_filtered_owner->view();
         }
 
-        // All columns are keys for deduplication
         std::vector<cudf::size_type> all_key_indices;
         for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
           all_key_indices.push_back(k);
         }
+        auto distinct_result = cudf::distinct(
+          effective_dedup_table, all_key_indices,
+          cudf::duplicate_keep_option::KEEP_ANY,
+          cudf::null_equality::EQUAL,
+          cudf::nan_equality::ALL_EQUAL,
+          rmm::cuda_stream_default,
+          gpuBufferManager->mr);
 
-        auto distinct_result = cudf::distinct(effective_dedup_table,
-                                              all_key_indices,
-                                              cudf::duplicate_keep_option::KEEP_ANY,
-                                              cudf::null_equality::EQUAL,
-                                              cudf::nan_equality::ALL_EQUAL,
-                                              rmm::cuda_stream_default,
-                                              gpuBufferManager->mr);
-        SIRIUS_LOG_DEBUG(
-          "Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
+        SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
 
         std::vector<cudf::column_view> dedup_keys_views;
         for (int key = 0; key < num_keys; key++) {
@@ -305,8 +262,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         auto dedup_keys_table = cudf::table_view(dedup_keys_views);
 
         cudf::groupby::groupby grpby_phase2(
-          dedup_keys_table,
-          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 
         std::vector<cudf::groupby::aggregation_request> phase2_requests;
         phase2_requests.emplace_back();
@@ -315,294 +271,43 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         phase2_requests[0].values = distinct_result->get_column(num_keys);
 
         auto phase2_result = grpby_phase2.aggregate(phase2_requests);
-
         auto result_key = std::move(phase2_result.first);
+
         for (int key = 0; key < num_keys; key++) {
           cudf::column group_key = result_key->get_column(key);
-          keys[key]->setFromCudfColumn(
-            group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
         }
 
         auto agg_val      = std::move(phase2_result.second[0].results[0]);
         auto agg_val_view = agg_val->view();
-        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
-                                              agg_val_view.size());
-        auto validity_mask  = createNullMask(agg_val_view.size());
+        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+        auto validity_mask = createNullMask(agg_val_view.size());
+
         aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
                                                          GPUColumnType(GPUColumnTypeId::INT64),
                                                          reinterpret_cast<uint8_t*>(temp_data),
                                                          validity_mask);
       }
-
       STOP_TIMER();
-      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}",
-                       keys[0]->column_length);
+      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}", keys[0]->column_length);
       return;
     }
   }
 
-  // --- Mixed aggregate: COUNT_DISTINCT + other aggregates ---
-  // When some (but not all) aggregates are COUNT_DISTINCT, split into:
-  //   1. Normal groupby for non-CD aggregates (with cheap placeholder for CD slots)
-  //   2. Two-phase COUNT DISTINCT for each CD aggregate
-  // Both groupbys sort output by the same keys → results are positionally aligned.
-  //
-  // Guard: skip P1b when input is large relative to expected output groups.
-  // At high rows/group the distinct step doesn't shrink data enough to justify
-  // the two-pass overhead.
-  // Tune via SIRIUS_P1B_K env var (default 1000); disable with SIRIUS_P1B_NO_GUARD=1.
-  {
-    static idx_t p1b_K = []() -> idx_t {
-      const char* env = std::getenv("SIRIUS_P1B_K");
-      return env ? std::stoull(env) : 1000ULL;
-    }();
-    static bool p1b_no_guard = []() -> bool {
-      const char* env = std::getenv("SIRIUS_P1B_NO_GUARD");
-      return env != nullptr && env[0] == '1';
-    }();
-
-    int num_cd = 0;
-    for (int agg = 0; agg < num_aggregates; agg++) {
-      if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) num_cd++;
-    }
-
-    bool skip_p1b = false;
-    if (!p1b_no_guard && num_cd > 0 && num_cd < num_aggregates && estimated_output_groups > 0) {
-      idx_t size_threshold = p1b_K * estimated_output_groups;
-      if (size > size_threshold) {
-        skip_p1b = true;
-        SIRIUS_LOG_DEBUG("P1b guard: skip (size={} > K={} * groups={} = {})",
-                         size,
-                         p1b_K,
-                         estimated_output_groups,
-                         size_threshold);
-      }
-    }
-
-    if (num_cd > 0 && num_cd < num_aggregates && !skip_p1b) {
-      SIRIUS_LOG_DEBUG(
-        "Mixed aggregate: {} COUNT_DISTINCT + {} other", num_cd, num_aggregates - num_cd);
-
-      // Step 1: Normal groupby with COUNT placeholder for CD aggregates
-      cudf::groupby::groupby grpby_normal(
-        keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
-
-      std::vector<cudf::groupby::aggregation_request> normal_requests;
-      for (int agg = 0; agg < num_aggregates; agg++) {
-        normal_requests.emplace_back(cudf::groupby::aggregation_request());
-
-        if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) {
-          // Cheap placeholder — will be overwritten by two-phase result
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
-                   agg_mode[agg] == AggregationType::COUNT &&
-                   aggregate_keys[agg]->column_length == 0) {
-          auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
-          normal_requests[agg].aggregations.push_back(std::move(aggregate));
-          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-          cudaMemset(temp, 0, size * sizeof(uint64_t));
-          auto validity_mask = createNullMask(size);
-          shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size,
-                                       GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp),
-                                       validity_mask);
-          normal_requests[agg].values = temp_column->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
-                   agg_mode[agg] == AggregationType::SUM &&
-                   aggregate_keys[agg]->column_length == 0) {
-          auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
-          normal_requests[agg].aggregations.push_back(std::move(aggregate));
-          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-          cudaMemset(temp, 0, size * sizeof(uint64_t));
-          auto validity_mask = createNullMask(size, cudf::mask_state::ALL_NULL);
-          shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size,
-                                       GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp),
-                                       validity_mask);
-          normal_requests[agg].values = temp_column->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
-                   agg_mode[agg] == AggregationType::COUNT_STAR &&
-                   aggregate_keys[agg]->column_length != 0) {
-          auto aggregate =
-            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
-          normal_requests[agg].aggregations.push_back(std::move(aggregate));
-          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-          cudaMemset(temp, 0, size * sizeof(uint64_t));
-          auto validity_mask = createNullMask(size);
-          shared_ptr<GPUColumn> temp_column =
-            make_shared_ptr<GPUColumn>(size,
-                                       GPUColumnType(GPUColumnTypeId::INT64),
-                                       reinterpret_cast<uint8_t*>(temp),
-                                       validity_mask);
-          normal_requests[agg].values = temp_column->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::SUM) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::AVERAGE) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_mean_aggregation<cudf::groupby_aggregation>());
-          if (aggregate_keys[agg]->data_wrapper.type.id() == GPUColumnTypeId::DECIMAL) {
-            if (aggregate_keys[agg]->data_wrapper.getColumnTypeSize() != sizeof(int64_t)) {
-              throw NotImplementedException("Only support decimal64 for decimal AVG group-by");
-            }
-            auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
-            auto to_cudf_type          = cudf::data_type(cudf::type_id::FLOAT64);
-            auto to_cudf_column        = cudf::cast(from_cudf_column_view,
-                                             to_cudf_type,
-                                             rmm::cuda_stream_default,
-                                             GPUBufferManager::GetInstance().mr);
-            aggregate_keys[agg]->setFromCudfColumn(
-              *to_cudf_column, false, nullptr, 0, gpuBufferManager);
-          }
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::MIN) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_min_aggregation<cudf::groupby_aggregation>());
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::MAX) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_max_aggregation<cudf::groupby_aggregation>());
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::COUNT) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (agg_mode[agg] == AggregationType::COUNT_STAR) {
-          normal_requests[agg].aggregations.push_back(
-            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
-          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else {
-          throw NotImplementedException("Aggregate function not supported in mixed path: %d",
-                                        static_cast<int>(agg_mode[agg]));
-        }
-      }
-
-      auto normal_result = grpby_normal.aggregate(normal_requests);
-
-      // Extract group keys
-      auto result_key = std::move(normal_result.first);
-      for (int key = 0; key < num_keys; key++) {
-        cudf::column group_key = result_key->get_column(key);
-        keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
-      }
-
-      // Extract non-CD aggregate results
-      for (int agg = 0; agg < num_aggregates; agg++) {
-        if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) continue;
-        auto agg_val = std::move(normal_result.second[agg].results[0]);
-        if (agg_mode[agg] == AggregationType::COUNT ||
-            agg_mode[agg] == AggregationType::COUNT_STAR) {
-          auto agg_val_view = agg_val->view();
-          auto temp_data = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
-                                                agg_val_view.size());
-          auto validity_mask  = createNullMask(agg_val_view.size());
-          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
-                                                           GPUColumnType(GPUColumnTypeId::INT64),
-                                                           reinterpret_cast<uint8_t*>(temp_data),
-                                                           validity_mask);
-        } else {
-          aggregate_keys[agg]->setFromCudfColumn(*agg_val, false, nullptr, 0, gpuBufferManager);
-        }
-      }
-
-      // Step 2: Two-phase COUNT DISTINCT for each CD aggregate
-      for (int agg = 0; agg < num_aggregates; agg++) {
-        if (agg_mode[agg] != AggregationType::COUNT_DISTINCT) continue;
-
-        // Phase 1: distinct(group_keys + value), excluding NULL values
-        std::vector<cudf::column_view> dedup_columns;
-        for (int key = 0; key < num_keys; key++) {
-          dedup_columns.push_back(keys_cudf_for_distinct[key]);
-        }
-        auto value_view = aggregate_keys[agg]->convertToCudfColumn();
-        dedup_columns.push_back(to_distinct_view(value_view));
-
-        auto dedup_table = cudf::table_view(dedup_columns);
-
-        // COUNT DISTINCT must not count NULLs — drop rows where value is NULL
-        std::unique_ptr<cudf::table> null_filtered_owner;
-        cudf::table_view effective_dedup_table = dedup_table;
-        if (value_view.nullable() && value_view.null_count() > 0) {
-          null_filtered_owner   = cudf::drop_nulls(dedup_table,
-                                                   {static_cast<cudf::size_type>(num_keys)},
-                                                 rmm::cuda_stream_default,
-                                                 gpuBufferManager->mr);
-          effective_dedup_table = null_filtered_owner->view();
-        }
-
-        std::vector<cudf::size_type> all_key_indices;
-        for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
-          all_key_indices.push_back(k);
-        }
-
-        auto distinct_result = cudf::distinct(effective_dedup_table,
-                                              all_key_indices,
-                                              cudf::duplicate_keep_option::KEEP_ANY,
-                                              cudf::null_equality::EQUAL,
-                                              cudf::nan_equality::ALL_EQUAL,
-                                              rmm::cuda_stream_default,
-                                              gpuBufferManager->mr);
-
-        SIRIUS_LOG_DEBUG(
-          "Mixed two-phase: {} -> {} after distinct", size, distinct_result->num_rows());
-
-        // Phase 2: groupby COUNT_STAR on deduplicated table
-        std::vector<cudf::column_view> dedup_keys_views;
-        for (int key = 0; key < num_keys; key++) {
-          dedup_keys_views.push_back(distinct_result->get_column(key));
-        }
-        auto dedup_keys_table = cudf::table_view(dedup_keys_views);
-
-        cudf::groupby::groupby grpby_phase2(
-          dedup_keys_table,
-          has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
-
-        std::vector<cudf::groupby::aggregation_request> phase2_requests;
-        phase2_requests.emplace_back();
-        phase2_requests[0].aggregations.push_back(
-          cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
-        phase2_requests[0].values = distinct_result->get_column(num_keys);
-
-        auto phase2_result = grpby_phase2.aggregate(phase2_requests);
-
-        // Both the normal groupby (step 1) and this phase2 groupby sort their output by the
-        // same key columns and operate on the same key domain, so results are positionally
-        // aligned — no join needed.
-        auto cd_count_col = std::move(phase2_result.second[0].results[0]);
-        auto cd_view      = cd_count_col->view();
-        auto temp_data =
-          convertInt32ToUInt64(const_cast<int32_t*>(cd_view.data<int32_t>()), cd_view.size());
-        auto validity_mask  = createNullMask(cd_view.size());
-        aggregate_keys[agg] = make_shared_ptr<GPUColumn>(cd_view.size(),
-                                                         GPUColumnType(GPUColumnTypeId::INT64),
-                                                         reinterpret_cast<uint8_t*>(temp_data),
-                                                         validity_mask);
-      }
-
-      STOP_TIMER();
-      SIRIUS_LOG_DEBUG("CUDF Groupby (mixed COUNT DISTINCT) result count: {}",
-                       keys[0]->column_length);
-      return;
-    }
-  }
-
+  // --- NATIVE AGGREGATE PATH (Mixed and Standard) ---
   cudf::groupby::groupby grpby_obj(
     keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 
   std::vector<cudf::groupby::aggregation_request> requests;
   for (int agg = 0; agg < num_aggregates; agg++) {
     requests.emplace_back(cudf::groupby::aggregation_request());
+
     if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
         agg_mode[agg] == AggregationType::COUNT && aggregate_keys[agg]->column_length == 0) {
       auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
       requests[agg].aggregations.push_back(std::move(aggregate));
       uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-      cudaMemset(temp, 0, size * sizeof(uint64_t));
+      cudaMemsetAsync(temp, 0, size * sizeof(uint64_t), rmm::cuda_stream_default.value());
       auto validity_mask = createNullMask(size);
       shared_ptr<GPUColumn> temp_column =
         make_shared_ptr<GPUColumn>(size,
@@ -610,12 +315,13 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                                    reinterpret_cast<uint8_t*>(temp),
                                    validity_mask);
       requests[agg].values = temp_column->convertToCudfColumn();
+
     } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
                agg_mode[agg] == AggregationType::SUM && aggregate_keys[agg]->column_length == 0) {
       auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
       requests[agg].aggregations.push_back(std::move(aggregate));
       uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-      cudaMemset(temp, 0, size * sizeof(uint64_t));
+      cudaMemsetAsync(temp, 0, size * sizeof(uint64_t), rmm::cuda_stream_default.value());
       auto validity_mask = createNullMask(size, cudf::mask_state::ALL_NULL);
       shared_ptr<GPUColumn> temp_column =
         make_shared_ptr<GPUColumn>(size,
@@ -623,6 +329,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                                    reinterpret_cast<uint8_t*>(temp),
                                    validity_mask);
       requests[agg].values = temp_column->convertToCudfColumn();
+
     } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
                agg_mode[agg] == AggregationType::COUNT_STAR &&
                aggregate_keys[agg]->column_length != 0) {
@@ -630,7 +337,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
       requests[agg].aggregations.push_back(std::move(aggregate));
       uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
-      cudaMemset(temp, 0, size * sizeof(uint64_t));
+      cudaMemsetAsync(temp, 0, size * sizeof(uint64_t), rmm::cuda_stream_default.value());
       auto validity_mask = createNullMask(size);
       shared_ptr<GPUColumn> temp_column =
         make_shared_ptr<GPUColumn>(size,
@@ -638,6 +345,7 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                                    reinterpret_cast<uint8_t*>(temp),
                                    validity_mask);
       requests[agg].values = temp_column->convertToCudfColumn();
+
     } else if (agg_mode[agg] == AggregationType::SUM) {
       auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
       requests[agg].aggregations.push_back(std::move(aggregate));
@@ -645,15 +353,13 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
     } else if (agg_mode[agg] == AggregationType::AVERAGE) {
       auto aggregate = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
       requests[agg].aggregations.push_back(std::move(aggregate));
-      // If aggregate input column is decimal, need to convert to double following duckdb
-      // Support all DECIMAL sizes (DECIMAL32, DECIMAL64, DECIMAL128)
       if (aggregate_keys[agg]->data_wrapper.type.id() == GPUColumnTypeId::DECIMAL) {
         auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
         auto to_cudf_type          = cudf::data_type(cudf::type_id::FLOAT64);
         auto to_cudf_column        = cudf::cast(from_cudf_column_view,
-                                         to_cudf_type,
-                                         rmm::cuda_stream_default,
-                                         GPUBufferManager::GetInstance().mr);
+                                                to_cudf_type,
+                                                rmm::cuda_stream_default,
+                                                GPUBufferManager::GetInstance().mr);
         aggregate_keys[agg]->setFromCudfColumn(
           *to_cudf_column, false, nullptr, 0, gpuBufferManager);
       }
@@ -683,7 +389,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
   }
 
   auto result = grpby_obj.aggregate(requests);
-
   auto result_key = std::move(result.first);
   for (int key = 0; key < num_keys; key++) {
     cudf::column group_key = result_key->get_column(key);
@@ -692,17 +397,11 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
   for (int agg = 0; agg < num_aggregates; agg++) {
     auto agg_val = std::move(result.second[agg].results[0]);
-
-    // cudf::bitmask_type* host_mask = gpuBufferManager->customCudaHostAlloc<cudf::bitmask_type>(1);
-    // callCudaMemcpyDeviceToHost<uint8_t>(reinterpret_cast<uint8_t*>(host_mask),
-    //     reinterpret_cast<uint8_t*>(agg_val->view()->), sizeof(cudf::bitmask_type), 0);
-    // printf("host_mask: %x\n", host_mask);
-    // printf("host_mask: %b\n", host_mask);
     if (agg_mode[agg] == AggregationType::COUNT || agg_mode[agg] == AggregationType::COUNT_STAR ||
         agg_mode[agg] == AggregationType::COUNT_DISTINCT) {
       auto agg_val_view   = agg_val->view();
       auto temp_data      = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()),
-                                            agg_val_view.size());
+                                                 agg_val_view.size());
       auto validity_mask  = createNullMask(agg_val_view.size());
       aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
                                                        GPUColumnType(GPUColumnTypeId::INT64),
@@ -719,10 +418,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
 
 template void combineColumns<int32_t>(
   int32_t* a, int32_t* b, int32_t*& c, uint64_t N_a, uint64_t N_b);
-
 template void combineColumns<uint64_t>(
   uint64_t* a, uint64_t* b, uint64_t*& c, uint64_t N_a, uint64_t N_b);
-
 template void combineColumns<double>(double* a, double* b, double*& c, uint64_t N_a, uint64_t N_b);
 
 }  // namespace duckdb

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -303,7 +303,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       return;
     }
   }
-  // --- End two-phase COUNT DISTINCT optimization ---
 
   // --- Mixed aggregate: COUNT_DISTINCT + other aggregates ---
   // When some (but not all) aggregates are COUNT_DISTINCT, split into:
@@ -356,29 +355,41 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
           normal_requests[agg].aggregations.push_back(
             cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
           normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::COUNT && aggregate_keys[agg]->column_length == 0) {
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
+                   agg_mode[agg] == AggregationType::COUNT &&
+                   aggregate_keys[agg]->column_length == 0) {
           auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
           normal_requests[agg].aggregations.push_back(std::move(aggregate));
           uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size);
-          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          shared_ptr<GPUColumn> temp_column =
+            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::SUM && aggregate_keys[agg]->column_length == 0) {
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
+                   agg_mode[agg] == AggregationType::SUM &&
+                   aggregate_keys[agg]->column_length == 0) {
           auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
           normal_requests[agg].aggregations.push_back(std::move(aggregate));
           uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size, cudf::mask_state::ALL_NULL);
-          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          shared_ptr<GPUColumn> temp_column =
+            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
-        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::COUNT_STAR && aggregate_keys[agg]->column_length != 0) {
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr &&
+                   agg_mode[agg] == AggregationType::COUNT_STAR &&
+                   aggregate_keys[agg]->column_length != 0) {
           auto aggregate = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
           normal_requests[agg].aggregations.push_back(std::move(aggregate));
           uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
           cudaMemset(temp, 0, size * sizeof(uint64_t));
           auto validity_mask = createNullMask(size);
-          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          shared_ptr<GPUColumn> temp_column =
+            make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64),
+                                       reinterpret_cast<uint8_t*>(temp), validity_mask);
           normal_requests[agg].values = temp_column->convertToCudfColumn();
         } else if (agg_mode[agg] == AggregationType::SUM) {
           normal_requests[agg].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
@@ -430,10 +441,13 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
         if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) continue;
         auto agg_val = std::move(normal_result.second[agg].results[0]);
         if (agg_mode[agg] == AggregationType::COUNT || agg_mode[agg] == AggregationType::COUNT_STAR) {
-          auto agg_val_view = agg_val->view();
-          auto temp_data = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+          auto agg_val_view  = agg_val->view();
+          auto temp_data     = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
           auto validity_mask = createNullMask(agg_val_view.size());
-          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(), GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp_data), validity_mask);
+          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
+                                                           GPUColumnType(GPUColumnTypeId::INT64),
+                                                           reinterpret_cast<uint8_t*>(temp_data),
+                                                           validity_mask);
         } else {
           aggregate_keys[agg]->setFromCudfColumn(*agg_val, false, nullptr, 0, gpuBufferManager);
         }
@@ -512,7 +526,6 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
       return;
     }
   }
-  // --- End mixed aggregate optimization ---
 
   cudf::groupby::groupby grpby_obj(
     keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);

--- a/src/cuda/cudf/cudf_groupby.cu
+++ b/src/cuda/cudf/cudf_groupby.cu
@@ -19,6 +19,8 @@
 #include "gpu_buffer_manager.hpp"
 #include "log/logging.hpp"
 #include "operator/gpu_physical_grouped_aggregate.hpp"
+#include <cudf/stream_compaction.hpp>
+#include <cstdlib>
 
 namespace duckdb {
 
@@ -144,7 +146,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                   vector<shared_ptr<GPUColumn>>& aggregate_keys,
                   uint64_t num_keys,
                   uint64_t num_aggregates,
-                  AggregationType* agg_mode)
+                  AggregationType* agg_mode,
+                  idx_t estimated_output_groups)
 {
   if (keys[0]->column_length == 0) {
     SIRIUS_LOG_DEBUG("Input size is 0");
@@ -215,6 +218,303 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
   }
 
   auto keys_table = cudf::table_view(keys_cudf);
+
+  // --- Two-phase COUNT DISTINCT optimization (P1) ---
+  // When ALL aggregates are COUNT_DISTINCT, use distinct(keys+value) → count_star groupby
+  // instead of cudf's sort-based nunique. Avoids materializing sorted order.
+  {
+    int num_cd = 0;
+    for (int agg = 0; agg < num_aggregates; agg++) {
+      if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) num_cd++;
+    }
+
+    if (num_cd == num_aggregates && num_cd > 0) {
+      SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} aggregates", num_cd);
+
+      for (int agg = 0; agg < num_aggregates; agg++) {
+        auto value_view = aggregate_keys[agg]->convertToCudfColumn();
+
+        std::vector<cudf::column_view> dedup_columns;
+        for (int key = 0; key < num_keys; key++) {
+          dedup_columns.push_back(keys_cudf[key]);
+        }
+        dedup_columns.push_back(value_view);
+
+        auto dedup_table = cudf::table_view(dedup_columns);
+
+        // COUNT DISTINCT must not count NULLs — drop rows where value is NULL
+        std::unique_ptr<cudf::table> null_filtered_owner;
+        cudf::table_view effective_dedup_table = dedup_table;
+        if (value_view.nullable() && value_view.null_count() > 0) {
+          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
+          effective_dedup_table = null_filtered_owner->view();
+        }
+
+        std::vector<cudf::size_type> all_key_indices;
+        for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
+          all_key_indices.push_back(k);
+        }
+
+        auto distinct_result = cudf::distinct(
+          effective_dedup_table, all_key_indices,
+          cudf::duplicate_keep_option::KEEP_ANY,
+          cudf::null_equality::EQUAL,
+          cudf::nan_equality::ALL_EQUAL,
+          rmm::cuda_stream_default,
+          gpuBufferManager->mr);
+
+        SIRIUS_LOG_DEBUG("Two-phase COUNT DISTINCT: {} -> {} after distinct", size, distinct_result->num_rows());
+
+        std::vector<cudf::column_view> dedup_keys_views;
+        for (int key = 0; key < num_keys; key++) {
+          dedup_keys_views.push_back(distinct_result->get_column(key));
+        }
+        auto dedup_keys_table = cudf::table_view(dedup_keys_views);
+
+        cudf::groupby::groupby grpby_phase2(
+          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+
+        std::vector<cudf::groupby::aggregation_request> phase2_requests;
+        phase2_requests.emplace_back();
+        phase2_requests[0].aggregations.push_back(
+          cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
+        phase2_requests[0].values = distinct_result->get_column(num_keys);
+
+        auto phase2_result = grpby_phase2.aggregate(phase2_requests);
+
+        auto result_key = std::move(phase2_result.first);
+        for (int key = 0; key < num_keys; key++) {
+          cudf::column group_key = result_key->get_column(key);
+          keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+        }
+
+        auto agg_val      = std::move(phase2_result.second[0].results[0]);
+        auto agg_val_view = agg_val->view();
+        auto temp_data    = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+        auto validity_mask = createNullMask(agg_val_view.size());
+        aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(),
+                                                         GPUColumnType(GPUColumnTypeId::INT64),
+                                                         reinterpret_cast<uint8_t*>(temp_data),
+                                                         validity_mask);
+      }
+
+      STOP_TIMER();
+      SIRIUS_LOG_DEBUG("CUDF Groupby (two-phase COUNT DISTINCT) result count: {}", keys[0]->column_length);
+      return;
+    }
+  }
+  // --- End two-phase COUNT DISTINCT optimization ---
+
+  // --- Mixed aggregate: COUNT_DISTINCT + other aggregates ---
+  // When some (but not all) aggregates are COUNT_DISTINCT, split into:
+  //   1. Normal groupby for non-CD aggregates (with cheap placeholder for CD slots)
+  //   2. Two-phase COUNT DISTINCT for each CD aggregate
+  // Both groupbys sort output by the same keys → results are positionally aligned.
+  //
+  // Guard: skip P1b when input is large relative to expected output groups.
+  // At high rows/group the distinct step doesn't shrink data enough to justify
+  // the two-pass overhead.
+  // Tune via SIRIUS_P1B_K env var (default 1000); disable with SIRIUS_P1B_NO_GUARD=1.
+  {
+    static idx_t p1b_K = []() -> idx_t {
+      const char* env = std::getenv("SIRIUS_P1B_K");
+      return env ? std::stoull(env) : 1000ULL;
+    }();
+    static bool p1b_no_guard = []() -> bool {
+      const char* env = std::getenv("SIRIUS_P1B_NO_GUARD");
+      return env != nullptr && env[0] == '1';
+    }();
+
+    int num_cd = 0;
+    for (int agg = 0; agg < num_aggregates; agg++) {
+      if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) num_cd++;
+    }
+
+    bool skip_p1b = false;
+    if (!p1b_no_guard && num_cd > 0 && num_cd < num_aggregates && estimated_output_groups > 0) {
+      idx_t size_threshold = p1b_K * estimated_output_groups;
+      if (size > size_threshold) {
+        skip_p1b = true;
+        SIRIUS_LOG_DEBUG("P1b guard: skip (size={} > K={} * groups={} = {})",
+                         size, p1b_K, estimated_output_groups, size_threshold);
+      }
+    }
+
+    if (num_cd > 0 && num_cd < num_aggregates && !skip_p1b) {
+      SIRIUS_LOG_DEBUG("Mixed aggregate: {} COUNT_DISTINCT + {} other", num_cd, num_aggregates - num_cd);
+
+      // Step 1: Normal groupby with COUNT placeholder for CD aggregates
+      cudf::groupby::groupby grpby_normal(
+        keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+
+      std::vector<cudf::groupby::aggregation_request> normal_requests;
+      for (int agg = 0; agg < num_aggregates; agg++) {
+        normal_requests.emplace_back(cudf::groupby::aggregation_request());
+
+        if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) {
+          // Cheap placeholder — will be overwritten by two-phase result
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::COUNT && aggregate_keys[agg]->column_length == 0) {
+          auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
+          normal_requests[agg].aggregations.push_back(std::move(aggregate));
+          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
+          cudaMemset(temp, 0, size * sizeof(uint64_t));
+          auto validity_mask = createNullMask(size);
+          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          normal_requests[agg].values = temp_column->convertToCudfColumn();
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::SUM && aggregate_keys[agg]->column_length == 0) {
+          auto aggregate = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
+          normal_requests[agg].aggregations.push_back(std::move(aggregate));
+          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
+          cudaMemset(temp, 0, size * sizeof(uint64_t));
+          auto validity_mask = createNullMask(size, cudf::mask_state::ALL_NULL);
+          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          normal_requests[agg].values = temp_column->convertToCudfColumn();
+        } else if (aggregate_keys[agg]->data_wrapper.data == nullptr && agg_mode[agg] == AggregationType::COUNT_STAR && aggregate_keys[agg]->column_length != 0) {
+          auto aggregate = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
+          normal_requests[agg].aggregations.push_back(std::move(aggregate));
+          uint64_t* temp = gpuBufferManager->customCudaMalloc<uint64_t>(size, 0, 0);
+          cudaMemset(temp, 0, size * sizeof(uint64_t));
+          auto validity_mask = createNullMask(size);
+          shared_ptr<GPUColumn> temp_column = make_shared_ptr<GPUColumn>(size, GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp), validity_mask);
+          normal_requests[agg].values = temp_column->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::SUM) {
+          normal_requests[agg].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::AVERAGE) {
+          normal_requests[agg].aggregations.push_back(cudf::make_mean_aggregation<cudf::groupby_aggregation>());
+          if (aggregate_keys[agg]->data_wrapper.type.id() == GPUColumnTypeId::DECIMAL) {
+            if (aggregate_keys[agg]->data_wrapper.getColumnTypeSize() != sizeof(int64_t)) {
+              throw NotImplementedException("Only support decimal64 for decimal AVG group-by");
+            }
+            auto from_cudf_column_view = aggregate_keys[agg]->convertToCudfColumn();
+            auto to_cudf_type = cudf::data_type(cudf::type_id::FLOAT64);
+            auto to_cudf_column = cudf::cast(
+              from_cudf_column_view, to_cudf_type, rmm::cuda_stream_default, GPUBufferManager::GetInstance().mr);
+            aggregate_keys[agg]->setFromCudfColumn(*to_cudf_column, false, nullptr, 0, gpuBufferManager);
+          }
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::MIN) {
+          normal_requests[agg].aggregations.push_back(cudf::make_min_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::MAX) {
+          normal_requests[agg].aggregations.push_back(cudf::make_max_aggregation<cudf::groupby_aggregation>());
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::COUNT) {
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE));
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else if (agg_mode[agg] == AggregationType::COUNT_STAR) {
+          normal_requests[agg].aggregations.push_back(
+            cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
+          normal_requests[agg].values = aggregate_keys[agg]->convertToCudfColumn();
+        } else {
+          throw NotImplementedException("Aggregate function not supported in mixed path: %d",
+                                        static_cast<int>(agg_mode[agg]));
+        }
+      }
+
+      auto normal_result = grpby_normal.aggregate(normal_requests);
+
+      // Extract group keys
+      auto result_key = std::move(normal_result.first);
+      for (int key = 0; key < num_keys; key++) {
+        cudf::column group_key = result_key->get_column(key);
+        keys[key]->setFromCudfColumn(group_key, keys[key]->is_unique, nullptr, 0, gpuBufferManager);
+      }
+
+      // Extract non-CD aggregate results
+      for (int agg = 0; agg < num_aggregates; agg++) {
+        if (agg_mode[agg] == AggregationType::COUNT_DISTINCT) continue;
+        auto agg_val = std::move(normal_result.second[agg].results[0]);
+        if (agg_mode[agg] == AggregationType::COUNT || agg_mode[agg] == AggregationType::COUNT_STAR) {
+          auto agg_val_view = agg_val->view();
+          auto temp_data = convertInt32ToUInt64(const_cast<int32_t*>(agg_val_view.data<int32_t>()), agg_val_view.size());
+          auto validity_mask = createNullMask(agg_val_view.size());
+          aggregate_keys[agg] = make_shared_ptr<GPUColumn>(agg_val_view.size(), GPUColumnType(GPUColumnTypeId::INT64), reinterpret_cast<uint8_t*>(temp_data), validity_mask);
+        } else {
+          aggregate_keys[agg]->setFromCudfColumn(*agg_val, false, nullptr, 0, gpuBufferManager);
+        }
+      }
+
+      // Step 2: Two-phase COUNT DISTINCT for each CD aggregate
+      for (int agg = 0; agg < num_aggregates; agg++) {
+        if (agg_mode[agg] != AggregationType::COUNT_DISTINCT) continue;
+
+        // Phase 1: distinct(group_keys + value), excluding NULL values
+        std::vector<cudf::column_view> dedup_columns;
+        for (int key = 0; key < num_keys; key++) {
+          dedup_columns.push_back(keys_cudf[key]);
+        }
+        auto value_view = aggregate_keys[agg]->convertToCudfColumn();
+        dedup_columns.push_back(value_view);
+
+        auto dedup_table = cudf::table_view(dedup_columns);
+
+        // COUNT DISTINCT must not count NULLs — drop rows where value is NULL
+        std::unique_ptr<cudf::table> null_filtered_owner;
+        cudf::table_view effective_dedup_table = dedup_table;
+        if (value_view.nullable() && value_view.null_count() > 0) {
+          null_filtered_owner = cudf::drop_nulls(dedup_table, {static_cast<cudf::size_type>(num_keys)},
+                                                 rmm::cuda_stream_default, gpuBufferManager->mr);
+          effective_dedup_table = null_filtered_owner->view();
+        }
+
+        std::vector<cudf::size_type> all_key_indices;
+        for (int k = 0; k < static_cast<int>(effective_dedup_table.num_columns()); k++) {
+          all_key_indices.push_back(k);
+        }
+
+        auto distinct_result = cudf::distinct(
+          effective_dedup_table, all_key_indices,
+          cudf::duplicate_keep_option::KEEP_ANY,
+          cudf::null_equality::EQUAL,
+          cudf::nan_equality::ALL_EQUAL,
+          rmm::cuda_stream_default,
+          gpuBufferManager->mr);
+
+        SIRIUS_LOG_DEBUG("Mixed two-phase: {} -> {} after distinct", size, distinct_result->num_rows());
+
+        // Phase 2: groupby COUNT_STAR on deduplicated table
+        std::vector<cudf::column_view> dedup_keys_views;
+        for (int key = 0; key < num_keys; key++) {
+          dedup_keys_views.push_back(distinct_result->get_column(key));
+        }
+        auto dedup_keys_table = cudf::table_view(dedup_keys_views);
+
+        cudf::groupby::groupby grpby_phase2(
+          dedup_keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+
+        std::vector<cudf::groupby::aggregation_request> phase2_requests;
+        phase2_requests.emplace_back();
+        phase2_requests[0].aggregations.push_back(
+          cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
+        phase2_requests[0].values = distinct_result->get_column(num_keys);
+
+        auto phase2_result = grpby_phase2.aggregate(phase2_requests);
+
+        // Both the normal groupby (step 1) and this phase2 groupby sort their output by the
+        // same key columns and operate on the same key domain, so results are positionally
+        // aligned — no join needed.
+        auto cd_count_col  = std::move(phase2_result.second[0].results[0]);
+        auto cd_view       = cd_count_col->view();
+        auto temp_data     = convertInt32ToUInt64(const_cast<int32_t*>(cd_view.data<int32_t>()), cd_view.size());
+        auto validity_mask = createNullMask(cd_view.size());
+        aggregate_keys[agg] = make_shared_ptr<GPUColumn>(
+          cd_view.size(), GPUColumnType(GPUColumnTypeId::INT64),
+          reinterpret_cast<uint8_t*>(temp_data), validity_mask);
+      }
+
+      STOP_TIMER();
+      SIRIUS_LOG_DEBUG("CUDF Groupby (mixed COUNT DISTINCT) result count: {}", keys[0]->column_length);
+      return;
+    }
+  }
+  // --- End mixed aggregate optimization ---
+
   cudf::groupby::groupby grpby_obj(
     keys_table, has_nullable_key ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
 

--- a/src/cuda/cudf/cudf_orderby.cu
+++ b/src/cuda/cudf/cudf_orderby.cu
@@ -1069,20 +1069,7 @@ void cudf_orderby(vector<shared_ptr<GPUColumn>>& keys,
 
   auto keys_table = cudf::table_view(columns_cudf);
 
-  cudaEvent_t sort_start, sort_stop;
-  cudaEventCreate(&sort_start);
-  cudaEventCreate(&sort_stop);
-  cudaEventRecord(sort_start, 0);
-  cudaEventSynchronize(sort_start);
   auto sorted_order = cudf::sorted_order(keys_table, orders, null_orders);
-  cudaEventRecord(sort_stop, 0);
-  cudaEventSynchronize(sort_stop);
-  float sort_ms = 0;
-  cudaEventElapsedTime(&sort_ms, sort_start, sort_stop);
-  SIRIUS_LOG_INFO("[INVESTIGATE] cudf::sorted_order: {:.3f} ms, {} rows, {} key col(s)",
-                  sort_ms, (long long)keys_table.num_rows(), (int)columns_cudf.size());
-  cudaEventDestroy(sort_start);
-  cudaEventDestroy(sort_stop);
 
   auto sorted_order_view = sorted_order->view();
 

--- a/src/cuda/cudf/cudf_orderby.cu
+++ b/src/cuda/cudf/cudf_orderby.cu
@@ -1067,8 +1067,23 @@ void cudf_orderby(vector<shared_ptr<GPUColumn>>& keys,
     }
   }
 
-  auto keys_table        = cudf::table_view(columns_cudf);
-  auto sorted_order      = cudf::sorted_order(keys_table, orders, null_orders);
+  auto keys_table = cudf::table_view(columns_cudf);
+
+  cudaEvent_t sort_start, sort_stop;
+  cudaEventCreate(&sort_start);
+  cudaEventCreate(&sort_stop);
+  cudaEventRecord(sort_start, 0);
+  cudaEventSynchronize(sort_start);
+  auto sorted_order = cudf::sorted_order(keys_table, orders, null_orders);
+  cudaEventRecord(sort_stop, 0);
+  cudaEventSynchronize(sort_stop);
+  float sort_ms = 0;
+  cudaEventElapsedTime(&sort_ms, sort_start, sort_stop);
+  SIRIUS_LOG_INFO("[INVESTIGATE] cudf::sorted_order: {:.3f} ms, {} rows, {} key col(s)",
+                  sort_ms, (long long)keys_table.num_rows(), (int)columns_cudf.size());
+  cudaEventDestroy(sort_start);
+  cudaEventDestroy(sort_stop);
+
   auto sorted_order_view = sorted_order->view();
 
   std::vector<cudf::column_view> projection_cudf;

--- a/src/cuda/operator/empty_str_check.cu
+++ b/src/cuda/operator/empty_str_check.cu
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator/empty_str_check.cuh"
+#include <cstdint>
+#include <rmm/device_uvector.hpp>
+#include <cudf/column/column.hpp>
+
+namespace duckdb {
+namespace sirius {
+
+static constexpr int BLOCK_SIZE = 256;
+
+__global__ void empty_str_check_kernel(const uint64_t* __restrict__ offsets,
+                                       bool* __restrict__ output,
+                                       size_t num_rows) {
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < num_rows) {
+        output[tid] = (offsets[tid + 1] - offsets[tid]) > 0;
+    }
+}
+
+__global__ void empty_str_check_with_rowids_kernel(const uint64_t* __restrict__ offsets,
+                                                    const uint64_t* __restrict__ row_ids,
+                                                    bool* __restrict__ output,
+                                                    size_t num_rows) {
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < num_rows) {
+        uint64_t rid = row_ids[tid];
+        output[tid] = (offsets[rid + 1] - offsets[rid]) > 0;
+    }
+}
+
+std::unique_ptr<cudf::column> EmptyStrCheck(const uint64_t* offsets,
+                                             const uint64_t* row_ids,
+                                             size_t num_rows,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr) {
+    rmm::device_uvector<bool> output(num_rows, stream, mr);
+
+    if (num_rows > 0) {
+        int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        if (row_ids != nullptr) {
+            empty_str_check_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+                offsets, row_ids, output.data(), num_rows);
+        } else {
+            empty_str_check_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+                offsets, output.data(), num_rows);
+        }
+    }
+
+    return std::make_unique<cudf::column>(std::move(output),
+                                          rmm::device_buffer(0, stream, mr),
+                                          0);
+}
+
+} // namespace sirius
+} // namespace duckdb

--- a/src/cuda/operator/empty_str_check.cu
+++ b/src/cuda/operator/empty_str_check.cu
@@ -15,9 +15,12 @@
  */
 
 #include "operator/empty_str_check.cuh"
-#include <cstdint>
-#include <rmm/device_uvector.hpp>
+
 #include <cudf/column/column.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cstdint>
 
 namespace duckdb {
 namespace sirius {
@@ -26,46 +29,45 @@ static constexpr int BLOCK_SIZE = 256;
 
 __global__ void empty_str_check_kernel(const uint64_t* __restrict__ offsets,
                                        bool* __restrict__ output,
-                                       size_t num_rows) {
-    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < num_rows) {
-        output[tid] = (offsets[tid + 1] - offsets[tid]) > 0;
-    }
+                                       size_t num_rows)
+{
+  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < num_rows) { output[tid] = (offsets[tid + 1] - offsets[tid]) > 0; }
 }
 
 __global__ void empty_str_check_with_rowids_kernel(const uint64_t* __restrict__ offsets,
-                                                    const uint64_t* __restrict__ row_ids,
-                                                    bool* __restrict__ output,
-                                                    size_t num_rows) {
-    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < num_rows) {
-        uint64_t rid = row_ids[tid];
-        output[tid] = (offsets[rid + 1] - offsets[rid]) > 0;
-    }
+                                                   const uint64_t* __restrict__ row_ids,
+                                                   bool* __restrict__ output,
+                                                   size_t num_rows)
+{
+  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < num_rows) {
+    uint64_t rid = row_ids[tid];
+    output[tid]  = (offsets[rid + 1] - offsets[rid]) > 0;
+  }
 }
 
 std::unique_ptr<cudf::column> EmptyStrCheck(const uint64_t* offsets,
-                                             const uint64_t* row_ids,
-                                             size_t num_rows,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::device_async_resource_ref mr) {
-    rmm::device_uvector<bool> output(num_rows, stream, mr);
+                                            const uint64_t* row_ids,
+                                            size_t num_rows,
+                                            rmm::cuda_stream_view stream,
+                                            rmm::device_async_resource_ref mr)
+{
+  rmm::device_uvector<bool> output(num_rows, stream, mr);
 
-    if (num_rows > 0) {
-        int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        if (row_ids != nullptr) {
-            empty_str_check_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
-                offsets, row_ids, output.data(), num_rows);
-        } else {
-            empty_str_check_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
-                offsets, output.data(), num_rows);
-        }
+  if (num_rows > 0) {
+    int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    if (row_ids != nullptr) {
+      empty_str_check_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+        offsets, row_ids, output.data(), num_rows);
+    } else {
+      empty_str_check_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+        offsets, output.data(), num_rows);
     }
+  }
 
-    return std::make_unique<cudf::column>(std::move(output),
-                                          rmm::device_buffer(0, stream, mr),
-                                          0);
+  return std::make_unique<cudf::column>(std::move(output), rmm::device_buffer(0, stream, mr), 0);
 }
 
-} // namespace sirius
-} // namespace duckdb
+}  // namespace sirius
+}  // namespace duckdb

--- a/src/cuda/operator/strlen_from_offsets.cu
+++ b/src/cuda/operator/strlen_from_offsets.cu
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator/strlen_from_offsets.cuh"
+#include <cstdint>
+#include <rmm/device_uvector.hpp>
+#include <cudf/column/column.hpp>
+
+namespace duckdb {
+namespace sirius {
+
+static constexpr int BLOCK_SIZE = 256;
+
+__global__ void strlen_from_offsets_kernel(const uint64_t* __restrict__ offsets,
+                                           int32_t* __restrict__ output,
+                                           size_t num_rows) {
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < num_rows) {
+        output[tid] = static_cast<int32_t>(offsets[tid + 1] - offsets[tid]);
+    }
+}
+
+__global__ void strlen_from_offsets_with_rowids_kernel(const uint64_t* __restrict__ offsets,
+                                                       const uint64_t* __restrict__ row_ids,
+                                                       int32_t* __restrict__ output,
+                                                       size_t num_rows) {
+    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < num_rows) {
+        uint64_t rid = row_ids[tid];
+        output[tid] = static_cast<int32_t>(offsets[rid + 1] - offsets[rid]);
+    }
+}
+
+std::unique_ptr<cudf::column> StrlenFromOffsets(const uint64_t* offsets,
+                                                 const uint64_t* row_ids,
+                                                 size_t num_rows,
+                                                 rmm::cuda_stream_view stream,
+                                                 rmm::device_async_resource_ref mr) {
+    rmm::device_uvector<int32_t> output(num_rows, stream, mr);
+
+    if (num_rows > 0) {
+        int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        if (row_ids != nullptr) {
+            strlen_from_offsets_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+                offsets, row_ids, output.data(), num_rows);
+        } else {
+            strlen_from_offsets_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+                offsets, output.data(), num_rows);
+        }
+    }
+
+    return std::make_unique<cudf::column>(std::move(output),
+                                          rmm::device_buffer(0, stream, mr),
+                                          0);
+}
+
+} // namespace sirius
+} // namespace duckdb

--- a/src/cuda/operator/strlen_from_offsets.cu
+++ b/src/cuda/operator/strlen_from_offsets.cu
@@ -15,9 +15,12 @@
  */
 
 #include "operator/strlen_from_offsets.cuh"
-#include <cstdint>
-#include <rmm/device_uvector.hpp>
+
 #include <cudf/column/column.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cstdint>
 
 namespace duckdb {
 namespace sirius {
@@ -26,46 +29,45 @@ static constexpr int BLOCK_SIZE = 256;
 
 __global__ void strlen_from_offsets_kernel(const uint64_t* __restrict__ offsets,
                                            int32_t* __restrict__ output,
-                                           size_t num_rows) {
-    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < num_rows) {
-        output[tid] = static_cast<int32_t>(offsets[tid + 1] - offsets[tid]);
-    }
+                                           size_t num_rows)
+{
+  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < num_rows) { output[tid] = static_cast<int32_t>(offsets[tid + 1] - offsets[tid]); }
 }
 
 __global__ void strlen_from_offsets_with_rowids_kernel(const uint64_t* __restrict__ offsets,
                                                        const uint64_t* __restrict__ row_ids,
                                                        int32_t* __restrict__ output,
-                                                       size_t num_rows) {
-    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < num_rows) {
-        uint64_t rid = row_ids[tid];
-        output[tid] = static_cast<int32_t>(offsets[rid + 1] - offsets[rid]);
-    }
+                                                       size_t num_rows)
+{
+  size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < num_rows) {
+    uint64_t rid = row_ids[tid];
+    output[tid]  = static_cast<int32_t>(offsets[rid + 1] - offsets[rid]);
+  }
 }
 
 std::unique_ptr<cudf::column> StrlenFromOffsets(const uint64_t* offsets,
-                                                 const uint64_t* row_ids,
-                                                 size_t num_rows,
-                                                 rmm::cuda_stream_view stream,
-                                                 rmm::device_async_resource_ref mr) {
-    rmm::device_uvector<int32_t> output(num_rows, stream, mr);
+                                                const uint64_t* row_ids,
+                                                size_t num_rows,
+                                                rmm::cuda_stream_view stream,
+                                                rmm::device_async_resource_ref mr)
+{
+  rmm::device_uvector<int32_t> output(num_rows, stream, mr);
 
-    if (num_rows > 0) {
-        int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
-        if (row_ids != nullptr) {
-            strlen_from_offsets_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
-                offsets, row_ids, output.data(), num_rows);
-        } else {
-            strlen_from_offsets_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
-                offsets, output.data(), num_rows);
-        }
+  if (num_rows > 0) {
+    int num_blocks = (num_rows + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    if (row_ids != nullptr) {
+      strlen_from_offsets_with_rowids_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+        offsets, row_ids, output.data(), num_rows);
+    } else {
+      strlen_from_offsets_kernel<<<num_blocks, BLOCK_SIZE, 0, stream.value()>>>(
+        offsets, output.data(), num_rows);
     }
+  }
 
-    return std::make_unique<cudf::column>(std::move(output),
-                                          rmm::device_buffer(0, stream, mr),
-                                          0);
+  return std::make_unique<cudf::column>(std::move(output), rmm::device_buffer(0, stream, mr), 0);
 }
 
-} // namespace sirius
-} // namespace duckdb
+}  // namespace sirius
+}  // namespace duckdb

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -324,7 +324,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundComparis
         right_val.GetValue<std::string>().empty()) {
       auto& ref = expr.left->Cast<BoundReferenceExpression>();
       auto& col = input_columns[ref.index];
-      if (col->data_wrapper.is_string_data && col->data_wrapper.offset != nullptr) {
+      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR && col->data_wrapper.offset != nullptr) {
         size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
         return sirius::EmptyStrCheck(col->data_wrapper.offset,
                                     col->row_ids,

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -314,23 +314,19 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundComparis
   // P5: empty-string check via offsets on the old gpu_processing path.
   // Rewrites (varchar_col <> '') to offset-based non-empty check, avoiding
   // string char buffer materialization entirely.
-  if (!use_data_batch_apis &&
-      expr.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL &&
+  if (!use_data_batch_apis && expr.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL &&
       expr.left->type == ExpressionType::BOUND_REF &&
       expr.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
     auto& right_val = expr.right->Cast<BoundConstantExpression>().value;
-    if (right_val.type().id() == LogicalTypeId::VARCHAR &&
-        !right_val.IsNull() &&
+    if (right_val.type().id() == LogicalTypeId::VARCHAR && !right_val.IsNull() &&
         right_val.GetValue<std::string>().empty()) {
       auto& ref = expr.left->Cast<BoundReferenceExpression>();
       auto& col = input_columns[ref.index];
-      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR && col->data_wrapper.offset != nullptr) {
+      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR &&
+          col->data_wrapper.offset != nullptr) {
         size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
-        return sirius::EmptyStrCheck(col->data_wrapper.offset,
-                                    col->row_ids,
-                                    num_rows,
-                                    execution_stream,
-                                    resource_ref);
+        return sirius::EmptyStrCheck(
+          col->data_wrapper.offset, col->row_ids, num_rows, execution_stream, resource_ref);
       }
     }
   }

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -16,8 +16,11 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "expression_executor/gpu_expression_executor_state.hpp"
+#include "operator/empty_str_check.cuh"
 
 #include <cudf/binaryop.hpp>
 #include <cudf/scalar/scalar.hpp>
@@ -307,6 +310,30 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundComparis
                                                              GpuExpressionState* state)
 {
   auto return_type = GetCudfType(expr.return_type);
+
+  // P5: empty-string check via offsets on the old gpu_processing path.
+  // Rewrites (varchar_col <> '') to offset-based non-empty check, avoiding
+  // string char buffer materialization entirely.
+  if (!use_data_batch_apis &&
+      expr.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL &&
+      expr.left->type == ExpressionType::BOUND_REF &&
+      expr.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+    auto& right_val = expr.right->Cast<BoundConstantExpression>().value;
+    if (right_val.type().id() == LogicalTypeId::VARCHAR &&
+        !right_val.IsNull() &&
+        right_val.GetValue<std::string>().empty()) {
+      auto& ref = expr.left->Cast<BoundReferenceExpression>();
+      auto& col = input_columns[ref.index];
+      if (col->data_wrapper.is_string_data && col->data_wrapper.offset != nullptr) {
+        size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
+        return sirius::EmptyStrCheck(col->data_wrapper.offset,
+                                    col->row_ids,
+                                    num_rows,
+                                    execution_stream,
+                                    resource_ref);
+      }
+    }
+  }
 
   // Execute the comparison
   switch (expr.GetExpressionType()) {

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -743,7 +743,7 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
     if (!use_data_batch_apis && expr.children[0]->type == ExpressionType::BOUND_REF) {
       auto& ref = expr.children[0]->Cast<BoundReferenceExpression>();
       auto& col = input_columns[ref.index];
-      if (col->data_wrapper.is_string_data && col->data_wrapper.offset != nullptr) {
+      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR && col->data_wrapper.offset != nullptr) {
         size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
         return sirius::StrlenFromOffsets(col->data_wrapper.offset,
                                         col->row_ids,

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -19,11 +19,13 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_dispatcher.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "expression_executor/gpu_expression_executor_state.hpp"
 #include "expression_executor/regex/regex_playground.hpp"
 #include "operator/gpu_physical_strings_matching.hpp"
+#include "operator/strlen_from_offsets.cuh"
 
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
@@ -736,6 +738,20 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
 
   //----------Unary Functions----------//
   else if (func_str == STRLEN_FUNC_STR) {
+    // P3: compute STRLEN directly from offsets when on the old gpu_processing path.
+    // Avoids materializing the string chars buffer entirely.
+    if (!use_data_batch_apis && expr.children[0]->type == ExpressionType::BOUND_REF) {
+      auto& ref = expr.children[0]->Cast<BoundReferenceExpression>();
+      auto& col = input_columns[ref.index];
+      if (col->data_wrapper.is_string_data && col->data_wrapper.offset != nullptr) {
+        size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
+        return sirius::StrlenFromOffsets(col->data_wrapper.offset,
+                                        col->row_ids,
+                                        num_rows,
+                                        execution_stream,
+                                        resource_ref);
+      }
+    }
     UnaryFunctionDispatcher<UnaryFunctionType::STRLEN> dispatcher(*this);
     return dispatcher(expr, state);
   } else if (func_str == LENGTH_FUNC_STR) {

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -743,13 +743,11 @@ std::unique_ptr<cudf::column> GpuExpressionExecutor::Execute(const BoundFunction
     if (!use_data_batch_apis && expr.children[0]->type == ExpressionType::BOUND_REF) {
       auto& ref = expr.children[0]->Cast<BoundReferenceExpression>();
       auto& col = input_columns[ref.index];
-      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR && col->data_wrapper.offset != nullptr) {
+      if (col->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR &&
+          col->data_wrapper.offset != nullptr) {
         size_t num_rows = col->row_ids != nullptr ? col->row_id_count : col->column_length;
-        return sirius::StrlenFromOffsets(col->data_wrapper.offset,
-                                        col->row_ids,
-                                        num_rows,
-                                        execution_stream,
-                                        resource_ref);
+        return sirius::StrlenFromOffsets(
+          col->data_wrapper.offset, col->row_ids, num_rows, execution_stream, resource_ref);
       }
     }
     UnaryFunctionDispatcher<UnaryFunctionType::STRLEN> dispatcher(*this);

--- a/src/include/operator/empty_str_check.cuh
+++ b/src/include/operator/empty_str_check.cuh
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <memory>
+#include <cudf/column/column.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace duckdb {
+namespace sirius {
+
+// Returns a BOOL8 column where result[i] = true iff the string at position i is non-empty.
+// Computed via offset arithmetic: result[i] = (offsets[i+1] - offsets[i]) > 0.
+// Equivalent to (col <> '') but avoids materializing the string chars buffer.
+std::unique_ptr<cudf::column> EmptyStrCheck(const uint64_t* offsets,
+                                             const uint64_t* row_ids,
+                                             size_t num_rows,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr);
+
+} // namespace sirius
+} // namespace duckdb

--- a/src/include/operator/empty_str_check.cuh
+++ b/src/include/operator/empty_str_check.cuh
@@ -16,12 +16,14 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
-#include <memory>
 #include <cudf/column/column.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 
 namespace duckdb {
 namespace sirius {
@@ -30,10 +32,10 @@ namespace sirius {
 // Computed via offset arithmetic: result[i] = (offsets[i+1] - offsets[i]) > 0.
 // Equivalent to (col <> '') but avoids materializing the string chars buffer.
 std::unique_ptr<cudf::column> EmptyStrCheck(const uint64_t* offsets,
-                                             const uint64_t* row_ids,
-                                             size_t num_rows,
-                                             rmm::cuda_stream_view stream,
-                                             rmm::device_async_resource_ref mr);
+                                            const uint64_t* row_ids,
+                                            size_t num_rows,
+                                            rmm::cuda_stream_view stream,
+                                            rmm::device_async_resource_ref mr);
 
-} // namespace sirius
-} // namespace duckdb
+}  // namespace sirius
+}  // namespace duckdb

--- a/src/include/operator/gpu_physical_grouped_aggregate.hpp
+++ b/src/include/operator/gpu_physical_grouped_aggregate.hpp
@@ -33,7 +33,8 @@ void cudf_groupby(vector<shared_ptr<GPUColumn>>& keys,
                   vector<shared_ptr<GPUColumn>>& aggregate_keys,
                   uint64_t num_keys,
                   uint64_t num_aggregates,
-                  AggregationType* agg_mode);
+                  AggregationType* agg_mode,
+                  idx_t estimated_output_groups = 0);
 
 void cudf_duplicate_elimination(vector<shared_ptr<GPUColumn>>& keys, uint64_t num_keys);
 

--- a/src/include/operator/strlen_from_offsets.cuh
+++ b/src/include/operator/strlen_from_offsets.cuh
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <memory>
+#include <cudf/column/column.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace duckdb {
+namespace sirius {
+
+std::unique_ptr<cudf::column> StrlenFromOffsets(const uint64_t* offsets,
+                                                 const uint64_t* row_ids,
+                                                 size_t num_rows,
+                                                 rmm::cuda_stream_view stream,
+                                                 rmm::device_async_resource_ref mr);
+
+} // namespace sirius
+} // namespace duckdb

--- a/src/include/operator/strlen_from_offsets.cuh
+++ b/src/include/operator/strlen_from_offsets.cuh
@@ -26,6 +26,9 @@
 namespace duckdb {
 namespace sirius {
 
+// Returns an INT32 column where result[i] = length in bytes of the string at position i.
+// Computed via offset arithmetic: result[i] = offsets[i+1] - offsets[i].
+// Equivalent to LENGTH(col) but avoids materializing the string chars buffer.
 std::unique_ptr<cudf::column> StrlenFromOffsets(const uint64_t* offsets,
                                                  const uint64_t* row_ids,
                                                  size_t num_rows,

--- a/src/include/operator/strlen_from_offsets.cuh
+++ b/src/include/operator/strlen_from_offsets.cuh
@@ -16,12 +16,14 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
-#include <memory>
 #include <cudf/column/column.hpp>
+
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 
 namespace duckdb {
 namespace sirius {
@@ -30,10 +32,10 @@ namespace sirius {
 // Computed via offset arithmetic: result[i] = offsets[i+1] - offsets[i].
 // Equivalent to LENGTH(col) but avoids materializing the string chars buffer.
 std::unique_ptr<cudf::column> StrlenFromOffsets(const uint64_t* offsets,
-                                                 const uint64_t* row_ids,
-                                                 size_t num_rows,
-                                                 rmm::cuda_stream_view stream,
-                                                 rmm::device_async_resource_ref mr);
+                                                const uint64_t* row_ids,
+                                                size_t num_rows,
+                                                rmm::cuda_stream_view stream,
+                                                rmm::device_async_resource_ref mr);
 
-} // namespace sirius
-} // namespace duckdb
+}  // namespace sirius
+}  // namespace duckdb

--- a/src/operator/gpu_physical_grouped_aggregate.cpp
+++ b/src/operator/gpu_physical_grouped_aggregate.cpp
@@ -186,7 +186,12 @@ void HandleGroupByAggregateCuDF(vector<shared_ptr<GPUColumn>>& group_by_keys,
     }
   }
 
-  cudf_groupby(group_by_keys, aggregate_keys, num_group_keys, aggregates.size(), agg_mode, estimated_output_groups);
+  cudf_groupby(group_by_keys,
+               aggregate_keys,
+               num_group_keys,
+               aggregates.size(),
+               agg_mode,
+               estimated_output_groups);
 }
 
 void HandleDistinctGroupByCuDF(vector<shared_ptr<GPUColumn>>& group_by_keys,
@@ -477,9 +482,12 @@ SinkResultType GPUPhysicalGroupedAggregate::Sink(GPUIntermediateRelation& input_
         throw NotImplementedException(
           "Group by column length or aggregate column length is too large for CuDF");
       } else {
-        HandleGroupByAggregateCuDF(
-          group_by_column, aggregate_column, gpuBufferManager, aggregates, num_group_keys,
-          estimated_cardinality);
+        HandleGroupByAggregateCuDF(group_by_column,
+                                   aggregate_column,
+                                   gpuBufferManager,
+                                   aggregates,
+                                   num_group_keys,
+                                   estimated_cardinality);
       }
     }
   }

--- a/src/operator/gpu_physical_grouped_aggregate.cpp
+++ b/src/operator/gpu_physical_grouped_aggregate.cpp
@@ -113,7 +113,8 @@ void HandleGroupByAggregateCuDF(vector<shared_ptr<GPUColumn>>& group_by_keys,
                                 vector<shared_ptr<GPUColumn>>& aggregate_keys,
                                 GPUBufferManager* gpuBufferManager,
                                 const vector<unique_ptr<Expression>>& aggregates,
-                                int num_group_keys)
+                                int num_group_keys,
+                                idx_t estimated_output_groups)
 {
   AggregationType* agg_mode =
     gpuBufferManager->customCudaHostAlloc<AggregationType>(aggregates.size());
@@ -185,7 +186,7 @@ void HandleGroupByAggregateCuDF(vector<shared_ptr<GPUColumn>>& group_by_keys,
     }
   }
 
-  cudf_groupby(group_by_keys, aggregate_keys, num_group_keys, aggregates.size(), agg_mode);
+  cudf_groupby(group_by_keys, aggregate_keys, num_group_keys, aggregates.size(), agg_mode, estimated_output_groups);
 }
 
 void HandleDistinctGroupByCuDF(vector<shared_ptr<GPUColumn>>& group_by_keys,
@@ -477,7 +478,8 @@ SinkResultType GPUPhysicalGroupedAggregate::Sink(GPUIntermediateRelation& input_
           "Group by column length or aggregate column length is too large for CuDF");
       } else {
         HandleGroupByAggregateCuDF(
-          group_by_column, aggregate_column, gpuBufferManager, aggregates, num_group_keys);
+          group_by_column, aggregate_column, gpuBufferManager, aggregates, num_group_keys,
+          estimated_cardinality);
       }
     }
   }

--- a/src/operator/gpu_physical_limit.cpp
+++ b/src/operator/gpu_physical_limit.cpp
@@ -36,47 +36,90 @@ GPUPhysicalStreamingLimit::GPUPhysicalStreamingLimit(vector<LogicalType> types,
 {
 }
 
+// Returns element size in bytes for fixed-width GPU column types.
+static size_t GetElementSizeBytes(const GPUColumnType& col_type)
+{
+  switch (col_type.id()) {
+    case GPUColumnTypeId::BOOLEAN:      return sizeof(uint8_t);
+    case GPUColumnTypeId::INT16:        return sizeof(int16_t);
+    case GPUColumnTypeId::INT32:
+    case GPUColumnTypeId::DATE:
+    case GPUColumnTypeId::FLOAT32:      return sizeof(int32_t);
+    case GPUColumnTypeId::INT64:
+    case GPUColumnTypeId::FLOAT64:
+    case GPUColumnTypeId::TIMESTAMP_SEC:
+    case GPUColumnTypeId::TIMESTAMP_MS:
+    case GPUColumnTypeId::TIMESTAMP_US:
+    case GPUColumnTypeId::TIMESTAMP_NS: return sizeof(int64_t);
+    case GPUColumnTypeId::INT128:       return sizeof(__int128_t);
+    case GPUColumnTypeId::DECIMAL: {
+      auto* info = col_type.GetDecimalTypeInfo();
+      return info ? info->GetDecimalTypeSize() : sizeof(int64_t);
+    }
+    default: return 0;
+  }
+}
+
 OperatorResultType GPUPhysicalStreamingLimit::Execute(
   GPUIntermediateRelation& input_relation, GPUIntermediateRelation& output_relation) const
 {
   SIRIUS_LOG_DEBUG("Executing streaming limit");
-  // SIRIUS_LOG_DEBUG("limit type: {}", limit_val.Type());
   SIRIUS_LOG_DEBUG("Limit value {}", limit_val.GetConstantValue());
   if (limit_val.Type() != LimitNodeType::CONSTANT_VALUE) {
     throw NotImplementedException("Streaming limit other than constant value not implemented");
   }
   auto limit_const = limit_val.GetConstantValue();
-  // SIRIUS_LOG_DEBUG("Offset value {}", offset_val.GetConstantValue());
-  // auto offset_const = offset_val.GetConstantValue();
-  // if (offset_const > 0) {
-  //   throw NotImplementedException("Streaming limit with offset not implemented");
-  // }
+
+  idx_t offset_const = 0;
+  if (offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+    offset_const = offset_val.GetConstantValue();
+  }
+
   GPUBufferManager* gpuBufferManager = &(GPUBufferManager::GetInstance());
   for (int col_idx = 0; col_idx < output_relation.columns.size(); col_idx++) {
     shared_ptr<GPUColumn> materialize_column =
       HandleMaterializeExpression(input_relation.columns[col_idx], gpuBufferManager);
 
-    limit_const = std::min(limit_const, materialize_column->column_length);
+    idx_t col_len = materialize_column->column_length;
+    idx_t skip    = std::min(offset_const, col_len);
+    idx_t take    = std::min(limit_const, col_len - skip);
+
+    uint8_t*  new_data   = materialize_column->data_wrapper.data;
+    uint64_t* new_offset = materialize_column->data_wrapper.offset;
+
+    if (skip > 0) {
+      auto type_id = materialize_column->data_wrapper.type.id();
+      if (type_id == GPUColumnTypeId::VARCHAR) {
+        // Offsets are absolute char positions; shift pointer so new_offset[0] = offset[skip].
+        // The char data pointer stays at base — downstream reads data[new_offset[i]] correctly.
+        new_offset = materialize_column->data_wrapper.offset + skip;
+      } else {
+        size_t elem_size = GetElementSizeBytes(materialize_column->data_wrapper.type);
+        new_data = materialize_column->data_wrapper.data + skip * elem_size;
+      }
+    }
+
     output_relation.columns[col_idx] =
-      make_shared_ptr<GPUColumn>(limit_const,
+      make_shared_ptr<GPUColumn>(take,
                                  materialize_column->data_wrapper.type,
-                                 materialize_column->data_wrapper.data,
-                                 materialize_column->data_wrapper.offset,
+                                 new_data,
+                                 new_offset,
                                  materialize_column->data_wrapper.num_bytes,
                                  materialize_column->data_wrapper.is_string_data,
                                  materialize_column->data_wrapper.validity_mask);
     output_relation.columns[col_idx]->is_unique = materialize_column->is_unique;
-    if (limit_const > 0 &&
+
+    // For VARCHAR: read new_offset[take] = offset[skip+take] as the absolute end char position.
+    if (take > 0 &&
         output_relation.columns[col_idx]->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR) {
       Allocator& allocator = Allocator::DefaultAllocator();
-      uint64_t* new_num_bytes =
+      uint64_t* end_pos =
         reinterpret_cast<uint64_t*>(allocator.AllocateData(sizeof(uint64_t)));
-      callCudaMemcpyDeviceToHost<uint64_t>(
-        new_num_bytes, materialize_column->data_wrapper.offset + limit_const, 1, 0);
-      output_relation.columns[col_idx]->data_wrapper.num_bytes = new_num_bytes[0];
+      callCudaMemcpyDeviceToHost<uint64_t>(end_pos, new_offset + take, 1, 0);
+      output_relation.columns[col_idx]->data_wrapper.num_bytes = end_pos[0];
     }
-    SIRIUS_LOG_DEBUG(
-      "Column {} has {} rows", col_idx, output_relation.columns[col_idx]->column_length);
+    SIRIUS_LOG_DEBUG("Column {} has {} rows (offset={}, take={})",
+                     col_idx, output_relation.columns[col_idx]->column_length, skip, take);
   }
 
   return OperatorResultType::FINISHED;

--- a/src/operator/gpu_physical_limit.cpp
+++ b/src/operator/gpu_physical_limit.cpp
@@ -40,18 +40,18 @@ GPUPhysicalStreamingLimit::GPUPhysicalStreamingLimit(vector<LogicalType> types,
 static size_t GetElementSizeBytes(const GPUColumnType& col_type)
 {
   switch (col_type.id()) {
-    case GPUColumnTypeId::BOOLEAN:      return sizeof(uint8_t);
-    case GPUColumnTypeId::INT16:        return sizeof(int16_t);
+    case GPUColumnTypeId::BOOLEAN: return sizeof(uint8_t);
+    case GPUColumnTypeId::INT16: return sizeof(int16_t);
     case GPUColumnTypeId::INT32:
     case GPUColumnTypeId::DATE:
-    case GPUColumnTypeId::FLOAT32:      return sizeof(int32_t);
+    case GPUColumnTypeId::FLOAT32: return sizeof(int32_t);
     case GPUColumnTypeId::INT64:
     case GPUColumnTypeId::FLOAT64:
     case GPUColumnTypeId::TIMESTAMP_SEC:
     case GPUColumnTypeId::TIMESTAMP_MS:
     case GPUColumnTypeId::TIMESTAMP_US:
     case GPUColumnTypeId::TIMESTAMP_NS: return sizeof(int64_t);
-    case GPUColumnTypeId::INT128:       return sizeof(__int128_t);
+    case GPUColumnTypeId::INT128: return sizeof(__int128_t);
     case GPUColumnTypeId::DECIMAL: {
       auto* info = col_type.GetDecimalTypeInfo();
       return info ? info->GetDecimalTypeSize() : sizeof(int64_t);
@@ -84,7 +84,7 @@ OperatorResultType GPUPhysicalStreamingLimit::Execute(
     idx_t skip    = std::min(offset_const, col_len);
     idx_t take    = std::min(limit_const, col_len - skip);
 
-    uint8_t*  new_data   = materialize_column->data_wrapper.data;
+    uint8_t* new_data    = materialize_column->data_wrapper.data;
     uint64_t* new_offset = materialize_column->data_wrapper.offset;
 
     if (skip > 0) {
@@ -95,7 +95,7 @@ OperatorResultType GPUPhysicalStreamingLimit::Execute(
         new_offset = materialize_column->data_wrapper.offset + skip;
       } else {
         size_t elem_size = GetElementSizeBytes(materialize_column->data_wrapper.type);
-        new_data = materialize_column->data_wrapper.data + skip * elem_size;
+        new_data         = materialize_column->data_wrapper.data + skip * elem_size;
       }
     }
 
@@ -113,13 +113,15 @@ OperatorResultType GPUPhysicalStreamingLimit::Execute(
     if (take > 0 &&
         output_relation.columns[col_idx]->data_wrapper.type.id() == GPUColumnTypeId::VARCHAR) {
       Allocator& allocator = Allocator::DefaultAllocator();
-      uint64_t* end_pos =
-        reinterpret_cast<uint64_t*>(allocator.AllocateData(sizeof(uint64_t)));
+      uint64_t* end_pos    = reinterpret_cast<uint64_t*>(allocator.AllocateData(sizeof(uint64_t)));
       callCudaMemcpyDeviceToHost<uint64_t>(end_pos, new_offset + take, 1, 0);
       output_relation.columns[col_idx]->data_wrapper.num_bytes = end_pos[0];
     }
     SIRIUS_LOG_DEBUG("Column {} has {} rows (offset={}, take={})",
-                     col_idx, output_relation.columns[col_idx]->column_length, skip, take);
+                     col_idx,
+                     output_relation.columns[col_idx]->column_length,
+                     skip,
+                     take);
   }
 
   return OperatorResultType::FINISHED;

--- a/src/operator/gpu_physical_top_n.cpp
+++ b/src/operator/gpu_physical_top_n.cpp
@@ -75,10 +75,6 @@ void HandleTopN(vector<shared_ptr<GPUColumn>>& order_by_keys,
 SinkResultType GPUPhysicalTopN::Sink(GPUIntermediateRelation& input_relation) const
 {
   auto start = std::chrono::high_resolution_clock::now();
-  // Reset sort_result so stale data from a previous run never conflicts with this run.
-  for (int col = 0; col < static_cast<int>(types.size()); col++) {
-    sort_result->columns[col] = nullptr;
-  }
   // throw NotImplementedException("Top N Sink not implemented");
   if (dynamic_filter) {
     // `dynamic_filter` is currently not leveraged

--- a/src/operator/gpu_physical_top_n.cpp
+++ b/src/operator/gpu_physical_top_n.cpp
@@ -75,6 +75,10 @@ void HandleTopN(vector<shared_ptr<GPUColumn>>& order_by_keys,
 SinkResultType GPUPhysicalTopN::Sink(GPUIntermediateRelation& input_relation) const
 {
   auto start = std::chrono::high_resolution_clock::now();
+  // Reset sort_result so stale data from a previous run never conflicts with this run.
+  for (int col = 0; col < static_cast<int>(types.size()); col++) {
+    sort_result->columns[col] = nullptr;
+  }
   // throw NotImplementedException("Top N Sink not implemented");
   if (dynamic_filter) {
     // `dynamic_filter` is currently not leveraged


### PR DESCRIPTION
Optimizations from the Clickbench branch:
1. COUNT DISTINCT with cudf dedup then group back instead of cudf:ngroup sort. This also applied to mixed aggregation and had an overhead guard against high cardinality using DuckDB statistic (no point in performing separate aggregation then merging back if count distinct does not have low cardinality)
2. STRLEN calculation without string materialization 
3. Empty string check converts to comparing STRLEN to 0