### PR TITLE
CI: Add benchmark runner Docker image and build workflow

### DIFF
--- a/.github/docker/benchmark-runner/Dockerfile
+++ b/.github/docker/benchmark-runner/Dockerfile
@@ -1,0 +1,60 @@
+# Benchmark runner image for Sirius TPC-H benchmarks.
+#
+# Provides the pixi environment manager, which installs the full CUDA toolchain
+# and all Sirius build dependencies. The CUDA runtime is injected at container
+# startup by nvidia-container-toolkit on the host — no CUDA base layer needed.
+#
+# Built natively for linux/amd64 (T4 runners, developer workstations) and
+# linux/arm64 (DGX Spark) and published as a single multi-arch manifest at:
+#   ghcr.io/sirius-db/sirius/benchmark-runner:latest
+#
+# BAKE_SCCACHE=true triggers a full dev build during image construction to
+# pre-warm the sccache. Pass this in the nightly workflow only — a developer
+# pulling the image gets yesterday's dev cache and only compiles the delta.
+# Default is false so toolchain-only rebuilds are fast.
+#
+# Local usage with act:
+#   act --container-options "--gpus all" \
+#       -P self-hosted=ghcr.io/sirius-db/sirius/benchmark-runner:latest
+#
+# Or with a local sccache mount (skips cache bake, uses your own cache):
+#   act --container-options "--gpus all -v $HOME/.cache/sccache:/root/.cache/sccache"
+
+FROM nvidia/cuda:13.0.2-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pixi — manages the full CUDA toolchain and all Sirius dependencies.
+# Version is pinned to match check.yml (pixi-version: v0.65.0).
+ARG PIXI_VERSION=0.65.0
+RUN curl -fsSL https://pixi.prefix.dev/install.sh \
+    | PIXI_VERSION=${PIXI_VERSION} bash -s -- --no-modify-path
+ENV PATH="/root/.pixi/bin:$PATH"
+
+# sccache cache directory. Populated by the nightly bake (BAKE_SCCACHE=true)
+# or by mounting a local cache directory at runtime.
+ENV SCCACHE_DIR=/root/.cache/sccache
+
+# --- Nightly sccache bake ---
+# Clone dev, run a full build to populate sccache, then discard the source and
+# build artifacts. Only the sccache directory is kept in the image layer.
+# This reduces incremental build time for PRs and on-demand benchmarks.
+ARG BAKE_SCCACHE=false
+ARG SIRIUS_REF=dev
+RUN if [ "$BAKE_SCCACHE" = "true" ]; then \
+    echo "Baking sccache from sirius@${SIRIUS_REF}..." && \
+    git clone --recurse-submodules --depth=1 --branch ${SIRIUS_REF} \
+        https://github.com/sirius-db/sirius.git /tmp/sirius-build && \
+    cd /tmp/sirius-build && \
+    pixi install && \
+    pixi run -- bash -c 'cd duckdb && cmake --preset release' && \
+    pixi run -- cmake --build build/release \
+        --target sirius_loadable_extension --target duckdb \
+        -j$(nproc) && \
+    echo "sccache stats:" && pixi run -- sccache --show-stats && \
+    rm -rf /tmp/sirius-build; \
+fi

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -41,7 +41,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ghcr.io/${{ github.repository }}/benchmark-runner
+  # Temporarily publishing to a personal ghcr.io account until org packages are enabled.
+  # Switch back to ghcr.io/${{ github.repository }}/benchmark-runner once unblocked.
+  IMAGE: ghcr.io/mike-wendt/sirius-benchmark-runner
 
 jobs:
   # Build each arch natively to avoid slow QEMU emulation.
@@ -71,8 +73,8 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: mike-wendt
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -137,8 +139,8 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: mike-wendt
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -41,9 +41,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # Temporarily publishing to a personal ghcr.io account until org packages are enabled.
-  # Switch back to ghcr.io/${{ github.repository }}/benchmark-runner once unblocked.
-  IMAGE: ghcr.io/mike-wendt/sirius-benchmark-runner
+  IMAGE: ghcr.io/${{ github.repository }}/benchmark-runner
 
 jobs:
   # Build each arch natively to avoid slow QEMU emulation.
@@ -73,8 +71,8 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: mike-wendt
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -139,8 +137,8 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: mike-wendt
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -1,0 +1,151 @@
+# NOTICE - Actions permissions policy (Settings > Actions > General):
+#   - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
+#     - Allow actions created by GitHub: YES (covers actions/*)
+#     - Allow actions by Marketplace verified creators: NO
+#     - Explicitly allowed third-party actions:
+#       prefix-dev/setup-pixi@*
+#       mozilla-actions/sccache-action@*
+#       pre-commit/action@*
+#       docker/login-action@*
+#       docker/setup-buildx-action@*
+#       docker/build-push-action@*
+#     - Require actions to be pinned to a full-length commit SHA: NO
+#
+# Adding a new action? You must:
+#   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
+#   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
+#      project-level allowlist above before merging
+name: Build benchmark runner image
+
+# Triggers:
+#   - Dockerfile changes merged to dev: rebuild toolchain layer only (no cache bake)
+#   - Nightly cron: rebuild with fresh sccache from latest dev
+#   - Manual dispatch: supports on-demand rebuilds and cache bake override
+on:
+  push:
+    branches: [dev]
+    paths: ['.github/docker/benchmark-runner/**']
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC nightly
+  workflow_dispatch:
+    inputs:
+      bake_sccache:
+        description: 'Bake sccache from dev into the image'
+        type: boolean
+        default: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository }}/benchmark-runner
+
+jobs:
+  # Build each arch natively to avoid slow QEMU emulation.
+  # Each job pushes its image by digest, which the merge job combines into
+  # a single multi-arch manifest. Docker and act pull the right variant automatically.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      # Pass digests to the merge job via outputs (one per arch)
+      digest-amd64: ${{ matrix.arch == 'amd64' && steps.build.outputs.digest || '' }}
+      digest-arm64: ${{ matrix.arch == 'arm64' && steps.build.outputs.digest || '' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Determine whether to bake sccache
+        id: flags
+        run: |
+          # Bake sccache on nightly cron or when explicitly requested via workflow_dispatch
+          if [ "${{ github.event_name }}" = "schedule" ] || \
+             [ "${{ inputs.bake_sccache }}" = "true" ]; then
+            echo "bake=true" >> $GITHUB_OUTPUT
+          else
+            echo "bake=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .github/docker/benchmark-runner
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          # Push by digest — the merge job creates the named tag
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true
+          build-args: |
+            BAKE_SCCACHE=${{ steps.flags.outputs.bake }}
+            SIRIUS_REF=dev
+          # Layer cache scoped per arch so amd64 and arm64 don't collide
+          cache-from: type=gha,scope=benchmark-runner-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=benchmark-runner-${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge per-arch digests into a single multi-arch manifest under :latest
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          # Build the list of per-arch image references from the digest files
+          IMAGES=$(printf "${{ env.IMAGE }}@sha256:%s " *)
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE }}:latest \
+            --tag ${{ env.IMAGE }}:${{ github.sha }} \
+            $IMAGES
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:latest

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -18,10 +18,15 @@
 name: Build benchmark runner image
 
 # Triggers:
+#   - PRs touching the Dockerfile or this workflow: validate the build before merge
 #   - Dockerfile changes merged to dev: rebuild toolchain layer only (no cache bake)
 #   - Nightly cron: rebuild with fresh sccache from latest dev
 #   - Manual dispatch: supports on-demand rebuilds and cache bake override
 on:
+  pull_request:
+    paths:
+      - '.github/docker/benchmark-runner/**'
+      - '.github/workflows/benchmark-runner-image.yml'
   push:
     branches: [dev]
     paths: ['.github/docker/benchmark-runner/**']
@@ -142,10 +147,22 @@ jobs:
         run: |
           # Build the list of per-arch image references from the digest files
           IMAGES=$(printf "${{ env.IMAGE }}@sha256:%s " *)
-          docker buildx imagetools create \
-            --tag ${{ env.IMAGE }}:latest \
-            --tag ${{ env.IMAGE }}:${{ github.sha }} \
-            $IMAGES
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PRs push to :pr-latest (single overwritten tag) for testing; :latest is not touched
+            docker buildx imagetools create \
+              --tag ${{ env.IMAGE }}:pr-latest \
+              $IMAGES
+          else
+            docker buildx imagetools create \
+              --tag ${{ env.IMAGE }}:latest \
+              --tag ${{ env.IMAGE }}:${{ github.sha }} \
+              $IMAGES
+          fi
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.IMAGE }}:latest
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            docker buildx imagetools inspect ${{ env.IMAGE }}:pr-latest
+          else
+            docker buildx imagetools inspect ${{ env.IMAGE }}:latest
+          fi

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -100,9 +100,10 @@ jobs:
           build-args: |
             BAKE_SCCACHE=${{ steps.flags.outputs.bake }}
             SIRIUS_REF=dev
-          # Layer cache scoped per arch so amd64 and arm64 don't collide
-          cache-from: type=gha,scope=benchmark-runner-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=benchmark-runner-${{ matrix.arch }}
+          # Layer cache stored in the registry (not GHA cache) to avoid consuming
+          # the 10 GB GHA cache limit. Scoped per arch so amd64 and arm64 don't collide.
+          cache-from: type=registry,ref=${{ env.IMAGE }}:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.IMAGE }}:cache-${{ matrix.arch }},mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/benchmark-runner-image.yml
+++ b/.github/workflows/benchmark-runner-image.yml
@@ -15,7 +15,7 @@
 #   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
 #   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
 #      project-level allowlist above before merging
-name: Build benchmark runner image
+name: Benchmark Docker
 
 # Triggers:
 #   - PRs touching the Dockerfile or this workflow: validate the build before merge


### PR DESCRIPTION
## Summary

- Adds `.github/docker/benchmark-runner/Dockerfile` — a multi-arch benchmark runner image based on `nvidia/cuda:13.0.2-devel-ubuntu22.04` with pixi v0.65.0 pre-installed
  - Optional `BAKE_SCCACHE=true` build-arg pre-warms the sccache from a full dev build at image creation time, so subsequent benchmark runs only compile the delta
- Adds `.github/workflows/benchmark-runner-image.yml` — builds and publishes the image to `ghcr.io/sirius-db/sirius/benchmark-runner` as a multi-arch manifest (amd64 + arm64)
  - Triggers: PRs touching the Dockerfile or workflow (for validation), Dockerfile changes on `dev`, nightly cron (with sccache bake), manual `workflow_dispatch`
  - Native builds per arch (no QEMU), merge job creates the manifest
  - PRs push to `:pr-latest` (single overwritten tag) so changes can be tested before merge without touching `:latest`
  - Pushes to `:latest` and `:<sha>` on merge to `dev`
  - BuildKit layer cache stored in the registry (`type=registry`) to avoid consuming the 10 GB GHA cache limit
- Engineers can reproduce benchmark runs locally using `act`:
  ```
  act --container-options "--gpus all" \
      -P self-hosted=ghcr.io/sirius-db/sirius/benchmark-runner:latest
  ```

## Test plan
- [x] Add actions to allowlist to enable testing
- [x] Move PR to upstream branch so secrets are available to CI
- [x] Verify the PR build completes and `:pr-latest` is published
- [x] Pull `:pr-latest` on zeno-04 and verify the image works as expected (`nvidia-smi` passes)
- [x] Verify the multi-arch manifest covers both amd64 and arm64
- [ ] After merge, confirm nightly cron builds and publishes `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)