### PR TITLE
Use probing hash for mixed_join

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -286,38 +286,35 @@ void task_creator::manager_loop()
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
           auto* parquet_scan             = &node->Cast<op::sirius_physical_parquet_scan>();
-          while (true) {
-            pipeline->mark_task_created();
-            auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
-            if (!partition_idx.has_value()) {
-              pipeline->mark_task_completed();
-              if (pipeline->is_pipeline_finished()) {
-                auto output_consumers = pipeline->get_output_consumers();
-                for (auto& output_consumer : output_consumers) {
-                  schedule(output_consumer);
-                }
+          pipeline->mark_task_created();
+          auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
+          if (!partition_idx.has_value()) {
+            pipeline->mark_task_completed();
+            if (pipeline->is_pipeline_finished()) {
+              auto output_consumers = pipeline->get_output_consumers();
+              for (auto& output_consumer : output_consumers) {
+                schedule(output_consumer);
               }
-              return;
             }
-            if (!parquet_task_global_state->has_more_partitions()) {
-              parquet_scan->has_more_partitions = false;
-            }
-
-            auto parquet_task_local_state =
-              std::make_unique<op::scan::parquet_scan_task_local_state>(*parquet_task_global_state,
-                                                                        *partition_idx);
-
-            if (destination_data_repositories.empty()) {
-              throw std::runtime_error(
-                "No destination data repositories provided for parquet scan task creation.");
-            }
-            auto parquet_task =
-              std::make_unique<op::scan::parquet_scan_task>(get_next_task_id(),
-                                                            destination_data_repositories[0],
-                                                            std::move(parquet_task_local_state),
-                                                            parquet_task_global_state);
-            _pipeline_executor->schedule(std::move(parquet_task));
+            return;
           }
+          if (!parquet_task_global_state->has_more_partitions()) {
+            parquet_scan->has_more_partitions = false;
+          }
+
+          auto parquet_task_local_state = std::make_unique<op::scan::parquet_scan_task_local_state>(
+            *parquet_task_global_state, *partition_idx);
+
+          if (destination_data_repositories.empty()) {
+            throw std::runtime_error(
+              "No destination data repositories provided for parquet scan task creation.");
+          }
+          auto parquet_task =
+            std::make_unique<op::scan::parquet_scan_task>(get_next_task_id(),
+                                                          destination_data_repositories[0],
+                                                          std::move(parquet_task_local_state),
+                                                          parquet_task_global_state);
+          _pipeline_executor->schedule(std::move(parquet_task));
         } else {
           // need to exhaust input batches until all ports are empty
           while (!node->all_ports_empty()) {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -285,35 +285,38 @@ void task_creator::manager_loop()
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
           auto* parquet_scan             = &node->Cast<op::sirius_physical_parquet_scan>();
-          pipeline->mark_task_created();
-          auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
-          if (!partition_idx.has_value()) {
-            pipeline->mark_task_completed();
-            if (pipeline->is_pipeline_finished()) {
-              auto output_consumers = pipeline->get_output_consumers();
-              for (auto& output_consumer : output_consumers) {
-                schedule(output_consumer);
+          while (true) {
+            pipeline->mark_task_created();
+            auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
+            if (!partition_idx.has_value()) {
+              pipeline->mark_task_completed();
+              if (pipeline->is_pipeline_finished()) {
+                auto output_consumers = pipeline->get_output_consumers();
+                for (auto& output_consumer : output_consumers) {
+                  schedule(output_consumer);
+                }
               }
+              return;
             }
-            return;
-          }
-          if (!parquet_task_global_state->has_more_partitions()) {
-            parquet_scan->has_more_partitions = false;
-          }
+            if (!parquet_task_global_state->has_more_partitions()) {
+              parquet_scan->has_more_partitions = false;
+            }
 
-          auto parquet_task_local_state = std::make_unique<op::scan::parquet_scan_task_local_state>(
-            *parquet_task_global_state, *partition_idx);
+            auto parquet_task_local_state =
+              std::make_unique<op::scan::parquet_scan_task_local_state>(*parquet_task_global_state,
+                                                                        *partition_idx);
 
-          if (destination_data_repositories.empty()) {
-            throw std::runtime_error(
-              "No destination data repositories provided for parquet scan task creation.");
+            if (destination_data_repositories.empty()) {
+              throw std::runtime_error(
+                "No destination data repositories provided for parquet scan task creation.");
+            }
+            auto parquet_task =
+              std::make_unique<op::scan::parquet_scan_task>(get_next_task_id(),
+                                                            destination_data_repositories[0],
+                                                            std::move(parquet_task_local_state),
+                                                            parquet_task_global_state);
+            _pipeline_executor->schedule(std::move(parquet_task));
           }
-          auto parquet_task =
-            std::make_unique<op::scan::parquet_scan_task>(get_next_task_id(),
-                                                          destination_data_repositories[0],
-                                                          std::move(parquet_task_local_state),
-                                                          parquet_task_global_state);
-          _pipeline_executor->schedule(std::move(parquet_task));
         } else {
           // Need to exhaust input batches until all ports are empty.
           while (!node->all_ports_empty()) {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -144,14 +144,19 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
       throw std::runtime_error(
         "During get_operator_for_next_task Producer is nullptr for operator " + node->get_name());
     }
-    // WSM TODO: how do we handle other ports that are not default?
+    SIRIUS_LOG_INFO("[SCHED] {} (op={}) READY -> producer {} (op={})",
+                    node->get_name(),
+                    node->get_operator_id(),
+                    hint.value().producer->get_name(),
+                    hint.value().producer->get_operator_id());
     return hint.value().producer;
   } else if (hint.has_value() &&
              hint.value().hint == op::TaskCreationHint::WAITING_FOR_INPUT_DATA) {
     auto* producer = hint.value().producer;
-    // DuckDB scan tasks create their own continuations internally, so the
-    // task creator should never schedule additional scans from downstream.
-    // (Parquet scans are fine — they use partition indices that self-limit.)
+    SIRIUS_LOG_INFO("[SCHED] {} (op={}) WAITING -> producer {}",
+                    node->get_name(),
+                    node->get_operator_id(),
+                    producer ? producer->get_name() : "null");
     if (producer != nullptr && producer->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
       auto& global_state = _scan_operator_global_state_map.at(producer->get_operator_id());
       if (global_state->is_source_drained() || !global_state->can_create_more_tasks()) {
@@ -214,9 +219,14 @@ void task_creator::manager_loop()
     auto node = request->node;
     if (node == nullptr) { continue; }
 
+    SIRIUS_LOG_INFO(
+      "[SCHED] schedule request for {} (op={})", node->get_name(), node->get_operator_id());
     node = get_operator_for_next_task(node);
 
-    if (node == nullptr) { continue; }
+    if (node == nullptr) {
+      SIRIUS_LOG_INFO("[SCHED]   -> resolved to null, skipping");
+      continue;
+    }
 
     // Schedule the task creation work on the thread pool
     _thread_pool->schedule([this, node, ticket = std::move(ticket)]() mutable {
@@ -279,8 +289,10 @@ void task_creator::manager_loop()
                                                // repositories
             std::move(scan_task_local_state),
             scan_task_global_state);
-          pipeline->mark_task_created();  // WSM TODO: this needs to be done atomically
-                                          // with the task creation
+          SIRIUS_LOG_INFO("[TASK] DUCKDB_SCAN pipeline={} op={}",
+                          pipeline->get_pipeline_id(),
+                          node->get_operator_id());
+          pipeline->mark_task_created();
           _pipeline_executor->schedule(std::move(scan_task));
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
           size_t operator_id             = node->get_operator_id();
@@ -290,14 +302,25 @@ void task_creator::manager_loop()
           auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
           if (!partition_idx.has_value()) {
             pipeline->mark_task_completed();
+            SIRIUS_LOG_INFO("[TASK] PARQUET_SCAN pipeline={} op={} exhausted (finished={})",
+                            pipeline->get_pipeline_id(),
+                            operator_id,
+                            pipeline->is_pipeline_finished());
             if (pipeline->is_pipeline_finished()) {
               auto output_consumers = pipeline->get_output_consumers();
               for (auto& output_consumer : output_consumers) {
+                SIRIUS_LOG_INFO("[TASK]   -> scheduling consumer {} (op={})",
+                                output_consumer->get_name(),
+                                output_consumer->get_operator_id());
                 schedule(output_consumer);
               }
             }
             return;
           }
+          SIRIUS_LOG_INFO("[TASK] PARQUET_SCAN pipeline={} op={} partition={}",
+                          pipeline->get_pipeline_id(),
+                          operator_id,
+                          *partition_idx);
           if (!parquet_task_global_state->has_more_partitions()) {
             parquet_scan->has_more_partitions = false;
           }
@@ -316,30 +339,33 @@ void task_creator::manager_loop()
                                                           parquet_task_global_state);
           _pipeline_executor->schedule(std::move(parquet_task));
         } else {
-          // need to exhaust input batches until all ports are empty
+          int batch_count = 0;
           while (!node->all_ports_empty()) {
-            // Mark task created BEFORE popping data from ports to prevent a race
-            // condition where update_pipeline_status() sees empty ports and matching
-            // task counters, prematurely marking the pipeline as finished.
             pipeline->mark_task_created();
 
             auto input_data = node->get_next_task_input_data();
             if (!input_data || input_data->get_data_batches().empty()) {
-              // No data was available (e.g., another thread already consumed it).
-              // Balance the counter. mark_task_completed() calls update_pipeline_status()
-              // which is correct: if all ports are truly empty and all real tasks have
-              // completed, the pipeline should finish.
               pipeline->mark_task_completed();
+              SIRIUS_LOG_INFO(
+                "[TASK] GPU pipeline={} {} (op={}) no-data after {} batches (finished={})",
+                pipeline->get_pipeline_id(),
+                node->get_name(),
+                node->get_operator_id(),
+                batch_count,
+                pipeline->is_pipeline_finished());
               if (pipeline->is_pipeline_finished()) {
                 auto output_consumers = pipeline->get_output_consumers();
                 for (auto& output_consumer : output_consumers) {
+                  SIRIUS_LOG_INFO("[TASK]   -> scheduling consumer {} (op={})",
+                                  output_consumer->get_name(),
+                                  output_consumer->get_operator_id());
                   this->schedule(output_consumer);
                 }
               }
               break;
             }
+            batch_count++;
 
-            // Check to see if you need to create a new global state for this operator
             size_t operator_id                  = node->get_operator_id();
             auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
 
@@ -351,6 +377,13 @@ void task_creator::manager_loop()
                                                             std::move(local_state),
                                                             gpu_pipeline_task_global_state);
             _pipeline_executor->schedule(std::move(task));
+          }
+          if (batch_count > 0) {
+            SIRIUS_LOG_INFO("[TASK] GPU pipeline={} {} (op={}) created {} tasks",
+                            pipeline->get_pipeline_id(),
+                            node->get_name(),
+                            node->get_operator_id(),
+                            batch_count);
           }
         }
       } catch (const std::exception& e) {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -144,19 +144,13 @@ op::sirius_physical_operator* task_creator::get_operator_for_next_task(
       throw std::runtime_error(
         "During get_operator_for_next_task Producer is nullptr for operator " + node->get_name());
     }
-    SIRIUS_LOG_INFO("[SCHED] {} (op={}) READY -> producer {} (op={})",
-                    node->get_name(),
-                    node->get_operator_id(),
-                    hint.value().producer->get_name(),
-                    hint.value().producer->get_operator_id());
     return hint.value().producer;
   } else if (hint.has_value() &&
              hint.value().hint == op::TaskCreationHint::WAITING_FOR_INPUT_DATA) {
     auto* producer = hint.value().producer;
-    SIRIUS_LOG_INFO("[SCHED] {} (op={}) WAITING -> producer {}",
-                    node->get_name(),
-                    node->get_operator_id(),
-                    producer ? producer->get_name() : "null");
+    // DuckDB scan tasks create their own continuations internally, so the
+    // task creator should never schedule additional scans from downstream.
+    // (Parquet scans are fine — they use partition indices that self-limit.)
     if (producer != nullptr && producer->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
       auto& global_state = _scan_operator_global_state_map.at(producer->get_operator_id());
       if (global_state->is_source_drained() || !global_state->can_create_more_tasks()) {
@@ -219,14 +213,9 @@ void task_creator::manager_loop()
     auto node = request->node;
     if (node == nullptr) { continue; }
 
-    SIRIUS_LOG_INFO(
-      "[SCHED] schedule request for {} (op={})", node->get_name(), node->get_operator_id());
     node = get_operator_for_next_task(node);
 
-    if (node == nullptr) {
-      SIRIUS_LOG_INFO("[SCHED]   -> resolved to null, skipping");
-      continue;
-    }
+    if (node == nullptr) { continue; }
 
     // Schedule the task creation work on the thread pool
     _thread_pool->schedule([this, node, ticket = std::move(ticket)]() mutable {
@@ -289,10 +278,8 @@ void task_creator::manager_loop()
                                                // repositories
             std::move(scan_task_local_state),
             scan_task_global_state);
-          SIRIUS_LOG_INFO("[TASK] DUCKDB_SCAN pipeline={} op={}",
-                          pipeline->get_pipeline_id(),
-                          node->get_operator_id());
-          pipeline->mark_task_created();
+          pipeline->mark_task_created();  // WSM TODO: this needs to be done atomically
+                                          // with the task creation
           _pipeline_executor->schedule(std::move(scan_task));
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
           size_t operator_id             = node->get_operator_id();
@@ -302,25 +289,14 @@ void task_creator::manager_loop()
           auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
           if (!partition_idx.has_value()) {
             pipeline->mark_task_completed();
-            SIRIUS_LOG_INFO("[TASK] PARQUET_SCAN pipeline={} op={} exhausted (finished={})",
-                            pipeline->get_pipeline_id(),
-                            operator_id,
-                            pipeline->is_pipeline_finished());
             if (pipeline->is_pipeline_finished()) {
               auto output_consumers = pipeline->get_output_consumers();
               for (auto& output_consumer : output_consumers) {
-                SIRIUS_LOG_INFO("[TASK]   -> scheduling consumer {} (op={})",
-                                output_consumer->get_name(),
-                                output_consumer->get_operator_id());
                 schedule(output_consumer);
               }
             }
             return;
           }
-          SIRIUS_LOG_INFO("[TASK] PARQUET_SCAN pipeline={} op={} partition={}",
-                          pipeline->get_pipeline_id(),
-                          operator_id,
-                          *partition_idx);
           if (!parquet_task_global_state->has_more_partitions()) {
             parquet_scan->has_more_partitions = false;
           }
@@ -339,33 +315,30 @@ void task_creator::manager_loop()
                                                           parquet_task_global_state);
           _pipeline_executor->schedule(std::move(parquet_task));
         } else {
-          int batch_count = 0;
+          // Need to exhaust input batches until all ports are empty.
           while (!node->all_ports_empty()) {
+            // Mark task created BEFORE popping data from ports to prevent a race
+            // condition where update_pipeline_status() sees empty ports and matching
+            // task counters, prematurely marking the pipeline as finished.
             pipeline->mark_task_created();
 
             auto input_data = node->get_next_task_input_data();
             if (!input_data || input_data->get_data_batches().empty()) {
+              // No data was available (e.g., another thread already consumed it).
+              // Balance the counter. mark_task_completed() calls update_pipeline_status()
+              // which is correct: if all ports are truly empty and all real tasks have
+              // completed, the pipeline should finish.
               pipeline->mark_task_completed();
-              SIRIUS_LOG_INFO(
-                "[TASK] GPU pipeline={} {} (op={}) no-data after {} batches (finished={})",
-                pipeline->get_pipeline_id(),
-                node->get_name(),
-                node->get_operator_id(),
-                batch_count,
-                pipeline->is_pipeline_finished());
               if (pipeline->is_pipeline_finished()) {
                 auto output_consumers = pipeline->get_output_consumers();
                 for (auto& output_consumer : output_consumers) {
-                  SIRIUS_LOG_INFO("[TASK]   -> scheduling consumer {} (op={})",
-                                  output_consumer->get_name(),
-                                  output_consumer->get_operator_id());
                   this->schedule(output_consumer);
                 }
               }
               break;
             }
-            batch_count++;
 
+            // Check to see if you need to create a new global state for this operator
             size_t operator_id                  = node->get_operator_id();
             auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
 
@@ -377,13 +350,6 @@ void task_creator::manager_loop()
                                                             std::move(local_state),
                                                             gpu_pipeline_task_global_state);
             _pipeline_executor->schedule(std::move(task));
-          }
-          if (batch_count > 0) {
-            SIRIUS_LOG_INFO("[TASK] GPU pipeline={} {} (op={}) created {} tasks",
-                            pipeline->get_pipeline_id(),
-                            node->get_name(),
-                            node->get_operator_id(),
-                            batch_count);
           }
         }
       } catch (const std::exception& e) {

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -48,7 +48,14 @@ namespace op {
 // for better pipelining with other operators, and allows reusing the hash table. MIXED_JOIN uses
 // cudf's mixed_join API for joins with both equality and inequality conditions.
 enum class HASH_JOIN_MODE { STANDARD, BUILD_PROBE, MIXED_JOIN };
-enum class BUILD_HASH_TABLE_STATE { NOT_BUILT, SCHEDULING, SCHEDULED, BUILT, DESTROYED };
+enum class BUILD_HASH_TABLE_STATE {
+  NOT_BUILT,
+  SCHEDULING,
+  SCHEDULED,
+  BUILT,
+  FINALIZING,
+  DESTROYED
+};
 
 class sirius_physical_hash_join : public sirius_physical_partition_consumer_operator {
  public:
@@ -163,7 +170,9 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
   std::unique_ptr<cudf::filtered_join>
-    _filtered_hash_table;  // filtered hash object for SEMI/ANTI in BUILD_PROBE mode
+    _filtered_hash_table;  // filtered hash object for SEMI/ANTI/RIGHT_SEMI/RIGHT_ANTI/MARK
+  std::unique_ptr<cudf::column>
+    _build_match_bitmap;  // BOOL8 bitmap tracking matched build rows for RIGHT_SEMI/RIGHT_ANTI
   std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -29,6 +29,8 @@
 #include "sirius_config.hpp"
 #include "utils.hpp"
 
+#include <cudf/join/filtered_join.hpp>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -160,6 +162,8 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
+  std::unique_ptr<cudf::filtered_join>
+    _filtered_hash_table;  // filtered hash object for SEMI/ANTI in BUILD_PROBE mode
   std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -260,11 +260,15 @@ parquet_scan_task_global_state::parquet_scan_task_global_state(
                     projected_columns.emplace_back(scan_op->names[col_idx]);
                   });
 
+    // libcudf hybrid_scan rejects an empty column list ("No columns selected"). If the
+    // selected set is empty (e.g. plan shape with LIMIT/OFFSET), read all columns instead.
+    if (!projected_columns.empty()) {
 #if CUDF_VERSION_NUM >= 2604
-    _reader_options.set_column_names(std::move(projected_columns));
+      _reader_options.set_column_names(std::move(projected_columns));
 #else
-    _reader_options.set_columns(std::move(projected_columns));
+      _reader_options.set_columns(std::move(projected_columns));
 #endif
+    }
   }
 
   // Compute the byte counts per row group for the selected columns for task partitioning

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -490,15 +490,6 @@ void sirius_physical_hash_join::build_pipelines(pipeline::sirius_pipeline& curre
 void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64_t build_side_bytes)
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
-  SIRIUS_LOG_INFO(
-    "update_join_exec_mode id {} join_type={} num_partitions={} build_side_bytes={} "
-    "current_mode={} max_build_bytes={}",
-    this->get_operator_id(),
-    duckdb::JoinTypeToString(join_type),
-    num_partitions,
-    build_side_bytes,
-    static_cast<int>(_join_mode),
-    _max_build_hash_table_bytes);
   if (num_partitions == 1 && join_type != duckdb::JoinType::RIGHT &&
       _join_mode != HASH_JOIN_MODE::BUILD_PROBE) {
     bool has_inequality = (num_equality_conditions < conditions.size());
@@ -513,13 +504,9 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
       // Keep STANDARD mode.
     } else if (!has_inequality || join_type == duckdb::JoinType::INNER) {
       _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
-      SIRIUS_LOG_INFO(
-        "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and "
-        "build side size {} bytes{}",
-        this->get_operator_id(),
-        num_partitions,
-        build_side_bytes,
-        has_inequality ? " (with inequality post-filter)" : "");
+      SIRIUS_LOG_DEBUG("sirius_physical_hash_join id {} switching to BUILD_PROBE mode{}",
+                       this->get_operator_id(),
+                       has_inequality ? " (with inequality post-filter)" : "");
     }
   }
 }
@@ -907,13 +894,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       "Error sirius_physical_hash_join being asked to do all inequality join of type: " +
       duckdb::JoinTypeToString(join_type));
   }
-
-  SIRIUS_LOG_INFO("hash_join::execute id {} join_type={} mode={} build_state={} batches={}",
-                  this->get_operator_id(),
-                  duckdb::JoinTypeToString(join_type),
-                  static_cast<int>(_join_mode),
-                  static_cast<int>(_hash_table_build_state),
-                  input_batches.size());
 
   cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -17,6 +17,7 @@
 #include "op/sirius_physical_hash_join.hpp"
 
 #include "cudf/binaryop.hpp"
+#include "cudf/concatenate.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
@@ -587,20 +588,21 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
       std::to_string(this->get_operator_id()));
   }
   if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULING) {
-    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) != 1 ||
-        probe_port->repo->num_partitions() != 1) {
+    if (build_port->repo->num_partitions() != 1 || probe_port->repo->num_partitions() != 1) {
       throw std::runtime_error(
         "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected exactly 1 "
-        "partition and 1 batch in default (build) port in operator " +
+        "partition in build and probe ports in operator " +
         std::to_string(this->get_operator_id()));
     }
-    // When the hash table is not build yet, we will send both the build and probe side. To build
-    // the hash table and perform the first join.
+    // Pop the first probe batch and ALL build batches. The execute() method will
+    // concatenate multiple build batches into one table before building the hash table.
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
-    auto probe_batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
-    auto build_batch = build_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
-    input_batch.push_back(std::move(probe_batch));
-    input_batch.push_back(std::move(build_batch));
+    input_batch.push_back(probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created));
+    while (true) {
+      auto build_batch = build_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
+      if (!build_batch) break;
+      input_batch.push_back(std::move(build_batch));
+    }
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULED;
     return std::make_unique<operator_data>(input_batch);
 
@@ -934,7 +936,23 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     }
 
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
-      auto build_keys_result      = prepare_join_keys(input_batches[1],
+      // Concatenate build batches if more than one (input_batches[1..n] are build batches).
+      std::shared_ptr<cucascade::data_batch> build_batch;
+      if (input_batches.size() > 2) {
+        std::vector<cudf::table_view> build_views;
+        build_views.reserve(input_batches.size() - 1);
+        for (size_t i = 1; i < input_batches.size(); ++i) {
+          build_views.push_back(get_cudf_table_view(*input_batches[i]));
+        }
+        auto concat_table = cudf::concatenate(
+          build_views, stream, input_batches[1]->get_memory_space()->get_default_allocator());
+        build_batch =
+          make_data_batch(std::move(concat_table), *input_batches[1]->get_memory_space());
+      } else {
+        build_batch = input_batches[1];
+      }
+
+      auto build_keys_result      = prepare_join_keys(build_batch,
                                                  right_key_col_indices,
                                                  cast_necessary,
                                                  key_casts,
@@ -944,7 +962,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       {
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
-        _build_table              = input_batches[1];
+        _build_table              = std::move(build_batch);
         if (join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::ANTI ||
             join_type == duckdb::JoinType::MARK) {
           _filtered_hash_table = std::make_unique<cudf::filtered_join>(

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -375,8 +375,7 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
-      join_type != duckdb::JoinType::SEMI && join_type != duckdb::JoinType::RIGHT_SEMI &&
-      join_type != duckdb::JoinType::ANTI && join_type != duckdb::JoinType::RIGHT_ANTI &&
+      join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI &&
       join_type != duckdb::JoinType::RIGHT && join_type != duckdb::JoinType::MARK &&
       _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets
@@ -783,8 +782,13 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = input_batches[1];
-        _hash_table =
-          std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+        if (join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::ANTI) {
+          _filtered_hash_table = std::make_unique<cudf::filtered_join>(
+            build_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
+        } else {
+          _hash_table =
+            std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+        }
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
                                // batches to proceed.
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
@@ -813,6 +817,10 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         auto result   = _hash_table->full_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);
         right_indices = std::move(result.second);
+      } else if (join_type == duckdb::JoinType::SEMI) {
+        left_indices = _filtered_hash_table->semi_join(probe_keys, stream);
+      } else if (join_type == duckdb::JoinType::ANTI) {
+        left_indices = _filtered_hash_table->anti_join(probe_keys, stream);
       } else {
         throw std::runtime_error("Unsupported join type in BUILD_PROBE mode: " +
                                  duckdb::JoinTypeToString(join_type));
@@ -1062,6 +1070,7 @@ void sirius_physical_hash_join::finalize_operator()
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     _hash_table.reset();
+    _filtered_hash_table.reset();
     _build_table.reset();
     _built_table_cast_columns.clear();
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -499,14 +499,19 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
     build_side_bytes,
     static_cast<int>(_join_mode),
     _max_build_hash_table_bytes);
-  // num_partitions == 1 guarantees the partition operator decided the data fits in GPU memory.
-  // No additional size check is needed — BUILD_PROBE uses less peak memory than MIXED_JOIN or
-  // STANDARD (which materialise both sides at once), since it only holds the build table + one
-  // probe batch at a time.
   if (num_partitions == 1 && join_type != duckdb::JoinType::RIGHT &&
       _join_mode != HASH_JOIN_MODE::BUILD_PROBE) {
     bool has_inequality = (num_equality_conditions < conditions.size());
-    if (!has_inequality || join_type == duckdb::JoinType::INNER) {
+
+    // RIGHT_SEMI/RIGHT_ANTI with equality-only conditions: STANDARD mode's
+    // filtered_join::semi_join/anti_join is a single optimised cudf call, whereas BUILD_PROBE
+    // requires an extra bitmap scatter + boolean mask.  Only enable BUILD_PROBE when inequality
+    // conditions are present (which forces MIXED_JOIN otherwise — a full barrier).
+    bool is_right_semi_anti =
+      (join_type == duckdb::JoinType::RIGHT_SEMI || join_type == duckdb::JoinType::RIGHT_ANTI);
+    if (is_right_semi_anti && !has_inequality) {
+      // Keep STANDARD mode.
+    } else if (!has_inequality || join_type == duckdb::JoinType::INNER) {
       _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
       SIRIUS_LOG_INFO(
         "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and "

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -375,11 +375,19 @@ void sirius_physical_hash_join::build_pipelines(pipeline::sirius_pipeline& curre
 void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64_t build_side_bytes)
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
+  SIRIUS_LOG_INFO(
+    "update_join_exec_mode id {} join_type={} num_partitions={} build_side_bytes={} "
+    "current_mode={} max_build_bytes={}",
+    this->get_operator_id(),
+    duckdb::JoinTypeToString(join_type),
+    num_partitions,
+    build_side_bytes,
+    static_cast<int>(_join_mode),
+    _max_build_hash_table_bytes);
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
       join_type != duckdb::JoinType::RIGHT && _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
-    // Switch to a more efficient join strategy for small datasets
     _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
-    SIRIUS_LOG_DEBUG(
+    SIRIUS_LOG_INFO(
       "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and build "
       "side size {} bytes",
       this->get_operator_id(),
@@ -770,6 +778,13 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       "Error sirius_physical_hash_join being asked to do all inequality join of type: " +
       duckdb::JoinTypeToString(join_type));
   }
+
+  SIRIUS_LOG_INFO("hash_join::execute id {} join_type={} mode={} build_state={} batches={}",
+                  this->get_operator_id(),
+                  duckdb::JoinTypeToString(join_type),
+                  static_cast<int>(_join_mode),
+                  static_cast<int>(_hash_table_build_state),
+                  input_batches.size());
 
   cudf::table_view left_full, right_full;
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -498,11 +498,13 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
     build_side_bytes,
     static_cast<int>(_join_mode),
     _max_build_hash_table_bytes);
-  if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
-      join_type != duckdb::JoinType::RIGHT && _join_mode != HASH_JOIN_MODE::BUILD_PROBE) {
+  // num_partitions == 1 guarantees the partition operator decided the data fits in GPU memory.
+  // No additional size check is needed — BUILD_PROBE uses less peak memory than MIXED_JOIN or
+  // STANDARD (which materialise both sides at once), since it only holds the build table + one
+  // probe batch at a time.
+  if (num_partitions == 1 && join_type != duckdb::JoinType::RIGHT &&
+      _join_mode != HASH_JOIN_MODE::BUILD_PROBE) {
     bool has_inequality = (num_equality_conditions < conditions.size());
-    // For mixed joins (equality + inequality), enable BUILD_PROBE only for INNER where
-    // inequality conditions can be applied as a post-filter on equality-matched rows.
     if (!has_inequality || join_type == duckdb::JoinType::INNER) {
       _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
       SIRIUS_LOG_INFO(

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -16,6 +16,7 @@
 
 #include "op/sirius_physical_hash_join.hpp"
 
+#include "cudf/binaryop.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
@@ -51,6 +52,119 @@ static void collect_bound_ref_indices(duckdb::Expression& expr,
   }
   duckdb::ExpressionIterator::EnumerateChildren(
     expr, [&](duckdb::Expression& child) { collect_bound_ref_indices(child, indices); });
+}
+
+/// Extract the column index from a join condition expression (handles BOUND_REF and BOUND_CAST).
+static cudf::size_type extract_condition_col_index(duckdb::Expression const& expr)
+{
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+    return static_cast<cudf::size_type>(expr.Cast<duckdb::BoundReferenceExpression>().index);
+  }
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
+    return extract_condition_col_index(*expr.Cast<duckdb::BoundCastExpression>().child);
+  }
+  throw std::runtime_error(
+    "Cannot extract column index from inequality condition expression of class " +
+    std::to_string(static_cast<int>(expr.GetExpressionClass())));
+}
+
+/// Map a DuckDB comparison type to a cuDF binary operator for inequality post-filtering.
+static cudf::binary_operator comparison_to_binary_op(duckdb::ExpressionType cmp)
+{
+  switch (cmp) {
+    case duckdb::ExpressionType::COMPARE_NOTEQUAL: return cudf::binary_operator::NOT_EQUAL;
+    case duckdb::ExpressionType::COMPARE_LESSTHAN: return cudf::binary_operator::LESS;
+    case duckdb::ExpressionType::COMPARE_GREATERTHAN: return cudf::binary_operator::GREATER;
+    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+      return cudf::binary_operator::LESS_EQUAL;
+    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return cudf::binary_operator::GREATER_EQUAL;
+    default:
+      throw std::runtime_error("Unsupported comparison for inequality post-filter: " +
+                               duckdb::ExpressionTypeToString(cmp));
+  }
+}
+
+/// Evaluate inequality join conditions on equality-matched row pairs and filter the index vectors
+/// in-place. After this call, left_indices and right_indices contain only the pairs that satisfy
+/// all inequality conditions.
+static void apply_inequality_post_filter(
+  duckdb::vector<duckdb::JoinCondition> const& conditions,
+  std::size_t num_equality_conditions,
+  cudf::table_view probe_full,
+  cudf::table_view build_full,
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>>& left_indices,
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>>& right_indices,
+  rmm::cuda_stream_view stream)
+{
+  if (left_indices->size() == 0) { return; }
+
+  auto const num_matched = static_cast<cudf::size_type>(left_indices->size());
+  cudf::column_view left_map(
+    cudf::data_type(cudf::type_id::INT32), num_matched, left_indices->data(), nullptr, 0, 0, {});
+  cudf::column_view right_map(
+    cudf::data_type(cudf::type_id::INT32), num_matched, right_indices->data(), nullptr, 0, 0, {});
+
+  std::unique_ptr<cudf::column> combined_mask;
+
+  for (std::size_t i = num_equality_conditions; i < conditions.size(); i++) {
+    auto const& cond   = conditions[i];
+    auto left_col_idx  = extract_condition_col_index(*cond.left);
+    auto right_col_idx = extract_condition_col_index(*cond.right);
+
+    auto left_gathered  = cudf::gather(cudf::table_view({probe_full.column(left_col_idx)}),
+                                      left_map,
+                                      cudf::out_of_bounds_policy::DONT_CHECK,
+                                      stream);
+    auto right_gathered = cudf::gather(cudf::table_view({build_full.column(right_col_idx)}),
+                                       right_map,
+                                       cudf::out_of_bounds_policy::DONT_CHECK,
+                                       stream);
+
+    auto op          = comparison_to_binary_op(cond.comparison);
+    auto cond_result = cudf::binary_operation(left_gathered->get_column(0).view(),
+                                              right_gathered->get_column(0).view(),
+                                              op,
+                                              cudf::data_type(cudf::type_id::BOOL8),
+                                              stream);
+
+    if (combined_mask) {
+      combined_mask = cudf::binary_operation(combined_mask->view(),
+                                             cond_result->view(),
+                                             cudf::binary_operator::BITWISE_AND,
+                                             cudf::data_type(cudf::type_id::BOOL8),
+                                             stream);
+    } else {
+      combined_mask = std::move(cond_result);
+    }
+  }
+
+  // Filter the index pairs using the combined mask.
+  cudf::table_view indices_table({left_map, right_map});
+  auto filtered      = cudf::apply_boolean_mask(indices_table, combined_mask->view(), stream);
+  auto filtered_cols = filtered->release();
+
+  // Move filtered data into new device_uvectors.
+  auto new_left = std::make_unique<rmm::device_uvector<cudf::size_type>>(
+    static_cast<std::size_t>(filtered_cols[0]->view().size()), stream);
+  auto new_right = std::make_unique<rmm::device_uvector<cudf::size_type>>(
+    static_cast<std::size_t>(filtered_cols[1]->view().size()), stream);
+
+  if (new_left->size() > 0) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(new_left->data(),
+                                  filtered_cols[0]->view().data<cudf::size_type>(),
+                                  new_left->size() * sizeof(cudf::size_type),
+                                  cudaMemcpyDeviceToDevice,
+                                  stream.value()));
+    CUDF_CUDA_TRY(cudaMemcpyAsync(new_right->data(),
+                                  filtered_cols[1]->view().data<cudf::size_type>(),
+                                  new_right->size() * sizeof(cudf::size_type),
+                                  cudaMemcpyDeviceToDevice,
+                                  stream.value()));
+  }
+
+  left_indices  = std::move(new_left);
+  right_indices = std::move(new_right);
 }
 
 bool sirius_physical_hash_join::are_conditions_supported(
@@ -385,14 +499,20 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
     static_cast<int>(_join_mode),
     _max_build_hash_table_bytes);
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
-      join_type != duckdb::JoinType::RIGHT && _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
-    _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
-    SIRIUS_LOG_INFO(
-      "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and build "
-      "side size {} bytes",
-      this->get_operator_id(),
-      num_partitions,
-      build_side_bytes);
+      join_type != duckdb::JoinType::RIGHT && _join_mode != HASH_JOIN_MODE::BUILD_PROBE) {
+    bool has_inequality = (num_equality_conditions < conditions.size());
+    // For mixed joins (equality + inequality), enable BUILD_PROBE only for INNER where
+    // inequality conditions can be applied as a post-filter on equality-matched rows.
+    if (!has_inequality || join_type == duckdb::JoinType::INNER) {
+      _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
+      SIRIUS_LOG_INFO(
+        "sirius_physical_hash_join id {} switching to BUILD_PROBE mode with {} partitions and "
+        "build side size {} bytes{}",
+        this->get_operator_id(),
+        num_partitions,
+        build_side_bytes,
+        has_inequality ? " (with inequality post-filter)" : "");
+    }
   }
 }
 
@@ -916,6 +1036,20 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         auto result   = _hash_table->inner_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);
         right_indices = std::move(result.second);
+        if (num_equality_conditions < conditions.size()) {
+          auto probe_full = get_cudf_table_view(*input_batches[0]);
+          auto build_full = _build_table->get_data()
+                              ->cast<cucascade::gpu_table_representation>()
+                              .get_table()
+                              .view();
+          apply_inequality_post_filter(conditions,
+                                       num_equality_conditions,
+                                       probe_full,
+                                       build_full,
+                                       left_indices,
+                                       right_indices,
+                                       stream);
+        }
       } else if (join_type == duckdb::JoinType::LEFT) {
         auto result   = _hash_table->left_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -20,6 +20,7 @@
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
 #include "cudf/join/mixed_join.hpp"
+#include "cudf/stream_compaction.hpp"
 #include "cudf/table/table_view.hpp"
 #include "cudf/types.hpp"
 #include "cudf/unary.hpp"
@@ -375,9 +376,7 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
-      join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI &&
-      join_type != duckdb::JoinType::RIGHT && join_type != duckdb::JoinType::MARK &&
-      _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
+      join_type != duckdb::JoinType::RIGHT && _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets
     _join_mode = HASH_JOIN_MODE::BUILD_PROBE;
     SIRIUS_LOG_DEBUG(
@@ -424,14 +423,20 @@ std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint(
       auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
       return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
     } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
-      // Hash table is built, we can process probe only batches.
       if (ports["default"]->repo->total_size() > 0) {
         return task_creation_hint{TaskCreationHint::READY, this};
+      } else if ((join_type == duckdb::JoinType::RIGHT_SEMI ||
+                  join_type == duckdb::JoinType::RIGHT_ANTI) &&
+                 probe_port->src_pipeline->is_pipeline_finished()) {
+        _hash_table_build_state = BUILD_HASH_TABLE_STATE::FINALIZING;
+        return task_creation_hint{TaskCreationHint::READY, this};
       } else {
-        // No probe batch available yet, hint to wait for probe input data.
         auto* producer = &ports["default"]->src_pipeline->get_operators()[0].get();
         return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
       }
+    } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::FINALIZING) {
+      auto* producer = &probe_port->src_pipeline->get_operators()[0].get();
+      return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
     } else {
       throw std::runtime_error(
         "Invalid hash table build state in sirius_physical_hash_join::get_next_task_hint");
@@ -476,8 +481,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         "partition in operator " +
         std::to_string(this->get_operator_id()));
     }
-    // If the hash table has already been build, we only send the probe side. The hash table should
-    // already be built and we can perform the join with the probe side batches.
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     auto batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
     if (batch) {
@@ -489,6 +492,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         std::to_string(this->get_operator_id()));
     }
     return std::make_unique<operator_data>(input_batch);
+  } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::FINALIZING) {
+    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
   } else {
     SIRIUS_LOG_WARN(fmt::format(
       "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: invalid hash table "
@@ -770,6 +775,27 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
   std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_indices, right_indices;
 
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
+    if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::FINALIZING) {
+      auto build_view =
+        _build_table->get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
+      auto selected = build_view.select(rhs_output_columns.col_idxs);
+
+      std::unique_ptr<cudf::table> result;
+      if (join_type == duckdb::JoinType::RIGHT_SEMI) {
+        result = cudf::apply_boolean_mask(selected, _build_match_bitmap->view(), stream);
+      } else {
+        auto negated =
+          cudf::unary_operation(_build_match_bitmap->view(), cudf::unary_operator::NOT, stream);
+        result = cudf::apply_boolean_mask(selected, negated->view(), stream);
+      }
+      {
+        std::lock_guard<std::mutex> lg(op_state_mutex);
+        _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;
+      }
+      return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
+        make_data_batch(std::move(result), *_build_table->get_memory_space())});
+    }
+
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
       auto build_keys_result      = prepare_join_keys(input_batches[1],
                                                  right_key_col_indices,
@@ -782,21 +808,30 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = input_batches[1];
-        if (join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::ANTI) {
+        if (join_type == duckdb::JoinType::SEMI || join_type == duckdb::JoinType::ANTI ||
+            join_type == duckdb::JoinType::MARK) {
           _filtered_hash_table = std::make_unique<cudf::filtered_join>(
             build_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
+        } else if (join_type == duckdb::JoinType::RIGHT_SEMI ||
+                   join_type == duckdb::JoinType::RIGHT_ANTI) {
+          _hash_table =
+            std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+          auto num_build_rows = _build_table->get_data()
+                                  ->cast<cucascade::gpu_table_representation>()
+                                  .get_table()
+                                  .view()
+                                  .num_rows();
+          cudf::numeric_scalar<bool> false_scalar(false, true, stream);
+          _build_match_bitmap = cudf::make_column_from_scalar(false_scalar, num_build_rows, stream);
         } else {
           _hash_table =
             std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
         }
-        stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
-                               // batches to proceed.
+        stream.synchronize();
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
       }
     }
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
-      // Hash table is built, we can process probe batches. The probe-side keys will be processed in
-      // the same way as the mixed join path, but with an equality-only predicate.
       auto probe_keys_result      = prepare_join_keys(input_batches[0],
                                                  left_key_col_indices,
                                                  cast_necessary,
@@ -805,7 +840,64 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                  stream);
       cudf::table_view probe_keys = probe_keys_result.keys;
 
-      if (join_type == duckdb::JoinType::INNER) {
+      if (join_type == duckdb::JoinType::RIGHT_SEMI || join_type == duckdb::JoinType::RIGHT_ANTI) {
+        auto join_result            = _hash_table->inner_join(probe_keys, {}, stream);
+        auto& matched_build_indices = join_result.second;
+        if (matched_build_indices->size() > 0) {
+          cudf::numeric_scalar<bool> true_scalar(true, true, stream);
+          cudf::column_view scatter_map(cudf::data_type(cudf::type_id::INT32),
+                                        static_cast<cudf::size_type>(matched_build_indices->size()),
+                                        matched_build_indices->data(),
+                                        nullptr,
+                                        0,
+                                        0,
+                                        {});
+          auto true_col = cudf::make_column_from_scalar(
+            true_scalar, static_cast<cudf::size_type>(matched_build_indices->size()), stream);
+          auto true_table     = cudf::table_view({true_col->view()});
+          auto target_table   = cudf::table_view({_build_match_bitmap->view()});
+          auto scatter_result = cudf::scatter(true_table, scatter_map, target_table, stream);
+          _build_match_bitmap = std::move(scatter_result->release()[0]);
+        }
+
+        auto* probe_port = get_port("default");
+        if (probe_port->repo->total_size() == 0 &&
+            probe_port->src_pipeline->is_pipeline_finished()) {
+          // All probe data consumed — produce final output from bitmap.
+          auto build_view = _build_table->get_data()
+                              ->cast<cucascade::gpu_table_representation>()
+                              .get_table()
+                              .view();
+          auto selected = build_view.select(rhs_output_columns.col_idxs);
+
+          std::unique_ptr<cudf::table> final_result;
+          if (join_type == duckdb::JoinType::RIGHT_SEMI) {
+            final_result = cudf::apply_boolean_mask(selected, _build_match_bitmap->view(), stream);
+          } else {
+            auto negated =
+              cudf::unary_operation(_build_match_bitmap->view(), cudf::unary_operator::NOT, stream);
+            final_result = cudf::apply_boolean_mask(selected, negated->view(), stream);
+          }
+          {
+            std::lock_guard<std::mutex> lg(op_state_mutex);
+            _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;
+          }
+          return std::make_unique<operator_data>(
+            std::vector<std::shared_ptr<::cucascade::data_batch>>{
+              make_data_batch(std::move(final_result), *_build_table->get_memory_space())});
+        }
+
+        // More probe batches to come — return empty result for now.
+        right_indices = std::make_unique<rmm::device_uvector<cudf::size_type>>(0, stream);
+        left_full     = get_cudf_table_view(*input_batches[0]);
+        right_full =
+          _build_table->get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
+      } else if (join_type == duckdb::JoinType::MARK) {
+        auto semi_indices = _filtered_hash_table->semi_join(probe_keys, stream);
+        left_full         = get_cudf_table_view(*input_batches[0]);
+        return resolve_mark_join_result(
+          *semi_indices, left_full, lhs_output_columns.col_idxs, input_batches[0], stream);
+      } else if (join_type == duckdb::JoinType::INNER) {
         auto result   = _hash_table->inner_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);
         right_indices = std::move(result.second);
@@ -825,11 +917,13 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         throw std::runtime_error("Unsupported join type in BUILD_PROBE mode: " +
                                  duckdb::JoinTypeToString(join_type));
       }
-      left_full = get_cudf_table_view(*input_batches[0]);
-      right_full =
-        _build_table->get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
-
-    } else {
+      if (join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::RIGHT_ANTI &&
+          join_type != duckdb::JoinType::MARK) {
+        left_full = get_cudf_table_view(*input_batches[0]);
+        right_full =
+          _build_table->get_data()->cast<cucascade::gpu_table_representation>().get_table().view();
+      }
+    } else if (_hash_table_build_state != BUILD_HASH_TABLE_STATE::BUILT) {
       throw std::runtime_error(fmt::format(
         "In sirius_physical_hash_join::execute: invalid hash table build state {} in BUILD_PROBE "
         "mode for operator id {}",
@@ -1071,6 +1165,7 @@ void sirius_physical_hash_join::finalize_operator()
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     _hash_table.reset();
     _filtered_hash_table.reset();
+    _build_match_bitmap.reset();
     _build_table.reset();
     _built_table_cast_columns.clear();
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -161,7 +161,15 @@ std::future<void> pipeline_executor::start_query()
     gpu_exec->set_completion_handler(_completion_handler.get());
   }
 
-  schedule_next_scan_tasks();
+  // Schedule all scans. Build-side scans appear first (sorted in query::build_indices()),
+  // so their I/O tasks are enqueued before probe-side scans.
+  {
+    std::lock_guard<std::mutex> lock(_priority_scans_mutex);
+    while (!_priority_scans.empty()) {
+      _task_creator->schedule(_priority_scans.front());
+      _priority_scans.pop();
+    }
+  }
 
   return future;
 }

--- a/src/planner/query.cpp
+++ b/src/planner/query.cpp
@@ -16,6 +16,10 @@
 
 #include "planner/query.hpp"
 
+#include "op/sirius_physical_partition.hpp"
+
+#include <algorithm>
+
 namespace sirius::planner {
 
 query::query(sirius_pipeline_hashmap pipeline_hashmap)
@@ -51,6 +55,20 @@ void query::build_indices()
       _operator_to_pipeline[&op_ref.get()] = pipeline;
     }
   }
+
+  // Prioritize build-side scans: hash join build partitions must complete before
+  // probe partitions can determine num_partitions, so starting build-side I/O
+  // first reduces the critical path.
+  std::stable_sort(_scan_operators.begin(), _scan_operators.end(), [this](auto* a, auto* b) {
+    auto is_build_scan = [this](op::sirius_physical_operator* scan_op) {
+      auto it = _operator_to_pipeline.find(scan_op);
+      if (it == _operator_to_pipeline.end()) { return false; }
+      auto sink = it->second->get_sink();
+      return sink && sink->type == op::SiriusPhysicalOperatorType::PARTITION &&
+             sink->Cast<op::sirius_physical_partition>().is_build_partition();
+    };
+    return is_build_scan(a) > is_build_scan(b);
+  });
 }
 
 const duckdb::vector<op::sirius_physical_operator*>& query::get_scan_operators() const


### PR DESCRIPTION
This PR adds some join optimizations targeting Q21 particularly, by converting the mixed_join into a probing hash combined with a post-processing step. This lifts the barrier on the large side of the join, allowing data to stream, overlapping a large part of the computation.

Some other optimizations are included like prioritizing scans on the build side of joins.
In the current state of this PR Q1 has a severe regression, I've got a fix for that but it sometimes stalls the engine. So once I fix that I will push it to this branch.

This code improves Q21 from 4.3s to 2.7s, and some other queries too (Q7, Q9, Q17).