### PR TITLE
Add prepare_for_processing virtual method to operator_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ cufile.log
 .pixi/*
 !.pixi/config.toml
 compile_commands.json
+.cache
 
 # Zed editor settings
 .zed

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 namespace sirius {
 
@@ -85,6 +86,25 @@ class operator_data {
   {
     return _data_batches;
   }
+
+  /**
+   * @brief Lock all data batches for processing in the requested memory space.
+   *
+   * Iterates over all batches and locks (or converts then locks) each one into the
+   * requested memory space. Returns the processing handles that keep the batches locked
+   * until they go out of scope.
+   *
+   * Returns std::nullopt if any batch fails to lock (triggers a retry/reschedule).
+   * Propagates rmm::out_of_memory so the caller can record metrics and reschedule.
+   *
+   * @param requested_memory_space  Target memory space; may be nullptr to use each batch's
+   *                                current space.
+   * @param stream                  CUDA stream used for any data-movement kernels.
+   * @return Processing handles for all batches, or std::nullopt on lock failure.
+   */
+  virtual std::optional<std::vector<::cucascade::data_batch_processing_handle>>
+  prepare_for_processing(const ::cucascade::memory::memory_space* requested_memory_space,
+                         rmm::cuda_stream_view stream);
 
  private:
   std::vector<std::shared_ptr<::cucascade::data_batch>> _data_batches;

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "log/logging.hpp"
+
+#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/sirius_converter_registry.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace sirius {
+namespace pipeline {
+
+/**
+ * @brief Lock or prepare a single data batch for processing in the requested memory space.
+ *
+ * If the batch is already in the requested memory space it is locked in place. If it resides
+ * elsewhere the batch is first converted (moved) to the requested space and then locked.
+ *
+ * @param batch                   The batch to lock/prepare.
+ * @param requested_memory_space  Target memory space; may be nullptr to use the batch's current
+ *                                space.
+ * @param stream                  CUDA stream used for any data-movement kernels.
+ * @return A processing handle that keeps the batch locked, or std::nullopt on failure.
+ * @throws rmm::out_of_memory  If a GPU memory allocation fails during the conversion.
+ */
+inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
+  const std::shared_ptr<cucascade::data_batch>& batch,
+  const cucascade::memory::memory_space* requested_memory_space,
+  rmm::cuda_stream_view stream)
+{
+  using status = cucascade::lock_for_processing_status;
+  const auto* target_space =
+    requested_memory_space != nullptr ? requested_memory_space : batch->get_memory_space();
+  if (target_space == nullptr) { return std::nullopt; }
+
+  // NOTE: only works in single gpu setup
+  // wait for processing in case a shared batch is in transit in another thread.
+  auto lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
+
+  auto cancel_task_if_needed = []() {
+    SIRIUS_LOG_ERROR(
+      "gpu_pipeline_task: failed to lock batch for processing and cannot prepare batch for "
+      "processing. This likely means the batch is in transit and there is a bug in "
+      "the in-transit locking logic. Cancelling task to avoid deadlock.");
+  };
+
+  while (!lock_result.success && lock_result.status == status::memory_space_mismatch) {
+    try {
+      auto& registry = sirius::converter_registry::get();
+      switch (requested_memory_space->get_tier()) {
+        case cucascade::memory::Tier::GPU: {
+          auto prev_state = batch->get_state();
+          if (!batch->try_to_lock_for_in_transit()) {
+            auto current_state = batch->get_state();
+            if (current_state == cucascade::batch_state::in_transit) {
+              // If another thread has taken the in_transit lock, wait to acquire the processing
+              // lock.
+              lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
+              continue;
+            }
+            cancel_task_if_needed();
+            return std::nullopt;
+          }
+          try {
+            batch->convert_to<cucascade::gpu_table_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
+          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
+          break;
+        }
+        case cucascade::memory::Tier::HOST: {
+          auto prev_state = batch->get_state();
+          if (!batch->try_to_lock_for_in_transit()) {
+            cancel_task_if_needed();
+            return std::nullopt;
+          }
+          try {
+            batch->convert_to<cucascade::host_data_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
+          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
+          break;
+        }
+        default: cancel_task_if_needed(); return std::nullopt;
+      }
+
+      lock_result = batch->try_to_lock_for_processing(requested_memory_space->get_id());
+    } catch (...) {
+      throw;
+    }
+  }
+
+  if (!lock_result.success) {
+    cancel_task_if_needed();
+    return std::nullopt;
+  }
+
+  return std::move(lock_result.handle);
+}
+
+}  // namespace pipeline
+}  // namespace sirius

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -18,13 +18,13 @@
 
 #include "log/logging.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <data/sirius_converter_registry.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
 #include <optional>

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -36,8 +36,7 @@ namespace op {
 
 std::optional<std::vector<::cucascade::data_batch_processing_handle>>
 operator_data::prepare_for_processing(
-  const ::cucascade::memory::memory_space* requested_memory_space,
-  rmm::cuda_stream_view stream)
+  const ::cucascade::memory::memory_space* requested_memory_space, rmm::cuda_stream_view stream)
 {
   std::vector<::cucascade::data_batch_processing_handle> handles;
   handles.reserve(_data_batches.size());
@@ -47,10 +46,9 @@ operator_data::prepare_for_processing(
     try {
       handle = pipeline::lock_or_prepare_batch(batch, requested_memory_space, stream);
     } catch (const rmm::out_of_memory&) {
-      SIRIUS_LOG_ERROR(
-        "operator_data: OOM at batch {} preparing for processing, state: {}",
-        batch->get_batch_id(),
-        static_cast<int>(batch->get_state()));
+      SIRIUS_LOG_ERROR("operator_data: OOM at batch {} preparing for processing, state: {}",
+                       batch->get_batch_id(),
+                       static_cast<int>(batch->get_state()));
       throw;
     } catch (const std::exception& e) {
       SIRIUS_LOG_ERROR(

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -17,15 +17,55 @@
 #include "op/sirius_physical_operator.hpp"
 
 #include "gpu_executor.hpp"
+#include "log/logging.hpp"
+#include "pipeline/batch_lock_utils.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/error.hpp>
 
 #include <optional>
 
 namespace sirius {
 namespace op {
+
+//===--------------------------------------------------------------------===//
+// operator_data
+//===--------------------------------------------------------------------===//
+
+std::optional<std::vector<::cucascade::data_batch_processing_handle>>
+operator_data::prepare_for_processing(
+  const ::cucascade::memory::memory_space* requested_memory_space,
+  rmm::cuda_stream_view stream)
+{
+  std::vector<::cucascade::data_batch_processing_handle> handles;
+  handles.reserve(_data_batches.size());
+
+  for (const auto& batch : _data_batches) {
+    std::optional<::cucascade::data_batch_processing_handle> handle;
+    try {
+      handle = pipeline::lock_or_prepare_batch(batch, requested_memory_space, stream);
+    } catch (const rmm::out_of_memory&) {
+      SIRIUS_LOG_ERROR(
+        "operator_data: OOM at batch {} preparing for processing, state: {}",
+        batch->get_batch_id(),
+        static_cast<int>(batch->get_state()));
+      throw;
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_ERROR(
+        "operator_data: Unknown error at batch {} preparing for processing, state: {}: {}",
+        batch->get_batch_id(),
+        static_cast<int>(batch->get_state()),
+        e.what());
+      throw;
+    }
+    if (!handle) { return std::nullopt; }
+    handles.emplace_back(std::move(*handle));
+  }
+
+  return handles;
+}
 
 //===--------------------------------------------------------------------===//
 // Operator

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -313,8 +313,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   std::optional<std::vector<cucascade::data_batch_processing_handle>> handles_opt;
   try {
-    handles_opt =
-      local_state._input_data->prepare_for_processing(requested_memory_space, stream);
+    handles_opt = local_state._input_data->prepare_for_processing(requested_memory_space, stream);
   } catch (const rmm::out_of_memory& oom) {
     auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
     auto input_basis = local_state.get_task_consumption_basis();
@@ -323,10 +322,10 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
     SIRIUS_LOG_ERROR("Pipeline {}: OOM preparing batches for processing",
                      pipeline->get_pipeline_id());
-    throw oom_reschedule_exception(std::move(local_state._input_data),
-                                   0,
-                                   std::string("OOM while preparing batches for processing: ") +
-                                     oom.what());
+    throw oom_reschedule_exception(
+      std::move(local_state._input_data),
+      0,
+      std::string("OOM while preparing batches for processing: ") + oom.what());
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Unknown error in prepare_for_processing for pipeline {}: {}",
                      pipeline->get_pipeline_id(),
@@ -336,12 +335,10 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   if (!handles_opt) {
     // trick to retry the task
-    throw oom_reschedule_exception(std::move(local_state._input_data),
-                                   0,
-                                   "Failed to lock or prepare batches for processing");
+    throw oom_reschedule_exception(
+      std::move(local_state._input_data), 0, "Failed to lock or prepare batches for processing");
   }
-  std::vector<cucascade::data_batch_processing_handle> processing_handles =
-    std::move(*handles_opt);
+  std::vector<cucascade::data_batch_processing_handle> processing_handles = std::move(*handles_opt);
 
   auto const prepare_end = std::chrono::high_resolution_clock::now();
   auto const prepare_duration =

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -24,14 +24,11 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <absl/cleanup/cleanup.h>
-#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/error.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <data/data_batch_utils.hpp>
-#include <data/sirius_converter_registry.hpp>
 
 #include <format>
 #include <optional>
@@ -40,87 +37,6 @@ namespace sirius {
 namespace pipeline {
 
 namespace {
-
-std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
-  const std::shared_ptr<cucascade::data_batch>& batch,
-  const cucascade::memory::memory_space* requested_memory_space,
-  rmm::cuda_stream_view stream)
-{
-  using status = cucascade::lock_for_processing_status;
-  const auto* target_space =
-    requested_memory_space != nullptr ? requested_memory_space : batch->get_memory_space();
-  if (target_space == nullptr) { return std::nullopt; }
-
-  // NOTE: only works in single gpu setup
-  // wait for processing in case a shared batch is in transit in another thread.
-  auto lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
-
-  auto cancel_task_if_needed = []() {
-    SIRIUS_LOG_ERROR(
-      "gpu_pipeline_task: failed to lock batch for processing and cannot prepare batch for "
-      "processing. This likely means the batch is in transit and there is a bug in "
-      "the in-transit locking logic. Cancelling task to avoid deadlock.");
-  };
-
-  while (!lock_result.success && lock_result.status == status::memory_space_mismatch) {
-    try {
-      auto& registry = sirius::converter_registry::get();
-      switch (requested_memory_space->get_tier()) {
-        case cucascade::memory::Tier::GPU: {
-          auto prev_state = batch->get_state();
-          if (!batch->try_to_lock_for_in_transit()) {
-            auto current_state = batch->get_state();
-            if (current_state == cucascade::batch_state::in_transit) {
-              // If another thread has taken the in_transit lock, wait to acquire the processing
-              // lock.
-              lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
-              continue;
-            }
-            cancel_task_if_needed();
-            return std::nullopt;
-          }
-          try {
-            batch->convert_to<cucascade::gpu_table_representation>(
-              registry, requested_memory_space, stream);
-          } catch (...) {
-            batch->try_to_release_in_transit();
-            throw;
-          }
-          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
-          break;
-        }
-        case cucascade::memory::Tier::HOST: {
-          auto prev_state = batch->get_state();
-          if (!batch->try_to_lock_for_in_transit()) {
-            cancel_task_if_needed();
-            return std::nullopt;
-          }
-          try {
-            batch->convert_to<cucascade::host_data_representation>(
-              registry, requested_memory_space, stream);
-          } catch (...) {
-            batch->try_to_release_in_transit();
-            throw;
-          }
-          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
-          break;
-        }
-        default: cancel_task_if_needed(); return std::nullopt;
-      }
-
-      lock_result = batch->try_to_lock_for_processing(requested_memory_space->get_id());
-    } catch (...) {
-      throw;
-    }
-  }
-
-  if (!lock_result.success) {
-    cancel_task_if_needed();
-    return std::nullopt;
-  }
-
-  return std::move(lock_result.handle);
-}
 
 void validate_operator_output_types(const op::operator_data* data,
                                     const op::sirius_physical_operator& op)
@@ -391,61 +307,41 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     allocator->reset_stream_reservation(stream);
   };
 
-  std::vector<cucascade::data_batch_processing_handle> processing_handles;
   if (!local_state._input_data) {
     throw std::runtime_error("gpu_pipeline_task::execute: input_data is null");
   }
-  processing_handles.reserve(local_state._input_data->get_data_batches().size());
 
-  for (const auto& batch : local_state._input_data->get_data_batches()) {
-    auto* resident_space = batch->get_memory_space();
-    if (requested_memory_space && resident_space &&
-        resident_space->get_id() != requested_memory_space->get_id()) {
-      SIRIUS_LOG_TRACE(
-        "Pipeline {}: fetching batch {} from tier {} to tier {} for operator {} (id={})",
-        pipeline->get_pipeline_id(),
-        batch->get_batch_id(),
-        static_cast<int>(resident_space->get_tier()),
-        static_cast<int>(requested_memory_space->get_tier()),
-        first_op.get_name(),
-        first_op.get_operator_id());
-    }
-    std::optional<cucascade::data_batch_processing_handle> handle;
-    try {
-      handle = lock_or_prepare_batch(batch, requested_memory_space, stream);
-    } catch (const rmm::out_of_memory& oom) {
-      auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
-      auto input_basis = local_state.get_task_consumption_basis();
-      auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
-      global.get_memory_history().record_on_failure(input_basis, peak_bytes);
+  std::optional<std::vector<cucascade::data_batch_processing_handle>> handles_opt;
+  try {
+    handles_opt =
+      local_state._input_data->prepare_for_processing(requested_memory_space, stream);
+  } catch (const rmm::out_of_memory& oom) {
+    auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
+    auto input_basis = local_state.get_task_consumption_basis();
+    auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
+    global.get_memory_history().record_on_failure(input_basis, peak_bytes);
 
-      SIRIUS_LOG_ERROR("Pipeline {}: OOM at batch {} preparing for processing, state: {}",
-                       pipeline->get_pipeline_id(),
-                       batch->get_batch_id(),
-                       static_cast<int>(batch->get_state()));
-      throw oom_reschedule_exception(std::move(local_state._input_data),
-                                     0,
-                                     "Failed to lock or prepare batch " +
-                                       std::to_string(batch->get_batch_id()) + " for processing");
-    } catch (const std::exception& e) {
-      SIRIUS_LOG_ERROR(
-        "Unknown error: {};  in lock or prepare for pipeline {}, batch {}, state: {}",
-        e.what(),
-        pipeline->get_pipeline_id(),
-        batch->get_batch_id(),
-        static_cast<int>(batch->get_state()));
-      throw;
-    }
-    if (!handle) {
-      // trick to retry the task
-      throw oom_reschedule_exception(std::move(local_state._input_data),
-                                     0,
-                                     "Failed to lock or prepare batch " +
-                                       std::to_string(batch->get_batch_id()) + " for processing");
-      return;
-    }
-    processing_handles.emplace_back(std::move(*handle));
+    SIRIUS_LOG_ERROR("Pipeline {}: OOM preparing batches for processing",
+                     pipeline->get_pipeline_id());
+    throw oom_reschedule_exception(std::move(local_state._input_data),
+                                   0,
+                                   std::string("OOM while preparing batches for processing: ") +
+                                     oom.what());
+  } catch (const std::exception& e) {
+    SIRIUS_LOG_ERROR("Unknown error in prepare_for_processing for pipeline {}: {}",
+                     pipeline->get_pipeline_id(),
+                     e.what());
+    throw;
   }
+
+  if (!handles_opt) {
+    // trick to retry the task
+    throw oom_reschedule_exception(std::move(local_state._input_data),
+                                   0,
+                                   "Failed to lock or prepare batches for processing");
+  }
+  std::vector<cucascade::data_batch_processing_handle> processing_handles =
+    std::move(*handles_opt);
 
   auto const prepare_end = std::chrono::high_resolution_clock::now();
   auto const prepare_duration =


### PR DESCRIPTION
Extract batch locking logic from gpu_pipeline_task::execute into a virtual operator_data::prepare_for_processing method. The method iterates over all data batches, locking each into the requested memory space via the shared lock_or_prepare_batch utility, and returns the processing handles to the caller.

gpu_pipeline_task::execute now calls prepare_for_processing and handles OOM by recording memory metrics and raising oom_reschedule_exception, keeping exception-handling policy out of operator_data.