### PR TITLE
CI: Add TPC-H performance snapshot to CI job summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,8 @@ jobs:
         run: |
           ./setup_test_datasets.sh
           chmod -R a+r test_datasets/
+          mkdir -p test_datasets/tpch_parquet_sf1
+          ./build/release/duckdb -f scripts/tpch_to_parquet.sql
 
       - name: Run sqllogic tests
         run: |
@@ -95,6 +97,7 @@ jobs:
       - name: TPC-H performance snapshot
         env:
           SIRIUS_CONFIG_FILE: ${{ github.workspace }}/test/cpp/integration/integration.cfg
+          PARQUET_DIR: ${{ github.workspace }}/test_datasets/tpch_parquet_sf1
         run: |
           ./test/tpch_performance/benchmark_and_validate.sh 1
           RUN_DIR=$(ls -td runs/*/ | head -1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,16 @@ jobs:
             echo "Test failures detected!"
             exit 1
           fi
+
+      - name: TPC-H performance snapshot
+        env:
+          SIRIUS_CONFIG_FILE: ${{ github.workspace }}/test/cpp/integration/integration.cfg
+        run: |
+          ./test/tpch_performance/benchmark_and_validate.sh 1
+          RUN_DIR=$(ls -td runs/*/ | head -1)
+          {
+            echo "## TPC-H Performance (SF1)"
+            echo '```'
+            cat "$RUN_DIR/comparison.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/tpch_to_parquet.sql
+++ b/scripts/tpch_to_parquet.sql
@@ -1,0 +1,100 @@
+-- Loads TPC-H SF1 data from .tbl files and exports to Parquet.
+-- Used by CI to prepare benchmark data without tpchgen-rs.
+-- Run from the project root: ./build/release/duckdb -f scripts/tpch_to_parquet.sql
+
+DROP TABLE IF EXISTS nation;
+DROP TABLE IF EXISTS region;
+DROP TABLE IF EXISTS part;
+DROP TABLE IF EXISTS supplier;
+DROP TABLE IF EXISTS partsupp;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS customer;
+DROP TABLE IF EXISTS lineitem;
+
+CREATE TABLE nation  ( n_nationkey  INTEGER NOT NULL UNIQUE PRIMARY KEY,
+                       n_name       CHAR(25) NOT NULL,
+                       n_regionkey  INTEGER NOT NULL,
+                       n_comment    VARCHAR(152));
+
+CREATE TABLE region  ( r_regionkey  INTEGER NOT NULL UNIQUE PRIMARY KEY,
+                       r_name       CHAR(25) NOT NULL,
+                       r_comment    VARCHAR(152));
+
+CREATE TABLE part  ( p_partkey     BIGINT NOT NULL UNIQUE PRIMARY KEY,
+                     p_name        VARCHAR(55) NOT NULL,
+                     p_mfgr        CHAR(25) NOT NULL,
+                     p_brand       CHAR(10) NOT NULL,
+                     p_type        VARCHAR(25) NOT NULL,
+                     p_size        INTEGER NOT NULL,
+                     p_container   CHAR(10) NOT NULL,
+                     p_retailprice DECIMAL(15,2) NOT NULL,
+                     p_comment     VARCHAR(23) NOT NULL );
+
+CREATE TABLE supplier ( s_suppkey     BIGINT NOT NULL UNIQUE PRIMARY KEY,
+                        s_name        CHAR(25) NOT NULL,
+                        s_address     VARCHAR(40) NOT NULL,
+                        s_nationkey   INTEGER NOT NULL,
+                        s_phone       CHAR(15) NOT NULL,
+                        s_acctbal     DECIMAL(15,2) NOT NULL,
+                        s_comment     VARCHAR(101) NOT NULL);
+
+CREATE TABLE partsupp ( ps_partkey     BIGINT NOT NULL,
+                        ps_suppkey     BIGINT NOT NULL,
+                        ps_availqty    INTEGER NOT NULL,
+                        ps_supplycost  DECIMAL(15,2)  NOT NULL,
+                        ps_comment     VARCHAR(199) NOT NULL,
+                        CONSTRAINT PS_PARTSUPPKEY UNIQUE(PS_PARTKEY, PS_SUPPKEY) );
+
+CREATE TABLE customer ( c_custkey     INTEGER NOT NULL UNIQUE PRIMARY KEY,
+                        c_name        VARCHAR(25) NOT NULL,
+                        c_address     VARCHAR(40) NOT NULL,
+                        c_nationkey   INTEGER NOT NULL,
+                        c_phone       CHAR(15) NOT NULL,
+                        c_acctbal     DECIMAL(15,2)   NOT NULL,
+                        c_mktsegment  CHAR(10) NOT NULL,
+                        c_comment     VARCHAR(117) NOT NULL);
+
+CREATE TABLE orders  ( o_orderkey       BIGINT NOT NULL UNIQUE PRIMARY KEY,
+                       o_custkey        INTEGER NOT NULL,
+                       o_orderstatus    CHAR(1) NOT NULL,
+                       o_totalprice     DECIMAL(15,2) NOT NULL,
+                       o_orderdate      DATE NOT NULL,
+                       o_orderpriority  CHAR(15) NOT NULL,
+                       o_clerk          CHAR(15) NOT NULL,
+                       o_shippriority   INTEGER NOT NULL,
+                       o_comment        VARCHAR(79) NOT NULL);
+
+CREATE TABLE lineitem ( l_orderkey    BIGINT NOT NULL,
+                        l_partkey     BIGINT NOT NULL,
+                        l_suppkey     BIGINT NOT NULL,
+                        l_linenumber  INTEGER NOT NULL,
+                        l_quantity    DECIMAL(15,2) NOT NULL,
+                        l_extendedprice  DECIMAL(15,2) NOT NULL,
+                        l_discount    DECIMAL(15,2) NOT NULL,
+                        l_tax         DECIMAL(15,2) NOT NULL,
+                        l_returnflag  CHAR(1) NOT NULL,
+                        l_linestatus  CHAR(1) NOT NULL,
+                        l_shipdate    DATE NOT NULL,
+                        l_commitdate  DATE NOT NULL,
+                        l_receiptdate DATE NOT NULL,
+                        l_shipinstruct CHAR(25) NOT NULL,
+                        l_shipmode     CHAR(10) NOT NULL,
+                        l_comment      VARCHAR(44) NOT NULL);
+
+COPY nation    FROM 'test_datasets/tpch-dbgen/s1/nation.tbl'    (HEADER false, DELIMITER '|');
+COPY region    FROM 'test_datasets/tpch-dbgen/s1/region.tbl'    (HEADER false, DELIMITER '|');
+COPY part      FROM 'test_datasets/tpch-dbgen/s1/part.tbl'      (HEADER false, DELIMITER '|');
+COPY supplier  FROM 'test_datasets/tpch-dbgen/s1/supplier.tbl'  (HEADER false, DELIMITER '|');
+COPY partsupp  FROM 'test_datasets/tpch-dbgen/s1/partsupp.tbl'  (HEADER false, DELIMITER '|');
+COPY customer  FROM 'test_datasets/tpch-dbgen/s1/customer.tbl'  (HEADER false, DELIMITER '|');
+COPY orders    FROM 'test_datasets/tpch-dbgen/s1/orders.tbl'    (HEADER false, DELIMITER '|');
+COPY lineitem  FROM 'test_datasets/tpch-dbgen/s1/lineitem.tbl'  (HEADER false, DELIMITER '|');
+
+COPY nation    TO 'test_datasets/tpch_parquet_sf1/nation.parquet'    (FORMAT PARQUET);
+COPY region    TO 'test_datasets/tpch_parquet_sf1/region.parquet'    (FORMAT PARQUET);
+COPY part      TO 'test_datasets/tpch_parquet_sf1/part.parquet'      (FORMAT PARQUET);
+COPY supplier  TO 'test_datasets/tpch_parquet_sf1/supplier.parquet'  (FORMAT PARQUET);
+COPY partsupp  TO 'test_datasets/tpch_parquet_sf1/partsupp.parquet'  (FORMAT PARQUET);
+COPY customer  TO 'test_datasets/tpch_parquet_sf1/customer.parquet'  (FORMAT PARQUET);
+COPY orders    TO 'test_datasets/tpch_parquet_sf1/orders.parquet'    (FORMAT PARQUET);
+COPY lineitem  TO 'test_datasets/tpch_parquet_sf1/lineitem.parquet'  (FORMAT PARQUET);


### PR DESCRIPTION
## Summary

- Adds a **TPC-H performance snapshot** step to the `test` job in `test.yml`
- After sqllogic tests pass, runs `benchmark_and_validate.sh` at SF1 (2 iterations: 1 cold + 1 warm) for all 22 TPC-H queries
- Writes the Sirius vs DuckDB comparison table (cold/warm runtimes + speedup per query) to the GitHub Actions job summary
- Adds `scripts/tpch_to_parquet.sql` which converts the existing SF1 `.tbl` files (already generated by `setup_test_datasets.sh`) to Parquet using the built DuckDB binary — no tpchgen-rs clone or Rust compilation required
- Sets `PARQUET_DIR` so `benchmark_and_validate.sh` uses the pre-generated Parquet data directly

Developers can now check the job summary of any CI run to see per-query runtimes and speedups without any additional tooling.

## Test plan
- [x] Verify the job summary on the next CI run shows the `## TPC-H Performance (SF1)` table
- [x] Confirm the `Prepare SQL test datasets` step generates Parquet from `.tbl` files without invoking tpchgen-rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)