### PR TITLE
Fix scan cache deadlock on DuckDB table scans + skip redundant binding on warm runs

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -75,6 +75,9 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
     size_t operator_id = source_operator->get_operator_id();
 
     if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
+      // In preload mode, DuckDB scans are served from cache — skip creating
+      // global state (which calls init_global and acquires DuckDB locks).
+      if (_pipeline_executor->get_scan_executor().is_preload_mode()) { continue; }
       _scan_operator_global_state_map.emplace(
         operator_id,
         std::make_shared<op::scan::duckdb_scan_task_global_state>(
@@ -83,6 +86,9 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
+      // In preload mode, all scans are served from cache — skip rebind (which
+      // resets has_more_partitions) and skip constructor (which reads footers).
+      if (_pipeline_executor->get_scan_executor().is_preload_mode()) { continue; }
       auto it = _parquet_scan_operator_global_state_map.find(operator_id);
       if (it != _parquet_scan_operator_global_state_map.end()) {
         it->second->rebind(pipeline, &source_operator->Cast<op::sirius_physical_parquet_scan>());
@@ -129,9 +135,13 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
   if (node == nullptr) { return nullptr; }
 
   if (node->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
-    size_t operator_id             = node->get_operator_id();
-    auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
-    if (parquet_task_global_state->has_more_partitions()) {
+    size_t operator_id = node->get_operator_id();
+    auto it            = _parquet_scan_operator_global_state_map.find(operator_id);
+    if (it == _parquet_scan_operator_global_state_map.end()) {
+      // Preloaded scan — no global state exists, no more tasks to create
+      return nullptr;
+    }
+    if (it->second->has_more_partitions()) {
       return node;
     } else {
       return nullptr;
@@ -153,8 +163,12 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
     // task creator should never schedule additional scans from downstream.
     // (Parquet scans are fine — they use partition indices that self-limit.)
     if (producer != nullptr && producer->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
-      auto& global_state = _scan_operator_global_state_map.at(producer->get_operator_id());
-      if (global_state->is_source_drained() || !global_state->can_create_more_tasks()) {
+      auto it = _scan_operator_global_state_map.find(producer->get_operator_id());
+      if (it == _scan_operator_global_state_map.end()) {
+        // Preloaded scan — no global state exists, no more tasks to create
+        return nullptr;
+      }
+      if (it->second->is_source_drained() || !it->second->can_create_more_tasks()) {
         return nullptr;
       }
     }

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -191,6 +191,25 @@ class duckdb_scan_executor {
   void prepare_cache_for_scan_operators(
     const std::vector<sirius::op::sirius_physical_operator*>& scan_operators);
 
+  /**
+   * @brief Inject cached scan data directly into pipeline data repositories.
+   *
+   * In preload mode, this bypasses the entire scan task infrastructure
+   * (global state init, local state, compute_task) and pushes cached
+   * data_batch objects straight into the downstream operator ports.
+   *
+   * For each scan operator (DuckDB or parquet) whose data is cached:
+   *   1. Cached batches are cloned or shared based on cache level
+   *   2. All batches are pushed to the sink's downstream repos
+   *   3. The scan operator is marked exhausted / pipeline finished
+   *
+   * @param scan_operators All scan operators in the current query
+   * @return Downstream consumer operators that should be scheduled,
+   *         or empty if not in preload mode.
+   */
+  std::vector<op::sirius_physical_operator*> preload_into_pipelines(
+    const std::vector<op::sirius_physical_operator*>& scan_operators);
+
  private:
   /**
    * @brief Manager loop to consume tasks from queue and dispatch to the thread pool
@@ -204,6 +223,35 @@ class duckdb_scan_executor {
 
   std::unique_ptr<op::operator_data> get_scan_output(pipeline::sirius_pipeline_itask* task,
                                                      rmm::cuda_stream_view stream);
+
+  /// Identifies the type of scan for cache cloning dispatch.
+  enum class scan_type { DUCKDB, PARQUET };
+
+  /**
+   * @brief Clone or share cached batches based on cache level and scan type.
+   *
+   * Single source of truth for the cloning strategy:
+   *   - TABLE_GPU: zero-copy (return as-is)
+   *   - Other levels + DUCKDB: deep clone via data_batch::clone()
+   *   - Other levels + PARQUET: shallow_clone() on host representations
+   *
+   * @param batches The cached batch vector to clone
+   * @param type    The scan type that produced these batches
+   * @param stream  CUDA stream for async copy (used by clone)
+   * @return Cloned or shared batch vector ready for pipeline injection
+   */
+  std::vector<std::shared_ptr<cucascade::data_batch>> clone_cached_batches(
+    const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
+    scan_type type,
+    rmm::cuda_stream_view stream);
+
+  /**
+   * @brief Mark a scan operator's pipeline as finished for preload.
+   *
+   * Sets the appropriate exhausted/has_more_partitions flag based on
+   * scan type, then calls update_pipeline_status().
+   */
+  static void mark_scan_pipeline_finished(op::sirius_physical_operator* scan_op);
 
   struct cache_entry {
     std::vector<std::vector<std::shared_ptr<cucascade::data_batch>>> batches;

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -181,6 +181,7 @@ class pipeline_executor {
 
   std::mutex _priority_scans_mutex;
   std::queue<op::sirius_physical_operator*> _priority_scans;
+  std::vector<op::sirius_physical_operator*> _preloaded_consumers;
 
   exec::interruptible_mpmc<std::unique_ptr<sirius::parallel::itask>>
     _task_queue;  ///< Queue for GPU pipeline tasks

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -24,9 +24,13 @@
 #include "data/data_batch_utils.hpp"
 #include "data/host_parquet_representation.hpp"
 #include "log/logging.hpp"
+#include "op/scan/duckdb_scan_task.hpp"
 #include "op/scan/parquet_scan_task.hpp"
+#include "op/sirius_physical_duckdb_scan.hpp"
 #include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_parquet_scan.hpp"
 #include "pipeline/completion_handler.hpp"
+#include "pipeline/sirius_pipeline.hpp"
 #include "pipeline/sirius_pipeline_task_states.hpp"
 
 #include <cudf/utilities/default_stream.hpp>
@@ -197,41 +201,54 @@ void duckdb_scan_executor::submit_scan_request()
     _task_request_publisher.send(std::make_unique<sirius::pipeline::task_request>(0, true));
 }
 
+std::vector<std::shared_ptr<cucascade::data_batch>> duckdb_scan_executor::clone_cached_batches(
+  const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
+  scan_type type,
+  rmm::cuda_stream_view stream)
+{
+  if (_cache_level == cache_level::TABLE_GPU) { return batches; }
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> cloned;
+  cloned.reserve(batches.size());
+
+  if (type == scan_type::DUCKDB) {
+    for (auto& batch : batches) {
+      cloned.push_back(batch->clone(get_next_batch_id(), stream));
+    }
+  } else {
+    // Parquet cache entries use host representations that support shallow_clone
+    for (auto& batch : batches) {
+      auto* idata_rep = batch->get_data();
+      if (auto* host_data = dynamic_cast<cached_host_data_representation*>(idata_rep)) {
+        cloned.push_back(
+          std::make_shared<cucascade::data_batch>(get_next_batch_id(), host_data->shallow_clone()));
+      } else if (auto* parquet_rep = dynamic_cast<cached_host_parquet_representation*>(idata_rep)) {
+        cloned.push_back(std::make_shared<cucascade::data_batch>(get_next_batch_id(),
+                                                                 parquet_rep->shallow_clone()));
+      } else {
+        throw std::runtime_error("Unexpected data representation in parquet cache entry");
+      }
+    }
+  }
+  return cloned;
+}
+
+void duckdb_scan_executor::mark_scan_pipeline_finished(op::sirius_physical_operator* scan_op)
+{
+  auto pipeline = scan_op->get_pipeline();
+  if (scan_op->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
+    scan_op->Cast<op::sirius_physical_duckdb_scan>().exhausted.store(true);
+  } else if (scan_op->type == op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
+    scan_op->Cast<op::sirius_physical_parquet_scan>().has_more_partitions.store(false);
+  }
+  pipeline->update_pipeline_status();
+}
+
 std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
   pipeline::sirius_pipeline_itask* task, rmm::cuda_stream_view stream)
 {
-  bool is_duckdb_scan  = dynamic_cast<duckdb_scan_task*>(task) != nullptr;
-  bool is_parquet_scan = !is_duckdb_scan and dynamic_cast<parquet_scan_task*>(task) != nullptr;
-
-  auto clone_batches = [&](const std::vector<std::shared_ptr<cucascade::data_batch>>& batches,
-                           rmm::cuda_stream_view stream) {
-    if (_cache_level == cache_level::TABLE_GPU) { return batches; }
-    std::vector<std::shared_ptr<cucascade::data_batch>> cloned_batches;
-    cloned_batches.reserve(batches.size());
-    if (is_duckdb_scan) {
-      for (auto& batch : batches) {
-        cloned_batches.push_back(batch->clone(get_next_batch_id(), stream));
-      }
-    } else if (is_parquet_scan) {
-      for (auto& batch : batches) {
-        auto* idata_rep = batch->get_data();
-        if (auto* host_data = dynamic_cast<cached_host_data_representation*>(idata_rep);
-            host_data) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
-            get_next_batch_id(), host_data->shallow_clone()));
-        } else if (auto* parquet_rep = dynamic_cast<cached_host_parquet_representation*>(idata_rep);
-                   parquet_rep) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
-            get_next_batch_id(), parquet_rep->shallow_clone()));
-        } else {
-          throw std::runtime_error("Invalid data representation type");
-        }
-      }
-    } else {
-      throw std::runtime_error("Invalid task type");
-    }
-    return cloned_batches;
-  };
+  auto type =
+    dynamic_cast<duckdb_scan_task*>(task) != nullptr ? scan_type::DUCKDB : scan_type::PARQUET;
 
   if (_cache_level == cache_level::NONE) {
     return task->compute_task(stream);
@@ -241,14 +258,17 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
     auto& entry = _cache.at(pipe_id);
     if (!entry) { throw std::runtime_error("Scan results for query not cached"); }
     if (_preload_mode) {
+      // Preload is normally handled by preload_into_pipelines() before any tasks
+      // are created.  This fallback handles the edge case where a task slips through.
       if (entry->batch_index >= entry->batches.size()) {
-        throw std::runtime_error("Scan results for query not cached");
+        return std::make_unique<op::operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{});
       }
-      auto batches = entry->batches[entry->batch_index++];
-      return std::make_unique<op::operator_data>(clone_batches(std::move(batches), stream));
+      auto cloned = clone_cached_batches(entry->batches[entry->batch_index++], type, stream);
+      return std::make_unique<op::operator_data>(std::move(cloned));
     } else {
       auto scan_output = task->compute_task(stream);
-      entry->batches.push_back(clone_batches(scan_output->get_data_batches(), stream));
+      entry->batches.push_back(clone_cached_batches(scan_output->get_data_batches(), type, stream));
       return scan_output;
     }
   }
@@ -332,6 +352,77 @@ void duckdb_scan_executor::manager_loop()
       }
     });
   }
+}
+
+std::vector<op::sirius_physical_operator*> duckdb_scan_executor::preload_into_pipelines(
+  const std::vector<op::sirius_physical_operator*>& scan_operators)
+{
+  if (!_preload_mode) { return {}; }
+
+  std::vector<op::sirius_physical_operator*> all_consumers;
+  std::lock_guard<std::mutex> lock(_cache_mutex);
+
+  auto exc_stream = _stream_pool->acquire_stream(
+    cucascade::memory::exclusive_stream_pool::stream_acquire_policy::GROW);
+
+  for (auto* scan_op : scan_operators) {
+    // Determine scan type — skip unknown operator types
+    scan_type type;
+    if (scan_op->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
+      type = scan_type::DUCKDB;
+    } else if (scan_op->type == op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
+      type = scan_type::PARQUET;
+    } else {
+      continue;
+    }
+
+    auto pipeline    = scan_op->get_pipeline();
+    auto pipeline_id = pipeline->get_pipeline_id();
+    auto it          = _cache.find(pipeline_id);
+    if (it == _cache.end() || !it->second) {
+      SIRIUS_LOG_WARN("Preload: no cache entry for scan pipeline {}", pipeline_id);
+      continue;
+    }
+
+    auto& entry = it->second;
+
+    // Find destination data repositories (same logic as task_creator)
+    auto sink = pipeline->get_sink();
+    if (!sink) { continue; }
+    auto next_ports = sink->get_next_port_after_sink();
+    if (next_ports.empty()) { continue; }
+
+    // Collect all cached batches, cloned or shared based on cache level + scan type
+    std::vector<std::shared_ptr<cucascade::data_batch>> all_batches;
+    while (entry->batch_index < entry->batches.size()) {
+      auto cloned = clone_cached_batches(entry->batches[entry->batch_index++], type, exc_stream);
+      all_batches.insert(all_batches.end(),
+                         std::make_move_iterator(cloned.begin()),
+                         std::make_move_iterator(cloned.end()));
+    }
+
+    // Push batches to all destination repos
+    for (auto& batch : all_batches) {
+      for (auto& [next_op, port_id] : next_ports) {
+        auto* port = next_op->get_port(port_id);
+        if (port && port->repo) { port->repo->add_data_batch(batch); }
+      }
+    }
+
+    mark_scan_pipeline_finished(scan_op);
+
+    SIRIUS_LOG_INFO("Preload: injected {} batches for {} scan pipeline {}",
+                    all_batches.size(),
+                    type == scan_type::DUCKDB ? "DuckDB" : "parquet",
+                    pipeline_id);
+
+    auto consumers = pipeline->get_output_consumers();
+    all_consumers.insert(all_consumers.end(), consumers.begin(), consumers.end());
+  }
+
+  if (_cache_level != cache_level::TABLE_GPU) { exc_stream->synchronize(); }
+
+  return all_consumers;
 }
 
 }  // namespace sirius::op::scan

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -140,12 +140,23 @@ void pipeline_executor::prepare_for_query(duckdb::shared_ptr<planner::query> que
   auto scans = query->get_scan_operators();
   _scan_executor->prepare_cache_for_scan_operators(scans);
 
+  // In preload mode, inject cached DuckDB scan data directly into pipelines,
+  // bypassing the entire scan task infrastructure (global state init, local
+  // state, compute_task).  Only non-preloaded scans go through the normal path.
+  _preloaded_consumers = _scan_executor->preload_into_pipelines(scans);
+
   std::lock_guard<std::mutex> lock(_priority_scans_mutex);
   while (!_priority_scans.empty()) {
     _priority_scans.pop();
   }
   for (auto* scan : scans) {
     _priority_scans.push(scan);
+  }
+  // In preload mode, all scans are served from cache — no tasks to schedule
+  if (_scan_executor->is_preload_mode()) {
+    while (!_priority_scans.empty()) {
+      _priority_scans.pop();
+    }
   }
 }
 
@@ -162,6 +173,12 @@ std::future<void> pipeline_executor::start_query()
   }
 
   schedule_next_scan_tasks();
+
+  // Schedule downstream consumers from preloaded DuckDB scans
+  for (auto* consumer : _preloaded_consumers) {
+    _task_creator->schedule(consumer);
+  }
+  _preloaded_consumers.clear();
 
   return future;
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -87,11 +87,13 @@ void SiriusContext::QueryBegin(ClientContext& context)
 
   auto query = context.GetCurrentQuery();
   spdlog::info("QueryBegin: {}", query.substr(0, std::min(query.size(), size_t(120))));
+  // Propagate cache level to the scan executor BEFORE checking for cache hits,
+  // so the first query in a session can populate the cache.
+  pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
   bool query_cache_hit = false;
   if (config_.is_scan_caching_enabled()) {
     query_cache_hit = pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
   }
-  pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
 
   task_creator_->reset(query_cache_hit);
   task_creator_->set_client_context(context);


### PR DESCRIPTION
## Reproduction

Start with a config file that has **no** cache setting, enable via SET, then repeat the same query:

```sql
INSTALL tpch; LOAD tpch;
CALL dbgen(sf=1);

SET scan_cache_level = 'table_gpu';

.timer on
-- Run 1 (cold — scans from DuckDB, populates cache)
call gpu_execution('select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty
  from lineitem where l_shipdate <= date ''1995-08-19''
  group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus');

-- Run 2 (should be cached at ~0.06s, but rescans at ~0.2s)
call gpu_execution('select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty
  from lineitem where l_shipdate <= date ''1995-08-19''
  group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus');

-- Run 3: HANGS — must kill process
call gpu_execution('select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty
  from lineitem where l_shipdate <= date ''1995-08-19''
  group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus');
```

```
Run 1: 0.58s  — cold scan
Run 2: 0.21s  — cache miss, rescans from DuckDB (should be ~0.06s)
Run 3: HANG   — deadlock, process must be killed
```

If the cache is set in the config file instead of via SET, the deadlock happens on Run 2 (Run 1 populates, Run 2 hangs).

## Why tests never caught this

- `integration.cfg` has no cache setting (defaults to `none`)
- The benchmark script issues `SET scan_cache_level` before **each** query, so every query is the "first query after SET" — the deadlock only triggers when the same query runs a second time with an already-populated cache
- No test runs the same `gpu_execution` query twice on DuckDB tables with `table_gpu` cache

## What goes wrong

Two bugs compound:

### Bug 1 — Ordering in QueryBegin (Run 2 slow instead of fast)

In `SiriusContext::QueryBegin`, `set_scan_caching_config()` ran **after** `cache_scan_results_for_query()`:

```cpp
// BEFORE
cache_scan_results_for_query(query);                   // _cache_level is still NONE → bails, hash not stored
set_scan_caching_config(config_.get_cache_level());    // too late — sets _cache_level to TABLE_GPU
```

When cache level is changed via `SET scan_cache_level` mid-session, the scan executor's `_cache_level` hasn't been propagated yet when the cache check runs. So Run 1 never stores the query hash. On Run 2, the hash doesn't match (was never stored) → cache is cleared and repopulated instead of being reused. This wastes one full cold scan.

### Bug 2 — Deadlock in preload mode (Run 3 hangs)

On Run 3 (or Run 2 if cache is set via config file), `_preload_mode = true` because the cache is non-empty. The old code tries to serve cached data **through** the scan task infrastructure, which doesn't work:

1. `task_creator::prepare_for_query()` creates `duckdb_scan_task_global_state` → calls DuckDB `init_global`, acquires locks
2. Scan tasks are scheduled through the kiosk and thread pool as normal
3. Each task calls `get_scan_output()` which serves cached batches from `_cache`
4. When all cached batches are exhausted, `get_scan_output()` **throws** `"Scan results for query not cached"` instead of signaling completion
5. DuckDB scans use a self-scheduling model: `compute_task()` returns data and creates continuation tasks until it returns empty, which sets `exhausted = true`. In preload mode `compute_task()` is never called, so `exhausted` is never set.
6. The pipeline waits for scan completion that never arrives → **deadlock**

Parquet scans don't deadlock because they use upfront partition counting (`has_more_partitions`) instead of the self-scheduling `exhausted` flag — but they still waste time re-reading parquet footer metadata (~25-60ms per table) on every warm run via `rebind()`.

## Fix

Bypass the scan task infrastructure entirely when the cache is hot:

**`duckdb_scan_executor`** — Add `preload_into_pipelines()`: walks the scan operators, clones cached batches, pushes them directly into downstream pipeline data repositories (found via `sink->get_next_port_after_sink()`), and explicitly marks each scan pipeline as finished (`exhausted = true` for DuckDB scans, `has_more_partitions = false` for parquet scans). No scan tasks are created. Extract `clone_cached_batches()` (handles TABLE_GPU zero-copy vs deep clone vs parquet shallow_clone) and `mark_scan_pipeline_finished()` as helpers. Fix the `get_scan_output()` preload fallback to return empty data instead of throwing.

**`pipeline_executor`** — Call `preload_into_pipelines()` during `prepare_for_query()`. If in preload mode, clear the priority scan queue (no scan tasks to schedule). In `start_query()`, schedule the downstream consumers returned by preload so GPU pipeline tasks begin immediately.

**`task_creator`** — In preload mode, skip `duckdb_scan_task_global_state` creation (avoids `init_global` and DuckDB lock acquisition) and skip parquet `rebind()` (avoids re-reading parquet file footers). Change `.at()` to `.find()` for both DuckDB and parquet global state lookups so that preloaded scans gracefully return `nullptr` (no more tasks) instead of throwing.

**`sirius_context`** — Move `set_scan_caching_config()` before `cache_scan_results_for_query()` so the scan executor has the correct cache level before deciding whether to cache or preload.

**After fix:**
```
Run 1: 0.67s  — cold scan, populates cache
Run 2: 0.06s  — preload, no deadlock, no binding overhead
Run 3: 0.06s  — stable
```

## TPC-H SF10 warm run benchmark (parquet views)

The benchmark script issues `SET scan_cache_level` before each query group, which avoids the deadlock on old code. But the preload fix still saves time by skipping `init_global` binding and scan task thread pool overhead on every warm run. The exact savings depend on the number of scan pipelines (joins have more) and data source (parquet binding is more expensive than DuckDB table binding).

| Query | Old warm | New warm | Saved |
|-------|----------|----------|-------|
| Q1    | 0.102s   | 0.101s   | -1ms  |
| Q2    | 0.081s   | 0.061s   | -20ms |
| Q3    | 0.061s   | 0.051s   | -10ms |
| Q4    | 0.061s   | 0.050s   | -11ms |
| Q5    | 0.072s   | 0.061s   | -11ms |
| Q6    | 0.041s   | 0.051s   | +10ms |
| Q7    | 0.091s   | 0.091s   | 0ms   |
| Q8    | 0.071s   | 0.081s   | +10ms |
| Q9    | 0.132s   | 0.112s   | -20ms |
| Q10   | 0.102s   | 0.081s   | -21ms |
| Q11   | 0.051s   | 0.040s   | -11ms |
| Q12   | 0.061s   | 0.051s   | -10ms |
| Q13   | 0.111s   | 0.102s   | -9ms  |
| Q14   | 0.040s   | 0.031s   | -9ms  |
| Q15   | 0.051s   | 0.051s   | 0ms   |
| Q16   | 0.091s   | 0.071s   | -20ms |
| Q17   | 0.101s   | 0.082s   | -19ms |
| Q18   | 0.132s   | 0.111s   | -21ms |
| Q19   | 0.092s   | 0.070s   | -22ms |
| Q20   | 0.080s   | 0.059s   | -21ms |
| Q21   | 0.182s   | 0.173s   | -9ms  |
| Q22   | 0.051s   | 0.040s   | -11ms |

Most queries save 10-20ms. Q6 and Q8 show noise (single-table scans where binding overhead is minimal and measurement variance dominates).
