### PR TITLE
Replace pre-commit/action with pixi global install 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,0 @@
-duckdb/.editorconfig

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,6 @@
 #     - Explicitly allowed third-party actions:
 #       prefix-dev/setup-pixi@*
 #       mozilla-actions/sccache-action@*
-#       pre-commit/action@*
 #     - Require actions to be pinned to a full-length commit SHA: NO
 #
 # Adding a new action? You must:
@@ -28,7 +27,14 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+        with:
+          cache: false
+          pixi-version: v0.65.0
+          run-install: false
+          global-install: pre-commit
+
+      - run: pre-commit run --show-diff-on-failure --all-files
 
   build:
     env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
 
       - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           cache: false
           pixi-version: v0.65.0
-          run-install: false
-          global-install: pre-commit
+          global-environments: |
+            pre-commit
 
       - run: pre-commit run --show-diff-on-failure --all-files
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@
 #     - Explicitly allowed third-party actions:
 #       prefix-dev/setup-pixi@*
 #       mozilla-actions/sccache-action@*
-#       pre-commit/action@*
 #     - Require actions to be pinned to a full-length commit SHA: NO
 #
 # Adding a new action? You must:


### PR DESCRIPTION
https://github.com/pre-commit/action/blob/1b06ec171f2f6faa71ed760c4042bd969e4f8b43/action.yml#L15

`
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
`