### PR TITLE
Enable autofix for pretty-format-json pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
           )
       - id: mixed-line-ending
       - id: pretty-format-json
+        args: [--autofix]
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
     rev: 25.1.0


### PR DESCRIPTION
## Summary
- Add `--autofix` arg to `pretty-format-json` pre-commit hook so it auto-formats JSON files instead of just reporting

## Test plan
- [ ] `pixi run pre-commit` auto-formats JSON files that need it

🤖 Generated with [Claude Code](https://claude.com/claude-code)