### PR TITLE
docs: add NVIDIA driver >= 570 requirement and fix mkdir -p for TPC-H setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Experiment Setup:
 ## Supported OS/GPU/CUDA/CMake
 - Ubuntu >= 22.04
 - NVIDIA Volta™ or higher with compute capability 7.0+
-- CUDA >= 13.0
+- CUDA >= 13.0 (requires NVIDIA driver >= 570)
 - CMake >= 3.30.4 (follow this [instruction](https://medium.com/@yulin_li/how-to-update-cmake-on-ubuntu-9602521deecb) to upgrade CMake)
 - libcudf >= 26.04
 - We recommend building Sirius with at least **16 vCPUs** to ensure faster compilation.
@@ -75,7 +75,7 @@ To generate the TPC-H dataset
 cd test_datasets
 unzip tpch-dbgen.zip
 cd tpch-dbgen
-./dbgen -s 1 && mkdir s1 && mv *.tbl s1  # this generates dataset of SF1
+./dbgen -s 1 && mkdir -p s1 && mv *.tbl s1  # this generates dataset of SF1
 cd ../../
 ```
 


### PR DESCRIPTION
## Summary

Two small documentation fixes found during installation on GCP (Ubuntu 22.04, Tesla T4). See #459 for full context.

- **NVIDIA driver version**: The README states `CUDA >= 13.0` but does not specify the minimum driver version required to support CUDA 13.x at runtime. Added `(requires NVIDIA driver >= 570)` inline. Without this, users installing the commonly suggested driver 535.x will hit a silent crash at `gpu_buffer_init`.
- **`mkdir -p` for TPC-H setup**: Changed `mkdir s1` to `mkdir -p s1` so the dataset generation step does not fail if the directory already exists on re-runs.

## Changes

- `docs/README.md`: CUDA requirement line updated with driver version
- `docs/README.md`: `mkdir` → `mkdir -p` in TPC-H dataset generation step

Closes #459