### PR TITLE
Use string_view in cudf::strings::like to fix deprecation warnings

### DIFF
--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -132,8 +132,8 @@ struct StringMatchingDispatcher {
 
         auto like = cudf::strings::like(
           cudf::strings_column_view(input_view),
-          cudf::string_scalar(match_str, true, executor.execution_stream, executor.resource_ref),
-          cudf::string_scalar("", true, executor.execution_stream, executor.resource_ref),
+          std::string_view(match_str),
+          std::string_view(),
           executor.execution_stream,
           executor.resource_ref);
 
@@ -161,9 +161,8 @@ struct StringMatchingDispatcher {
         }
         return cudf::strings::like(
           cudf::strings_column_view(input_view),
-          cudf::string_scalar(
-            "%" + match_str + "%", true, executor.execution_stream, executor.resource_ref),
-          cudf::string_scalar("", true, executor.execution_stream, executor.resource_ref),
+          std::string_view("%" + match_str + "%"),
+          std::string_view(),
           executor.execution_stream,
           executor.resource_ref);
 #else

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -130,12 +130,11 @@ struct StringMatchingDispatcher {
                     MatchType == StringMatchingType::NOT_LIKE) {
         std::vector<std::string> match_terms = string_split(match_str, SPLIT_DELIMITER);
 
-        auto like = cudf::strings::like(
-          cudf::strings_column_view(input_view),
-          std::string_view(match_str),
-          std::string_view(),
-          executor.execution_stream,
-          executor.resource_ref);
+        auto like = cudf::strings::like(cudf::strings_column_view(input_view),
+                                        std::string_view(match_str),
+                                        std::string_view(),
+                                        executor.execution_stream,
+                                        executor.resource_ref);
 
         // LIKE or NOT LIKE?
         if constexpr (MatchType == StringMatchingType::LIKE) {
@@ -159,12 +158,11 @@ struct StringMatchingDispatcher {
             executor.execution_stream,
             executor.resource_ref);
         }
-        return cudf::strings::like(
-          cudf::strings_column_view(input_view),
-          std::string_view("%" + match_str + "%"),
-          std::string_view(),
-          executor.execution_stream,
-          executor.resource_ref);
+        return cudf::strings::like(cudf::strings_column_view(input_view),
+                                   std::string_view("%" + match_str + "%"),
+                                   std::string_view(),
+                                   executor.execution_stream,
+                                   executor.resource_ref);
 #else
         return cudf::strings::contains(
           input->view(),


### PR DESCRIPTION
The cudf::strings::like API now accepts std::string_view instead of cudf::string_scalar for pattern and escape character parameters (rapidsai/cudf#20428).

As reported in #461.