### PR TITLE
Add UNION ALL support for gpu_processing (legacy Sirius)

### DIFF
--- a/src/include/legacy/gpu_physical_plan_generator.hpp
+++ b/src/include/legacy/gpu_physical_plan_generator.hpp
@@ -94,7 +94,7 @@ class GPUPhysicalPlanGenerator {
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalInsert &op);
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalCopyToFile &op);
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalExplain &op);
-  // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalSetOperation &op);
+  unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalSetOperation& op);
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalUpdate &op);
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalPrepare &expr);
   // unique_ptr<GPUPhysicalOperator> CreatePlan(LogicalWindow &expr);

--- a/src/include/legacy/gpu_query_result.hpp
+++ b/src/include/legacy/gpu_query_result.hpp
@@ -25,7 +25,7 @@ namespace duckdb {
 
 class GPUResultCollection {
  public:
-  GPUResultCollection() : read_idx(0), write_idx(0), num_rows(0), data_chunks(nullptr) {}
+  GPUResultCollection() : read_idx(0), num_rows(0) {}
 
   void SetCapacity(size_t capacity);
   void AddChunk(DataChunk& chunk);
@@ -33,14 +33,10 @@ class GPUResultCollection {
 
   size_t size() { return num_rows; }
 
-  ~GPUResultCollection()
-  {
-    if (data_chunks != nullptr) { delete[] data_chunks; }
-  }
+  ~GPUResultCollection() = default;
 
-  DataChunk* data_chunks;
+  vector<unique_ptr<DataChunk>> data_chunks;
   size_t num_rows;
-  size_t write_idx;
   size_t read_idx;
 };
 

--- a/src/include/legacy/operator/gpu_physical_union.hpp
+++ b/src/include/legacy/operator/gpu_physical_union.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "gpu_physical_operator.hpp"
+
+namespace duckdb {
+
+class GPUPhysicalUnion : public GPUPhysicalOperator {
+ public:
+  static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UNION;
+
+ public:
+  GPUPhysicalUnion(vector<LogicalType> types,
+                   unique_ptr<GPUPhysicalOperator> top,
+                   unique_ptr<GPUPhysicalOperator> bottom,
+                   idx_t estimated_cardinality);
+  ~GPUPhysicalUnion() override;
+
+ public:
+  // Pipeline construction
+  void BuildPipelines(GPUPipeline& current, GPUMetaPipeline& meta_pipeline) override;
+
+  vector<const_reference<GPUPhysicalOperator>> GetSources() const override;
+};
+
+}  // namespace duckdb

--- a/src/legacy/CMakeLists.txt
+++ b/src/legacy/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SIRIUS_LEGACY_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/operator/gpu_physical_substring.cpp
     ${CMAKE_CURRENT_LIST_DIR}/operator/gpu_physical_table_scan.cpp
     ${CMAKE_CURRENT_LIST_DIR}/operator/gpu_physical_top_n.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/operator/gpu_physical_union.cpp
     ${CMAKE_CURRENT_LIST_DIR}/operator/gpu_physical_ungrouped_aggregate.cpp
     PARENT_SCOPE)
 
@@ -61,6 +62,7 @@ if(ENABLE_LEGACY_SIRIUS)
       ${CMAKE_CURRENT_LIST_DIR}/plan/gpu_plan_order.cpp
       ${CMAKE_CURRENT_LIST_DIR}/plan/gpu_plan_projection.cpp
       ${CMAKE_CURRENT_LIST_DIR}/plan/gpu_plan_recursive_cte.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/plan/gpu_plan_set_operation.cpp
       ${CMAKE_CURRENT_LIST_DIR}/plan/gpu_plan_top_n.cpp
       PARENT_SCOPE)
   set(SIRIUS_LEGACY_COMPILE_DEFINITIONS SIRIUS_ENABLE_LEGACY PARENT_SCOPE)

--- a/src/legacy/gpu_executor.cpp
+++ b/src/legacy/gpu_executor.cpp
@@ -258,12 +258,21 @@ void GPUExecutor::InitializeInternal(GPUPhysicalOperator& plan)
             break;
           }
         }
-        // check if all dependencies are scheduled
-        for (int dep = 0; dep < base_pipeline->dependencies.size(); dep++) {
-          if (find(scheduled.begin(), scheduled.end(), base_pipeline->dependencies[dep]) ==
-              scheduled.end()) {
-            should_schedule = false;
-            break;
+        // check if all dependencies are scheduled (check ALL pipelines in this meta-pipeline,
+        // not just the base pipeline, because dependencies may be on non-base pipelines e.g.
+        // when a hash join build side dependency is on the probe pipeline, not the first pipeline)
+        {
+          vector<shared_ptr<GPUPipeline>> all_pipelines_in_meta;
+          to_schedule[to_schedule.size() - 1 - meta]->GetPipelines(all_pipelines_in_meta, false);
+          for (auto& mp_pipeline : all_pipelines_in_meta) {
+            for (int dep = 0; dep < mp_pipeline->dependencies.size(); dep++) {
+              if (find(scheduled.begin(), scheduled.end(), mp_pipeline->dependencies[dep]) ==
+                  scheduled.end()) {
+                should_schedule = false;
+                break;
+              }
+            }
+            if (!should_schedule) break;
           }
         }
       }

--- a/src/legacy/gpu_physical_plan_generator.cpp
+++ b/src/legacy/gpu_physical_plan_generator.cpp
@@ -179,10 +179,11 @@ unique_ptr<GPUPhysicalOperator> GPUPhysicalPlanGenerator::CreatePlan(LogicalOper
       // plan = CreatePlan(op.Cast<LogicalPositionalJoin>());
       break;
     case LogicalOperatorType::LOGICAL_UNION:
+      plan = CreatePlan(op.Cast<LogicalSetOperation>());
+      break;
     case LogicalOperatorType::LOGICAL_EXCEPT:
     case LogicalOperatorType::LOGICAL_INTERSECT:
-      throw NotImplementedException("Set operation not supported");
-      // plan = CreatePlan(op.Cast<LogicalSetOperation>());
+      throw NotImplementedException("EXCEPT/INTERSECT not supported on GPU");
       break;
     case LogicalOperatorType::LOGICAL_INSERT:
       throw NotImplementedException("Insert not supported");

--- a/src/legacy/gpu_query_result.cpp
+++ b/src/legacy/gpu_query_result.cpp
@@ -21,22 +21,26 @@
 
 namespace duckdb {
 
-void GPUResultCollection::SetCapacity(size_t capacity) { data_chunks = new DataChunk[capacity]; }
+void GPUResultCollection::SetCapacity(size_t capacity)
+{
+  data_chunks.reserve(data_chunks.size() + capacity);
+}
 
 void GPUResultCollection::AddChunk(DataChunk& chunk)
 {
   num_rows += chunk.size();
-  data_chunks[write_idx].Move(chunk);
-  write_idx += 1;
+  auto new_chunk = make_uniq<DataChunk>();
+  new_chunk->Move(chunk);
+  data_chunks.push_back(std::move(new_chunk));
 }
 
 unique_ptr<DataChunk> GPUResultCollection::GetNext()
 {
   // We have returned all of the values then return the empty result
-  if (read_idx >= write_idx) { return nullptr; }
+  if (read_idx >= data_chunks.size()) { return nullptr; }
 
   // Create a result that references the value in the buffer
-  DataChunk& return_chunk            = data_chunks[read_idx];
+  DataChunk& return_chunk            = *data_chunks[read_idx];
   unique_ptr<DataChunk> result_value = make_uniq<DataChunk>();
 
   result_value->InitializeEmpty(return_chunk.GetTypes());

--- a/src/legacy/operator/gpu_physical_union.cpp
+++ b/src/legacy/operator/gpu_physical_union.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operator/gpu_physical_union.hpp"
+
+#include "gpu_meta_pipeline.hpp"
+#include "gpu_pipeline.hpp"
+
+namespace duckdb {
+
+GPUPhysicalUnion::GPUPhysicalUnion(vector<LogicalType> types,
+                                   unique_ptr<GPUPhysicalOperator> top,
+                                   unique_ptr<GPUPhysicalOperator> bottom,
+                                   idx_t estimated_cardinality)
+  : GPUPhysicalOperator(PhysicalOperatorType::UNION, std::move(types), estimated_cardinality)
+{
+  children.push_back(std::move(top));
+  children.push_back(std::move(bottom));
+}
+
+GPUPhysicalUnion::~GPUPhysicalUnion() {}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void GPUPhysicalUnion::BuildPipelines(GPUPipeline& current, GPUMetaPipeline& meta_pipeline)
+{
+  op_state.reset();
+  sink_state.reset();
+
+  // Check if order matters based on sink properties
+  auto sink          = meta_pipeline.GetSink();
+  bool order_matters = false;
+  if (current.IsOrderDependent()) { order_matters = true; }
+  if (sink) {
+    if (sink->SinkOrderDependent()) { order_matters = true; }
+    if (!sink->ParallelSink()) { order_matters = true; }
+  }
+
+  // Create a union pipeline that shares the same sink as 'current'
+  auto& union_pipeline = meta_pipeline.CreateUnionPipeline(current, order_matters);
+
+  // Build the first child into the current pipeline
+  children[0]->BuildPipelines(current, meta_pipeline);
+
+  if (order_matters) {
+    // Union pipeline comes after all pipelines created by building current
+    meta_pipeline.AddDependenciesFrom(union_pipeline, union_pipeline, false);
+  }
+
+  // Build the second child into the union pipeline
+  children[1]->BuildPipelines(union_pipeline, meta_pipeline);
+
+  // Assign proper batch index to the union pipeline
+  meta_pipeline.AssignNextBatchIndex(union_pipeline);
+}
+
+vector<const_reference<GPUPhysicalOperator>> GPUPhysicalUnion::GetSources() const
+{
+  vector<const_reference<GPUPhysicalOperator>> result;
+  for (auto& child : children) {
+    auto child_sources = child->GetSources();
+    result.insert(result.end(), child_sources.begin(), child_sources.end());
+  }
+  return result;
+}
+
+}  // namespace duckdb

--- a/src/legacy/plan/gpu_plan_set_operation.cpp
+++ b/src/legacy/plan/gpu_plan_set_operation.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+#include "gpu_physical_plan_generator.hpp"
+#include "operator/gpu_physical_union.hpp"
+
+namespace duckdb {
+
+unique_ptr<GPUPhysicalOperator> GPUPhysicalPlanGenerator::CreatePlan(LogicalSetOperation& op)
+{
+  D_ASSERT(op.children.size() == 2);
+
+  auto left  = CreatePlan(*op.children[0]);
+  auto right = CreatePlan(*op.children[1]);
+
+  if (left->types != right->types) {
+    throw InvalidInputException("Type mismatch for SET OPERATION");
+  }
+
+  switch (op.type) {
+    case LogicalOperatorType::LOGICAL_UNION: {
+      auto result = make_uniq<GPUPhysicalUnion>(
+        op.types, std::move(left), std::move(right), op.estimated_cardinality);
+      return result;
+    }
+    default:
+      throw NotImplementedException("Only UNION ALL is supported on GPU, not EXCEPT/INTERSECT");
+  }
+}
+
+}  // namespace duckdb


### PR DESCRIPTION
gpu_processing queries with UNION ALL fall back to CPU

Implementation:
  - Added GPUPhysicalUnion operator (src/legacy/operator/gpu_physical_union.cpp) following the same pipeline construction pattern as DuckDB's PhysicalUnion — creates a union pipeline that shares the same sink as the current pipeline, builds each child into its respective pipeline, and respects order-dependent sinks.
  - Added gpu_plan_set_operation.cpp to map LogicalSetOperation → GPUPhysicalUnion in the plan generator. Only UNION ALL is supported; EXCEPT/INTERSECT throw NotImplementedException for now but you can try to build them
  - Wired up CreatePlan(LogicalSetOperation&) in GPUPhysicalPlanGenerator to route LOGICAL_UNION through the new operator.
  - Refactored GPUResultCollection from raw DataChunk* array with manual new[]/delete[] to vector<unique_ptr<DataChunk>>, fixing a potential issue when multiple pipelines append results concurrently.
  - Fixed pipeline dependency scheduling in gpu_executor.cpp to check dependencies across all pipelines in a meta-pipeline, not just the base pipeline — without this, UNION ALL pipelines could be scheduled before their build-side dependencies completed.