### PR TITLE
renaming get_logical_data_size_in_bytes() to get_uncompressed_data_size_in_bytes()

### DIFF
--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -161,7 +161,7 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_host_pa
     std::move(host_src.get_row_group_indices()),
     std::move(host_src.get_column_chunk_byte_ranges()),
     data_size,
-    host_src.get_logical_data_size_in_bytes(),
+    host_src.get_uncompressed_data_size_in_bytes(),
     host_src.get_file_size(),
     host_src.get_fallback_datasource());
   if (host_src.has_post_convert_fn()) { dst->set_post_convert_fn(host_src.get_post_convert_fn()); }

--- a/src/include/data/cached_data_representation.hpp
+++ b/src/include/data/cached_data_representation.hpp
@@ -81,9 +81,9 @@ class cached_shared_representation : public cucascade::idata_representation {
   /**
    * @copydoc idata_representation::get_logical_data_size_in_bytes
    */
-  [[nodiscard]] std::size_t get_logical_data_size_in_bytes() const override
+  [[nodiscard]] std::size_t get_uncompressed_data_size_in_bytes() const override
   {
-    return _representation->get_logical_data_size_in_bytes();
+    return _representation->get_uncompressed_data_size_in_bytes();
   }
 
   /**

--- a/src/include/data/host_parquet_representation.hpp
+++ b/src/include/data/host_parquet_representation.hpp
@@ -230,7 +230,7 @@ class host_parquet_representation : public cucascade::idata_representation {
    *
    * @return The uncompressed size of the data.
    */
-  [[nodiscard]] std::size_t get_logical_data_size_in_bytes() const override
+  [[nodiscard]] std::size_t get_uncompressed_data_size_in_bytes() const override
   {
     return _uncompressed_size_in_bytes;
   }

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -100,7 +100,7 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
     if (_input_data) {
       for (const auto& batch : _input_data->get_data_batches()) {
         if (batch && batch->get_data()) {
-          input_size += batch->get_data()->get_logical_data_size_in_bytes();
+          input_size += batch->get_data()->get_uncompressed_data_size_in_bytes();
         }
       }
     }
@@ -115,7 +115,7 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
       for (const auto& batch : _input_data->get_data_batches()) {
         if (batch && batch->get_data() &&
             batch->get_data()->get_current_tier() != cucascade::memory::Tier::GPU) {
-          input_size += batch->get_data()->get_logical_data_size_in_bytes();
+          input_size += batch->get_data()->get_uncompressed_data_size_in_bytes();
         }
       }
     }

--- a/test/cpp/data/test_host_parquet_representation.cpp
+++ b/test/cpp/data/test_host_parquet_representation.cpp
@@ -267,7 +267,7 @@ TEST_CASE("host_parquet_representation construction", "[host_parquet_representat
 
   SECTION("has correct uncompressed size")
   {
-    REQUIRE(repr->get_logical_data_size_in_bytes() == fixture.uncompressed_size_in_bytes);
+    REQUIRE(repr->get_uncompressed_data_size_in_bytes() == fixture.uncompressed_size_in_bytes);
   }
 
   SECTION("has row group indices")
@@ -329,7 +329,8 @@ TEST_CASE("host_parquet_representation clone creates independent copy",
 
   SECTION("cloned representation has same uncompressed size")
   {
-    REQUIRE(cloned->get_logical_data_size_in_bytes() == repr->get_logical_data_size_in_bytes());
+    REQUIRE(cloned->get_uncompressed_data_size_in_bytes() ==
+            repr->get_uncompressed_data_size_in_bytes());
   }
 
   SECTION("cloned representation has same row group indices")


### PR DESCRIPTION
This is a small change that I forgot to add to https://github.com/sirius-db/sirius/pull/473

It needs to be merged with https://github.com/NVIDIA/cuCascade/pull/92 