### PR TITLE
Refactor next port info

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -232,27 +232,31 @@ void task_creator::manager_loop()
           auto& delim_join    = pipeline->get_sink()->Cast<op::sirius_physical_right_delim_join>();
           auto partition_join = delim_join.partition_join;
           auto distinct_op    = delim_join.distinct.get();
-          for (auto& [next_op, port_id] : partition_join->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
+          for (auto& next_port : partition_join->get_next_port_after_sink()) {
+            destination_data_repositories.push_back(
+              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
           }
-          for (auto& [next_op, port_id] : distinct_op->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
+          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
+            destination_data_repositories.push_back(
+              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
           }
         } else if (pipeline->get_sink()->type ==
                    ::sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
           auto& delim_join      = pipeline->get_sink()->Cast<op::sirius_physical_left_delim_join>();
           auto distinct_op      = delim_join.distinct.get();
           auto column_data_scan = delim_join.column_data_scan;
-          for (auto& [next_op, port_id] : column_data_scan->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
+          for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
+            destination_data_repositories.push_back(
+              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
           }
-          for (auto& [next_op, port_id] : distinct_op->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
+          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
+            destination_data_repositories.push_back(
+              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
           }
         } else {
-          auto next_port_after_sink = pipeline->get_sink()->get_next_port_after_sink();
-          for (auto& [next_op, port_id] : next_port_after_sink) {
-            destination_data_repositories.push_back(next_op->get_port(port_id)->repo);
+          for (auto& next_port : pipeline->get_sink()->get_next_port_after_sink()) {
+            destination_data_repositories.push_back(
+              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
           }
         }
         // scheduling scan task

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -133,8 +133,8 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
   {
     std::vector<sirius_physical_operator*> output_consumers;
     auto ports = _op.get_next_port_after_sink();
-    for (auto& [child, port_id] : ports) {
-      output_consumers.push_back(child);
+    for (auto& next_port : ports) {
+      output_consumers.push_back(next_port.next_operator);
     }
     return output_consumers;
   }

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -438,8 +438,8 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
     auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
     std::vector<sirius_physical_operator*> output_consumers;
     auto ports = g_state.get_operator().get_next_port_after_sink();
-    for (auto& [child, port_id] : ports) {
-      output_consumers.push_back(child);
+    for (auto& next_port : ports) {
+      output_consumers.push_back(next_port.next_operator);
     }
     return output_consumers;
   }

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -263,8 +263,12 @@ class sirius_physical_operator {
     duckdb::shared_ptr<pipeline::sirius_pipeline> dest_pipeline;
   };
 
+  /// Describes a downstream operator and the port through which data is pushed after this
+  /// operator acts as a sink.
   struct next_port_info {
+    //! The downstream operator that receives data batches from this sink
     sirius_physical_operator* next_operator;
+    //! The port name on the downstream operator to push data into
     std::string_view next_operator_port_name;
   };
 
@@ -281,8 +285,7 @@ class sirius_physical_operator {
   //! Returns true if any FULL-barrier port has src_pipeline == src
   bool has_full_barrier_from(const pipeline::sirius_pipeline* src) const;
   //! Add a next port after sink
-  void add_next_port_after_sink(
-    std::pair<sirius_physical_operator*, std::string_view> port_locator);
+  void add_next_port_after_sink(next_port_info port_info);
   //! Get the next ports after sink
   std::vector<sirius_physical_operator::next_port_info>& get_next_port_after_sink();
 

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -263,8 +263,7 @@ class sirius_physical_operator {
     duckdb::shared_ptr<pipeline::sirius_pipeline> dest_pipeline;
   };
 
-  /// Describes a downstream operator and the port through which data is pushed after this
-  /// operator acts as a sink.
+  /// Describes a downstream operator's port to which data is pushed
   struct next_port_info {
     //! The downstream operator that receives data batches from this sink
     sirius_physical_operator* next_operator;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -263,6 +263,11 @@ class sirius_physical_operator {
     duckdb::shared_ptr<pipeline::sirius_pipeline> dest_pipeline;
   };
 
+  struct next_port_info {
+    sirius_physical_operator* next_operator;
+    std::string_view next_operator_port_name;
+  };
+
   // source pipeline pushed to repo of the ports
   void push_data_batch(std::string_view port_id, std::shared_ptr<::cucascade::data_batch> batch);
   //! Add a port to the operator
@@ -279,7 +284,7 @@ class sirius_physical_operator {
   void add_next_port_after_sink(
     std::pair<sirius_physical_operator*, std::string_view> port_locator);
   //! Get the next ports after sink
-  std::vector<std::pair<sirius_physical_operator*, std::string_view>>& get_next_port_after_sink();
+  std::vector<sirius_physical_operator::next_port_info>& get_next_port_after_sink();
 
   //! Get the next task hint
   virtual std::optional<task_creation_hint> get_next_task_hint();
@@ -326,7 +331,7 @@ class sirius_physical_operator {
   //! in `ports` are never invalidated by insertions.
   std::list<std::unique_ptr<port>> _ports_list;
   //! The next operators to be executed after this operator when it is used as a sink
-  std::vector<std::pair<sirius_physical_operator*, std::string_view>> next_port_after_sink;
+  std::vector<sirius_physical_operator::next_port_info> next_port_after_sink;
 };
 
 }  // namespace op

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -210,15 +210,16 @@ void sirius_physical_concat::sink(const operator_data& output_data, rmm::cuda_st
   auto partitioned_output_data = dynamic_cast<const partitioned_operator_data*>(&output_data);
   auto partition_idx           = partitioned_output_data->get_partition_idx();
   for (auto& batch : partitioned_output_data->get_data_batches()) {
-    for (auto& [next_op, port_id] : next_port_after_sink) {
+    for (auto& next_port_info : next_port_after_sink) {
       auto partition_consumer_op =
-        dynamic_cast<sirius_physical_partition_consumer_operator*>(next_op);
+        dynamic_cast<sirius_physical_partition_consumer_operator*>(next_port_info.next_operator);
       if (partition_consumer_op) {
-        partition_consumer_op->push_data_batch_partitioned(port_id, batch, partition_idx);
+        partition_consumer_op->push_data_batch_partitioned(
+          next_port_info.next_operator_port_name, batch, partition_idx);
       } else {
         throw std::runtime_error(
           "sirius_physical_concat::sink(): Next operator is not a partition consumer operator: " +
-          SiriusPhysicalOperatorToString(next_op->type));
+          SiriusPhysicalOperatorToString(next_port_info.next_operator->type));
       }
     }
   }

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -213,11 +213,9 @@ void sirius_physical_operator::push_data_batch(std::string_view port_id,
   if (p && p->repo) { p->repo->add_data_batch(std::move(batch)); }
 }
 
-void sirius_physical_operator::add_next_port_after_sink(
-  std::pair<sirius_physical_operator*, std::string_view> port_locator)
+void sirius_physical_operator::add_next_port_after_sink(next_port_info port_info)
 {
-  next_port_after_sink.push_back(
-    next_port_info{port_locator.first, port_locator.second});
+  next_port_after_sink.push_back(port_info);
 }
 
 std::vector<sirius_physical_operator::next_port_info>&

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -193,8 +193,8 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
 void sirius_physical_operator::sink(const operator_data& output_data, rmm::cuda_stream_view stream)
 {
   for (auto& batch : output_data.get_data_batches()) {
-    for (auto& [next_op, port_id] : next_port_after_sink) {
-      next_op->push_data_batch(port_id, batch);
+    for (auto& next_port_info : next_port_after_sink) {
+      next_port_info.next_operator->push_data_batch(next_port_info.next_operator_port_name, batch);
     }
   }
 }
@@ -216,10 +216,11 @@ void sirius_physical_operator::push_data_batch(std::string_view port_id,
 void sirius_physical_operator::add_next_port_after_sink(
   std::pair<sirius_physical_operator*, std::string_view> port_locator)
 {
-  next_port_after_sink.push_back(port_locator);
+  next_port_after_sink.push_back(
+    next_port_info{port_locator.first, port_locator.second});
 }
 
-std::vector<std::pair<sirius_physical_operator*, std::string_view>>&
+std::vector<sirius_physical_operator::next_port_info>&
 sirius_physical_operator::get_next_port_after_sink()
 {
   return next_port_after_sink;

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -200,13 +200,14 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
   (void)stream;  // sink does not use stream for push_data_batch_partitioned
   int partition_id = 0;
   for (auto& batch : input_batches) {
-    for (auto& [next_op, port_id] : next_port_after_sink) {
+    for (auto& next_port_info : next_port_after_sink) {
       // the next operator is a partition consumer operator, so we need to push the batch into the
       // specific partition
       auto partition_consumer_op =
-        dynamic_cast<sirius_physical_partition_consumer_operator*>(next_op);
+        dynamic_cast<sirius_physical_partition_consumer_operator*>(next_port_info.next_operator);
       if (partition_consumer_op) {
-        partition_consumer_op->push_data_batch_partitioned(port_id, batch, partition_id);
+        partition_consumer_op->push_data_batch_partitioned(
+          next_port_info.next_operator_port_name, batch, partition_id);
       } else {
         throw std::runtime_error("Next operator is not a partition consumer operator");
       }

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -286,9 +286,9 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
           hash_join.is_build_probe_mode()) {
         // Either sibling may run this block first; configure the build-side CONCAT only.
         auto enable_build_concat_all = [](sirius_physical_operator& part_op) {
-          for (auto& [next_op, port_id] : part_op.get_next_port_after_sink()) {
-            if (next_op->type != SiriusPhysicalOperatorType::CONCAT) { continue; }
-            auto& concat = next_op->Cast<sirius_physical_concat>();
+          for (auto& next_port : part_op.get_next_port_after_sink()) {
+            if (next_port.next_operator->type != SiriusPhysicalOperatorType::CONCAT) { continue; }
+            auto& concat = next_port.next_operator->Cast<sirius_physical_concat>();
             if (concat.is_build_concat()) { concat.set_concat_all(true); }
           }
         };

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -1037,7 +1037,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
                               data_repo_manager.get_repository(op_id, port_id).get(),
                               new_scheduled[i],
                               dependent_pipeline));
-          new_scheduled[i]->get_sink()->add_next_port_after_sink(std::make_pair(next_op, port_id));
+          new_scheduled[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN ||
                  new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
@@ -1055,7 +1055,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
                               data_repo_manager.get_repository(op_id, port_id).get(),
                               new_scheduled[i],
                               dependent_pipeline));
-          new_scheduled[i]->get_sink()->add_next_port_after_sink(std::make_pair(next_op, port_id));
+          new_scheduled[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
         }
       } else if (new_scheduled[i]->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
         // No action needed for RESULT_COLLECTOR sinks

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -1279,8 +1279,8 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
       // Print ports and next operators after sink
       SIRIUS_LOG_INFO("  Sink next operators and ports:");
       for (auto& next_port : pipeline->sink->get_next_port_after_sink()) {
-        auto next_op = next_port.first;
-        auto port_id = next_port.second;
+        auto next_op = next_port.next_operator;
+        auto port_id = next_port.next_operator_port_name;
         SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}'",
                         next_op->get_name(),
                         next_op->get_operator_id(),
@@ -1305,22 +1305,26 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             delim_join->Cast<op::sirius_physical_right_delim_join>().partition_join;
           SIRIUS_LOG_INFO("  Partition Join next operators:");
           for (auto& next_port : partition_join->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-                            next_port.first->get_name(),
-                            next_port.first->get_operator_id(),
-                            next_port.second.data(),
-                            static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
+            SIRIUS_LOG_INFO(
+              "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
+              next_port.next_operator->get_name(),
+              next_port.next_operator->get_operator_id(),
+              next_port.next_operator_port_name.data(),
+              static_cast<void*>(
+                next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
           }
 
           auto distinct_op =
             delim_join->Cast<op::sirius_physical_right_delim_join>().distinct.get();
           SIRIUS_LOG_INFO("  Distinct next operators:");
           for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-                            next_port.first->get_name(),
-                            next_port.first->get_operator_id(),
-                            next_port.second.data(),
-                            static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
+            SIRIUS_LOG_INFO(
+              "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
+              next_port.next_operator->get_name(),
+              next_port.next_operator->get_operator_id(),
+              next_port.next_operator_port_name.data(),
+              static_cast<void*>(
+                next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
           }
         }
 
@@ -1329,20 +1333,24 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             delim_join->Cast<op::sirius_physical_left_delim_join>().column_data_scan;
           SIRIUS_LOG_INFO("  Column Data Scan next operators:");
           for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-                            next_port.first->get_name(),
-                            next_port.first->get_operator_id(),
-                            next_port.second.data(),
-                            static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
+            SIRIUS_LOG_INFO(
+              "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
+              next_port.next_operator->get_name(),
+              next_port.next_operator->get_operator_id(),
+              next_port.next_operator_port_name.data(),
+              static_cast<void*>(
+                next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
           }
           auto distinct_op = delim_join->Cast<op::sirius_physical_left_delim_join>().distinct.get();
           SIRIUS_LOG_INFO("  Partition Distinct next operators:");
           for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-                            next_port.first->get_name(),
-                            next_port.first->get_operator_id(),
-                            next_port.second.data(),
-                            static_cast<void*>(next_port.first->get_port(next_port.second)->repo));
+            SIRIUS_LOG_INFO(
+              "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
+              next_port.next_operator->get_name(),
+              next_port.next_operator->get_operator_id(),
+              next_port.next_operator_port_name.data(),
+              static_cast<void*>(
+                next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
           }
         }
       }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -1083,17 +1083,21 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
           auto partition_join = delim_join.partition_join;
           auto* distinct_op   = delim_join.distinct.get();
           for (auto& next_port : partition_join->get_next_port_after_sink()) {
-            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)
+                  ->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)
+                    ->dest_pipeline));
             }
           }
           for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)
+                  ->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)
+                    ->dest_pipeline));
             }
           }
         } else if (new_scheduled[i]->sink.get()->type ==
@@ -1103,26 +1107,31 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
           auto* distinct_op     = delim_join.distinct.get();
           auto column_data_scan = delim_join.column_data_scan;
           for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)
+                  ->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)
+                    ->dest_pipeline));
             }
           }
           for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)
+                  ->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)
+                    ->dest_pipeline));
             }
           }
         } else {
-          for (auto& next_port :
-               new_scheduled[i]->sink.get()->get_next_port_after_sink()) {
-            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
+          for (auto& next_port : new_scheduled[i]->sink.get()->get_next_port_after_sink()) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)
+                  ->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)
+                    ->dest_pipeline));
             }
           }
         }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -1082,18 +1082,18 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             new_scheduled[i]->sink.get()->Cast<op::sirius_physical_right_delim_join>();
           auto partition_join = delim_join.partition_join;
           auto* distinct_op   = delim_join.distinct.get();
-          for (auto& [next_op, port_id] : partition_join->get_next_port_after_sink()) {
-            if (next_op->get_port(port_id)->dest_pipeline) {
+          for (auto& next_port : partition_join->get_next_port_after_sink()) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_op->get_port(port_id)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
             }
           }
-          for (auto& [next_op, port_id] : distinct_op->get_next_port_after_sink()) {
-            if (next_op->get_port(port_id)->dest_pipeline) {
+          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_op->get_port(port_id)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
             }
           }
         } else if (new_scheduled[i]->sink.get()->type ==
@@ -1102,27 +1102,27 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
             new_scheduled[i]->sink.get()->Cast<op::sirius_physical_left_delim_join>();
           auto* distinct_op     = delim_join.distinct.get();
           auto column_data_scan = delim_join.column_data_scan;
-          for (auto& [next_op, port_id] : column_data_scan->get_next_port_after_sink()) {
-            if (next_op->get_port(port_id)->dest_pipeline) {
+          for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_op->get_port(port_id)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
             }
           }
-          for (auto& [next_op, port_id] : distinct_op->get_next_port_after_sink()) {
-            if (next_op->get_port(port_id)->dest_pipeline) {
+          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_op->get_port(port_id)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
             }
           }
         } else {
-          for (auto& [next_op, port_id] :
+          for (auto& next_port :
                new_scheduled[i]->sink.get()->get_next_port_after_sink()) {
-            if (next_op->get_port(port_id)->dest_pipeline) {
+            if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
               new_scheduled[i]->parents.push_back(
                 duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-                  next_op->get_port(port_id)->dest_pipeline));
+                  next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
             }
           }
         }

--- a/test/cpp/pipeline/test_modified_pipeline.cpp
+++ b/test/cpp/pipeline/test_modified_pipeline.cpp
@@ -597,7 +597,9 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
         // Verify port is "build"
         auto& next_ports = sink->get_next_port_after_sink();
         for (auto& next_port : next_ports) {
-          if (std::string(next_port.next_operator_port_name) != "build") { info.build_partition_has_right_port = false; }
+          if (std::string(next_port.next_operator_port_name) != "build") {
+            info.build_partition_has_right_port = false;
+          }
         }
       } else {
         // Probe side partition
@@ -606,7 +608,9 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
         // Verify port is "default"
         auto& next_ports = sink->get_next_port_after_sink();
         for (auto& next_port : next_ports) {
-          if (std::string(next_port.next_operator_port_name) != "default") { info.probe_partition_has_default_port = false; }
+          if (std::string(next_port.next_operator_port_name) != "default") {
+            info.probe_partition_has_default_port = false;
+          }
         }
       }
 

--- a/test/cpp/pipeline/test_modified_pipeline.cpp
+++ b/test/cpp/pipeline/test_modified_pipeline.cpp
@@ -596,8 +596,8 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
 
         // Verify port is "build"
         auto& next_ports = sink->get_next_port_after_sink();
-        for (auto& [next_op, port_id] : next_ports) {
-          if (std::string(port_id) != "build") { info.build_partition_has_right_port = false; }
+        for (auto& next_port : next_ports) {
+          if (std::string(next_port.next_operator_port_name) != "build") { info.build_partition_has_right_port = false; }
         }
       } else {
         // Probe side partition
@@ -605,8 +605,8 @@ HashJoinBreakdownInfo analyze_hash_join_breakdown(
 
         // Verify port is "default"
         auto& next_ports = sink->get_next_port_after_sink();
-        for (auto& [next_op, port_id] : next_ports) {
-          if (std::string(port_id) != "default") { info.probe_partition_has_default_port = false; }
+        for (auto& next_port : next_ports) {
+          if (std::string(next_port.next_operator_port_name) != "default") { info.probe_partition_has_default_port = false; }
         }
       }
 
@@ -788,9 +788,9 @@ void validate_modified_pipeline_structure(sirius_engine& engine, const std::stri
 
       // Validate next_port_after_sink connections
       auto& next_ports = sink->get_next_port_after_sink();
-      for (auto& [next_op, next_port_id] : next_ports) {
-        REQUIRE(next_op != nullptr);
-        REQUIRE(std::string(next_port_id) == port_id);
+      for (auto& next_port : next_ports) {
+        REQUIRE(next_port.next_operator != nullptr);
+        REQUIRE(std::string(next_port.next_operator_port_name) == port_id);
       }
 
     } else if (sink->type == SiriusPhysicalOperatorType::MERGE_GROUP_BY ||
@@ -1256,9 +1256,9 @@ TEST_CASE("Pipeline breakdown - HASH_JOIN probe side validation",
       if (!partition.is_build_partition()) {
         // This is a probe partition - check it uses "default" port
         auto& next_ports = sink->get_next_port_after_sink();
-        for (auto& [next_op, port_id] : next_ports) {
-          INFO("Probe partition port: " << port_id);
-          REQUIRE(std::string(port_id) == "default");
+        for (auto& next_port : next_ports) {
+          INFO("Probe partition port: " << next_port.next_operator_port_name);
+          REQUIRE(std::string(next_port.next_operator_port_name) == "default");
         }
 
         // Check if dependent pipeline has HASH_JOIN


### PR DESCRIPTION
Replaces `std::pair<sirius_physical_operator*, std::string_view>` with a named `next_port_info` struct having explicit `next_operator` and `next_operator_port_name` fields for readability and extensibility.