### PR TITLE
Restore SIRIUS_LOG_DIR/SIRIUS_LOG_LEVEL env var initialization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -222,7 +222,15 @@ build/release/extension/sirius/test/cpp/log
 Just like duckdb, we are using [Catch2](https://github.com/catchorg/Catch2) as our testing framework so more details about writing and running tests can be found there.
 
 ## Logging
-Sirius uses [spdlog](https://github.com/gabime/spdlog) for logging messages during query execution. Default log directory is `log` (relative to the current working directory) and default log level is `info`. Both can be configured at runtime via DuckDB's `SET` command:
+Sirius uses [spdlog](https://github.com/gabime/spdlog) for logging messages during query execution. Default log directory is `log` (relative to the current working directory) and default log level is `info`.
+
+Log directory and level can be initialized via environment variables before loading the extension:
+```bash
+export SIRIUS_LOG_DIR=/path/to/logs
+export SIRIUS_LOG_LEVEL=debug
+```
+
+Both can also be configured at runtime via DuckDB's `SET` command:
 ```sql
 SET sirius_log_dir = '/path/to/logs';
 SET sirius_log_level = 'debug';

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -343,6 +343,8 @@ void SiriusContext::throw_if_not_initialized() const
 
 SiriusContextExtensionCallback::SiriusContextExtensionCallback()
 {
+  if (auto* env = std::getenv("SIRIUS_LOG_DIR")) { Config::LOG_DIR = env; }
+  if (auto* env = std::getenv("SIRIUS_LOG_LEVEL")) { Config::LOG_LEVEL = env; }
   InitGlobalLogger(Config::LOG_LEVEL, Config::LOG_DIR, Config::LOG_FLUSH_SECONDS);
   read_config_file_if_exists();
 }


### PR DESCRIPTION
## Summary
- #354 moved log configuration from compile-time to runtime engine settings but removed the environment variable initialization path
- This restores initialization of `Config::LOG_DIR` and `Config::LOG_LEVEL` from `SIRIUS_LOG_DIR` and `SIRIUS_LOG_LEVEL` environment variables at extension load time (before `InitGlobalLogger` is called)

## Test plan
- [ ] Set `SIRIUS_LOG_DIR=/tmp/sirius-logs` and verify logs are written there
- [ ] Set `SIRIUS_LOG_LEVEL=debug` and verify debug-level messages appear
- [ ] Verify default behavior (no env vars set) is unchanged

🤖 Created by Claude

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>