### PR TITLE
Fix `-rdynamic [-Wunused-command-line-argument]` for clang

### DIFF
--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -50,7 +50,8 @@
         "CMAKE_CUDA_HOST_COMPILER": "$env{CONDA_PREFIX}/bin/clang++",
         "CMAKE_CXX_COMPILER": "$env{CONDA_PREFIX}/bin/clang++",
         "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
-        "CMAKE_C_COMPILER": "$env{CONDA_PREFIX}/bin/clang"
+        "CMAKE_C_COMPILER": "$env{CONDA_PREFIX}/bin/clang",
+        "EXPORT_DYNAMIC_SYMBOLS": "OFF"
       },
       "hidden": true,
       "inherits": "base",


### PR DESCRIPTION
`EXPORT_DYNAMIC_SYMBOLS=ON` adds `-rdynamic` globally. Clang doesn't use it during compilation (only linking).