### PR TITLE
Allow larger build side for probing hashes, tuned scan scheduling at query startup

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -103,6 +103,8 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
         operator_id, std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline));
     }
   }
+  _num_scans_in_plan =
+    _scan_operator_global_state_map.size() + _parquet_scan_operator_global_state_map.size();
 }
 
 void task_creator::drain_pending_tasks()
@@ -286,8 +288,6 @@ void task_creator::manager_loop()
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
           auto* parquet_scan             = &node->Cast<op::sirius_physical_parquet_scan>();
-          size_t const num_scans_in_plan =
-            _scan_operator_global_state_map.size() + _parquet_scan_operator_global_state_map.size();
           while (true) {
             pipeline->mark_task_created();
             auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
@@ -322,7 +322,7 @@ void task_creator::manager_loop()
 
             // If there is only a single scan in the plan, continue creating scan tasks to create
             // I/O parallelism. Otherwise, let the plan drive the creation of more tasks.
-            if (num_scans_in_plan >= 2) { break; }
+            if (_num_scans_in_plan >= 2) { break; }
           }
         } else {
           // need to exhaust input batches until all ports are empty

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -286,6 +286,8 @@ void task_creator::manager_loop()
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
           auto* parquet_scan             = &node->Cast<op::sirius_physical_parquet_scan>();
+          size_t const num_scans_in_plan =
+            _scan_operator_global_state_map.size() + _parquet_scan_operator_global_state_map.size();
           while (true) {
             pipeline->mark_task_created();
             auto const partition_idx = parquet_task_global_state->get_next_rg_partition_idx();
@@ -317,6 +319,10 @@ void task_creator::manager_loop()
                                                             std::move(parquet_task_local_state),
                                                             parquet_task_global_state);
             _pipeline_executor->schedule(std::move(parquet_task));
+
+            // If there is only a single scan in the plan, continue creating scan tasks to create
+            // I/O parallelism. Otherwise, let the plan drive the creation of more tasks.
+            if (num_scans_in_plan >= 2) { break; }
           }
         } else {
           // need to exhaust input batches until all ports are empty

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -184,6 +184,7 @@ class task_creator {
   sirius::pipeline::pipeline_executor* _pipeline_executor{nullptr};
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
+  size_t _num_scans_in_plan{0};
 
   // Queue for creating tasks based on operators. The operator is the starting point to start
   // looking which task should be created, not necessarily the operator for whose pipeline the task

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -60,6 +60,10 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   //! Get the parent operator (e.g., HASH_JOIN for build concat)
   sirius_physical_operator* get_parent_op() const { return _parent_op; }
 
+  //! Used when PARTITION + `update_join_exec_mode` selects BUILD_PROBE: merge all build batches
+  //! before the join so the hash join sees a single build batch.
+  void set_concat_all(bool concat_all);
+
  private:
   sirius_physical_operator* _parent_op;
   bool _is_build;

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -130,6 +130,9 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   /// @param build_side_bytes
   void update_join_exec_mode(int num_partitions, uint64_t build_side_bytes);
 
+  /// @brief True when this join runs in build-then-probe mode (see `update_join_exec_mode`).
+  [[nodiscard]] bool is_build_probe_mode();
+
   std::unique_ptr<operator_data> get_next_task_input_data_for_build_probe();
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 

--- a/src/include/pipeline/pipeline_executor.hpp
+++ b/src/include/pipeline/pipeline_executor.hpp
@@ -177,8 +177,6 @@ class pipeline_executor {
  private:
   void management_eventloop();
 
-  void schedule_next_scan_tasks();
-
   std::mutex _priority_scans_mutex;
   std::queue<op::sirius_physical_operator*> _priority_scans;
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -59,17 +59,8 @@ struct operator_params {
   uint64_t concat_batch_bytes = config::DEFAULT_CONCAT_BATCH_BYTES;
 
   /// Maximum build-side bytes for switching to BUILD_PROBE join mode.
-  /// This value must be smaller than concat_batch_bytes
+  /// May be larger than concat_batch_bytes; build-side batches will be concatenated if needed.
   uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
-
-  /// Ensures max_build_hash_table_bytes < concat_batch_bytes.
-  /// If violated, clamps max_build_hash_table_bytes to concat_batch_bytes - 1.
-  void validate_and_fix()
-  {
-    if (concat_batch_bytes > 0 && max_build_hash_table_bytes >= concat_batch_bytes) {
-      max_build_hash_table_bytes = concat_batch_bytes - 1;
-    }
-  }
 };
 
 struct sirius_config {

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -232,5 +232,11 @@ bool sirius_physical_concat::is_sink() const { return true; }
 
 bool sirius_physical_concat::is_build_concat() { return _is_build; }
 
+void sirius_physical_concat::set_concat_all(bool concat_all)
+{
+  std::lock_guard<std::mutex> lg(lock);
+  _concat_all = concat_all;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -16,6 +16,7 @@
 
 #include "op/sirius_physical_hash_join.hpp"
 
+#include "cudf/concatenate.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
@@ -453,20 +454,27 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
       std::to_string(this->get_operator_id()));
   }
   if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULING) {
-    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) != 1 ||
+    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) < 1 ||
         probe_port->repo->num_partitions() != 1) {
       throw std::runtime_error(
         "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected exactly 1 "
-        "partition and 1 batch in default (build) port in operator " +
+        "partition and at least 1 batch in build port in operator " +
         std::to_string(this->get_operator_id()));
     }
-    // When the hash table is not build yet, we will send both the build and probe side. To build
-    // the hash table and perform the first join.
+    // When the hash table is not built yet, send the probe batch and all available build batches.
+    // Multiple build batches will be concatenated in execute() before building the hash table.
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     auto probe_batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
-    auto build_batch = build_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
     input_batch.push_back(std::move(probe_batch));
-    input_batch.push_back(std::move(build_batch));
+    while (build_port->repo->size(0) > 0) {
+      auto build_batch =
+        build_port->repo->pop_data_batch(::cucascade::batch_state::task_created, 0);
+      if (build_batch) {
+        input_batch.push_back(std::move(build_batch));
+      } else {
+        break;
+      }
+    }
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULED;
     return std::make_unique<operator_data>(input_batch);
 
@@ -772,7 +780,22 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
-      auto build_keys_result      = prepare_join_keys(input_batches[1],
+      std::shared_ptr<cucascade::data_batch> build_batch;
+      if (input_batches.size() == 2) {
+        build_batch = input_batches[1];
+      } else {
+        // Multiple build batches: concatenate before building the hash table.
+        std::vector<cudf::table_view> build_views;
+        build_views.reserve(input_batches.size() - 1);
+        for (size_t i = 1; i < input_batches.size(); ++i) {
+          build_views.push_back(get_cudf_table_view(*input_batches[i]));
+        }
+        auto& memory_space = *input_batches[1]->get_memory_space();
+        auto concat_table =
+          cudf::concatenate(build_views, stream, memory_space.get_default_allocator());
+        build_batch = make_data_batch(std::move(concat_table), memory_space);
+      }
+      auto build_keys_result      = prepare_join_keys(build_batch,
                                                  right_key_col_indices,
                                                  cast_necessary,
                                                  key_casts,
@@ -782,7 +805,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       {
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
-        _build_table              = input_batches[1];
+        _build_table              = std::move(build_batch);
         _hash_table =
           std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -16,7 +16,6 @@
 
 #include "op/sirius_physical_hash_join.hpp"
 
-#include "cudf/concatenate.hpp"
 #include "cudf/copying.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
@@ -391,6 +390,12 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions, uint64
   }
 }
 
+bool sirius_physical_hash_join::is_build_probe_mode()
+{
+  std::lock_guard<std::mutex> lg(op_state_mutex);
+  return _join_mode == HASH_JOIN_MODE::BUILD_PROBE;
+}
+
 std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint()
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
@@ -454,27 +459,20 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
       std::to_string(this->get_operator_id()));
   }
   if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULING) {
-    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) < 1 ||
+    if (build_port->repo->num_partitions() != 1 || build_port->repo->size(0) != 1 ||
         probe_port->repo->num_partitions() != 1) {
       throw std::runtime_error(
         "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: expected exactly 1 "
-        "partition and at least 1 batch in build port in operator " +
+        "partition and 1 batch in default (build) port in operator " +
         std::to_string(this->get_operator_id()));
     }
-    // When the hash table is not built yet, send the probe batch and all available build batches.
-    // Multiple build batches will be concatenated in execute() before building the hash table.
+    // When the hash table is not build yet, we will send both the build and probe side. To build
+    // the hash table and perform the first join.
     std::vector<std::shared_ptr<cucascade::data_batch>> input_batch;
     auto probe_batch = probe_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
+    auto build_batch = build_port->repo->pop_data_batch(::cucascade::batch_state::task_created);
     input_batch.push_back(std::move(probe_batch));
-    while (build_port->repo->size(0) > 0) {
-      auto build_batch =
-        build_port->repo->pop_data_batch(::cucascade::batch_state::task_created, 0);
-      if (build_batch) {
-        input_batch.push_back(std::move(build_batch));
-      } else {
-        break;
-      }
-    }
+    input_batch.push_back(std::move(build_batch));
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULED;
     return std::make_unique<operator_data>(input_batch);
 
@@ -780,21 +778,14 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::SCHEDULED) {
-      std::shared_ptr<cucascade::data_batch> build_batch;
-      if (input_batches.size() == 2) {
-        build_batch = input_batches[1];
-      } else {
-        // Multiple build batches: concatenate before building the hash table.
-        std::vector<cudf::table_view> build_views;
-        build_views.reserve(input_batches.size() - 1);
-        for (size_t i = 1; i < input_batches.size(); ++i) {
-          build_views.push_back(get_cudf_table_view(*input_batches[i]));
-        }
-        auto& memory_space = *input_batches[1]->get_memory_space();
-        auto concat_table =
-          cudf::concatenate(build_views, stream, memory_space.get_default_allocator());
-        build_batch = make_data_batch(std::move(concat_table), memory_space);
+      if (input_batches.size() != 2) {
+        throw std::runtime_error(
+          "In sirius_physical_hash_join::execute: BUILD_PROBE SCHEDULED expects probe + build "
+          "batch, got " +
+          std::to_string(input_batches.size()) + " batches in operator " +
+          std::to_string(this->get_operator_id()));
       }
+      auto build_batch            = input_batches[1];
       auto build_keys_result      = prepare_join_keys(build_batch,
                                                  right_key_col_indices,
                                                  cast_necessary,

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -279,8 +279,21 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
     std::scoped_lock guard(lock, sibling.lock);
     if (!_num_partitions.has_value()) {
       auto [num_parts, total_bytes] = determine_num_partitions();
-      _hash_join_op->Cast<sirius_physical_hash_join>().update_join_exec_mode(num_parts,
-                                                                             total_bytes);
+      auto& hash_join               = _hash_join_op->Cast<sirius_physical_hash_join>();
+      hash_join.update_join_exec_mode(num_parts, total_bytes);
+      if (_hash_join_op->type == SiriusPhysicalOperatorType::HASH_JOIN &&
+          hash_join.is_build_probe_mode()) {
+        // Either sibling may run this block first; configure the build-side CONCAT only.
+        auto enable_build_concat_all = [](sirius_physical_operator& part_op) {
+          for (auto& [next_op, port_id] : part_op.get_next_port_after_sink()) {
+            if (next_op->type != SiriusPhysicalOperatorType::CONCAT) { continue; }
+            auto& concat = next_op->Cast<sirius_physical_concat>();
+            if (concat.is_build_concat()) { concat.set_concat_all(true); }
+          }
+        };
+        enable_build_concat_all(*this);
+        enable_build_concat_all(sibling);
+      }
       _num_partitions         = num_parts;
       sibling._num_partitions = num_parts;
       SIRIUS_LOG_DEBUG(

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -437,19 +437,8 @@ std::size_t gpu_pipeline_task::get_input_size() const
 
 std::size_t gpu_pipeline_task::get_estimated_reservation_size() const
 {
-  std::size_t base = get_input_size();
-  auto* pipeline   = _global_state != nullptr
-                       ? _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()
-                       : nullptr;
-  if (pipeline != nullptr) {
-    for (auto& op_ref : pipeline->get_operators()) {
-      if (op_ref.get().type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
-        // Hash join keeps build side in memory; reserve 1.5x input size.
-        return (base * 3) / 2;
-      }
-    }
-  }
-  return base;
+  // WSM TODO: this is a placeholder for the actual reservation size
+  return get_input_size() * 1;
 }
 
 std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consumers()

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -437,8 +437,19 @@ std::size_t gpu_pipeline_task::get_input_size() const
 
 std::size_t gpu_pipeline_task::get_estimated_reservation_size() const
 {
-  // WSM TODO: this is a placeholder for the actual reservation size
-  return get_input_size() * 1;
+  std::size_t base = get_input_size();
+  auto* pipeline   = _global_state != nullptr
+                       ? _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()
+                       : nullptr;
+  if (pipeline != nullptr) {
+    for (auto& op_ref : pipeline->get_operators()) {
+      if (op_ref.get().type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
+        // Hash join keeps build side in memory; reserve 1.5x input size.
+        return (base * 3) / 2;
+      }
+    }
+  }
+  return base;
 }
 
 std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consumers()

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -161,7 +161,12 @@ std::future<void> pipeline_executor::start_query()
     gpu_exec->set_completion_handler(_completion_handler.get());
   }
 
-  schedule_next_scan_tasks();
+  constexpr int k_initial_scans = 2;
+  for (int i = 0; i < k_initial_scans && !_priority_scans.empty(); ++i) {
+    auto* scan_op = _priority_scans.front();
+    _task_creator->schedule(scan_op);
+    _priority_scans.pop();
+  }
 
   return future;
 }
@@ -213,21 +218,7 @@ void pipeline_executor::management_eventloop()
         break;
       }
       _gpu_executors.at(request->device_id)->schedule(std::move(task));
-    } else {
-      // TODO(amin): think about eager scheduling again when state of next tasks are stored in the
-      // operator
-      // schedule_next_scan_tasks();
     }
-  }
-}
-
-void pipeline_executor::schedule_next_scan_tasks()
-{
-  std::lock_guard<std::mutex> lock(_priority_scans_mutex);
-  if (!_priority_scans.empty()) {
-    auto* scan_op = _priority_scans.front();
-    _task_creator->schedule(scan_op);
-    _priority_scans.pop();
   }
 }
 

--- a/src/pipeline/pipeline_executor.cpp
+++ b/src/pipeline/pipeline_executor.cpp
@@ -162,6 +162,7 @@ std::future<void> pipeline_executor::start_query()
   }
 
   constexpr int k_initial_scans = 2;
+  std::lock_guard<std::mutex> lock(_priority_scans_mutex);
   for (int i = 0; i < k_initial_scans && !_priority_scans.empty(); ++i) {
     auto* scan_op = _priority_scans.front();
     _task_creator->schedule(scan_op);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -283,8 +283,6 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       "Failed to load Sirius configuration from file: " + config_path.string() + " " + e.what());
   }
 
-  _operator_params.validate_and_fix();
-
   // std::cerr << "Loaded Sirius configuration from file: " << config_path << std::endl;
 
   std::copy(gpu_memory_space_configs.begin(),

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -815,7 +815,6 @@ static void SetConcatBatchBytes(ClientContext& context, SetScope scope, Value& p
   auto* params = get_operator_params(context);
   if (!params) { return; }
   params->concat_batch_bytes = UBigIntValue::Get(parameter);
-  params->validate_and_fix();
   SIRIUS_LOG_DEBUG("Updated config CONCAT_BATCH_BYTES to {}", params->concat_batch_bytes);
 }
 
@@ -845,7 +844,6 @@ static void SetMaxBuildHashTableBytes(ClientContext& context, SetScope scope, Va
   auto* params = get_operator_params(context);
   if (!params) { return; }
   params->max_build_hash_table_bytes = UBigIntValue::Get(parameter);
-  params->validate_and_fix();
   SIRIUS_LOG_DEBUG("Updated config MAX_BUILD_HASH_TABLE_BYTES to {}",
                    params->max_build_hash_table_bytes);
 }


### PR DESCRIPTION
This PR improves TPC-H query sum from 21.79s to 19.41s because of 2 changes:
- Decoupling the `max_build_hash_table_bytes` and `concat_batch_bytes` config parameters, so that `max_build_hash_table_bytes` is now allowed to be larger. When that happens, the partition operator will configure the following concat operator to concatenate all batches. This will allow the much more efficient probing join mode to be used more often, but at the same time other joins (standard & mixed) will still use the batch size that is configured with the `concat_batch_bytes`. Currently, the user would need to inflate the `concat_batch_bytes` setting to allow probing to be used for larger joins, but it will have negative impact in other areas. This change improves query sum to approx 20s.
- Small changes to scan scheduling: at query startup, we schedule up to 2 scans. Then in the task creator, we no longer always keep creating tasks for a scan until it is depleted. We only do that if there is only a single scan in the plan (to provide some more I/O parallelis). For the rest, we let the plan topology drive task creation (via the next_task_hint mechanism). This improves performance with an addition 0.6s.