### PR TITLE
Changed get_ranges for cached data use nullptr instead of exception throwing

### DIFF
--- a/src/include/op/scan/cached_ranges.hpp
+++ b/src/include/op/scan/cached_ranges.hpp
@@ -66,9 +66,9 @@ class cache_ranges {
 
   // Returns a list of spans that together cover [query_offset, query_offset+query_size).
   // Each span points directly into one of the underlying chunk buffers.
-  // Throws std::out_of_range if the query does not fall within a cached range.
-  [[nodiscard]] std::vector<std::span<const std::byte>> get_ranges(std::size_t query_offset,
-                                                                   std::size_t query_size) const;
+  // Returns std::nullopt if the query does not fall within a cached range.
+  [[nodiscard]] std::optional<std::vector<std::span<const std::byte>>> get_ranges(
+    std::size_t query_offset, std::size_t query_size) const;
 
   [[nodiscard]] std::size_t max_offset() const noexcept;
 

--- a/src/op/scan/cached_ranges.cpp
+++ b/src/op/scan/cached_ranges.cpp
@@ -70,8 +70,8 @@ cache_ranges::cache_ranges(std::vector<range> ranges,
   total_packed_bytes_ = running;
 }
 
-std::vector<std::span<const std::byte>> cache_ranges::get_ranges(std::size_t query_offset,
-                                                                 std::size_t query_size) const
+std::optional<std::vector<std::span<const std::byte>>> cache_ranges::get_ranges(
+  std::size_t query_offset, std::size_t query_size) const
 {
   if (query_size == 0) return {};
 
@@ -84,7 +84,7 @@ std::vector<std::span<const std::byte>> cache_ranges::get_ranges(std::size_t que
     // Find the range that contains cur_offset.
     auto idx = find_range(cur_offset);
     if (idx == ranges_.size()) {
-      throw std::out_of_range("cache_ranges::get_ranges: offset not covered by any cached range");
+      return std::nullopt;  // offset not covered by any cached range
     }
 
     auto const& r         = ranges_[idx];
@@ -93,7 +93,7 @@ std::vector<std::span<const std::byte>> cache_ranges::get_ranges(std::size_t que
     if (cur_offset + remaining > range_end) {
       // The query spans beyond a single cached range – we only
       // support queries that are fully covered by the cache.
-      throw std::out_of_range("cache_ranges::get_ranges: query extends beyond a cached range");
+      return std::nullopt;  // query extends beyond a cached range
     }
 
     // How many bytes into range r is cur_offset?

--- a/src/op/scan/prefetched_data_source.cpp
+++ b/src/op/scan/prefetched_data_source.cpp
@@ -51,17 +51,20 @@ size_t prefetched_data_source::host_read(size_t offset, size_t size, uint8_t* ds
 {
   if (size == 0) return 0;
 
-  try {
-    auto spans          = ranges_->get_ranges(offset, size);
+  auto spans = ranges_->get_ranges(offset, size);
+  if (spans.has_value()) {
     size_t bytes_copied = 0;
-    for (auto const& span : spans) {
+    for (auto const& span : spans.value()) {
       std::memcpy(dst + bytes_copied, span.data(), span.size());
       bytes_copied += span.size();
     }
     total_bytes_read_from_cache_.fetch_add(size, std::memory_order_relaxed);
     return bytes_copied;
-  } catch (std::out_of_range const&) {
-    if (!fallback_) throw;
+  } else {
+    if (!fallback_) {
+      throw std::out_of_range(
+        "prefetched_data_source::host_read: offset not covered by cache and no fallback source");
+    }
     size_t bytes_read = fallback_->host_read(offset, size, dst);
     total_bytes_read_from_fallback_.fetch_add(bytes_read, std::memory_order_relaxed);
     return bytes_read;
@@ -94,25 +97,28 @@ std::unique_ptr<cudf::io::datasource::buffer> prefetched_data_source::device_rea
 prefetched_data_source::copy_result prefetched_data_source::enqueue_device_copies(
   size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream)
 {
-  std::vector<std::span<const std::byte>> spans;
-  try {
-    spans = ranges_->get_ranges(offset, size);
-  } catch (std::out_of_range const&) {
-    if (!fallback_) throw;
-
-    size_t bytes_read = 0;
-    if (fallback_->supports_device_read()) {
-      bytes_read = fallback_->device_read(offset, size, dst, stream);
+  auto spans_opt = ranges_->get_ranges(offset, size);
+  if (!spans_opt.has_value()) {
+    if (!fallback_) {
+      throw std::out_of_range(
+        "prefetched_data_source::enqueue_device_copies: offset not covered by cache and no "
+        "fallback source");
     } else {
-      auto host_buf = fallback_->host_read(offset, size);
-      RMM_CUDA_TRY(::cudaMemcpyAsync(
-        dst, host_buf->data(), host_buf->size(), cudaMemcpyHostToDevice, stream.value()));
-      bytes_read = host_buf->size();
+      size_t bytes_read = 0;
+      if (fallback_->supports_device_read()) {
+        bytes_read = fallback_->device_read(offset, size, dst, stream);
+      } else {
+        auto host_buf = fallback_->host_read(offset, size);
+        RMM_CUDA_TRY(::cudaMemcpyAsync(
+          dst, host_buf->data(), host_buf->size(), cudaMemcpyHostToDevice, stream.value()));
+        bytes_read = host_buf->size();
+      }
+      total_bytes_read_from_fallback_.fetch_add(bytes_read, std::memory_order_relaxed);
+      return {bytes_read, stream.value()};
     }
-    total_bytes_read_from_fallback_.fetch_add(bytes_read, std::memory_order_relaxed);
-    return {bytes_read, stream.value()};
   }
 
+  std::vector<std::span<const std::byte>> spans = std::move(spans_opt.value());
   std::vector<void*> src_ptrs;
   std::vector<void*> dst_ptrs;
   std::vector<size_t> counts;


### PR DESCRIPTION
This PR changes `cache_ranges::get_ranges()` function to return a std::nullptr when it does not find the data instead of throwing an exception.  This exception was being used to then trigger a fallback (regular reading of parquet). This happens all the time when it does not find something in the cache. Which means in a way , its using an exception throw as part of regular behaviour business logic, which is an anti-pattern.

I usually run gdb with it set to stop on all caught exceptions. The way this is right now, i cant do that anymore, so I am changing it.