### PR TITLE
Add TPC-DS benchmark skill, DuckDB baseline script, and config handling fixes

### DIFF
--- a/.claude/skills/tpcds-benchmark/SKILL.md
+++ b/.claude/skills/tpcds-benchmark/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: tpcds-benchmark
+description: Run TPC-DS benchmarks on Legacy Sirius, Super Sirius, or DuckDB CPU baseline — generate data, execute queries, and compare results across engines.
+---
+
+# TPC-DS Benchmark Runner
+
+You are running TPC-DS benchmarks for Sirius, a GPU-accelerated SQL query engine built on DuckDB. This skill manages data generation, benchmark execution across three engines (Legacy Sirius, Super Sirius, DuckDB CPU), and result comparison.
+
+## Three Engines
+
+| Engine | Script | Entry Point | Config |
+|--------|--------|-------------|--------|
+| **Legacy Sirius** | `run_tpcds_legacy.sh` / `run_tpcds_legacy_gpu.sh` | `gpu_buffer_init` + `gpu_processing("...")` | Unsets `SIRIUS_CONFIG_FILE` |
+| **Super Sirius** | `run_tpcds_super.sh` / `run_tpcds_super_gpu.sh` | `gpu_execution("...")` | **Requires** `SIRIUS_CONFIG_FILE` |
+| **DuckDB CPU** | `run_tpcds_duckdb.sh` | Raw SQL (no GPU wrapping) | Unsets `SIRIUS_CONFIG_FILE` |
+
+**Config file behavior:**
+- Legacy Sirius: `SIRIUS_CONFIG_FILE` is automatically unset — it interferes with `gpu_buffer_init`
+- Super Sirius: `SIRIUS_CONFIG_FILE` must be set and point to a valid file — the script errors if not
+- DuckDB CPU: `SIRIUS_CONFIG_FILE` is automatically unset — pure CPU baseline
+
+## Working Directory
+
+All commands run from the **project root**. Scripts are in `test/tpcds_performance/`.
+
+## TPC-DS Tables
+
+All 24 TPC-DS tables: `call_center`, `catalog_page`, `catalog_returns`, `catalog_sales`, `customer`, `customer_address`, `customer_demographics`, `date_dim`, `household_demographics`, `income_band`, `inventory`, `item`, `promotion`, `reason`, `ship_mode`, `store`, `store_returns`, `store_sales`, `time_dim`, `warehouse`, `web_page`, `web_returns`, `web_sales`, `web_site`.
+
+## Identifying GPU Fallback and Errors
+
+When a query cannot run on GPU, each engine produces distinct error messages (see `src/sirius_extension.cpp`). A query is considered **failing** if any of these conditions are true:
+1. The log contains a fallback or error message (query ran on CPU, not GPU)
+2. The timer output is missing (`-1` in timings.csv / `NO_TIMER` status) — indicates the query crashed or hung
+3. The timings.csv shows `FAILED` status
+
+**Legacy Sirius (`gpu_processing`) messages:**
+- `"Error in GPUGeneratePhysicalPlan: <message>"` — logged when plan generation fails; sets `plan_error = true`, always falls back
+- `"Error in GPUExecuteQuery, fallback to DuckDB"` — printed to stdout when:
+  - `GPUBufferManager` not initialized (missing `gpu_buffer_init`)
+  - Plan generation failed (`plan_error = true`)
+  - Execution error (`GPUExecuteQuery` returned an error)
+- Legacy **always** falls back silently to DuckDB CPU — it never throws to the caller
+
+**Super Sirius (`gpu_execution`) messages:**
+- `"Error in SiriusGeneratePhysicalPlan: <message>"` — logged when plan generation fails. If `ENABLE_DUCKDB_FALLBACK` is true, sets `plan_error = true` and falls back. If false, throws `std::runtime_error`.
+- `"Error in SiriusExecuteQuery, fallback to DuckDB"` — printed to stdout when plan or execution error occurs AND fallback is enabled
+- `"SiriusExecuteQuery error: <message>"` — thrown as `std::runtime_error` when `ENABLE_DUCKDB_FALLBACK` is false
+
+**How to detect failures in benchmark logs:**
+```bash
+# Check which queries fell back to DuckDB (ran on CPU, not GPU)
+grep -l "fallback to DuckDB" <output_dir>/log_q*.txt
+
+# Check for plan generation errors
+grep -l "Error in GPUGeneratePhysicalPlan" <output_dir>/log_q*.txt      # Legacy
+grep -l "Error in SiriusGeneratePhysicalPlan" <output_dir>/log_q*.txt   # Super
+
+# Check for execution errors
+grep -l "Error in GPUExecuteQuery" <output_dir>/log_q*.txt              # Legacy
+grep -l "Error in SiriusExecuteQuery" <output_dir>/log_q*.txt           # Super
+
+# Check for queries that failed to produce timer output (crash/hang)
+grep "NO_TIMER\|FAILED" <output_dir>/timings.csv
+
+# Find queries that ran successfully on GPU (no fallback, no errors, timer present)
+for log in <output_dir>/log_q*.txt; do
+    if ! grep -q "fallback to DuckDB\|Error in.*PhysicalPlan\|Error in.*ExecuteQuery" "$log"; then
+        echo "$log"
+    fi
+done
+```
+
+A query is **GPU-clean** only if its log contains NO fallback/error messages AND its timings.csv entry shows `OK` status for both runs.
+
+## Workflows
+
+### Workflow A: Generate TPC-DS Data
+
+```bash
+bash test/tpcds_performance/generate_tpcds_data.sh <scale_factor> [--format parquet|duckdb]
+```
+
+- Default format is `duckdb` (creates a `.duckdb` database file)
+- Use `--format parquet` for parquet files (needed by Super Sirius and DuckDB parquet mode)
+- Output location: `test_datasets/tpcds_sf<SF>.duckdb` or `test_datasets/tpcds_parquet_sf<SF>/`
+- Also generates query files in `test/tpcds_performance/queries/q1.sql` through `q99.sql`
+
+Examples:
+```bash
+# Generate SF1 DuckDB database
+bash test/tpcds_performance/generate_tpcds_data.sh 1
+
+# Generate SF10 parquet files
+bash test/tpcds_performance/generate_tpcds_data.sh 10 --format parquet
+```
+
+### Workflow B: Run Legacy Sirius Benchmark
+
+Legacy Sirius uses `gpu_buffer_init` + `gpu_processing`. Config file is automatically unset.
+
+**All 99 queries:**
+```bash
+bash test/tpcds_performance/run_tpcds_legacy.sh "<gpu_caching_size>" "<gpu_processing_size>" [options]
+```
+
+**GPU-only queries (22 queries):**
+```bash
+bash test/tpcds_performance/run_tpcds_legacy_gpu.sh "<gpu_caching_size>" "<gpu_processing_size>" [options]
+```
+
+Options:
+- `--sf <N>` — Scale factor, used to locate database (default: 1)
+- `--db <path>` — Override path to DuckDB database file
+- `--queries <N...>` — Specific query numbers
+- `--output-dir <path>` — Results directory (default: `tpcds_results_sf<SF>/`)
+
+Examples:
+```bash
+# Run all queries at SF1
+bash test/tpcds_performance/run_tpcds_legacy.sh "1 GB" "2 GB"
+
+# Run GPU-only queries at SF10
+bash test/tpcds_performance/run_tpcds_legacy_gpu.sh "10 GB" "20 GB" --sf 10
+
+# Run specific queries
+bash test/tpcds_performance/run_tpcds_legacy.sh "1 GB" "2 GB" --queries 3 7 42
+```
+
+### Workflow C: Run Super Sirius Benchmark
+
+Super Sirius uses `gpu_execution`. **Requires `SIRIUS_CONFIG_FILE` to be set.**
+
+**All 99 queries:**
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+bash test/tpcds_performance/run_tpcds_super.sh <parquet_dir> [options]
+```
+
+**GPU-only queries (15 queries):**
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+bash test/tpcds_performance/run_tpcds_super_gpu.sh <parquet_dir> [options]
+```
+
+Options:
+- `--queries <N...>` — Specific query numbers
+- `--output-dir <path>` — Results directory (default: `tpcds_super_results/`)
+
+Examples:
+```bash
+# Run all queries
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+bash test/tpcds_performance/run_tpcds_super.sh test_datasets/tpcds_parquet_sf1
+
+# Run GPU-only queries
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+bash test/tpcds_performance/run_tpcds_super_gpu.sh test_datasets/tpcds_parquet_sf10
+
+# Run specific queries with custom output
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+bash test/tpcds_performance/run_tpcds_super.sh /data/tpcds_parquet_sf100 --queries 3 7 --output-dir /results/super_sf100
+```
+
+### Workflow D: Run DuckDB CPU Baseline
+
+Pure DuckDB execution — no Sirius, no GPU. Supports both parquet and DuckDB database sources.
+
+**From parquet files:**
+```bash
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir <path> [options]
+```
+
+**From DuckDB database:**
+```bash
+bash test/tpcds_performance/run_tpcds_duckdb.sh --db <path> [options]
+```
+
+Options:
+- `--queries <N...>` — Specific query numbers (default: all 1-99)
+- `--output-dir <path>` — Results directory (default: `tpcds_duckdb_results/`)
+
+Examples:
+```bash
+# Run all queries from parquet
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir test_datasets/tpcds_parquet_sf1
+
+# Run specific queries from database
+bash test/tpcds_performance/run_tpcds_duckdb.sh --db test_datasets/tpcds_sf1.duckdb --queries 3 7 42
+
+# Custom output directory
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir /data/tpcds_parquet_sf10 --output-dir /results/duckdb_sf10
+```
+
+### Workflow E: Compare Results
+
+Compare timing results across engines. Each script produces a `timings.csv` with the same format:
+```
+query,run1_time,run1_status,run2_time,run2_status
+```
+
+**To compare, read the timings.csv files from each engine's output directory and build a comparison table:**
+
+```bash
+# Example: compare Super Sirius vs DuckDB CPU
+# 1. Run both benchmarks (same queries, same data)
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+bash test/tpcds_performance/run_tpcds_super.sh test_datasets/tpcds_parquet_sf1 --queries 3 7 42 --output-dir results_super/
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir test_datasets/tpcds_parquet_sf1 --queries 3 7 42 --output-dir results_duckdb/
+
+# 2. Compare timings.csv files
+# Claude will read both files and produce a comparison table with speedup ratios
+```
+
+**Comparison output format:**
+| Query | DuckDB Cold | DuckDB Warm | Sirius Cold | Sirius Warm | Speedup (Warm) |
+|-------|-------------|-------------|-------------|-------------|----------------|
+
+Use warm (Run 2) timings for speedup calculation since cold runs include I/O and caching overhead.
+
+### Workflow F: Full Suite + Report
+
+Run all three engines on the same data and produce a comprehensive report.
+
+**Steps:**
+1. Generate data (if not already present)
+2. Run DuckDB CPU baseline
+3. Run Legacy Sirius (if applicable)
+4. Run Super Sirius (if applicable)
+5. Compare all results and produce a summary report
+
+```bash
+# 1. Generate SF1 parquet data
+bash test/tpcds_performance/generate_tpcds_data.sh 1 --format parquet
+
+# 2. DuckDB baseline
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir test_datasets/tpcds_parquet_sf1 --output-dir results/duckdb_sf1/
+
+# 3. Super Sirius (GPU-compatible queries)
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+bash test/tpcds_performance/run_tpcds_super_gpu.sh test_datasets/tpcds_parquet_sf1 --output-dir results/super_sf1/
+
+# 4. Compare
+# Claude reads results/duckdb_sf1/timings.csv and results/super_sf1/timings.csv
+# and produces a comparison table
+```
+
+## Output Format
+
+All scripts produce the same output structure:
+- `timings.csv` — Per-query timing data (cold + warm runs)
+- `result_q<N>.txt` — Query output for each query
+- `log_q<N>.txt` — Full DuckDB output including errors for each query
+
+Each query runs twice:
+- **Run 1 (cold)**: First execution — includes I/O, JIT compilation, caching overhead
+- **Run 2 (warm)**: Second execution — benefits from cached data
+
+## Before Running
+
+- **Ask the user** for any paths you don't know. Do NOT assume paths.
+- Ensure the DuckDB binary is built: `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make`
+- For Super Sirius: ensure `SIRIUS_CONFIG_FILE` is set
+- For Legacy Sirius: the config is automatically unset, no action needed
+- Query files must exist in `test/tpcds_performance/queries/` — run `generate_tpcds_data.sh` first
+
+## GPU-Compatible Query Lists
+
+Not all TPC-DS queries can run on GPU. The GPU-only wrapper scripts select known-good queries:
+
+- **Legacy Sirius GPU** (`run_tpcds_legacy_gpu.sh`, 22 queries): 3, 7, 17, 25, 26, 29, 37, 42, 43, 46, 50, 52, 55, 62, 68, 69, 79, 82, 85, 91, 92, 96
+- **Super Sirius GPU** (`run_tpcds_super_gpu.sh`, 15 queries): 3, 7, 22, 26, 32, 37, 42, 52, 55, 62, 82, 85, 92, 93, 97
+
+These lists are maintained in the respective `*_gpu.sh` wrapper scripts. To update them:
+1. Run all 99 queries with the full script (e.g., `run_tpcds_super.sh`)
+2. Check which queries fell back: `grep -l "fallback to DuckDB" <output_dir>/log_q*.txt`
+3. Check for plan generation errors: `grep -l "Error in SiriusGeneratePhysicalPlan" <output_dir>/log_q*.txt`
+4. Check for missing timer output: `grep "NO_TIMER\|FAILED" <output_dir>/timings.csv`
+5. Queries whose logs contain NO fallback/error messages AND show `OK` status in timings.csv ran purely on GPU
+6. Update the `GPU_QUERIES` array in the wrapper script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,353 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Sirius is a GPU-native SQL engine that integrates with DuckDB as an extension. It leverages NVIDIA CUDA-X libraries (cuDF, RMM) to accelerate SQL query execution on GPUs. Sirius intercepts DuckDB's physical plan execution and routes supported operations to GPU execution while gracefully falling back to DuckDB's CPU execution for unsupported cases.
+
+**Key Integration Points:**
+- DuckDB extension architecture: Sirius loads as a DuckDB extension (`sirius.duckdb_extension`)
+- cuCascade: Third-party library for GPU memory management (tiered memory across GPU/host/disk)
+- RAPIDS cuDF: GPU DataFrame library for data manipulation
+- RMM: RAPIDS Memory Manager for GPU memory allocation
+
+## Build System
+
+### Environment Setup
+
+**Using Pixi (Recommended):**
+```bash
+pixi shell                    # Activate environment with all dependencies
+source setup_sirius.sh        # Set SIRIUS_HOME_PATH and LDFLAGS
+```
+
+**Manual Setup:**
+```bash
+source setup_sirius.sh
+export LIBCUDF_ENV_PREFIX=/path/to/miniconda3/envs/libcudf-env  # If using conda
+```
+
+### Building
+
+```bash
+# Full build (uses all cores by default)
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+
+# If build consumes too much memory, reduce parallelism
+CMAKE_BUILD_PARALLEL_LEVEL=8 make
+
+# After build errors, clean build directory
+rm -rf build
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+```
+
+Build outputs:
+- Static extension: `build/release/extension/sirius/sirius.duckdb_extension`
+- Loadable extension: `build/release/extension/sirius/sirius_loadable.duckdb_extension`
+- Unit test binary: `build/release/extension/sirius/test/cpp/sirius_unittest`
+
+### Building Python API
+
+```bash
+cd duckdb-python
+pip install .
+cd ..
+```
+
+## Testing
+
+### SQL Logic Tests (End-to-End)
+```bash
+make test                                              # Run all SQLLogicTests
+make test_debug                                        # Debug build tests
+
+# Run specific test file
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+build/release/test/unittest --test-dir . test/sql/tpch-sirius.test
+```
+
+### C++ Unit Tests
+```bash
+# Build and run all unit tests
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+build/release/extension/sirius/test/cpp/sirius_unittest
+
+# Run tests with specific tag
+build/release/extension/sirius/test/cpp/sirius_unittest "[cpu_cache]"
+
+# Run specific test
+build/release/extension/sirius/test/cpp/sirius_unittest "test_cpu_cache_basic_string_single_col"
+```
+
+Test logs are saved to: `build/release/extension/sirius/test/cpp/log`
+
+Unit tests use Catch2 framework. Test files are in `test/cpp/` organized by component.
+
+### Performance Testing
+```bash
+# Requires duckdb-python to be built
+python3 test/tpch_performance/generate_test_data.py {SCALE_FACTOR}
+python3 test/tpch_performance/performance_test.py {SCALE_FACTOR}
+```
+
+## Code Formatting & Linting
+
+Sirius uses pre-commit hooks for code quality:
+
+```bash
+pre-commit run -a                    # Run all hooks on all files
+pre-commit install                   # Install git hooks (runs on every commit)
+```
+
+**Code style tools:**
+- C++/CUDA: clang-format (style defined in `.clang-format`)
+- Python: black
+- CMake: cmake-format
+- Spell check: codespell (custom words in `.codespell_words`)
+
+Configuration files:
+- `.clang-format`: C++/CUDA formatting rules
+- `.clang-tidy`: C++ linting rules
+- `.pre-commit-config.yaml`: All pre-commit hooks
+
+## Architecture
+
+### Two Code Paths (Legacy vs New Sirius)
+
+Sirius has two parallel execution modes, both coexisting in `src/`:
+
+**Legacy Sirius** (`gpu_processing`):
+- Uses `namespace duckdb`
+- Entry point: `CALL gpu_processing('SELECT ...')`
+- Physical plan generator: `GPUPhysicalPlanGenerator` (`src/gpu_physical_plan_generator.cpp`)
+- Operators: `GPUPhysicalOperator` subclasses in `src/operator/` (e.g., `gpu_physical_hash_join.cpp`)
+- Plan builders: `src/plan/` (e.g., `gpu_plan_filter.cpp`, `gpu_plan_aggregate.cpp`)
+- Executor: `src/gpu_executor.cpp`
+- Memory: requires `gpu_buffer_init()` before use; uses `GPUBufferManager` and `GPUContext`
+
+**New Sirius** (`gpu_execution`):
+- Uses `namespace sirius`
+- Entry point: `CALL gpu_execution('SELECT ...')`
+- Physical plan generator: `sirius_physical_plan_generator` (`src/planner/sirius_physical_plan_generator.cpp`)
+- Operators: `sirius_physical_operator` subclasses in `src/op/` (e.g., `sirius_physical_hash_join.cpp`)
+- Plan builders: `src/planner/` (e.g., `sirius_plan_filter.cpp`, `sirius_plan_aggregate.cpp`)
+- Engine: `src/sirius_engine.cpp`, pipelines in `src/pipeline/`
+- Interface: `src/sirius_interface.cpp` (uses `sirius_interface` class)
+- Includes task-based execution: `src/creator/`, `src/downgrade/`, `src/op/scan/`
+
+**Shared code** (used by both, in `namespace duckdb`):
+- `src/sirius_extension.cpp`: Extension entry point, registers both `gpu_processing` and `gpu_execution` table functions
+- `src/expression_executor/`: GPU expression evaluation
+- `src/config.cpp` / `src/include/config.hpp`: Runtime configuration
+- `src/cuda/`: CUDA kernels (cuDF wrappers, expression dispatch)
+
+New development should target the **new Sirius** (`namespace sirius` / `gpu_execution`) code path.
+
+### Execution Flow
+
+Sirius implements a custom execution engine that processes DuckDB's physical plans:
+
+1. **Thread Coordinator**: Main thread receives logical plan from DuckDB, populates Pipeline Metadata Hash Map
+2. **Task Creator**: Creates Scan Tasks and Pipeline Tasks based on data availability in Data Repository
+3. **Scan Executor**: Uses DuckDB to scan data from storage, converts to GPU format, stores in Data Repository
+4. **Pipeline Executor**: GPU thread pool executing operators via cuDF, stores results in Data Repository
+5. **Downgrade Executor**: Moves data from GPU to CPU when GPU memory is constrained
+
+### Key Components
+
+**Data Flow:**
+- `Data Batch`: Wrapper for pipeline input/output (cudf::table or spilling::allocation)
+- `Data Repository`: Container for Data Batches, manages movement across memory tiers (GPU/CPU/disk via cuCascade)
+- `Pipeline Task`: Operators chain + Data Batch to be executed on GPU
+- `Scan Task`: DuckDB-based data scan that produces Data Batches
+
+**Execution:**
+- `sirius_engine`: Top-level orchestrator, owns pipelines and physical plan
+- `sirius_pipeline`: Collection of operators that can be executed together
+- `sirius_meta_pipeline`: Manages pipeline dependencies and scheduling
+- `GPU Thread Pool`: Stream-per-thread model for parallel GPU execution
+- `Memory Reservation Manager`: Prevents GPU OOM by enforcing memory limits
+
+**Operators** (`src/include/operator/`):
+See [Supported Features](#supported-features) for the full list of implemented operators.
+
+### Directory Structure
+
+**Core source code:**
+- `src/include/`: Header files organized by module
+  - `operator/`: GPU physical operators (filter, join, aggregate, etc.)
+  - `pipeline/`: Pipeline execution framework (tasks, executors, queues)
+  - `memory/`: Memory management interfaces (integrates with cuCascade)
+  - `op/`: Sirius-specific physical operator wrappers
+  - `planner/`: Physical plan generation and optimization
+  - `data/`: Data structures (columns, batches)
+  - `cudf/`: cuDF integration utilities
+  - `expression_executor/`: Expression evaluation on GPU
+
+**Important files:**
+- `src/sirius_extension.cpp`: Extension entry point, registers functions with DuckDB
+- `src/sirius_interface.cpp`: API for `gpu_buffer_init` and `gpu_processing`
+- `src/gpu_executor.cpp`: Main GPU execution coordinator
+- `src/gpu_buffer_manager.cpp`: GPU memory allocation and caching
+
+**Third-party dependencies:**
+- `cucascade/`: GPU memory management library (built as subdirectory)
+- `duckdb/`: DuckDB core (git submodule)
+- `third_party/`: spdlog (logging), other dependencies via CMake
+
+**Build configuration:**
+- `CMakeLists.txt`: Main build configuration
+- `extension_config.cmake`: Extension-specific DuckDB config
+- `third_party/*.cmake`: External dependency fetching (spdlog, cucascade)
+- `pixi.toml`: Pixi environment specification (CUDA versions, dependencies)
+
+### Memory Management
+
+Sirius uses cuCascade for sophisticated GPU memory management:
+
+- **GPU Caching Region**: Stores raw input data on GPU
+- **GPU Processing Region**: Holds intermediate results (hash tables, join results)
+- **Pinned Host Memory**: Fast CPU-GPU transfers
+- **Memory Reservations**: Pre-allocation strategy to avoid OOM during execution
+
+Initialization via `gpu_buffer_init("1 GB", "2 GB", pinned_memory_size = "4 GB")`
+
+### Logging
+
+Sirius uses spdlog for structured logging:
+
+```bash
+export SIRIUS_LOG_DIR=/path/to/logs      # Default: ${CMAKE_BINARY_DIR}/log
+export SIRIUS_LOG_LEVEL=debug            # Levels: trace, debug, info, warn, error
+```
+
+Logs are essential for debugging GPU execution, memory allocation, and pipeline scheduling.
+
+## Development Guidelines
+
+### Fallback Strategy
+
+Sirius gracefully falls back to DuckDB CPU execution when:
+- Data size exceeds GPU memory regions (caching or processing)
+- Unsupported data types (nested types, some temporal types)
+- Unsupported operators (window functions, ASOF JOIN, etc.)
+- libcudf row count limitations (~2B rows due to int32_t row IDs)
+
+The fallback mechanism is implemented in `src/fallback.cpp` and integrates with DuckDB's execution engine.
+
+### Supported Features
+
+**Data types:** INTEGER, BIGINT, FLOAT, DOUBLE, VARCHAR, DATE, TIMESTAMP, DECIMAL
+**Operators:** FILTER, PROJECTION, JOIN (Hash/Nested Loop/Delim), GROUP BY, ORDER BY, AGGREGATION, TOP-N, LIMIT, CTE, TABLE SCAN
+**Join types:** INNER, LEFT, RIGHT, OUTER (implemented via cudf::left_join, cudf::inner_join, etc.)
+
+### Code Organization
+
+- GPU kernels (`.cu` files) are in `src/cuda/` and subdirectories
+- CPU-side logic (`.cpp` files) coordinates GPU execution
+- Header files (`.hpp`) in `src/include/` mirror source structure
+- Each operator has both a DuckDB-facing interface (`operator/`) and cuDF implementation (`cuda/operator/`)
+
+### Adding New Operators
+
+1. Create header in `src/include/operator/gpu_physical_<operator>.hpp`
+2. Implement DuckDB integration in `src/operator/gpu_physical_<operator>.cpp`
+3. Add cuDF/CUDA implementation in `src/cuda/operator/<operator>.cu`
+4. Register in physical plan generator (`src/gpu_physical_plan_generator.cpp`)
+5. Add tests in `test/cpp/operator/` and `test/sql/`
+
+### CMake Notes
+
+- Uses CUDA 13+ (specified in `pixi.toml` features)
+- Requires C++20 and CUDA standard 20
+- Separable compilation enabled for CUDA (`CMAKE_CUDA_SEPARABLE_COMPILATION ON`)
+- GPU architectures: Turing through Blackwell (75, 80, 86, 90a, 100f, 120a, 120)
+- Links against: cudf::cudf, rmm::rmm, libnuma, libconfig++, absl::any_invocable, spdlog, cuCascade
+
+## Common Issues
+
+**Build Issues:**
+
+If you see undefined reference errors related to GLIBCXX or CXXABI:
+```bash
+export LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib $LDFLAGS"
+rm -rf build
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+```
+
+**Memory Issues:**
+
+If build consumes too much RAM, reduce parallel jobs:
+```bash
+CMAKE_BUILD_PARALLEL_LEVEL=4 make
+```
+
+**Test Datasets:**
+
+TPC-H and ClickBench datasets must be generated before running tests. See `test_datasets/` and run `setup_test_datasets.sh` (automatically run in pixi activation).
+
+## Extension Development
+
+This is a DuckDB extension project using the extension template. The build system integrates with DuckDB's extension infrastructure via `extension-ci-tools`.
+
+**Key files for extension integration:**
+- `Makefile`: Thin wrapper including `extension-ci-tools/makefiles/duckdb_extension.Makefile`
+- `extension_config.cmake`: Specifies which extensions to load (sirius, json, tpcds, tpch, parquet, icu)
+- `src/sirius_extension.cpp`: Extension registration (LoadInternal function)
+
+**Extension API Usage:**
+
+CLI:
+```sql
+LOAD 'build/release/extension/sirius/sirius.duckdb_extension';
+CALL gpu_buffer_init('1 GB', '2 GB');
+-- Legacy mode:
+CALL gpu_processing('SELECT ...');
+-- New mode (preferred):
+CALL gpu_execution('SELECT ...');
+```
+
+Python:
+```python
+con = duckdb.connect('db.duckdb', config={"allow_unsigned_extensions": "true"})
+con.execute("LOAD '/path/to/sirius.duckdb_extension'")
+con.execute("CALL gpu_buffer_init('1 GB', '2 GB')")
+# Legacy mode:
+con.execute("CALL gpu_processing('SELECT ...')").fetchall()
+# New mode (preferred):
+con.execute("CALL gpu_execution('SELECT ...')").fetchall()
+```
+
+## Performance Characteristics
+
+- **Cold runs are slow**: First query loads data from storage and converts DuckDB format to GPU format
+- **Warm runs benefit from GPU caching**: Subsequent queries use cached GPU data
+- **Best for**: Interactive analytics, financial workloads, ETL jobs, large aggregations/joins
+- **Benchmark**: ~8x speedup on TPC-H SF=100 vs CPU at equivalent hardware cost
+
+## Glossary Terms
+
+Key terminology used throughout the codebase (see `docs/glossary.md` for complete definitions):
+
+- **Pipeline**: Chain of operators executed together as a unit
+- **Data Batch**: Input/output wrapper for pipeline execution
+- **Data Repository**: Central storage for Data Batches with tier management
+- **GPU Scheduling Thread**: Stream-associated thread that pulls tasks from queue
+- **Memory Reservation**: Lease on memory to prevent oversubscription
+- **Task Creator**: Thread that polls completions and creates new tasks
+- **Thread Coordinator**: Main thread orchestrating Sirius execution
+
+## Claude Code Skills
+
+Sirius includes Claude Code skills for performance analysis and dataset management. Invoke them via slash commands:
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| Profile Analyzer | `/profile-analyzer` | Analyzes GPU performance from nsys profiles — kernel occupancy, memory bandwidth, operator attribution, and regression detection. |
+| Dataset Manager | `/dataset-manager` | Manages TPC-H parquet datasets — generate at any scale factor, consolidate files, inspect layout, optimize row groups. |
+| Optimization Advisor | `/optimization-advisor` | Maps GPU hotspots from nsys profiles to source functions, detects efficiency bottlenecks, sync overhead, and parallelism opportunities. |
+| TPC-DS Benchmark | `/tpcds-benchmark` | Runs TPC-DS benchmarks on Legacy Sirius, Super Sirius, or DuckDB CPU baseline — generate data, execute queries, and compare results. |
+
+**Useful debugging tools:**
+- `tools/parse_pipeline_log.py`: Parses Sirius pipeline logs to show per-operator row counts for debugging incorrect query results.

--- a/test/tpcds_performance/generate_tpcds_data.sh
+++ b/test/tpcds_performance/generate_tpcds_data.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Generate TPC-DS data using DuckDB's dsdgen() extension.
+#
+# Usage:
+#   ./generate_tpcds_data.sh <scale_factor> [--format duckdb|parquet] [--output <path>]
+#
+# Examples:
+#   ./generate_tpcds_data.sh 1
+#   ./generate_tpcds_data.sh 10 --format parquet
+#   ./generate_tpcds_data.sh 100 --format duckdb --output /data/tpcds_sf100.duckdb
+#   ./generate_tpcds_data.sh 100 --format parquet --output /data/tpcds_parquet_sf100
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="$PROJECT_DIR/build/release/duckdb"
+
+# --- Parse arguments ---
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <scale_factor> [--format duckdb|parquet] [--output <path>]"
+    exit 1
+fi
+
+SF="$1"
+shift
+
+FORMAT="duckdb"
+OUTPUT=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --format)
+            FORMAT="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$FORMAT" != "duckdb" ] && [ "$FORMAT" != "parquet" ]; then
+    echo "ERROR: format must be 'duckdb' or 'parquet', got: $FORMAT"
+    exit 1
+fi
+
+# --- Set default output path ---
+if [ -z "$OUTPUT" ]; then
+    if [ "$FORMAT" = "duckdb" ]; then
+        OUTPUT="$PROJECT_DIR/test_datasets/tpcds_sf${SF}.duckdb"
+    else
+        OUTPUT="$PROJECT_DIR/test_datasets/tpcds_parquet_sf${SF}"
+    fi
+fi
+
+# --- Validate prerequisites ---
+if [ ! -x "$DUCKDB" ]; then
+    echo "ERROR: DuckDB binary not found at $DUCKDB"
+    echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
+    exit 1
+fi
+
+# --- Extract query texts (skip if already present) ---
+QUERY_DIR="$SCRIPT_DIR/queries"
+if [ -d "$QUERY_DIR" ] && [ -f "$QUERY_DIR/q99.sql" ]; then
+    echo "Query files already exist in $QUERY_DIR, skipping extraction."
+else
+    mkdir -p "$QUERY_DIR"
+
+    echo "Extracting TPC-DS query texts to $QUERY_DIR..."
+    EXTRACT_SQL="INSTALL tpcds; LOAD tpcds;"$'\n'
+    for q in $(seq 1 99); do
+        EXTRACT_SQL+="COPY (SELECT query FROM tpcds_queries() WHERE query_nr = ${q}) TO '${QUERY_DIR}/q${q}.sql' (HEADER false, QUOTE '', DELIMITER '');"$'\n'
+    done
+
+    # Use a temporary database for query extraction (dsdgen not needed for queries)
+    TEMP_DB="$PROJECT_DIR/tpcds_extract_tmp.duckdb"
+    rm -f "$TEMP_DB"
+    echo "$EXTRACT_SQL" | "$DUCKDB" "$TEMP_DB" 2>&1
+    rm -f "$TEMP_DB"
+    echo "Extracted 99 query files to $QUERY_DIR"
+
+    # Convert double-quoted identifiers to single quotes in all queries
+    # e.g. "order count" -> 'order count'
+    # This allows uniform gpu_processing("...") wrapping without escaping conflicts
+    echo "Converting double-quoted identifiers to single quotes..."
+    for f in "$QUERY_DIR"/q*.sql; do
+        sed -i 's/"/'"'"'/g' "$f"
+    done
+fi
+
+# --- Generate TPC-DS data ---
+if [ "$FORMAT" = "duckdb" ]; then
+    echo ""
+    echo "Generating TPC-DS data at SF${SF} into $OUTPUT ..."
+    if [ -f "$OUTPUT" ]; then
+        echo "WARNING: Database file already exists, will overwrite tables"
+    fi
+
+    "$DUCKDB" "$OUTPUT" -c "INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=${SF}, overwrite=true);"
+    echo "Done. Database saved to: $OUTPUT"
+
+elif [ "$FORMAT" = "parquet" ]; then
+    echo ""
+    echo "Generating TPC-DS data at SF${SF} (parquet export to $OUTPUT) ..."
+    mkdir -p "$OUTPUT"
+
+    TEMP_DB="$PROJECT_DIR/tpcds_gen_tmp.duckdb"
+    rm -f "$TEMP_DB"
+    "$DUCKDB" "$TEMP_DB" <<EOF
+INSTALL tpcds;
+LOAD tpcds;
+CALL dsdgen(sf=${SF});
+EXPORT DATABASE '${OUTPUT}' (FORMAT PARQUET);
+EOF
+    rm -f "$TEMP_DB"
+    echo "Done. Parquet files saved to: $OUTPUT"
+fi
+
+echo ""
+echo "Summary:"
+echo "  Scale factor: $SF"
+echo "  Format:       $FORMAT"
+echo "  Output:       $OUTPUT"
+echo "  Queries:      $QUERY_DIR/q{1..99}.sql"

--- a/test/tpcds_performance/run_tpcds_duckdb.sh
+++ b/test/tpcds_performance/run_tpcds_duckdb.sh
@@ -1,56 +1,47 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Run TPC-DS benchmark on legacy Sirius (gpu_processing).
+# Run TPC-DS benchmark on plain DuckDB (CPU baseline, no GPU).
 #
-# Requires data to be pre-generated via generate_tpcds_data.sh.
-# Each query runs in its own DuckDB process. Each query is run twice
-# (cold + warm).
+# Runs raw SQL queries directly on DuckDB without any Sirius GPU wrapping.
+# Supports both parquet-based and DuckDB database-based data sources.
+# Each query runs twice (cold + warm).
 #
 # Usage:
-#   ./run_tpcds_legacy.sh <gpu_caching_size> <gpu_processing_size> [options]
+#   ./run_tpcds_duckdb.sh --parquet-dir <path> [options]
+#   ./run_tpcds_duckdb.sh --db <path> [options]
 #
 # Examples:
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB"
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --sf 1 --queries 1 2 3
-#   ./run_tpcds_legacy.sh "10 GB" "20 GB" --sf 10 --queries $(seq 1 99)
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --db /data/tpcds_sf1.duckdb
+#   ./run_tpcds_duckdb.sh --parquet-dir /data/tpcds_parquet_sf1
+#   ./run_tpcds_duckdb.sh --db /data/tpcds_sf1.duckdb --queries 3 7 17 25
+#   ./run_tpcds_duckdb.sh --parquet-dir /data/tpcds_parquet_sf10 --output-dir /results/duckdb_sf10
 #
 # Options:
-#   --sf <N>              Scale factor, used to locate database (default: 1)
-#   --db <path>           Override path to DuckDB database file
+#   --parquet-dir <path>  Directory containing TPC-DS parquet files
+#   --db <path>           Path to DuckDB database file
 #   --queries <N...>      Specific query numbers to run (default: all 1-99)
-#   --output-dir <path>   Directory for results
+#   --output-dir <path>   Directory for results (default: tpcds_duckdb_results/)
 # =============================================================================
 
 set -uo pipefail
 
+# Prevent Sirius config from interfering — this is a pure CPU baseline
+unset SIRIUS_CONFIG_FILE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DUCKDB="$PROJECT_DIR/build/release/duckdb"
-EXTENSION="$PROJECT_DIR/build/release/extension/sirius/sirius.duckdb_extension"
 QUERY_DIR="$SCRIPT_DIR/queries"
 
 # --- Parse arguments ---
-if [ $# -lt 2 ]; then
-    echo "Usage: $0 <gpu_caching_size> <gpu_processing_size> [--sf N] [--db path] [--queries N...] [--output-dir path]"
-    echo "Example: $0 '1 GB' '2 GB' --sf 1 --queries 1 2 3"
-    exit 1
-fi
-
-GPU_CACHING_SIZE="$1"
-shift
-GPU_PROCESSING_SIZE="$1"
-shift
-
-SF=1
+PARQUET_DIR=""
 DB_PATH=""
 OUTPUT_DIR=""
 QUERIES=()
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --sf)
-            SF="$2"
+        --parquet-dir)
+            PARQUET_DIR="$2"
             shift 2
             ;;
         --db)
@@ -70,25 +61,31 @@ while [ $# -gt 0 ]; do
             ;;
         *)
             echo "Unknown option: $1"
+            echo "Usage: $0 --parquet-dir <path> | --db <path> [--queries N...] [--output-dir path]"
             exit 1
             ;;
     esac
 done
 
-# Legacy Sirius uses gpu_buffer_init + gpu_processing; config file interferes
-unset SIRIUS_CONFIG_FILE
-
-# Defaults
-if [ -z "$DB_PATH" ]; then
-    DB_PATH="$PROJECT_DIR/test_datasets/tpcds_sf${SF}.duckdb"
+# Validate: exactly one data source required
+if [ -z "$PARQUET_DIR" ] && [ -z "$DB_PATH" ]; then
+    echo "ERROR: Must specify either --parquet-dir or --db"
+    echo "Usage: $0 --parquet-dir <path> | --db <path> [--queries N...] [--output-dir path]"
+    exit 1
 fi
 
+if [ -n "$PARQUET_DIR" ] && [ -n "$DB_PATH" ]; then
+    echo "ERROR: Specify only one of --parquet-dir or --db, not both"
+    exit 1
+fi
+
+# Defaults
 if [ ${#QUERIES[@]} -eq 0 ]; then
     QUERIES=($(seq 1 99))
 fi
 
 if [ -z "$OUTPUT_DIR" ]; then
-    OUTPUT_DIR="$PROJECT_DIR/tpcds_results_sf${SF}"
+    OUTPUT_DIR="$PROJECT_DIR/tpcds_duckdb_results"
 fi
 mkdir -p "$OUTPUT_DIR"
 
@@ -99,42 +96,73 @@ if [ ! -x "$DUCKDB" ]; then
     exit 1
 fi
 
-if [ ! -f "$EXTENSION" ]; then
-    echo "ERROR: Sirius extension not found at $EXTENSION"
-    echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
+if [ -n "$PARQUET_DIR" ] && [ ! -d "$PARQUET_DIR" ]; then
+    echo "ERROR: Parquet directory not found: $PARQUET_DIR"
+    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh <SF> --format parquet"
     exit 1
 fi
 
-if [ ! -f "$DB_PATH" ]; then
+if [ -n "$DB_PATH" ] && [ ! -f "$DB_PATH" ]; then
     echo "ERROR: Database file not found: $DB_PATH"
-    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh <SF>"
     exit 1
 fi
 
 if [ ! -d "$QUERY_DIR" ]; then
     echo "ERROR: Query directory not found: $QUERY_DIR"
-    echo "Generate queries first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+    echo "Generate queries first: bash $SCRIPT_DIR/generate_tpcds_data.sh <SF>"
     exit 1
+fi
+
+# --- Build CREATE VIEW statements (parquet mode only) ---
+VIEW_SQL=""
+if [ -n "$PARQUET_DIR" ]; then
+    TPCDS_TABLES=(
+        call_center catalog_page catalog_returns catalog_sales
+        customer customer_address customer_demographics date_dim
+        household_demographics income_band inventory item
+        promotion reason ship_mode store
+        store_returns store_sales time_dim warehouse
+        web_page web_returns web_sales web_site
+    )
+
+    for TABLE_NAME in "${TPCDS_TABLES[@]}"; do
+        FILES=()
+        for f in "$PARQUET_DIR/${TABLE_NAME}.parquet" \
+                 "$PARQUET_DIR/${TABLE_NAME}_"*.parquet \
+                 "$PARQUET_DIR/${TABLE_NAME}/"*.parquet; do
+            [ -f "$f" ] && FILES+=("'$f'")
+        done
+        if [ ${#FILES[@]} -eq 0 ]; then
+            echo "WARNING: No parquet files found for table $TABLE_NAME"
+            continue
+        fi
+        FILE_LIST=$(IFS=,; echo "${FILES[*]}")
+        VIEW_SQL+="CREATE VIEW ${TABLE_NAME} AS SELECT * FROM read_parquet([${FILE_LIST}]);"$'\n'
+    done
 fi
 
 # --- Initialize output ---
 TIMING_FILE="$OUTPUT_DIR/timings.csv"
 echo "query,run1_time,run1_status,run2_time,run2_status" > "$TIMING_FILE"
 
+DATA_SOURCE=""
+if [ -n "$PARQUET_DIR" ]; then
+    DATA_SOURCE="$PARQUET_DIR (parquet)"
+else
+    DATA_SOURCE="$DB_PATH (duckdb)"
+fi
+
 echo "=========================================="
-echo "TPC-DS Benchmark — Legacy Sirius (gpu_processing)"
+echo "TPC-DS Benchmark — DuckDB CPU Baseline"
 echo "=========================================="
-echo "Scale Factor:     $SF"
-echo "Database:         $DB_PATH"
-echo "GPU Caching:      $GPU_CACHING_SIZE"
-echo "GPU Processing:   $GPU_PROCESSING_SIZE"
+echo "Data Source:       $DATA_SOURCE"
 echo "Queries:          ${QUERIES[*]}"
 echo "Output:           $OUTPUT_DIR"
 echo "=========================================="
 echo ""
 
 # parse_timer_output <output_text>
-# Extracts real (wall clock) times from DuckDB .timer output.
 parse_timer_output() {
     echo "$1" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+'
 }
@@ -157,27 +185,26 @@ for q in "${QUERIES[@]}"; do
 
     echo "--- Query ${q} ---"
 
-    # Strip trailing semicolons from the query
-    CLEANED_SQL=$(echo "$QUERY_SQL" | sed 's/;[[:space:]]*$//')
-
-    # Escape inner double quotes, then wrap with gpu_processing("...")
-    ESCAPED_SQL=$(echo "$CLEANED_SQL" | sed 's/"/\\"/g')
-
-    # Write SQL file using printf to avoid bash heredoc expansion issues
+    # Write SQL file: optional views, timer, then run raw SQL twice
     TEMP_SQL="$OUTPUT_DIR/tmp_q${q}.sql"
     {
-        printf "CALL gpu_buffer_init('%s', '%s');\n" "$GPU_CACHING_SIZE" "$GPU_PROCESSING_SIZE"
+        if [ -n "$VIEW_SQL" ]; then
+            printf '%s\n' "$VIEW_SQL"
+        fi
         printf ".timer on\n"
-        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
-        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
+        printf '%s\n' "$QUERY_SQL"
+        printf '%s\n' "$QUERY_SQL"
     } > "$TEMP_SQL"
 
     Q_RESULT_FILE="$OUTPUT_DIR/result_q${q}.txt"
     Q_LOG="$OUTPUT_DIR/log_q${q}.txt"
 
-    # Run in a fresh DuckDB process against the pre-generated database
-    OUTPUT=$("$DUCKDB" "$DB_PATH" < "$TEMP_SQL" 2>&1) || true
-    EXIT_CODE=${PIPESTATUS[0]:-$?}
+    # Run in a fresh DuckDB process
+    if [ -n "$DB_PATH" ]; then
+        OUTPUT=$("$DUCKDB" "$DB_PATH" < "$TEMP_SQL" 2>&1) || true
+    else
+        OUTPUT=$("$DUCKDB" < "$TEMP_SQL" 2>&1) || true
+    fi
 
     echo "$OUTPUT" > "$Q_LOG"
     rm -f "$TEMP_SQL"

--- a/test/tpcds_performance/run_tpcds_gpu.sh
+++ b/test/tpcds_performance/run_tpcds_gpu.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Run the 22 TPC-DS queries that execute on GPU via legacy Sirius (gpu_processing).
+#
+# Usage:
+#   ./run_tpcds_gpu.sh <gpu_caching_size> <gpu_processing_size> [options]
+#
+# Examples:
+#   ./run_tpcds_gpu.sh "1 GB" "2 GB"
+#   ./run_tpcds_gpu.sh "10 GB" "20 GB" --sf 10
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# TPC-DS queries confirmed to run on GPU (no fallback to DuckDB)
+GPU_QUERIES=(3 7 17 25 26 29 37 42 43 46 50 52 55 62 68 69 79 82 85 91 92 96)
+
+exec bash "$SCRIPT_DIR/run_tpcds_legacy.sh" "$@" --queries "${GPU_QUERIES[@]}"

--- a/test/tpcds_performance/run_tpcds_legacy.sh
+++ b/test/tpcds_performance/run_tpcds_legacy.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Run TPC-DS benchmark on legacy Sirius (gpu_processing).
+#
+# Requires data to be pre-generated via generate_tpcds_data.sh.
+# Each query runs in its own DuckDB process. Each query is run twice
+# (cold + warm).
+#
+# Usage:
+#   ./run_tpcds_legacy.sh <gpu_caching_size> <gpu_processing_size> [options]
+#
+# Examples:
+#   ./run_tpcds_legacy.sh "1 GB" "2 GB"
+#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --sf 1 --queries 1 2 3
+#   ./run_tpcds_legacy.sh "10 GB" "20 GB" --sf 10 --queries $(seq 1 99)
+#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --db /data/tpcds_sf1.duckdb
+#
+# Options:
+#   --sf <N>              Scale factor, used to locate database (default: 1)
+#   --db <path>           Override path to DuckDB database file
+#   --queries <N...>      Specific query numbers to run (default: all 1-99)
+#   --output-dir <path>   Directory for results
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="$PROJECT_DIR/build/release/duckdb"
+EXTENSION="$PROJECT_DIR/build/release/extension/sirius/sirius.duckdb_extension"
+QUERY_DIR="$SCRIPT_DIR/queries"
+
+# --- Parse arguments ---
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <gpu_caching_size> <gpu_processing_size> [--sf N] [--db path] [--queries N...] [--output-dir path]"
+    echo "Example: $0 '1 GB' '2 GB' --sf 1 --queries 1 2 3"
+    exit 1
+fi
+
+GPU_CACHING_SIZE="$1"
+shift
+GPU_PROCESSING_SIZE="$1"
+shift
+
+SF=1
+DB_PATH=""
+OUTPUT_DIR=""
+QUERIES=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sf)
+            SF="$2"
+            shift 2
+            ;;
+        --db)
+            DB_PATH="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --queries)
+            shift
+            while [ $# -gt 0 ] && [[ "$1" != --* ]]; do
+                QUERIES+=("$1")
+                shift
+            done
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Defaults
+if [ -z "$DB_PATH" ]; then
+    DB_PATH="$PROJECT_DIR/test_datasets/tpcds_sf${SF}.duckdb"
+fi
+
+if [ ${#QUERIES[@]} -eq 0 ]; then
+    QUERIES=($(seq 1 99))
+fi
+
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR="$PROJECT_DIR/tpcds_results_sf${SF}"
+fi
+mkdir -p "$OUTPUT_DIR"
+
+# --- Validate prerequisites ---
+if [ ! -x "$DUCKDB" ]; then
+    echo "ERROR: DuckDB binary not found at $DUCKDB"
+    echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
+    exit 1
+fi
+
+if [ ! -f "$EXTENSION" ]; then
+    echo "ERROR: Sirius extension not found at $EXTENSION"
+    echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
+    exit 1
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+    echo "ERROR: Database file not found: $DB_PATH"
+    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+    exit 1
+fi
+
+if [ ! -d "$QUERY_DIR" ]; then
+    echo "ERROR: Query directory not found: $QUERY_DIR"
+    echo "Generate queries first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+    exit 1
+fi
+
+# --- Initialize output ---
+TIMING_FILE="$OUTPUT_DIR/timings.csv"
+echo "query,run1_time,run1_status,run2_time,run2_status" > "$TIMING_FILE"
+
+echo "=========================================="
+echo "TPC-DS Benchmark — Legacy Sirius (gpu_processing)"
+echo "=========================================="
+echo "Scale Factor:     $SF"
+echo "Database:         $DB_PATH"
+echo "GPU Caching:      $GPU_CACHING_SIZE"
+echo "GPU Processing:   $GPU_PROCESSING_SIZE"
+echo "Queries:          ${QUERIES[*]}"
+echo "Output:           $OUTPUT_DIR"
+echo "=========================================="
+echo ""
+
+# parse_timer_output <output_text>
+# Extracts real (wall clock) times from DuckDB .timer output.
+parse_timer_output() {
+    echo "$1" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+'
+}
+
+# --- Run each query ---
+for q in "${QUERIES[@]}"; do
+    QUERY_FILE="$QUERY_DIR/q${q}.sql"
+    if [ ! -f "$QUERY_FILE" ]; then
+        echo "WARNING: Query file not found: $QUERY_FILE, skipping Q${q}"
+        echo "${q},-1,SKIP,-1,SKIP" >> "$TIMING_FILE"
+        continue
+    fi
+
+    QUERY_SQL=$(cat "$QUERY_FILE")
+    if [ -z "$QUERY_SQL" ]; then
+        echo "WARNING: Query ${q} is empty, skipping"
+        echo "${q},-1,EMPTY,-1,EMPTY" >> "$TIMING_FILE"
+        continue
+    fi
+
+    echo "--- Query ${q} ---"
+
+    # Strip trailing semicolons from the query
+    CLEANED_SQL=$(echo "$QUERY_SQL" | sed 's/;[[:space:]]*$//')
+
+    # Escape inner double quotes, then wrap with gpu_processing("...")
+    ESCAPED_SQL=$(echo "$CLEANED_SQL" | sed 's/"/\\"/g')
+
+    # Write SQL file using printf to avoid bash heredoc expansion issues
+    TEMP_SQL="$OUTPUT_DIR/tmp_q${q}.sql"
+    {
+        printf "CALL gpu_buffer_init('%s', '%s');\n" "$GPU_CACHING_SIZE" "$GPU_PROCESSING_SIZE"
+        printf ".timer on\n"
+        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
+        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
+    } > "$TEMP_SQL"
+
+    Q_RESULT_FILE="$OUTPUT_DIR/result_q${q}.txt"
+    Q_LOG="$OUTPUT_DIR/log_q${q}.txt"
+
+    # Run in a fresh DuckDB process against the pre-generated database
+    OUTPUT=$("$DUCKDB" "$DB_PATH" < "$TEMP_SQL" 2>&1) || true
+    EXIT_CODE=${PIPESTATUS[0]:-$?}
+
+    echo "$OUTPUT" > "$Q_LOG"
+    rm -f "$TEMP_SQL"
+
+    # Parse timer output — expect two "Run Time" lines
+    readarray -t TIMES < <(parse_timer_output "$OUTPUT")
+
+    RUN1_TIME="${TIMES[0]:--1}"
+    RUN2_TIME="${TIMES[1]:--1}"
+
+    # Check for errors in the output
+    HAS_ERROR=$(echo "$OUTPUT" | grep -ci "error" || true)
+
+    if [ "$HAS_ERROR" -gt 0 ] && [ "$RUN1_TIME" = "-1" ]; then
+        ERROR_MSG=$(echo "$OUTPUT" | grep -i "error" | head -1)
+        echo "  Run 1: FAILED — $ERROR_MSG"
+        echo "  Run 2: FAILED"
+        echo "${q},${RUN1_TIME},FAILED,${RUN2_TIME},FAILED" >> "$TIMING_FILE"
+    else
+        RUN1_STATUS="OK"
+        RUN2_STATUS="OK"
+
+        if [ "$RUN1_TIME" = "-1" ]; then
+            RUN1_STATUS="NO_TIMER"
+        fi
+        if [ "$RUN2_TIME" = "-1" ]; then
+            RUN2_STATUS="NO_TIMER"
+        fi
+
+        echo "  Run 1 (cold): ${RUN1_TIME}s  [${RUN1_STATUS}]"
+        echo "  Run 2 (warm): ${RUN2_TIME}s  [${RUN2_STATUS}]"
+        echo "${q},${RUN1_TIME},${RUN1_STATUS},${RUN2_TIME},${RUN2_STATUS}" >> "$TIMING_FILE"
+    fi
+
+    # Save query result (output minus timer lines)
+    echo "$OUTPUT" | grep -v "Run Time (s):" > "$Q_RESULT_FILE"
+done
+
+# --- Summary ---
+echo ""
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+printf "%-8s %12s %12s %10s\n" "Query" "Cold (s)" "Warm (s)" "Status"
+printf "%s\n" "----------------------------------------------"
+
+PASSED=0
+FAILED=0
+while IFS=, read -r q t1 s1 t2 s2; do
+    [ "$q" = "query" ] && continue  # skip header
+    if [ "$s1" = "OK" ] && [ "$s2" = "OK" ]; then
+        STATUS="OK"
+        ((PASSED++))
+    else
+        STATUS="FAILED"
+        ((FAILED++))
+    fi
+    printf "%-8s %12s %12s %10s\n" "$q" "$t1" "$t2" "$STATUS"
+done < "$TIMING_FILE"
+
+printf "%s\n" "----------------------------------------------"
+echo "Passed: $PASSED / $((PASSED + FAILED))"
+[ $FAILED -gt 0 ] && echo "Failed: $FAILED / $((PASSED + FAILED))"
+echo ""
+echo "Timings:  $TIMING_FILE"
+echo "Results:  $OUTPUT_DIR/result_q*.txt"
+echo "Logs:     $OUTPUT_DIR/log_q*.txt"

--- a/test/tpcds_performance/run_tpcds_legacy_gpu.sh
+++ b/test/tpcds_performance/run_tpcds_legacy_gpu.sh
@@ -3,11 +3,11 @@
 # Run the 22 TPC-DS queries that execute on GPU via legacy Sirius (gpu_processing).
 #
 # Usage:
-#   ./run_tpcds_gpu.sh <gpu_caching_size> <gpu_processing_size> [options]
+#   ./run_tpcds_legacy_gpu.sh <gpu_caching_size> <gpu_processing_size> [options]
 #
 # Examples:
-#   ./run_tpcds_gpu.sh "1 GB" "2 GB"
-#   ./run_tpcds_gpu.sh "10 GB" "20 GB" --sf 10
+#   ./run_tpcds_legacy_gpu.sh "1 GB" "2 GB"
+#   ./run_tpcds_legacy_gpu.sh "10 GB" "20 GB" --sf 10
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/test/tpcds_performance/run_tpcds_super.sh
+++ b/test/tpcds_performance/run_tpcds_super.sh
@@ -1,23 +1,19 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Run TPC-DS benchmark on legacy Sirius (gpu_processing).
+# Run TPC-DS benchmark on new Sirius (gpu_execution) against parquet files.
 #
-# Requires data to be pre-generated via generate_tpcds_data.sh.
-# Each query runs in its own DuckDB process. Each query is run twice
-# (cold + warm).
+# Uses gpu_execution (new Sirius) — no gpu_buffer_init needed.
+# Creates views from parquet files, then runs each query twice (cold + warm).
 #
 # Usage:
-#   ./run_tpcds_legacy.sh <gpu_caching_size> <gpu_processing_size> [options]
+#   ./run_tpcds_super.sh <parquet_dir> [options]
 #
 # Examples:
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB"
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --sf 1 --queries 1 2 3
-#   ./run_tpcds_legacy.sh "10 GB" "20 GB" --sf 10 --queries $(seq 1 99)
-#   ./run_tpcds_legacy.sh "1 GB" "2 GB" --db /data/tpcds_sf1.duckdb
+#   ./run_tpcds_super.sh /data/tpcds_parquet_sf1
+#   ./run_tpcds_super.sh /data/tpcds_parquet_sf10 --queries 3 7 17 25
+#   ./run_tpcds_super.sh /data/tpcds_parquet_sf100 --output-dir /results/sf100
 #
 # Options:
-#   --sf <N>              Scale factor, used to locate database (default: 1)
-#   --db <path>           Override path to DuckDB database file
 #   --queries <N...>      Specific query numbers to run (default: all 1-99)
 #   --output-dir <path>   Directory for results
 # =============================================================================
@@ -27,36 +23,23 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DUCKDB="$PROJECT_DIR/build/release/duckdb"
-EXTENSION="$PROJECT_DIR/build/release/extension/sirius/sirius.duckdb_extension"
 QUERY_DIR="$SCRIPT_DIR/queries"
 
 # --- Parse arguments ---
-if [ $# -lt 2 ]; then
-    echo "Usage: $0 <gpu_caching_size> <gpu_processing_size> [--sf N] [--db path] [--queries N...] [--output-dir path]"
-    echo "Example: $0 '1 GB' '2 GB' --sf 1 --queries 1 2 3"
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <parquet_dir> [--queries N...] [--output-dir path]"
+    echo "Example: $0 /data/tpcds_parquet_sf1 --queries 3 7 17 25"
     exit 1
 fi
 
-GPU_CACHING_SIZE="$1"
-shift
-GPU_PROCESSING_SIZE="$1"
+PARQUET_DIR="$1"
 shift
 
-SF=1
-DB_PATH=""
 OUTPUT_DIR=""
 QUERIES=()
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --sf)
-            SF="$2"
-            shift 2
-            ;;
-        --db)
-            DB_PATH="$2"
-            shift 2
-            ;;
         --output-dir)
             OUTPUT_DIR="$2"
             shift 2
@@ -75,66 +58,87 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# Legacy Sirius uses gpu_buffer_init + gpu_processing; config file interferes
-unset SIRIUS_CONFIG_FILE
-
 # Defaults
-if [ -z "$DB_PATH" ]; then
-    DB_PATH="$PROJECT_DIR/test_datasets/tpcds_sf${SF}.duckdb"
-fi
-
 if [ ${#QUERIES[@]} -eq 0 ]; then
     QUERIES=($(seq 1 99))
 fi
 
 if [ -z "$OUTPUT_DIR" ]; then
-    OUTPUT_DIR="$PROJECT_DIR/tpcds_results_sf${SF}"
+    OUTPUT_DIR="$PROJECT_DIR/tpcds_super_results"
 fi
 mkdir -p "$OUTPUT_DIR"
 
 # --- Validate prerequisites ---
+if [ -z "${SIRIUS_CONFIG_FILE:-}" ]; then
+    echo "ERROR: SIRIUS_CONFIG_FILE is not set."
+    echo "Super Sirius (gpu_execution) requires a config file."
+    echo "Usage: export SIRIUS_CONFIG_FILE=/path/to/config.cfg"
+    exit 1
+fi
+
+if [ ! -f "$SIRIUS_CONFIG_FILE" ]; then
+    echo "ERROR: Config file not found: $SIRIUS_CONFIG_FILE"
+    exit 1
+fi
+
 if [ ! -x "$DUCKDB" ]; then
     echo "ERROR: DuckDB binary not found at $DUCKDB"
     echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
     exit 1
 fi
 
-if [ ! -f "$EXTENSION" ]; then
-    echo "ERROR: Sirius extension not found at $EXTENSION"
-    echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
-    exit 1
-fi
-
-if [ ! -f "$DB_PATH" ]; then
-    echo "ERROR: Database file not found: $DB_PATH"
-    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+if [ ! -d "$PARQUET_DIR" ]; then
+    echo "ERROR: Parquet directory not found: $PARQUET_DIR"
+    echo "Generate data first: bash $SCRIPT_DIR/generate_tpcds_data.sh <SF> --format parquet"
     exit 1
 fi
 
 if [ ! -d "$QUERY_DIR" ]; then
     echo "ERROR: Query directory not found: $QUERY_DIR"
-    echo "Generate queries first: bash $SCRIPT_DIR/generate_tpcds_data.sh $SF"
+    echo "Generate queries first: bash $SCRIPT_DIR/generate_tpcds_data.sh <SF>"
     exit 1
 fi
+
+# --- Build CREATE VIEW statements for all TPC-DS tables ---
+TPCDS_TABLES=(
+    call_center catalog_page catalog_returns catalog_sales
+    customer customer_address customer_demographics date_dim
+    household_demographics income_band inventory item
+    promotion reason ship_mode store
+    store_returns store_sales time_dim warehouse
+    web_page web_returns web_sales web_site
+)
+
+VIEW_SQL=""
+for TABLE_NAME in "${TPCDS_TABLES[@]}"; do
+    FILES=()
+    for f in "$PARQUET_DIR/${TABLE_NAME}.parquet" \
+             "$PARQUET_DIR/${TABLE_NAME}_"*.parquet \
+             "$PARQUET_DIR/${TABLE_NAME}/"*.parquet; do
+        [ -f "$f" ] && FILES+=("'$f'")
+    done
+    if [ ${#FILES[@]} -eq 0 ]; then
+        echo "WARNING: No parquet files found for table $TABLE_NAME"
+        continue
+    fi
+    FILE_LIST=$(IFS=,; echo "${FILES[*]}")
+    VIEW_SQL+="CREATE VIEW ${TABLE_NAME} AS SELECT * FROM read_parquet([${FILE_LIST}]);"$'\n'
+done
 
 # --- Initialize output ---
 TIMING_FILE="$OUTPUT_DIR/timings.csv"
 echo "query,run1_time,run1_status,run2_time,run2_status" > "$TIMING_FILE"
 
 echo "=========================================="
-echo "TPC-DS Benchmark — Legacy Sirius (gpu_processing)"
+echo "TPC-DS Benchmark — New Sirius (gpu_execution)"
 echo "=========================================="
-echo "Scale Factor:     $SF"
-echo "Database:         $DB_PATH"
-echo "GPU Caching:      $GPU_CACHING_SIZE"
-echo "GPU Processing:   $GPU_PROCESSING_SIZE"
+echo "Parquet Dir:      $PARQUET_DIR"
 echo "Queries:          ${QUERIES[*]}"
 echo "Output:           $OUTPUT_DIR"
 echo "=========================================="
 echo ""
 
 # parse_timer_output <output_text>
-# Extracts real (wall clock) times from DuckDB .timer output.
 parse_timer_output() {
     echo "$1" | grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+'
 }
@@ -160,24 +164,23 @@ for q in "${QUERIES[@]}"; do
     # Strip trailing semicolons from the query
     CLEANED_SQL=$(echo "$QUERY_SQL" | sed 's/;[[:space:]]*$//')
 
-    # Escape inner double quotes, then wrap with gpu_processing("...")
+    # Escape inner double quotes, then wrap with gpu_execution("...")
     ESCAPED_SQL=$(echo "$CLEANED_SQL" | sed 's/"/\\"/g')
 
-    # Write SQL file using printf to avoid bash heredoc expansion issues
+    # Write SQL file: views, timer, then two runs of gpu_execution
     TEMP_SQL="$OUTPUT_DIR/tmp_q${q}.sql"
     {
-        printf "CALL gpu_buffer_init('%s', '%s');\n" "$GPU_CACHING_SIZE" "$GPU_PROCESSING_SIZE"
+        printf '%s\n' "$VIEW_SQL"
         printf ".timer on\n"
-        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
-        printf 'CALL gpu_processing("%s");\n' "$ESCAPED_SQL"
+        printf 'CALL gpu_execution("%s");\n' "$ESCAPED_SQL"
+        printf 'CALL gpu_execution("%s");\n' "$ESCAPED_SQL"
     } > "$TEMP_SQL"
 
     Q_RESULT_FILE="$OUTPUT_DIR/result_q${q}.txt"
     Q_LOG="$OUTPUT_DIR/log_q${q}.txt"
 
-    # Run in a fresh DuckDB process against the pre-generated database
-    OUTPUT=$("$DUCKDB" "$DB_PATH" < "$TEMP_SQL" 2>&1) || true
-    EXIT_CODE=${PIPESTATUS[0]:-$?}
+    # Run in a fresh DuckDB process (no database file needed — views read parquet)
+    OUTPUT=$("$DUCKDB" < "$TEMP_SQL" 2>&1) || true
 
     echo "$OUTPUT" > "$Q_LOG"
     rm -f "$TEMP_SQL"

--- a/test/tpcds_performance/run_tpcds_super_gpu.sh
+++ b/test/tpcds_performance/run_tpcds_super_gpu.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Run the 15 TPC-DS queries that execute cleanly on GPU via new Sirius (gpu_execution).
+#
+# Usage:
+#   ./run_tpcds_super_gpu.sh <parquet_dir> [options]
+#
+# Examples:
+#   ./run_tpcds_super_gpu.sh /data/tpcds_parquet_sf1
+#   ./run_tpcds_super_gpu.sh /data/tpcds_parquet_sf10 --output-dir /results/sf10
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# TPC-DS queries confirmed to run cleanly on GPU with new Sirius (no errors)
+GPU_QUERIES=(3 7 22 26 32 37 42 52 55 62 82 85 92 93 97)
+
+exec bash "$SCRIPT_DIR/run_tpcds_super.sh" "$@" --queries "${GPU_QUERIES[@]}"


### PR DESCRIPTION
  Summary

  - Rename run_tpcds_gpu.sh → run_tpcds_legacy_gpu.sh for consistency with other legacy scripts
  - Fix config interference: Legacy Sirius (gpu_processing) now unsets SIRIUS_CONFIG_FILE before running — the config file interferes with gpu_buffer_init
  - Require config for Super Sirius: run_tpcds_super.sh now validates that SIRIUS_CONFIG_FILE is set and points to an existing file, erroring early with a clear
  message if not
  - Add DuckDB CPU baseline script (run_tpcds_duckdb.sh): Runs raw SQL on DuckDB without any GPU wrapping. Supports both --parquet-dir and --db data sources. Same
  output format (timings.csv, result_q*.txt, log_q*.txt) as the Sirius scripts for easy comparison
  - Add /tpcds-benchmark Claude Code skill with six workflows:
    - A: Generate TPC-DS data (parquet or duckdb format)
    - B: Run Legacy Sirius benchmark (gpu_processing)
    - C: Run Super Sirius benchmark (gpu_execution)
    - D: Run DuckDB CPU baseline
    - E: Compare results across engines
    - F: Full suite + report
  - Track run_tpcds_super.sh and run_tpcds_super_gpu.sh (previously untracked)

  The skill documents all GPU fallback/error messages from src/sirius_extension.cpp (GPUGeneratePhysicalPlan, GPUExecuteQuery, SiriusGeneratePhysicalPlan,
  SiriusExecuteQuery) and explains how to identify which queries actually ran on GPU vs fell back to CPU.

  Test plan

  - Run run_tpcds_legacy.sh — verify SIRIUS_CONFIG_FILE is unset during execution
  - Run run_tpcds_super.sh without config — verify it errors with a clear message
  - Run run_tpcds_super.sh with config — verify it works as before
  - Run run_tpcds_duckdb.sh --parquet-dir — verify plain SQL execution, no GPU involvement
  - Run run_tpcds_duckdb.sh --db — verify database mode works
  - Invoke /tpcds-benchmark skill — verify it loads correctly