### PR TITLE
Skip file I/O when running from cache

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -66,7 +66,6 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 
   _scan_operator_global_state_map.clear();
   _gpu_operator_global_state_map.clear();
-  _parquet_scan_operator_global_state_map.clear();
 
   const auto& pipelines = query.get_pipelines();
   for (const auto& pipeline : pipelines) {
@@ -84,16 +83,21 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
-      const auto& op_params =
-        _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
-          ->get_config()
-          .get_operator_params();
-      _parquet_scan_operator_global_state_map.emplace(
-        operator_id,
-        std::make_shared<op::scan::parquet_scan_task_global_state>(
-          pipeline,
-          &source_operator->Cast<op::sirius_physical_parquet_scan>(),
-          op_params.scan_task_batch_size));
+      auto it = _parquet_scan_operator_global_state_map.find(operator_id);
+      if (it != _parquet_scan_operator_global_state_map.end()) {
+        it->second->rebind(pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>());
+      } else {
+        const auto& op_params =
+          _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
+            ->get_config()
+            .get_operator_params();
+        _parquet_scan_operator_global_state_map.emplace(
+          operator_id,
+          std::make_shared<op::scan::parquet_scan_task_global_state>(
+            pipeline,
+            &source_operator->Cast<op::sirius_physical_parquet_scan>(),
+            op_params.scan_task_batch_size));
+      }
     } else {
       _gpu_operator_global_state_map.emplace(
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
@@ -109,11 +113,11 @@ void task_creator::drain_pending_tasks()
   _kiosk.wait_all();
 }
 
-void task_creator::reset()
+void task_creator::reset(bool keep_parquet_metadata)
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
   _scan_operator_global_state_map.clear();
-  _parquet_scan_operator_global_state_map.clear();
+  if (!keep_parquet_metadata) { _parquet_scan_operator_global_state_map.clear(); }
   _gpu_operator_global_state_map.clear();
   _thread_context.reset();
   _execution_context.reset();

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -66,10 +66,31 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 
   _scan_operator_global_state_map.clear();
   _gpu_operator_global_state_map.clear();
-  // Parquet map is NOT cleared here — it may hold cached metadata from a
-  // previous iteration.  Entries are either rebound or freshly created below.
 
+  // Check whether every parquet scan in this query already has a cached
+  // global state.  If so, this is a re-execution of the same query and we
+  // can rebind (reuse cached file metadata, avoiding footer reads).
+  // If any operator_id is missing, this is a different query — clear the
+  // map to prevent stale metadata from a previous query being reused
+  // (operator_ids can collide across different queries).
   const auto& pipelines = query.get_pipelines();
+
+  bool can_rebind = !_parquet_scan_operator_global_state_map.empty();
+  if (can_rebind) {
+    for (const auto& pipeline : pipelines) {
+      auto source_operator = pipeline->get_source();
+      if (source_operator &&
+          source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
+        if (_parquet_scan_operator_global_state_map.find(source_operator->get_operator_id()) ==
+            _parquet_scan_operator_global_state_map.end()) {
+          can_rebind = false;
+          break;
+        }
+      }
+    }
+  }
+  if (!can_rebind) { _parquet_scan_operator_global_state_map.clear(); }
+
   for (const auto& pipeline : pipelines) {
     auto source_operator = pipeline->get_source();
     if (source_operator == nullptr) { continue; }
@@ -87,8 +108,6 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
       auto it = _parquet_scan_operator_global_state_map.find(operator_id);
       if (it != _parquet_scan_operator_global_state_map.end()) {
-        // Reuse cached file metadata — just rebind to the new pipeline/operator
-        // and reset the partition counter.
         it->second->rebind(pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>());
       } else {
         const auto& op_params =

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -17,6 +17,7 @@
 #include "creator/task_creator.hpp"
 
 #include "log/logging.hpp"
+#include "op/scan/duckdb_scan_executor.hpp"
 #include "op/scan/duckdb_scan_task.hpp"
 #include "op/scan/parquet_scan_task.hpp"
 #include "op/sirius_physical_delim_join.hpp"
@@ -63,15 +64,13 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
 
-  // Clear the global state maps for the new query
   _scan_operator_global_state_map.clear();
-  _parquet_scan_operator_global_state_map.clear();
   _gpu_operator_global_state_map.clear();
+  // Parquet map is NOT cleared here — it may hold cached metadata from a
+  // previous iteration.  Entries are either rebound or freshly created below.
 
-  // Iterate through all pipelines in the query and create global states
   const auto& pipelines = query.get_pipelines();
   for (const auto& pipeline : pipelines) {
-    // Get the sink operator of the pipeline
     auto source_operator = pipeline->get_source();
     if (source_operator == nullptr) { continue; }
 
@@ -86,16 +85,23 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
-      const auto& op_params =
-        _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
-          ->get_config()
-          .get_operator_params();
-      _parquet_scan_operator_global_state_map.emplace(
-        operator_id,
-        std::make_shared<op::scan::parquet_scan_task_global_state>(
-          pipeline,
-          &source_operator->Cast<op::sirius_physical_parquet_scan>(),
-          op_params.scan_task_batch_size));
+      auto it = _parquet_scan_operator_global_state_map.find(operator_id);
+      if (it != _parquet_scan_operator_global_state_map.end()) {
+        // Reuse cached file metadata — just rebind to the new pipeline/operator
+        // and reset the partition counter.
+        it->second->rebind(pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>());
+      } else {
+        const auto& op_params =
+          _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
+            ->get_config()
+            .get_operator_params();
+        _parquet_scan_operator_global_state_map.emplace(
+          operator_id,
+          std::make_shared<op::scan::parquet_scan_task_global_state>(
+            pipeline,
+            &source_operator->Cast<op::sirius_physical_parquet_scan>(),
+            op_params.scan_task_batch_size));
+      }
     } else {
       _gpu_operator_global_state_map.emplace(
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
@@ -113,10 +119,13 @@ void task_creator::drain_pending_tasks()
 
 void task_creator::reset()
 {
-  // Clear the scan operator global state map for the new query
   std::lock_guard<std::mutex> lock(_global_state_mutex);
   _scan_operator_global_state_map.clear();
-  _parquet_scan_operator_global_state_map.clear();
+  // Keep parquet global states in preload mode — they hold cached file
+  // metadata that is expensive to reconstruct (footer reads).
+  if (!_pipeline_executor || !_pipeline_executor->get_scan_executor().is_preload_mode()) {
+    _parquet_scan_operator_global_state_map.clear();
+  }
   _gpu_operator_global_state_map.clear();
   _thread_context.reset();
   _execution_context.reset();

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -66,31 +66,9 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 
   _scan_operator_global_state_map.clear();
   _gpu_operator_global_state_map.clear();
+  _parquet_scan_operator_global_state_map.clear();
 
-  // Check whether every parquet scan in this query already has a cached
-  // global state.  If so, this is a re-execution of the same query and we
-  // can rebind (reuse cached file metadata, avoiding footer reads).
-  // If any operator_id is missing, this is a different query — clear the
-  // map to prevent stale metadata from a previous query being reused
-  // (operator_ids can collide across different queries).
   const auto& pipelines = query.get_pipelines();
-
-  bool can_rebind = !_parquet_scan_operator_global_state_map.empty();
-  if (can_rebind) {
-    for (const auto& pipeline : pipelines) {
-      auto source_operator = pipeline->get_source();
-      if (source_operator &&
-          source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
-        if (_parquet_scan_operator_global_state_map.find(source_operator->get_operator_id()) ==
-            _parquet_scan_operator_global_state_map.end()) {
-          can_rebind = false;
-          break;
-        }
-      }
-    }
-  }
-  if (!can_rebind) { _parquet_scan_operator_global_state_map.clear(); }
-
   for (const auto& pipeline : pipelines) {
     auto source_operator = pipeline->get_source();
     if (source_operator == nullptr) { continue; }
@@ -106,21 +84,16 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
-      auto it = _parquet_scan_operator_global_state_map.find(operator_id);
-      if (it != _parquet_scan_operator_global_state_map.end()) {
-        it->second->rebind(pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>());
-      } else {
-        const auto& op_params =
-          _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
-            ->get_config()
-            .get_operator_params();
-        _parquet_scan_operator_global_state_map.emplace(
-          operator_id,
-          std::make_shared<op::scan::parquet_scan_task_global_state>(
-            pipeline,
-            &source_operator->Cast<op::sirius_physical_parquet_scan>(),
-            op_params.scan_task_batch_size));
-      }
+      const auto& op_params =
+        _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
+          ->get_config()
+          .get_operator_params();
+      _parquet_scan_operator_global_state_map.emplace(
+        operator_id,
+        std::make_shared<op::scan::parquet_scan_task_global_state>(
+          pipeline,
+          &source_operator->Cast<op::sirius_physical_parquet_scan>(),
+          op_params.scan_task_batch_size));
     } else {
       _gpu_operator_global_state_map.emplace(
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
@@ -140,11 +113,7 @@ void task_creator::reset()
 {
   std::lock_guard<std::mutex> lock(_global_state_mutex);
   _scan_operator_global_state_map.clear();
-  // Keep parquet global states in preload mode — they hold cached file
-  // metadata that is expensive to reconstruct (footer reads).
-  if (!_pipeline_executor || !_pipeline_executor->get_scan_executor().is_preload_mode()) {
-    _parquet_scan_operator_global_state_map.clear();
-  }
+  _parquet_scan_operator_global_state_map.clear();
   _gpu_operator_global_state_map.clear();
   _thread_context.reset();
   _execution_context.reset();

--- a/src/data/host_parquet_representation.cpp
+++ b/src/data/host_parquet_representation.cpp
@@ -54,6 +54,7 @@ std::unique_ptr<cucascade::idata_representation> host_parquet_representation::cl
                                                        _column_chunk_byte_ranges,
                                                        _size_in_bytes,
                                                        _uncompressed_size_in_bytes,
+                                                       _file_size,
                                                        _fallback_datasource);
 }
 
@@ -69,6 +70,7 @@ std::unique_ptr<cucascade::idata_representation> host_parquet_representation::sh
                                     _column_chunk_byte_ranges,
                                     _size_in_bytes,
                                     _uncompressed_size_in_bytes,
+                                    _file_size,
                                     _fallback_datasource));
   hpr->_column_chunks = _column_chunks;
   return hpr;

--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -185,7 +185,7 @@ convert_host_parquet_to_gpu_with_prefetched_data_source(
                                                      host_src.get_device_id());  // NUMA node id
 
   auto data_source = std::make_unique<sirius::op::scan::prefetched_data_source>(
-    std::move(ranges), host_src.get_fallback_datasource());
+    std::move(ranges), host_src.get_file_size(), host_src.get_fallback_datasource());
 
   // Point the reader options at our in-memory datasource and call cudf::io::read_parquet.
   auto opts = host_src.get_reader_options();
@@ -262,6 +262,7 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_host_pa
     std::move(host_src.get_column_chunk_byte_ranges()),
     data_size,
     host_src.get_uncompressed_size_in_bytes(),
+    host_src.get_file_size(),
     host_src.get_fallback_datasource());
 }
 

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -108,7 +108,9 @@ class task_creator {
   void prepare_for_query(const sirius::planner::query& query);
 
   /// \brief clean-up query bound resources and prepare the task creator for next query
-  void reset();
+  /// @param keep_parquet_metadata When true, parquet scan global states are kept
+  ///        so that cached file metadata (footers) can be reused on a warm re-run.
+  void reset(bool keep_parquet_metadata = false);
 
   /**
    * @brief Stop the task creator and its thread pool.

--- a/src/include/data/host_parquet_representation.hpp
+++ b/src/include/data/host_parquet_representation.hpp
@@ -70,6 +70,7 @@ class host_parquet_representation : public cucascade::idata_representation {
                               std::vector<cudf::io::text::byte_range_info> column_chunk_byte_ranges,
                               std::size_t size_in_bytes,
                               std::size_t uncompressed_size_in_bytes,
+                              std::size_t file_size,
                               std::shared_ptr<cudf::io::datasource> fallback_datasource)
     : idata_representation(*memory_space),
       _column_chunks(std::move(column_chunks)),
@@ -79,6 +80,7 @@ class host_parquet_representation : public cucascade::idata_representation {
       _column_chunk_byte_ranges(std::move(column_chunk_byte_ranges)),
       _size_in_bytes(size_in_bytes),
       _uncompressed_size_in_bytes(uncompressed_size_in_bytes),
+      _file_size(file_size),
       _fallback_datasource(fallback_datasource)
   {
   }
@@ -218,6 +220,11 @@ class host_parquet_representation : public cucascade::idata_representation {
   }
 
   /**
+   * @brief Gets the original parquet file size in bytes.
+   */
+  [[nodiscard]] std::size_t get_file_size() const { return _file_size; }
+
+  /**
    * @brief Sets the fallback datasource for uncached byte ranges.
    *
    * @param ds A shared_ptr to the fallback datasource.
@@ -235,6 +242,7 @@ class host_parquet_representation : public cucascade::idata_representation {
                               std::vector<cudf::io::text::byte_range_info> column_chunk_byte_ranges,
                               std::size_t size_in_bytes,
                               std::size_t uncompressed_size_in_bytes,
+                              std::size_t file_size,
                               std::shared_ptr<cudf::io::datasource> fallback_datasource)
     : idata_representation(*memory_space),
       _parquet_reader(std::move(parquet_reader)),
@@ -243,6 +251,7 @@ class host_parquet_representation : public cucascade::idata_representation {
       _column_chunk_byte_ranges(std::move(column_chunk_byte_ranges)),
       _size_in_bytes(size_in_bytes),
       _uncompressed_size_in_bytes(uncompressed_size_in_bytes),
+      _file_size(file_size),
       _fallback_datasource(fallback_datasource)
   {
   }
@@ -255,6 +264,7 @@ class host_parquet_representation : public cucascade::idata_representation {
   std::vector<cudf::io::text::byte_range_info> _column_chunk_byte_ranges;
   std::size_t _size_in_bytes;
   std::size_t _uncompressed_size_in_bytes;
+  std::size_t _file_size{0};
   std::shared_ptr<cudf::io::datasource> _fallback_datasource;
 };
 }  // namespace sirius

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -163,6 +163,13 @@ class duckdb_scan_executor {
   }
 
   /**
+   * @brief Check if the scan executor is in preload mode (cache is hot).
+   *
+   * @return True if preload mode is active, false otherwise.
+   */
+  [[nodiscard]] bool is_preload_mode() const noexcept { return _preload_mode; }
+
+  /**
    * @brief Prepare cache for scan operators
    *
    * In CACHE mode: ensures cache is empty and creates entries for each operator's ID

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -142,8 +142,10 @@ class duckdb_scan_executor {
    * @brief Cache scan results for the given query
    *
    * @param query The query string to cache results for
+   * @return True if this is a re-execution of the same query (cache hit),
+   *         false if the query changed (cache miss / cleared).
    */
-  void cache_scan_results_for_query(const std::string& query);
+  [[nodiscard]] bool cache_scan_results_for_query(const std::string& query);
 
   /**
    * @brief Configure scan result caching level

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -198,6 +198,8 @@ class parquet_scan_task_global_state : public pipeline::sirius_pipeline_task_glo
     set_pipeline(std::move(pipeline));
     _scan_op = scan_op;
     _next_rg_partition.store(0, std::memory_order_relaxed);
+    scan_op->has_more_partitions.store(true, std::memory_order_relaxed);
+    scan_op->exhausted.store(false, std::memory_order_relaxed);
   }
 
  private:

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -185,6 +185,21 @@ class parquet_scan_task_global_state : public pipeline::sirius_pipeline_task_glo
     return std::make_unique<hybrid_scan_reader>(_file_metadatas[file_idx], _reader_options);
   }
 
+  /**
+   * @brief Rebind this global state to a new pipeline and scan operator.
+   *
+   * Reuses all cached file metadata and row group partitions, avoiding
+   * footer reads and metadata parsing.  Only the pipeline/operator pointers
+   * and the partition counter are updated.
+   */
+  void rebind(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
+              sirius_physical_parquet_scan* scan_op)
+  {
+    set_pipeline(std::move(pipeline));
+    _scan_op = scan_op;
+    _next_rg_partition.store(0, std::memory_order_relaxed);
+  }
+
  private:
   /**
    * @brief Fill the vector of column indices for this scan after projection.
@@ -348,8 +363,6 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
       _task_id(task_id),
       _data_repo(data_repo)
   {
-    auto& l_state_cast = this->_local_state->cast<parquet_scan_task_local_state>();
-    _datasource = cudf::io::datasource::create(g_state->get_file_path(l_state_cast.get_file_idx()));
   }
 
   ~parquet_scan_task() override;

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -202,6 +202,29 @@ class parquet_scan_task_global_state : public pipeline::sirius_pipeline_task_glo
     scan_op->exhausted.store(false, std::memory_order_relaxed);
   }
 
+  /**
+   * @brief Get the file size for the given file index.
+   */
+  [[nodiscard]] size_t get_file_size(size_t file_idx) const { return _file_sizes[file_idx]; }
+
+  /**
+   * @brief Get the total number of parquet metadata bytes (header + footer + trailer)
+   * that must be cached alongside the column-chunk data for file @p file_idx.
+   */
+  [[nodiscard]] size_t get_metadata_byte_size(size_t file_idx) const
+  {
+    return _metadata_byte_sizes[file_idx];
+  }
+
+  /**
+   * @brief Get the file offset where the parquet footer begins for file @p file_idx.
+   * The footer range covers [footer_offset, file_size).
+   */
+  [[nodiscard]] size_t get_footer_offset(size_t file_idx) const
+  {
+    return _footer_offsets[file_idx];
+  }
+
  private:
   /**
    * @brief Fill the vector of column indices for this scan after projection.
@@ -228,6 +251,10 @@ class parquet_scan_task_global_state : public pipeline::sirius_pipeline_task_glo
   std::vector<std::string> _file_paths;                          ///< The parquet file paths
   std::vector<cudf::io::parquet::FileMetaData> _file_metadatas;  ///< The parquet file metadata
   cudf::io::parquet_reader_options _reader_options;              ///< Parquet reader options
+
+  std::vector<size_t> _file_sizes;           ///< Per-file total file size in bytes
+  std::vector<size_t> _metadata_byte_sizes;  ///< Per-file header+footer+trailer bytes
+  std::vector<size_t> _footer_offsets;       ///< Per-file offset where footer begins
 
   std::vector<std::vector<size_t>>
     _row_group_uncompressed_bytes;  ///< Per-(file,row-group) uncompressed bytes

--- a/src/include/op/scan/prefetched_data_source.hpp
+++ b/src/include/op/scan/prefetched_data_source.hpp
@@ -27,9 +27,12 @@ namespace sirius::op::scan {
 
 class prefetched_data_source : public cudf::io::datasource {
  public:
+  // file_size is the original parquet file size; used by size() so cuDF
+  // can compute footer offsets without a fallback datasource.
   // If fallback_source is provided, any offset that is not covered by cache_ranges will be
   // fetched from fallback_source instead of throwing.
   explicit prefetched_data_source(std::unique_ptr<cache_ranges> ranges,
+                                  std::size_t file_size,
                                   std::shared_ptr<cudf::io::datasource> fallback_source = nullptr);
 
   ~prefetched_data_source() override;
@@ -70,6 +73,7 @@ class prefetched_data_source : public cudf::io::datasource {
                                     rmm::cuda_stream_view stream);
 
   std::unique_ptr<cache_ranges> ranges_;
+  std::size_t file_size_;
   std::shared_ptr<cudf::io::datasource> fallback_;
   std::atomic<size_t> total_bytes_read_from_cache_{0};
   std::atomic<size_t> total_bytes_read_from_fallback_{0};

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -52,6 +52,11 @@ class sirius_pipeline_task_global_state : public sirius::parallel::itask_global_
 
   [[nodiscard]] size_t get_pipeline_id() const { return _pipeline->get_pipeline_id(); }
 
+  void set_pipeline(duckdb::shared_ptr<sirius_pipeline> pipeline)
+  {
+    _pipeline = std::move(pipeline);
+  }
+
  private:
   duckdb::shared_ptr<sirius_pipeline> _pipeline;  ///< Shared pointer to the GPU pipeline to execute
 };

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -103,18 +103,19 @@ void duckdb_scan_executor::set_completion_handler(
   _completion_handler = handler;
 }
 
-void duckdb_scan_executor::cache_scan_results_for_query(const std::string& query)
+bool duckdb_scan_executor::cache_scan_results_for_query(const std::string& query)
 {
-  if (_cache_level == cache_level::NONE) { return; }
+  if (_cache_level == cache_level::NONE) { return false; }
   std::hash<std::string> hash_fn;
   auto new_query_hash = hash_fn(query);
   if (new_query_hash == _query_hash) {
     SIRIUS_LOG_INFO("Scan results for query already cached, preloading: {}", query);
-    return;
+    return true;
   }
   SIRIUS_LOG_INFO("Caching scan results for query: {}", query);
   _query_hash = new_query_hash;
   _cache.clear();
+  return false;
 }
 
 void duckdb_scan_executor::set_scan_caching_enabled(cache_level level)

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -366,7 +366,12 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
 {
   auto& l_state = this->_local_state->cast<parquet_scan_task_local_state>();
   auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
-  auto reader   = g_state.make_reader(l_state.get_file_idx());
+
+  if (!_datasource) {
+    _datasource = cudf::io::datasource::create(g_state.get_file_path(l_state.get_file_idx()));
+  }
+
+  auto reader = g_state.make_reader(l_state.get_file_idx());
 
   auto& scan_op      = g_state.get_operator();
   auto const num_rgs = l_state.get_rg_span().size();

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -183,21 +183,41 @@ parquet_scan_task_global_state::parquet_scan_task_global_state(
   std::for_each(
     files.begin(), files.end(), [this](auto const& file) { _file_paths.push_back(file.path); });
 
-  // Construct the io_sources and read the footers
+  // Construct the io_sources and read the footers.
+  // Also record each file's total size and footer offset so that scan tasks
+  // can cache the parquet header+footer alongside the column-chunk data,
+  // eliminating all file I/O during subsequent (preload) iterations.
+  constexpr size_t PARQUET_MAGIC_SIZE = 4;
+  constexpr size_t FOOTER_TAIL_SIZE   = 8;  // 4-byte footer_len + 4-byte magic
+
   std::vector<std::unique_ptr<cudf::io::datasource>> datasources;
   std::vector<std::unique_ptr<cudf::io::datasource::buffer>> footer_buffers;
   datasources.reserve(files.size());
   footer_buffers.reserve(files.size());
-  std::for_each(
-    _file_paths.begin(), _file_paths.end(), [&datasources, &footer_buffers](auto const& file_path) {
-      auto datasource = cudf::io::datasource::create(file_path);
-      datasources.push_back(std::move(datasource));
+  _file_sizes.reserve(files.size());
+  _metadata_byte_sizes.reserve(files.size());
+  _footer_offsets.reserve(files.size());
+
+  for (auto const& file_path : _file_paths) {
+    auto datasource      = cudf::io::datasource::create(file_path);
+    auto const file_size = datasource->size();
+    datasources.push_back(std::move(datasource));
+
 #if CUDF_VERSION_NUM >= 2604
-      footer_buffers.push_back(cudf::io::parquet::fetch_footer_to_host(*datasources.back()));
+    footer_buffers.push_back(cudf::io::parquet::fetch_footer_to_host(*datasources.back()));
+    auto const footer_len = footer_buffers.back()->size();
 #else
-      footer_buffers.push_back(fetch_footer_to_host_fallback(*datasources.back()));
+    footer_buffers.push_back(fetch_footer_to_host_fallback(*datasources.back()));
+    auto const footer_len = footer_buffers.back()->size();
 #endif
-    });
+
+    auto const footer_offset  = file_size - FOOTER_TAIL_SIZE - footer_len;
+    auto const metadata_bytes = PARQUET_MAGIC_SIZE + footer_len + FOOTER_TAIL_SIZE;
+
+    _file_sizes.push_back(file_size);
+    _footer_offsets.push_back(footer_offset);
+    _metadata_byte_sizes.push_back(metadata_bytes);
+  }
 
   // Initialize reader options for applying projections (FUTURE: filters)
   _reader_options = cudf::io::parquet_reader_options::builder().build();
@@ -333,7 +353,8 @@ parquet_scan_task_local_state::parquet_scan_task_local_state(
   _rg_indices.resize(partition.row_group_count);
   std::iota(_rg_indices.begin(), _rg_indices.end(), partition.start_row_group);
   _reserved_uncompressed_bytes = partition.reserved_uncompressed_bytes;
-  _reserved_compressed_bytes   = partition.reserved_compressed_bytes;
+  _reserved_compressed_bytes =
+    partition.reserved_compressed_bytes + g_state.get_metadata_byte_size(_file_idx);
 }
 
 std::unique_ptr<parquet_scan_task_local_state::multiple_blocks_allocation>
@@ -389,9 +410,25 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
   memory::multiple_blocks_allocation_accessor<uint8_t> data_accessor;
   data_accessor.initialize(0, allocation);
 
-  // Get the byte ranges for the range of row groups assigned to this task
-  auto byte_ranges =
+  // Get the byte ranges for the range of row groups assigned to this task.
+  // Prepend the parquet header (4-byte magic at offset 0) and append the
+  // footer + trailer so that the cache covers ALL bytes cuDF needs to open
+  // the file, enabling zero file I/O during preload iterations.
+  auto const file_idx    = l_state.get_file_idx();
+  auto const file_size   = g_state.get_file_size(file_idx);
+  auto const footer_off  = g_state.get_footer_offset(file_idx);
+  auto const footer_size = file_size - footer_off;
+
+  using range_t = cudf::io::text::byte_range_info;
+
+  auto column_chunk_ranges =
     reader->all_column_chunks_byte_ranges(l_state.get_rg_span(), g_state.get_options());
+
+  std::vector<range_t> byte_ranges;
+  byte_ranges.reserve(column_chunk_ranges.size() + 2);
+  byte_ranges.emplace_back(0, 4);  // PAR1 header
+  byte_ranges.insert(byte_ranges.end(), column_chunk_ranges.begin(), column_chunk_ranges.end());
+  byte_ranges.emplace_back(footer_off, footer_size);  // footer + trailer
 
   // Read each byte range into the allocation asynchronously
   int64_t bytes_read = 0;
@@ -404,7 +441,6 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
   std::for_each(read_futures.begin(), read_futures.end(), [](auto& future) { future.get(); });
 
   if (bytes_read != l_state.get_reserved_compressed_bytes()) {
-    // Metadata / file data mismatch
     throw std::runtime_error(
       "[parquet_scan_task] Error in reading byte ranges: total bytes read does not match reserved "
       "compressed bytes");
@@ -420,6 +456,7 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
                                                   std::move(byte_ranges),
                                                   l_state.get_reserved_compressed_bytes(),
                                                   l_state.get_reserved_uncompressed_bytes(),
+                                                  file_size,
                                                   _datasource);
 
   std::shared_ptr<cucascade::data_batch> batch;

--- a/src/op/scan/prefetched_data_source.cpp
+++ b/src/op/scan/prefetched_data_source.cpp
@@ -32,8 +32,10 @@
 namespace sirius::op::scan {
 
 prefetched_data_source::prefetched_data_source(
-  std::unique_ptr<cache_ranges> ranges, std::shared_ptr<cudf::io::datasource> fallback_source)
-  : ranges_(std::move(ranges)), fallback_(std::move(fallback_source))
+  std::unique_ptr<cache_ranges> ranges,
+  std::size_t file_size,
+  std::shared_ptr<cudf::io::datasource> fallback_source)
+  : ranges_(std::move(ranges)), file_size_(file_size), fallback_(std::move(fallback_source))
 {
 }
 
@@ -197,7 +199,7 @@ std::future<size_t> prefetched_data_source::device_read_async(size_t offset,
 
 size_t prefetched_data_source::size() const
 {
-  // If a fallback datasource is present, report its size (it covers the full file).
+  if (file_size_ > 0) return file_size_;
   if (fallback_) return fallback_->size();
   return ranges_->max_offset();
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -87,13 +87,13 @@ void SiriusContext::QueryBegin(ClientContext& context)
 
   auto query = context.GetCurrentQuery();
   spdlog::info("QueryBegin: {}", query.substr(0, std::min(query.size(), size_t(120))));
+  bool query_cache_hit = false;
   if (config_.is_scan_caching_enabled()) {
-    pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
+    query_cache_hit = pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
   }
   pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
 
-  // Reset task creator state (including scan operator global state map) for the new query
-  task_creator_->reset();
+  task_creator_->reset(query_cache_hit);
   task_creator_->set_client_context(context);
 }
 

--- a/test/cpp/data/test_host_parquet_representation.cpp
+++ b/test/cpp/data/test_host_parquet_representation.cpp
@@ -225,6 +225,7 @@ struct parquet_test_fixture {
                                                          _original_byte_ranges,
                                                          size_in_bytes,
                                                          uncompressed_size_in_bytes,
+                                                         _datasource->size(),
                                                          _datasource);
   }
 
@@ -602,6 +603,7 @@ TEST_CASE("host_parquet_representation converts to GPU with projected columns",
                                                             byte_ranges,
                                                             total_size,
                                                             total_size * 2,
+                                                            datasource->size(),
                                                             datasource);
 
   auto stream     = gpu_space->acquire_stream();


### PR DESCRIPTION
Make sure no I/O is being performed when we are running from cache. In addition, this PR adds the parquet header and footer to the cached byte ranges so libcudf doesn't have to fallback to creating and reading from a datasource when trying to e.g. get the filesize. That doesn't benefit `table_host` or `table_gpu` runs, but helps when `cache = parquet`.