### PR TITLE
Drain and restart task creator during pipeline executor drain

### DIFF
--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -175,6 +175,9 @@ void pipeline_executor::terminate_query(std::exception_ptr error)
 void pipeline_executor::drain_after_error()
 {
   SIRIUS_LOG_INFO("pipeline_executor: draining after error");
+  // Drain the task creator first so no thread is inside get_next_task_input_data()/
+  // pop_data_batch() when QueryEnd() clears repositories (avoids use-after-free).
+  if (_task_creator) { _task_creator->stop_thread_pool(); }
   // Drain the top-level task queue so management_eventloop doesn't dispatch
   // stale tasks from the failed query.
   _task_queue.drain();
@@ -191,6 +194,7 @@ void pipeline_executor::drain_after_error()
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->drain_and_wait();
   }
+  if (_task_creator) { _task_creator->start_thread_pool(); }
   SIRIUS_LOG_INFO("pipeline_executor: DONE draining after error");
 }
 


### PR DESCRIPTION
I ran the tests on this PR 3x now and there were no failures