### PR TITLE
Per query config

### DIFF
--- a/.claude/skills/config-optimizer/SKILL.md
+++ b/.claude/skills/config-optimizer/SKILL.md
@@ -10,9 +10,7 @@ You are tuning sirius configurations for optimal performance on TPC-H datasets a
 ## Configuration Parameters
 - `sirius.executor.pipeline.num_threads`: [1-10] change number of threads(streams) used for gpu tasks in pipeline executor.
 - `sirius.executor.duckdb_scan.num_threads`: [1-10] change number of threads used for duckdb scan operator.
-- `sirius.executor.duckdb_scan.cache`: [true, false] Whether to cache compressed parquet row groups in pinned memory
-- `sirius.executor.duckdb_scan.cache_decoded_table`: [true, false] Whether to cache decoded cudf tables in pinned memory
-- `sirius.executor.duckdb_scan.cache_in_gpu`: [true, false] Whether to cache decoded cudf tables in gpu memory
+- `sirius.executor.duckdb_scan.cache`: ["none", "parquet", "table_gpu", "table_host"] cache mode, cache noting, cache parquet rowgorups in pinned memory, cache scanned table in pgu, and cache scanned table in pinned memory, respectively.
 - `sirius.operator_params.scan_task_batch_size`: [500MB - 5GB] the batch size in bytes for scan tasks, which determines how much data is processed in each scan task.
 - `sirius.operator_params.concat_batch_bytes`: [500MB - 5GB] the batch size in bytes for concatenation tasks, which determines how much data is processed in each concatenation task.
 - `sirius.operator_params.hash_partition_bytes`: [500MB - 5GB] the batch size in bytes for hash_partition_bytes tasks, which determines how much data is processed in each concatenation task.

--- a/src/include/op/scan/config.hpp
+++ b/src/include/op/scan/config.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace sirius::op::scan {
+
+/// Controls where and how scan results are cached between query executions.
+enum class cache_level {
+  NONE,        ///< No caching
+  TABLE_GPU,   ///< Cache decoded table in GPU memory
+  TABLE_HOST,  ///< Cache decoded table in host memory
+  PARQUET,     ///< Cache raw parquet data in host memory
+};
+
+inline bool string_to_enum(std::string_view sv, cache_level& level)
+{
+  static const std::unordered_map<std::string_view, cache_level> map = {
+    {"none", cache_level::NONE},
+    {"off", cache_level::NONE},
+    {"table_gpu", cache_level::TABLE_GPU},
+    {"table_host", cache_level::TABLE_HOST},
+    {"parquet", cache_level::PARQUET},
+  };
+  auto it = map.find(sv);
+  if (it != map.end()) {
+    level = it->second;
+    return true;
+  }
+  return false;
+}
+
+inline bool enum_to_string(cache_level level, std::string& s)
+{
+  switch (level) {
+    case cache_level::NONE: s = "none"; return true;
+    case cache_level::TABLE_GPU: s = "table_gpu"; return true;
+    case cache_level::TABLE_HOST: s = "table_host"; return true;
+    case cache_level::PARQUET: s = "parquet"; return true;
+  }
+  return false;
+}
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -21,6 +21,7 @@
 #include "exec/interruptible_mpmc.hpp"
 #include "exec/kiosk.hpp"
 #include "exec/thread_pool.hpp"
+#include "op/scan/config.hpp"
 #include "op/scan/duckdb_scan_task.hpp"
 #include "parallel/task.hpp"
 #include "pipeline/task_request.hpp"
@@ -145,20 +146,21 @@ class duckdb_scan_executor {
   void cache_scan_results_for_query(const std::string& query);
 
   /**
-   * @brief Enable or disable scan result caching
+   * @brief Configure scan result caching level
    *
-   * @param enabled True to enable caching, false to disable
+   * @param level The cache level to use
    */
-  void set_scan_caching_enabled(bool enabled,
-                                bool cache_decoded_table = false,
-                                bool cache_in_gpu        = false);
+  void set_scan_caching_enabled(cache_level level);
 
   /**
    * @brief Check if scan result caching is enabled
    *
    * @return True if caching is enabled, false otherwise
    */
-  [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return _caching_enabled; }
+  [[nodiscard]] bool is_scan_caching_enabled() const noexcept
+  {
+    return _cache_level != cache_level::NONE;
+  }
 
   /**
    * @brief Prepare cache for scan operators
@@ -193,10 +195,7 @@ class duckdb_scan_executor {
   mutable std::mutex _cache_mutex;
   std::unordered_map<size_t, std::unique_ptr<cache_entry>> _cache;
   std::size_t _query_hash{0};
-  bool _caching_enabled{false};
-  bool _cache_decoded_table{false};
-  bool _wrap_batch_data{false};
-  bool _cache_in_gpu{false};
+  cache_level _cache_level{cache_level::NONE};
   bool _preload_mode{false};
 
   std::atomic<bool> _running{false};

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -21,6 +21,7 @@
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
+#include "op/scan/config.hpp"
 #include "op/sirius_physical_duckdb_scan.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "parallel/task.hpp"
@@ -127,13 +128,11 @@ class pipeline_executor {
   [[nodiscard]] const sirius::op::scan::duckdb_scan_executor& get_scan_executor() const noexcept;
 
   /**
-   * @brief Enable or disable scan result caching
+   * @brief Configure scan result caching level
    *
-   * @param enabled True to enable caching, false to disable
+   * @param level The cache level to use
    */
-  void set_scan_caching_config(bool enabled,
-                               bool cache_decoded_table = false,
-                               bool cache_in_gpu        = false);
+  void set_scan_caching_config(sirius::op::scan::cache_level level);
 
   /**
    * @brief Set the priority scan operators

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -131,9 +131,9 @@ class pipeline_executor {
    *
    * @param enabled True to enable caching, false to disable
    */
-  void set_scan_caching_enabled(bool enabled,
-                                bool cache_decoded_table = false,
-                                bool cache_in_gpu        = false);
+  void set_scan_caching_config(bool enabled,
+                               bool cache_decoded_table = false,
+                               bool cache_in_gpu        = false);
 
   /**
    * @brief Set the priority scan operators

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -88,7 +88,27 @@ struct sirius_config {
 
   [[nodiscard]] bool is_cache_in_gpu_enabled() const noexcept { return _cache_in_gpu; }
 
-  void set_cache_in_gpu(bool enabled) noexcept { _cache_in_gpu = enabled; }
+  void set_cache_in_gpu(bool enabled) noexcept
+  {
+    if (enabled) {
+      _cache_in_gpu        = true;
+      _enable_scan_caching = true;
+    } else {
+      _cache_in_gpu = false;
+    }
+  }
+
+  void set_decoded_table_cache(bool enabled) noexcept
+  {
+    if (enabled) {
+      _cache_decoded_table = true;
+      _enable_scan_caching = true;
+    } else {
+      _cache_decoded_table = false;
+    }
+  }
+
+  void set_scan_caching(bool enabled) noexcept { _enable_scan_caching = enabled; }
 
   [[nodiscard]] const operator_params& get_operator_params() const noexcept
   {

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -19,6 +19,7 @@
 #include "config.hpp"
 #include "config_option.hpp"
 #include "exec/config.hpp"
+#include "op/scan/config.hpp"
 
 #include <cucascade/memory/config.hpp>
 #include <cucascade/memory/topology_discovery.hpp>
@@ -79,36 +80,24 @@ struct sirius_config {
 
   [[nodiscard]] const exec::thread_pool_config& get_duckdb_scan_executor_config() const noexcept;
 
-  [[nodiscard]] bool is_scan_caching_enabled() const noexcept { return _enable_scan_caching; }
+  [[nodiscard]] bool is_scan_caching_enabled() const noexcept
+  {
+    return _cache_level != op::scan::cache_level::NONE;
+  }
 
   [[nodiscard]] bool is_cache_decoded_table_enabled() const noexcept
   {
-    return _cache_decoded_table;
+    return _cache_level == op::scan::cache_level::TABLE_HOST;
   }
 
-  [[nodiscard]] bool is_cache_in_gpu_enabled() const noexcept { return _cache_in_gpu; }
-
-  void set_cache_in_gpu(bool enabled) noexcept
+  [[nodiscard]] bool is_cache_in_gpu_enabled() const noexcept
   {
-    if (enabled) {
-      _cache_in_gpu        = true;
-      _enable_scan_caching = true;
-    } else {
-      _cache_in_gpu = false;
-    }
+    return _cache_level == op::scan::cache_level::TABLE_GPU;
   }
 
-  void set_decoded_table_cache(bool enabled) noexcept
-  {
-    if (enabled) {
-      _cache_decoded_table = true;
-      _enable_scan_caching = true;
-    } else {
-      _cache_decoded_table = false;
-    }
-  }
+  [[nodiscard]] op::scan::cache_level get_cache_level() const noexcept { return _cache_level; }
 
-  void set_scan_caching(bool enabled) noexcept { _enable_scan_caching = enabled; }
+  void set_cache_level(op::scan::cache_level level) noexcept { _cache_level = level; }
 
   [[nodiscard]] const operator_params& get_operator_params() const noexcept
   {
@@ -128,9 +117,7 @@ struct sirius_config {
                                                       .thread_name_prefix = "downgrade"};
   exec::thread_pool_config _duckdb_scan_executor_config{.num_threads        = 4,
                                                         .thread_name_prefix = "duckdb_scan"};
-  bool _enable_scan_caching = false;
-  bool _cache_decoded_table = false;
-  bool _cache_in_gpu        = false;
+  op::scan::cache_level _cache_level = op::scan::cache_level::NONE;
   operator_params _operator_params;
 };
 

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -105,7 +105,7 @@ void duckdb_scan_executor::set_completion_handler(
 
 void duckdb_scan_executor::cache_scan_results_for_query(const std::string& query)
 {
-  if (!_caching_enabled) { return; }
+  if (_cache_level == cache_level::NONE) { return; }
   std::hash<std::string> hash_fn;
   auto new_query_hash = hash_fn(query);
   if (new_query_hash == _query_hash) {
@@ -117,32 +117,23 @@ void duckdb_scan_executor::cache_scan_results_for_query(const std::string& query
   _cache.clear();
 }
 
-void duckdb_scan_executor::set_scan_caching_enabled(bool enabled,
-                                                    bool cache_decoded_table,
-                                                    bool cache_in_gpu)
+void duckdb_scan_executor::set_scan_caching_enabled(cache_level level)
 {
-  if (enabled == _caching_enabled && cache_decoded_table == _cache_decoded_table &&
-      cache_in_gpu == _cache_in_gpu) {
-    return;  // No change
-  }
+  if (level == _cache_level) { return; }
   {
     std::lock_guard lock(_cache_mutex);
     _cache.clear();  // Clear cache when changing caching config
   }
-  _caching_enabled     = enabled;
-  _cache_decoded_table = cache_decoded_table;
-  _cache_in_gpu        = cache_in_gpu;
-  _wrap_batch_data     = _caching_enabled && !_cache_in_gpu;
-  SIRIUS_LOG_INFO("Scan caching {} (cache_decoded_table={}, cache_in_gpu={})",
-                  enabled ? "enabled" : "disabled",
-                  cache_decoded_table,
-                  cache_in_gpu);
+  _cache_level = level;
+  std::string level_str;
+  enum_to_string(level, level_str);
+  SIRIUS_LOG_INFO("Scan caching level set to {}", level_str);
 }
 
 void duckdb_scan_executor::prepare_cache_for_scan_operators(
   const std::vector<sirius::op::sirius_physical_operator*>& scan_operators)
 {
-  if (!_caching_enabled) { return; }
+  if (_cache_level == cache_level::NONE) { return; }
 
   std::lock_guard<std::mutex> lock(_cache_mutex);
   _preload_mode = !_cache.empty();
@@ -182,7 +173,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
 
   auto clone_batches = [&](const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
                            rmm::cuda_stream_view stream) {
-    if (_cache_in_gpu) { return batches; }
+    if (_cache_level == cache_level::TABLE_GPU) { return batches; }
     std::vector<std::shared_ptr<cucascade::data_batch>> cloned_batches;
     cloned_batches.reserve(batches.size());
     if (is_duckdb_scan) {
@@ -210,7 +201,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
     return cloned_batches;
   };
 
-  if (!_caching_enabled) {
+  if (_cache_level == cache_level::NONE) {
     return task->compute_task(stream);
   } else {
     auto pipe_id = task->get_pipeline_id();
@@ -257,9 +248,11 @@ void duckdb_scan_executor::manager_loop()
     auto* scan_task = dynamic_cast<pipeline::sirius_pipeline_itask*>(task.get());
     if (scan_task && scan_task->is<parquet_scan_task>()) {
       auto* parquet_task = dynamic_cast<parquet_scan_task*>(scan_task);
-      if (_caching_enabled || _cache_in_gpu) {
+      if (_cache_level != cache_level::NONE) {
+        bool wrap_batch_data     = _cache_level != cache_level::TABLE_GPU;
+        bool cache_decoded_table = _cache_level == cache_level::TABLE_HOST;
         parquet_task->set_materialized_columns(
-          _wrap_batch_data, _cache_decoded_table, _gpu_memory_space);
+          wrap_batch_data, cache_decoded_table, _gpu_memory_space);
       }
       auto bytes_needed = scan_task->get_estimated_reservation_size();
       auto reservation  = _mem_mgr->request_reservation(

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -121,6 +121,14 @@ void duckdb_scan_executor::set_scan_caching_enabled(bool enabled,
                                                     bool cache_decoded_table,
                                                     bool cache_in_gpu)
 {
+  if (enabled == _caching_enabled && cache_decoded_table == _cache_decoded_table &&
+      cache_in_gpu == _cache_in_gpu) {
+    return;  // No change
+  }
+  {
+    std::lock_guard lock(_cache_mutex);
+    _cache.clear();  // Clear cache when changing caching config
+  }
   _caching_enabled     = enabled;
   _cache_decoded_table = cache_decoded_table;
   _cache_in_gpu        = cache_in_gpu;

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -124,11 +124,9 @@ pipeline_executor::get_scan_executor() noexcept
   return *_scan_executor;
 }
 
-void pipeline_executor::set_scan_caching_config(bool enabled,
-                                                bool cache_decoded_table,
-                                                bool cache_in_gpu)
+void pipeline_executor::set_scan_caching_config(sirius::op::scan::cache_level level)
 {
-  _scan_executor->set_scan_caching_enabled(enabled, cache_decoded_table, cache_in_gpu);
+  _scan_executor->set_scan_caching_enabled(level);
 }
 
 void pipeline_executor::prepare_for_query(duckdb::shared_ptr<planner::query> query)

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -124,9 +124,9 @@ pipeline_executor::get_scan_executor() noexcept
   return *_scan_executor;
 }
 
-void pipeline_executor::set_scan_caching_enabled(bool enabled,
-                                                 bool cache_decoded_table,
-                                                 bool cache_in_gpu)
+void pipeline_executor::set_scan_caching_config(bool enabled,
+                                                bool cache_decoded_table,
+                                                bool cache_in_gpu)
 {
   _scan_executor->set_scan_caching_enabled(enabled, cache_decoded_table, cache_in_gpu);
 }

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -254,9 +254,7 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
   config_setter.add_config("sirius.executor.pipeline", _gpu_pipeline_executor_config);
   config_setter.add_config("sirius.executor.downgrade", _downgrade_executor_config);
   config_setter.add_config("sirius.executor.duckdb_scan", _duckdb_scan_executor_config);
-  config_setter.add_config("sirius.executor.duckdb_scan.cache", _enable_scan_caching);
-  config_setter.add_config("sirius.executor.duckdb_scan.cache_decoded_table", _cache_decoded_table);
-  config_setter.add_config("sirius.executor.duckdb_scan.cache_in_gpu", _cache_in_gpu);
+  config_setter.add_config("sirius.executor.duckdb_scan.cache", _cache_level);
   config_setter.add_config("sirius.operator_params", _operator_params);
 
   config_setter.add_config("sirius.space.gpu", gpu_memory_space_configs);

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -89,9 +89,7 @@ void SiriusContext::QueryBegin(ClientContext& context)
   if (config_.is_scan_caching_enabled()) {
     pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
   }
-  pipeline_executor_->set_scan_caching_config(config_.is_scan_caching_enabled(),
-                                              config_.is_cache_decoded_table_enabled(),
-                                              config_.is_cache_in_gpu_enabled());
+  pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
 
   // Reset task creator state (including scan operator global state map) for the new query
   task_creator_->reset();
@@ -197,9 +195,7 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   pipeline_executor_->start();
 
   // Configure scan caching based on config
-  pipeline_executor_->set_scan_caching_config(config_.is_scan_caching_enabled(),
-                                              config_.is_cache_decoded_table_enabled(),
-                                              config_.is_cache_in_gpu_enabled());
+  pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
 
   is_initialized_ = true;
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -89,6 +89,9 @@ void SiriusContext::QueryBegin(ClientContext& context)
   if (config_.is_scan_caching_enabled()) {
     pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
   }
+  pipeline_executor_->set_scan_caching_config(config_.is_scan_caching_enabled(),
+                                              config_.is_cache_decoded_table_enabled(),
+                                              config_.is_cache_in_gpu_enabled());
 
   // Reset task creator state (including scan operator global state map) for the new query
   task_creator_->reset();
@@ -194,9 +197,9 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   pipeline_executor_->start();
 
   // Configure scan caching based on config
-  pipeline_executor_->set_scan_caching_enabled(config_.is_scan_caching_enabled(),
-                                               config_.is_cache_decoded_table_enabled(),
-                                               config_.is_cache_in_gpu_enabled());
+  pipeline_executor_->set_scan_caching_config(config_.is_scan_caching_enabled(),
+                                              config_.is_cache_decoded_table_enabled(),
+                                              config_.is_cache_in_gpu_enabled());
 
   is_initialized_ = true;
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -682,43 +682,23 @@ static void SetModifiedPipeline(ClientContext& context, SetScope scope, Value& p
   SIRIUS_LOG_DEBUG("Updated config MODIFIED_PIPELINE to {}", Config::MODIFIED_PIPELINE);
 }
 
-static void SetCacheInGpu(ClientContext& context, SetScope scope, Value& parameter)
+static void SetCacheScanLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (sirius_ctx == nullptr) {
-    SIRIUS_LOG_DEBUG("SiriusContext not available; cache_in_gpu SET ignored");
+    SIRIUS_LOG_DEBUG("SiriusContext not available; cache_scan_level SET ignored");
     return;
   }
-  bool enabled = BooleanValue::Get(parameter);
-  auto& cfg    = sirius_ctx->get_config();
-  cfg.set_cache_in_gpu(enabled);
-  SIRIUS_LOG_DEBUG("Updated config cache_in_gpu to {}", enabled);
-}
-
-static void SetCacheDecodedTable(ClientContext& context, SetScope scope, Value& parameter)
-{
-  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
-  if (sirius_ctx == nullptr) {
-    SIRIUS_LOG_DEBUG("SiriusContext not available; cache_decoded_table SET ignored");
-    return;
+  auto level_str = StringValue::Get(parameter);
+  sirius::op::scan::cache_level level;
+  if (!sirius::op::scan::string_to_enum(level_str, level)) {
+    throw InvalidInputException(
+      "Invalid cache_scan_level '{}'. Valid values: none, table_gpu, table_host, parquet",
+      level_str);
   }
-  bool enabled = BooleanValue::Get(parameter);
-  auto& cfg    = sirius_ctx->get_config();
-  cfg.set_decoded_table_cache(enabled);
-  SIRIUS_LOG_DEBUG("Updated config cache_in_gpu to {}", enabled);
-}
-
-static void SetScanCaching(ClientContext& context, SetScope scope, Value& parameter)
-{
-  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
-  if (sirius_ctx == nullptr) {
-    SIRIUS_LOG_DEBUG("SiriusContext not available; scan_caching SET ignored");
-    return;
-  }
-  bool enabled = BooleanValue::Get(parameter);
-  auto& cfg    = sirius_ctx->get_config();
-  cfg.set_scan_caching(enabled);
-  SIRIUS_LOG_DEBUG("Updated config scan_caching to {}", enabled);
+  auto& cfg = sirius_ctx->get_config();
+  cfg.set_cache_level(level);
+  SIRIUS_LOG_DEBUG("Updated config cache_scan_level to {}", level_str);
 }
 
 static sirius::operator_params* get_operator_params(ClientContext& context)
@@ -883,23 +863,11 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             Value::UBIGINT(sirius::operator_params{}.concat_batch_bytes),
                             SetConcatBatchBytes);
 
-  config.AddExtensionOption("cache_scan_in_gpu",
-                            "Whether to cache scan results in GPU memory instead of host memory",
-                            LogicalType::BOOLEAN,
-                            Value::BOOLEAN(false),
-                            SetCacheInGpu);
-
-  config.AddExtensionOption("cache_scan_decoded_table",
-                            "Whether to cache decoded tables in GPU memory instead of host memory",
-                            LogicalType::BOOLEAN,
-                            Value::BOOLEAN(false),
-                            SetCacheDecodedTable);
-
-  config.AddExtensionOption("cache_scan",
-                            "Whether to cache scan results in GPU memory instead of host memory",
-                            LogicalType::BOOLEAN,
-                            Value::BOOLEAN(false),
-                            SetScanCaching);
+  config.AddExtensionOption("scan_cache_level",
+                            "Scan result caching level: none, table_gpu, table_host, parquet",
+                            LogicalType::VARCHAR,
+                            Value("none"),
+                            SetCacheScanLevel);
 }
 
 static void LoadInternal(ExtensionLoader& loader)

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -692,9 +692,33 @@ static void SetCacheInGpu(ClientContext& context, SetScope scope, Value& paramet
   bool enabled = BooleanValue::Get(parameter);
   auto& cfg    = sirius_ctx->get_config();
   cfg.set_cache_in_gpu(enabled);
-  sirius_ctx->get_pipeline_executor().set_scan_caching_enabled(
-    cfg.is_scan_caching_enabled(), cfg.is_cache_decoded_table_enabled(), enabled);
   SIRIUS_LOG_DEBUG("Updated config cache_in_gpu to {}", enabled);
+}
+
+static void SetCacheDecodedTable(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (sirius_ctx == nullptr) {
+    SIRIUS_LOG_DEBUG("SiriusContext not available; cache_decoded_table SET ignored");
+    return;
+  }
+  bool enabled = BooleanValue::Get(parameter);
+  auto& cfg    = sirius_ctx->get_config();
+  cfg.set_decoded_table_cache(enabled);
+  SIRIUS_LOG_DEBUG("Updated config cache_in_gpu to {}", enabled);
+}
+
+static void SetScanCaching(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (sirius_ctx == nullptr) {
+    SIRIUS_LOG_DEBUG("SiriusContext not available; scan_caching SET ignored");
+    return;
+  }
+  bool enabled = BooleanValue::Get(parameter);
+  auto& cfg    = sirius_ctx->get_config();
+  cfg.set_scan_caching(enabled);
+  SIRIUS_LOG_DEBUG("Updated config scan_caching to {}", enabled);
 }
 
 static sirius::operator_params* get_operator_params(ClientContext& context)
@@ -859,11 +883,23 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             Value::UBIGINT(sirius::operator_params{}.concat_batch_bytes),
                             SetConcatBatchBytes);
 
-  config.AddExtensionOption("cache_in_gpu",
+  config.AddExtensionOption("cache_scan_in_gpu",
                             "Whether to cache scan results in GPU memory instead of host memory",
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(false),
                             SetCacheInGpu);
+
+  config.AddExtensionOption("cache_scan_decoded_table",
+                            "Whether to cache decoded tables in GPU memory instead of host memory",
+                            LogicalType::BOOLEAN,
+                            Value::BOOLEAN(false),
+                            SetCacheDecodedTable);
+
+  config.AddExtensionOption("cache_scan",
+                            "Whether to cache scan results in GPU memory instead of host memory",
+                            LogicalType::BOOLEAN,
+                            Value::BOOLEAN(false),
+                            SetScanCaching);
 }
 
 static void LoadInternal(ExtensionLoader& loader)

--- a/test/cpp/config/data/single_node_cache.cfg
+++ b/test/cpp/config/data/single_node_cache.cfg
@@ -19,7 +19,7 @@ sirius = {
             num_threads = 4;
         };
         duckdb_scan = {
-            cache = true;
+            cache = "parquet";
             num_threads = 5;
         };
     };


### PR DESCRIPTION
this PR make caching parameters configurable in duckdb
to achieve that , I made a breaking change in the config, consolidating three config parameters to 1 enum (string)

- cache: `off` or `none`
- cache: `parquet` => row_groups in pinned memory
- cache: `table_host` => decoded_tables in pinned memmory
- cache: `table_gpu` => decoded tables in gpu

in duckdb you can set them using 

scan_cache_level = "option"