### PR TITLE
Add trace info about spilling and fetching batches

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -92,10 +92,8 @@ void downgrade_executor::monitor_loop()
       if (amount > 0) {
         // Collect all repositories from the manager
         std::vector<downgrade_repository_info> repos;
-        _data_repo_mgr.for_each_repository([&repos](const cucascade::operator_port_key& key,
-                                                    cucascade::shared_data_repository* repo) {
-          repos.push_back({repo, key.operator_id, key.port_id});
-        });
+        _data_repo_mgr.for_each_repository(
+          [&repos](cucascade::shared_data_repository* repo) { repos.push_back({repo}); });
         if (!repos.empty()) { run_downgrade_pass(std::move(repos), amount); }
       }
     }
@@ -174,8 +172,6 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     cucascade::shared_data_repository* repo;
     size_t tier_data_size;
     bool is_partitioned;
-    size_t consumer_operator_id;
-    std::string port_id;
   };
 
   std::vector<scored_repo> scored_repos;
@@ -183,11 +179,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     if (!info.repo) continue;
     size_t tier_size = get_repo_data_size_on_tier(info.repo, source_tier);
     if (tier_size == 0) continue;
-    scored_repos.push_back({info.repo,
-                            tier_size,
-                            info.repo->num_partitions() > 1,
-                            info.consumer_operator_id,
-                            info.port_id});
+    scored_repos.push_back({info.repo, tier_size, info.repo->num_partitions() > 1});
   }
 
   std::sort(
@@ -196,13 +188,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
       return a.tier_data_size > b.tier_data_size;
     });
 
-  struct downgrade_candidate {
-    std::shared_ptr<cucascade::data_batch> batch;
-    size_t consumer_operator_id;
-    std::string port_id;
-  };
-
-  std::vector<downgrade_candidate> all_candidates;
+  std::vector<std::shared_ptr<cucascade::data_batch>> all_candidates;
   size_t collected_bytes = 0;
 
   // Pass 1: Non-active partitions (last to first)
@@ -215,7 +201,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
       auto candidates = collect_candidates_from_partition(
         sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
       for (auto& c : candidates) {
-        all_candidates.push_back({std::move(c), sr.consumer_operator_id, sr.port_id});
+        all_candidates.push_back(std::move(c));
       }
     }
   }
@@ -231,7 +217,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
         auto candidates = collect_candidates_from_partition(
           sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
         for (auto& c : candidates) {
-          all_candidates.push_back({std::move(c), sr.consumer_operator_id, sr.port_id});
+          all_candidates.push_back(std::move(c));
         }
       }
     }
@@ -243,18 +229,14 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     _reservation_manager, _data_repo_mgr, _message_queue);
 
   size_t task_count = 0;
-  for (auto& candidate : all_candidates) {
-    auto data_size =
-      candidate.batch->get_data() ? candidate.batch->get_data()->get_size_in_bytes() : 0;
-    SIRIUS_LOG_TRACE(
-      "[downgrade] scheduling batch {} ({} B) from repo [consumer_op={}, port={}] on tier {}",
-      candidate.batch->get_batch_id(),
-      data_size,
-      candidate.consumer_operator_id,
-      candidate.port_id,
-      static_cast<int>(source_tier));
+  for (auto& batch : all_candidates) {
+    auto data_size = batch->get_data() ? batch->get_data()->get_size_in_bytes() : 0;
+    SIRIUS_LOG_TRACE("[downgrade] scheduling batch {} ({} B) on tier {}",
+                     batch->get_batch_id(),
+                     data_size,
+                     static_cast<int>(source_tier));
     auto local_state = std::make_unique<downgrade_task_local_state>(
-      duckdb::UUIDv7().GenerateRandomUUID().lower, 0, std::move(candidate.batch));
+      duckdb::UUIDv7().GenerateRandomUUID().lower, 0, std::move(batch));
     auto task = std::make_unique<downgrade_task>(std::move(local_state), global_state);
     schedule_downgrade_task(std::move(task));
     ++task_count;

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -16,6 +16,7 @@
 
 #include "downgrade/downgrade_executor.hpp"
 
+#include "duckdb/common/types/uuid.hpp"
 #include "log/logging.hpp"
 
 #include <rmm/cuda_stream.hpp>
@@ -26,21 +27,6 @@
 
 namespace sirius {
 namespace parallel {
-
-void downgrade_executor::schedule(std::unique_ptr<itask> task)
-{
-  auto downgrade_task = cast_to_downgrade_task(task.get());
-  if (!downgrade_task) {
-    itask_executor::schedule(std::move(task));
-    return;
-  }
-  itask_executor::schedule(std::move(task));
-}
-
-downgrade_task* downgrade_executor::cast_to_downgrade_task(itask* task)
-{
-  return dynamic_cast<downgrade_task*>(task);
-}
 
 void downgrade_executor::start()
 {
@@ -106,8 +92,10 @@ void downgrade_executor::monitor_loop()
       if (amount > 0) {
         // Collect all repositories from the manager
         std::vector<downgrade_repository_info> repos;
-        _data_repo_mgr.for_each_repository(
-          [&repos](cucascade::shared_data_repository* repo) { repos.push_back({repo}); });
+        _data_repo_mgr.for_each_repository([&repos](const cucascade::operator_port_key& key,
+                                                    cucascade::shared_data_repository* repo) {
+          repos.push_back({repo, key.operator_id, key.port_id});
+        });
         if (!repos.empty()) { run_downgrade_pass(std::move(repos), amount); }
       }
     }
@@ -186,6 +174,8 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     cucascade::shared_data_repository* repo;
     size_t tier_data_size;
     bool is_partitioned;
+    size_t consumer_operator_id;
+    std::string port_id;
   };
 
   std::vector<scored_repo> scored_repos;
@@ -193,7 +183,11 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     if (!info.repo) continue;
     size_t tier_size = get_repo_data_size_on_tier(info.repo, source_tier);
     if (tier_size == 0) continue;
-    scored_repos.push_back({info.repo, tier_size, info.repo->num_partitions() > 1});
+    scored_repos.push_back({info.repo,
+                            tier_size,
+                            info.repo->num_partitions() > 1,
+                            info.consumer_operator_id,
+                            info.port_id});
   }
 
   std::sort(
@@ -202,7 +196,13 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
       return a.tier_data_size > b.tier_data_size;
     });
 
-  std::vector<std::shared_ptr<cucascade::data_batch>> all_candidates;
+  struct downgrade_candidate {
+    std::shared_ptr<cucascade::data_batch> batch;
+    size_t consumer_operator_id;
+    std::string port_id;
+  };
+
+  std::vector<downgrade_candidate> all_candidates;
   size_t collected_bytes = 0;
 
   // Pass 1: Non-active partitions (last to first)
@@ -215,7 +215,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
       auto candidates = collect_candidates_from_partition(
         sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
       for (auto& c : candidates) {
-        all_candidates.push_back(std::move(c));
+        all_candidates.push_back({std::move(c), sr.consumer_operator_id, sr.port_id});
       }
     }
   }
@@ -231,7 +231,7 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
         auto candidates = collect_candidates_from_partition(
           sr.repo, pidx, _space_id, amount_to_downgrade, collected_bytes);
         for (auto& c : candidates) {
-          all_candidates.push_back(std::move(c));
+          all_candidates.push_back({std::move(c), sr.consumer_operator_id, sr.port_id});
         }
       }
     }
@@ -243,9 +243,18 @@ size_t downgrade_executor::run_downgrade_pass(std::vector<downgrade_repository_i
     _reservation_manager, _data_repo_mgr, _message_queue);
 
   size_t task_count = 0;
-  for (auto& batch : all_candidates) {
-    auto local_state =
-      std::make_unique<downgrade_task_local_state>(task_count, 0, std::move(batch));
+  for (auto& candidate : all_candidates) {
+    auto data_size =
+      candidate.batch->get_data() ? candidate.batch->get_data()->get_size_in_bytes() : 0;
+    SIRIUS_LOG_TRACE(
+      "[downgrade] scheduling batch {} ({} B) from repo [consumer_op={}, port={}] on tier {}",
+      candidate.batch->get_batch_id(),
+      data_size,
+      candidate.consumer_operator_id,
+      candidate.port_id,
+      static_cast<int>(source_tier));
+    auto local_state = std::make_unique<downgrade_task_local_state>(
+      duckdb::UUIDv7().GenerateRandomUUID().lower, 0, std::move(candidate.batch));
     auto task = std::make_unique<downgrade_task>(std::move(local_state), global_state);
     schedule_downgrade_task(std::move(task));
     ++task_count;

--- a/src/downgrade/downgrade_task.cpp
+++ b/src/downgrade/downgrade_task.cpp
@@ -15,13 +15,16 @@
  */
 
 #include "downgrade/downgrade_task.hpp"
-// #include "downgrade/downgrade_executor.hpp"
+
 #include "data/sirius_converter_registry.hpp"
+#include "log/logging.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
+
+#include <chrono>
 
 namespace sirius {
 namespace parallel {
@@ -51,6 +54,7 @@ void downgrade_task::execute(rmm::cuda_stream_view stream)
   }
 
   auto data_size = batch->get_data()->get_size_in_bytes();
+  auto t_start   = std::chrono::steady_clock::now();
 
   try {
     auto& mr_manager = _global_state->cast<downgrade_task_global_state>()._reservation_manager;
@@ -70,6 +74,16 @@ void downgrade_task::execute(rmm::cuda_stream_view stream)
 
     // Release the in-transit lock, restoring the batch to its previous state
     batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
+
+    auto duration_ms =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_start).count();
+    double throughput_mbs =
+      (duration_ms > 0.0) ? (data_size / (1024.0 * 1024.0)) / (duration_ms / 1000.0) : 0.0;
+    SIRIUS_LOG_TRACE("[downgrade] batch {} done: {} B in {:.2f} ms ({:.1f} MB/s)",
+                     batch->get_batch_id(),
+                     data_size,
+                     duration_ms,
+                     throughput_mbs);
 
     mark_task_completion();
     return;

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -38,8 +38,6 @@ namespace parallel {
  */
 struct downgrade_repository_info {
   cucascade::shared_data_repository* repo;
-  size_t consumer_operator_id;
-  std::string port_id;
 };
 
 /**

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -38,6 +38,8 @@ namespace parallel {
  */
 struct downgrade_repository_info {
   cucascade::shared_data_repository* repo;
+  size_t consumer_operator_id;
+  std::string port_id;
 };
 
 /**
@@ -94,7 +96,6 @@ class downgrade_executor : public itask_executor {
     this->schedule(std::move(downgrade_task));
   }
 
-  void schedule(std::unique_ptr<itask> task) override;
   void worker_loop(int worker_id) override;
   void start() override;
   void stop() override;
@@ -129,8 +130,6 @@ class downgrade_executor : public itask_executor {
                             size_t amount_to_downgrade);
 
  private:
-  downgrade_task* cast_to_downgrade_task(itask* task);
-
   /**
    * @brief Monitor loop that polls the memory space for pressure and triggers downgrades.
    *

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -331,6 +331,18 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   processing_handles.reserve(local_state._input_data->get_data_batches().size());
 
   for (const auto& batch : local_state._input_data->get_data_batches()) {
+    auto* resident_space = batch->get_memory_space();
+    if (requested_memory_space && resident_space &&
+        resident_space->get_id() != requested_memory_space->get_id()) {
+      SIRIUS_LOG_TRACE(
+        "Pipeline {}: fetching batch {} from tier {} to tier {} for operator {} (id={})",
+        pipeline->get_pipeline_id(),
+        batch->get_batch_id(),
+        static_cast<int>(resident_space->get_tier()),
+        static_cast<int>(requested_memory_space->get_tier()),
+        first_op.get_name(),
+        first_op.get_operator_id());
+    }
     auto handle = lock_or_prepare_batch(batch, requested_memory_space, stream);
     if (!handle) {
       // Failed to lock (or convert) one of the batches. Caller can retry later.


### PR DESCRIPTION
Adds some prints to the downgrades and conversions during batch preparation, including batch id, so that we can match spills and fetches from a trace log. Also adds a unique-ish downgrade ID and removes a redundant schedule() override.