### PR TITLE
Use cudf::distinct_hash_join for INNER joins with unique build keys in Super Sirius

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(EXTENSION_SOURCES
     src/op/sirius_physical_filter.cpp
     src/op/sirius_physical_grouped_aggregate.cpp
     src/op/sirius_physical_grouped_aggregate_merge.cpp
+    src/op/build_hash_table.cpp
     src/op/sirius_physical_hash_join.cpp
     src/op/sirius_physical_limit.cpp
     src/op/sirius_physical_merge_sort.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_top_n.cpp
     test/cpp/operator/test_physical_ungrouped_aggregate.cpp
     test/cpp/parallel/test_task_executor.cpp
+    test/cpp/planner/test_column_property_propagation.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/src/include/op/build_hash_table.hpp
+++ b/src/include/op/build_hash_table.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cudf/cudf_utils.hpp"
+
+#include <memory>
+
+namespace sirius::op {
+
+using join_index_pair = std::pair<std::unique_ptr<rmm::device_uvector<cudf::size_type>>,
+                                  std::unique_ptr<rmm::device_uvector<cudf::size_type>>>;
+
+/// Wrapper that unifies cudf::hash_join and cudf::distinct_hash_join behind a single API.
+/// When unique_keys is true (and join type supports it), uses the faster distinct_hash_join.
+class build_hash_table {
+ public:
+  build_hash_table()  = default;
+  ~build_hash_table() = default;
+
+  build_hash_table(const build_hash_table&)            = delete;
+  build_hash_table& operator=(const build_hash_table&) = delete;
+  build_hash_table(build_hash_table&&)                 = default;
+  build_hash_table& operator=(build_hash_table&&)      = default;
+
+  /// Build the hash table from the given keys.
+  void build(cudf::table_view build_keys,
+             bool unique_keys,
+             cudf::null_equality null_eq,
+             rmm::cuda_stream_view stream);
+
+  /// Probe for INNER join.
+  join_index_pair inner_join(cudf::table_view probe_keys, rmm::cuda_stream_view stream) const;
+
+  /// Probe for LEFT join.
+  join_index_pair left_join(cudf::table_view probe_keys, rmm::cuda_stream_view stream) const;
+
+  /// Probe for FULL OUTER join (only available with generic hash_join).
+  join_index_pair full_join(cudf::table_view probe_keys, rmm::cuda_stream_view stream) const;
+
+  void reset();
+
+  bool is_built() const;
+
+  bool is_distinct() const;
+
+ private:
+  std::unique_ptr<cudf::hash_join> _generic;
+  std::unique_ptr<cudf::distinct_hash_join> _distinct;
+};
+
+}  // namespace sirius::op

--- a/src/include/op/build_hash_table.hpp
+++ b/src/include/op/build_hash_table.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "cudf/cudf_utils.hpp"
+#include "duckdb/common/enums/join_type.hpp"
 
 #include <memory>
 
@@ -38,8 +39,10 @@ class build_hash_table {
   build_hash_table& operator=(build_hash_table&&)      = default;
 
   /// Build the hash table from the given keys.
+  /// Uses distinct_hash_join when unique_keys is true and join_type supports it (INNER, LEFT).
   void build(cudf::table_view build_keys,
              bool unique_keys,
+             duckdb::JoinType join_type,
              cudf::null_equality null_eq,
              rmm::cuda_stream_view stream);
 

--- a/src/include/op/column_property.hpp
+++ b/src/include/op/column_property.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/include/op/column_property.hpp
+++ b/src/include/op/column_property.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace sirius::op {
+
+struct column_property {
+  bool is_unique = false;
+};
+
+}  // namespace sirius::op

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -88,6 +88,14 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
   bool has_count_distinct = false;
 
  public:
+  //! Mark group key columns as unique (GROUP BY output keys are always unique).
+  void propagate_column_properties_from_child(size_t child_idx = 0) override
+  {
+    for (size_t i = 0; i < group_idx.size() && i < output_column_properties.size(); i++) {
+      output_column_properties[i].is_unique = true;
+    }
+  }
+
   std::vector<int> get_output_grouping_indices() const
   {
     std::vector<int> indices(group_idx.size());

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -25,6 +25,7 @@
 #include "duckdb/execution/operator/join/physical_join.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
+#include "op/build_hash_table.hpp"
 #include "op/sirius_physical_partition_consumer_operator.hpp"
 #include "sirius_config.hpp"
 #include "utils.hpp"
@@ -162,9 +163,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   HASH_JOIN_MODE _join_mode                      = HASH_JOIN_MODE::STANDARD;
   BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
-  std::unique_ptr<cudf::hash_join> _hash_table;  // generic hash join (BUILD_PROBE mode)
-  std::unique_ptr<cudf::distinct_hash_join>
-    _distinct_hash_table;  // distinct hash join for unique build keys (BUILD_PROBE only)
+  build_hash_table _hash_table;
   std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -164,7 +164,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
   std::unique_ptr<cudf::hash_join> _hash_table;  // generic hash join (BUILD_PROBE mode)
   std::unique_ptr<cudf::distinct_hash_join>
-    _distinct_hash_table;  // distinct hash join for unique build keys (BUILD_PROBE INNER only)
+    _distinct_hash_table;  // distinct hash join for unique build keys (BUILD_PROBE only)
   std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -162,7 +162,9 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   HASH_JOIN_MODE _join_mode                      = HASH_JOIN_MODE::STANDARD;
   BUILD_HASH_TABLE_STATE _hash_table_build_state = BUILD_HASH_TABLE_STATE::NOT_BUILT;
   uint64_t _max_build_hash_table_bytes           = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
-  std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
+  std::unique_ptr<cudf::hash_join> _hash_table;  // generic hash join (BUILD_PROBE mode)
+  std::unique_ptr<cudf::distinct_hash_join>
+    _distinct_hash_table;  // distinct hash join for unique build keys (BUILD_PROBE INNER only)
   std::shared_ptr<::cucascade::data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -178,8 +178,7 @@ class sirius_physical_operator {
   }
 
   //! Propagate output column properties from a child operator.
-  //! Default: 1:1 copy from child. Override in subclasses for operator-specific logic
-  //! (e.g., projection passthrough, aggregate group key marking).
+  //! Default: 1:1 copy from child. Override in subclasses for operator-specific logic.
   virtual void propagate_column_properties_from_child(size_t child_idx = 0)
   {
     if (child_idx < children.size() && children[child_idx]) {

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -28,6 +28,7 @@
 #include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "helper/types.hpp"
+#include "op/column_property.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 
 #include <cucascade/data/data_batch.hpp>
@@ -131,6 +132,7 @@ class sirius_physical_operator {
       estimated_cardinality(estimated_cardinality),
       operator_id(next_operator_id++)
   {
+    output_column_properties.resize(this->types.size());
   }
   sirius_physical_operator() : operator_id(next_operator_id++) {}
   virtual ~sirius_physical_operator() {}
@@ -141,6 +143,8 @@ class sirius_physical_operator {
   duckdb::vector<duckdb::unique_ptr<sirius_physical_operator>> children;
   //! The types returned by this physical operator
   duckdb::vector<duckdb::LogicalType> types;
+  //! Per-column metadata (e.g., uniqueness) for this operator's output columns
+  std::vector<column_property> output_column_properties;
   //! The estimated cardinality of this physical operator
   duckdb::idx_t estimated_cardinality;
   //! The unique ID of this operator (auto-incremented at creation)
@@ -166,6 +170,20 @@ class sirius_physical_operator {
 
   //! Return a vector of the types that will be returned by this operator
   const duckdb::vector<duckdb::LogicalType>& get_types() const { return types; }
+
+  //! Return per-column property metadata for this operator's output
+  const std::vector<column_property>& get_output_column_properties() const
+  {
+    return output_column_properties;
+  }
+
+  //! Copy output column properties from a child operator (1:1 column mapping)
+  void propagate_column_properties_from_child(size_t child_idx = 0)
+  {
+    if (child_idx < children.size() && children[child_idx]) {
+      output_column_properties = children[child_idx]->output_column_properties;
+    }
+  }
 
   //! Get the unique operator ID
   size_t get_operator_id() const { return operator_id; }

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -177,11 +177,28 @@ class sirius_physical_operator {
     return output_column_properties;
   }
 
-  //! Copy output column properties from a child operator (1:1 column mapping)
-  void propagate_column_properties_from_child(size_t child_idx = 0)
+  //! Propagate output column properties from a child operator.
+  //! Default: 1:1 copy from child. Override in subclasses for operator-specific logic
+  //! (e.g., projection passthrough, aggregate group key marking).
+  virtual void propagate_column_properties_from_child(size_t child_idx = 0)
   {
     if (child_idx < children.size() && children[child_idx]) {
       output_column_properties = children[child_idx]->output_column_properties;
+    }
+  }
+
+  //! Propagate output column properties through a projection map.
+  //! output[i] gets properties from child[projection_map[i]].
+  void propagate_column_properties_from_child(const duckdb::vector<duckdb::idx_t>& projection_map,
+                                              size_t child_idx = 0)
+  {
+    if (child_idx >= children.size() || !children[child_idx]) { return; }
+    auto& child_props = children[child_idx]->output_column_properties;
+    for (duckdb::idx_t i = 0; i < projection_map.size() && i < output_column_properties.size();
+         i++) {
+      if (projection_map[i] < child_props.size()) {
+        output_column_properties[i] = child_props[projection_map[i]];
+      }
     }
   }
 

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -49,6 +49,9 @@ class sirius_physical_order : public sirius_physical_operator {
   duckdb::vector<duckdb::idx_t> projections;
   bool is_index_sort;
 
+  //! Propagate uniqueness through the order's projection map.
+  void propagate_column_properties_from_child(size_t child_idx = 0) override;
+
   bool is_source() const override { return true; }
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -34,6 +34,9 @@ class sirius_physical_projection : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
+  //! Propagate uniqueness for passthrough BoundReferenceExpression columns only.
+  void propagate_column_properties_from_child(size_t child_idx = 0) override;
+
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
 };
 

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -43,6 +43,14 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
   duckdb::unique_ptr<duckdb::DistinctAggregateData> distinct_data;
   duckdb::unique_ptr<duckdb::DistinctAggregateCollectionInfo> distinct_collection_info;
 
+  //! Ungrouped aggregate output is a single row — all columns are trivially unique.
+  void propagate_column_properties_from_child(size_t child_idx = 0) override
+  {
+    for (auto& prop : output_column_properties) {
+      prop.is_unique = true;
+    }
+  }
+
   bool is_source() const override { return true; }
 
  public:

--- a/src/op/build_hash_table.cpp
+++ b/src/op/build_hash_table.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/build_hash_table.hpp"
+
+#include <numeric>
+#include <stdexcept>
+
+namespace sirius::op {
+
+/// Create a device_uvector containing the sequence [0, 1, 2, ..., num_rows-1].
+static std::unique_ptr<rmm::device_uvector<cudf::size_type>> make_sequential_indices(
+  cudf::size_type num_rows, rmm::cuda_stream_view stream)
+{
+  auto indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
+  auto host_seq = std::vector<cudf::size_type>(num_rows);
+  std::iota(host_seq.begin(), host_seq.end(), 0);
+  cudaMemcpyAsync(indices->data(),
+                  host_seq.data(),
+                  num_rows * sizeof(cudf::size_type),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  return indices;
+}
+
+void build_hash_table::build(cudf::table_view build_keys,
+                             bool unique_keys,
+                             cudf::null_equality null_eq,
+                             rmm::cuda_stream_view stream)
+{
+  reset();
+  if (unique_keys) {
+    _distinct = std::make_unique<cudf::distinct_hash_join>(build_keys, null_eq, 0.5, stream);
+  } else {
+    _generic = std::make_unique<cudf::hash_join>(build_keys, null_eq, stream);
+  }
+}
+
+join_index_pair build_hash_table::inner_join(cudf::table_view probe_keys,
+                                             rmm::cuda_stream_view stream) const
+{
+  if (_distinct) { return _distinct->inner_join(probe_keys, stream); }
+  return _generic->inner_join(probe_keys, {}, stream);
+}
+
+join_index_pair build_hash_table::left_join(cudf::table_view probe_keys,
+                                            rmm::cuda_stream_view stream) const
+{
+  if (_distinct) {
+    auto build_indices = _distinct->left_join(probe_keys, stream);
+    auto probe_indices =
+      make_sequential_indices(static_cast<cudf::size_type>(build_indices->size()), stream);
+    return {std::move(probe_indices), std::move(build_indices)};
+  }
+  return _generic->left_join(probe_keys, {}, stream);
+}
+
+join_index_pair build_hash_table::full_join(cudf::table_view probe_keys,
+                                            rmm::cuda_stream_view stream) const
+{
+  if (!_generic) { throw std::runtime_error("full_join is not supported with distinct_hash_join"); }
+  return _generic->full_join(probe_keys, {}, stream);
+}
+
+void build_hash_table::reset()
+{
+  _generic.reset();
+  _distinct.reset();
+}
+
+bool build_hash_table::is_built() const { return _generic != nullptr || _distinct != nullptr; }
+
+bool build_hash_table::is_distinct() const { return _distinct != nullptr; }
+
+}  // namespace sirius::op

--- a/src/op/build_hash_table.cpp
+++ b/src/op/build_hash_table.cpp
@@ -38,11 +38,14 @@ static std::unique_ptr<rmm::device_uvector<cudf::size_type>> make_sequential_ind
 
 void build_hash_table::build(cudf::table_view build_keys,
                              bool unique_keys,
+                             duckdb::JoinType join_type,
                              cudf::null_equality null_eq,
                              rmm::cuda_stream_view stream)
 {
   reset();
-  if (unique_keys) {
+  bool use_distinct = unique_keys && (join_type == duckdb::JoinType::INNER ||
+                                      join_type == duckdb::JoinType::LEFT);
+  if (use_distinct) {
     _distinct = std::make_unique<cudf::distinct_hash_join>(build_keys, null_eq, 0.5, stream);
   } else {
     _generic = std::make_unique<cudf::hash_join>(build_keys, null_eq, stream);

--- a/src/op/build_hash_table.cpp
+++ b/src/op/build_hash_table.cpp
@@ -43,8 +43,8 @@ void build_hash_table::build(cudf::table_view build_keys,
                              rmm::cuda_stream_view stream)
 {
   reset();
-  bool use_distinct = unique_keys && (join_type == duckdb::JoinType::INNER ||
-                                      join_type == duckdb::JoinType::LEFT);
+  bool use_distinct =
+    unique_keys && (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT);
   if (use_distinct) {
     _distinct = std::make_unique<cudf::distinct_hash_join>(build_keys, null_eq, 0.5, stream);
   } else {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -41,6 +41,21 @@
 namespace sirius {
 namespace op {
 
+/// Create a device_uvector containing the sequence [0, 1, 2, ..., num_rows-1].
+static std::unique_ptr<rmm::device_uvector<cudf::size_type>> make_sequential_indices(
+  cudf::size_type num_rows, rmm::cuda_stream_view stream)
+{
+  auto indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
+  auto host_seq = std::vector<cudf::size_type>(num_rows);
+  std::iota(host_seq.begin(), host_seq.end(), 0);
+  cudaMemcpyAsync(indices->data(),
+                  host_seq.data(),
+                  num_rows * sizeof(cudf::size_type),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  return indices;
+}
+
 /// Recursively collect all BoundReferenceExpression indices from an expression tree.
 static void collect_bound_ref_indices(duckdb::Expression& expr,
                                       std::unordered_set<duckdb::idx_t>& indices)
@@ -800,8 +815,6 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         _build_table              = std::move(build_batch);
         if (unique_build_keys &&
             (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
-          SIRIUS_LOG_DEBUG("Operator {}: using distinct_hash_join (unique build keys)",
-                           this->get_operator_id());
           _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
             build_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
         } else {
@@ -838,15 +851,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         if (_distinct_hash_table) {
           // distinct_hash_join::left_join returns only build indices; probe indices are 0..N-1
           right_indices = _distinct_hash_table->left_join(probe_keys, stream);
-          auto num_rows = static_cast<cudf::size_type>(right_indices->size());
-          left_indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
-          auto host_seq = std::vector<cudf::size_type>(num_rows);
-          std::iota(host_seq.begin(), host_seq.end(), 0);
-          cudaMemcpyAsync(left_indices->data(),
-                          host_seq.data(),
-                          num_rows * sizeof(cudf::size_type),
-                          cudaMemcpyHostToDevice,
-                          stream.value());
+          left_indices  = make_sequential_indices(
+            static_cast<cudf::size_type>(right_indices->size()), stream);
         } else {
           auto result   = _hash_table->left_join(probe_keys, {}, stream);
           left_indices  = std::move(result.first);
@@ -1056,15 +1062,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       if (unique_build_keys) {
         cudf::distinct_hash_join ht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
         right_indices = ht.left_join(left_keys, stream);
-        auto num_rows = static_cast<cudf::size_type>(right_indices->size());
-        left_indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
-        auto host_seq = std::vector<cudf::size_type>(num_rows);
-        std::iota(host_seq.begin(), host_seq.end(), 0);
-        cudaMemcpyAsync(left_indices->data(),
-                        host_seq.data(),
-                        num_rows * sizeof(cudf::size_type),
-                        cudaMemcpyHostToDevice,
-                        stream.value());
+        left_indices  = make_sequential_indices(
+          static_cast<cudf::size_type>(right_indices->size()), stream);
       } else {
         auto join_result =
           cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -35,26 +35,10 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <cstdio>
-#include <numeric>
 #include <unordered_set>
 
 namespace sirius {
 namespace op {
-
-/// Create a device_uvector containing the sequence [0, 1, 2, ..., num_rows-1].
-static std::unique_ptr<rmm::device_uvector<cudf::size_type>> make_sequential_indices(
-  cudf::size_type num_rows, rmm::cuda_stream_view stream)
-{
-  auto indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
-  auto host_seq = std::vector<cudf::size_type>(num_rows);
-  std::iota(host_seq.begin(), host_seq.end(), 0);
-  cudaMemcpyAsync(indices->data(),
-                  host_seq.data(),
-                  num_rows * sizeof(cudf::size_type),
-                  cudaMemcpyHostToDevice,
-                  stream.value());
-  return indices;
-}
 
 /// Recursively collect all BoundReferenceExpression indices from an expression tree.
 static void collect_bound_ref_indices(duckdb::Expression& expr,
@@ -813,14 +797,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = std::move(build_batch);
-        if (unique_build_keys &&
-            (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
-          _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
-            build_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
-        } else {
-          _hash_table =
-            std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
-        }
+        _hash_table.build(build_keys, unique_build_keys, cudf::null_equality::UNEQUAL, stream);
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
                                // batches to proceed.
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
@@ -838,28 +815,15 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       cudf::table_view probe_keys = probe_keys_result.keys;
 
       if (join_type == duckdb::JoinType::INNER) {
-        if (_distinct_hash_table) {
-          auto result   = _distinct_hash_table->inner_join(probe_keys, stream);
-          left_indices  = std::move(result.first);
-          right_indices = std::move(result.second);
-        } else {
-          auto result   = _hash_table->inner_join(probe_keys, {}, stream);
-          left_indices  = std::move(result.first);
-          right_indices = std::move(result.second);
-        }
+        auto result   = _hash_table.inner_join(probe_keys, stream);
+        left_indices  = std::move(result.first);
+        right_indices = std::move(result.second);
       } else if (join_type == duckdb::JoinType::LEFT) {
-        if (_distinct_hash_table) {
-          // distinct_hash_join::left_join returns only build indices; probe indices are 0..N-1
-          right_indices = _distinct_hash_table->left_join(probe_keys, stream);
-          left_indices  = make_sequential_indices(
-            static_cast<cudf::size_type>(right_indices->size()), stream);
-        } else {
-          auto result   = _hash_table->left_join(probe_keys, {}, stream);
-          left_indices  = std::move(result.first);
-          right_indices = std::move(result.second);
-        }
+        auto result   = _hash_table.left_join(probe_keys, stream);
+        left_indices  = std::move(result.first);
+        right_indices = std::move(result.second);
       } else if (join_type == duckdb::JoinType::OUTER) {
-        auto result   = _hash_table->full_join(probe_keys, {}, stream);
+        auto result   = _hash_table.full_join(probe_keys, stream);
         left_indices  = std::move(result.first);
         right_indices = std::move(result.second);
       } else {
@@ -1046,30 +1010,28 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     cudf::table_view left_keys  = left_keys_result.keys;
     cudf::table_view right_keys = right_keys_result.keys;
 
-    if (join_type == duckdb::JoinType::INNER) {
-      if (unique_build_keys) {
-        cudf::distinct_hash_join ht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
-        auto join_result = ht.inner_join(left_keys, stream);
-        left_indices     = std::move(join_result.first);
-        right_indices    = std::move(join_result.second);
-      } else {
-        auto join_result =
-          cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-        left_indices  = std::move(join_result.first);
-        right_indices = std::move(join_result.second);
-      }
+    if (join_type == duckdb::JoinType::INNER && unique_build_keys) {
+      build_hash_table ht;
+      ht.build(right_keys, true, cudf::null_equality::UNEQUAL, stream);
+      auto result   = ht.inner_join(left_keys, stream);
+      left_indices  = std::move(result.first);
+      right_indices = std::move(result.second);
+    } else if (join_type == duckdb::JoinType::INNER) {
+      auto join_result =
+        cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
+      left_indices  = std::move(join_result.first);
+      right_indices = std::move(join_result.second);
+    } else if (join_type == duckdb::JoinType::LEFT && unique_build_keys) {
+      build_hash_table ht;
+      ht.build(right_keys, true, cudf::null_equality::UNEQUAL, stream);
+      auto result   = ht.left_join(left_keys, stream);
+      left_indices  = std::move(result.first);
+      right_indices = std::move(result.second);
     } else if (join_type == duckdb::JoinType::LEFT) {
-      if (unique_build_keys) {
-        cudf::distinct_hash_join ht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
-        right_indices = ht.left_join(left_keys, stream);
-        left_indices  = make_sequential_indices(
-          static_cast<cudf::size_type>(right_indices->size()), stream);
-      } else {
-        auto join_result =
-          cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-        left_indices  = std::move(join_result.first);
-        right_indices = std::move(join_result.second);
-      }
+      auto join_result =
+        cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
+      left_indices  = std::move(join_result.first);
+      right_indices = std::move(join_result.second);
     } else if (join_type == duckdb::JoinType::RIGHT) {
       auto join_result =
         cudf::left_join(right_keys, left_keys, cudf::null_equality::UNEQUAL, stream);
@@ -1125,7 +1087,6 @@ void sirius_physical_hash_join::finalize_operator()
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     _hash_table.reset();
-    _distinct_hash_table.reset();
     _build_table.reset();
     _built_table_cast_columns.clear();
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -797,7 +797,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = std::move(build_batch);
-        _hash_table.build(build_keys, unique_build_keys, cudf::null_equality::UNEQUAL, stream);
+        _hash_table.build(
+          build_keys, unique_build_keys, join_type, cudf::null_equality::UNEQUAL, stream);
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
                                // batches to proceed.
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
@@ -1012,7 +1013,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
     if (join_type == duckdb::JoinType::INNER && unique_build_keys) {
       build_hash_table ht;
-      ht.build(right_keys, true, cudf::null_equality::UNEQUAL, stream);
+      ht.build(right_keys, true, join_type, cudf::null_equality::UNEQUAL, stream);
       auto result   = ht.inner_join(left_keys, stream);
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);
@@ -1023,7 +1024,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       right_indices = std::move(join_result.second);
     } else if (join_type == duckdb::JoinType::LEFT && unique_build_keys) {
       build_hash_table ht;
-      ht.build(right_keys, true, cudf::null_equality::UNEQUAL, stream);
+      ht.build(right_keys, true, join_type, cudf::null_equality::UNEQUAL, stream);
       auto result   = ht.left_join(left_keys, stream);
       left_indices  = std::move(result.first);
       right_indices = std::move(result.second);

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -797,8 +797,15 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = std::move(build_batch);
-        _hash_table =
-          std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+        if (unique_build_keys && join_type == duckdb::JoinType::INNER) {
+          SIRIUS_LOG_DEBUG("Operator {}: using distinct_hash_join (unique build keys)",
+                           this->get_operator_id());
+          _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
+            build_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
+        } else {
+          _hash_table =
+            std::make_unique<cudf::hash_join>(build_keys, cudf::null_equality::UNEQUAL, stream);
+        }
         stream.synchronize();  // Ensure the hash table is fully built before we allow any probe
                                // batches to proceed.
         _hash_table_build_state = BUILD_HASH_TABLE_STATE::BUILT;
@@ -816,9 +823,15 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       cudf::table_view probe_keys = probe_keys_result.keys;
 
       if (join_type == duckdb::JoinType::INNER) {
-        auto result   = _hash_table->inner_join(probe_keys, {}, stream);
-        left_indices  = std::move(result.first);
-        right_indices = std::move(result.second);
+        if (_distinct_hash_table) {
+          auto result   = _distinct_hash_table->inner_join(probe_keys, stream);
+          left_indices  = std::move(result.first);
+          right_indices = std::move(result.second);
+        } else {
+          auto result   = _hash_table->inner_join(probe_keys, {}, stream);
+          left_indices  = std::move(result.first);
+          right_indices = std::move(result.second);
+        }
       } else if (join_type == duckdb::JoinType::LEFT) {
         auto result   = _hash_table->left_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);
@@ -1012,10 +1025,17 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
     cudf::table_view right_keys = right_keys_result.keys;
 
     if (join_type == duckdb::JoinType::INNER) {
-      auto join_result =
-        cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-      left_indices  = std::move(join_result.first);
-      right_indices = std::move(join_result.second);
+      if (unique_build_keys) {
+        cudf::distinct_hash_join ht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
+        auto join_result = ht.inner_join(left_keys, stream);
+        left_indices     = std::move(join_result.first);
+        right_indices    = std::move(join_result.second);
+      } else {
+        auto join_result =
+          cudf::inner_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
+        left_indices  = std::move(join_result.first);
+        right_indices = std::move(join_result.second);
+      }
     } else if (join_type == duckdb::JoinType::LEFT) {
       auto join_result =
         cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
@@ -1076,6 +1096,7 @@ void sirius_physical_hash_join::finalize_operator()
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     _hash_table.reset();
+    _distinct_hash_table.reset();
     _build_table.reset();
     _built_table_cast_columns.clear();
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -35,6 +35,7 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <cstdio>
+#include <numeric>
 #include <unordered_set>
 
 namespace sirius {
@@ -797,7 +798,8 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = std::move(build_batch);
-        if (unique_build_keys && join_type == duckdb::JoinType::INNER) {
+        if (unique_build_keys &&
+            (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
           SIRIUS_LOG_DEBUG("Operator {}: using distinct_hash_join (unique build keys)",
                            this->get_operator_id());
           _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
@@ -833,9 +835,23 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
           right_indices = std::move(result.second);
         }
       } else if (join_type == duckdb::JoinType::LEFT) {
-        auto result   = _hash_table->left_join(probe_keys, {}, stream);
-        left_indices  = std::move(result.first);
-        right_indices = std::move(result.second);
+        if (_distinct_hash_table) {
+          // distinct_hash_join::left_join returns only build indices; probe indices are 0..N-1
+          right_indices = _distinct_hash_table->left_join(probe_keys, stream);
+          auto num_rows = static_cast<cudf::size_type>(right_indices->size());
+          left_indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
+          auto host_seq = std::vector<cudf::size_type>(num_rows);
+          std::iota(host_seq.begin(), host_seq.end(), 0);
+          cudaMemcpyAsync(left_indices->data(),
+                          host_seq.data(),
+                          num_rows * sizeof(cudf::size_type),
+                          cudaMemcpyHostToDevice,
+                          stream.value());
+        } else {
+          auto result   = _hash_table->left_join(probe_keys, {}, stream);
+          left_indices  = std::move(result.first);
+          right_indices = std::move(result.second);
+        }
       } else if (join_type == duckdb::JoinType::OUTER) {
         auto result   = _hash_table->full_join(probe_keys, {}, stream);
         left_indices  = std::move(result.first);
@@ -1037,10 +1053,24 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         right_indices = std::move(join_result.second);
       }
     } else if (join_type == duckdb::JoinType::LEFT) {
-      auto join_result =
-        cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
-      left_indices  = std::move(join_result.first);
-      right_indices = std::move(join_result.second);
+      if (unique_build_keys) {
+        cudf::distinct_hash_join ht(right_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
+        right_indices = ht.left_join(left_keys, stream);
+        auto num_rows = static_cast<cudf::size_type>(right_indices->size());
+        left_indices  = std::make_unique<rmm::device_uvector<cudf::size_type>>(num_rows, stream);
+        auto host_seq = std::vector<cudf::size_type>(num_rows);
+        std::iota(host_seq.begin(), host_seq.end(), 0);
+        cudaMemcpyAsync(left_indices->data(),
+                        host_seq.data(),
+                        num_rows * sizeof(cudf::size_type),
+                        cudaMemcpyHostToDevice,
+                        stream.value());
+      } else {
+        auto join_result =
+          cudf::left_join(left_keys, right_keys, cudf::null_equality::UNEQUAL, stream);
+        left_indices  = std::move(join_result.first);
+        right_indices = std::move(join_result.second);
+      }
     } else if (join_type == duckdb::JoinType::RIGHT) {
       auto join_result =
         cudf::left_join(right_keys, left_keys, cudf::null_equality::UNEQUAL, stream);

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -37,6 +37,17 @@ sirius_physical_order::sirius_physical_order(duckdb::vector<duckdb::LogicalType>
 {
 }
 
+void sirius_physical_order::propagate_column_properties_from_child(size_t child_idx)
+{
+  if (child_idx >= children.size() || !children[child_idx]) { return; }
+  auto& child_props = children[child_idx]->output_column_properties;
+  for (duckdb::idx_t i = 0; i < projections.size() && i < output_column_properties.size(); i++) {
+    if (projections[i] < child_props.size()) {
+      output_column_properties[i] = child_props[projections[i]];
+    }
+  }
+}
+
 std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_data& input_data,
                                                               rmm::cuda_stream_view stream)
 {

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -16,6 +16,7 @@
 
 #include "op/sirius_physical_projection.hpp"
 
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 
 #include <nvtx3/nvtx3.hpp>
@@ -31,6 +32,19 @@ sirius_physical_projection::sirius_physical_projection(
       SiriusPhysicalOperatorType::PROJECTION, std::move(types), estimated_cardinality),
     select_list(std::move(select_list))
 {
+}
+
+void sirius_physical_projection::propagate_column_properties_from_child(size_t child_idx)
+{
+  if (child_idx >= children.size() || !children[child_idx]) { return; }
+  auto& child_props = children[child_idx]->output_column_properties;
+  for (duckdb::idx_t i = 0; i < select_list.size() && i < output_column_properties.size(); i++) {
+    if (select_list[i]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+      auto& ref = select_list[i]->Cast<duckdb::BoundReferenceExpression>();
+      if (ref.index < child_props.size()) { output_column_properties[i] = child_props[ref.index]; }
+    }
+    // Non-passthrough expressions keep default is_unique=false
+  }
 }
 
 std::unique_ptr<operator_data> sirius_physical_projection::execute(const operator_data& input_data,

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -31,18 +31,6 @@
 
 namespace sirius::planner {
 
-/// Mark group key columns as unique on a grouped aggregate operator.
-/// GROUP BY output keys are always unique by definition.
-static void mark_group_keys_unique(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& op)
-{
-  auto& agg = op->Cast<sirius::op::sirius_physical_grouped_aggregate>();
-  for (size_t i = 0; i < agg.group_idx.size(); i++) {
-    if (i < op->output_column_properties.size()) {
-      op->output_column_properties[i].is_unique = true;
-    }
-  }
-}
-
 static uint32_t required_bits_for_value(uint32_t n)
 {
   duckdb::idx_t required_bits = 0;
@@ -285,10 +273,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
                                              sirius::op::sirius_physical_ungrouped_aggregate>(
         op.types, std::move(op.expressions), op.estimated_cardinality, op.distinct_validity);
       group_by->children.push_back(std::move(plan));
-      // Ungrouped aggregate output is a single row — all columns are trivially unique
-      for (auto& prop : group_by->output_column_properties) {
-        prop.is_unique = true;
-      }
+      group_by->propagate_column_properties_from_child();
       return group_by;
     }
     throw duckdb::NotImplementedException("Non simple aggregation is not supported");
@@ -322,7 +307,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       group_validity,
       op.distinct_validity);
     group_by->children.push_back(std::move(plan));
-    mark_group_keys_unique(group_by);
+    group_by->propagate_column_properties_from_child();
     return group_by;
   }
 
@@ -345,7 +330,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       group_validity,
       op.distinct_validity);
     group_by->children.push_back(std::move(plan));
-    mark_group_keys_unique(group_by);
+    group_by->propagate_column_properties_from_child();
     return group_by;
   }
 
@@ -361,7 +346,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     group_validity,
     op.distinct_validity);
   group_by->children.push_back(std::move(plan));
-  mark_group_keys_unique(group_by);
+  group_by->propagate_column_properties_from_child();
   return group_by;
 }
 

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -31,6 +31,18 @@
 
 namespace sirius::planner {
 
+/// Mark group key columns as unique on a grouped aggregate operator.
+/// GROUP BY output keys are always unique by definition.
+static void mark_group_keys_unique(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& op)
+{
+  auto& agg = op->Cast<sirius::op::sirius_physical_grouped_aggregate>();
+  for (size_t i = 0; i < agg.group_idx.size(); i++) {
+    if (i < op->output_column_properties.size()) {
+      op->output_column_properties[i].is_unique = true;
+    }
+  }
+}
+
 static uint32_t required_bits_for_value(uint32_t n)
 {
   duckdb::idx_t required_bits = 0;
@@ -273,6 +285,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
                                              sirius::op::sirius_physical_ungrouped_aggregate>(
         op.types, std::move(op.expressions), op.estimated_cardinality, op.distinct_validity);
       group_by->children.push_back(std::move(plan));
+      // Ungrouped aggregate output is a single row — all columns are trivially unique
+      for (auto& prop : group_by->output_column_properties) {
+        prop.is_unique = true;
+      }
       return group_by;
     }
     throw duckdb::NotImplementedException("Non simple aggregation is not supported");
@@ -306,6 +322,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       group_validity,
       op.distinct_validity);
     group_by->children.push_back(std::move(plan));
+    mark_group_keys_unique(group_by);
     return group_by;
   }
 
@@ -328,6 +345,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
       group_validity,
       op.distinct_validity);
     group_by->children.push_back(std::move(plan));
+    mark_group_keys_unique(group_by);
     return group_by;
   }
 
@@ -343,6 +361,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     group_validity,
     op.distinct_validity);
   group_by->children.push_back(std::move(plan));
+  mark_group_keys_unique(group_by);
   return group_by;
 }
 

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "op/sirius_physical_hash_join.hpp"
@@ -91,23 +92,34 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
     auto& hash_join      = join->Cast<sirius::op::sirius_physical_hash_join>();
     hash_join.join_stats = std::move(op.join_stats);
 
-    // Check if all equality build keys are unique (enables cudf::distinct_hash_join for INNER)
+    // Check if all equality build keys are unique (enables cudf::distinct_hash_join)
     bool all_build_keys_unique = true;
     bool has_equality_key      = false;
+    auto& build_props          = hash_join.children[1]->get_output_column_properties();
     for (auto& cond : hash_join.conditions) {
       if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
           cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
         continue;
       }
       has_equality_key = true;
-      if (cond.right->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
-        auto& ref         = cond.right->Cast<duckdb::BoundReferenceExpression>();
-        auto& build_props = hash_join.children[1]->get_output_column_properties();
-        if (ref.index >= build_props.size() || !build_props[ref.index].is_unique) {
+      // Extract the build-side column index, unwrapping BOUND_CAST if present
+      duckdb::idx_t build_col_idx;
+      auto right_class = cond.right->GetExpressionClass();
+      if (right_class == duckdb::ExpressionClass::BOUND_REF) {
+        build_col_idx = cond.right->Cast<duckdb::BoundReferenceExpression>().index;
+      } else if (right_class == duckdb::ExpressionClass::BOUND_CAST) {
+        auto& cast = cond.right->Cast<duckdb::BoundCastExpression>();
+        if (cast.child->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+          build_col_idx = cast.child->Cast<duckdb::BoundReferenceExpression>().index;
+        } else {
           all_build_keys_unique = false;
           break;
         }
       } else {
+        all_build_keys_unique = false;
+        break;
+      }
+      if (build_col_idx >= build_props.size() || !build_props[build_col_idx].is_unique) {
         all_build_keys_unique = false;
         break;
       }

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_nested_loop_join.hpp"
@@ -87,7 +88,32 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       op.estimated_cardinality,
       std::move(op.filter_pushdown),
       op_params.max_build_hash_table_bytes);
-    join->Cast<sirius::op::sirius_physical_hash_join>().join_stats = std::move(op.join_stats);
+    auto& hash_join      = join->Cast<sirius::op::sirius_physical_hash_join>();
+    hash_join.join_stats = std::move(op.join_stats);
+
+    // Check if all equality build keys are unique (enables cudf::distinct_hash_join for INNER)
+    bool all_build_keys_unique = true;
+    bool has_equality_key      = false;
+    for (auto& cond : hash_join.conditions) {
+      if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
+          cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+        continue;
+      }
+      has_equality_key = true;
+      if (cond.right->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+        auto& ref         = cond.right->Cast<duckdb::BoundReferenceExpression>();
+        auto& build_props = hash_join.children[1]->get_output_column_properties();
+        if (ref.index >= build_props.size() || !build_props[ref.index].is_unique) {
+          all_build_keys_unique = false;
+          break;
+        }
+      } else {
+        all_build_keys_unique = false;
+        break;
+      }
+    }
+    hash_join.unique_build_keys = has_equality_key && all_build_keys_unique;
+
     return join;
   }
 

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -33,6 +33,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
     auto filter = duckdb::make_uniq<sirius::op::sirius_physical_filter>(
       plan->types, std::move(op.expressions), op.estimated_cardinality);
     filter->children.push_back(std::move(plan));
+    filter->propagate_column_properties_from_child();
     plan = std::move(filter);
   }
   if (op.HasProjectionMap()) {
@@ -45,6 +46,12 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
     auto proj = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
       op.types, std::move(select_list), op.estimated_cardinality);
     proj->children.push_back(std::move(plan));
+    for (duckdb::idx_t i = 0; i < op.projection_map.size(); i++) {
+      auto src_idx = op.projection_map[i];
+      if (src_idx < proj->children[0]->output_column_properties.size()) {
+        proj->output_column_properties[i] = proj->children[0]->output_column_properties[src_idx];
+      }
+    }
     plan = std::move(proj);
   }
   return plan;

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -46,12 +46,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
     auto proj = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
       op.types, std::move(select_list), op.estimated_cardinality);
     proj->children.push_back(std::move(plan));
-    for (duckdb::idx_t i = 0; i < op.projection_map.size(); i++) {
-      auto src_idx = op.projection_map[i];
-      if (src_idx < proj->children[0]->output_column_properties.size()) {
-        proj->output_column_properties[i] = proj->children[0]->output_column_properties[src_idx];
-      }
-    }
+    proj->propagate_column_properties_from_child();
     plan = std::move(proj);
   }
   return plan;

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -241,14 +241,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     } else {
       projection->children.push_back(std::move(node));
     }
-    // Propagate uniqueness: each output column i maps to child column column_ids[i]
-    auto& child_props = projection->children[0]->output_column_properties;
-    for (duckdb::idx_t i = 0; i < column_ids.size(); i++) {
-      auto col_id = column_ids[i].GetPrimaryIndex();
-      if (col_id < child_props.size()) {
-        projection->output_column_properties[i] = child_props[col_id];
-      }
-    }
+    projection->propagate_column_properties_from_child();
     return std::move(projection);
   }
 

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -14,15 +14,62 @@
  * limitations under the License.
  */
 
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "op/sirius_physical_filter.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_table_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
-// #include "duckdb/common/types.hpp"
 
 namespace sirius::planner {
+
+/// Mark output columns as unique based on single-column UNIQUE/PRIMARY KEY constraints.
+/// table must be obtained via op.GetTable() BEFORE op.bind_data is moved away.
+static void mark_unique_columns_from_constraints(
+  duckdb::optional_ptr<duckdb::TableCatalogEntry> table,
+  sirius::op::sirius_physical_table_scan& node)
+{
+  if (!table) { return; }
+
+  auto& constraints = table->GetConstraints();
+  for (auto& constraint : constraints) {
+    if (constraint->type != duckdb::ConstraintType::UNIQUE) { continue; }
+    auto& unique_constraint = constraint->Cast<duckdb::UniqueConstraint>();
+    // Only handle single-column constraints (HasIndex() is true for index-based single-column)
+    if (!unique_constraint.HasIndex()) { continue; }
+    auto table_col_idx = unique_constraint.GetIndex().index;
+
+    // Find which position in column_ids corresponds to this table column
+    duckdb::optional_idx col_ids_pos;
+    for (duckdb::idx_t i = 0; i < node.column_ids.size(); i++) {
+      if (node.column_ids[i].GetPrimaryIndex() == table_col_idx) {
+        col_ids_pos = i;
+        break;
+      }
+    }
+    if (!col_ids_pos.IsValid()) { continue; }
+
+    // Map through projection_ids to find the output index
+    if (!node.projection_ids.empty()) {
+      for (duckdb::idx_t out_idx = 0; out_idx < node.projection_ids.size(); out_idx++) {
+        if (node.projection_ids[out_idx] == col_ids_pos.GetIndex()) {
+          if (out_idx < node.output_column_properties.size()) {
+            node.output_column_properties[out_idx].is_unique = true;
+          }
+          break;
+        }
+      }
+    } else {
+      // No projection_ids: output maps 1:1 with column_ids
+      auto out_idx = col_ids_pos.GetIndex();
+      if (out_idx < node.output_column_properties.size()) {
+        node.output_column_properties[out_idx].is_unique = true;
+      }
+    }
+  }
+}
 
 duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
   duckdb::TableFilterSet& table_filters, const duckdb::vector<duckdb::ColumnIndex>& column_ids)
@@ -50,6 +97,10 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 {
   auto column_ids = op.GetColumnIds();
+
+  // Save table pointer before bind_data is moved into the scan node.
+  // GetTable() requires bind_data, which will be consumed by make_uniq below.
+  auto table_entry = op.GetTable();
 
   if (!op.children.empty()) {
     throw duckdb::NotImplementedException("Table Input Output functions are not supported yet");
@@ -146,6 +197,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
                                                                 std::move(op.extra_info),
                                                                 std::move(op.parameters),
                                                                 std::move(op.virtual_columns));
+    mark_unique_columns_from_constraints(table_entry, *node);
     // first check if an additional projection is necessary
     if (column_ids.size() == op.returned_types.size()) {
       bool projection_necessary = false;
@@ -160,6 +212,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         // in that case we just return the node
         if (filter) {
           filter->children.push_back(std::move(node));
+          filter->propagate_column_properties_from_child();
           return std::move(filter);
         }
         return std::move(node);
@@ -183,9 +236,18 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         std::move(types), std::move(expressions), op.estimated_cardinality);
     if (filter) {
       filter->children.push_back(std::move(node));
+      filter->propagate_column_properties_from_child();
       projection->children.push_back(std::move(filter));
     } else {
       projection->children.push_back(std::move(node));
+    }
+    // Propagate uniqueness: each output column i maps to child column column_ids[i]
+    auto& child_props = projection->children[0]->output_column_properties;
+    for (duckdb::idx_t i = 0; i < column_ids.size(); i++) {
+      auto col_id = column_ids[i].GetPrimaryIndex();
+      if (col_id < child_props.size()) {
+        projection->output_column_properties[i] = child_props[col_id];
+      }
     }
     return std::move(projection);
   }
@@ -203,9 +265,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     std::move(op.extra_info),
     std::move(op.parameters),
     std::move(op.virtual_columns));
+  mark_unique_columns_from_constraints(table_entry, *node);
   node->dynamic_filters = op.dynamic_filters;
   if (filter) {
     filter->children.push_back(std::move(node));
+    filter->propagate_column_properties_from_child();
     return std::move(filter);
   }
   return std::move(node);

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -71,6 +71,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalLimit& op)
   }
 
   limit->children.push_back(std::move(plan));
+  limit->propagate_column_properties_from_child();
   return limit;
 }
 

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -38,6 +38,14 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
     auto order = duckdb::make_uniq<sirius::op::sirius_physical_order>(
       op.types, std::move(op.orders), std::move(projection_map), op.estimated_cardinality);
     order->children.push_back(std::move(plan));
+    // Propagate uniqueness through projection map
+    auto& child_props = order->children[0]->output_column_properties;
+    for (duckdb::idx_t i = 0; i < order->projections.size(); i++) {
+      auto src_idx = order->projections[i];
+      if (src_idx < child_props.size()) {
+        order->output_column_properties[i] = child_props[src_idx];
+      }
+    }
     plan = std::move(order);
   }
   return plan;

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -38,14 +38,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
     auto order = duckdb::make_uniq<sirius::op::sirius_physical_order>(
       op.types, std::move(op.orders), std::move(projection_map), op.estimated_cardinality);
     order->children.push_back(std::move(plan));
-    // Propagate uniqueness through projection map
-    auto& child_props = order->children[0]->output_column_properties;
-    for (duckdb::idx_t i = 0; i < order->projections.size(); i++) {
-      auto src_idx = order->projections[i];
-      if (src_idx < child_props.size()) {
-        order->output_column_properties[i] = child_props[src_idx];
-      }
-    }
+    order->propagate_column_properties_from_child();
     plan = std::move(order);
   }
   return plan;

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -52,31 +52,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalProjection& op)
     }
   }
 
-  // Save expression references before moving them into the projection
-  duckdb::vector<duckdb::optional_idx> passthrough_indices;
-  passthrough_indices.reserve(op.expressions.size());
-  for (auto& expr : op.expressions) {
-    if (expr->type == duckdb::ExpressionType::BOUND_REF) {
-      passthrough_indices.emplace_back(expr->Cast<duckdb::BoundReferenceExpression>().index);
-    } else {
-      passthrough_indices.emplace_back();
-    }
-  }
-
   auto projection = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
     op.types, std::move(op.expressions), op.estimated_cardinality);
   projection->children.push_back(std::move(plan));
-
-  // Propagate uniqueness for passthrough columns
-  auto& child_props = projection->children[0]->output_column_properties;
-  for (duckdb::idx_t i = 0; i < passthrough_indices.size(); i++) {
-    if (passthrough_indices[i].IsValid()) {
-      auto src_idx = passthrough_indices[i].GetIndex();
-      if (src_idx < child_props.size()) {
-        projection->output_column_properties[i] = child_props[src_idx];
-      }
-    }
-  }
+  projection->propagate_column_properties_from_child();
   return std::move(projection);
 }
 

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -52,9 +52,31 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalProjection& op)
     }
   }
 
+  // Save expression references before moving them into the projection
+  duckdb::vector<duckdb::optional_idx> passthrough_indices;
+  passthrough_indices.reserve(op.expressions.size());
+  for (auto& expr : op.expressions) {
+    if (expr->type == duckdb::ExpressionType::BOUND_REF) {
+      passthrough_indices.emplace_back(expr->Cast<duckdb::BoundReferenceExpression>().index);
+    } else {
+      passthrough_indices.emplace_back();
+    }
+  }
+
   auto projection = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
     op.types, std::move(op.expressions), op.estimated_cardinality);
   projection->children.push_back(std::move(plan));
+
+  // Propagate uniqueness for passthrough columns
+  auto& child_props = projection->children[0]->output_column_properties;
+  for (duckdb::idx_t i = 0; i < passthrough_indices.size(); i++) {
+    if (passthrough_indices[i].IsValid()) {
+      auto src_idx = passthrough_indices[i].GetIndex();
+      if (src_idx < child_props.size()) {
+        projection->output_column_properties[i] = child_props[src_idx];
+      }
+    }
+  }
   return std::move(projection);
 }
 

--- a/test/cpp/planner/test_column_property_propagation.cpp
+++ b/test/cpp/planner/test_column_property_propagation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Sirius Contributors.
+ * Copyright 2026, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/cpp/planner/test_column_property_propagation.cpp
+++ b/test/cpp/planner/test_column_property_propagation.cpp
@@ -147,17 +147,15 @@ TEST_CASE("column property - projection preserves uniqueness for passthrough col
   con.Query("CREATE TABLE proj_table (id INTEGER PRIMARY KEY, val DOUBLE)");
   con.Query("INSERT INTO proj_table VALUES (1, 10.0), (2, 20.0)");
 
-  // This projection reorders: val first, id second
+  // Output is [val, id] — projection reorders columns from [id, val]
   auto plan = generate_sirius_plan(con, "SELECT val, id FROM proj_table");
 
   REQUIRE(plan);
-  // After projection, id should still be unique but at the new position
-  // The plan structure may vary, so check the root output
-  bool found_unique = false;
-  for (size_t i = 0; i < plan->output_column_properties.size(); i++) {
-    if (plan->output_column_properties[i].is_unique) { found_unique = true; }
-  }
-  REQUIRE(found_unique);
+  REQUIRE(plan->output_column_properties.size() == 2);
+  // val (output index 0) is not unique
+  REQUIRE_FALSE(plan->output_column_properties[0].is_unique);
+  // id (output index 1) is the PK — should be unique even after reordering
+  REQUIRE(plan->output_column_properties[1].is_unique);
 }
 
 TEST_CASE("column property - filter preserves uniqueness", "[column_property]")
@@ -168,21 +166,15 @@ TEST_CASE("column property - filter preserves uniqueness", "[column_property]")
   con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val DOUBLE)");
   con.Query("INSERT INTO t VALUES (1, 10.0), (2, 20.0), (3, 30.0)");
 
+  // Output is [id, val] — filter should preserve uniqueness from scan
   auto plan = generate_sirius_plan(con, "SELECT id, val FROM t WHERE val > 15.0");
 
-  // Walk to find the root — it should have uniqueness on col 0 (id is PK)
   REQUIRE(plan);
-  // The plan should propagate uniqueness through filter
-  // Find the outermost operator and check its output properties
-  bool found_unique = false;
-  auto& props       = plan->output_column_properties;
-  for (size_t i = 0; i < props.size(); i++) {
-    if (props[i].is_unique) {
-      found_unique = true;
-      break;
-    }
-  }
-  REQUIRE(found_unique);
+  REQUIRE(plan->output_column_properties.size() == 2);
+  // id (output index 0) is the PK — should remain unique through filter
+  REQUIRE(plan->output_column_properties[0].is_unique);
+  // val (output index 1) is not unique
+  REQUIRE_FALSE(plan->output_column_properties[1].is_unique);
 }
 
 TEST_CASE("column property - aggregate marks group keys unique", "[column_property]")

--- a/test/cpp/planner/test_column_property_propagation.cpp
+++ b/test/cpp/planner/test_column_property_propagation.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_column_property_propagation.cpp
+ * @brief Tests that column uniqueness metadata is correctly propagated through
+ *        the Sirius physical plan and that unique_build_keys is set on hash
+ *        joins when build-side keys come from UNIQUE/PK columns.
+ */
+
+#include "op/sirius_physical_grouped_aggregate.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+
+using namespace duckdb;
+
+namespace {
+
+/// Generate a Sirius physical plan from a SQL query string.
+/// Must be called while a transaction is active on the connection.
+duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
+  Connection& con, const std::string& query)
+{
+  auto& context = *con.context;
+
+  auto original_disabled = DBConfig::GetConfig(context).options.disabled_optimizers;
+  auto& disabled         = DBConfig::GetConfig(context).options.disabled_optimizers;
+  disabled.insert(OptimizerType::IN_CLAUSE);
+  disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+
+  // Begin an explicit transaction so the planner has an active transaction context
+  con.Query("BEGIN TRANSACTION");
+
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> result;
+  try {
+    Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(!parser.statements.empty());
+
+    Planner planner(context);
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    auto plan = std::move(planner.plan);
+
+    if (context.config.enable_optimizer) {
+      Optimizer optimizer(*planner.binder, context);
+      plan = optimizer.Optimize(std::move(plan));
+    }
+
+    plan->ResolveOperatorTypes();
+
+    ColumnBindingResolver resolver;
+    ColumnBindingResolver::Verify(*plan);
+    resolver.VisitOperator(*plan);
+
+    sirius::planner::sirius_physical_plan_generator gen(context);
+    result = gen.create_plan(std::move(plan));
+  } catch (...) {
+    con.Query("ROLLBACK");
+    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    throw;
+  }
+
+  con.Query("COMMIT");
+  DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+  return result;
+}
+
+/// Walk the operator tree to find the first operator of the given type.
+sirius::op::sirius_physical_operator* find_operator(sirius::op::sirius_physical_operator* root,
+                                                    sirius::op::SiriusPhysicalOperatorType target)
+{
+  if (!root) { return nullptr; }
+  if (root->type == target) { return root; }
+  for (auto& child : root->children) {
+    auto* found = find_operator(child.get(), target);
+    if (found) { return found; }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("column property - scan marks PK columns unique", "[column_property]")
+{
+  DuckDB db(nullptr);
+  Connection con(db);
+
+  con.Query("CREATE TABLE pk_table (id INTEGER PRIMARY KEY, name VARCHAR, val DOUBLE)");
+  con.Query("INSERT INTO pk_table VALUES (1, 'a', 10.0), (2, 'b', 20.0)");
+
+  auto plan = generate_sirius_plan(con, "SELECT id, name, val FROM pk_table");
+
+  REQUIRE(plan);
+  // The PK column (id, output index 0) should be marked unique
+  REQUIRE(plan->output_column_properties.size() >= 3);
+  REQUIRE(plan->output_column_properties[0].is_unique);
+  REQUIRE_FALSE(plan->output_column_properties[1].is_unique);
+  REQUIRE_FALSE(plan->output_column_properties[2].is_unique);
+}
+
+TEST_CASE("column property - composite PK does NOT mark individual columns", "[column_property]")
+{
+  DuckDB db(nullptr);
+  Connection con(db);
+
+  con.Query("CREATE TABLE composite_pk (a INTEGER, b INTEGER, val DOUBLE, PRIMARY KEY (a, b))");
+  con.Query("INSERT INTO composite_pk VALUES (1, 1, 10.0), (1, 2, 20.0)");
+
+  auto plan = generate_sirius_plan(con, "SELECT a, b, val FROM composite_pk");
+
+  REQUIRE(plan);
+  // Composite PK columns should NOT be individually marked as unique
+  for (auto& prop : plan->output_column_properties) {
+    REQUIRE_FALSE(prop.is_unique);
+  }
+}
+
+TEST_CASE("column property - projection preserves uniqueness for passthrough columns",
+          "[column_property]")
+{
+  DuckDB db(nullptr);
+  Connection con(db);
+
+  con.Query("CREATE TABLE proj_table (id INTEGER PRIMARY KEY, val DOUBLE)");
+  con.Query("INSERT INTO proj_table VALUES (1, 10.0), (2, 20.0)");
+
+  // This projection reorders: val first, id second
+  auto plan = generate_sirius_plan(con, "SELECT val, id FROM proj_table");
+
+  REQUIRE(plan);
+  // After projection, id should still be unique but at the new position
+  // The plan structure may vary, so check the root output
+  bool found_unique = false;
+  for (size_t i = 0; i < plan->output_column_properties.size(); i++) {
+    if (plan->output_column_properties[i].is_unique) { found_unique = true; }
+  }
+  REQUIRE(found_unique);
+}
+
+TEST_CASE("column property - filter preserves uniqueness", "[column_property]")
+{
+  DuckDB db(nullptr);
+  Connection con(db);
+
+  con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val DOUBLE)");
+  con.Query("INSERT INTO t VALUES (1, 10.0), (2, 20.0), (3, 30.0)");
+
+  auto plan = generate_sirius_plan(con, "SELECT id, val FROM t WHERE val > 15.0");
+
+  // Walk to find the root — it should have uniqueness on col 0 (id is PK)
+  REQUIRE(plan);
+  // The plan should propagate uniqueness through filter
+  // Find the outermost operator and check its output properties
+  bool found_unique = false;
+  auto& props       = plan->output_column_properties;
+  for (size_t i = 0; i < props.size(); i++) {
+    if (props[i].is_unique) {
+      found_unique = true;
+      break;
+    }
+  }
+  REQUIRE(found_unique);
+}
+
+TEST_CASE("column property - aggregate marks group keys unique", "[column_property]")
+{
+  DuckDB db(nullptr);
+  Connection con(db);
+
+  con.Query("CREATE TABLE sales (product_id INTEGER, amount DOUBLE)");
+  con.Query("INSERT INTO sales VALUES (1, 10.0), (1, 20.0), (2, 30.0)");
+
+  auto plan =
+    generate_sirius_plan(con, "SELECT product_id, SUM(amount) FROM sales GROUP BY product_id");
+
+  REQUIRE(plan);
+  // The grouped aggregate should mark group keys as unique
+  // The result collector wraps the aggregate, so we need to find the aggregate
+  auto* agg_op = find_operator(plan.get(), sirius::op::SiriusPhysicalOperatorType::HASH_GROUP_BY);
+  if (agg_op) {
+    // Group key (product_id) at index 0 should be unique
+    REQUIRE(!agg_op->output_column_properties.empty());
+    REQUIRE(agg_op->output_column_properties[0].is_unique);
+    // Aggregate column (SUM) should not be unique
+    if (agg_op->output_column_properties.size() > 1) {
+      REQUIRE_FALSE(agg_op->output_column_properties[1].is_unique);
+    }
+  }
+}


### PR DESCRIPTION
Adds a column-level uniqueness propagation framework and uses it to select cudf::distinct_hash_join for INNER and LEFT joins when build-side keys are guaranteed unique (e.g., primary key / unique constraint).

Column property framework:
- New `column_property` struct on `sirius_physical_operator` tracks per-column guarantees (starting with is_unique)
- Table scan marks columns unique from DuckDB catalog constraints (UNIQUE / PRIMARY KEY)
- Properties propagate through filter, projection, limit, order, and aggregate operators at plan construction time
- Grouped aggregate marks grouping keys as unique (GROUP BY outputs are unique by definition)

Distinct hash join:
- New build_hash_table wrapper encapsulates both cudf::hash_join and cudf::distinct_hash_join behind a unified API
- BUILD_PROBE and STANDARD paths use distinct_hash_join when unique_build_keys is true
- Supports INNER (same return type) and LEFT (wrapper synthesizes trivial probe indices)
- FULL OUTER falls back to generic hash_join (cuDF has no distinct full join API)

Fixes #541 