### PR TITLE
Adaptive Join

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -160,7 +160,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
-  std::unique_ptr<cudf::table>
+  std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>
     _built_table_cast_columns;  // scope holder for any columns that may have had to be cast for the

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -40,6 +40,12 @@ class sirius_meta_pipeline;
 
 namespace op {
 
+// STANDARD uses cudf APIs where the build and probe is a single operation.
+// BUILD_PROBE builds the hash table in one step and then probes it in a separate step, which allows
+// for better pipelining with other operators, and allows reusing the hash table. MIXED_JOIN uses
+// cudf's mixed_join API for joins with both equality and inequality conditions.
+enum class HASH_JOIN_MODE { STANDARD, BUILD_PROBE, MIXED_JOIN };
+
 class sirius_physical_hash_join : public sirius_physical_partition_consumer_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::HASH_JOIN;
@@ -110,6 +116,14 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
 
+  /// @brief This is called by the partition operator to inform the hash join of the number of
+  /// partitions that will be produced by the partition operator, which can be used to make
+  /// decisions about the join execution strategy (e.g., whether to switch to a build-probe strategy
+  /// for small datasets).
+  /// @param num_partitions
+  /// @param build_side_bytes
+  void update_join_exec_mode(int num_partitions, uint64_t build_side_bytes);
+
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
@@ -125,16 +139,16 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   //! Becomes a source when it is an external join
   bool is_source() const override { return true; }
 
-  std::mutex batches_to_processed_mutex;
+  std::mutex op_state_mutex;
   std::size_t current_partition_index = 0;
   std::size_t num_batches_to_process  = 0;
   std::vector<std::vector<uint64_t>> left_batch_ids;
   std::vector<std::vector<uint64_t>> right_batch_ids;
 
   bool is_all_inequality_join = true;
-  // True when conditions contain both equality conditions (hashed) and inequality conditions
-  // (evaluated via cuDF mixed_join binary predicate).
-  bool is_mixed_join = false;
+
+  HASH_JOIN_MODE _join_mode = HASH_JOIN_MODE::STANDARD;
+  //
   // Number of equality conditions after reordering; inequality conditions follow at higher indices.
   std::size_t num_equality_conditions = 0;
   std::vector<cudf::size_type> left_key_col_indices;

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -26,6 +26,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 #include "op/sirius_physical_partition_consumer_operator.hpp"
+#include "sirius_config.hpp"
 #include "utils.hpp"
 
 #include <cstddef>
@@ -57,22 +58,26 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   };
 
  public:
-  sirius_physical_hash_join(duckdb::LogicalOperator& op,
-                            duckdb::unique_ptr<sirius_physical_operator> left,
-                            duckdb::unique_ptr<sirius_physical_operator> right,
-                            duckdb::vector<duckdb::JoinCondition> cond,
-                            duckdb::JoinType join_type,
-                            const duckdb::vector<duckdb::idx_t>& left_projection_map,
-                            const duckdb::vector<duckdb::idx_t>& right_projection_map,
-                            duckdb::vector<duckdb::LogicalType> delim_types,
-                            duckdb::idx_t estimated_cardinality,
-                            duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info);
-  sirius_physical_hash_join(duckdb::LogicalOperator& op,
-                            duckdb::unique_ptr<sirius_physical_operator> left,
-                            duckdb::unique_ptr<sirius_physical_operator> right,
-                            duckdb::vector<duckdb::JoinCondition> cond,
-                            duckdb::JoinType join_type,
-                            duckdb::idx_t estimated_cardinality);
+  sirius_physical_hash_join(
+    duckdb::LogicalOperator& op,
+    duckdb::unique_ptr<sirius_physical_operator> left,
+    duckdb::unique_ptr<sirius_physical_operator> right,
+    duckdb::vector<duckdb::JoinCondition> cond,
+    duckdb::JoinType join_type,
+    const duckdb::vector<duckdb::idx_t>& left_projection_map,
+    const duckdb::vector<duckdb::idx_t>& right_projection_map,
+    duckdb::vector<duckdb::LogicalType> delim_types,
+    duckdb::idx_t estimated_cardinality,
+    duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info,
+    uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES);
+  sirius_physical_hash_join(
+    duckdb::LogicalOperator& op,
+    duckdb::unique_ptr<sirius_physical_operator> left,
+    duckdb::unique_ptr<sirius_physical_operator> right,
+    duckdb::vector<duckdb::JoinCondition> cond,
+    duckdb::JoinType join_type,
+    duckdb::idx_t estimated_cardinality,
+    uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
   //! Scans where we should push generated filters into (if any)
@@ -153,6 +158,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   HASH_JOIN_MODE _join_mode                      = HASH_JOIN_MODE::STANDARD;
   BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
+  uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
   std::unique_ptr<cudf::table>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -45,7 +45,7 @@ namespace op {
 // for better pipelining with other operators, and allows reusing the hash table. MIXED_JOIN uses
 // cudf's mixed_join API for joins with both equality and inequality conditions.
 enum class HASH_JOIN_MODE { STANDARD, BUILD_PROBE, MIXED_JOIN };
-enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULING, SCHEDULED, BUILT };
+enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULING, SCHEDULED, BUILT, DESTROYED };
 
 class sirius_physical_hash_join : public sirius_physical_partition_consumer_operator {
  public:
@@ -181,6 +181,8 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
  public:
   // Sink Interface
   bool is_sink() const override { return true; }
+
+  void finalize_operator() override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -45,7 +45,7 @@ namespace op {
 // for better pipelining with other operators, and allows reusing the hash table. MIXED_JOIN uses
 // cudf's mixed_join API for joins with both equality and inequality conditions.
 enum class HASH_JOIN_MODE { STANDARD, BUILD_PROBE, MIXED_JOIN };
-enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULED, BUILT };
+enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULING, SCHEDULED, BUILT };
 
 class sirius_physical_hash_join : public sirius_physical_partition_consumer_operator {
  public:

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -45,6 +45,7 @@ namespace op {
 // for better pipelining with other operators, and allows reusing the hash table. MIXED_JOIN uses
 // cudf's mixed_join API for joins with both equality and inequality conditions.
 enum class HASH_JOIN_MODE { STANDARD, BUILD_PROBE, MIXED_JOIN };
+enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULED, BUILT };
 
 class sirius_physical_hash_join : public sirius_physical_partition_consumer_operator {
  public:
@@ -124,7 +125,10 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   /// @param build_side_bytes
   void update_join_exec_mode(int num_partitions, uint64_t build_side_bytes);
 
+  std::unique_ptr<operator_data> get_next_task_input_data_for_build_probe();
   std::unique_ptr<operator_data> get_next_task_input_data() override;
+
+  std::optional<task_creation_hint> get_next_task_hint() override;
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
@@ -147,7 +151,14 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   bool is_all_inequality_join = true;
 
-  HASH_JOIN_MODE _join_mode = HASH_JOIN_MODE::STANDARD;
+  HASH_JOIN_MODE _join_mode                      = HASH_JOIN_MODE::STANDARD;
+  BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
+  std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
+  std::unique_ptr<cudf::table>
+    _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
+  std::vector<std::unique_ptr<cudf::column>>
+    _built_table_cast_columns;  // scope holder for any columns that may have had to be cast for the
+                                // build table
   //
   // Number of equality conditions after reordering; inequality conditions follow at higher indices.
   std::size_t num_equality_conditions = 0;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -231,6 +231,9 @@ class sirius_physical_operator {
   virtual void build_pipelines(pipeline::sirius_pipeline& current,
                                pipeline::sirius_meta_pipeline& meta_pipeline);
 
+  //! Called when the pipeline this operator belongs to finishes. Override to release resources.
+  virtual void finalize_operator() {}
+
  public:
   template <class TARGET>
   TARGET& Cast()

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -91,7 +91,10 @@ class sirius_physical_partition : public sirius_physical_operator {
 
  private:
   void get_partition_keys_and_type(sirius_physical_operator* op, bool is_build = false);
-  int determine_num_partitions();
+
+  /// Looks at the amount of data waiting on the input port and determines the number of partitions
+  /// to create. Returns a pair of (num_partitions, total_bytes).
+  std::pair<int, uint64_t> determine_num_partitions();
   sirius_physical_operator* _parent_op            = nullptr;
   sirius_physical_operator* _sibling_partition_op = nullptr;
   std::vector<int> _partition_keys;

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -97,6 +97,9 @@ class sirius_physical_partition : public sirius_physical_operator {
   std::pair<int, uint64_t> determine_num_partitions();
   sirius_physical_operator* _parent_op            = nullptr;
   sirius_physical_operator* _sibling_partition_op = nullptr;
+  sirius_physical_operator* _hash_join_op =
+    nullptr;  // hash join operator that this partition operator feeds into (optional: for
+              // hash_joins only)
   std::vector<int> _partition_keys;
   /// One entry per partition key. type_id::EMPTY means "hash as-is"; any other id means
   /// cast the key column to this type before hashing.  Used to align hash values when the

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -67,6 +67,8 @@ class sirius_physical_sort_partition : public sirius_physical_operator {
   //! Get the sample operator
   sirius_physical_sort_sample* get_sample_op() const { return _sample_op; }
 
+  void finalize_operator() override;
+
  private:
   sirius_physical_sort_sample* _sample_op = nullptr;
 };

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -77,6 +77,11 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Override the maximum bytes per partition (0 = use default GPU memory-based calculation)
   void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
 
+  //! Release the partition boundaries table to free GPU memory
+  void clear_partition_boundaries() { _partition_boundaries.reset(); }
+
+  void finalize_operator() override { clear_partition_boundaries(); }
+
  private:
   //! Partition boundary rows (P-1 rows containing sort key column values)
   std::unique_ptr<cudf::table> _partition_boundaries;

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -80,8 +80,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Release the partition boundaries table to free GPU memory
   void clear_partition_boundaries() { _partition_boundaries.reset(); }
 
-  void finalize_operator() override { clear_partition_boundaries(); }
-
  private:
   //! Partition boundary rows (P-1 rows containing sort key column values)
   std::unique_ptr<cudf::table> _partition_boundaries;

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -31,10 +31,11 @@ namespace sirius {
 namespace config {
 struct configuration_setter;
 
-constexpr uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE   = 512ULL * 1024 * 1024;  // 512 MB
-constexpr uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256LL;
-constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES   = 512ULL * 1024 * 1024;  // 512 MB
-constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES     = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE       = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE     = 256LL;
+constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES       = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES         = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_MAX_BUILD_HASH_TABLE_BYTES = 500ULL * 1024 * 1024;  // 500 MB
 
 }  // namespace config
 
@@ -56,6 +57,19 @@ struct operator_params {
 
   /// Target size (bytes) for the concat operator output batch.
   uint64_t concat_batch_bytes = config::DEFAULT_CONCAT_BATCH_BYTES;
+
+  /// Maximum build-side bytes for switching to BUILD_PROBE join mode.
+  /// This value must be smaller than concat_batch_bytes
+  uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
+
+  /// Ensures max_build_hash_table_bytes < concat_batch_bytes.
+  /// If violated, clamps max_build_hash_table_bytes to concat_batch_bytes - 1.
+  void validate_and_fix()
+  {
+    if (concat_batch_bytes > 0 && max_build_hash_table_bytes >= concat_batch_bytes) {
+      max_build_hash_table_bytes = concat_batch_bytes - 1;
+    }
+  }
 };
 
 struct sirius_config {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -394,8 +394,9 @@ std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint(
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
-    // In build-probe mode, we must build the hash table before we can process any probe batches.
-    // If the hash table is not built yet, hint to prioritize building it.
+    // In build-probe mode, we want the first task to be with one batch from either side.
+    // In the first batch we will build the hash table, then we only need batches from the probe
+    // side.
     auto* build_port = get_port("build");
     auto* probe_port = get_port("default");
     if (!build_port || !probe_port) {
@@ -1059,10 +1060,12 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 void sirius_physical_hash_join::finalize_operator()
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
-  _hash_table.reset();
-  _build_table.reset();
-  _built_table_cast_columns.clear();
-  _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;
+  if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
+    _hash_table.reset();
+    _build_table.reset();
+    _built_table_cast_columns.clear();
+    _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;
+  }
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -354,9 +354,9 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (num_partitions == 1 && build_side_bytes < MAX_BUILD_HASH_TABLE_BYTES &&
-      (join_type != duckdb::JoinType::SEMI || join_type != duckdb::JoinType::RIGHT_SEMI ||
-       join_type != duckdb::JoinType::ANTI || join_type != duckdb::JoinType::RIGHT_ANTI ||
-       join_type != duckdb::JoinType::RIGHT) &&
+      join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::RIGHT_SEMI &&
+      join_type != duckdb::JoinType::ANTI && join_type != duckdb::JoinType::RIGHT_ANTI &&
+      join_type != duckdb::JoinType::RIGHT && join_type != duckdb::JoinType::MARK &&
       _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets
     _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
@@ -371,6 +371,7 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
 
 std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint()
 {
+  std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     // In build-probe mode, we must build the hash table before we can process any probe batches.
     // If the hash table is not built yet, hint to prioritize building it.
@@ -381,10 +382,13 @@ std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint(
         "In sirius_physical_hash_join:get_next_task_hint: missing expected ports in operator " +
         std::to_string(this->get_operator_id()));
     }
+    auto build_size = build_port->repo->total_size();
+    auto probe_size = probe_port->repo->total_size();
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::NOT_BUILT) {
-      if (build_port->repo->total_size() > 0 && probe_port->repo->total_size() > 0) {
+      if (build_size > 0 && probe_size > 0) {
+        _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULING;
         return task_creation_hint{TaskCreationHint::READY, this};
-      } else if (build_port->repo->total_size() == 0) {
+      } else if (build_size == 0) {
         // No build batch available yet, hint to wait for build input data.
         auto* producer = &build_port->src_pipeline->get_operators()[0].get();
         return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
@@ -393,7 +397,8 @@ std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint(
         auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
         return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
       }
-    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
+    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULING ||
+               _hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
       // Hash table is currently being built, hint to wait for it to be ready.
       auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
       return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
@@ -425,7 +430,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
       "ports in operator " +
       std::to_string(this->get_operator_id()));
   }
-  if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::NOT_BUILT) {
+  if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULING) {
     if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) != 1 ||
         probe_port->repo->num_partitions() != 1) {
       throw std::runtime_error(
@@ -464,10 +469,12 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     }
     return std::make_unique<operator_data>(input_batch);
   } else {
-    throw std::runtime_error(
+    SIRIUS_LOG_WARN(fmt::format(
       "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: invalid hash table "
-      "build state in operator " +
-      std::to_string(this->get_operator_id()));
+      "build state {} in operator {}",
+      _hash_table_build_state,
+      this->get_operator_id()));
+    return nullptr;
   }
 }
 
@@ -731,10 +738,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_hash_join::execute"};
   const auto& input_batches = input_data.get_data_batches();
-  if (input_batches.size() != 2) {
-    throw std::runtime_error("Expected 2 input batches for hash join, got " +
-                             std::to_string(input_batches.size()) + " input batches");
-  }
+
   if (is_all_inequality_join) {
     throw std::runtime_error(
       "Error sirius_physical_hash_join being asked to do all inequality join of type: " +
@@ -764,8 +768,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                // batches to proceed.
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
       }
-
-    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
+    }
+    if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
       // Hash table is built, we can process probe batches. The probe-side keys will be processed in
       // the same way as the mixed join path, but with an equality-only predicate.
       auto probe_keys_result      = prepare_join_keys(input_batches[0],
@@ -796,12 +800,18 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       right_full = _build_table->view();
 
     } else {
-      throw std::runtime_error(
-        "In sirius_physical_hash_join::execute: invalid hash table build state in BUILD_PROBE "
-        "mode");
+      throw std::runtime_error(fmt::format(
+        "In sirius_physical_hash_join::execute: invalid hash table build state {} in BUILD_PROBE "
+        "mode for operator id {}",
+        static_cast<int>(_hash_table_build_state),
+        this->get_operator_id()));
     }
 
   } else if (_join_mode == HASH_JOIN_MODE::MIXED_JOIN) {
+    if (input_batches.size() != 2) {
+      throw std::runtime_error("Expected 2 input batches for hash join, got " +
+                               std::to_string(input_batches.size()) + " input batches");
+    }
     left_full  = get_cudf_table_view(*input_batches[0]);
     right_full = get_cudf_table_view(*input_batches[1]);
     // Mixed join: equality conditions drive the hash table; inequality conditions are evaluated
@@ -944,6 +954,10 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                duckdb::JoinTypeToString(join_type));
     }
   } else {  // STANDARD HASH JOIN
+    if (input_batches.size() != 2) {
+      throw std::runtime_error("Expected 2 input batches for hash join, got " +
+                               std::to_string(input_batches.size()) + " input batches");
+    }
     left_full                   = get_cudf_table_view(*input_batches[0]);
     right_full                  = get_cudf_table_view(*input_batches[1]);
     auto left_keys_result       = prepare_join_keys(input_batches[0],

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -354,6 +354,9 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (num_partitions == 1 && build_side_bytes < MAX_BUILD_HASH_TABLE_BYTES &&
+      (join_type != duckdb::JoinType::SEMI || join_type != duckdb::JoinType::RIGHT_SEMI ||
+       join_type != duckdb::JoinType::ANTI || join_type != duckdb::JoinType::RIGHT_ANTI ||
+       join_type != duckdb::JoinType::RIGHT) &&
       _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets
     _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
@@ -366,11 +369,117 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
   }
 }
 
+std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint()
+{
+  if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
+    // In build-probe mode, we must build the hash table before we can process any probe batches.
+    // If the hash table is not built yet, hint to prioritize building it.
+    auto* build_port = get_port("build");
+    auto* probe_port = get_port("default");
+    if (!build_port || !probe_port) {
+      throw std::runtime_error(
+        "In sirius_physical_hash_join:get_next_task_hint: missing expected ports in operator " +
+        std::to_string(this->get_operator_id()));
+    }
+    if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::NOT_BUILT) {
+      if (build_port->repo->total_size() > 0 && probe_port->repo->total_size() > 0) {
+        return task_creation_hint{TaskCreationHint::READY, this};
+      } else if (build_port->repo->total_size() == 0) {
+        // No build batch available yet, hint to wait for build input data.
+        auto* producer = &build_port->src_pipeline->get_operators()[0].get();
+        return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
+      } else {
+        // Build batch is available but no probe batch yet, hint to wait for probe input data.
+        auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
+        return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
+      }
+    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
+      // Hash table is currently being built, hint to wait for it to be ready.
+      auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
+      return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
+    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
+      // Hash table is built, we can process probe only batches.
+      if (ports["default"]->repo->total_size() > 0) {
+        return task_creation_hint{TaskCreationHint::READY, this};
+      } else {
+        // No probe batch available yet, hint to wait for probe input data.
+        auto* producer = &ports["default"]->src_pipeline->get_operators()[0].get();
+        return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
+      }
+    } else {
+      throw std::runtime_error(
+        "Invalid hash table build state in sirius_physical_hash_join::get_next_task_hint");
+    }
+  } else {
+    return sirius_physical_operator::get_next_task_hint();
+  }
+}
+
+std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_data_for_build_probe()
+{
+  auto* build_port = get_port("build");
+  auto* probe_port = get_port("default");
+  if (!build_port || !probe_port) {
+    throw std::runtime_error(
+      "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: missing expected "
+      "ports in operator " +
+      std::to_string(this->get_operator_id()));
+  }
+  if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::NOT_BUILT) {
+    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) != 1 ||
+        probe_port->repo->num_partitions() != 1) {
+      throw std::runtime_error(
+        "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected exactly 1 "
+        "partition and 1 batch in default (build) port in operator " +
+        std::to_string(this->get_operator_id()));
+    }
+    // When the hash table is not build yet, we will send both the build and probe side. To build
+    // the hash table and perform the first join.
+    std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
+    auto probe_batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
+    auto build_batch = build_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
+    input_batch.push_back(std::move(probe_batch));
+    input_batch.push_back(std::move(build_batch));
+    _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULED;
+    return std::make_unique<operator_data>(input_batch);
+
+  } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
+    if (probe_port->repo->num_partitions() != 1) {
+      throw std::runtime_error(
+        "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected exactly 1 "
+        "partition in operator " +
+        std::to_string(this->get_operator_id()));
+    }
+    // If the hash table has already been build, we only send the probe side. The hash table should
+    // already be built and we can perform the join with the probe side batches.
+    std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
+    auto batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
+    if (batch) {
+      input_batch.push_back(std::move(batch));
+    } else {
+      SIRIUS_LOG_WARN(
+        "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected to pop a "
+        "batch from the default port but got none in operator " +
+        std::to_string(this->get_operator_id()));
+    }
+    return std::make_unique<operator_data>(input_batch);
+  } else {
+    throw std::runtime_error(
+      "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: invalid hash table "
+      "build state in operator " +
+      std::to_string(this->get_operator_id()));
+  }
+}
+
 std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_data()
 {
   // Hold the mutex for the entire operation to prevent concurrent pop/get races.
   // A pop on one thread must not remove a batch that another thread's get expects to find.
   std::lock_guard<std::mutex> lg(op_state_mutex);
+
+  if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
+    return get_next_task_input_data_for_build_probe();
+  }
 
   // One-time initialization: snapshot all batch IDs from both ports.
   if (left_batch_ids.empty() && right_batch_ids.empty()) {
@@ -437,70 +546,124 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
   }
 }
 
-/// Result of prepare_join_keys: the key table views and any cast columns that must remain alive.
-struct join_keys_result {
-  // Owned cast columns - kept alive so the table views referencing them remain valid
+/// Result of prepare_join_keys for a single join side: the key table view and any cast columns
+/// that must remain alive.
+struct join_side_keys_result {
+  // Owned cast columns - kept alive so the table view referencing them remains valid
   std::vector<std::unique_ptr<cudf::column>> owned_cast_columns;
-  cudf::table_view left_keys;
-  cudf::table_view right_keys;
-  // Storage for column views used to build the table_views (must outlive the table_views)
-  std::vector<cudf::column_view> left_key_views;
-  std::vector<cudf::column_view> right_key_views;
+  cudf::table_view keys;
+  // Storage for column views used to build the table_view (must outlive the table_view)
+  std::vector<cudf::column_view> key_views;
 };
 
-/// Build the left and right key table views for the join.
-/// If cast_necessary is false, this simply selects the key columns from the input batches.
+/// Build the key table view for one side of the join.
+/// If cast_necessary is false, this simply selects the key columns from the input batch.
 /// If cast_necessary is true, each key column that requires a cast is cast to its target type
 /// via cudf::cast before being included in the key table.
-static join_keys_result prepare_join_keys(
-  const std::vector<std::shared_ptr<::cucascade::data_batch>>& input_batches,
-  const std::vector<cudf::size_type>& left_key_col_indices,
-  const std::vector<cudf::size_type>& right_key_col_indices,
+/// @param is_left_side  If true, uses cast_left/left_target_type from key_casts; otherwise uses
+///                      cast_right/right_target_type.
+static join_side_keys_result prepare_join_keys(
+  const std::shared_ptr<::cucascade::data_batch>& input_batch,
+  const std::vector<cudf::size_type>& key_col_indices,
   bool cast_necessary,
   const std::vector<sirius_physical_hash_join::key_cast_info>& key_casts,
+  bool is_left_side,
   rmm::cuda_stream_view stream)
 {
-  join_keys_result result;
+  join_side_keys_result result;
+
+  cudf::table_view table = get_cudf_table_view(*input_batch);
 
   if (!cast_necessary) {
-    // Fast path: no casts needed, just select columns directly
-    result.left_keys  = get_cudf_table_view(*input_batches[0]).select(left_key_col_indices);
-    result.right_keys = get_cudf_table_view(*input_batches[1]).select(right_key_col_indices);
+    result.keys = table.select(key_col_indices);
     return result;
   }
 
   // Slow path: iterate over key columns and cast where needed
-  cudf::table_view left_table  = get_cudf_table_view(*input_batches[0]);
-  cudf::table_view right_table = get_cudf_table_view(*input_batches[1]);
-
-  for (size_t i = 0; i < left_key_col_indices.size(); i++) {
+  for (size_t i = 0; i < key_col_indices.size(); i++) {
     const auto& cast_info = key_casts[i];
+    cudf::column_view col = table.column(key_col_indices[i]);
+    bool needs_cast       = is_left_side ? cast_info.cast_left : cast_info.cast_right;
+    cudf::data_type target_type =
+      is_left_side ? cast_info.left_target_type : cast_info.right_target_type;
 
-    // Left key column
-    cudf::column_view left_col = left_table.column(left_key_col_indices[i]);
-    if (cast_info.cast_left) {
-      auto cast_col = cudf::cast(left_col, cast_info.left_target_type, stream);
-      result.left_key_views.push_back(cast_col->view());
+    if (needs_cast) {
+      auto cast_col = cudf::cast(col, target_type, stream);
+      result.key_views.push_back(cast_col->view());
       result.owned_cast_columns.push_back(std::move(cast_col));
     } else {
-      result.left_key_views.push_back(left_col);
-    }
-
-    // Right key column
-    cudf::column_view right_col = right_table.column(right_key_col_indices[i]);
-    if (cast_info.cast_right) {
-      auto cast_col = cudf::cast(right_col, cast_info.right_target_type, stream);
-      result.right_key_views.push_back(cast_col->view());
-      result.owned_cast_columns.push_back(std::move(cast_col));
-    } else {
-      result.right_key_views.push_back(right_col);
+      result.key_views.push_back(col);
     }
   }
 
-  // Build table_views from the column_view vectors
-  result.left_keys  = cudf::table_view(result.left_key_views);
-  result.right_keys = cudf::table_view(result.right_key_views);
+  result.keys = cudf::table_view(result.key_views);
   return result;
+}
+
+/// Gather output columns from both sides of a join using row index vectors, then assemble the
+/// result into an operator_data. Handles collect/oob policy selection based on join type.
+/// @param left_indices   Row indices into left_full; may be null if the left side is not collected.
+/// @param right_indices  Row indices into right_full; may be null if the right side is not
+///                       collected.
+/// @param memory_space   Memory space of the input batch used to tag the output data batch.
+static std::unique_ptr<operator_data> gather_join_output(
+  duckdb::JoinType join_type,
+  cudf::table_view left_full,
+  cudf::table_view right_full,
+  std::vector<cudf::size_type> const& lhs_col_idxs,
+  std::vector<cudf::size_type> const& rhs_col_idxs,
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices,
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_indices,
+  cucascade::memory::memory_space& memory_space,
+  rmm::cuda_stream_view stream)
+{
+  bool collect_left =
+    (join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI);
+  bool collect_right = (join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::ANTI);
+
+  cudf::out_of_bounds_policy left_oob  = cudf::out_of_bounds_policy::DONT_CHECK;
+  cudf::out_of_bounds_policy right_oob = cudf::out_of_bounds_policy::DONT_CHECK;
+  if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
+      join_type == duckdb::JoinType::SEMI) {
+    right_oob = cudf::out_of_bounds_policy::NULLIFY;
+  }
+  if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
+      join_type == duckdb::JoinType::RIGHT_SEMI) {
+    left_oob = cudf::out_of_bounds_policy::NULLIFY;
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> out_cols;
+  if (collect_left) {
+    cudf::table_view left_cols_to_gather = left_full.select(lhs_col_idxs);
+    cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
+                                    left_indices->size(),
+                                    left_indices->data(),
+                                    nullptr,
+                                    0,
+                                    0,
+                                    {});
+    auto left_result = cudf::gather(left_cols_to_gather, left_map_view, left_oob, stream);
+    out_cols         = left_result->release();
+  }
+  if (collect_right) {
+    cudf::table_view right_cols_to_gather = right_full.select(rhs_col_idxs);
+    cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
+                                     right_indices->size(),
+                                     right_indices->data(),
+                                     nullptr,
+                                     0,
+                                     0,
+                                     {});
+    auto right_result   = cudf::gather(right_cols_to_gather, right_map_view, right_oob, stream);
+    auto right_out_cols = right_result->release();
+    for (auto& col : right_out_cols) {
+      out_cols.push_back(std::move(col));
+    }
+  }
+
+  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
+  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+    make_data_batch(std::move(output_cudf_table), memory_space)});
 }
 
 /// @brief the MARK join output from the semi_join matching row indices.
@@ -578,24 +741,85 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       duckdb::JoinTypeToString(join_type));
   }
 
-  // Full input table views used as both gather sources and (for mixed joins) conditional views.
-  // Hoisted here so both join paths and the shared gather tail can reference them.
-  cudf::table_view left_full  = get_cudf_table_view(*input_batches[0]);
-  cudf::table_view right_full = get_cudf_table_view(*input_batches[1]);
-
+  cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
 
-  if (_join_mode == HASH_JOIN_MODE::MIXED_JOIN) {
+  if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
+    if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
+      auto build_keys_result      = prepare_join_keys(input_batches[1],
+                                                 right_key_col_indices,
+                                                 cast_necessary,
+                                                 key_casts,
+                                                 /*is_left_side=*/false,
+                                                 stream);
+      cudf::table_view build_keys = build_keys_result.keys;
+      {
+        std::lock_guard<std::mutex> lg(op_state_mutex);
+        _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
+        _build_table =
+          input_batches[1]->get_data()->cast<cucascade::gpu_table_representation>().release_table();
+        _hash_table =
+          std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+        stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
+                               // batches to proceed.
+        _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
+      }
+
+    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
+      // Hash table is built, we can process probe batches. The probe-side keys will be processed in
+      // the same way as the mixed join path, but with an equality-only predicate.
+      auto probe_keys_result      = prepare_join_keys(input_batches[0],
+                                                 left_key_col_indices,
+                                                 cast_necessary,
+                                                 key_casts,
+                                                 /*is_left_side=*/true,
+                                                 stream);
+      cudf::table_view probe_keys = probe_keys_result.keys;
+
+      if (join_type == duckdb::JoinType::INNER) {
+        auto result   = _hash_table->inner_join(probe_keys, {}, stream);
+        left_indices  = std::move(result.first);
+        right_indices = std::move(result.second);
+      } else if (join_type == duckdb::JoinType::LEFT) {
+        auto result   = _hash_table->left_join(probe_keys, {}, stream);
+        left_indices  = std::move(result.first);
+        right_indices = std::move(result.second);
+      } else if (join_type == duckdb::JoinType::OUTER) {
+        auto result   = _hash_table->full_join(probe_keys, {}, stream);
+        left_indices  = std::move(result.first);
+        right_indices = std::move(result.second);
+      } else {
+        throw std::runtime_error("Unsupported join type in BUILD_PROBE mode: " +
+                                 duckdb::JoinTypeToString(join_type));
+      }
+      left_full  = get_cudf_table_view(*input_batches[0]);
+      right_full = _build_table->view();
+
+    } else {
+      throw std::runtime_error(
+        "In sirius_physical_hash_join::execute: invalid hash table build state in BUILD_PROBE "
+        "mode");
+    }
+
+  } else if (_join_mode == HASH_JOIN_MODE::MIXED_JOIN) {
+    left_full  = get_cudf_table_view(*input_batches[0]);
+    right_full = get_cudf_table_view(*input_batches[1]);
     // Mixed join: equality conditions drive the hash table; inequality conditions are evaluated
     // via a cuDF AST binary predicate on the full input tables.
-    auto keys                 = prepare_join_keys(input_batches,
-                                  left_key_col_indices,
-                                  right_key_col_indices,
-                                  cast_necessary,
-                                  key_casts,
-                                  stream);
-    cudf::table_view left_eq  = keys.left_keys;
-    cudf::table_view right_eq = keys.right_keys;
+    auto left_keys_result     = prepare_join_keys(input_batches[0],
+                                              left_key_col_indices,
+                                              cast_necessary,
+                                              key_casts,
+                                              /*is_left_side=*/true,
+                                              stream);
+    auto right_keys_result    = prepare_join_keys(input_batches[1],
+                                               right_key_col_indices,
+                                               cast_necessary,
+                                               key_casts,
+                                               /*is_left_side=*/false,
+                                               stream);
+    cudf::table_view left_eq  = left_keys_result.keys;
+    cudf::table_view right_eq = right_keys_result.keys;
 
     sirius::gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
     auto pred =
@@ -719,15 +943,23 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       throw std::runtime_error("Unsupported join type for mixed join: " +
                                duckdb::JoinTypeToString(join_type));
     }
-  } else {
-    auto keys                   = prepare_join_keys(input_batches,
-                                  left_key_col_indices,
-                                  right_key_col_indices,
-                                  cast_necessary,
-                                  key_casts,
-                                  stream);
-    cudf::table_view left_keys  = keys.left_keys;
-    cudf::table_view right_keys = keys.right_keys;
+  } else {  // STANDARD HASH JOIN
+    left_full                   = get_cudf_table_view(*input_batches[0]);
+    right_full                  = get_cudf_table_view(*input_batches[1]);
+    auto left_keys_result       = prepare_join_keys(input_batches[0],
+                                              left_key_col_indices,
+                                              cast_necessary,
+                                              key_casts,
+                                              /*is_left_side=*/true,
+                                              stream);
+    auto right_keys_result      = prepare_join_keys(input_batches[1],
+                                               right_key_col_indices,
+                                               cast_necessary,
+                                               key_casts,
+                                               /*is_left_side=*/false,
+                                               stream);
+    cudf::table_view left_keys  = left_keys_result.keys;
+    cudf::table_view right_keys = right_keys_result.keys;
 
     if (join_type == duckdb::JoinType::INNER) {
       auto join_result =
@@ -778,55 +1010,15 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     }
   }
 
-  // Shared tail: which sides to collect, out-of-bounds nullification policy, and gather.
-  // collect_left/right are purely a function of join type and apply to both mixed and non-mixed.
-  bool collect_left =
-    (join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI);
-  bool collect_right = (join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::ANTI);
-
-  cudf::out_of_bounds_policy left_oob  = cudf::out_of_bounds_policy::DONT_CHECK;
-  cudf::out_of_bounds_policy right_oob = cudf::out_of_bounds_policy::DONT_CHECK;
-  if (join_type == duckdb::JoinType::LEFT || join_type == duckdb::JoinType::OUTER ||
-      join_type == duckdb::JoinType::SEMI) {
-    right_oob = cudf::out_of_bounds_policy::NULLIFY;
-  }
-  if (join_type == duckdb::JoinType::RIGHT || join_type == duckdb::JoinType::OUTER ||
-      join_type == duckdb::JoinType::RIGHT_SEMI) {
-    left_oob = cudf::out_of_bounds_policy::NULLIFY;
-  }
-
-  std::vector<std::unique_ptr<cudf::column>> out_cols;
-  if (collect_left) {
-    cudf::table_view left_cols_to_gather = left_full.select(lhs_output_columns.col_idxs);
-    cudf::column_view left_map_view(cudf::data_type(cudf::type_id::INT32),
-                                    left_indices->size(),
-                                    left_indices->data(),
-                                    nullptr,
-                                    0,
-                                    0,
-                                    {});
-    auto left_result = cudf::gather(left_cols_to_gather, left_map_view, left_oob, stream);
-    out_cols         = left_result->release();
-  }
-  if (collect_right) {
-    cudf::table_view right_cols_to_gather = right_full.select(rhs_output_columns.col_idxs);
-    cudf::column_view right_map_view(cudf::data_type(cudf::type_id::INT32),
-                                     right_indices->size(),
-                                     right_indices->data(),
-                                     nullptr,
-                                     0,
-                                     0,
-                                     {});
-    auto right_result   = cudf::gather(right_cols_to_gather, right_map_view, right_oob, stream);
-    auto right_out_cols = right_result->release();
-    for (auto& col : right_out_cols) {
-      out_cols.push_back(std::move(col));
-    }
-  }
-
-  auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
-  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-    make_data_batch(std::move(output_cudf_table), *input_batches[0]->get_memory_space())});
+  return gather_join_output(join_type,
+                            left_full,
+                            right_full,
+                            lhs_output_columns.col_idxs,
+                            rhs_output_columns.col_idxs,
+                            std::move(left_indices),
+                            std::move(right_indices),
+                            *input_batches[0]->get_memory_space(),
+                            stream);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -155,13 +155,15 @@ sirius_physical_hash_join::sirius_physical_hash_join(
   const duckdb::vector<duckdb::idx_t>& right_projection_map,
   duckdb::vector<duckdb::LogicalType> delim_types,
   duckdb::idx_t estimated_cardinality,
-  duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p)
+  duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p,
+  uint64_t max_build_hash_table_bytes)
   : sirius_physical_partition_consumer_operator(
       SiriusPhysicalOperatorType::HASH_JOIN, op.types, estimated_cardinality),
     conditions(std::move(cond)),
     join_type(join_type),
     delim_types(std::move(delim_types))
 {
+  _max_build_hash_table_bytes = max_build_hash_table_bytes;
   reorder_join_conditions(conditions);
 
   filter_pushdown = std::move(pushdown_info_p);
@@ -282,6 +284,28 @@ sirius_physical_hash_join::sirius_physical_hash_join(
   }
 };
 
+sirius_physical_hash_join::sirius_physical_hash_join(
+  duckdb::LogicalOperator& op,
+  duckdb::unique_ptr<sirius_physical_operator> left,
+  duckdb::unique_ptr<sirius_physical_operator> right,
+  duckdb::vector<duckdb::JoinCondition> cond,
+  duckdb::JoinType join_type,
+  duckdb::idx_t estimated_cardinality,
+  uint64_t max_build_hash_table_bytes)
+  : sirius_physical_hash_join(op,
+                              std::move(left),
+                              std::move(right),
+                              std::move(cond),
+                              join_type,
+                              {},
+                              {},
+                              {},
+                              estimated_cardinality,
+                              nullptr,
+                              max_build_hash_table_bytes)
+{
+}
+
 //===--------------------------------------------------------------------===//
 // Pipeline Construction
 //===--------------------------------------------------------------------===//
@@ -347,13 +371,10 @@ void sirius_physical_hash_join::build_pipelines(pipeline::sirius_pipeline& curre
   sirius_physical_hash_join::build_join_pipelines(current, meta_pipeline, *this);
 }
 
-// WSM TODO: make this a config variable
-constexpr uint64_t MAX_BUILD_HASH_TABLE_BYTES = 512ULL * 1024ULL * 1024ULL;  // 512MB
-
 void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64_t build_side_bytes)
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
-  if (num_partitions == 1 && build_side_bytes < MAX_BUILD_HASH_TABLE_BYTES &&
+  if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
       join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::RIGHT_SEMI &&
       join_type != duckdb::JoinType::ANTI && join_type != duckdb::JoinType::RIGHT_ANTI &&
       join_type != duckdb::JoinType::RIGHT && join_type != duckdb::JoinType::MARK &&

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -782,8 +782,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       {
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
-        _build_table =
-          input_batches[1]->get_data()->cast<cucascade::gpu_table_representation>().release_table();
+        _build_table              = input_batches[1];
         _hash_table =
           std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
@@ -818,8 +817,9 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         throw std::runtime_error("Unsupported join type in BUILD_PROBE mode: " +
                                  duckdb::JoinTypeToString(join_type));
       }
-      left_full  = get_cudf_table_view(*input_batches[0]);
-      right_full = _build_table->view();
+      left_full = get_cudf_table_view(*input_batches[0]);
+      right_full =
+        _build_table->get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
 
     } else {
       throw std::runtime_error(fmt::format(

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -1035,5 +1035,14 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                             stream);
 }
 
+void sirius_physical_hash_join::finalize_operator()
+{
+  std::lock_guard<std::mutex> lg(op_state_mutex);
+  _hash_table.reset();
+  _build_table.reset();
+  _built_table_cast_columns.clear();
+  _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -277,7 +277,9 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
   // Mixed join: has at least one equality condition (for hashing) and at least one inequality
   // condition (for the binary predicate).
-  is_mixed_join = !is_all_inequality_join && (num_equality_conditions < conditions.size());
+  if (!is_all_inequality_join && (num_equality_conditions < conditions.size())) {
+    _join_mode = HASH_JOIN_MODE::MIXED_JOIN;
+  }
 };
 
 //===--------------------------------------------------------------------===//
@@ -345,11 +347,30 @@ void sirius_physical_hash_join::build_pipelines(pipeline::sirius_pipeline& curre
   sirius_physical_hash_join::build_join_pipelines(current, meta_pipeline, *this);
 }
 
+// WSM TODO: make this a config variable
+constexpr uint64_t MAX_BUILD_HASH_TABLE_BYTES = 512ULL * 1024ULL * 1024ULL;  // 512MB
+
+void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64_t build_side_bytes)
+{
+  std::lock_guard<std::mutex> lg(op_state_mutex);
+  if (num_partitions == 1 && build_side_bytes < MAX_BUILD_HASH_TABLE_BYTES &&
+      _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
+    // Switch to a more efficient join strategy for small datasets
+    _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
+    SIRIUS_LOG_DEBUG(
+      "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and build "
+      "side size {} bytes",
+      this->get_operator_id(),
+      num_partitions,
+      build_side_bytes);
+  }
+}
+
 std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_data()
 {
   // Hold the mutex for the entire operation to prevent concurrent pop/get races.
   // A pop on one thread must not remove a batch that another thread's get expects to find.
-  std::lock_guard<std::mutex> lg(batches_to_processed_mutex);
+  std::lock_guard<std::mutex> lg(op_state_mutex);
 
   // One-time initialization: snapshot all batch IDs from both ports.
   if (left_batch_ids.empty() && right_batch_ids.empty()) {
@@ -564,7 +585,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
 
-  if (is_mixed_join) {
+  if (_join_mode == HASH_JOIN_MODE::MIXED_JOIN) {
     // Mixed join: equality conditions drive the hash table; inequality conditions are evaluated
     // via a cuDF AST binary predicate on the full input tables.
     auto keys                 = prepare_join_keys(input_batches,

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -214,7 +214,7 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
   }
 }
 
-int sirius_physical_partition::determine_num_partitions()
+std::pair<int, uint64_t> sirius_physical_partition::determine_num_partitions()
 {
   if (ports.find("default") == ports.end()) {
     throw std::runtime_error(
@@ -228,7 +228,8 @@ int sirius_physical_partition::determine_num_partitions()
     auto batch = repo->get_data_batch_by_id(batch_id, std::nullopt, 0);
     if (batch && batch->get_data()) { total_bytes += batch->get_data()->get_size_in_bytes(); }
   }
-  return static_cast<int>(std::max(uint64_t{1}, total_bytes / s_partition_size));
+  int num_partitions = static_cast<int>(std::max(uint64_t{1}, total_bytes / s_partition_size));
+  return std::make_pair(num_partitions, total_bytes);
 }
 
 void sirius_physical_partition::set_num_partitions(int num_partitions)
@@ -276,23 +277,28 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
     auto& sibling = _sibling_partition_op->Cast<sirius_physical_partition>();
     std::scoped_lock guard(lock, sibling.lock);
     if (!_num_partitions.has_value()) {
-      _num_partitions         = determine_num_partitions();
-      sibling._num_partitions = _num_partitions.value();
+      uint64_t total_bytes;
+      [ _num_partitions, total_bytes ] = determine_num_partitions();
+      sibling._num_partitions          = _num_partitions.value();
       SIRIUS_LOG_DEBUG(
-        "sirius_physical_partition id {} determined {} partitions on sibling id {} and {} build "
+        "sirius_physical_partition id {} determined {} partitions from {} bytes on sibling id {} "
+        "and {} build "
         "side",
         this->get_operator_id(),
         _num_partitions.value(),
+        total_bytes,
         _sibling_partition_op->get_operator_id(),
         (_is_build ? "is" : "is not"));
     }
   } else {
     std::lock_guard<std::mutex> guard(lock);
     if (!_num_partitions.has_value()) {
-      _num_partitions = determine_num_partitions();
-      SIRIUS_LOG_DEBUG("sirius_physical_partition id {} determined {} partitions",
+      uint64_t total_bytes;
+      [ _num_partitions, total_bytes ] = determine_num_partitions();
+      SIRIUS_LOG_DEBUG("sirius_physical_partition id {} determined {} partitions from {} bytes",
                        this->get_operator_id(),
-                       _num_partitions.value());
+                       _num_partitions.value(),
+                       total_bytes);
     }
   }
   return sirius_physical_operator::get_next_task_input_data();

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -73,6 +73,7 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
                                                             bool is_build)
 {
   if (op->type == SiriusPhysicalOperatorType::HASH_JOIN) {
+    _hash_join_op      = op;  // set the hash join operator pointer for later use
     _partition_type    = PartitionType::HASH;
     auto& hash_join_op = op->Cast<sirius_physical_hash_join>();
     for (duckdb::idx_t cond_idx = 0; cond_idx < hash_join_op.conditions.size(); cond_idx++) {
@@ -278,8 +279,10 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
     std::scoped_lock guard(lock, sibling.lock);
     if (!_num_partitions.has_value()) {
       auto [num_parts, total_bytes] = determine_num_partitions();
-      _num_partitions               = num_parts;
-      sibling._num_partitions       = num_parts;
+      _hash_join_op->Cast<sirius_physical_hash_join>().update_join_exec_mode(num_parts,
+                                                                             total_bytes);
+      _num_partitions         = num_parts;
+      sibling._num_partitions = num_parts;
       SIRIUS_LOG_DEBUG(
         "sirius_physical_partition id {} determined {} partitions from {} bytes on sibling id {} "
         "and {} build "

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -277,9 +277,9 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
     auto& sibling = _sibling_partition_op->Cast<sirius_physical_partition>();
     std::scoped_lock guard(lock, sibling.lock);
     if (!_num_partitions.has_value()) {
-      uint64_t total_bytes;
-      [ _num_partitions, total_bytes ] = determine_num_partitions();
-      sibling._num_partitions          = _num_partitions.value();
+      auto [num_parts, total_bytes] = determine_num_partitions();
+      _num_partitions               = num_parts;
+      sibling._num_partitions       = num_parts;
       SIRIUS_LOG_DEBUG(
         "sirius_physical_partition id {} determined {} partitions from {} bytes on sibling id {} "
         "and {} build "
@@ -293,8 +293,8 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
   } else {
     std::lock_guard<std::mutex> guard(lock);
     if (!_num_partitions.has_value()) {
-      uint64_t total_bytes;
-      [ _num_partitions, total_bytes ] = determine_num_partitions();
+      auto [num_parts, total_bytes] = determine_num_partitions();
+      _num_partitions               = num_parts;
       SIRIUS_LOG_DEBUG("sirius_physical_partition id {} determined {} partitions from {} bytes",
                        this->get_operator_id(),
                        _num_partitions.value(),

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -164,5 +164,10 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   return std::make_unique<operator_data>(output_batches);
 }
 
+void sirius_physical_sort_partition::finalize_operator()
+{
+  if (_sample_op) { _sample_op->clear_partition_boundaries(); }
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -210,7 +210,9 @@ void gpu_pipeline_executor::manager_loop()
         for (auto* consumer : consumers) {
           // Don't wake up FULL-barrier consumers until the pipeline is completely
           // done — doing so just causes repeated no-op dependency walks (spin loop).
-          if (consumer && !pipeline_done && consumer->has_full_barrier_from(pipeline)) { continue; }
+          // if (consumer && !pipeline_done /*&& consumer->has_full_barrier_from(pipeline)*/) {
+          //   continue;
+          // }
           _task_creator->schedule(consumer);
         }
       }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -208,12 +208,7 @@ void gpu_pipeline_executor::manager_loop()
       if (!query_complete && _task_creator) {
         bool pipeline_done = pipeline && pipeline->is_pipeline_finished();
         for (auto* consumer : consumers) {
-          // Don't wake up FULL-barrier consumers until the pipeline is completely
-          // done — doing so just causes repeated no-op dependency walks (spin loop).
-          // if (consumer && !pipeline_done /*&& consumer->has_full_barrier_from(pipeline)*/) {
-          //   continue;
-          // }
-          _task_creator->schedule(consumer);
+          if (consumer) { _task_creator->schedule(consumer); }
         }
       }
 

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -308,7 +308,12 @@ void sirius_pipeline::update_pipeline_status()
     // done atomically.
     if (limit_exhausted ||
         (first_node->is_source_pipeline_finished() && first_node->all_ports_empty())) {
-      if (tasks_created.load() == tasks_completed.load()) { pipeline_finished = true; }
+      if (tasks_created.load() == tasks_completed.load()) {
+        pipeline_finished.store(true);
+        for (auto& op : get_operators()) {
+          op.get().finalize_operator();
+        }
+      }
     }
   }
 }

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -21,6 +21,7 @@
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_nested_loop_join.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius_context.hpp"
 
 namespace sirius::planner {
 
@@ -71,17 +72,21 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
     //                                     std::move(op.filter_pushdown));
     // join.Cast<PhysicalHashJoin>().join_stats = std::move(op.join_stats);
     // return join;
-    auto join =
-      duckdb::make_uniq<sirius::op::sirius_physical_hash_join>(op,
-                                                               std::move(left),
-                                                               std::move(right),
-                                                               std::move(op.conditions),
-                                                               op.join_type,
-                                                               op.left_projection_map,
-                                                               op.right_projection_map,
-                                                               std::move(op.mark_types),
-                                                               op.estimated_cardinality,
-                                                               std::move(op.filter_pushdown));
+    const auto& op_params = context.registered_state->Get<duckdb::SiriusContext>("sirius_state")
+                              ->get_config()
+                              .get_operator_params();
+    auto join = duckdb::make_uniq<sirius::op::sirius_physical_hash_join>(
+      op,
+      std::move(left),
+      std::move(right),
+      std::move(op.conditions),
+      op.join_type,
+      op.left_projection_map,
+      op.right_projection_map,
+      std::move(op.mark_types),
+      op.estimated_cardinality,
+      std::move(op.filter_pushdown),
+      op_params.max_build_hash_table_bytes);
     join->Cast<sirius::op::sirius_physical_hash_join>().join_stats = std::move(op.join_stats);
     return join;
   }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -221,6 +221,7 @@ struct sirius::config::custom_config_registrar<sirius::operator_params> {
     setter.add_config("max_sort_partition_bytes", opt.max_sort_partition_bytes);
     setter.add_config("hash_partition_bytes", opt.hash_partition_bytes);
     setter.add_config("concat_batch_bytes", opt.concat_batch_bytes);
+    setter.add_config("max_build_hash_table_bytes", opt.max_build_hash_table_bytes);
   }
 };
 
@@ -269,6 +270,8 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
     throw std::runtime_error(
       "Failed to load Sirius configuration from file: " + config_path.string() + " " + e.what());
   }
+
+  _operator_params.validate_and_fix();
 
   // std::cerr << "Loaded Sirius configuration from file: " << config_path << std::endl;
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -930,7 +930,7 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::VARCHAR,
                             Value("none"),
                             SetCacheScanLevel);
-                            
+
   config.AddExtensionOption("max_build_hash_table_bytes",
                             "Maximum size a build-side table can be where it will create a "
                             "reusable hash table for hash joins (i.e. BUILD_PROBE mode)",

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -756,6 +756,7 @@ static void SetConcatBatchBytes(ClientContext& context, SetScope scope, Value& p
   auto* params = get_operator_params(context);
   if (!params) { return; }
   params->concat_batch_bytes = UBigIntValue::Get(parameter);
+  params->validate_and_fix();
   SIRIUS_LOG_DEBUG("Updated config CONCAT_BATCH_BYTES to {}", params->concat_batch_bytes);
 }
 
@@ -778,6 +779,16 @@ static void SetLogFlushSeconds(ClientContext& context, SetScope scope, Value& pa
   Config::LOG_FLUSH_SECONDS = IntegerValue::Get(parameter);
   SetGlobalLogFlush(Config::LOG_FLUSH_SECONDS);
   SIRIUS_LOG_DEBUG("Updated config LOG_FLUSH_SECONDS to {}", Config::LOG_FLUSH_SECONDS);
+}
+
+static void SetMaxBuildHashTableBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->max_build_hash_table_bytes = UBigIntValue::Get(parameter);
+  params->validate_and_fix();
+  SIRIUS_LOG_DEBUG("Updated config MAX_BUILD_HASH_TABLE_BYTES to {}",
+                   params->max_build_hash_table_bytes);
 }
 
 void SiriusExtension::InitialGPUConfigs(DBConfig& config)
@@ -919,6 +930,13 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::VARCHAR,
                             Value("none"),
                             SetCacheScanLevel);
+                            
+  config.AddExtensionOption("max_build_hash_table_bytes",
+                            "Maximum size a build-side table can be where it will create a "
+                            "reusable hash table for hash joins (i.e. BUILD_PROBE mode)",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(sirius::operator_params{}.max_build_hash_table_bytes),
+                            SetMaxBuildHashTableBytes);
 }
 
 static void LoadInternal(ExtensionLoader& loader)

--- a/test/cpp/integration/integration.cfg
+++ b/test/cpp/integration/integration.cfg
@@ -29,11 +29,12 @@ sirius = {
         };
     };
     operator_params = {
-        scan_task_batch_size = 1000000000;
+        scan_task_batch_size = 100000000;
         default_scan_task_varchar_size = 256;
         max_sort_partition_bytes = 0;
-        hash_partition_bytes = 1000000000;
-        concat_batch_bytes = 1000000000;
+        hash_partition_bytes = 100000000;
+        concat_batch_bytes = 100000000;
+        max_build_hash_table_bytes = 90000000;
 
     };
 };

--- a/test/cpp/integration/integration.cfg
+++ b/test/cpp/integration/integration.cfg
@@ -29,11 +29,11 @@ sirius = {
         };
     };
     operator_params = {
-        scan_task_batch_size = 100000000;
+        scan_task_batch_size = 1000000000;
         default_scan_task_varchar_size = 256;
         max_sort_partition_bytes = 0;
-        hash_partition_bytes = 100000000;
-        concat_batch_bytes = 100000000;
+        hash_partition_bytes = 1000000000;
+        concat_batch_bytes = 1000000000;
 
     };
 };


### PR DESCRIPTION
This PR introduces a new join modality for the Hash Join operator called BUILD_PROBE.
It can be enabled when the partition operator signals to the hash join operator how many partitions the build side has and how many bytes. If its only one partition, and if the table is less than `max_build_hash_table_bytes` bytes, and if its an inner, left or outer join, then it can enable the BUIlD_PROBE mode.

In this mode, it will create a task when the single batch from the build side and one batch from the probe side arrive (it no longer behaves like a full barrier on both sides). In this first task it will create a hash table which will stay in memory for the duration of the operator. Then in subsquent tasks, this hash table will be used for all join operations, for each probe batch.

Once the hash join operator's pipeline is complete a new sirius_physical_operator method `finalize_operator()` is invoked to free the hash_table and build table. 

Note that max_build_hash_table_bytes is a new sirius config operator_param. 

Note that this PR also uses finalize_operator() method on the sort_sample operator to free the boundary conditions data when its no longer needed. 