### PR TITLE
CI: Ensure GPU tests run on ALL `dev` commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }} # cancel existing runs on PRs but run on all `dev` commits
 
 jobs:
   build:


### PR DESCRIPTION
Previously the `concurrency` settings in `test.yml` canceled previous `Test` runs to prevent using resources for commits that were no longer relevant. While this works for PRs, it creates an issue for `dev` commits when commits are merged before CI testing from the previous commit finishes causing:
<img width="670" height="267" alt="Screenshot 2026-03-10 at 10 48 43" src="https://github.com/user-attachments/assets/c62604bd-6b26-4c7a-857a-4121a401dff6" />

This PR updates the `cancel-in-progress` to not cancel tests on the `dev` branch; ensuring every commit to `dev` is tested