### PR TITLE
CI: Catch all sqllogic test failures and resolve test_datasets permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Run sqllogic tests
         run: |
-          ./build/release/test/unittest "$PWD/test/*" | tee test.log
-          if grep -q "Error in GPUExecuteQuery" test.log; then
-            echo "GPU execution errors detected!"
+          ./build/release/test/unittest "$PWD/test/*" | tee test.log; EXIT=${PIPESTATUS[0]}
+          if grep -qE "FAILURES SUMMARY|Error in GPUExecuteQuery" test.log || [ "$EXIT" -ne 0 ]; then
+            echo "Test failures detected!"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,9 @@ jobs:
         run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
 
       - name: Prepare SQL test datasets
-        run: ./setup_test_datasets.sh
+        run: |
+          ./setup_test_datasets.sh
+          chmod -R a+r test_datasets/
 
       - name: Run sqllogic tests
         run: |


### PR DESCRIPTION
## Summary

- **Permission denied on `test_datasets/`**: Self-hosted GPU runners reuse the workspace between runs. Files from previous runs could be owned by a different user, causing `setup_test_datasets.sh` to skip regeneration (files already exist) while the test binary fails to read them. Fixed by adding `chmod -R a+r test_datasets/` after the setup script.

- **Sqllogic test failures silently passing**: The `tee` pipe masked the test binary's exit code — `tee` always exits 0, so even a failing test run would pass the CI step. Also, the existing `grep` only caught `Error in GPUExecuteQuery`, missing other failure modes. Fixed by capturing `PIPESTATUS[0]` (the test binary's exit code) and expanding the grep to also match `FAILURES SUMMARY`.

Reported by @bwyogatama 

## Test plan
- [x] Trigger a CI run and verify the `Run sqllogic tests` step fails correctly when tests fail
- [x] Verify `test_datasets/` permissions no longer cause `IO Error: Permission denied` on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)