### PR TITLE
Limit on task retry and drain on error

### DIFF
--- a/src/include/exec/interruptible_mpmc.hpp
+++ b/src/include/exec/interruptible_mpmc.hpp
@@ -121,6 +121,15 @@ class interruptible_mpmc {
   }
 
   /**
+   * \brief Returns true if the queue is approximately empty.
+   *
+   * Uses size_approx() from the underlying concurrent queue, which may
+   * transiently over- or under-count in the presence of concurrent producers
+   * and consumers. Safe for assertions in quiescent states (e.g. after drain).
+   */
+  [[nodiscard]] bool is_empty() const noexcept { return queue.size_approx() == 0; }
+
+  /**
    * Resets the queue state to active (useful for restarting workers).
    */
   void reset() { _is_active.store(true, std::memory_order_relaxed); }

--- a/src/include/exec/kiosk.hpp
+++ b/src/include/exec/kiosk.hpp
@@ -69,6 +69,15 @@ class kiosk {
     cv_.notify_all();
   }
 
+  // Re-enable the kiosk after a stop() so it can accept new tickets.
+  // Must only be called once all outstanding tickets have been released
+  // (i.e. after wait_all() has returned).
+  void reset_stopped()
+  {
+    std::lock_guard lock(mutex_);
+    stopped_ = false;
+  }
+
   // Blocking: acquire a ticket (waits if bounded and at capacity)
   [[nodiscard]] ticket acquire();
 

--- a/src/include/exec/kiosk.hpp
+++ b/src/include/exec/kiosk.hpp
@@ -72,7 +72,7 @@ class kiosk {
   // Re-enable the kiosk after a stop() so it can accept new tickets.
   // Must only be called once all outstanding tickets have been released
   // (i.e. after wait_all() has returned).
-  void reset_stopped()
+  void resume()
   {
     std::lock_guard lock(mutex_);
     stopped_ = false;

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -132,6 +132,15 @@ class duckdb_scan_executor {
   void drain_leftover_tasks();
 
   /**
+   * @brief Drain tasks and wait for all in-flight work to complete.
+   *
+   * Interrupts the manager loop so it releases its kiosk ticket, waits for
+   * all in-flight thread-pool tasks, then restarts the manager so the
+   * executor is ready for the next query.  Used during error cleanup.
+   */
+  void drain_and_wait();
+
+  /**
    * @brief Set the completion handler for query completion signaling
    *
    * @param handler Pointer to the completion handler

--- a/src/include/pipeline/completion_handler.hpp
+++ b/src/include/pipeline/completion_handler.hpp
@@ -53,6 +53,7 @@ class completion_handler {
     bool expected = false;
     if (_completed.compare_exchange_strong(expected, true)) {
       try {
+        _has_error.store(true);
         _promise.set_exception(error);
       } catch (...) {
         // Promise already satisfied or other error - ignore
@@ -73,6 +74,7 @@ class completion_handler {
     bool expected = false;
     if (_completed.compare_exchange_strong(expected, true)) {
       try {
+        _has_error.store(true);
         _promise.set_exception(std::make_exception_ptr(std::runtime_error(error.data())));
       } catch (...) {
         // Promise already satisfied or other error - ignore
@@ -112,9 +114,17 @@ class completion_handler {
    */
   [[nodiscard]] bool is_completed() const noexcept { return _completed.load(); }
 
+  /**
+   * @brief Check if the handler has already been completed with an error.
+   *
+   * @return True if an error has been reported, false otherwise.
+   */
+  [[nodiscard]] bool has_error() const noexcept { return _has_error.load(); }
+
  private:
   std::promise<void> _promise;
   std::atomic<bool> _completed{false};
+  std::atomic<bool> _has_error{false};
 };
 
 }  // namespace sirius::pipeline

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -117,6 +117,17 @@ class gpu_pipeline_executor {
   void drain_leftover_tasks();
 
   /**
+   * @brief Drain all in-flight tasks after a query error.
+   *
+   * Interrupts the task queue so the manager loop exits, waits for all
+   * in-flight thread-pool tasks to complete (via kiosk), then resets the
+   * queue and restarts the manager thread so the executor is ready for the
+   * next query.  Must only be called after report_error() has been issued
+   * (i.e. in the execute() error path, before QueryEnd clears repositories).
+   */
+  void drain_and_wait();
+
+  /**
    * @brief Set the completion handler for query completion signaling
    *
    * @param handler Pointer to the completion handler

--- a/src/include/pipeline/gpu_pipeline_executor.hpp
+++ b/src/include/pipeline/gpu_pipeline_executor.hpp
@@ -128,6 +128,16 @@ class gpu_pipeline_executor {
   void drain_and_wait();
 
   /**
+   * @brief Check if the internal task queue is empty.
+   *
+   * Useful for verifying that drain_and_wait() has fully cleared the queue.
+   * Only reliable when the executor is quiescent (no concurrent producers).
+   *
+   * @return true if the task queue contains no pending tasks.
+   */
+  [[nodiscard]] bool is_task_queue_empty() const noexcept;
+
+  /**
    * @brief Set the completion handler for query completion signaling
    *
    * @param handler Pointer to the completion handler

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -26,6 +26,7 @@
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -70,12 +71,16 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
   std::unique_ptr<op::operator_data> _input_data;  ///< Input data batches for the pipeline
   size_t _start_operator_index = 0;  ///< Operator index to resume from (0 = start of pipeline)
 
+  /// Number of times this task has been retried due to OOM (0 = first attempt).
+  uint32_t retry_count = 0;
+  /// Task ID of the original (non-retried) task; only meaningful when retry_count > 0.
+  uint64_t original_task_id = 0;
+
   /**
    * @brief Get a const pointer to the reservation (non-owning).
    *
    * @return const cucascade::memory::reservation* Pointer to the reservation, or nullptr
    */
-  // WSM TODO: remove this method?
   const cucascade::memory::reservation* get_reservation() const { return _reservation.get(); }
 };
 
@@ -208,7 +213,8 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
  private:
   uint64_t _task_id;
   std::vector<cucascade::shared_data_repository*> _data_repos;
-  bool _oom_rescheduled = false;
+  bool _oom_rescheduled                                             = false;
+  cucascade::memory::reservation_aware_resource_adaptor* _allocator = nullptr;
 };
 
 }  // namespace pipeline

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -163,6 +163,17 @@ class pipeline_executor {
    */
   void terminate_query(std::exception_ptr error);
 
+  /**
+   * @brief Drain all in-flight tasks after a query error.
+   *
+   * Drains the top-level task queue and waits for each GPU executor to finish
+   * all in-flight thread-pool tasks.  After this call it is safe for QueryEnd
+   * to destroy data repositories without causing a use-after-free in executing
+   * tasks.  Each GPU executor's manager thread is restarted so the executor is
+   * ready for the next query.
+   */
+  void drain_after_error();
+
  private:
   void management_eventloop();
 

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -114,7 +114,7 @@ void duckdb_scan_executor::drain_and_wait()
   _kiosk.wait_all();
 
   // Re-enable the kiosk and queue so the executor is ready for the next query.
-  _kiosk.reset_stopped();
+  _kiosk.resume();
   _task_queue.reset();
   _manager_thread = std::thread(&duckdb_scan_executor::manager_loop, this);
 }

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -97,6 +97,28 @@ void duckdb_scan_executor::set_task_creator(sirius::creator::task_creator* task_
 
 void duckdb_scan_executor::drain_leftover_tasks() { _task_queue.drain(); }
 
+void duckdb_scan_executor::drain_and_wait()
+{
+  // Stop the kiosk so the manager_loop's acquire() returns an invalid ticket
+  // (the manager may be blocked there when all thread-pool slots are full).
+  _kiosk.stop();
+
+  // Interrupt pop() so the manager_loop sees a nullptr and breaks out.
+  _task_queue.interrupt();
+  _task_queue.drain();
+
+  // Join the manager thread so we know it has exited.
+  if (_manager_thread.joinable()) { _manager_thread.join(); }
+
+  // Wait for all in-flight thread-pool tasks to finish.
+  _kiosk.wait_all();
+
+  // Re-enable the kiosk and queue so the executor is ready for the next query.
+  _kiosk.reset_stopped();
+  _task_queue.reset();
+  _manager_thread = std::thread(&duckdb_scan_executor::manager_loop, this);
+}
+
 void duckdb_scan_executor::set_completion_handler(
   sirius::pipeline::completion_handler* handler) noexcept
 {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -101,8 +101,10 @@ void gpu_pipeline_executor::manager_loop()
     auto* gpu_task = cast_to_gpu_pipeline_task(pipeline_task.get());
     if (!gpu_task) {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
-      _completion_handler->report_error(
-        "GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
+      if (_completion_handler) {
+        _completion_handler->report_error(
+          "GPU Pipeline Executor: Failed to cast pipeline task to gpu_pipeline_task");
+      }
       break;
     }
     auto bytes_needs = gpu_task->get_estimated_reservation_size();
@@ -118,9 +120,11 @@ void gpu_pipeline_executor::manager_loop()
     if (!reservation) {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to acquire memory reservation for task {}",
                        gpu_task->get_task_id());
-      _completion_handler->report_error(
-        "GPU Pipeline Executor: Failed to acquire memory reservation for task " +
-        std::to_string(gpu_task->get_task_id()));
+      if (_completion_handler) {
+        _completion_handler->report_error(
+          "GPU Pipeline Executor: Failed to acquire memory reservation for task " +
+          std::to_string(gpu_task->get_task_id()));
+      }
       break;
     }
     if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
@@ -129,9 +133,11 @@ void gpu_pipeline_executor::manager_loop()
     } else {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast local state for task {}",
                        gpu_task->get_task_id());
-      _completion_handler->report_error(
-        "GPU Pipeline Executor: Failed to cast local state for task " +
-        std::to_string(gpu_task->get_task_id()));
+      if (_completion_handler) {
+        _completion_handler->report_error(
+          "GPU Pipeline Executor: Failed to cast local state for task " +
+          std::to_string(gpu_task->get_task_id()));
+      }
       break;
     }
     auto output_consumers = gpu_task->get_output_consumers();
@@ -147,7 +153,7 @@ void gpu_pipeline_executor::manager_loop()
       try {
         task->execute(exc_stream);
       } catch (oom_reschedule_exception& oom) {
-        if (_completion_handler->has_error()) {
+        if (_completion_handler && _completion_handler->has_error()) {
           // If the completion handler is already in an error state, then we can just return and not
           // try to reschedule
           return;
@@ -300,13 +306,15 @@ void gpu_pipeline_executor::drain_and_wait()
   _kiosk.wait_all();
 
   // Re-enable the kiosk so the restarted manager can acquire tickets again.
-  _kiosk.reset_stopped();
+  _kiosk.resume();
 
   // Reset the queue and restart the manager so the executor is ready for
   // the next query.
   _task_queue.reset();
   _manager_thread = std::thread(&gpu_pipeline_executor::manager_loop, this);
 }
+
+bool gpu_pipeline_executor::is_task_queue_empty() const noexcept { return _task_queue.is_empty(); }
 
 void gpu_pipeline_executor::set_completion_handler(completion_handler* handler) noexcept
 {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -106,6 +106,14 @@ void gpu_pipeline_executor::manager_loop()
       break;
     }
     auto bytes_needs = gpu_task->get_estimated_reservation_size();
+    SIRIUS_LOG_TRACE(
+      "GPU Pipeline Executor: Acquiring memory reservation of {} bytes for task {}. Memory "
+      "available: {}, total reserved: {}, max: {}",
+      bytes_needs,
+      gpu_task->get_task_id(),
+      _memory_space->get_available_memory(),
+      _memory_space->get_total_reserved_memory(),
+      _memory_space->get_max_memory());
     auto reservation = _memory_space->make_reservation(bytes_needs);
     if (!reservation) {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to acquire memory reservation for task {}",
@@ -139,9 +147,11 @@ void gpu_pipeline_executor::manager_loop()
       try {
         task->execute(exc_stream);
       } catch (oom_reschedule_exception& oom) {
-        SIRIUS_LOG_WARN("GPU Pipeline Executor: OOM reschedule, resuming from operator index {}",
-                        oom.get_resume_operator_index());
-
+        if (_completion_handler->has_error()) {
+          // If the completion handler is already in an error state, then we can just return and not
+          // try to reschedule
+          return;
+        }
         auto* gpu_task = cast_to_gpu_pipeline_task(task.get());
         if (!gpu_task) {
           SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast task for OOM reschedule");
@@ -151,6 +161,42 @@ void gpu_pipeline_executor::manager_loop()
           }
           return;
         }
+
+        // Determine retry count and original task ID for this rescheduled attempt.
+        auto* cur_local = dynamic_cast<gpu_pipeline_task_local_state*>(gpu_task->local_state());
+        uint32_t next_retry_count = 1;
+        uint64_t orig_task_id     = gpu_task->get_task_id();
+        if (cur_local && cur_local->retry_count > 0) {
+          next_retry_count = cur_local->retry_count + 1;
+          orig_task_id     = cur_local->original_task_id;
+        }
+
+        static constexpr uint32_t MAX_OOM_RETRIES = 10;
+        if (next_retry_count > MAX_OOM_RETRIES) {
+          SIRIUS_LOG_ERROR(
+            "GPU Pipeline Executor: task {} (original task {}) exceeded {} OOM retries at "
+            "operator index {} — terminating query",
+            gpu_task->get_task_id(),
+            orig_task_id,
+            MAX_OOM_RETRIES,
+            oom.get_resume_operator_index());
+          if (_completion_handler) {
+            _completion_handler->report_error(std::make_exception_ptr(
+              std::runtime_error("GPU pipeline task exceeded maximum OOM retry limit (" +
+                                 std::to_string(MAX_OOM_RETRIES) + ") for original task " +
+                                 std::to_string(orig_task_id))));
+          }
+          return;
+        }
+
+        SIRIUS_LOG_WARN(
+          "GPU Pipeline Executor: OOM reschedule (retry {}/{}) for task {} (original task {}), "
+          "resuming from operator index {}",
+          next_retry_count,
+          MAX_OOM_RETRIES,
+          gpu_task->get_task_id(),
+          orig_task_id,
+          oom.get_resume_operator_index());
 
         // Mark old task as rescheduled so its destructor skips mark_task_completed().
         // The rescheduled task will handle completion instead.
@@ -169,6 +215,9 @@ void gpu_pipeline_executor::manager_loop()
         // Build the rescheduled task via virtual factory (preserves derived type).
         auto new_local_state = std::make_unique<gpu_pipeline_task_local_state>(
           std::move(intermediate_data), oom.get_resume_operator_index());
+        new_local_state->retry_count      = next_retry_count;
+        new_local_state->original_task_id = orig_task_id;
+
         auto new_task_id =
           _task_creator ? _task_creator->get_next_task_id() : gpu_task->get_task_id();
         auto new_task = gpu_task->create_rescheduled_task(new_task_id, std::move(new_local_state));
@@ -229,6 +278,35 @@ void gpu_pipeline_executor::set_task_creator(sirius::creator::task_creator* task
 }
 
 void gpu_pipeline_executor::drain_leftover_tasks() { _task_queue.drain(); }
+
+void gpu_pipeline_executor::drain_and_wait()
+{
+  // Stop the kiosk so acquire() unblocks immediately with an invalid ticket.
+  // This is necessary when the manager loop is blocked at acquire() (i.e. all
+  // thread-pool slots are full) — interrupting the task queue alone won't help.
+  _kiosk.stop();
+
+  // Interrupt pop() so the manager_loop sees a nullptr return and breaks out
+  // of its while loop (within at most the 10 ms poll interval in pop()).
+  _task_queue.interrupt();
+  _task_queue.drain();
+
+  // Join the manager thread so we know it has exited (it will have seen either
+  // an invalid ticket from the stopped kiosk or a nullptr from the interrupted queue).
+  if (_manager_thread.joinable()) { _manager_thread.join(); }
+
+  // Wait for all in-flight thread-pool tasks to finish (each holds a kiosk
+  // ticket that is released when the lambda completes).
+  _kiosk.wait_all();
+
+  // Re-enable the kiosk so the restarted manager can acquire tickets again.
+  _kiosk.reset_stopped();
+
+  // Reset the queue and restart the manager so the executor is ready for
+  // the next query.
+  _task_queue.reset();
+  _manager_thread = std::thread(&gpu_pipeline_executor::manager_loop, this);
+}
 
 void gpu_pipeline_executor::set_completion_handler(completion_handler* handler) noexcept
 {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -165,6 +165,33 @@ void validate_operator_output_types(const op::operator_data* data,
   }
 }
 
+void log_operator_data(const op::sirius_physical_operator& op,
+                       const op::operator_data& data,
+                       const sirius_pipeline* pipeline,
+                       const char* label,
+                       const std::string& extra_info = "")
+{
+  std::string batch_rows = "";
+  size_t total_bytes     = 0;
+  for (auto& batch : data.get_data_batches()) {
+    auto view = get_cudf_table_view(*batch);
+    batch_rows += std::to_string(view.num_rows()) + "  ";
+    total_bytes += batch->get_data()->get_size_in_bytes();
+  }
+  SIRIUS_LOG_TRACE(
+    "Pipeline {}: operator {} (id={}) {} {} batches, num rows: {}, "
+    "size: {} bytes ({:.2f} MB). {}",
+    pipeline->get_pipeline_id(),
+    op.get_name(),
+    op.get_operator_id(),
+    label,
+    data.get_data_batches().size(),
+    batch_rows,
+    total_bytes,
+    static_cast<double>(total_bytes) / (1024.0 * 1024.0),
+    extra_info);
+}
+
 std::unique_ptr<op::operator_data> run_one_operator(
   op::sirius_physical_operator& op,
   const op::operator_data& operator_input_data,
@@ -174,36 +201,26 @@ std::unique_ptr<op::operator_data> run_one_operator(
   size_t num_operators,
   cucascade::memory::reservation_aware_resource_adaptor* allocator)
 {
+  log_operator_data(op, operator_input_data, pipeline, "executing on");
+
   auto nvtx_label = std::format(
     "Pipeline {}: {} (id={})", pipeline->get_pipeline_id(), op.get_name(), op.get_operator_id());
   nvtx3::scoped_range nvtx_range{nvtx_label.c_str()};
   auto start                = std::chrono::high_resolution_clock::now();
   auto operator_output_data = op.execute(operator_input_data, stream);
   stream.synchronize();
-  auto end            = std::chrono::high_resolution_clock::now();
-  auto duration       = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  batch_sizes         = "";
-  size_t output_bytes = 0;
-  for (auto& batch : operator_output_data->get_data_batches()) {
-    auto view = get_cudf_table_view(*batch);
-    batch_sizes += std::to_string(view.num_rows()) + "  ";
-    output_bytes += batch->get_data()->get_size_in_bytes();
-  }
-  auto peak_bytes = allocator ? allocator->get_peak_allocated_bytes(stream) : 0;
-  SIRIUS_LOG_TRACE(
-    "Pipeline {}: operator {} (id={}) produced {} batches with num rows: {}, "
-    "output size: {} bytes ({:.2f} MB), execution time: "
-    "{:.2f} ms, peak allocated: {} bytes ({:.2f} MB)",
-    pipeline->get_pipeline_id(),
-    op.get_name(),
-    op.get_operator_id(),
-    operator_output_data ? operator_output_data->get_data_batches().size() : 0u,
-    batch_sizes,
-    output_bytes,
-    static_cast<double>(output_bytes) / (1024.0 * 1024.0),
+  auto end      = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+  auto peak_bytes        = allocator ? allocator->get_peak_allocated_bytes(stream) : 0;
+  std::string extra_info = fmt::format(
+    "execution time: {:.2f} ms, "
+    "peak allocated: {} bytes ({:.2f} MB)",
     duration.count() / 1000.0,
     peak_bytes,
     static_cast<double>(peak_bytes) / (1024.0 * 1024.0));
+  log_operator_data(op, *operator_output_data, pipeline, "produced", extra_info);
+
   validate_operator_output_types(operator_output_data.get(), op);
   return operator_output_data;
 }
@@ -255,53 +272,36 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
   }
 
   for (size_t i = start_index; i < operators.size(); i++) {
-    std::string batch_sizes = "";
-    size_t total_bytes      = 0;
-    for (auto& batch : operator_input_output_data->get_data_batches()) {
-      auto view = get_cudf_table_view(*batch);
-      batch_sizes += std::to_string(view.num_rows()) + "  ";
-      total_bytes += batch->get_data()->get_size_in_bytes();
-    }
     auto& op = operators[i].get();
-    SIRIUS_LOG_TRACE(
-      "Pipeline {}: operator {} (id={}) executing on {} batches with num rows: {}, "
-      "input size: {} bytes ({:.2f} MB)",
-      pipeline->get_pipeline_id(),
-      op.get_name(),
-      op.get_operator_id(),
-      operator_input_output_data->get_data_batches().size(),
-      batch_sizes,
-      total_bytes,
-      static_cast<double>(total_bytes) / (1024.0 * 1024.0));
     try {
       operator_input_output_data = run_one_operator(
-        op, *operator_input_output_data, stream, pipeline, i, operators.size(), batch_sizes);
-    } catch (const rmm::out_of_memory&) {
-      auto peak_bytes = _allocator ? _allocator->get_peak_allocated_bytes(stream) : 0;
+        op, *operator_input_output_data, stream, pipeline, i, operators.size(), _allocator);
+    } catch (const rmm::out_of_memory& oom) {
+      auto peak_bytes        = _allocator ? _allocator->get_peak_allocated_bytes(stream) : 0;
       size_t requested_bytes = 0;
-      size_t global_usage = 0;
+      size_t global_usage    = 0;
       if (auto const* cc_oom =
-              dynamic_cast<const cucascade::memory::cucascade_out_of_memory*>(&oom)) {
+            dynamic_cast<const cucascade::memory::cucascade_out_of_memory*>(&oom)) {
         requested_bytes = cc_oom->requested_bytes;
-        global_usage = cc_oom->global_usage;
-              }
+        global_usage    = cc_oom->global_usage;
+      }
       SIRIUS_LOG_WARN(
-            "Pipeline {}: OOM at operator {} (id={}, index {}/{}), "
-            "requested {} bytes ({:.2f} MB), global usage {} bytes ({:.2f} MB), "
-            "peak allocated {} bytes ({:.2f} MB), "
-            "rescheduling task {}",
-            pipeline->get_pipeline_id(),
-            op.get_name(),
-            op.get_operator_id(),
-            i,
-            operators.size(),
-            requested_bytes,
-            static_cast<double>(requested_bytes) / (1024.0 * 1024.0),
-            global_usage,
-            static_cast<double>(global_usage) / (1024.0 * 1024.0),
-            peak_bytes,
-            static_cast<double>(peak_bytes) / (1024.0 * 1024.0),
-          _task_id);
+        "Pipeline {}: OOM at operator {} (id={}, index {}/{}), "
+        "requested {} bytes ({:.2f} MB), global usage {} bytes ({:.2f} MB), "
+        "peak allocated {} bytes ({:.2f} MB), "
+        "rescheduling task {}",
+        pipeline->get_pipeline_id(),
+        op.get_name(),
+        op.get_operator_id(),
+        i,
+        operators.size(),
+        requested_bytes,
+        static_cast<double>(requested_bytes) / (1024.0 * 1024.0),
+        global_usage,
+        static_cast<double>(global_usage) / (1024.0 * 1024.0),
+        peak_bytes,
+        static_cast<double>(peak_bytes) / (1024.0 * 1024.0),
+        _task_id);
       throw oom_reschedule_exception(
         std::move(operator_input_output_data),
         i,

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -27,6 +27,7 @@
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/error.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <data/data_batch_utils.hpp>
@@ -164,13 +165,14 @@ void validate_operator_output_types(const op::operator_data* data,
   }
 }
 
-std::unique_ptr<op::operator_data> run_one_operator(op::sirius_physical_operator& op,
-                                                    const op::operator_data& operator_input_data,
-                                                    rmm::cuda_stream_view stream,
-                                                    const sirius_pipeline* pipeline,
-                                                    size_t op_index,
-                                                    size_t num_operators,
-                                                    std::string& batch_sizes)
+std::unique_ptr<op::operator_data> run_one_operator(
+  op::sirius_physical_operator& op,
+  const op::operator_data& operator_input_data,
+  rmm::cuda_stream_view stream,
+  const sirius_pipeline* pipeline,
+  size_t op_index,
+  size_t num_operators,
+  cucascade::memory::reservation_aware_resource_adaptor* allocator)
 {
   auto nvtx_label = std::format(
     "Pipeline {}: {} (id={})", pipeline->get_pipeline_id(), op.get_name(), op.get_operator_id());
@@ -178,22 +180,30 @@ std::unique_ptr<op::operator_data> run_one_operator(op::sirius_physical_operator
   auto start                = std::chrono::high_resolution_clock::now();
   auto operator_output_data = op.execute(operator_input_data, stream);
   stream.synchronize();
-  auto end      = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  batch_sizes   = "";
+  auto end            = std::chrono::high_resolution_clock::now();
+  auto duration       = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  batch_sizes         = "";
+  size_t output_bytes = 0;
   for (auto& batch : operator_output_data->get_data_batches()) {
     auto view = get_cudf_table_view(*batch);
     batch_sizes += std::to_string(view.num_rows()) + "  ";
+    output_bytes += batch->get_data()->get_size_in_bytes();
   }
+  auto peak_bytes = allocator ? allocator->get_peak_allocated_bytes(stream) : 0;
   SIRIUS_LOG_TRACE(
-    "Pipeline {}: operator {} (id={}) produced {} batches with num rows: {}, execution time: "
-    "{:.2f} ms",
+    "Pipeline {}: operator {} (id={}) produced {} batches with num rows: {}, "
+    "output size: {} bytes ({:.2f} MB), execution time: "
+    "{:.2f} ms, peak allocated: {} bytes ({:.2f} MB)",
     pipeline->get_pipeline_id(),
     op.get_name(),
     op.get_operator_id(),
     operator_output_data ? operator_output_data->get_data_batches().size() : 0u,
     batch_sizes,
-    duration.count() / 1000.0);
+    output_bytes,
+    static_cast<double>(output_bytes) / (1024.0 * 1024.0),
+    duration.count() / 1000.0,
+    peak_bytes,
+    static_cast<double>(peak_bytes) / (1024.0 * 1024.0));
   validate_operator_output_types(operator_output_data.get(), op);
   return operator_output_data;
 }
@@ -244,31 +254,54 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
                     operators.size());
   }
 
-  std::string batch_sizes = "";
-  for (auto& batch : operator_input_output_data->get_data_batches()) {
-    auto view = get_cudf_table_view(*batch);
-    batch_sizes += std::to_string(view.num_rows()) + "  ";
-  }
   for (size_t i = start_index; i < operators.size(); i++) {
+    std::string batch_sizes = "";
+    size_t total_bytes      = 0;
+    for (auto& batch : operator_input_output_data->get_data_batches()) {
+      auto view = get_cudf_table_view(*batch);
+      batch_sizes += std::to_string(view.num_rows()) + "  ";
+      total_bytes += batch->get_data()->get_size_in_bytes();
+    }
     auto& op = operators[i].get();
-    SIRIUS_LOG_TRACE("Pipeline {}: operator {} (id={}) executing on {} batches with num row: {}",
-                     pipeline->get_pipeline_id(),
-                     op.get_name(),
-                     op.get_operator_id(),
-                     operator_input_output_data->get_data_batches().size(),
-                     batch_sizes);
+    SIRIUS_LOG_TRACE(
+      "Pipeline {}: operator {} (id={}) executing on {} batches with num rows: {}, "
+      "input size: {} bytes ({:.2f} MB)",
+      pipeline->get_pipeline_id(),
+      op.get_name(),
+      op.get_operator_id(),
+      operator_input_output_data->get_data_batches().size(),
+      batch_sizes,
+      total_bytes,
+      static_cast<double>(total_bytes) / (1024.0 * 1024.0));
     try {
       operator_input_output_data = run_one_operator(
         op, *operator_input_output_data, stream, pipeline, i, operators.size(), batch_sizes);
     } catch (const rmm::out_of_memory&) {
+      auto peak_bytes = _allocator ? _allocator->get_peak_allocated_bytes(stream) : 0;
+      size_t requested_bytes = 0;
+      size_t global_usage = 0;
+      if (auto const* cc_oom =
+              dynamic_cast<const cucascade::memory::cucascade_out_of_memory*>(&oom)) {
+        requested_bytes = cc_oom->requested_bytes;
+        global_usage = cc_oom->global_usage;
+              }
       SIRIUS_LOG_WARN(
-        "Pipeline {}: OOM again at operator {} (id={}, index {}/{}), rescheduling task {}",
-        pipeline->get_pipeline_id(),
-        op.get_name(),
-        op.get_operator_id(),
-        i,
-        operators.size(),
-        _task_id);
+            "Pipeline {}: OOM at operator {} (id={}, index {}/{}), "
+            "requested {} bytes ({:.2f} MB), global usage {} bytes ({:.2f} MB), "
+            "peak allocated {} bytes ({:.2f} MB), "
+            "rescheduling task {}",
+            pipeline->get_pipeline_id(),
+            op.get_name(),
+            op.get_operator_id(),
+            i,
+            operators.size(),
+            requested_bytes,
+            static_cast<double>(requested_bytes) / (1024.0 * 1024.0),
+            global_usage,
+            static_cast<double>(global_usage) / (1024.0 * 1024.0),
+            peak_bytes,
+            static_cast<double>(peak_bytes) / (1024.0 * 1024.0),
+          _task_id);
       throw oom_reschedule_exception(
         std::move(operator_input_output_data),
         i,
@@ -380,6 +413,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   // 2. Set reservation_aware_memory_resource_ref as the default cudf allocator
   // 3. Execute cudf operators on the pipeline
+  _allocator       = allocator;
   auto output_data = compute_task(stream);
 
   if (output_data) { publish_output(*output_data, stream); }

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -172,6 +172,28 @@ void pipeline_executor::terminate_query(std::exception_ptr error)
   stop();
 }
 
+void pipeline_executor::drain_after_error()
+{
+  SIRIUS_LOG_INFO("pipeline_executor: draining after error");
+  // Drain the top-level task queue so management_eventloop doesn't dispatch
+  // stale tasks from the failed query.
+  _task_queue.drain();
+
+  // Stop the scan executor's manager loop, wait for in-flight scan tasks to
+  // finish, then restart the manager for the next query.  We must use
+  // drain_and_wait() (not just drain + wait_all) because the scan manager
+  // thread holds a kiosk ticket while blocked on pop(); without interrupting
+  // the queue and stopping the kiosk first, wait_all() deadlocks.
+  _scan_executor->drain_and_wait();
+
+  // Interrupt each GPU executor's manager loop, wait for in-flight thread-pool
+  // tasks to finish, then restart the manager for the next query.
+  for (auto& [device_id, gpu_exec] : _gpu_executors) {
+    gpu_exec->drain_and_wait();
+  }
+  SIRIUS_LOG_INFO("pipeline_executor: DONE draining after error");
+}
+
 void pipeline_executor::management_eventloop()
 {
   while (_running.load()) {

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -202,12 +202,16 @@ void sirius_engine::execute()
   try {
     future.get();
   } catch (const std::exception& e) {
-    /// todo(bobbi) we should handle the error properly, clean the query context and then return the
-    /// error to duckdb
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
+    // Drain all in-flight GPU tasks before returning.  QueryEnd() will call
+    // clear_all_repositories() immediately after execute() throws; without
+    // this drain, tasks still running in the thread pool hold raw pointers to
+    // those repositories and cause a use-after-free / heap corruption.
+    sirius_ctx->get_pipeline_executor().drain_after_error();
     throw;
   } catch (...) {
     SIRIUS_LOG_ERROR("Unknown error executing query");
+    sirius_ctx->get_pipeline_executor().drain_after_error();
     throw;
   }
 }

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -17,6 +17,7 @@
 #include "catch.hpp"
 #include "exec/channel.hpp"
 #include "exec/config.hpp"
+#include "pipeline/completion_handler.hpp"
 #include "pipeline/gpu_pipeline_executor.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/oom_reschedule_exception.hpp"
@@ -26,7 +27,6 @@
 
 #include <rmm/mr/device_memory_resource.hpp>
 
-#include <absl/cleanup/cleanup.h>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 
@@ -40,25 +40,11 @@
 
 namespace {
 
-// Memory layout:
+// Memory layout constants shared across all tests.
 //   GPU capacity  = 1100 MB (software limit)
 //   Reservation   =  50 MB per task (intentionally small)
-//   Allocation    = 400 MB per task (much larger than reservation)
-//
-// With 3 threads, all 3 tasks start concurrently.
-// Accounting after 3 reservations: 150 MB
-// First  allocation (+350 MB overflow): total =  500 MB ≤ 1100 → OK
-// Second allocation (+350 MB overflow): total =  850 MB ≤ 1100 → OK
-// Third  allocation (+350 MB overflow): total = 1200 MB > 1100 → OOM!
-//
-// The OOM'd task gets rescheduled. After the first two complete, enough
-// accounting headroom is freed for the rescheduled task to succeed.
-// (Note: cucascade's cross-boundary deallocation accounting leaves some
-//  residual in _total_allocated_bytes, hence the extra capacity margin.)
 constexpr std::size_t kGpuCapacity     = 1100ULL * 1024 * 1024;  // 1100 MB
 constexpr std::size_t kReservationSize = 50ULL * 1024 * 1024;    // 50 MB
-constexpr std::size_t kAllocationBytes = 400ULL * 1024 * 1024;   // 400 MB
-constexpr auto kHoldDuration           = std::chrono::milliseconds(30);
 
 //------------------------------------------------------------------------------
 // Test global state — shared across all tasks
@@ -82,72 +68,64 @@ class oom_test_global_state : public sirius::pipeline::sirius_pipeline_task_glob
 };
 
 //------------------------------------------------------------------------------
-// Test task — allocates kAllocationBytes of GPU memory, holds it, then frees.
-// If OOM occurs, throws oom_reschedule_exception for the executor to handle.
+// Test fixture: memory manager + executor + channel, reused by all test cases.
 //------------------------------------------------------------------------------
-class oom_test_task : public sirius::pipeline::gpu_pipeline_task {
+struct oom_test_fixture {
+  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
+  cucascade::memory::memory_space* mem_space = nullptr;
+  sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
+  std::unique_ptr<sirius::pipeline::gpu_pipeline_executor> executor;
+  sirius::pipeline::completion_handler completion;
+
+  // Returns false if setup failed (no GPU available) — caller should WARN and return.
+  bool setup(int num_threads, const std::string& thread_name_prefix)
+  {
+    try {
+      cucascade::memory::reservation_manager_configurator builder;
+      builder.set_number_of_gpus(1)
+        .set_gpu_usage_limit(kGpuCapacity)
+        .set_reservation_fraction_per_gpu(0.95)
+        .set_per_host_capacity(1ULL * 1024 * 1024 * 1024)
+        .use_host_per_gpu()
+        .track_reservation_per_stream(false)
+        .set_reservation_fraction_per_host(0.75);
+      auto space_configs = builder.build();
+      manager            = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
+        std::move(space_configs));
+    } catch (const std::exception&) {
+      return false;
+    }
+
+    mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
+    if (!mem_space) { return false; }
+
+    auto request_publisher = request_channel.make_publisher();
+
+    sirius::exec::thread_pool_config config;
+    config.num_threads        = num_threads;
+    config.thread_name_prefix = thread_name_prefix;
+
+    executor = std::make_unique<sirius::pipeline::gpu_pipeline_executor>(
+      config, mem_space, std::move(request_publisher));
+    executor->set_completion_handler(&completion);
+    return true;
+  }
+};
+
+//------------------------------------------------------------------------------
+// Base class for test tasks — handles the common constructor, trivial overrides,
+// and the reservation-setup boilerplate shared by all task types.
+//------------------------------------------------------------------------------
+class oom_test_task_base : public sirius::pipeline::gpu_pipeline_task {
  public:
-  oom_test_task(uint64_t task_id,
-                std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state> local_state,
-                std::shared_ptr<oom_test_global_state> global_state)
+  oom_test_task_base(uint64_t task_id,
+                     std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state> local_state,
+                     std::shared_ptr<oom_test_global_state> global_state)
     : gpu_pipeline_task(task_id,
                         std::vector<cucascade::shared_data_repository*>{},
                         std::move(local_state),
                         std::move(global_state))
   {
-  }
-
-  void execute(rmm::cuda_stream_view stream) override
-  {
-    auto& global = _global_state->cast<oom_test_global_state>();
-    auto& local  = _local_state->cast<sirius::pipeline::gpu_pipeline_task_local_state>();
-
-    auto reservation = local.release_reservation();
-    if (!reservation) {
-      global.add_error("Missing GPU memory reservation for OOM test task.");
-      global.completed_count.fetch_add(1, std::memory_order_relaxed);
-      return;
-    }
-
-    auto* allocator =
-      reservation->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
-    if (!allocator) {
-      global.add_error("Missing reservation-aware allocator for OOM test task.");
-      global.completed_count.fetch_add(1, std::memory_order_relaxed);
-      return;
-    }
-
-    // Attach with ignore policy — reservations are intentionally small so the
-    // actual allocation (kAllocationBytes >> kReservationSize) exceeds the
-    // reservation. The ignore policy lets the allocation proceed to the
-    // upstream pool, where it will OOM if the software capacity is exceeded.
-    if (!allocator->attach_reservation_to_tracker(
-          stream,
-          std::move(reservation),
-          std::make_unique<cucascade::memory::ignore_reservation_limit_policy>(),
-          nullptr)) {
-      global.add_error("Failed to attach reservation to stream tracker.");
-      global.completed_count.fetch_add(1, std::memory_order_relaxed);
-      return;
-    }
-    absl::Cleanup cleanup = [allocator, stream]() { allocator->reset_stream_reservation(stream); };
-
-    void* allocation = nullptr;
-    try {
-      allocation = allocator->allocate(stream, kAllocationBytes);
-    } catch (const rmm::out_of_memory&) {
-      global.oom_count.fetch_add(1, std::memory_order_relaxed);
-      // Throw oom_reschedule_exception so the executor reschedules this task.
-      // Pass the input data through so the rescheduled task can use it.
-      throw sirius::pipeline::oom_reschedule_exception(
-        std::move(local._input_data), 0, "OOM in test task allocation");
-    }
-
-    // Hold the memory for a while to create pressure on concurrent tasks.
-    std::this_thread::sleep_for(kHoldDuration);
-
-    allocator->deallocate(stream, allocation, kAllocationBytes);
-    global.completed_count.fetch_add(1, std::memory_order_relaxed);
   }
 
   std::unique_ptr<sirius::op::operator_data> compute_task(rmm::cuda_stream_view) override
@@ -160,6 +138,99 @@ class oom_test_task : public sirius::pipeline::gpu_pipeline_task {
   std::size_t get_estimated_reservation_size() const override { return kReservationSize; }
 
   std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
+
+ protected:
+  // RAII guard that resets the stream reservation on destruction.
+  struct allocator_guard {
+    cucascade::memory::reservation_aware_resource_adaptor* allocator;
+    rmm::cuda_stream_view stream;
+
+    allocator_guard(cucascade::memory::reservation_aware_resource_adaptor* a,
+                    rmm::cuda_stream_view s)
+      : allocator(a), stream(s)
+    {
+    }
+    ~allocator_guard() { allocator->reset_stream_reservation(stream); }
+
+    allocator_guard(const allocator_guard&)            = delete;
+    allocator_guard& operator=(const allocator_guard&) = delete;
+    allocator_guard(allocator_guard&&)                 = delete;
+    allocator_guard& operator=(allocator_guard&&)      = delete;
+  };
+
+  // Performs the common reservation → allocator → attach → cleanup setup.
+  // Returns the allocator guard on success, or nullptr on failure (after
+  // recording an error on global_state).
+  std::unique_ptr<allocator_guard> setup_allocator(rmm::cuda_stream_view stream,
+                                                   const std::string& task_label)
+  {
+    auto& global = _global_state->cast<oom_test_global_state>();
+    auto& local  = _local_state->cast<sirius::pipeline::gpu_pipeline_task_local_state>();
+
+    auto reservation = local.release_reservation();
+    if (!reservation) {
+      global.add_error("Missing GPU memory reservation for " + task_label + ".");
+      return nullptr;
+    }
+
+    auto* allocator =
+      reservation->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
+    if (!allocator) {
+      global.add_error("Missing reservation-aware allocator for " + task_label + ".");
+      return nullptr;
+    }
+
+    if (!allocator->attach_reservation_to_tracker(
+          stream,
+          std::move(reservation),
+          std::make_unique<cucascade::memory::ignore_reservation_limit_policy>(),
+          nullptr)) {
+      global.add_error("Failed to attach reservation to stream tracker for " + task_label + ".");
+      return nullptr;
+    }
+
+    return std::make_unique<allocator_guard>(allocator, stream);
+  }
+};
+
+//------------------------------------------------------------------------------
+// Task that allocates kAllocationBytes of GPU memory, holds it, then frees.
+// If OOM occurs, throws oom_reschedule_exception for the executor to handle.
+//------------------------------------------------------------------------------
+constexpr std::size_t kAllocationBytes = 400ULL * 1024 * 1024;  // 400 MB
+constexpr auto kHoldDuration           = std::chrono::milliseconds(30);
+
+class oom_test_task : public oom_test_task_base {
+ public:
+  using oom_test_task_base::oom_test_task_base;
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto& global = _global_state->cast<oom_test_global_state>();
+    auto& local  = _local_state->cast<sirius::pipeline::gpu_pipeline_task_local_state>();
+
+    auto guard = setup_allocator(stream, "OOM test task");
+    if (!guard) {
+      global.completed_count.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+    auto* allocator = guard->allocator;
+
+    void* allocation = nullptr;
+    try {
+      allocation = allocator->allocate(stream, kAllocationBytes);
+    } catch (const rmm::out_of_memory&) {
+      global.oom_count.fetch_add(1, std::memory_order_relaxed);
+      throw sirius::pipeline::oom_reschedule_exception(
+        std::move(local._input_data), 0, "OOM in test task allocation");
+    }
+
+    // Hold the memory for a while to create pressure on concurrent tasks.
+    std::this_thread::sleep_for(kHoldDuration);
+
+    allocator->deallocate(stream, allocation, kAllocationBytes);
+    global.completed_count.fetch_add(1, std::memory_order_relaxed);
+  }
 
   std::unique_ptr<gpu_pipeline_task> create_rescheduled_task(
     uint64_t task_id,
@@ -174,62 +245,120 @@ class oom_test_task : public sirius::pipeline::gpu_pipeline_task {
   }
 };
 
+//------------------------------------------------------------------------------
+// Small task — allocates a tiny amount of GPU memory and completes immediately.
+//------------------------------------------------------------------------------
+constexpr std::size_t kSmallAllocationBytes = 1ULL * 1024 * 1024;  // 1 MB
+
+class small_task : public oom_test_task_base {
+ public:
+  using oom_test_task_base::oom_test_task_base;
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto& global = _global_state->cast<oom_test_global_state>();
+
+    auto guard = setup_allocator(stream, "small test task");
+    if (!guard) { return; }
+    auto* allocator = guard->allocator;
+
+    void* allocation = allocator->allocate(stream, kSmallAllocationBytes);
+    allocator->deallocate(stream, allocation, kSmallAllocationBytes);
+    global.completed_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  std::unique_ptr<gpu_pipeline_task> create_rescheduled_task(
+    uint64_t task_id,
+    std::unique_ptr<sirius::pipeline::sirius_pipeline_task_local_state> local_state) override
+  {
+    auto typed_local = std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state>(
+      static_cast<sirius::pipeline::gpu_pipeline_task_local_state*>(local_state.release()));
+    return std::make_unique<small_task>(
+      task_id,
+      std::move(typed_local),
+      std::dynamic_pointer_cast<oom_test_global_state>(_global_state));
+  }
+};
+
+//------------------------------------------------------------------------------
+// XL task — always allocates more than the total GPU capacity so it can never
+// succeed, guaranteeing it will be rescheduled until the retry limit is hit.
+//------------------------------------------------------------------------------
+constexpr std::size_t kXlAllocationBytes = 2ULL * 1024 * 1024 * 1024;  // 2 GB (> kGpuCapacity)
+
+class xl_task : public oom_test_task_base {
+ public:
+  using oom_test_task_base::oom_test_task_base;
+
+  void execute(rmm::cuda_stream_view stream) override
+  {
+    auto& global = _global_state->cast<oom_test_global_state>();
+    auto& local  = _local_state->cast<sirius::pipeline::gpu_pipeline_task_local_state>();
+
+    auto guard = setup_allocator(stream, "XL test task");
+    if (!guard) { return; }
+
+    try {
+      guard->allocator->allocate(stream, kXlAllocationBytes);
+    } catch (const rmm::out_of_memory&) {
+      global.oom_count.fetch_add(1, std::memory_order_relaxed);
+      throw sirius::pipeline::oom_reschedule_exception(
+        std::move(local._input_data), 0, "OOM in XL test task allocation");
+    }
+
+    // Should never reach here — allocation always exceeds capacity.
+    global.add_error("XL task allocation unexpectedly succeeded.");
+  }
+
+  std::unique_ptr<gpu_pipeline_task> create_rescheduled_task(
+    uint64_t task_id,
+    std::unique_ptr<sirius::pipeline::sirius_pipeline_task_local_state> local_state) override
+  {
+    auto typed_local = std::unique_ptr<sirius::pipeline::gpu_pipeline_task_local_state>(
+      static_cast<sirius::pipeline::gpu_pipeline_task_local_state*>(local_state.release()));
+    return std::make_unique<xl_task>(
+      task_id,
+      std::move(typed_local),
+      std::dynamic_pointer_cast<oom_test_global_state>(_global_state));
+  }
+};
+
 }  // namespace
 
+// ---------------------------------------------------------------------------
+// Memory layout for the reschedule test:
+//   Allocation    = 400 MB per task (much larger than the 50 MB reservation)
+//
+// With 3 threads, all 3 tasks start concurrently.
+// Accounting after 3 reservations: 150 MB
+// First  allocation (+350 MB overflow): total =  500 MB ≤ 1100 → OK
+// Second allocation (+350 MB overflow): total =  850 MB ≤ 1100 → OK
+// Third  allocation (+350 MB overflow): total = 1200 MB > 1100 → OOM!
+//
+// The OOM'd task gets rescheduled. After the first two complete, enough
+// accounting headroom is freed for the rescheduled task to succeed.
+// (Note: cucascade's cross-boundary deallocation accounting leaves some
+//  residual in _total_allocated_bytes, hence the extra capacity margin.)
+// ---------------------------------------------------------------------------
 TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_executor][oom]")
 {
-  //--------------------------------------------------------------------------
-  // 1. Set up a constrained GPU memory environment (900 MB software limit)
-  //--------------------------------------------------------------------------
-  std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> manager;
-  try {
-    cucascade::memory::reservation_manager_configurator builder;
-    builder.set_number_of_gpus(1)
-      .set_gpu_usage_limit(kGpuCapacity)
-      .set_reservation_fraction_per_gpu(0.95)
-      .set_per_host_capacity(1ULL * 1024 * 1024 * 1024)
-      .use_host_per_gpu()
-      .track_reservation_per_stream(false)
-      .set_reservation_fraction_per_host(0.75);
-    auto space_configs = builder.build();
-    manager =
-      std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
-  } catch (const std::exception& e) {
-    WARN("Skipping OOM reschedule test due to insufficient GPUs: " << e.what());
+  oom_test_fixture f;
+  if (!f.setup(3, "oom-test")) {
+    WARN("Skipping OOM reschedule test — no GPU available.");
     return;
   }
 
-  auto* mem_space = manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
-  if (!mem_space) {
-    WARN("Skipping OOM reschedule test because no GPU memory space is available.");
-    return;
-  }
-
-  //--------------------------------------------------------------------------
-  // 2. Create the executor with 3 worker threads so all tasks run concurrently
-  //--------------------------------------------------------------------------
-  sirius::exec::channel<std::unique_ptr<sirius::pipeline::task_request>> request_channel;
-  auto request_publisher = request_channel.make_publisher();
-
-  sirius::exec::thread_pool_config config;
-  config.num_threads        = 3;
-  config.thread_name_prefix = "oom-test";
-
-  sirius::pipeline::gpu_pipeline_executor executor(config, mem_space, request_publisher);
   auto global_state = std::make_shared<oom_test_global_state>();
 
-  //--------------------------------------------------------------------------
-  // 3. Schedule 3 tasks (total demand 3×400MB = 1.2GB > 900MB capacity)
-  //--------------------------------------------------------------------------
   const int num_tasks = 3;
   std::atomic<int> dispatched{0};
 
-  executor.start();
+  f.executor->start();
 
   // Thread that responds to task requests from the executor's manager_loop.
   std::thread request_handler([&]() {
     while (dispatched.load(std::memory_order_relaxed) < num_tasks) {
-      auto request = request_channel.get();
+      auto request = f.request_channel.get();
       if (!request) { break; }
 
       auto local_state = std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(
@@ -239,7 +368,7 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
         static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed)),
         std::move(local_state),
         global_state);
-      executor.schedule(std::move(task));
+      f.executor->schedule(std::move(task));
       dispatched.fetch_add(1, std::memory_order_relaxed);
     }
 
@@ -247,21 +376,21 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
     // Rescheduled tasks are already in the executor's queue — we just drain
     // the request channel to prevent the manager_loop from blocking.
     while (global_state->completed_count.load(std::memory_order_relaxed) < num_tasks) {
-      auto request = request_channel.get();
+      auto request = f.request_channel.get();
       if (!request) { break; }
     }
   });
 
   //--------------------------------------------------------------------------
-  // 4. Wait for all tasks to complete (including rescheduled ones)
+  // Wait for all tasks to complete (including rescheduled ones)
   //--------------------------------------------------------------------------
   auto start_time = std::chrono::steady_clock::now();
   auto timeout    = std::chrono::seconds(30);
   while (global_state->completed_count.load(std::memory_order_relaxed) < num_tasks) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     if (std::chrono::steady_clock::now() - start_time > timeout) {
-      executor.stop();
-      request_channel.close();
+      f.executor->stop();
+      f.request_channel.close();
       request_handler.join();
       FAIL("Timed out waiting for OOM rescheduled tasks to complete. "
            << "Completed: " << global_state->completed_count.load()
@@ -269,12 +398,12 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
     }
   }
 
-  executor.stop();
-  request_channel.close();
+  f.executor->stop();
+  f.request_channel.close();
   request_handler.join();
 
   //--------------------------------------------------------------------------
-  // 5. Validate results
+  // Validate results
   //--------------------------------------------------------------------------
   if (global_state->error_count.load(std::memory_order_relaxed) > 0) {
     std::lock_guard<std::mutex> lock(global_state->error_mutex);
@@ -290,4 +419,122 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
 
   INFO("OOM reschedule test passed: " << global_state->oom_count.load() << " task(s) rescheduled, "
                                       << num_tasks << " completed successfully");
+}
+
+// ---------------------------------------------------------------------------
+// Test: tasks that can never succeed exhaust their retry budget (MAX_OOM_RETRIES=10)
+// and cause the query to fail, while small tasks that fit in memory still complete.
+//
+// Memory layout:
+//   GPU capacity  = 1100 MB
+//   small_task    =    1 MB allocation  → always succeeds
+//   xl_task       = 2048 MB allocation  → always OOMs (exceeds capacity)
+//
+// We dispatch 5 small tasks + 3 XL tasks = 8 total.
+// The XL tasks will be rescheduled up to 10 times each before the executor
+// reports a max-retry error on the completion handler.
+// The 5 small tasks should all complete regardless.
+// After the error, drain_and_wait() should empty the task queue.
+// ---------------------------------------------------------------------------
+TEST_CASE("GPU pipeline executor fails after max OOM retries",
+          "[gpu_pipeline_executor][oom][max_retries]")
+{
+  oom_test_fixture f;
+  if (!f.setup(3, "oom-retry")) {
+    WARN("Skipping max-retry OOM test — no GPU available.");
+    return;
+  }
+
+  auto global_state = std::make_shared<oom_test_global_state>();
+
+  const int num_small = 5;
+  const int num_xl    = 3;
+  const int num_tasks = num_small + num_xl;
+  std::atomic<int> dispatched{0};
+
+  f.executor->start();
+
+  // Request handler thread: creates and schedules tasks as the manager_loop
+  // requests them. First num_small requests become small_tasks, the rest xl_tasks.
+  // After all initial tasks are dispatched, keep draining the request channel
+  // so the manager_loop doesn't block when rescheduled XL tasks re-enter the queue.
+  std::thread request_handler([&]() {
+    while (dispatched.load(std::memory_order_relaxed) < num_tasks) {
+      auto request = f.request_channel.get();
+      if (!request) { break; }
+
+      auto id          = static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed));
+      auto local_state = std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(
+        std::make_unique<sirius::op::operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{}));
+
+      std::unique_ptr<sirius::parallel::itask> task;
+      if (id < static_cast<uint64_t>(num_small)) {
+        task = std::make_unique<small_task>(id, std::move(local_state), global_state);
+      } else {
+        task = std::make_unique<xl_task>(id, std::move(local_state), global_state);
+      }
+      f.executor->schedule(std::move(task));
+      dispatched.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Keep draining task requests so rescheduled XL tasks can proceed through
+    // the manager_loop until the completion handler signals an error.
+    while (!f.completion.has_error()) {
+      auto request = f.request_channel.try_get();
+      if (!request) { std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
+    }
+  });
+
+  //--------------------------------------------------------------------------
+  // Wait for the completion handler to report an error (max retries exceeded)
+  //--------------------------------------------------------------------------
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout    = std::chrono::seconds(60);
+  while (!f.completion.has_error()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    if (std::chrono::steady_clock::now() - start_time > timeout) {
+      f.executor->stop();
+      f.request_channel.close();
+      request_handler.join();
+      FAIL("Timed out waiting for max-retry OOM error. "
+           << "Completed: " << global_state->completed_count.load()
+           << ", OOM count: " << global_state->oom_count.load());
+    }
+  }
+
+  //--------------------------------------------------------------------------
+  // Drain remaining tasks and shut down
+  //--------------------------------------------------------------------------
+  f.executor->drain_and_wait();
+  f.request_channel.close();
+  request_handler.join();
+  f.executor->stop();
+
+  //--------------------------------------------------------------------------
+  // Validate results
+  //--------------------------------------------------------------------------
+  if (global_state->error_count.load(std::memory_order_relaxed) > 0) {
+    std::lock_guard<std::mutex> lock(global_state->error_mutex);
+    for (const auto& error : global_state->errors) {
+      INFO(error);
+    }
+  }
+
+  // All small tasks should have completed successfully.
+  REQUIRE(global_state->error_count.load(std::memory_order_relaxed) == 0);
+  REQUIRE(global_state->completed_count.load(std::memory_order_relaxed) == num_small);
+
+  // The completion handler should be in an error state from exceeding max retries.
+  REQUIRE(f.completion.has_error());
+
+  // XL tasks should have OOM'd many times (at least 10 for the one that hit the limit).
+  REQUIRE(global_state->oom_count.load(std::memory_order_relaxed) >= 10);
+
+  // After drain_and_wait(), the task queue should be empty.
+  REQUIRE(f.executor->is_task_queue_empty());
+
+  INFO("Max-retry OOM test passed: " << global_state->oom_count.load() << " OOM events, "
+                                     << global_state->completed_count.load()
+                                     << " small tasks completed, error correctly reported");
 }

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -58,7 +58,7 @@ namespace {
 constexpr std::size_t kGpuCapacity     = 1100ULL * 1024 * 1024;  // 1100 MB
 constexpr std::size_t kReservationSize = 50ULL * 1024 * 1024;    // 50 MB
 constexpr std::size_t kAllocationBytes = 400ULL * 1024 * 1024;   // 400 MB
-constexpr auto kHoldDuration           = std::chrono::milliseconds(800);
+constexpr auto kHoldDuration           = std::chrono::milliseconds(30);
 
 //------------------------------------------------------------------------------
 // Test global state — shared across all tasks


### PR DESCRIPTION
This PR adds a limit to the number of retries a task can have. It also will clean up the tasks queues if a task is failing. This way the query does not hang and ends appropriatelly.
I also improved some of the logging for each task so that we also capture the number of  bytes in the input and output and the peak memory consumption.

After this, we need should track memory consumption of operators or pipelines so that we can use that to improve our task memory consumption needs which right now are WAY off. 
And then we also need to make requests for the downgrade scheduler as needed