### PR TITLE
Add module-context, module-discover, and profile-analyzer Claude Code skills

### DIFF
--- a/.claude/skills/bisect/SKILL.md
+++ b/.claude/skills/bisect/SKILL.md
@@ -35,9 +35,7 @@ Find which commit introduced a bug using `git bisect` with automated build+test.
    ```bash
    #!/bin/bash
    set -e
-   # Build (replace <preset> with user's chosen preset)
-   CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make <preset> 2>&1 | tail -5
-   if [ $? -ne 0 ]; then exit 125; fi  # skip if build fails
+   # Build  (look in Claude.md)
 
    # Run test
    <test_command>

--- a/.claude/skills/module-context/SKILL.md
+++ b/.claude/skills/module-context/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: module-context
+description: Automatically identify which dependency library modules are relevant to a task and load their API documentation into context. Use PROACTIVELY before implementing features, fixing bugs, or writing new operators — analyzes the task description and loads cudf, rmm, duckdb, cucascade module docs to improve code quality. Trigger when the user asks to implement, add, fix, or modify GPU operators, pipeline components, memory management, joins, aggregations, sorting, expressions, or data I/O.
+---
+
+# Module Context Loader
+
+You are a context-routing skill for the Sirius GPU SQL engine. Your job is to analyze a task description and load the relevant dependency module documentation so that the implementing agent has accurate API knowledge.
+
+## Available Documentation
+
+Module docs are pre-generated at `.claude/skills/module-discover/docs/`. Each library has:
+- `README.md` — Module map with USED/UNUSED status and file-to-module mappings
+- `modules/<name>.md` — Per-module API reference with signatures, descriptions, and usage examples
+
+### Library Index
+
+| Library | Namespace | Modules | Docs Path |
+|---------|-----------|---------|-----------|
+| **cudf** | `cudf::` | 25 modules (19 USED) | `docs/cudf/` |
+| **rmm** | `rmm::`, `rmm::mr::` | 17 modules (8 USED) | `docs/rmm/` |
+| **duckdb** | `duckdb::` | 13 modules (10 USED) | `docs/duckdb/` |
+| **cucascade** | `cucascade::` | 3 modules (2 USED) | `docs/cucascade/` |
+| **libkvikio** | `kvikio::` | 7 modules (0 USED) | `docs/libkvikio/` |
+
+## Workflow
+
+### Step 1: Analyze the Task
+
+Read the user's task description and identify which **functional areas** it touches. Use this keyword-to-module mapping:
+
+#### Join operations
+**Keywords**: join, hash join, inner join, left join, right join, full join, semi join, anti join, nested loop, conditional join, equi-join, non-equi
+**Modules to load**:
+- `cudf/modules/join.md` — hash_join, conditional_join, mixed_join APIs
+- `cudf/modules/ast.md` — AST expressions for conditional/mixed joins
+- `cudf/modules/copying.md` — gather() to materialize join results
+- `duckdb/modules/planner.md` — BoundExpression types for join conditions
+- `duckdb/modules/execution.md` — PhysicalOperator for plan translation
+- `cucascade/modules/data.md` — data_batch for pipeline I/O
+
+#### Aggregation / Group By
+**Keywords**: aggregate, group by, groupby, sum, count, min, max, avg, mean, distinct, reduce, having
+**Modules to load**:
+- `cudf/modules/aggregation.md` — groupby, reduce, aggregation factories
+- `cudf/modules/stream_compaction.md` — drop_duplicates for DISTINCT
+- `cudf/modules/dictionary.md` — dictionary encoding for merge optimization
+- `duckdb/modules/function.md` — FunctionBinder for aggregate functions
+- `cucascade/modules/data.md` — data_batch
+
+#### Sorting / Order By / Top-N
+**Keywords**: sort, order by, top-n, limit, merge sort, rank, partition
+**Modules to load**:
+- `cudf/modules/sorting.md` — sorted_order, merge, search bounds
+- `cudf/modules/copying.md` — gather, slice, concatenate
+- `cudf/modules/partitioning.md` — hash_partition
+- `duckdb/modules/execution.md` — PhysicalOperator
+
+#### Filter / Projection / Expressions
+**Keywords**: filter, where, projection, expression, cast, comparison, like, regex, substring, between, case when, coalesce, in list
+**Modules to load**:
+- `cudf/modules/unary_binary.md` — binary_operation, cast, unary_operation
+- `cudf/modules/scalar.md` — numeric_scalar, string_scalar for constants
+- `cudf/modules/strings.md` — GPU string operations (like, contains, regex)
+- `cudf/modules/datetime.md` — date/time extraction
+- `duckdb/modules/planner.md` — BoundExpression hierarchy
+- `duckdb/modules/common.md` — LogicalType, Value
+
+#### Data I/O / Table Scan
+**Keywords**: scan, parquet, read, datasource, I/O, file, hybrid scan, table scan
+**Modules to load**:
+- `cudf/modules/io.md` — parquet reader, datasource, hybrid_scan
+- `cudf/modules/table.md` — table, table_view, column_view
+- `cucascade/modules/data.md` — data_batch, data representations
+- `cucascade/modules/memory.md` — memory spaces, host memory resources
+- `duckdb/modules/execution.md` — scan task infrastructure
+
+#### Memory Management
+**Keywords**: memory, OOM, allocation, buffer, pool, reservation, spill, downgrade, evict, GPU memory, pinned memory
+**Modules to load**:
+- `rmm/modules/memory_resources.md` — device_memory_resource, pool_memory_resource
+- `rmm/modules/resource_refs.md` — device_async_resource_ref
+- `rmm/modules/device_containers.md` — device_buffer, device_uvector
+- `rmm/modules/cuda_streams.md` — cuda_stream_view
+- `rmm/modules/error_handling.md` — out_of_memory exception
+- `cucascade/modules/memory.md` — reservation_manager, memory_space, tiered memory
+
+#### Pipeline / Execution Engine
+**Keywords**: pipeline, task, executor, stream, thread pool, scheduling, meta pipeline, sink, source
+**Modules to load**:
+- `cucascade/modules/data.md` — data_batch, data_repository
+- `cucascade/modules/memory.md` — reservations, stream_pool
+- `rmm/modules/cuda_streams.md` — cuda_stream_view
+- `duckdb/modules/parallel.md` — ThreadContext, TaskScheduler
+- `duckdb/modules/execution.md` — ExecutionContext
+
+#### Type System / Data Types
+**Keywords**: type, data type, decimal, varchar, string, date, timestamp, integer, logical type, type_id
+**Modules to load**:
+- `cudf/modules/types_core.md` — type_id, data_type, size_type
+- `cudf/modules/fixed_point.md` — DECIMAL support
+- `cudf/modules/table.md` — column_view, type accessors
+- `duckdb/modules/common.md` — LogicalType, Value, PhysicalType
+
+#### New Operator Implementation
+**Keywords**: new operator, implement operator, add operator, physical operator
+**Modules to load**:
+- `duckdb/modules/execution.md` — PhysicalOperator base class
+- `duckdb/modules/planner.md` — expression types for plan translation
+- `cudf/modules/table.md` — table/column views
+- `cudf/modules/copying.md` — gather, scatter, concatenate
+- `rmm/modules/resource_refs.md` — device_async_resource_ref parameter pattern
+- `rmm/modules/cuda_streams.md` — stream parameter pattern
+- `cucascade/modules/data.md` — data_batch I/O pattern
+- Load the specific cudf module for the operator's function (join, sort, aggregate, etc.)
+
+#### Extension / Registration
+**Keywords**: extension, register, table function, load, configuration, setting
+**Modules to load**:
+- `duckdb/modules/main.md` — ClientContext, Connection, DBConfig
+- `duckdb/modules/function.md` — TableFunction, ScalarFunction
+- `duckdb/modules/parser.md` — CreateTableFunctionInfo
+- `duckdb/modules/catalog.md` — Catalog registration
+
+### Step 2: Load Module Documentation
+
+For each identified module:
+
+1. Read the module's `.md` file from `.claude/skills/module-discover/docs/<library>/modules/<module>.md`
+2. Extract the **API Reference** section (signatures + descriptions)
+3. Extract the **Our Usage** examples (existing call sites in our codebase)
+
+**Loading priority** (if context is limited):
+1. APIs we already use (highest — patterns to follow)
+2. APIs in included headers (medium — available and likely useful)
+3. APIs available but unused (lowest — only if the task requires new functionality)
+
+### Step 3: Present Context
+
+Output a structured context block that the implementing agent can reference:
+
+```markdown
+## Relevant Library Context for: <task summary>
+
+### Modules Loaded
+- cudf/join — hash_join, conditional_join (for implementing the join operator)
+- rmm/cuda_streams — cuda_stream_view (standard stream parameter)
+- ...
+
+### Key APIs
+
+#### <API Name> (`<library>/<module>`)
+<signature>
+<brief description>
+**Existing usage pattern**: `<file>:<line>` — <how we use it>
+
+#### <Next API...>
+
+### Patterns to Follow
+- <Pattern observed from our existing code, e.g., "All operators take rmm::cuda_stream_view as parameter">
+- <Pattern, e.g., "Join operators build hash table on smaller side, then gather results">
+```
+
+### Step 4: Flag Gaps
+
+If the task requires functionality that:
+- Exists in an UNUSED module → mention the module and suggest loading its docs
+- Doesn't exist in any documented library → flag it explicitly
+- Requires a version-specific API → note the version condition
+
+## Guidelines
+
+1. **Be selective.** Don't load every module. A typical task needs 3-6 modules. Loading too much dilutes the signal.
+2. **Prioritize used modules.** Our existing usage patterns are the most valuable context — they show how APIs are actually integrated.
+3. **Include the file-to-module mapping** from the README when relevant, so the implementer knows which existing files to look at.
+4. **Cross-reference libraries.** Most tasks span multiple libraries (e.g., a join needs cudf/join + duckdb/planner + rmm/streams + cucascade/data).
+5. **Surface version gotchas.** cudf has significant API differences between 25.04 and 26.04+. Always note when a loaded API has version-conditional behavior.
+6. **Read the actual module docs.** Don't summarize from memory — read the `.md` files to get accurate signatures.

--- a/.claude/skills/module-discover/SKILL.md
+++ b/.claude/skills/module-discover/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: module-discover
+description: Discover and document a dependency library or submodule — analyzes all uses within the codebase, divides the library into logical modules, identifies which modules are used, and generates LLM-consumable API documentation for each module. Use when the user wants to understand a library dependency, map its modules, or generate API reference docs for a submodule.
+---
+
+# Library Module Discovery & Documentation
+
+You are analyzing a dependency library or submodule used by this project. Your goal is to produce a structured, LLM-consumable module map and API reference that helps agents quickly understand what the library provides and how this project uses it.
+
+## Before Starting
+
+Ask the user:
+1. **Which library/submodule?** (e.g., `cucascade`, `duckdb`, `cudf`, `rmm`, `spdlog`, or a path to any dependency)
+2. **Where is the library source?** If it's a submodule, it's already in the repo. If it's an installed dependency, ask for the include path (e.g., `$CONDA_PREFIX/include/cudf` or `$LIBCUDF_ENV_PREFIX/include/rmm`).
+3. **Output location?** Default: `.claude/skills/module-discover/docs/<library_name>/`
+
+If the user gives just a name (e.g., "cudf"), try these locations in order:
+- Submodule in repo root: `./<name>/`
+- Conda prefix: `$CONDA_PREFIX/include/<name>/` or `$LIBCUDF_ENV_PREFIX/include/<name>/`
+- System include: `/usr/include/<name>/` or `/usr/local/include/<name>/`
+
+## Workflow
+
+### Phase 1: Discover Our Usage
+
+Find every place in **our codebase** (under `src/`, `test/`, `CMakeLists.txt`, `*.cmake`) that references the target library.
+
+**Step 1a: Find includes**
+```bash
+# Find all #include directives referencing the library
+grep -rn '#include.*<LIBRARY_NAME/' src/ test/ --include='*.hpp' --include='*.cpp' --include='*.cu' --include='*.cuh'
+grep -rn '#include.*"LIBRARY_NAME/' src/ test/ --include='*.hpp' --include='*.cpp' --include='*.cu' --include='*.cuh'
+```
+
+**Step 1b: Find API calls**
+Search for namespace-qualified calls and type references:
+```bash
+# For namespaced libraries (e.g., cudf::, rmm::, cucascade::)
+grep -rn 'NAMESPACE::' src/ test/ --include='*.hpp' --include='*.cpp' --include='*.cu' --include='*.cuh'
+```
+
+**Step 1c: Find CMake references**
+```bash
+grep -rn 'LIBRARY_NAME' CMakeLists.txt third_party/*.cmake extension_config.cmake
+```
+
+**Step 1d: Compile usage inventory**
+Create a list of:
+- Every header we include from the library
+- Every function/method we call
+- Every type we use (classes, enums, typedefs)
+- Every macro we reference
+
+Group these by source file to understand usage patterns.
+
+### Phase 2: Map the Library's Module Structure
+
+Explore the library's source/headers to identify logical modules.
+
+**Step 2a: Survey top-level structure**
+```bash
+# List top-level directories and key header files
+ls -la LIBRARY_PATH/
+ls -la LIBRARY_PATH/include/ 2>/dev/null
+find LIBRARY_PATH/include/ -maxdepth 2 -type d 2>/dev/null
+```
+
+**Step 2b: Identify modules**
+A "module" is a logical grouping of related functionality. Look for:
+- Top-level subdirectories under `include/` (strongest signal)
+- Namespace subdivisions (e.g., `cudf::io`, `cudf::strings`, `rmm::mr`)
+- Separate header groups that serve a distinct purpose
+- README or docs that describe the library's architecture
+
+**Guidelines for module count:**
+- Aim for 3-8 modules for most libraries
+- A very large library (cudf, duckdb) may have 10-12
+- A small library (spdlog, abseil component) may have 2-4
+- Each module should represent a coherent unit of functionality
+- Prefer fewer, broader modules over many granular ones
+
+**Step 2c: Classify modules**
+For each module, determine:
+- **USED**: Our codebase includes headers from or calls APIs in this module
+- **UNUSED**: No references found in our codebase
+
+### Phase 3: Document Used Modules (Deep)
+
+For each USED module, produce detailed API documentation.
+
+**Step 3a: List all public headers**
+```bash
+find LIBRARY_PATH/include/MODULE_PATH -name '*.hpp' -o -name '*.h' | sort
+```
+
+**Step 3b: Extract API surface**
+For each public header that we use (or that's closely related to what we use), extract:
+- **Classes/Structs**: Name, brief purpose, key public methods with signatures
+- **Free functions**: Signature and brief description
+- **Enums**: Values and meaning
+- **Type aliases**: What they resolve to
+- **Constants/Macros**: Name and value/purpose
+
+Focus on:
+1. APIs we actually call (highest priority — include usage examples from our code)
+2. APIs in the same headers we include (medium priority — we might need them)
+3. Other public APIs in the module (lower priority — available but unused)
+
+**Step 3c: Document usage patterns**
+For each used API, find 1-2 representative call sites in our codebase showing how we use it. Include file path and line number.
+
+### Phase 4: Document Unused Modules (Light)
+
+For each UNUSED module, produce a brief summary:
+- Module name and path
+- 2-3 sentence description of what it provides
+- Key classes/functions (names only, no signatures)
+- Potential relevance to our project (if any)
+
+### Phase 5: Generate Output
+
+Write the documentation in the output directory with this structure:
+
+```
+docs/<library_name>/
+  README.md           — Overview: library purpose, version, module map, usage summary
+  modules/
+    <module_name>.md  — Per-module documentation (deep for USED, light for UNUSED)
+```
+
+## Output Format
+
+### README.md Template
+
+```markdown
+# <Library Name> — Module Reference
+
+**Version**: <version or git commit>
+**Location**: <path to library source>
+**Namespace**: <primary namespace>
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| <name> | USED   | <one-line>  | <top 3 APIs>  |
+| <name> | UNUSED | <one-line>  | —             |
+
+## Our Usage Summary
+
+We use <N> of <M> modules. Primary integration points:
+- <bullet summary of how we use the library>
+
+## Files That Reference This Library
+
+| Source File | Modules Used | Key APIs |
+|-------------|-------------|----------|
+| <path>      | <modules>   | <APIs>   |
+```
+
+### Per-Module Documentation (USED — Deep)
+
+```markdown
+# <Module Name>
+
+**Status**: USED
+**Path**: <path within library>
+**Headers we include**: <list>
+
+## Summary
+<2-3 sentences: what this module does and how we use it>
+
+## API Reference
+
+### <Class/Function Name>
+
+**Header**: `<header_path>`
+**Signature**:
+\`\`\`cpp
+<full signature>
+\`\`\`
+
+**Description**: <what it does, key parameters, return value>
+
+**Our usage**:
+- `<our_file.cpp>:<line>` — <brief context of how we call it>
+
+### <Next API...>
+
+## APIs Available but Not Used
+
+These APIs exist in this module but are not currently called by our codebase:
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| <name> | <header> | <one-line> |
+```
+
+### Per-Module Documentation (UNUSED — Light)
+
+```markdown
+# <Module Name>
+
+**Status**: UNUSED
+**Path**: <path within library>
+
+## Summary
+<2-3 sentences: what this module provides>
+
+## Key APIs
+- `<ClassName>` — <one-line>
+- `<function_name>()` — <one-line>
+
+## Potential Relevance
+<1-2 sentences on whether/how this could be useful to our project, or "Not applicable to our use case">
+```
+
+## Important Guidelines
+
+1. **Be thorough in Phase 1.** Missing a usage means misclassifying a module as UNUSED.
+2. **Read headers, don't guess.** Extract actual signatures from the source code.
+3. **Include line references.** Every usage example should include `file:line`.
+4. **Keep unused module docs brief.** Don't spend time documenting APIs we don't use in detail.
+5. **Use consistent formatting.** LLMs parse markdown tables and code blocks reliably.
+6. **Note version-specific APIs.** If you notice the library version matters (e.g., API changed between versions), flag it.
+7. **Parallelize where possible.** Phase 1 searches and Phase 3 header reads can be parallelized across modules.
+8. **For very large libraries** (100+ headers in a module), focus deep documentation on the headers we actually include, and list the rest in a summary table.
+
+## Updating Existing Documentation
+
+If documentation already exists for a library in the output directory:
+1. Read the existing README.md to understand what was previously documented
+2. Re-run Phase 1 to detect any new or removed usages
+3. Update only the modules/files that changed
+4. Update the README.md module map and usage summary
+
+## Example Invocations
+
+```
+User: "Document the cucascade submodule"
+→ Library: cucascade, Path: ./cucascade/, Output: .claude/skills/module-discover/docs/cucascade/
+
+User: "Map out how we use cudf"
+→ Library: cudf, Path: $CONDA_PREFIX/include/cudf/ (or $LIBCUDF_ENV_PREFIX/include/cudf/), Output: .claude/skills/module-discover/docs/cudf/
+
+User: "What parts of rmm do we use?"
+→ Library: rmm, Path: $CONDA_PREFIX/include/rmm/ (or $LIBCUDF_ENV_PREFIX/include/rmm/), Output: .claude/skills/module-discover/docs/rmm/
+
+User: "Analyze spdlog dependency"
+→ Library: spdlog, Path: (find via FetchContent in CMake), Output: .claude/skills/module-discover/docs/spdlog/
+```

--- a/.claude/skills/module-discover/docs/cucascade/README.md
+++ b/.claude/skills/module-discover/docs/cucascade/README.md
@@ -1,0 +1,52 @@
+# cuCascade — Module Reference
+
+**Version**: git submodule (see `cucascade/` in repo root)
+**Location**: `./cucascade/`
+**Namespace**: `cucascade` (data types), `cucascade::memory` (memory management)
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| data | USED | Data representation, batching, and repository management | `data_batch`, `gpu_table_representation`, `shared_data_repository`, `data_repository_manager` |
+| memory | USED | GPU/Host/Disk memory spaces, reservations, and resource adaptors | `memory_reservation_manager`, `reservation_aware_resource_adaptor`, `memory_space`, `fixed_size_host_memory_resource` |
+| utils | UNUSED | Internal atomic helpers and metaprogramming utilities | — |
+
+## Our Usage Summary
+
+We use **2 of 3** modules. Primary integration points:
+
+- **Data representation**: All pipeline data flows through `cucascade::data_batch` wrapping either `gpu_table_representation` (GPU cudf::table) or `host_data_representation` (CPU). Repositories (`shared_data_repository`) store batches between pipeline stages.
+- **Memory management**: `memory_reservation_manager` orchestrates tiered memory (GPU→Host→Disk). Each GPU pipeline task gets a `reservation` that wraps a `reservation_aware_resource_adaptor` for OOM-safe allocation. Host memory uses `fixed_size_host_memory_resource` with block-based allocation for pinned memory.
+- **Configuration**: `reservation_manager_configurator` (builder pattern) creates memory space configs. `topology_discovery` detects GPU/NUMA topology at startup.
+- **Stream management**: `exclusive_stream_pool` provides CUDA streams for parallel GPU execution.
+
+## Files That Reference This Library
+
+| Source File | Modules Used | Key APIs |
+|-------------|-------------|----------|
+| `src/sirius_engine.cpp` | data | `data_repository_manager` |
+| `src/sirius_context.cpp` | memory | `fixed_size_host_memory_resource`, `small_pinned_host_memory_resource` |
+| `src/sirius_config.cpp` | memory | `config`, `reservation_manager_configurator` |
+| `src/pipeline/gpu_pipeline_task.cpp` | data, memory | `data_batch`, `gpu_table_representation`, `cpu_data_representation`, `memory_space`, `reservation_aware_resource_adaptor` |
+| `src/pipeline/pipeline_executor.cpp` | memory | `memory_reservation`, `memory_space`, `common` |
+| `src/pipeline/gpu_pipeline_executor.cpp` | memory | `stream_pool`, `memory_reservation`, `memory_space` |
+| `src/memory/sirius_memory_reservation_manager.cpp` | memory | `memory_reservation_manager`, `Tier` |
+| `src/op/scan/duckdb_scan_task.cpp` | data, memory | `cpu_data_representation`, `data_batch`, `memory_space`, `memory_reservation` |
+| `src/op/scan/parquet_scan_task.cpp` | data, memory | `data_batch`, `cpu/gpu_data_representation`, `fixed_size_host_memory_resource`, `memory_reservation_manager` |
+| `src/op/scan/duckdb_scan_executor.cpp` | data, memory | `cpu/gpu_data_representation`, `data_batch`, `common` |
+| `src/expression_executor/gpu_expression_executor.cpp` | data | `data_batch`, `gpu_table_representation` |
+| `src/downgrade/downgrade_task.cpp` | data, memory | `cpu_data_representation`, `common` |
+| `src/data/host_parquet_representation_converters.cpp` | data, memory | `gpu_data_representation`, `fixed_size_host_memory_resource`, `memory_space` |
+| `src/op/sirius_physical_result_collector.cpp` | data, memory | `cpu_data_representation`, `data_batch`, `memory_reservation_manager` |
+| `src/op/sirius_physical_ungrouped_aggregate.cpp` | data | `data_batch`, `gpu_table_representation` |
+
+## CMake Integration
+
+```cmake
+# Built as subdirectory
+add_subdirectory(cucascade "${CMAKE_BINARY_DIR}/cucascade" EXCLUDE_FROM_ALL)
+
+# Linked as static library
+target_link_libraries(sirius_extension ... cuCascade::cucascade)
+```

--- a/.claude/skills/module-discover/docs/cucascade/modules/data.md
+++ b/.claude/skills/module-discover/docs/cucascade/modules/data.md
@@ -1,0 +1,294 @@
+# Data Module
+
+**Status**: USED
+**Path**: `cucascade/include/cucascade/data/`
+**Headers we include**: `common.hpp`, `cpu_data_representation.hpp`, `data_batch.hpp`, `data_repository.hpp`, `data_repository_manager.hpp`, `gpu_data_representation.hpp`, `representation_converter.hpp`
+
+## Summary
+
+The data module provides the core data abstraction layer for cuCascade. It defines how data is represented across memory tiers (GPU tables, CPU host tables), how batches of data are managed with thread-safe state machines, and how repositories store and dispatch batches between pipeline stages. This is the most heavily used cuCascade module in Sirius — virtually every operator and pipeline component touches `data_batch` or `gpu_table_representation`.
+
+## API Reference
+
+### `cucascade::idata_representation` (abstract base)
+
+**Header**: `cucascade/data/common.hpp`
+
+```cpp
+class idata_representation {
+public:
+  idata_representation(cucascade::memory::memory_space& memory_space);
+  virtual ~idata_representation() = default;
+
+  memory::Tier get_current_tier() const;
+  int get_device_id() const;
+  cucascade::memory::memory_space& get_memory_space();
+  const cucascade::memory::memory_space& get_memory_space() const;
+
+  virtual std::size_t get_size_in_bytes() const = 0;
+  virtual std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) = 0;
+
+  template <class TargetType>
+    requires std::derived_from<TargetType, idata_representation>
+  TargetType& cast();
+
+  template <class TargetType>
+    requires std::derived_from<TargetType, idata_representation>
+  const TargetType& cast() const;
+};
+```
+
+**Description**: Base class for all data representations. Tracks which memory tier and space the data lives in. Use `cast<T>()` to downcast to concrete types.
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_executor.cpp:253` — `input_batch->get_data()->cast<cucascade::gpu_table_representation>()` to access cudf::table
+- `src/pipeline/gpu_pipeline_task.cpp` — checks tier and casts between GPU/CPU representations
+
+---
+
+### `cucascade::gpu_table_representation`
+
+**Header**: `cucascade/data/gpu_data_representation.hpp`
+
+```cpp
+class gpu_table_representation : public idata_representation {
+public:
+  gpu_table_representation(std::unique_ptr<cudf::table> table,
+                           cucascade::memory::memory_space& memory_space);
+
+  std::size_t get_size_in_bytes() const override;
+  std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) override;
+  const cudf::table& get_table() const;
+  std::unique_ptr<cudf::table> release_table();
+};
+```
+
+**Description**: Wraps a `cudf::table` on GPU memory. Primary data representation for all GPU pipeline operations.
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_executor.cpp:253` — `cast<gpu_table_representation>()` then `.get_table()` to access cudf columns
+- `src/expression_executor/gpu_expression_executor.cpp:283` — constructs new `gpu_table_representation` with output table
+- `src/op/scan/duckdb_scan_executor.cpp` — wraps scanned data as gpu_table_representation
+- `src/op/sirius_physical_table_scan.cpp:25` — accesses GPU data from batches
+- Nearly every operator uses this to read input and produce output
+
+---
+
+### `cucascade::host_data_representation`
+
+**Header**: `cucascade/data/cpu_data_representation.hpp`
+
+```cpp
+class host_data_representation : public idata_representation {
+public:
+  host_data_representation(std::unique_ptr<memory::host_table_allocation> host_table,
+                           memory::memory_space* memory_space);
+
+  std::size_t get_size_in_bytes() const override;
+  std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) override;
+  const std::unique_ptr<memory::host_table_allocation>& get_host_table() const;
+};
+```
+
+**Description**: Wraps a host (CPU) table allocation. Used when data is downgraded from GPU to CPU memory.
+
+**Our usage**:
+- `src/downgrade/downgrade_task.cpp:24` — converts GPU data to host representation during downgrade
+- `src/op/scan/duckdb_scan_executor.cpp:20` — creates host representation from scanned data
+- `src/op/sirius_physical_result_collector.cpp:29` — reads host data for final result output
+
+---
+
+### `cucascade::host_data_packed_representation`
+
+**Header**: `cucascade/data/cpu_data_representation.hpp`
+
+```cpp
+class host_data_packed_representation : public idata_representation {
+public:
+  host_data_packed_representation(
+    std::unique_ptr<cucascade::memory::host_table_packed_allocation> host_table,
+    cucascade::memory::memory_space* memory_space);
+
+  std::size_t get_size_in_bytes() const override;
+  std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) override;
+  const std::unique_ptr<cucascade::memory::host_table_packed_allocation>& get_host_table() const;
+};
+```
+
+**Description**: Packed (serialized) host table format. Uses cuDF's packed table format for efficient GPU↔CPU transfers. Used as an intermediate during representation conversion.
+
+---
+
+### `cucascade::data_batch`
+
+**Header**: `cucascade/data/data_batch.hpp`
+
+```cpp
+enum class batch_state { idle, task_created, processing, in_transit };
+
+enum class lock_for_processing_status {
+  success, task_not_created, invalid_state,
+  memory_space_mismatch, missing_data, not_attempted
+};
+
+struct lock_for_processing_result {
+  bool success{false};
+  data_batch_processing_handle handle{};
+  lock_for_processing_status status{lock_for_processing_status::not_attempted};
+};
+
+class data_batch : public std::enable_shared_from_this<data_batch> {
+public:
+  data_batch(uint64_t batch_id, std::unique_ptr<idata_representation> data);
+
+  // State queries
+  memory::Tier get_current_tier() const;
+  uint64_t get_batch_id() const;
+  batch_state get_state() const;
+  size_t get_processing_count() const;
+  idata_representation* get_data() const;
+  cucascade::memory::memory_space* get_memory_space() const;
+
+  // State transitions (blocking)
+  void wait_to_create_task();
+  void wait_to_cancel_task();
+  lock_for_processing_result wait_to_lock_for_processing(memory::memory_space_id requested);
+  void wait_to_lock_for_in_transit();
+  void wait_to_release_in_transit(std::optional<batch_state> target = std::nullopt);
+
+  // State transitions (non-blocking)
+  bool try_to_create_task();
+  lock_for_processing_result try_to_lock_for_processing(memory::memory_space_id requested);
+  bool try_to_lock_for_in_transit();
+  bool try_to_release_in_transit(std::optional<batch_state> target = std::nullopt);
+
+  // Data manipulation
+  void set_data(std::unique_ptr<idata_representation> data);
+  std::shared_ptr<data_batch> clone(uint64_t new_batch_id, rmm::cuda_stream_view stream);
+
+  template <typename TargetRepresentation>
+  void convert_to(representation_converter_registry& registry,
+                  const memory::memory_space* target, rmm::cuda_stream_view stream);
+
+  template <typename TargetRepresentation>
+  std::shared_ptr<data_batch> clone_to(representation_converter_registry& registry,
+                                       uint64_t new_batch_id,
+                                       const memory::memory_space* target,
+                                       rmm::cuda_stream_view stream);
+};
+```
+
+**Description**: Thread-safe container for a single batch of data flowing through the pipeline. Implements a state machine (`idle` → `task_created` → `processing` → `idle`) with mutex-protected transitions. The `data_batch_processing_handle` RAII type automatically releases the processing lock on destruction.
+
+**Our usage**:
+- `src/pipeline/gpu_pipeline_task.cpp:24-28` — core pipeline task operates on data_batch, locks for processing, reads/writes data
+- `src/op/scan/duckdb_scan_executor.cpp:21` — creates new data_batch from scanned data
+- `src/op/sirius_physical_result_collector.cpp:30` — reads batch data for result output
+- `src/creator/task_creator.hpp:32` — task creator queries batch states to schedule work
+- `src/expression_executor/gpu_expression_executor.cpp:242` — accepts and returns data_batch
+
+---
+
+### `cucascade::idata_repository<PtrType>` / `shared_data_repository`
+
+**Header**: `cucascade/data/data_repository.hpp`
+
+```cpp
+template <typename PtrType>
+class idata_repository {
+public:
+  virtual void add_data_batch(PtrType batch, size_t partition_idx = 0);
+  void notify_state_change();
+
+  virtual PtrType pop_data_batch(batch_state target_state, size_t partition_idx = 0);
+  virtual PtrType pop_data_batch_by_id(uint64_t batch_id, std::optional<batch_state> target,
+                                       size_t partition_idx = 0);
+  virtual PtrType get_data_batch_by_id(uint64_t batch_id, std::optional<batch_state> target,
+                                       size_t partition_idx = 0);
+  virtual std::vector<uint64_t> get_batch_ids(size_t partition_idx = 0) const;
+
+  std::size_t size(size_t partition_idx = 0) const;
+  bool empty(size_t partition_idx = 0) const;
+  std::size_t total_size() const;
+  bool all_empty() const;
+  std::size_t num_partitions() const;
+};
+
+using shared_data_repository = idata_repository<std::shared_ptr<data_batch>>;
+using unique_data_repository = idata_repository<std::unique_ptr<data_batch>>;
+```
+
+**Description**: Thread-safe container for data batches, partitioned by index. Supports popping batches that match a target state (for scheduling). `shared_data_repository` (shared_ptr) is used in pipelines where multiple consumers read the same batch; `unique_data_repository` for exclusive ownership.
+
+**Our usage**:
+- `src/include/op/sirius_physical_operator.hpp:34` — operators read from upstream repository
+- `src/include/pipeline/gpu_pipeline_task.hpp:26` — pipeline tasks reference repositories
+- `src/include/creator/task_creator.hpp:33` — task creator polls repositories for available data
+- `test/cpp/operator/test_physical_concat.cpp:309` — tests create `shared_data_repository` instances
+
+---
+
+### `cucascade::data_repository_manager<PtrType>` / `shared_data_repository_manager`
+
+**Header**: `cucascade/data/data_repository_manager.hpp`
+
+```cpp
+template <typename PtrType>
+class data_repository_manager {
+public:
+  void add_new_repository(size_t operator_id, std::string_view port_id,
+                          std::unique_ptr<repository_type> repository);
+  void add_data_batch(PtrType batch, std::vector<std::pair<size_t, std::string_view>> ops);
+  std::unique_ptr<repository_type>& get_repository(size_t operator_id, std::string_view port_id);
+  uint64_t get_next_data_batch_id();
+  std::vector<leaked_repository_info> clear_all_repositories();
+  std::vector<PtrType> get_data_batches_for_downgrade(memory_space_id space, size_t amount);
+  void for_each_repository(std::function<void(repository_type*)> visitor);
+};
+
+using shared_data_repository_manager = data_repository_manager<std::shared_ptr<data_batch>>;
+```
+
+**Description**: Manages all repositories across the query plan, keyed by `(operator_id, port_id)`. Each operator's input/output port gets its own repository. The `get_next_data_batch_id()` provides globally unique batch IDs.
+
+**Our usage**:
+- `src/sirius_engine.cpp:44` — engine owns the `data_repository_manager`
+- `src/include/sirius_engine.hpp:29` — declared as member of `sirius_engine`
+- `src/include/expression_executor/gpu_expression_executor.hpp:38` — expression executor references it
+- `src/include/downgrade/downgrade_executor.hpp:25` — downgrade executor uses it to find batches to downgrade
+
+---
+
+### `cucascade::representation_converter_registry`
+
+**Header**: `cucascade/data/representation_converter.hpp`
+
+```cpp
+class representation_converter_registry {
+public:
+  template <typename SourceType, typename TargetType>
+  void register_converter(representation_converter_fn converter);
+
+  template <typename SourceType, typename TargetType>
+  bool has_converter() const;
+
+  template <typename TargetType>
+  std::unique_ptr<TargetType> convert(idata_representation& source,
+                                      const memory::memory_space* target,
+                                      rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+};
+
+void register_builtin_converters(representation_converter_registry& registry);
+```
+
+**Description**: Registry of type-erased conversion functions between data representations. `register_builtin_converters()` registers GPU↔Host converters.
+
+**Our usage**:
+- `src/include/data/sirius_converter_registry.hpp:19` — Sirius defines its own converter registry
+- `src/include/data/host_parquet_representation_converters.hpp:20` — registers parquet-specific converters
+- `test/cpp/data/test_host_parquet_representation.cpp:30` — tests use converter registry
+
+## APIs Available but Not Used
+
+All APIs in this module are used by our codebase.

--- a/.claude/skills/module-discover/docs/cucascade/modules/memory.md
+++ b/.claude/skills/module-discover/docs/cucascade/modules/memory.md
@@ -1,0 +1,526 @@
+# Memory Module
+
+**Status**: USED
+**Path**: `cucascade/include/cucascade/memory/`
+**Headers we include**: `common.hpp`, `config.hpp`, `fixed_size_host_memory_resource.hpp`, `host_table.hpp`, `memory_reservation.hpp`, `memory_reservation_manager.hpp`, `memory_space.hpp`, `numa_region_pinned_host_allocator.hpp`, `reservation_aware_resource_adaptor.hpp`, `reservation_manager_configurator.hpp`, `small_pinned_host_memory_resource.hpp`, `stream_pool.hpp`, `topology_discovery.hpp`
+
+## Summary
+
+The memory module implements cuCascade's tiered memory management system. It provides memory spaces (GPU, Host, Disk), a reservation system to prevent OOM, and resource adaptors that integrate with RMM. Sirius uses this module to manage all GPU and pinned host memory, schedule downgrades when GPU memory is constrained, and provide per-stream memory tracking.
+
+## API Reference
+
+### `cucascade::memory::Tier` (enum)
+
+**Header**: `cucascade/memory/common.hpp`
+
+```cpp
+enum class Tier : int32_t { GPU, HOST, DISK, SIZE };
+```
+
+**Description**: Identifies the memory tier. `SIZE` is a sentinel for iteration.
+
+**Our usage**:
+- `src/memory/sirius_memory_reservation_manager.cpp:35` — `get_memory_spaces_for_tier(Tier::GPU)` to find GPU spaces
+- Used throughout pipeline code to check data batch tier
+
+---
+
+### `cucascade::memory::memory_space_id`
+
+**Header**: `cucascade/memory/common.hpp`
+
+```cpp
+struct memory_space_id {
+  Tier tier;
+  int32_t device_id;
+  explicit memory_space_id(Tier t, int32_t d_id);
+  auto operator<=>(const memory_space_id&) const noexcept = default;
+  std::size_t uuid() const noexcept;
+};
+```
+
+**Description**: Unique identifier for a memory space (tier + device ID). Supports three-way comparison and hashing.
+
+**Our usage**:
+- `src/pipeline/gpu_pipeline_task.cpp:27` — passed to `wait_to_lock_for_processing()` to request specific memory space
+- `src/include/pipeline/task_request.hpp:24` — task requests specify target memory space
+
+---
+
+### `cucascade::memory::memory_space`
+
+**Header**: `cucascade/memory/memory_space.hpp`
+
+```cpp
+class memory_space {
+public:
+  explicit memory_space(const gpu_memory_space_config& config);
+  explicit memory_space(const host_memory_space_config& config);
+  explicit memory_space(const disk_memory_space_config& config);
+
+  memory_space_id get_id() const noexcept;
+  Tier get_tier() const noexcept;
+  int get_device_id() const noexcept;
+
+  // Reservation creation
+  std::unique_ptr<reservation> make_reservation_or_null(size_t size);
+  std::unique_ptr<reservation> make_reservation_upto(size_t size);
+  std::unique_ptr<reservation> make_reservation(size_t size);
+
+  // Stream acquisition
+  rmm::cuda_stream_view acquire_stream() const;
+
+  // State queries
+  std::size_t get_active_reservation_count() const;
+  bool should_downgrade_memory() const;
+  bool should_stop_downgrading_memory() const;
+  size_t get_amount_to_downgrade() const;
+  size_t get_available_memory(rmm::cuda_stream_view stream) const;
+  size_t get_available_memory() const;
+  size_t get_total_reserved_memory() const;
+  size_t get_max_memory() const noexcept;
+
+  // Allocator access
+  rmm::mr::device_memory_resource* get_default_allocator() const noexcept;
+  template <typename T> T* get_memory_resource_as() const noexcept;
+  template <Tier TIER> auto* get_memory_resource_of() const noexcept;
+
+  std::string to_string() const;
+  void shutdown();
+};
+```
+
+**Description**: Represents a single memory region (e.g., one GPU, one NUMA node). Owns the underlying memory resource and provides reservation/query interface. The `should_downgrade_memory()` method signals the downgrade executor.
+
+**Our usage**:
+- `src/pipeline/gpu_pipeline_task.cpp:27` — accesses memory space from data batches
+- `src/include/pipeline/gpu_pipeline_executor.hpp:30` — pipeline executor queries available memory
+- `src/data/host_parquet_representation_converters.cpp:27` — gets memory space for host allocations
+
+---
+
+### `cucascade::memory::reservation`
+
+**Header**: `cucascade/memory/memory_reservation.hpp`
+
+```cpp
+class reservation {
+public:
+  static std::unique_ptr<reservation> create(memory_space& space,
+                                             std::unique_ptr<reserved_arena> arena);
+  size_t size() const noexcept;
+  Tier tier() const noexcept;
+  int device_id() const noexcept;
+
+  rmm::mr::device_memory_resource* get_memory_resource() const noexcept;
+  const memory_space& get_memory_space() const noexcept;
+
+  template <typename T>
+    requires std::derived_from<T, rmm::mr::device_memory_resource>
+  T* get_memory_resource_as() const noexcept;
+
+  template <Tier TIER>
+  auto* get_memory_resource_of() const noexcept;
+
+  bool grow_by(size_t additional_bytes);
+  void shrink_to_fit();
+};
+```
+
+**Description**: A lease on memory within a memory space. Wraps a `reserved_arena` and provides access to the underlying memory resource for allocation. Automatically releases the reservation on destruction.
+
+**Our usage**:
+- `src/include/pipeline/gpu_pipeline_task.hpp:28` — each pipeline task holds a reservation
+- `src/include/op/scan/duckdb_scan_task.hpp:39` — scan tasks hold reservations
+- `src/include/parallel/task.hpp:25` — base task class includes reservation
+- `src/include/pipeline/gpu_pipeline_executor.hpp:29` — executor manages reservations
+
+---
+
+### `cucascade::memory::memory_reservation_manager`
+
+**Header**: `cucascade/memory/memory_reservation_manager.hpp`
+
+```cpp
+class memory_reservation_manager {
+public:
+  explicit memory_reservation_manager(std::vector<memory_space_config> configs);
+  ~memory_reservation_manager();
+
+  // Reservation interface
+  std::unique_ptr<reservation> request_reservation(
+    const reservation_request_strategy& request, size_t size);
+
+  // Memory space access
+  const memory_space* get_memory_space(Tier tier, int32_t device_id) const;
+  memory_space* get_memory_space(Tier tier, int32_t device_id);
+  std::span<const memory_space*> get_memory_spaces_for_tier(Tier tier) const;
+  std::span<const memory_space*> get_all_memory_spaces() const noexcept;
+
+  // Aggregated queries
+  size_t get_available_memory_for_tier(Tier tier) const;
+  size_t get_total_reserved_memory_for_tier(Tier tier) const;
+  size_t get_active_reservation_count_for_tier(Tier tier) const;
+  size_t get_total_available_memory() const;
+  size_t get_total_reserved_memory() const;
+  size_t get_active_reservation_count() const;
+  void shutdown();
+};
+```
+
+**Description**: Top-level manager for all memory spaces. Constructs memory spaces from configs, handles reservation requests using pluggable strategies, and provides aggregate memory queries.
+
+**Reservation request strategies** (same header):
+- `any_memory_space_in_tier` — any space in a given tier
+- `any_memory_space_in_tier_with_preference` — prefer a specific device
+- `any_memory_space_in_tiers` — try multiple tiers in order
+- `specific_memory_space` — exact (tier, device_id)
+- `any_memory_space_to_downgrade` — find downgrade target
+- `any_memory_space_to_upgrade` — find upgrade target
+
+**Our usage**:
+- `src/memory/sirius_memory_reservation_manager.cpp:33` — `sirius_memory_reservation_manager` inherits from this
+- `src/memory/sirius_memory_reservation_manager.cpp:35` — `get_memory_spaces_for_tier(Tier::GPU)` at init
+- `src/op/scan/parquet_scan_task.cpp:31` — scan tasks request reservations
+- `src/include/op/scan/duckdb_scan_executor.hpp:29` — scan executor holds manager reference
+
+---
+
+### `cucascade::memory::reservation_aware_resource_adaptor`
+
+**Header**: `cucascade/memory/reservation_aware_resource_adaptor.hpp`
+
+```cpp
+class reservation_aware_resource_adaptor : public rmm::mr::device_memory_resource {
+public:
+  explicit reservation_aware_resource_adaptor(
+    memory_space_id space_id, rmm::device_async_resource_ref upstream,
+    std::size_t capacity,
+    std::unique_ptr<reservation_limit_policy> policy = nullptr,
+    std::unique_ptr<oom_handling_policy> oom_policy = nullptr,
+    AllocationTrackingScope tracking = AllocationTrackingScope::PER_STREAM,
+    cudaMemPool_t pool_handle = nullptr);
+
+  // Memory queries
+  rmm::device_async_resource_ref get_upstream_resource() const noexcept;
+  std::size_t get_available_memory() const noexcept;
+  std::size_t get_available_memory(rmm::cuda_stream_view stream) const noexcept;
+
+  // Allocation tracking
+  std::size_t get_allocated_bytes(rmm::cuda_stream_view stream) const;
+  std::size_t get_peak_allocated_bytes(rmm::cuda_stream_view stream) const;
+  std::size_t get_total_allocated_bytes() const;
+  std::size_t get_total_reserved_bytes() const;
+
+  // Reservation management
+  std::unique_ptr<reserved_arena> reserve(std::size_t bytes,
+                                          std::unique_ptr<event_notifier> notifier = nullptr);
+  std::unique_ptr<reserved_arena> reserve_upto(std::size_t bytes,
+                                               std::unique_ptr<event_notifier> notifier = nullptr);
+  bool attach_reservation_to_tracker(rmm::cuda_stream_view stream,
+                                     std::unique_ptr<reservation> reserved,
+                                     std::unique_ptr<reservation_limit_policy> policy = nullptr,
+                                     std::unique_ptr<oom_handling_policy> oom_policy = nullptr);
+  void reset_stream_reservation(rmm::cuda_stream_view stream);
+};
+```
+
+**Description**: RMM memory resource adaptor that enforces reservation-based allocation. Wraps an upstream allocator and tracks per-stream (or per-thread) allocations against reserved amounts. When allocation exceeds reservation, the `reservation_limit_policy` is invoked. On OOM from upstream, the `oom_handling_policy` handles it.
+
+**Our usage**:
+- `src/pipeline/gpu_pipeline_task.cpp:28` — pipeline tasks use this for reservation-aware GPU allocation
+- `test/cpp/pipeline/test_gpu_pipeline_executor.cpp:28` — tests create adaptors
+- `test/cpp/pipeline/test_oom_reschedule.cpp:31` — OOM handling tests
+
+---
+
+### `cucascade::memory::fixed_size_host_memory_resource`
+
+**Header**: `cucascade/memory/fixed_size_host_memory_resource.hpp`
+
+```cpp
+class fixed_size_host_memory_resource : public rmm::mr::device_memory_resource {
+public:
+  explicit fixed_size_host_memory_resource(
+    int device_id, rmm::device_async_resource_ref upstream_mr,
+    std::size_t mem_limit, std::size_t capacity,
+    std::size_t block_size = 1 << 20,    // 1MB default
+    std::size_t pool_size = 128,
+    std::size_t initial_pools = 4);
+
+  // Queries
+  std::size_t get_total_allocated_bytes() const noexcept;
+  std::size_t get_available_memory() const noexcept;
+  std::size_t get_block_size() const noexcept;
+  std::size_t get_free_blocks() const noexcept;
+  std::size_t get_total_blocks() const noexcept;
+  std::size_t get_total_reserved_bytes() const noexcept;
+
+  // Reservations
+  std::unique_ptr<reserved_arena> reserve(std::size_t bytes,
+                                          std::unique_ptr<event_notifier> notifier = nullptr);
+  std::unique_ptr<reserved_arena> reserve_upto(std::size_t bytes,
+                                               std::unique_ptr<event_notifier> notifier = nullptr);
+
+  // Block allocation
+  fixed_multiple_blocks_allocation allocate_multiple_blocks(std::size_t total_bytes,
+                                                           reservation* res = nullptr);
+};
+
+using fixed_multiple_blocks_allocation = std::unique_ptr<multiple_blocks_allocation>;
+```
+
+**Description**: Fixed-block-size host memory allocator. Allocates pinned host memory in fixed-size blocks (default 1MB) from pools. The `multiple_blocks_allocation` type provides a scatter-gather view over multiple blocks. Used for all host/CPU data storage.
+
+**Our usage**:
+- `src/sirius_context.cpp:31` — creates the host memory resource at startup
+- `src/data/host_parquet_representation_converters.cpp:26` — uses for host allocation during conversion
+- `src/include/data/host_parquet_representation.hpp:21` — host parquet data stored in blocks
+- `src/include/op/scan/duckdb_scan_task.hpp:37` — scan tasks allocate host blocks
+- `src/include/op/result/host_table_chunk_reader.hpp:35` — result reader uses block allocator
+
+---
+
+### `cucascade::memory::small_pinned_host_memory_resource`
+
+**Header**: `cucascade/memory/small_pinned_host_memory_resource.hpp`
+
+```cpp
+class small_pinned_host_memory_resource : public rmm::mr::device_memory_resource {
+public:
+  static constexpr std::size_t MAX_SLAB_SIZE = 8192;
+  static constexpr std::array<std::size_t, 5> SLAB_SIZES{512, 1024, 2048, 4096, 8192};
+
+  explicit small_pinned_host_memory_resource(fixed_size_host_memory_resource& upstream);
+  static std::size_t slab_index_for(std::size_t bytes) noexcept;
+};
+```
+
+**Description**: Slab allocator for small pinned host allocations (≤8KB). Carves small allocations from larger blocks obtained from `fixed_size_host_memory_resource`. Reduces fragmentation for metadata and small buffers.
+
+**Our usage**:
+- `src/sirius_context.cpp:32` — created alongside main host memory resource
+- `test/cpp/data/test_host_parquet_representation.cpp:34` — used in host data tests
+
+---
+
+### `cucascade::memory::reservation_manager_configurator`
+
+**Header**: `cucascade/memory/reservation_manager_configurator.hpp`
+
+```cpp
+class reservation_manager_configurator {
+public:
+  // GPU config (builder pattern — all return *this)
+  auto& set_number_of_gpus(std::size_t n_gpus);
+  auto& set_gpu_ids(const std::vector<int>& gpu_ids);
+  auto& set_gpu_usage_limit(std::size_t bytes);
+  auto& set_usage_limit_ratio_per_gpu(double fraction);
+  auto& set_reservation_limit_per_gpu(size_t bytes);
+  auto& set_reservation_fraction_per_gpu(double fraction);
+  auto& set_downgrade_fractions_per_gpu(double start, double end);
+  auto& track_reservation_per_stream(bool enable);
+  auto& set_gpu_memory_resource_factory(DeviceMemoryResourceFactoryFn fn);
+
+  // Host config
+  auto& use_host_per_gpu();
+  auto& use_host_per_numa();
+  auto& set_total_host_capacity(std::size_t bytes);
+  auto& set_per_host_capacity(std::size_t bytes);
+  auto& set_downgrade_fractions_per_host(double start, double end);
+  auto& set_host_memory_resource_factory(DeviceMemoryResourceFactoryFn fn);
+  auto& set_host_pool_features(std::size_t chunk_size, std::size_t block_size,
+                               std::size_t initial_block_count);
+
+  // Disk config
+  auto& set_disk_mounting_point(int uuid, std::size_t capacity, std::string mounting_point);
+
+  // Build
+  std::vector<memory_space_config> build(const system_topology_info& topology) const;
+  std::vector<memory_space_config> build() const;
+};
+```
+
+**Description**: Builder pattern for constructing `memory_space_config` vectors to initialize `memory_reservation_manager`. Supports multi-GPU, NUMA-aware host memory, and disk tiers.
+
+**Our usage**:
+- `src/sirius_config.cpp:23` — builds memory configs from Sirius runtime settings
+- `test/cpp/operator/operator_test_utils.hpp:38` — tests use configurator to set up memory
+- `test/cpp/creator/test_task_creator.cpp:27` — task creator tests
+- `test/cpp/expression_executor/test_gpu_expression_executor.cpp:23` — expression executor tests
+
+---
+
+### `cucascade::memory::exclusive_stream_pool`
+
+**Header**: `cucascade/memory/stream_pool.hpp`
+
+```cpp
+class borrowed_stream {
+public:
+  rmm::cuda_stream_view get() const noexcept;
+  operator rmm::cuda_stream_view() const;
+  void reset() noexcept;
+};
+
+class exclusive_stream_pool {
+public:
+  enum class stream_acquire_policy { GROW, BLOCK };
+  static constexpr std::size_t default_size{16};
+
+  explicit exclusive_stream_pool(rmm::cuda_device_id device_id = {},
+                                 std::size_t pool_size = default_size,
+                                 rmm::cuda_stream::flags flags = rmm::cuda_stream::flags::non_blocking);
+  borrowed_stream acquire_stream(stream_acquire_policy policy = stream_acquire_policy::BLOCK) noexcept;
+  std::size_t size() const noexcept;
+};
+```
+
+**Description**: Pool of exclusive CUDA streams. `acquire_stream()` returns a `borrowed_stream` RAII handle that returns the stream to the pool on destruction. Supports blocking or growing policy when pool is exhausted.
+
+**Our usage**:
+- `src/pipeline/gpu_pipeline_executor.cpp:20` — pipeline executor acquires streams for GPU work
+- `src/include/op/scan/duckdb_scan_executor.hpp:30` — scan executor uses stream pool
+
+---
+
+### `cucascade::memory::topology_discovery`
+
+**Header**: `cucascade/memory/topology_discovery.hpp`
+
+```cpp
+struct gpu_topology_info {
+  unsigned int id;
+  std::string name, pci_bus_id, uuid;
+  int numa_node;
+  std::string cpu_affinity_list;
+  std::vector<int> cpu_cores, memory_binding;
+  std::vector<std::string> network_devices;
+};
+
+struct system_topology_info {
+  std::string hostname;
+  unsigned int num_gpus;
+  int num_numa_nodes, num_network_devices;
+  std::vector<gpu_topology_info> gpus;
+  std::vector<network_device_info> network_devices;
+  std::vector<storage_device_info> storage_devices;
+};
+
+class topology_discovery {
+public:
+  bool discover();
+  system_topology_info const& get_topology() const;
+  bool is_discovered() const;
+};
+```
+
+**Description**: Discovers system hardware topology — GPUs, NUMA nodes, NIC devices, and storage. Used at startup to configure memory spaces based on actual hardware.
+
+**Our usage**:
+- `src/include/sirius_config.hpp:25` — sirius config uses topology for memory setup
+- `src/include/pipeline/pipeline_executor.hpp:33` — pipeline executor reads topology
+
+---
+
+### `cucascade::memory::host_table_allocation` / `column_metadata`
+
+**Header**: `cucascade/memory/host_table.hpp`
+
+```cpp
+struct column_metadata {
+  cudf::type_id type_id;
+  cudf::size_type num_rows, null_count;
+  int32_t scale;
+  bool has_null_mask;
+  std::size_t null_mask_offset, null_mask_size;
+  bool has_data;
+  std::size_t data_offset, data_size;
+  std::vector<column_metadata> children;
+  bool is_synthetic_empty_offsets = false;
+};
+
+struct host_table_allocation {
+  fixed_multiple_blocks_allocation allocation;
+  std::vector<column_metadata> columns;
+  std::size_t data_size;
+};
+```
+
+**Description**: Describes a cuDF table stored in host memory blocks. `column_metadata` stores per-column layout information (offsets, sizes, null masks). The actual data lives in the `multiple_blocks_allocation`.
+
+**Our usage**:
+- `src/include/op/scan/duckdb_scan_task.hpp:38` — scan tasks create host tables
+- `src/include/op/result/host_table_chunk_reader.hpp:36` — reads host table chunks for output
+
+---
+
+### Memory Config Types
+
+**Header**: `cucascade/memory/config.hpp`
+
+```cpp
+struct gpu_memory_space_config {
+  int device_id{-1};
+  double reservation_limit_fraction{0.9};
+  double downgrade_trigger_fraction{0.75};
+  double downgrade_stop_fraction{0.65};
+  std::size_t memory_capacity{0};
+  bool per_stream_reservation{true};
+  DeviceMemoryResourceFactoryFn mr_factory_fn{nullptr};
+
+  Tier tier() const;
+  std::size_t reservation_limit() const;
+  std::size_t downgrade_trigger_threshold() const;
+  std::size_t downgrade_stop_threshold() const;
+};
+
+struct host_memory_space_config { /* similar fields for host */ };
+struct disk_memory_space_config { /* disk tier config */ };
+
+using memory_space_config = std::variant<std::monostate,
+                                         gpu_memory_space_config,
+                                         host_memory_space_config,
+                                         disk_memory_space_config>;
+```
+
+**Description**: Configuration structs for each memory tier. Downgrade fractions control when the downgrade executor triggers (at 75% usage) and stops (at 65% usage).
+
+**Our usage**:
+- `src/sirius_config.cpp:22` — builds configs from runtime settings
+- `src/include/sirius_config.hpp:24` — stores config as member
+
+---
+
+### Reservation Limit Policies
+
+**Header**: `cucascade/memory/memory_reservation.hpp`
+
+```cpp
+class reservation_limit_policy { /* abstract */ };
+class ignore_reservation_limit_policy : public reservation_limit_policy { /* no-op */ };
+class fail_reservation_limit_policy : public reservation_limit_policy { /* throws */ };
+class increase_reservation_limit_policy : public reservation_limit_policy {
+public:
+  increase_reservation_limit_policy();
+  explicit increase_reservation_limit_policy(double padding_factor, bool allow_beyond_limit = false);
+};
+
+std::unique_ptr<reservation_limit_policy> make_default_reservation_limit_policy();
+```
+
+**Description**: Policies for what happens when a stream's allocation exceeds its reservation. `increase_reservation_limit_policy` tries to grow the reservation with optional padding.
+
+---
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `disk_access_limiter` | `disk_access_limiter.hpp` | Reservation-based disk I/O limiter with file-backed arenas |
+| `null_device_memory_resource` | `null_device_memory_resource.hpp` | No-op memory resource (all allocations return nullptr) |
+| `oom_handling_policy` | `oom_handling_policy.hpp` | Abstract OOM handler; `throw_on_oom_policy` rethrows (used internally by `reservation_aware_resource_adaptor` but not directly included by Sirius) |
+| `notification_channel` | `notification_channel.hpp` | Thread-safe notification primitive with `wait()`/`post()` semantics (used internally by reservation system) |
+| `host_table_packed_allocation` | `host_table_packed.hpp` | Packed cuDF table in host blocks (used via `host_data_packed_representation` but header not directly included) |
+| `cucascade_out_of_memory` | `error.hpp` | Custom OOM exception with allocation context metadata |

--- a/.claude/skills/module-discover/docs/cucascade/modules/utils.md
+++ b/.claude/skills/module-discover/docs/cucascade/modules/utils.md
@@ -1,0 +1,21 @@
+# Utils Module
+
+**Status**: UNUSED
+**Path**: `cucascade/include/cucascade/utils/` and `cucascade/include/cucascade/cuda_utils.hpp`
+
+## Summary
+
+Internal utility headers used within cuCascade's implementation. Provides atomic helpers for lock-free counters/trackers, a metaprogramming helper for `std::visit`, and CUDA error-checking macros.
+
+## Key APIs
+
+- `atomic_peak_tracker<T>` — Lock-free peak value tracker using CAS loop
+- `atomic_bounded_counter<T>` — Atomic counter with bounded `try_add`/`try_sub` operations and `add_bounded`/`sub_bounded` clamping
+- `overloaded<Ts...>` — Variadic struct for creating overloaded lambda sets (used with `std::visit`)
+- `CUCASCADE_CUDA_TRY(call)` — CUDA runtime error checking macro (throws `rmm::cuda_error`)
+- `CUCASCADE_CUDA_TRY_ALLOC(call)` — CUDA allocation error checking (throws `rmm::out_of_memory`)
+- `CUCASCADE_FUNC_RANGE()` — NVTX range annotation for profiling
+
+## Potential Relevance
+
+The atomic utilities (`atomic_bounded_counter`, `atomic_peak_tracker`) are used internally by `reservation_aware_resource_adaptor` for allocation tracking. The CUDA macros could be useful if writing CUDA code that interacts with cuCascade's error handling conventions, but Sirius uses its own error handling patterns instead.

--- a/.claude/skills/module-discover/docs/cudf/README.md
+++ b/.claude/skills/module-discover/docs/cudf/README.md
@@ -1,0 +1,90 @@
+# cuDF (libcudf) — Module Reference
+
+**Version**: 26.04+ (with 25.04 backward compatibility via `CUDF_VERSION_NUM` macro)
+**Location**: `/home/felipe/miniconda3/envs/libcudf-env/include/cudf/`
+**Namespace**: `cudf`
+**Build Integration**: Linked via CMake as `cudf::cudf`
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| [types_core](modules/types_core.md) | USED | Core type system: type_id, data_type, size_type, bitmask_type | `type_id`, `data_type`, `size_type` |
+| [table](modules/table.md) | USED | Table/column data structures (owning + views) | `table`, `table_view`, `column_view`, `column_factories` |
+| [join](modules/join.md) | USED | Hash, conditional, mixed, and distinct joins | `hash_join`, `inner_join`, `conditional_join`, `mixed_join` |
+| [aggregation](modules/aggregation.md) | USED | Groupby, reduction, and aggregation operations | `groupby`, `reduce`, `make_sum_aggregation` |
+| [sorting](modules/sorting.md) | USED | Sort, merge, and search operations | `sorted_order`, `merge`, `lower_bound` |
+| [copying](modules/copying.md) | USED | Gather, scatter, slice, concatenate | `gather`, `slice`, `concatenate`, `scatter` |
+| [unary_binary](modules/unary_binary.md) | USED | Unary/binary element-wise operations, type casting | `binary_operation`, `cast`, `unary_operation` |
+| [strings](modules/strings.md) | USED | GPU string operations (regex, find, slice, etc.) | `contains`, `like`, `slice_strings`, `regex_program` |
+| [io](modules/io.md) | USED | Parquet I/O, datasource abstraction, hybrid scan | `parquet_reader_options`, `datasource`, `hybrid_scan_reader` |
+| [ast](modules/ast.md) | USED | Expression trees for conditional joins | `tree`, `operation`, `column_reference`, `ast_operator` |
+| [scalar](modules/scalar.md) | USED | Device-side scalar values for expressions | `numeric_scalar`, `string_scalar`, `fixed_point_scalar` |
+| [stream_compaction](modules/stream_compaction.md) | USED | Duplicate elimination, filtering | `drop_duplicates` |
+| [utilities](modules/utilities.md) | USED | Stream, memory resource, type dispatch | `get_default_stream`, `set_current_device_resource`, `type_dispatcher` |
+| [dictionary](modules/dictionary.md) | USED | Dictionary-encoded columns for merge optimization | `dictionary_column_view`, `encode` |
+| [fixed_point](modules/fixed_point.md) | USED | DECIMAL type support | `fixed_point`, `scale_type` |
+| [lists](modules/lists.md) | USED | List column operations (count_elements only) | `count_elements` |
+| [datetime](modules/datetime.md) | USED | Date/time extraction and arithmetic | `extract_year`, `extract_month` |
+| [partitioning](modules/partitioning.md) | USED | Hash-based table partitioning | `hash_partition` |
+| [transform](modules/transform.md) | USED | Element-wise transforms with expressions | `compute_column` |
+| [hashing](modules/hashing.md) | UNUSED | Hash function implementations | — |
+| [rolling](modules/rolling.md) | UNUSED | Rolling window aggregations | — |
+| [json](modules/json.md) | UNUSED | JSON column support | — |
+| [structs](modules/structs.md) | UNUSED | Struct/record column support | — |
+| [tdigest](modules/tdigest.md) | UNUSED | T-Digest approximate percentiles | — |
+| [labeling](modules/labeling.md) | UNUSED | Bin labeling/categorization | — |
+
+## Our Usage Summary
+
+We use **19 of 25** modules. Primary integration points:
+
+- **Query execution**: Binary/unary ops for filter/projection expressions, AST for conditional joins
+- **Join processing**: Hash joins (inner, left, right, full), conditional joins via AST, mixed joins
+- **Aggregation**: Groupby with SUM/COUNT/MIN/MAX/MEAN/NUNIQUE, ungrouped reductions
+- **Sort/Order**: Lexicographic sorting with gather, merge for sorted streams, top-N via sort+slice
+- **Data I/O**: Parquet reading via hybrid_scan experimental API, custom datasource implementations
+- **String processing**: LIKE, regex matching, substring, length operations
+- **Memory management**: RMM device resource control, pinned memory configuration, stream management
+- **Type system**: cuDF type_id mapping to/from DuckDB types, DECIMAL via fixed_point
+
+## Version Compatibility
+
+Sirius handles cuDF API differences between 25.04 and 26.04+ via a version macro:
+```cpp
+#include <cudf/version_config.hpp>
+#define CUDF_VERSION_NUM (CUDF_VERSION_MAJOR * 100 + CUDF_VERSION_MINOR)
+```
+
+Key version differences:
+- **Join headers**: Unified `cudf/join.hpp` in ≤25.04, split into `cudf/join/*.hpp` in 26.04+
+- **Aggregation headers**: `cudf/aggregation.hpp` in ≤25.04, split headers in 26.04+
+- **Stream compaction**: Detail API access patterns differ
+- **Reduction**: `distinct_count` moved to `cudf/reduction/distinct_count.hpp` in 26.04+
+
+## Files That Reference cuDF
+
+| Source File | Modules Used | Key APIs |
+|-------------|-------------|----------|
+| `src/include/cudf/cudf_utils.hpp` | types, table, join, aggregation, sorting, copying, scalar, stream_compaction | Central cuDF include hub |
+| `src/cuda/cudf/cudf_join.cu` | join, copying | `hash_join`, `gather`, inner/left/right/full joins |
+| `src/cuda/cudf/cudf_groupby.cu` | aggregation, stream_compaction | `groupby`, aggregation factories |
+| `src/cuda/cudf/cudf_orderby.cu` | sorting, copying | `sorted_order`, `gather` |
+| `src/cuda/cudf/cudf_aggregate.cu` | aggregation | Reduction aggregation |
+| `src/expression_executor/specializations/gpu_execute_operator.cpp` | unary_binary, search | `binary_operation`, `cast` |
+| `src/expression_executor/specializations/gpu_execute_comparison.cpp` | unary_binary, scalar | `binary_operation`, scalar construction |
+| `src/expression_executor/specializations/gpu_execute_function.cpp` | strings, unary_binary, scalar, datetime | String functions, type casting |
+| `src/expression_executor/gpu_expression_translator.cpp` | ast, types | AST tree construction |
+| `src/op/sirius_physical_hash_join.cpp` | join, copying, unary_binary | `hash_join`, `gather`, `cast` |
+| `src/op/sirius_physical_nested_loop_join.cpp` | join, ast, copying | `conditional_join`, AST expressions |
+| `src/op/sirius_physical_ungrouped_aggregate.cpp` | aggregation, scalar, fixed_point | `reduce`, scalar extraction |
+| `src/op/scan/parquet_scan_task.cpp` | io | Parquet reading, hybrid_scan |
+| `src/op/aggregate/gpu_aggregate_impl.cpp` | aggregation, dictionary | Groupby, dictionary encoding |
+| `src/op/merge/gpu_merge_impl.cpp` | sorting, aggregation, dictionary, lists, copying | `merge`, dictionary, `concatenate` |
+| `src/op/sirius_physical_top_n.cpp` | sorting, copying | `sorted_order`, `gather`, `concatenate` |
+| `src/op/sirius_physical_sort_partition.cpp` | sorting, search | `lower_bound`, `upper_bound` |
+| `src/op/partition/gpu_partition_impl.cpp` | partitioning, unary_binary | `hash_partition` |
+| `src/memory/sirius_memory_reservation_manager.cpp` | utilities | `set_current_device_resource` |
+| `src/sirius_context.cpp` | utilities | Pinned memory configuration |
+| `src/include/data/host_parquet_representation.hpp` | io | `datasource`, `hybrid_scan_reader` |
+| `src/include/memory/host_table_utils.hpp` | table, utilities | `contiguous_split`, `host_span` |

--- a/.claude/skills/module-discover/docs/cudf/modules/aggregation.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/aggregation.md
@@ -1,0 +1,110 @@
+# Aggregation
+
+**Status**: USED
+**Path**: `cudf/aggregation.hpp`, `cudf/groupby.hpp`, `cudf/reduction.hpp`, `cudf/reduction/`, `cudf/detail/aggregation/`
+**Headers we include**: `cudf/aggregation.hpp`, `cudf/groupby.hpp`, `cudf/reduction.hpp`, `cudf/reduction/distinct_count.hpp`, `cudf/reduction/approx_distinct_count.hpp`, `cudf/detail/aggregation/aggregation.hpp`
+
+## Summary
+
+Sirius uses cuDF's aggregation module for both grouped (GROUP BY) and ungrouped aggregations. The groupby API processes multiple aggregation requests in a single pass. Factory functions create typed aggregation objects (SUM, COUNT, MIN, MAX, MEAN, NUNIQUE). Detail headers are used for version-compatibility.
+
+## API Reference
+
+### Aggregation Factory Functions
+
+**Header**: `cudf/aggregation.hpp`
+```cpp
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_sum_aggregation();
+std::unique_ptr<Base> make_mean_aggregation();
+std::unique_ptr<Base> make_min_aggregation();
+std::unique_ptr<Base> make_max_aggregation();
+std::unique_ptr<Base> make_count_aggregation(null_policy policy = null_policy::EXCLUDE);
+std::unique_ptr<Base> make_nunique_aggregation(null_policy policy = null_policy::EXCLUDE);
+std::unique_ptr<Base> make_any_aggregation();
+```
+
+**Description**: Template parameter `Base` is `cudf::groupby_aggregation` for groupby or `cudf::reduce_aggregation` for reductions.
+
+**Our usage**:
+- `src/cuda/cudf/cudf_groupby.cu` — Creates groupby aggregation objects: `make_sum_aggregation<groupby_aggregation>()`
+- `src/cuda/cudf/cudf_aggregate.cu` — Creates reduction aggregation objects
+- `src/op/sirius_physical_ungrouped_aggregate.cpp` — `make_sum_aggregation<reduce_aggregation>()`
+
+### `cudf::groupby::groupby`
+
+**Header**: `cudf/groupby.hpp`
+```cpp
+class groupby {
+    groupby(table_view const& keys, null_policy include_null_keys = null_policy::EXCLUDE,
+            sorted keys_are_sorted = sorted::NO, ...);
+
+    std::pair<std::unique_ptr<table>, std::vector<aggregation_result>>
+    aggregate(host_span<aggregation_request const> requests, ...);
+};
+
+struct aggregation_request {
+    column_view values;
+    std::vector<std::unique_ptr<groupby_aggregation>> aggregations;
+};
+
+struct aggregation_result {
+    std::vector<std::unique_ptr<column>> results;
+};
+```
+
+**Description**: Groups rows by key columns, then applies multiple aggregations per value column. Returns (unique_keys_table, vector_of_results).
+
+**Our usage**:
+- `src/cuda/cudf/cudf_groupby.cu` — Primary grouped aggregation. Constructs `aggregation_request` per value column, calls `aggregate()`.
+- `src/op/aggregate/gpu_aggregate_impl.cpp` — Groupby operator implementation
+
+### `cudf::reduce`
+
+**Header**: `cudf/reduction.hpp`
+```cpp
+std::unique_ptr<scalar> reduce(column_view const& col,
+                                reduce_aggregation const& agg,
+                                data_type output_dtype, ...);
+```
+
+**Description**: Reduces an entire column to a single scalar value.
+
+**Our usage**:
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:30` — Ungrouped aggregations (e.g., `SELECT SUM(x) FROM t`)
+- `src/expression_executor/specializations/gpu_execute_case.cpp:24` — Reduction in CASE expression evaluation
+
+### `cudf::distinct_count`
+
+**Header**: `cudf/reduction/distinct_count.hpp` (26.04+)
+```cpp
+size_type distinct_count(column_view const& input, null_policy null_handling, nan_policy nan_handling, ...);
+```
+
+**Our usage**:
+- `src/include/cudf/cudf_utils.hpp:42` — Conditionally included for COUNT DISTINCT
+
+### `cudf::approx_distinct_count`
+
+**Header**: `cudf/reduction/approx_distinct_count.hpp`
+```cpp
+size_type approx_distinct_count(column_view const& input, ...);
+```
+
+**Our usage**:
+- `src/op/merge/gpu_merge_impl.cpp:27` — Approximate distinct count for merge optimization decisions
+- `src/op/aggregate/gpu_aggregate_impl.cpp:25` — Cardinality estimation
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::make_variance_aggregation()` | `aggregation.hpp` | Variance computation |
+| `cudf::make_std_aggregation()` | `aggregation.hpp` | Standard deviation |
+| `cudf::make_median_aggregation()` | `aggregation.hpp` | Median value |
+| `cudf::make_quantile_aggregation()` | `aggregation.hpp` | Quantile computation |
+| `cudf::make_collect_list_aggregation()` | `aggregation.hpp` | Collect values into list |
+| `cudf::make_rank_aggregation()` | `aggregation.hpp` | Row ranking |
+| `cudf::groupby::scan()` | `groupby.hpp` | Grouped scan (running aggregation) |
+| `cudf::segmented_reduce()` | `reduction.hpp` | Segmented reduction |
+| `cudf::scan()` | `reduction.hpp` | Prefix scan (cumulative aggregation) |

--- a/.claude/skills/module-discover/docs/cudf/modules/ast.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/ast.md
@@ -1,0 +1,90 @@
+# AST (Abstract Syntax Tree)
+
+**Status**: USED
+**Path**: `cudf/ast/`
+**Headers we include**: `cudf/ast/expressions.hpp`, `cudf/ast/ast_operator.hpp`
+
+## Summary
+
+Sirius translates DuckDB expression trees to cuDF AST for conditional joins and expression evaluation. The AST is used as input to `conditional_join` and `mixed_join` operations, enabling complex non-equi join predicates on GPU.
+
+## API Reference
+
+### `cudf::ast::tree`
+
+**Header**: `cudf/ast/expressions.hpp`
+```cpp
+class tree {
+    template <typename T, typename... Args>
+    T& emplace(Args&&... args);  // Construct expression node in tree
+    expression& back();           // Last added expression
+    expression& front();          // First expression
+};
+```
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Building AST trees from DuckDB expressions
+
+### `cudf::ast::expression` (base class)
+
+**Header**: `cudf/ast/expressions.hpp`
+
+Subclasses:
+- `cudf::ast::operation` — Binary/unary operation node
+- `cudf::ast::literal` — Constant value node
+- `cudf::ast::column_reference` — Reference to table column
+
+### `cudf::ast::operation`
+
+**Header**: `cudf/ast/expressions.hpp`
+```cpp
+class operation : public expression {
+    operation(ast_operator op, expression const& input);           // Unary
+    operation(ast_operator op, expression const& lhs, expression const& rhs); // Binary
+};
+```
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Constructing comparison and logical operations
+
+### `cudf::ast::column_reference`
+
+**Header**: `cudf/ast/expressions.hpp`
+```cpp
+class column_reference : public expression {
+    column_reference(cudf::size_type column_index, table_reference table_source = table_reference::LEFT);
+};
+```
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Referencing left/right table columns in join conditions
+- `src/op/sirius_physical_nested_loop_join.cpp` — Column references for conditional join predicates
+
+### `cudf::ast::table_reference` (enum)
+
+**Header**: `cudf/ast/expressions.hpp`
+**Values**: `LEFT`, `RIGHT`
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Distinguishing left vs right table columns in join ASTs
+
+### `cudf::ast::ast_operator` (enum)
+
+**Header**: `cudf/ast/ast_operator.hpp`
+
+**Values used by Sirius**:
+- Comparison: `EQUAL`, `NOT_EQUAL`, `LESS`, `GREATER`, `LESS_EQUAL`, `GREATER_EQUAL`
+- Logical: `LOGICAL_AND`, `LOGICAL_OR`, `NOT`
+- Arithmetic: `ADD`, `SUB`, `MUL`, `DIV`, `MOD`
+- Null: `IS_NULL`
+- Cast: `CAST_TO_INT64`, `CAST_TO_UINT64`, `CAST_TO_FLOAT64`
+
+**Our usage**:
+- `src/include/expression_executor/gpu_expression_translator.hpp:36` — Operator mapping from DuckDB to cuDF
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::ast::literal` with device scalar | `expressions.hpp` | Literal values in AST (Sirius uses column_reference pattern instead) |
+| `cudf::compute_column()` with AST | `transform.hpp` | Evaluate AST expression on a table to produce column |

--- a/.claude/skills/module-discover/docs/cudf/modules/copying.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/copying.md
@@ -1,0 +1,101 @@
+# Copying
+
+**Status**: USED
+**Path**: `cudf/copying.hpp`, `cudf/concatenate.hpp`, `cudf/detail/contiguous_split.hpp`
+**Headers we include**: `cudf/copying.hpp`, `cudf/concatenate.hpp`, `cudf/detail/contiguous_split.hpp`
+
+## Summary
+
+The copying module provides the data movement primitives used throughout Sirius. `gather` is the most frequently used cuDF function — it materializes join results and sorted output by selecting rows via index arrays. `slice` implements LIMIT, and `concatenate` combines pipeline outputs.
+
+## API Reference
+
+### `cudf::gather`
+
+**Header**: `cudf/copying.hpp`
+```cpp
+std::unique_ptr<table> gather(table_view const& source_table,
+                               column_view const& gather_map,
+                               out_of_bounds_policy policy = out_of_bounds_policy::DONT_CHECK, ...);
+```
+
+**Description**: Selects rows from source table according to gather_map indices. `out_of_bounds_policy::NULLIFY` produces nulls for invalid indices (used in outer joins).
+
+**Our usage** (very high frequency, 10+ sites):
+- `src/op/sirius_physical_hash_join.cpp` — Materializes join results from gather maps
+- `src/cuda/cudf/cudf_join.cu` — Post-join gather
+- `src/cuda/cudf/cudf_orderby.cu` — Materializes sorted output
+- `src/op/sirius_physical_top_n.cpp` — Top-N row selection
+- `src/op/order/gpu_order_impl.cpp` — Sort result materialization
+
+### `cudf::slice`
+
+**Header**: `cudf/copying.hpp`
+```cpp
+std::vector<table_view> slice(table_view const& input,
+                               host_span<size_type const> indices, ...);
+```
+
+**Description**: Zero-copy slicing — returns views into the original table at specified [start, end) ranges.
+
+**Our usage**:
+- `src/op/sirius_physical_limit.cpp:21` — SQL LIMIT implementation
+- `src/cuda/cudf/cudf_orderby.cu` — Partial sort optimization (top-K)
+
+### `cudf::concatenate`
+
+**Header**: `cudf/concatenate.hpp`
+```cpp
+std::unique_ptr<table> concatenate(host_span<table_view const> tables_to_concat, ...);
+std::unique_ptr<column> concatenate(host_span<column_view const> columns_to_concat, ...);
+```
+
+**Description**: Vertically concatenates tables/columns. Allocates new memory and copies.
+
+**Our usage**:
+- `src/op/sirius_physical_top_n.cpp:25` — Combining partial top-N results across batches
+- `src/op/sirius_physical_sort_sample.cpp:25` — Combining sort samples
+- `src/op/merge/gpu_merge_impl.cpp:23` — Concatenating before merge when appropriate
+
+### `cudf::scatter`
+
+**Header**: `cudf/copying.hpp`
+```cpp
+std::unique_ptr<table> scatter(table_view const& source, column_view const& scatter_map,
+                                table_view const& target, ...);
+```
+
+**Our usage**:
+- `src/op/sirius_physical_nested_loop_join.cpp` — Scatter for mark join results
+
+### `cudf::copy_bitmask`
+
+**Header**: `cudf/copying.hpp`
+```cpp
+rmm::device_buffer copy_bitmask(column_view const& view, ...);
+```
+
+**Our usage**:
+- `src/operator/gpu_physical_result_collector.cpp` — Extracting validity masks
+
+### `cudf::contiguous_split`
+
+**Header**: `cudf/detail/contiguous_split.hpp`
+```cpp
+std::vector<packed_columns> contiguous_split(table_view const& input,
+                                              std::vector<size_type> const& splits, ...);
+```
+
+**Our usage**:
+- `src/include/memory/host_table_utils.hpp:34` — Serializing tables for GPU↔CPU transfer via cuCascade
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::reverse()` | `copying.hpp` | Reverse row order |
+| `cudf::repeat()` | `copying.hpp` | Repeat rows N times |
+| `cudf::shift()` | `copying.hpp` | Shift column values |
+| `cudf::split()` | `copying.hpp` | Split table at indices (like slice but returns tables) |
+| `cudf::copy_if_else()` | `copying.hpp` | Conditional column selection |
+| `cudf::boolean_mask_scatter()` | `copying.hpp` | Scatter with boolean mask |

--- a/.claude/skills/module-discover/docs/cudf/modules/datetime.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/datetime.md
@@ -1,0 +1,31 @@
+# Datetime
+
+**Status**: USED
+**Path**: `cudf/datetime.hpp`
+**Headers we include**: `cudf/datetime.hpp`
+
+## Summary
+
+Used for SQL date/time functions like EXTRACT(YEAR FROM ...), date arithmetic.
+
+## API Reference
+
+### Date Extraction Functions
+
+**Header**: `cudf/datetime.hpp`
+```cpp
+std::unique_ptr<column> extract_year(column_view const& timestamps, ...);
+std::unique_ptr<column> extract_month(column_view const& timestamps, ...);
+std::unique_ptr<column> extract_day(column_view const& timestamps, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp:32` — SQL EXTRACT and date_part functions
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::extract_hour/minute/second()` | `datetime.hpp` | Time component extraction |
+| `cudf::add_calendrical_months()` | `datetime.hpp` | Date arithmetic |
+| `cudf::last_day_of_month()` | `datetime.hpp` | Month-end calculation |

--- a/.claude/skills/module-discover/docs/cudf/modules/dictionary.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/dictionary.md
@@ -1,0 +1,37 @@
+# Dictionary
+
+**Status**: USED
+**Path**: `cudf/dictionary/`
+**Headers we include**: `cudf/dictionary/dictionary_column_view.hpp`, `cudf/dictionary/encode.hpp`
+
+## Summary
+
+Dictionary encoding is used as an optimization in merge and aggregate operations on string columns, reducing memory usage and improving comparison performance.
+
+## API Reference
+
+### `cudf::dictionary_column_view`
+
+**Header**: `cudf/dictionary/dictionary_column_view.hpp`
+```cpp
+class dictionary_column_view : public column_view {
+    column_view keys() const;     // Unique values
+    column_view indices() const;  // Index into keys
+    size_type keys_size() const;
+};
+```
+
+**Our usage**:
+- `src/op/merge/gpu_merge_impl.cpp:24` — Inspecting dictionary-encoded string columns
+- `src/op/aggregate/gpu_aggregate_impl.cpp:23` — Dictionary column handling in aggregation
+
+### `cudf::dictionary::encode`
+
+**Header**: `cudf/dictionary/encode.hpp`
+```cpp
+std::unique_ptr<column> encode(column_view const& input, ...);
+```
+
+**Our usage**:
+- `src/op/merge/gpu_merge_impl.cpp:25` — Encoding strings to dictionary before merge for performance
+- `src/op/aggregate/gpu_aggregate_impl.cpp:24` — Dictionary encoding for groupby

--- a/.claude/skills/module-discover/docs/cudf/modules/fixed_point.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/fixed_point.md
@@ -1,0 +1,34 @@
+# Fixed Point
+
+**Status**: USED
+**Path**: `cudf/fixed_point/`
+**Headers we include**: `cudf/fixed_point/fixed_point.hpp`
+
+## Summary
+
+Provides exact decimal arithmetic types (DECIMAL32, DECIMAL64, DECIMAL128) for SQL DECIMAL columns. Sirius uses these for financial/precision-sensitive computations.
+
+## API Reference
+
+### `cudf::numeric::fixed_point<T>`
+
+**Header**: `cudf/fixed_point/fixed_point.hpp`
+```cpp
+template <typename Rep, typename Radix>
+class fixed_point {
+    fixed_point(Rep value, scale_type scale);
+    Rep value() const;
+    scale_type scale() const;
+};
+
+using decimal32 = fixed_point<int32_t, numeric::Radix::BASE_10>;
+using decimal64 = fixed_point<int64_t, numeric::Radix::BASE_10>;
+using decimal128 = fixed_point<__int128_t, numeric::Radix::BASE_10>;
+
+enum class scale_type : int32_t {};
+```
+
+**Our usage**:
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:29` — DECIMAL result extraction from scalars
+- `src/include/expression_executor/gpu_expression_translator.hpp:38` — DECIMAL type handling in expressions
+- `test/cpp/utils/data_utils.hpp:22` — Creating test DECIMAL columns

--- a/.claude/skills/module-discover/docs/cudf/modules/hashing.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/hashing.md
@@ -1,0 +1,15 @@
+# Hashing
+
+**Status**: UNUSED
+**Path**: `cudf/hashing/`
+
+## Summary
+GPU hash function implementations (MurmurHash3, MD5, SHA-256, etc.) for computing hash values of column data. Used internally by join and partitioning modules.
+
+## Key APIs
+- `cudf::hashing::murmurhash3_x86_32()` — MurmurHash3 32-bit
+- `cudf::hashing::md5()` — MD5 hash
+- `cudf::hashing::sha256()` — SHA-256 hash
+
+## Potential Relevance
+Not directly needed — Sirius uses `hash_join` and `hash_partition` which internally use hashing. Could be useful if implementing custom hash-based operations.

--- a/.claude/skills/module-discover/docs/cudf/modules/io.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/io.md
@@ -1,0 +1,98 @@
+# I/O (Parquet)
+
+**Status**: USED
+**Path**: `cudf/io/`
+**Headers we include**: `cudf/io/parquet.hpp`, `cudf/io/datasource.hpp`, `cudf/io/experimental/hybrid_scan.hpp`, `cudf/io/parquet_schema.hpp`, `cudf/io/parquet_io_utils.hpp`, `cudf/io/text/byte_range_info.hpp`
+
+## Summary
+
+Sirius uses cuDF's I/O module exclusively for Parquet reading. The primary integration is through the experimental `hybrid_scan_reader` which enables GPU-accelerated Parquet decoding with CPU fallback. A custom `datasource` implementation provides prefetched data for I/O optimization.
+
+## API Reference
+
+### `cudf::io::datasource`
+
+**Header**: `cudf/io/datasource.hpp`
+```cpp
+class datasource {
+public:
+    virtual ~datasource() = default;
+    virtual std::unique_ptr<buffer> host_read(size_t offset, size_t size) = 0;
+    virtual size_t host_read(size_t offset, size_t size, uint8_t* dst) = 0;
+    virtual bool supports_device_read() const;
+    virtual std::unique_ptr<device_buffer> device_read(size_t offset, size_t size, ...);
+    virtual size_t size() const = 0;
+
+    // Factory methods
+    static std::unique_ptr<datasource> create(std::string const& filepath);
+    static std::unique_ptr<datasource> create(host_buffer const& buffer);
+};
+```
+
+**Our usage**:
+- `src/include/op/scan/prefetched_data_source.hpp:21` — Custom `prefetched_data_source` subclass for pre-fetched Parquet data
+- `src/op/scan/parquet_scan_task.cpp:42` — Creating datasource instances for Parquet files
+
+### `cudf::io::parquet_reader_options`
+
+**Header**: `cudf/io/parquet.hpp`
+```cpp
+class parquet_reader_options {
+    static parquet_reader_options_builder builder(source_info src);
+    // Configuration for column selection, row group selection, etc.
+};
+
+// Builder pattern
+parquet_reader_options_builder& columns(std::vector<std::string> col_names);
+parquet_reader_options_builder& row_groups(std::vector<std::vector<size_type>> row_groups);
+
+// Read function
+table_with_metadata read_parquet(parquet_reader_options const& options, ...);
+```
+
+**Our usage**:
+- `src/op/scan/parquet_scan_task.cpp:44` — Configuring Parquet reader for scan tasks
+
+### `cudf::io::experimental::hybrid_scan_reader` (Experimental)
+
+**Header**: `cudf/io/experimental/hybrid_scan.hpp`
+
+**Description**: GPU/CPU hybrid Parquet reader that can decode pages on either device. This is an experimental API that Sirius uses as its primary Parquet ingestion path for better performance.
+
+**Our usage**:
+- `src/include/data/host_parquet_representation.hpp:26` — Core data loading infrastructure
+- `src/op/scan/parquet_scan_task.cpp:43` — Scan task implementation
+- `test/cpp/data/test_host_parquet_representation.cpp:38` — Integration tests
+
+### `cudf::io::parquet_schema`
+
+**Header**: `cudf/io/parquet_schema.hpp`
+
+**Description**: Parquet schema introspection for column type mapping.
+
+**Our usage**:
+- `src/op/scan/parquet_scan_task.cpp:45` — Schema inspection during scan setup
+
+### `cudf::io::text::byte_range_info`
+
+**Header**: `cudf/io/text/byte_range_info.hpp`
+```cpp
+struct byte_range_info {
+    size_t offset;
+    size_t size;
+};
+```
+
+**Our usage**:
+- `src/include/op/scan/cached_ranges.hpp:19` — Byte range tracking for cached I/O
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::io::write_parquet()` | `parquet.hpp` | Write tables to Parquet files |
+| `cudf::io::read_csv()` | `csv.hpp` | CSV reader |
+| `cudf::io::read_json()` | `json.hpp` | JSON reader |
+| `cudf::io::read_orc()` | `orc.hpp` | ORC reader |
+| `cudf::io::chunked_parquet_reader` | `parquet.hpp` | Chunked Parquet reading |
+| `cudf::io::data_sink` | `data_sink.hpp` | Output interface for writers |

--- a/.claude/skills/module-discover/docs/cudf/modules/join.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/join.md
@@ -1,0 +1,116 @@
+# Join
+
+**Status**: USED
+**Path**: `cudf/join/` (26.04+) or `cudf/join.hpp` (≤25.04)
+**Headers we include**: `cudf/join/hash_join.hpp`, `cudf/join/join.hpp`, `cudf/join/conditional_join.hpp`, `cudf/join/mixed_join.hpp`, `cudf/join/distinct_hash_join.hpp`, `cudf/join/filtered_join.hpp`, `cudf/join.hpp`
+
+## Summary
+
+The join module is critical to Sirius — it implements all SQL join operations on GPU. Sirius uses hash joins for equi-joins (most common), conditional joins for non-equi predicates via AST expressions, and mixed joins combining both. Version-conditional includes handle the 25.04→26.04 header reorganization.
+
+## API Reference
+
+### `cudf::hash_join`
+
+**Header**: `cudf/join/hash_join.hpp`
+```cpp
+class hash_join {
+    hash_join(cudf::table_view const& build, null_equality compare_nulls,
+              rmm::cuda_stream_view stream = {});
+
+    // Probe methods return gather maps
+    std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+              std::unique_ptr<rmm::device_uvector<size_type>>>
+    inner_join(cudf::table_view const& probe, ...) const;
+
+    left_join(cudf::table_view const& probe, ...) const;
+    full_join(cudf::table_view const& probe, ...) const;
+};
+```
+
+**Description**: Build-once, probe-multiple-times hash join. Returns pairs of gather-map vectors (left indices, right indices). `JoinNoMatch` sentinel marks unmatched rows.
+
+**Our usage**:
+- `src/cuda/cudf/cudf_join.cu` — Primary join implementation. Builds hash table on smaller relation, probes with larger.
+- `src/op/sirius_physical_hash_join.cpp` — Hash join operator wrapping cudf_join
+
+### `cudf::inner_join` / `cudf::left_join` / `cudf::full_join`
+
+**Header**: `cudf/join/join.hpp`
+```cpp
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+inner_join(table_view const& left_keys, table_view const& right_keys,
+           null_equality compare_nulls = null_equality::EQUAL, ...);
+```
+
+**Description**: Convenience free functions (internally create hash_join). Sirius uses the `hash_join` class directly for better control over build/probe phases.
+
+**Our usage**:
+- `src/cuda/cudf/cudf_join.cu` — Fallback path for simple joins
+
+### `cudf::conditional_inner_join` / `cudf::conditional_left_join` / `cudf::conditional_full_join`
+
+**Header**: `cudf/join/conditional_join.hpp`
+```cpp
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+conditional_inner_join(table_view const& left, table_view const& right,
+                       ast::expression const& binary_predicate, ...);
+
+std::unique_ptr<rmm::device_uvector<size_type>>
+conditional_left_semi_join(table_view const& left, table_view const& right,
+                           ast::expression const& binary_predicate, ...);
+```
+
+**Description**: Joins using arbitrary AST expressions as predicates. Used for non-equi joins (e.g., `a.x > b.y AND a.z < b.w`).
+
+**Our usage**:
+- `src/op/sirius_physical_nested_loop_join.cpp:34` — Nested loop join with conditional predicates translated to cuDF AST
+
+### `cudf::mixed_inner_join` / `cudf::mixed_left_join`
+
+**Header**: `cudf/join/mixed_join.hpp`
+```cpp
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
+          std::unique_ptr<rmm::device_uvector<size_type>>>
+mixed_inner_join(table_view const& left_equality, table_view const& right_equality,
+                 table_view const& left_conditional, table_view const& right_conditional,
+                 ast::expression const& binary_predicate, null_equality compare_nulls, ...);
+```
+
+**Description**: Combines hash-based equality matching with conditional predicates for optimal performance on complex join conditions.
+
+**Our usage**:
+- `src/op/sirius_physical_hash_join.cpp` — Used when join has both equality and inequality conditions
+
+### `cudf::distinct_hash_join`
+
+**Header**: `cudf/join/distinct_hash_join.hpp`
+```cpp
+class distinct_hash_join {
+    distinct_hash_join(cudf::table_view const& build, null_equality compare_nulls, ...);
+    // Methods for semi/anti joins with distinct semantics
+};
+```
+
+**Our usage**:
+- `src/include/cudf/cudf_utils.hpp:27` — Included for availability, used in semi/anti join paths
+
+### `cudf::left_semi_join` / `cudf::left_anti_join`
+
+**Header**: `cudf/join/filtered_join.hpp`
+```cpp
+std::unique_ptr<rmm::device_uvector<size_type>>
+left_semi_join(table_view const& left_keys, table_view const& right_keys, ...);
+```
+
+**Our usage**:
+- `src/cuda/cudf/cudf_join.cu` — Semi and anti join implementations
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::cross_join()` | `join.hpp` | Cartesian product of two tables |
+| `cudf::sort_merge_join()` | `sort_merge_join.hpp` | Sort-merge join algorithm |

--- a/.claude/skills/module-discover/docs/cudf/modules/json.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/json.md
@@ -1,0 +1,13 @@
+# JSON
+
+**Status**: UNUSED
+**Path**: `cudf/json/`
+
+## Summary
+JSON column support for querying semi-structured JSON data stored in columns.
+
+## Key APIs
+- `cudf::json::get_json_object()` — Extract values from JSON strings using JSONPath
+
+## Potential Relevance
+Not applicable to current TPC-H/analytical workloads. Could be useful for JSON data processing if Sirius expands to semi-structured data support.

--- a/.claude/skills/module-discover/docs/cudf/modules/labeling.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/labeling.md
@@ -1,0 +1,13 @@
+# Labeling
+
+**Status**: UNUSED
+**Path**: `cudf/labeling/`
+
+## Summary
+Assigns labels to rows based on bin boundaries. Useful for histogram-style categorization.
+
+## Key APIs
+- `cudf::label_bins()` — Assign bin labels to column values
+
+## Potential Relevance
+Not applicable to current SQL workloads. Could be useful for WIDTH_BUCKET or histogram functions.

--- a/.claude/skills/module-discover/docs/cudf/modules/lists.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/lists.md
@@ -1,0 +1,30 @@
+# Lists
+
+**Status**: USED (minimal)
+**Path**: `cudf/lists/`
+**Headers we include**: `cudf/lists/count_elements.hpp`
+
+## Summary
+
+Minimal usage — only `count_elements` is used for counting elements in list columns during grouped aggregate merge operations.
+
+## API Reference
+
+### `cudf::lists::count_elements`
+
+**Header**: `cudf/lists/count_elements.hpp`
+```cpp
+std::unique_ptr<column> count_elements(lists_column_view const& input, ...);
+```
+
+**Our usage**:
+- `src/op/sirius_physical_grouped_aggregate_merge.cpp:24` — Counting elements in intermediate list aggregation results during merge
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::lists::contains()` | `contains.hpp` | Check if list contains value |
+| `cudf::lists::extract_list_element()` | `extract.hpp` | Extract element from list |
+| `cudf::lists::explode_outer()` | `explode.hpp` | Unnest lists to rows |
+| `cudf::lists::sort_lists()` | `sorting.hpp` | Sort elements within lists |

--- a/.claude/skills/module-discover/docs/cudf/modules/partitioning.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/partitioning.md
@@ -1,0 +1,26 @@
+# Partitioning
+
+**Status**: USED
+**Path**: `cudf/partitioning.hpp`
+**Headers we include**: `cudf/partitioning.hpp`
+
+## Summary
+
+Hash-based table partitioning for parallel pipeline execution. Distributes rows across partitions based on hash of key columns.
+
+## API Reference
+
+### `cudf::hash_partition`
+
+**Header**: `cudf/partitioning.hpp`
+```cpp
+std::pair<std::unique_ptr<table>, std::vector<size_type>>
+hash_partition(table_view const& input,
+               std::vector<size_type> const& columns_to_hash,
+               int num_partitions, ...);
+```
+
+**Description**: Returns (partitioned_table, partition_offsets). Rows with same hash key end up in same partition.
+
+**Our usage**:
+- `src/op/partition/gpu_partition_impl.cpp:21` — Repartitioning data for parallel join/aggregate execution

--- a/.claude/skills/module-discover/docs/cudf/modules/rolling.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/rolling.md
@@ -1,0 +1,15 @@
+# Rolling
+
+**Status**: UNUSED
+**Path**: `cudf/rolling/`
+
+## Summary
+Rolling (sliding) window aggregation operations. Computes aggregates over a window of rows (e.g., moving average, running sum).
+
+## Key APIs
+- `cudf::rolling_window()` — Apply aggregation over rolling window
+- `cudf::grouped_rolling_window()` — Rolling window within groups
+- `cudf::range_window_bounds` — Window boundary specification
+
+## Potential Relevance
+Would be needed to support SQL window functions (OVER clause with ROWS/RANGE). Currently Sirius falls back to DuckDB CPU for window functions.

--- a/.claude/skills/module-discover/docs/cudf/modules/scalar.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/scalar.md
@@ -1,0 +1,92 @@
+# Scalar
+
+**Status**: USED
+**Path**: `cudf/scalar/`
+**Headers we include**: `cudf/scalar/scalar.hpp`, `cudf/scalar/scalar_factories.hpp`
+
+## Summary
+
+Scalars represent single device-side values used in binary operations (column op scalar), aggregation results, and constant expression evaluation. Sirius constructs scalars for SQL literal values and extracts scalar results from reductions.
+
+## API Reference
+
+### `cudf::scalar` (base class)
+
+**Header**: `cudf/scalar/scalar.hpp`
+```cpp
+class scalar {
+    data_type type() const;
+    bool is_valid() const;
+};
+```
+
+### `cudf::numeric_scalar<T>`
+
+**Header**: `cudf/scalar/scalar.hpp`
+```cpp
+template <typename T>
+class numeric_scalar : public scalar {
+    numeric_scalar(T value, bool is_valid = true, rmm::cuda_stream_view stream = {}, ...);
+    T value(rmm::cuda_stream_view stream = {}) const;
+};
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_comparison.cpp` — Constructing comparison constants
+- `src/operator/gpu_physical_table_scan.cpp` — `cudf::numeric_scalar<bool>(false)` for null replacement
+- `src/gpu_columns.cpp` — Extracting scalar results
+
+### `cudf::string_scalar`
+
+**Header**: `cudf/scalar/scalar.hpp`
+```cpp
+class string_scalar : public scalar {
+    string_scalar(std::string const& value, bool is_valid = true, ...);
+    std::string to_string(rmm::cuda_stream_view stream = {}) const;
+};
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — String literal constants for LIKE patterns
+
+### `cudf::fixed_point_scalar<T>`
+
+**Header**: `cudf/scalar/scalar.hpp`
+```cpp
+template <typename T>  // T = numeric::decimal32, decimal64, decimal128
+class fixed_point_scalar : public scalar {
+    fixed_point_scalar(T value, bool is_valid = true, ...);
+    T value(rmm::cuda_stream_view stream = {}) const;
+    rep_type const* data() const;  // Raw representation
+};
+```
+
+**Our usage**:
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:29` — DECIMAL aggregation results
+- `src/expression_executor/gpu_expression_translator.cpp` — DECIMAL literal construction
+
+### `cudf::timestamp_scalar<T>`
+
+**Header**: `cudf/scalar/scalar.hpp`
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_comparison.cpp` — Timestamp comparison constants
+
+### Scalar Factory Functions
+
+**Header**: `cudf/scalar/scalar_factories.hpp`
+```cpp
+std::unique_ptr<scalar> make_default_constructed_scalar(data_type type, ...);
+std::unique_ptr<scalar> make_fixed_width_scalar(data_type type, ...);
+```
+
+**Our usage**:
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:32` — Creating typed scalars for empty aggregation results
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::duration_scalar<T>` | `scalar.hpp` | Duration scalar types |
+| `cudf::list_scalar` | `scalar.hpp` | List scalar type |
+| `cudf::struct_scalar` | `scalar.hpp` | Struct scalar type |

--- a/.claude/skills/module-discover/docs/cudf/modules/sorting.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/sorting.md
@@ -1,0 +1,79 @@
+# Sorting, Merge & Search
+
+**Status**: USED
+**Path**: `cudf/sorting.hpp`, `cudf/merge.hpp`, `cudf/search.hpp`
+**Headers we include**: `cudf/sorting.hpp`, `cudf/merge.hpp`, `cudf/search.hpp`
+
+## Summary
+
+Sirius uses sorting for ORDER BY, merge for combining pre-sorted pipeline outputs, and search for partitioning sorted data. The primary pattern is `sorted_order()` → `gather()` rather than in-place sort.
+
+## API Reference
+
+### `cudf::sorted_order`
+
+**Header**: `cudf/sorting.hpp`
+```cpp
+std::unique_ptr<column> sorted_order(table_view const& input,
+                                      std::vector<order> const& column_order = {},
+                                      std::vector<null_order> const& null_precedence = {}, ...);
+```
+
+**Description**: Returns a column of row indices that would sort the input table. Used with `gather()` to produce sorted output.
+
+**Our usage**:
+- `src/cuda/cudf/cudf_orderby.cu` — Primary ORDER BY implementation
+- `src/op/sirius_physical_top_n.cpp:28` — Sort indices for top-N selection
+
+### `cudf::stable_sorted_order`
+
+**Header**: `cudf/sorting.hpp`
+```cpp
+std::unique_ptr<column> stable_sorted_order(table_view const& input, ...);
+```
+
+**Description**: Like `sorted_order` but preserves relative order of equal elements.
+
+**Our usage**:
+- `src/cuda/cudf/cudf_orderby.cu` — Used when stable sort is required
+
+### `cudf::merge`
+
+**Header**: `cudf/merge.hpp`
+```cpp
+std::unique_ptr<table> merge(std::vector<table_view> const& tables_to_merge,
+                              std::vector<size_type> const& key_cols,
+                              std::vector<order> const& column_order,
+                              std::vector<null_order> const& null_precedence = {}, ...);
+```
+
+**Description**: Merges multiple pre-sorted tables into a single sorted table. More efficient than concatenate+sort when inputs are already sorted.
+
+**Our usage**:
+- `src/op/merge/gpu_merge_impl.cpp:26` — Merging sorted pipeline outputs in multi-stream execution
+
+### `cudf::lower_bound` / `cudf::upper_bound`
+
+**Header**: `cudf/search.hpp`
+```cpp
+std::unique_ptr<column> lower_bound(table_view const& haystack,
+                                     table_view const& needles,
+                                     std::vector<order> const& column_order,
+                                     std::vector<null_order> const& null_precedence, ...);
+```
+
+**Description**: Binary search in a sorted table. Returns indices where needles would be inserted.
+
+**Our usage**:
+- `src/op/sirius_physical_sort_partition.cpp:25` — Partitioning sorted data at sample boundaries for parallel merge
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::sort()` | `sorting.hpp` | In-place sort (returns new table) |
+| `cudf::sort_by_key()` | `sorting.hpp` | Sort one table by another's keys |
+| `cudf::rank()` | `sorting.hpp` | Compute row ranks |
+| `cudf::is_sorted()` | `sorting.hpp` | Check if table is sorted |
+| `cudf::segmented_sort_by_key()` | `sorting.hpp` | Sort within segments |
+| `cudf::contains()` | `search.hpp` | Check if value exists in column |

--- a/.claude/skills/module-discover/docs/cudf/modules/stream_compaction.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/stream_compaction.md
@@ -1,0 +1,32 @@
+# Stream Compaction
+
+**Status**: USED
+**Path**: `cudf/stream_compaction.hpp`, `cudf/detail/stream_compaction.hpp`
+**Headers we include**: `cudf/stream_compaction.hpp`, `cudf/detail/stream_compaction.hpp`
+
+## Summary
+
+Used for duplicate elimination (SQL DISTINCT). Sirius accesses both public and detail APIs for version compatibility.
+
+## API Reference
+
+### `cudf::drop_duplicates`
+
+**Header**: `cudf/stream_compaction.hpp`
+```cpp
+std::unique_ptr<table> drop_duplicates(table_view const& input,
+                                        std::vector<size_type> const& keys,
+                                        duplicate_keep_option keep, ...);
+```
+
+**Our usage**:
+- `src/cuda/cudf/cudf_duplicate_elimination.cu` — SQL DISTINCT implementation
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::apply_boolean_mask()` | `stream_compaction.hpp` | Filter rows by boolean column |
+| `cudf::unique()` | `stream_compaction.hpp` | Remove consecutive duplicates (sorted input) |
+| `cudf::distinct()` | `stream_compaction.hpp` | Keep distinct rows |
+| `cudf::stable_distinct()` | `stream_compaction.hpp` | Stable distinct preserving order |

--- a/.claude/skills/module-discover/docs/cudf/modules/strings.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/strings.md
@@ -1,0 +1,119 @@
+# Strings
+
+**Status**: USED
+**Path**: `cudf/strings/`
+**Headers we include**: `cudf/strings/strings_column_view.hpp`, `cudf/strings/contains.hpp`, `cudf/strings/find.hpp`, `cudf/strings/slice.hpp`, `cudf/strings/replace_re.hpp`, `cudf/strings/attributes.hpp`, `cudf/strings/regex/regex_program.hpp`
+
+## Summary
+
+Sirius uses GPU string operations for SQL string functions (LIKE, SUBSTRING, LENGTH, regex matching). The `strings_column_view` provides the interface to string column data, while individual operation headers provide functions for pattern matching, substring extraction, and string attributes.
+
+## API Reference
+
+### `cudf::strings_column_view`
+
+**Header**: `cudf/strings/strings_column_view.hpp`
+```cpp
+class strings_column_view : public column_view {
+    column_view offsets() const;   // Offset array (int32_t or int64_t)
+    column_view chars() const;     // Character data
+    size_type chars_size() const;  // Total bytes in character data
+};
+```
+
+**Our usage**:
+- `src/cuda/expression_executor/gpu_dispatch_string.cu:22` — Accessing string data for custom kernels
+- `src/op/merge/gpu_merge_impl.cpp:28` — String column introspection for merge optimization
+
+### `cudf::strings::contains_re`
+
+**Header**: `cudf/strings/contains.hpp`
+```cpp
+std::unique_ptr<column> contains_re(strings_column_view const& input,
+                                     regex_program const& prog, ...);
+std::unique_ptr<column> like(strings_column_view const& input,
+                              string_scalar const& pattern,
+                              string_scalar const& escape_char = {}, ...);
+std::unique_ptr<column> starts_with(strings_column_view const& input, string_scalar const& target, ...);
+std::unique_ptr<column> ends_with(strings_column_view const& input, string_scalar const& target, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — SQL LIKE, regex matching, prefix/suffix checks
+
+### `cudf::strings::find`
+
+**Header**: `cudf/strings/find.hpp`
+```cpp
+std::unique_ptr<column> find(strings_column_view const& input, string_scalar const& target, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — POSITION/INSTR function
+
+### `cudf::strings::slice_strings`
+
+**Header**: `cudf/strings/slice.hpp`
+```cpp
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                       numeric_scalar<size_type> const& start,
+                                       numeric_scalar<size_type> const& stop, ...);
+std::unique_ptr<column> slice_strings(strings_column_view const& input,
+                                       column_view const& starts,
+                                       column_view const& stops, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — SQL SUBSTRING function
+
+### `cudf::strings::count_characters` / `cudf::strings::count_bytes`
+
+**Header**: `cudf/strings/attributes.hpp`
+```cpp
+std::unique_ptr<column> count_characters(strings_column_view const& input, ...);
+std::unique_ptr<column> count_bytes(strings_column_view const& input, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — SQL LENGTH/CHAR_LENGTH
+
+### `cudf::strings::replace_re`
+
+**Header**: `cudf/strings/replace_re.hpp`
+```cpp
+std::unique_ptr<column> replace_re(strings_column_view const& input,
+                                    regex_program const& prog,
+                                    string_scalar const& replacement, ...);
+std::unique_ptr<column> replace_with_backrefs(strings_column_view const& input,
+                                               regex_program const& prog,
+                                               std::string_view replacement, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — SQL REGEXP_REPLACE
+
+### `cudf::strings::regex_program`
+
+**Header**: `cudf/strings/regex/regex_program.hpp`
+```cpp
+class regex_program {
+    static std::unique_ptr<regex_program> create(std::string_view pattern, regex_flags flags = {}, ...);
+};
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp:37` — Compiling regex patterns for LIKE/REGEXP operations
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::strings::capitalize()` | `capitalize.hpp` | Capitalize strings |
+| `cudf::strings::to_lower()` / `to_upper()` | `case.hpp` | Case conversion |
+| `cudf::strings::concatenate()` | `combine.hpp` | String concatenation |
+| `cudf::strings::strip()` | `strip.hpp` | Trim whitespace (TRIM/LTRIM/RTRIM) |
+| `cudf::strings::pad()` | `padding.hpp` | Pad strings (LPAD/RPAD) |
+| `cudf::strings::split()` | `split/split.hpp` | Split strings |
+| `cudf::strings::findall()` | `findall.hpp` | Find all regex matches |
+| `cudf::strings::extract()` | `extract.hpp` | Regex group extraction |
+| `cudf::strings::to_integers()` | `convert/convert_integers.hpp` | Parse integers from strings |

--- a/.claude/skills/module-discover/docs/cudf/modules/structs.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/structs.md
@@ -1,0 +1,14 @@
+# Structs
+
+**Status**: UNUSED
+**Path**: `cudf/structs/`
+
+## Summary
+Support for struct (record) columns — composite types with named fields. Provides views into struct column components.
+
+## Key APIs
+- `cudf::structs_column_view` — View into struct column
+- `cudf::structs::detail::flatten_nested_columns()` — Flatten nested structs
+
+## Potential Relevance
+Not applicable — Sirius does not support nested/struct data types and falls back to DuckDB for these.

--- a/.claude/skills/module-discover/docs/cudf/modules/table.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/table.md
@@ -1,0 +1,112 @@
+# Table & Column
+
+**Status**: USED
+**Path**: `cudf/table/`, `cudf/column/`
+**Headers we include**: `cudf/table/table.hpp`, `cudf/table/table_view.hpp`, `cudf/column/column.hpp`, `cudf/column/column_view.hpp`, `cudf/column/column_factories.hpp`
+
+## Summary
+
+Tables and columns are the fundamental data structures in cuDF. Sirius converts DuckDB data to cuDF tables for GPU processing, manipulates them through operators, and converts results back. The owning vs. view pattern is central to zero-copy data passing.
+
+## API Reference
+
+### `cudf::table`
+
+**Header**: `cudf/table/table.hpp`
+```cpp
+class table {
+    table(std::vector<std::unique_ptr<column>>&& columns);
+    table(table_view view, rmm::cuda_stream_view stream = {}, rmm::device_async_resource_ref mr = {});
+    table_view view() const;
+    mutable_table_view mutable_view();
+    size_type num_columns() const;
+    size_type num_rows() const;
+    std::vector<std::unique_ptr<column>> release();
+};
+```
+
+**Our usage**:
+- `src/cuda/cudf/cudf_join.cu` — Join results returned as tables
+- `src/op/sirius_physical_top_n.cpp` — Intermediate table construction
+- `src/cuda/cudf/cudf_groupby.cu` — Groupby keys table
+
+### `cudf::table_view`
+
+**Header**: `cudf/table/table_view.hpp`
+```cpp
+class table_view {
+    table_view(std::vector<column_view> const& columns);
+    column_view column(size_type index) const;
+    size_type num_columns() const;
+    size_type num_rows() const;
+    table_view select(std::vector<size_type> const& column_indices) const;
+};
+```
+
+**Our usage**: Pervasive — passed to virtually every cuDF operation as input.
+
+### `cudf::column`
+
+**Header**: `cudf/column/column.hpp`
+```cpp
+class column {
+    column(column_view view, rmm::cuda_stream_view stream = {}, rmm::device_async_resource_ref mr = {});
+    column_view view() const;
+    mutable_column_view mutable_view();
+    data_type type() const;
+    size_type size() const;
+    size_type null_count() const;
+    struct contents { std::unique_ptr<rmm::device_buffer> data; ... };
+    contents release();
+};
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/*.cpp` — Expression results as columns
+- `src/cuda/operator/empty_str_check.cu` — Column construction from device data
+
+### `cudf::column_view`
+
+**Header**: `cudf/column/column_view.hpp`
+```cpp
+class column_view {
+    column_view(data_type type, size_type size, void const* data,
+                bitmask_type const* null_mask = nullptr, size_type null_count = UNKNOWN_NULL_COUNT,
+                size_type offset = 0, std::vector<column_view> const& children = {});
+    data_type type() const;
+    size_type size() const;
+    template <typename T> T const* data() const;
+    template <typename T> T const* head() const;
+    bitmask_type const* null_mask() const;
+    size_type null_count() const;
+    size_type offset() const;
+    size_type num_children() const;
+    column_view child(size_type index) const;
+};
+```
+
+**Our usage**:
+- `src/gpu_columns.cpp` — Constructing column_views from GPU buffer data
+- `src/expression_executor/specializations/gpu_execute_operator.cpp` — Accessing column data for operations
+
+### `cudf::make_empty_column(data_type)`
+
+**Header**: `cudf/column/column_factories.hpp`
+```cpp
+std::unique_ptr<column> make_empty_column(data_type type);
+std::unique_ptr<column> make_numeric_column(data_type type, size_type size, mask_state state = UNALLOCATED, ...);
+std::unique_ptr<column> make_fixed_width_column(data_type type, size_type size, mask_state state = UNALLOCATED, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_function.cpp:31` — Creating empty result columns
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:27` — Empty columns for empty aggregation results
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::make_strings_column()` | `column_factories.hpp` | Create string column from device data |
+| `cudf::make_lists_column()` | `column_factories.hpp` | Create list column |
+| `cudf::make_structs_column()` | `column_factories.hpp` | Create struct column |
+| `cudf::mutable_table_view` | `table_view.hpp` | Mutable non-owning table view |

--- a/.claude/skills/module-discover/docs/cudf/modules/tdigest.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/tdigest.md
@@ -1,0 +1,14 @@
+# T-Digest
+
+**Status**: UNUSED
+**Path**: `cudf/tdigest/`
+
+## Summary
+T-Digest data structure for approximate percentile/quantile computation. Useful for streaming approximate analytics.
+
+## Key APIs
+- `cudf::tdigest_column_view` — View into t-digest column
+- `cudf::percentile_approx()` — Approximate percentile from t-digest
+
+## Potential Relevance
+Could be useful for implementing PERCENTILE_CONT/PERCENTILE_DISC approximate variants for large datasets.

--- a/.claude/skills/module-discover/docs/cudf/modules/transform.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/transform.md
@@ -1,0 +1,25 @@
+# Transform
+
+**Status**: USED
+**Path**: `cudf/transform.hpp`
+**Headers we include**: `cudf/transform.hpp`
+
+## Summary
+
+Element-wise transformation using cuDF AST expressions. Used in expression evaluation and testing.
+
+## API Reference
+
+### `cudf::compute_column`
+
+**Header**: `cudf/transform.hpp`
+```cpp
+std::unique_ptr<column> compute_column(table_view const& table,
+                                        ast::expression const& expr, ...);
+```
+
+**Description**: Evaluates an AST expression against a table, producing a result column.
+
+**Our usage**:
+- `src/include/expression_executor/regex/regex_playground.hpp:21` — Expression evaluation
+- `test/cpp/expression_executor/test_gpu_expression_translator.cpp:31` — Testing AST translation correctness

--- a/.claude/skills/module-discover/docs/cudf/modules/types_core.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/types_core.md
@@ -1,0 +1,100 @@
+# Types / Core
+
+**Status**: USED
+**Path**: `cudf/types.hpp`, `cudf/version_config.hpp`
+**Headers we include**: `cudf/types.hpp`, `cudf/version_config.hpp`
+
+## Summary
+
+The cuDF core type system defines fundamental types used throughout the library. Sirius maps DuckDB's type system to cuDF types for GPU execution, and uses `size_type` and `bitmask_type` extensively for column/row addressing and null mask management.
+
+## API Reference
+
+### `cudf::type_id` (enum)
+
+**Header**: `cudf/types.hpp`
+
+**Values used by Sirius**:
+- `INT8`, `INT16`, `INT32`, `INT64` — signed integers
+- `UINT8`, `UINT16`, `UINT32`, `UINT64` — unsigned integers
+- `FLOAT32`, `FLOAT64` — floating point
+- `BOOL8` — boolean
+- `STRING` — variable-length string
+- `TIMESTAMP_DAYS`, `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLISECONDS`, `TIMESTAMP_MICROSECONDS`, `TIMESTAMP_NANOSECONDS` — temporal types
+- `DECIMAL32`, `DECIMAL64`, `DECIMAL128` — fixed-point decimal
+- `STRUCT`, `EMPTY` — structural types
+
+**Our usage**:
+- `src/gpu_columns.cpp` — Maps DuckDB `LogicalTypeId` to `cudf::type_id` for column construction
+- `src/expression_executor/gpu_expression_translator.cpp` — Type dispatch for expression evaluation
+
+### `cudf::data_type`
+
+**Header**: `cudf/types.hpp`
+```cpp
+class data_type {
+    data_type(type_id id);
+    data_type(type_id id, int32_t scale);  // For DECIMAL types
+    type_id id() const;
+    int32_t scale() const;
+};
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_operator.cpp` — Constructing target types for `binary_operation`
+- `src/op/sirius_physical_ungrouped_aggregate.cpp` — Type construction for reduction results
+
+### `cudf::size_type`
+
+**Header**: `cudf/types.hpp`
+**Type**: `int32_t`
+
+Fundamental row-count and index type. Limits cuDF to ~2 billion rows per column.
+
+**Our usage**: Pervasive — used in every operator for row counts, gather maps, and indexing.
+
+### `cudf::bitmask_type`
+
+**Header**: `cudf/types.hpp`
+**Type**: `uint32_t`
+
+Used for null validity bitmasks. Each bit represents one row's validity.
+
+**Our usage**:
+- `src/operator/gpu_materialize.cpp` — Validity mask construction
+- `src/operator/gpu_physical_result_collector.cpp` — Null mask handling during result collection
+
+### `cudf::null_equality` (enum)
+
+**Header**: `cudf/types.hpp`
+**Values**: `EQUAL`, `UNEQUAL`
+
+**Our usage**:
+- `src/cuda/cudf/cudf_join.cu` — Controls null matching behavior in joins
+
+### `cudf::null_policy` (enum)
+
+**Header**: `cudf/types.hpp`
+**Values**: `INCLUDE`, `EXCLUDE`
+
+**Our usage**:
+- `src/cuda/cudf/cudf_groupby.cu` — Controls null inclusion in aggregation
+- `src/cuda/cudf/cudf_aggregate.cu` — Null handling in reductions
+
+### `cudf::order` / `cudf::null_order` (enums)
+
+**Header**: `cudf/types.hpp`
+- `cudf::order`: `ASCENDING`, `DESCENDING`
+- `cudf::null_order`: `BEFORE`, `AFTER`
+
+**Our usage**:
+- `src/cuda/cudf/cudf_orderby.cu` — Sort direction and null placement
+- `src/op/merge/gpu_merge_impl.cpp` — Merge order specification
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::thread_allocation_mode` | `cudf/types.hpp` | Thread-local allocation mode |
+| `cudf::interpolation` | `cudf/types.hpp` | Interpolation method for quantiles |
+| `cudf::mask_state` | `cudf/types.hpp` | Initial state for newly allocated masks |

--- a/.claude/skills/module-discover/docs/cudf/modules/unary_binary.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/unary_binary.md
@@ -1,0 +1,103 @@
+# Unary & Binary Operations
+
+**Status**: USED
+**Path**: `cudf/unary.hpp`, `cudf/binaryop.hpp`
+**Headers we include**: `cudf/unary.hpp`, `cudf/binaryop.hpp`
+
+## Summary
+
+The most frequently called cuDF APIs in Sirius. Every SQL expression involving arithmetic, comparison, or logical operations translates to `binary_operation` or `unary_operation`. Type casting via `cudf::cast` is also in this module.
+
+## API Reference
+
+### `cudf::binary_operation`
+
+**Header**: `cudf/binaryop.hpp`
+```cpp
+// Column op Column
+std::unique_ptr<column> binary_operation(column_view const& lhs, column_view const& rhs,
+                                          binary_operator op, data_type output_type, ...);
+// Scalar op Column
+std::unique_ptr<column> binary_operation(scalar const& lhs, column_view const& rhs,
+                                          binary_operator op, data_type output_type, ...);
+// Column op Scalar
+std::unique_ptr<column> binary_operation(column_view const& lhs, scalar const& rhs,
+                                          binary_operator op, data_type output_type, ...);
+```
+
+**Description**: Element-wise binary operation producing a new column.
+
+**Our usage** (40+ call sites):
+- `src/expression_executor/specializations/gpu_execute_operator.cpp` — Arithmetic ops (+, -, *, /, %)
+- `src/expression_executor/specializations/gpu_execute_comparison.cpp` — Comparison ops (<, >, =, etc.)
+- `src/expression_executor/specializations/gpu_execute_between.cpp` — BETWEEN as two comparisons + AND
+- `src/expression_executor/specializations/gpu_execute_conjunction.cpp` — AND/OR logical ops
+- `src/expression_executor/specializations/gpu_execute_function.cpp` — Date arithmetic
+
+### `cudf::binary_operator` (enum)
+
+**Header**: `cudf/binaryop.hpp`
+
+**Values used by Sirius**:
+- Arithmetic: `ADD`, `SUB`, `MUL`, `DIV`, `TRUE_DIV`, `FLOOR_DIV`, `MOD`, `PYMOD`
+- Comparison: `EQUAL`, `NOT_EQUAL`, `LESS`, `GREATER`, `LESS_EQUAL`, `GREATER_EQUAL`, `NULL_EQUALS`
+- Logical: `LOGICAL_AND`, `LOGICAL_OR`
+- Bitwise: `BITWISE_AND`, `BITWISE_OR`
+
+### `cudf::unary_operation`
+
+**Header**: `cudf/unary.hpp`
+```cpp
+std::unique_ptr<column> unary_operation(column_view const& input, unary_operator op, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_operator.cpp` — NOT, ABS, negation
+- `src/cuda/expression_executor/gpu_dispatch_string.cu` — IS_NULL checks
+
+### `cudf::cast`
+
+**Header**: `cudf/unary.hpp`
+```cpp
+std::unique_ptr<column> cast(column_view const& input, data_type out_type, ...);
+```
+
+**Description**: Type casting between cuDF data types.
+
+**Our usage** (10+ call sites):
+- `src/expression_executor/specializations/gpu_execute_cast.cpp:20` — SQL CAST expressions
+- `src/operator/gpu_physical_ungrouped_aggregate.cpp` — Cast before aggregation
+- `src/op/sirius_physical_hash_join.cpp:25` — Type alignment before join
+- `src/op/partition/gpu_partition_impl.cpp:22` — Cast for partitioning
+
+### `cudf::is_null` / `cudf::is_valid`
+
+**Header**: `cudf/unary.hpp`
+```cpp
+std::unique_ptr<column> is_null(column_view const& input, ...);
+std::unique_ptr<column> is_valid(column_view const& input, ...);
+```
+
+**Our usage**:
+- `src/expression_executor/specializations/gpu_execute_operator.cpp` — IS NULL / IS NOT NULL
+
+### `cudf::replace_nulls`
+
+**Header**: `cudf/replace.hpp` (also accessible via unary patterns)
+```cpp
+std::unique_ptr<column> replace_nulls(column_view const& input, scalar const& replacement, ...);
+std::unique_ptr<column> replace_nulls(column_view const& input, column_view const& replacement, ...);
+```
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Replace nulls in boolean filter masks
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::unary_operator::SIN/COS/TAN/...` | `unary.hpp` | Trigonometric functions |
+| `cudf::unary_operator::EXP/LOG/SQRT` | `unary.hpp` | Mathematical functions |
+| `cudf::binary_operator::POW` | `binaryop.hpp` | Exponentiation |
+| `cudf::binary_operator::LOG_BASE` | `binaryop.hpp` | Logarithm with base |
+| `cudf::binary_operator::NULL_MIN/NULL_MAX` | `binaryop.hpp` | Null-aware min/max |

--- a/.claude/skills/module-discover/docs/cudf/modules/utilities.md
+++ b/.claude/skills/module-discover/docs/cudf/modules/utilities.md
@@ -1,0 +1,103 @@
+# Utilities
+
+**Status**: USED
+**Path**: `cudf/utilities/`
+**Headers we include**: `cudf/utilities/default_stream.hpp`, `cudf/utilities/memory_resource.hpp`, `cudf/utilities/pinned_memory.hpp`, `cudf/utilities/type_dispatcher.hpp`, `cudf/utilities/span.hpp`, `cudf/utilities/bit.hpp`, `cudf/utilities/error.hpp`
+
+## Summary
+
+Utility functions for CUDA stream management, RMM memory resource control, type dispatch, and memory helpers. These are used pervasively throughout Sirius for GPU resource management.
+
+## API Reference
+
+### `cudf::get_default_stream()`
+
+**Header**: `cudf/utilities/default_stream.hpp`
+```cpp
+rmm::cuda_stream_view get_default_stream();
+```
+
+**Our usage** (20+ sites):
+- `src/parallel/task_executor.cpp:19` — Stream for task execution
+- `src/include/parallel/task.hpp:21` — Default stream for tasks
+- `test/cpp/utils/data_utils.hpp:26` — Test utilities
+
+### `cudf::get_current_device_resource_ref()` / `cudf::set_current_device_resource()`
+
+**Header**: `cudf/utilities/memory_resource.hpp`
+```cpp
+rmm::device_async_resource_ref get_current_device_resource_ref();
+rmm::mr::device_memory_resource* set_current_device_resource(rmm::mr::device_memory_resource* new_mr);
+```
+
+**Our usage**:
+- `src/memory/sirius_memory_reservation_manager.cpp:42` — Swapping memory resources for reservation-aware allocation
+- `src/op/sirius_physical_ungrouped_aggregate.cpp` — Passing resource to cuDF operations
+- `src/op/sirius_physical_hash_join.cpp:26` — Resource for join allocation
+
+### Pinned Memory Configuration
+
+**Header**: `cudf/utilities/pinned_memory.hpp`
+```cpp
+size_t get_allocate_host_as_pinned_threshold();
+void set_allocate_host_as_pinned_threshold(size_t threshold);
+rmm::host_async_resource_ref get_pinned_memory_resource();
+void set_pinned_memory_resource(rmm::host_async_resource_ref mr);
+```
+
+**Our usage**:
+- `src/sirius_context.cpp:27` — Configuring pinned memory for GPU↔CPU transfers at startup
+
+### `cudf::type_dispatcher`
+
+**Header**: `cudf/utilities/type_dispatcher.hpp`
+```cpp
+template <typename Functor, typename... Ts>
+decltype(auto) type_dispatcher(data_type dtype, Functor f, Ts&&... args);
+```
+
+**Description**: Dispatches to a functor's `operator()` template based on runtime `data_type`. Enables type-generic code without switch statements.
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_executor.cpp:35` — Type-based expression dispatch
+- `src/cuda/print.cu:28` — Debug printing of columns
+- `test/cpp/utils/test_validation_utility.hpp:28` — Test result validation
+
+### `cudf::host_span<T>` / `cudf::device_span<T>`
+
+**Header**: `cudf/utilities/span.hpp`
+```cpp
+template <typename T>
+class host_span {
+    host_span(T* data, size_t size);
+    T* data() const;
+    size_t size() const;
+};
+```
+
+**Our usage**:
+- `src/data/host_parquet_representation_converters.cpp:32` — Span over host parquet data
+- `src/include/memory/host_table_utils.hpp` — Host table data references
+
+### Bit Utilities
+
+**Header**: `cudf/utilities/bit.hpp`
+```cpp
+bool bit_is_set(bitmask_type const* bitmask, size_type bit_index);
+size_type word_index(size_type bit_index);
+size_type intra_word_index(size_type bit_index);
+```
+
+**Our usage**:
+- `test/cpp/operator/test_host_table_chunk_reader.cpp:30` — Null mask inspection in tests
+- `test/cpp/memory/test_host_table_utils.cpp:38` — Bit manipulation in tests
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cudf::prefetch()` | `prefetch.hpp` | Memory prefetch hints |
+| `cudf::is_fixed_width()` | `traits.hpp` | Check if type is fixed-width |
+| `cudf::is_numeric()` | `traits.hpp` | Check if type is numeric |
+| `CUDF_EXPECTS()` | `error.hpp` | Assertion macro with message |
+| `CUDF_FAIL()` | `error.hpp` | Unconditional failure macro |

--- a/.claude/skills/module-discover/docs/duckdb/README.md
+++ b/.claude/skills/module-discover/docs/duckdb/README.md
@@ -1,0 +1,50 @@
+# DuckDB — Module Reference
+
+**Version**: v1.4.3 (commit d1dc88f950)
+**Location**: `./duckdb/` (git submodule)
+**Namespace**: `duckdb`
+**Headers**: `duckdb/src/include/duckdb/`
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| main | USED | Database instance, client context, connections, config, query results | `ClientContext`, `Connection`, `DBConfig`, `QueryResult`, `PreparedStatementData` |
+| common | USED | Core types, data chunks, vectors, validity masks, enums, exceptions | `DataChunk`, `Vector`, `LogicalType`, `Value`, `ValidityMask`, `FlatVector` |
+| planner | USED | Bound expressions, logical operators, table filters, plan optimization | `BoundReferenceExpression`, `BoundConstantExpression`, `LogicalOperator`, `TableFilterSet` |
+| execution | USED | Physical operators, execution context, column binding resolver | `PhysicalOperator`, `ExecutionContext`, `ColumnBindingResolver` |
+| function | USED | Table functions, scalar functions, function binding | `TableFunction`, `FunctionBinder`, `ScalarFunction` |
+| parser | USED | SQL parser, parsed data, expression types | `Parser`, `CreateTableFunctionInfo`, `ConstantExpression` |
+| optimizer | USED | Query optimizer, optimizer types | `Optimizer`, `OptimizerType` |
+| parallel | USED | Thread context, task scheduling, meta pipelines | `ThreadContext`, `TaskScheduler`, `TaskExecutor` |
+| catalog | USED | Catalog access, table/function catalog entries | `Catalog`, `TableCatalogEntry`, `TableFunctionCatalogEntry` |
+| storage | USED (minimal) | Storage engine, buffer management, compression | `DataTable` |
+| transaction | UNUSED | Transaction management | — |
+| logging | UNUSED | DuckDB internal logging | — |
+| verification | UNUSED | Query verification / testing infrastructure | — |
+
+## Our Usage Summary
+
+We use **10 of 13** modules. Primary integration points:
+
+- **Extension registration**: Sirius registers as a DuckDB extension via `TableFunction` + `CreateTableFunctionInfo` in `sirius_extension.cpp`
+- **Query interception**: Parse SQL via `Parser` → plan via `Planner` → optimize via `Optimizer` → resolve bindings via `ColumnBindingResolver` → translate physical plan to GPU operators
+- **Data exchange**: Convert DuckDB `DataChunk`/`Vector` to cuDF GPU tables and back via `FlatVector::GetData()`, `ValidityMask`, etc.
+- **Expression translation**: Map DuckDB bound expressions (`BoundReferenceExpression`, `BoundComparisonExpression`, etc.) to GPU expression evaluators
+- **Physical plan generation**: Walk DuckDB's `PhysicalOperator` tree to create corresponding GPU operator pipelines
+- **Table scanning**: Use DuckDB's parquet/table scan infrastructure via `TableFunction` bind/init/execute callbacks
+
+## Files That Reference DuckDB (Key Files)
+
+| Source File | Modules Used | Key APIs |
+|-------------|-------------|----------|
+| `src/sirius_extension.cpp` | main, parser, optimizer, planner, execution, function, catalog | `ClientContext`, `Parser`, `Planner`, `Optimizer`, `TableFunction`, `Connection` |
+| `src/sirius_interface.cpp` | main, common, function | `ClientContext`, `TableFunction`, `DataChunk` |
+| `src/gpu_physical_plan_generator.cpp` | execution, planner, common | `PhysicalOperator`, `LogicalOperator`, `LogicalType` |
+| `src/planner/sirius_physical_plan_generator.cpp` | execution, planner, common | `PhysicalOperator`, `LogicalOperator`, `PhysicalOperatorType` |
+| `src/expression_executor/gpu_expression_translator.cpp` | planner, common | `BoundReferenceExpression`, `BoundComparisonExpression`, `BoundFunctionExpression` |
+| `src/op/scan/duckdb_scan_task.cpp` | execution, parallel, function, common | `ExecutionContext`, `ThreadContext`, `TableFunction`, `DataChunk` |
+| `src/op/result/host_table_chunk_reader.cpp` | common | `DataChunk`, `Vector`, `FlatVector`, `ValidityMask` |
+| `src/gpu_columns.cpp` | common | `LogicalType`, `Value`, `DecimalType` |
+| `src/plan/gpu_plan_aggregate.cpp` | execution, function, main, planner | `PhysicalHashAggregate`, `FunctionBinder`, `BoundAggregateExpression` |
+| `src/operator/gpu_physical_table_scan.cpp` | execution, parallel, planner, common | `ExecutionContext`, `ThreadContext`, `TaskScheduler`, `TableFilterSet` |

--- a/.claude/skills/module-discover/docs/duckdb/modules/catalog.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/catalog.md
@@ -1,0 +1,91 @@
+# catalog
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/catalog/`
+**Headers we include**:
+- `duckdb/catalog/catalog.hpp`
+- `duckdb/catalog/catalog_entry/table_catalog_entry.hpp`
+- `duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp`
+- `duckdb/catalog/catalog_transaction.hpp`
+
+## Summary
+
+The `catalog` module manages database metadata — schemas, tables, functions, types. Sirius uses it to register extension functions in the catalog and to look up table/function metadata during query planning.
+
+## API Reference
+
+### Catalog
+
+**Header**: `duckdb/catalog/catalog.hpp`
+**Signature**:
+```cpp
+class Catalog {
+public:
+    static Catalog &GetSystemCatalog(DatabaseInstance &db);
+    static Catalog &GetCatalog(AttachedDatabase &db);
+
+    optional_ptr<CatalogEntry> CreateTableFunction(ClientContext &context, CreateTableFunctionInfo &info);
+    optional_ptr<CatalogEntry> GetEntry(ClientContext &context, CatalogType type,
+                                         const string &schema, const string &name,
+                                         OnEntryNotFound if_not_found = OnEntryNotFound::THROW_EXCEPTION);
+};
+```
+
+**Description**: The system catalog. Provides access to all database objects (tables, functions, schemas).
+
+**Our usage**:
+- `src/sirius_extension.cpp` — `CreateTableFunction()` to register `gpu_processing`, `gpu_execution`, etc.
+- `test/cpp/scan/test_parquet_scan_task.cpp` — Look up parquet scan function in catalog
+- `test/cpp/integration/test_tpcds_plan_translation.cpp` — Register test functions
+
+### TableCatalogEntry
+
+**Header**: `duckdb/catalog/catalog_entry/table_catalog_entry.hpp`
+**Signature**:
+```cpp
+class TableCatalogEntry : public StandardEntry {
+public:
+    const ColumnList &GetColumns() const;
+    const vector<unique_ptr<Constraint>> &GetConstraints() const;
+};
+```
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Access table metadata
+- `test/cpp/scan/test_scan_executor.cpp` — Access table columns for scan tests
+
+### TableFunctionCatalogEntry
+
+**Header**: `duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp`
+**Signature**:
+```cpp
+class TableFunctionCatalogEntry : public FunctionEntry {
+public:
+    TableFunctionSet functions;
+};
+```
+
+**Our usage**:
+- `test/cpp/scan/test_parquet_scan_task.cpp` — Look up and access parquet scan function
+
+### CatalogTransaction
+
+**Header**: `duckdb/catalog/catalog_transaction.hpp`
+**Signature**:
+```cpp
+class CatalogTransaction {
+public:
+    static CatalogTransaction GetSystemTransaction(DatabaseInstance &db);
+};
+```
+
+**Our usage**:
+- `test/cpp/scan/test_scan_executor.cpp` — Create system transactions for catalog access
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `SchemaCatalogEntry` | `catalog_entry/schema_catalog_entry.hpp` | Schema metadata (indirectly included) |
+| `DefaultGenerator` | `default/` | Default catalog entries |
+| `ViewCatalogEntry` | `catalog_entry/view_catalog_entry.hpp` | View definitions |

--- a/.claude/skills/module-discover/docs/duckdb/modules/common.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/common.md
@@ -1,0 +1,274 @@
+# common
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/common/`
+**Headers we include**:
+- `duckdb/common/assert.hpp`
+- `duckdb/common/enums/expression_type.hpp`
+- `duckdb/common/enums/logical_operator_type.hpp`
+- `duckdb/common/enums/physical_operator_type.hpp`
+- `duckdb/common/helper.hpp`
+- `duckdb/common/types.hpp`
+- `duckdb/common/types/column/column_data_collection.hpp`
+- `duckdb/common/types/data_chunk.hpp`
+- `duckdb/common/types/decimal.hpp`
+- `duckdb/common/types/validity_mask.hpp`
+- `duckdb/common/types/value.hpp`
+- `duckdb/common/types/vector.hpp`
+- `duckdb/common/vector_size.hpp`
+- `duckdb/common/multi_file/multi_file_states.hpp`
+
+## Summary
+
+The `common` module is the largest DuckDB module and provides foundational types used throughout the system: data chunks, vectors, type system, values, enums, exceptions, and utility functions. Sirius uses it extensively for data exchange between CPU (DuckDB) and GPU (cuDF), type mapping, and expression type identification.
+
+## API Reference
+
+### DataChunk
+
+**Header**: `duckdb/common/types/data_chunk.hpp`
+**Signature**:
+```cpp
+class DataChunk {
+public:
+    vector<Vector> data;
+    idx_t size() const;
+    idx_t ColumnCount() const;
+    void SetCardinality(idx_t count);
+    void SetCardinality(const DataChunk &other);
+    void Initialize(Allocator &allocator, const vector<LogicalType> &types, idx_t capacity = STANDARD_VECTOR_SIZE);
+    void Reset();
+    void Flatten();
+    void Reference(DataChunk &chunk);
+};
+```
+
+**Description**: A columnar data batch — the fundamental unit of data exchange in DuckDB. Each `DataChunk` contains a set of `Vector` columns with a shared row count. Default capacity is `STANDARD_VECTOR_SIZE` (2048).
+
+**Our usage**:
+- `src/op/scan/duckdb_scan_task.cpp` — Receives scanned data from DuckDB as DataChunks, converts to GPU format
+- `src/op/result/host_table_chunk_reader.cpp` — Converts GPU results back to DataChunks for DuckDB
+- `src/operator/gpu_physical_table_scan.cpp` — Scans data into DataChunks
+- `src/sirius_extension.cpp` — Used in table function execute callbacks
+
+### Vector
+
+**Header**: `duckdb/common/types/vector.hpp`
+**Signature**:
+```cpp
+class Vector {
+public:
+    Vector(LogicalType type, idx_t capacity = STANDARD_VECTOR_SIZE);
+    VectorType GetVectorType() const;
+    LogicalType &GetType();
+    data_ptr_t GetData();
+    void SetVectorType(VectorType vector_type);
+    void Reference(const Value &value);
+    void Flatten(idx_t count);
+};
+```
+
+**Description**: A single column of data. Can be flat (contiguous), constant, dictionary-encoded, or sequence. Sirius primarily works with flat vectors.
+
+**Our usage**:
+- `src/op/result/host_table_chunk_reader.cpp` — Access raw vector data for GPU→CPU transfer
+- `src/gpu_columns.cpp` — Read vector data to build GPU columns
+
+### FlatVector
+
+**Header**: `duckdb/common/types/vector.hpp`
+**Signature**:
+```cpp
+struct FlatVector {
+    static data_ptr_t GetData(Vector &vector);
+    static const ValidityMask &Validity(const Vector &vector);
+    static void SetValidity(Vector &vector, ValidityMask &new_mask);
+    static bool IsNull(const Vector &vector, idx_t idx);
+    static void SetNull(Vector &vector, idx_t idx, bool is_null);
+};
+
+struct StringVector {
+    static void AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer);
+};
+```
+
+**Description**: Static helper for accessing flat (contiguous) vector data. Primary interface for reading/writing raw column data.
+
+**Our usage**:
+- `src/op/result/host_table_chunk_reader.cpp` — `FlatVector::GetData()` to get raw pointers, `FlatVector::Validity()` for null masks
+- `src/gpu_columns.cpp` — Read raw data from vectors
+- `test/cpp/memory/test_host_table_utils.cpp` — Test vector data access
+
+### ValidityMask
+
+**Header**: `duckdb/common/types/validity_mask.hpp`
+**Signature**:
+```cpp
+class ValidityMask {
+public:
+    validity_t *GetData() const;
+    bool RowIsValid(idx_t row_idx) const;
+    void SetInvalid(idx_t row_idx);
+    bool AllValid() const;
+    idx_t CountValid(idx_t count) const;
+    static constexpr idx_t BITS_PER_VALUE = sizeof(validity_t) * 8;  // 64
+    static constexpr idx_t STANDARD_MASK_SIZE = STANDARD_VECTOR_SIZE / BITS_PER_VALUE;
+};
+```
+
+**Description**: Bitmask tracking NULL values in a vector. Each bit represents one row (1 = valid, 0 = NULL).
+
+**Our usage**:
+- `src/op/result/host_table_chunk_reader.cpp` — Convert between DuckDB validity masks and cuDF null bitmasks
+- `test/cpp/memory/test_host_table_utils.cpp` — Test null handling
+
+### LogicalType / LogicalTypeId
+
+**Header**: `duckdb/common/types.hpp`
+**Signature**:
+```cpp
+enum class LogicalTypeId : uint8_t {
+    BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, UTINYINT, USMALLINT, UINTEGER, UBIGINT,
+    FLOAT, DOUBLE, DATE, TIMESTAMP, TIMESTAMP_NS, TIMESTAMP_MS, TIMESTAMP_SEC,
+    VARCHAR, BLOB, DECIMAL, HUGEINT, INTERVAL, STRUCT, LIST, MAP, ...
+};
+
+class LogicalType {
+public:
+    LogicalTypeId id() const;
+    PhysicalType InternalType() const;
+    bool operator==(const LogicalType &rhs) const;
+    static LogicalType INTEGER, BIGINT, FLOAT, DOUBLE, VARCHAR, BOOLEAN, DATE, TIMESTAMP;
+};
+
+struct DecimalType {
+    static uint8_t GetWidth(const LogicalType &type);
+    static uint8_t GetScale(const LogicalType &type);
+};
+```
+
+**Description**: DuckDB's type system. `LogicalTypeId` identifies the SQL type, `LogicalType` wraps it with extra info (e.g., decimal precision). Sirius maps these to cuDF data types.
+
+**Our usage**:
+- `src/gpu_columns.cpp` — Map DuckDB types to cuDF types
+- `src/expression_executor/gpu_expression_translator.cpp` — Determine GPU operation types from expression types
+- `src/planner/sirius_physical_plan_generator.cpp` — Check supported types for GPU execution
+- `src/fallback.cpp` — Check type support to decide CPU vs GPU execution
+
+### Value
+
+**Header**: `duckdb/common/types/value.hpp`
+**Signature**:
+```cpp
+class Value {
+public:
+    LogicalType type() const;
+    static Value BOOLEAN(bool value);
+    static Value INTEGER(int32_t value);
+    static Value BIGINT(int64_t value);
+    static Value UBIGINT(uint64_t value);
+    static Value MinimumValue(const LogicalType &type);
+    static Value MaximumValue(const LogicalType &type);
+    template <class T> T GetValue() const;
+    bool IsNull() const;
+};
+
+struct BooleanValue { static bool Get(const Value &value); };
+struct StringValue { static const string &Get(const Value &value); };
+struct IntegerValue { static int32_t Get(const Value &value); };
+struct UBigIntValue { static uint64_t Get(const Value &value); };
+```
+
+**Description**: Type-safe variant holding a single DuckDB value. Used for constants, configuration values, and statistics.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Extract function arguments (e.g., SQL query string, memory sizes)
+- `src/expression_executor/gpu_expression_translator.cpp` — Extract constant values for GPU expressions
+- `src/operator/gpu_physical_table_scan.cpp` — Build filter constants
+
+### ColumnDataCollection
+
+**Header**: `duckdb/common/types/column/column_data_collection.hpp`
+**Signature**:
+```cpp
+class ColumnDataCollection {
+public:
+    ColumnDataCollection(Allocator &allocator, vector<LogicalType> types);
+    void Append(DataChunk &chunk);
+    idx_t Count() const;
+    const vector<LogicalType> &Types() const;
+    void InitializeScan(ColumnDataScanState &state) const;
+    void Scan(ColumnDataScanState &state, DataChunk &result) const;
+};
+```
+
+**Description**: In-memory columnar storage that can hold arbitrary amounts of data (unlike DataChunk which is limited to STANDARD_VECTOR_SIZE). Used for materialization.
+
+**Our usage**:
+- `src/plan/gpu_plan_recursive_cte.cpp` — CTE materialization
+- `src/operator/gpu_physical_table_scan.cpp` — Collect scanned data
+
+### ExpressionType / PhysicalOperatorType / LogicalOperatorType (Enums)
+
+**Header**: `duckdb/common/enums/expression_type.hpp`, `duckdb/common/enums/physical_operator_type.hpp`, `duckdb/common/enums/logical_operator_type.hpp`
+
+**Key values used**:
+```cpp
+// Expression types
+ExpressionType::COMPARE_EQUAL, COMPARE_NOTEQUAL, COMPARE_LESSTHAN, COMPARE_GREATERTHAN,
+COMPARE_LESSTHANOREQUALTO, COMPARE_GREATERTHANOREQUALTO, COMPARE_DISTINCT_FROM,
+COMPARE_NOT_DISTINCT_FROM, COMPARE_IN, COMPARE_NOT_IN,
+CONJUNCTION_AND, CONJUNCTION_OR,
+OPERATOR_COALESCE, OPERATOR_NOT, OPERATOR_IS_NULL, OPERATOR_IS_NOT_NULL, OPERATOR_TRY,
+VALUE_CONSTANT, BOUND_REF, BOUND_FUNCTION, BOUND_AGGREGATE, BOUND_CAST
+
+// Physical operator types
+PhysicalOperatorType::FILTER, HASH_JOIN, HASH_GROUP_BY, UNGROUPED_AGGREGATE,
+ORDER_BY, TOP_N, TABLE_SCAN, PROJECTION, NESTED_LOOP_JOIN, DELIM_JOIN, ...
+
+// Logical operator types
+LogicalOperatorType::LOGICAL_GET, LOGICAL_FILTER, LOGICAL_AGGREGATE_AND_GROUP_BY,
+LOGICAL_ORDER_BY, LOGICAL_TOP_N, LOGICAL_LIMIT, LOGICAL_WINDOW, LOGICAL_CTE, ...
+```
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Switch on expression types to dispatch GPU evaluation
+- `src/gpu_physical_plan_generator.cpp` — Switch on physical/logical operator types to create GPU operators
+- `src/planner/sirius_physical_plan_generator.cpp` — Same as above for new Sirius code path
+- `src/fallback.cpp` — Check operator types for fallback decisions
+
+### Exceptions
+
+**Headers**: `duckdb/common/exception.hpp` and sub-headers
+```cpp
+class InvalidInputException : public Exception { ... };
+class BinderException : public Exception { ... };
+class NotImplementedException : public Exception { ... };
+class InternalException : public Exception { ... };
+```
+
+**Our usage**:
+- Throughout codebase for error handling when GPU operations fail or encounter unsupported features
+
+### Utility Functions
+
+**Header**: `duckdb/common/helper.hpp`
+```cpp
+template <class T, class... ARGS> unique_ptr<T> make_uniq(ARGS&&... args);
+template <class T, class... ARGS> shared_ptr<T> make_shared_ptr(ARGS&&... args);
+template <class SRC, class TGT> TGT &Cast(SRC &source);
+```
+
+**Our usage**:
+- Throughout codebase — `make_uniq<>()` for creating unique pointers, `Cast<>()` for safe downcasting
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `ArrowWrapper` | `common/arrow/` | Arrow format interop |
+| `Serializer/Deserializer` | `common/serializer/` | Binary serialization |
+| `RowOperations` | `common/row_operations/` | Tuple-format row operations |
+| `ProgressBar` | `common/progress_bar/` | Query progress tracking |
+| `VectorOperations` | `common/vector_operations/` | Vectorized operations (mostly; `Cast()` is used) |
+| `Crypto` | `common/crypto/` | Hashing and encryption utilities |

--- a/.claude/skills/module-discover/docs/duckdb/modules/execution.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/execution.md
@@ -1,0 +1,119 @@
+# execution
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/execution/`
+**Headers we include**:
+- `duckdb/execution/column_binding_resolver.hpp`
+- `duckdb/execution/execution_context.hpp`
+- `duckdb/execution/physical_operator.hpp`
+- `duckdb/execution/physical_plan_generator.hpp`
+- `duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp`
+- `duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp`
+
+## Summary
+
+The `execution` module provides the physical operator hierarchy and execution infrastructure. Sirius reads DuckDB's physical plan tree (`PhysicalOperator` subclasses) to understand operator configuration, then creates corresponding GPU operators. It also uses `ColumnBindingResolver` to resolve column references before GPU translation.
+
+## API Reference
+
+### PhysicalOperator
+
+**Header**: `duckdb/execution/physical_operator.hpp`
+**Signature**:
+```cpp
+class PhysicalOperator {
+public:
+    PhysicalOperator(PhysicalPlan &physical_plan, PhysicalOperatorType type,
+                     vector<LogicalType> types, idx_t estimated_cardinality);
+    PhysicalOperatorType type;
+    vector<LogicalType> types;
+    idx_t estimated_cardinality;
+    ArenaLinkedList<reference<PhysicalOperator>> children;
+
+    virtual string GetName() const;
+    const vector<LogicalType> &GetTypes() const;
+    vector<const_reference<PhysicalOperator>> GetChildren() const;
+};
+```
+
+**Description**: Base class for all physical operators. Sirius walks the physical plan tree to map operators to GPU equivalents.
+
+**Our usage**:
+- `src/gpu_physical_plan_generator.cpp` — Read operator type, children, types to create GPU operators
+- `src/planner/sirius_physical_plan_generator.cpp` — Same for new code path
+- `test/cpp/pipeline/test_modified_pipeline.cpp` — Build test physical plans
+
+### ExecutionContext
+
+**Header**: `duckdb/execution/execution_context.hpp`
+**Signature**:
+```cpp
+struct ExecutionContext {
+    ClientContext &client;
+    ThreadContext &thread;
+    optional_ptr<Pipeline> pipeline;
+};
+```
+
+**Description**: Bundles the client context, thread context, and current pipeline for operator execution.
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Passed to DuckDB scan functions
+- `src/op/scan/duckdb_scan_task.cpp` — Created for DuckDB-side table scans
+- `test/cpp/config/test_context.cpp` — Test execution context creation
+
+### ColumnBindingResolver
+
+**Header**: `duckdb/execution/column_binding_resolver.hpp`
+**Signature**:
+```cpp
+class ColumnBindingResolver : public LogicalOperatorVisitor {
+public:
+    ColumnBindingResolver();
+    void VisitOperator(LogicalOperator &op) override;
+};
+```
+
+**Description**: Resolves `ColumnBinding` references in logical plans to flat column indices (`BoundReferenceExpression`). Must be run before physical plan generation.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Run on logical plan before GPU physical plan generation
+- `test/cpp/pipeline/test_modified_pipeline.cpp` — Resolve bindings in test plans
+- `test/cpp/integration/test_tpcds_plan_translation.cpp` — Resolve bindings for TPC-DS plans
+
+### PhysicalPlanGenerator
+
+**Header**: `duckdb/execution/physical_plan_generator.hpp`
+**Signature**:
+```cpp
+class PhysicalPlanGenerator {
+public:
+    explicit PhysicalPlanGenerator(ClientContext &context);
+    unique_ptr<PhysicalOperator> CreatePlan(unique_ptr<LogicalOperator> logical);
+};
+```
+
+**Description**: Converts a logical plan to a physical plan. Sirius uses a modified version to generate GPU physical operators.
+
+**Our usage**:
+- `src/plan/gpu_plan_aggregate.cpp` — Reference DuckDB's aggregate physical plan generation
+- `src/plan/gpu_plan_recursive_cte.cpp` — Reference DuckDB's CTE handling
+
+### PhysicalHashAggregate / PhysicalPerfectHashAggregate
+
+**Headers**: `duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp`, `physical_perfecthash_aggregate.hpp`
+
+**Description**: DuckDB's concrete aggregate operators. Sirius reads their configuration (groups, aggregates, filter) but replaces execution with GPU.
+
+**Our usage**:
+- `src/plan/gpu_plan_aggregate.cpp` — Read aggregate configuration from DuckDB's physical plan
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `Executor` | `executor.hpp` | DuckDB's main executor (Sirius replaces this) |
+| `Pipeline` / `MetaPipeline` | `pipeline.hpp` | DuckDB's pipeline execution (Sirius has its own) |
+| `PhysicalHashJoin` | `operator/join/physical_hash_join.hpp` | DuckDB's hash join (replaced by GPU) |
+| `PhysicalOrder` | `operator/order/physical_order.hpp` | DuckDB's sort (replaced by GPU) |
+| `Expression Executor` | `expression_executor.hpp` | DuckDB's expression evaluator (replaced by GPU) |

--- a/.claude/skills/module-discover/docs/duckdb/modules/function.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/function.md
@@ -1,0 +1,152 @@
+# function
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/function/`
+**Headers we include**:
+- `duckdb/function/table_function.hpp`
+- `duckdb/function/function_binder.hpp`
+- `duckdb/function/scalar_function.hpp`
+- `duckdb/function/table/table_scan.hpp`
+
+## Summary
+
+The `function` module defines DuckDB's function system — table functions, scalar functions, and aggregate functions. Sirius uses table functions as its primary extension interface (`gpu_processing`, `gpu_execution`, `gpu_buffer_init`) and reads scalar/aggregate function metadata to map them to GPU equivalents.
+
+## API Reference
+
+### TableFunction
+
+**Header**: `duckdb/function/table_function.hpp`
+**Signature**:
+```cpp
+class TableFunction : public SimpleNamedParameterFunction {
+public:
+    TableFunction(string name, vector<LogicalType> arguments,
+                  table_function_t function, table_function_bind_t bind,
+                  table_function_init_global_t init_global = nullptr,
+                  table_function_init_local_t init_local = nullptr);
+
+    table_function_bind_t bind;
+    table_function_init_global_t init_global;
+    table_function_init_local_t init_local;
+    table_function_t function;           // Main execute callback
+    table_function_to_string_t to_string;
+    table_function_partition_t get_partition_info;
+
+    // Pushdown support
+    bool projection_pushdown;
+    bool filter_pushdown;
+    bool filter_prune;
+};
+```
+
+**Description**: Defines a table-valued function. This is the primary mechanism for Sirius to hook into DuckDB — `gpu_processing`, `gpu_execution`, `gpu_buffer_init`, `start_profiling`, and `stop_profiling` are all registered as table functions.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Register all Sirius table functions
+- `src/op/scan/duckdb_scan_task.cpp` — Call DuckDB's table scan functions (parquet reader)
+- `test/cpp/operator/test_physical_table_scan.cpp` — Test table scan function interface
+
+### TableFunctionBindInput / TableFunctionInitInput / TableFunctionInput
+
+**Header**: `duckdb/function/table_function.hpp`
+**Signature**:
+```cpp
+struct TableFunctionBindInput {
+    vector<Value> &inputs;
+    named_parameter_map_t &named_parameters;
+    vector<LogicalType> &input_table_types;
+    vector<string> &input_table_names;
+    ClientContext &context;
+};
+
+struct TableFunctionInitInput {
+    const TableFunction &function;
+    const TableFunctionData &bind_data;
+    const vector<column_t> &column_ids;
+    optional_ptr<TableFilterSet> filters;
+};
+
+struct TableFunctionInput {
+    const TableFunctionData &bind_data;
+    LocalTableFunctionState &local_state;
+    GlobalTableFunctionState &global_state;
+};
+```
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Used in bind/init/execute callbacks for Sirius table functions
+- `src/op/scan/duckdb_scan_task.cpp` — Construct these to call DuckDB's scan functions
+
+### GlobalTableFunctionState / LocalTableFunctionState / TableFunctionData
+
+**Header**: `duckdb/function/table_function.hpp`
+**Signature**:
+```cpp
+struct GlobalTableFunctionState {
+    virtual ~GlobalTableFunctionState();
+    virtual idx_t MaxThreads() const;
+    template <class TARGET> TARGET &Cast();
+};
+
+struct LocalTableFunctionState {
+    virtual ~LocalTableFunctionState();
+    template <class TARGET> TARGET &Cast();
+};
+
+struct TableFunctionData {
+    virtual ~TableFunctionData();
+    template <class TARGET> TARGET &Cast();
+};
+```
+
+**Description**: State objects for table function lifecycle. `TableFunctionData` is created in bind, global/local states in init.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Sirius defines its own subclasses (`GpuProcessingData`, `GpuExecutionData`, etc.)
+- `src/op/scan/duckdb_scan_task.cpp` — Access DuckDB's scan states
+
+### FunctionBinder
+
+**Header**: `duckdb/function/function_binder.hpp`
+**Signature**:
+```cpp
+class FunctionBinder {
+public:
+    explicit FunctionBinder(ClientContext &context);
+    void BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
+                             const vector<unique_ptr<Expression>> &groups);
+};
+```
+
+**Our usage**:
+- `src/plan/gpu_plan_aggregate.cpp` — Bind sorted aggregates when translating aggregate plans
+
+### ScalarFunction
+
+**Header**: `duckdb/function/scalar_function.hpp`
+
+**Description**: Defines a scalar (row-level) function. Sirius reads function names and types to map to GPU implementations.
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Read function name/type from `BoundFunctionExpression::function`
+- `test/cpp/operator/aggregate/aggregate_test_utils.hpp` — Create test aggregate functions
+
+### TableScanFunction
+
+**Header**: `duckdb/function/table/table_scan.hpp`
+
+**Description**: DuckDB's built-in table scan function.
+
+**Our usage**:
+- `test/cpp/scan/test_scan_executor.cpp` — Access table scan function for testing
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `AggregateFunction` | `aggregate_function.hpp` | Aggregate function definition (accessed indirectly via BoundAggregateExpression) |
+| `PragmaFunction` | `pragma/pragma_function.hpp` | PRAGMA command functions |
+| `CastFunction` | `cast/cast_function_set.hpp` | Type cast definitions |
+| `WindowFunction` | `window/` | Window function infrastructure |
+| `CompressionFunction` | `compression/` | Storage compression functions |

--- a/.claude/skills/module-discover/docs/duckdb/modules/logging.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/logging.md
@@ -1,0 +1,17 @@
+# logging
+
+**Status**: UNUSED
+**Path**: `duckdb/src/include/duckdb/logging/`
+
+## Summary
+
+The `logging` module provides DuckDB's internal logging infrastructure for diagnostic output.
+
+## Key APIs
+- `Logger` — Logging interface
+- `LogManager` — Log configuration and routing
+- `LogType` — Log entry classification
+
+## Potential Relevance
+
+Not applicable — Sirius uses its own logging via spdlog (`SIRIUS_LOG_DIR`, `SIRIUS_LOG_LEVEL`).

--- a/.claude/skills/module-discover/docs/duckdb/modules/main.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/main.md
@@ -1,0 +1,172 @@
+# main
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/main/`
+**Headers we include**:
+- `duckdb/main/client_context.hpp`
+- `duckdb/main/config.hpp`
+- `duckdb/main/connection.hpp`
+- `duckdb/main/database.hpp`
+- `duckdb/main/prepared_statement_data.hpp`
+- `duckdb/main/query_result.hpp`
+- `duckdb/main/relation.hpp`
+- `duckdb/main/settings.hpp`
+
+## Summary
+
+The `main` module provides the core database infrastructure: database instances, client contexts (sessions), connections, configuration, and query result handling. Sirius uses it extensively for extension registration, query execution orchestration, and accessing database/client configuration.
+
+## API Reference
+
+### ClientContext
+
+**Header**: `duckdb/main/client_context.hpp`
+**Signature**:
+```cpp
+class ClientContext : public enable_shared_from_this<ClientContext> {
+public:
+    explicit ClientContext(shared_ptr<DatabaseInstance> db);
+    shared_ptr<DatabaseInstance> db;
+    atomic<bool> interrupted;
+    ClientConfig config;
+    // Query execution
+    unique_ptr<PendingQueryResult> PendingQuery(const string &query, bool allow_stream_result);
+    unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement, bool allow_stream_result);
+    shared_ptr<PreparedStatementData> CreatePreparedStatement(ClientContextLock &lock, const string &query, ...);
+    // Catalog access
+    Catalog &GetCatalog();
+    DatabaseInstance &GetDatabase();
+};
+```
+
+**Description**: Represents a client session. Holds per-session state (config, transaction context, query profiler). Primary entry point for executing queries and accessing the catalog.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Accessed in table function callbacks to get database config, run queries, access catalog
+- `src/op/scan/duckdb_scan_task.cpp` — Used to create execution contexts for DuckDB table scans
+- `src/plan/gpu_plan_aggregate.cpp` — Accessed for client config settings (e.g., optimizer flags)
+
+### Connection
+
+**Header**: `duckdb/main/connection.hpp`
+**Signature**:
+```cpp
+class Connection {
+public:
+    explicit Connection(DuckDB &database);
+    explicit Connection(DatabaseInstance &database);
+    shared_ptr<ClientContext> context;
+    unique_ptr<QueryResult> Query(const string &query);
+    unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement);
+    shared_ptr<Relation> Table(const string &table_name);
+};
+```
+
+**Description**: Represents a connection to a DuckDB database. Wraps a ClientContext and provides a simplified query API.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Creates internal connections for query execution
+- `test/cpp/pipeline/test_modified_pipeline.cpp` — Used in tests for setting up test database connections
+
+### DBConfig
+
+**Header**: `duckdb/main/config.hpp`
+**Signature**:
+```cpp
+class DBConfig {
+public:
+    static DBConfig &GetConfig(ClientContext &context);
+    static DBConfig &GetConfig(DatabaseInstance &db);
+    template <class T> static T GetSetting(ClientContext &context);
+    // Extension callbacks
+    vector<ExtensionCallback> extension_callbacks;
+};
+```
+
+**Description**: Database-level configuration. Sirius reads settings to check optimizer flags and register extension callbacks.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — `DBConfig::GetConfig()` to register extension callbacks and read settings
+- `src/plan/gpu_plan_aggregate.cpp` — `DBConfig::GetSetting<>()` to check optimizer-related settings
+
+### PreparedStatementData
+
+**Header**: `duckdb/main/prepared_statement_data.hpp`
+**Signature**:
+```cpp
+class PreparedStatementData {
+public:
+    unique_ptr<LogicalOperator> plan;
+    vector<LogicalType> types;
+    vector<string> names;
+    StatementProperties properties;
+};
+```
+
+**Description**: Holds the logical plan and metadata for a prepared statement. Sirius accesses this to get the logical plan for GPU translation.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Extracts logical plan from prepared statements for GPU physical plan generation
+- `src/operator/gpu_physical_result_collector.cpp` — Accesses statement types/names for result collection
+
+### QueryResult / MaterializedQueryResult
+
+**Header**: `duckdb/main/query_result.hpp`
+**Signature**:
+```cpp
+class QueryResult {
+public:
+    vector<LogicalType> types;
+    vector<string> names;
+    virtual unique_ptr<DataChunk> Fetch();
+    bool HasError() const;
+    ErrorData &GetErrorObject();
+    string ToBox(ClientContext &context, const BoxRendererConfig &config);
+};
+
+class MaterializedQueryResult : public QueryResult {
+public:
+    ColumnDataCollection &Collection();
+};
+```
+
+**Description**: Represents query execution results. Sirius uses it to display results and check for errors.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Result display via `ToBox()`, error checking via `HasError()`
+
+### Relation
+
+**Header**: `duckdb/main/relation.hpp`
+
+**Description**: Represents a relational query (table, projection, filter, etc.) that can be lazily executed.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Used for query result handling
+
+### Settings (PreserveInsertionOrderSetting, etc.)
+
+**Header**: `duckdb/main/settings.hpp`
+**Signature**:
+```cpp
+struct PreserveInsertionOrderSetting { static constexpr const char *Name = "preserve_insertion_order"; };
+struct PreferRangeJoinsSetting { static constexpr const char *Name = "prefer_range_joins"; };
+struct NestedLoopJoinThresholdSetting { static constexpr const char *Name = "nested_loop_join_threshold"; };
+struct MergeJoinThresholdSetting { static constexpr const char *Name = "merge_join_threshold"; };
+```
+
+**Description**: Type-safe settings accessors used with `DBConfig::GetSetting<T>()`.
+
+**Our usage**:
+- `src/plan/gpu_plan_join.cpp` — Checks join threshold settings to match DuckDB's join selection behavior
+- `src/plan/gpu_plan_aggregate.cpp` — Checks `PreserveInsertionOrderSetting`
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `Appender` | `appender.hpp` | Bulk data insertion |
+| `QueryProfiler` | `query_profiler.hpp` | Query profiling and timing |
+| `ExtensionHelper` | `extension_helper.hpp` | Extension loading utilities |
+| `DatabaseManager` | `database_manager.hpp` | Multi-database management |
+| `PendingQueryResult` | `pending_query_result.hpp` | Async query execution (indirectly used via ClientContext) |

--- a/.claude/skills/module-discover/docs/duckdb/modules/optimizer.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/optimizer.md
@@ -1,0 +1,57 @@
+# optimizer
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/optimizer/`
+**Headers we include**:
+- `duckdb/optimizer/optimizer.hpp`
+
+## Summary
+
+The `optimizer` module provides query optimization passes. Sirius runs DuckDB's optimizer on the logical plan before translating to GPU, selectively disabling certain optimization passes that interfere with GPU execution.
+
+## API Reference
+
+### Optimizer
+
+**Header**: `duckdb/optimizer/optimizer.hpp`
+**Signature**:
+```cpp
+class Optimizer {
+public:
+    explicit Optimizer(Binder &binder, ClientContext &context);
+    unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan);
+    // Optimizer pass management
+    ClientContext &context;
+};
+```
+
+**Description**: Runs optimization passes on a logical plan (predicate pushdown, join ordering, filter/projection elimination, etc.).
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Optimize logical plan before GPU physical plan generation. Certain optimizer passes are disabled via `DBConfig::GetSetting<OptimizerType>()`.
+- `test/cpp/pipeline/test_modified_pipeline.cpp` — Optimize test plans
+- `test/cpp/integration/test_tpcds_plan_translation.cpp` — Optimize TPC-DS plans
+
+### OptimizerType (enum)
+
+**Header**: `duckdb/common/enums/optimizer_type.hpp` (used alongside optimizer)
+
+**Key values used**:
+```cpp
+OptimizerType::IN_CLAUSE                  // IN-list optimization
+OptimizerType::COMPRESSED_MATERIALIZATION // Compressed materialization pass
+OptimizerType::COLUMN_LIFETIME            // Column lifetime analysis
+OptimizerType::MATERIALIZED_CTE           // CTE materialization decisions
+```
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Disable `COMPRESSED_MATERIALIZATION` and `IN_CLAUSE` optimizations that interfere with GPU execution
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `JoinOrderOptimizer` | `join_order/` | Join ordering heuristics |
+| `Rule` | `rule/` | Individual optimizer rules |
+| `Matcher` | `matcher/` | Expression pattern matching for rules |
+| `FilterPullup/Pushdown` | Various | Filter movement optimizations |

--- a/.claude/skills/module-discover/docs/duckdb/modules/parallel.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/parallel.md
@@ -1,0 +1,77 @@
+# parallel
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/parallel/`
+**Headers we include**:
+- `duckdb/parallel/task_executor.hpp`
+- `duckdb/parallel/task_scheduler.hpp`
+- `duckdb/parallel/thread_context.hpp`
+
+## Summary
+
+The `parallel` module provides DuckDB's multi-threaded execution infrastructure. Sirius uses it to coordinate with DuckDB's thread pool for CPU-side table scanning — DuckDB's parallel scan framework handles multi-threaded parquet reading while Sirius manages its own GPU thread pool.
+
+## API Reference
+
+### ThreadContext
+
+**Header**: `duckdb/parallel/thread_context.hpp`
+**Signature**:
+```cpp
+class ThreadContext {
+public:
+    explicit ThreadContext(ClientContext &context);
+    ClientContext &context;
+    // Thread-local profiling data
+};
+```
+
+**Description**: Per-thread execution state, primarily for profiling and thread-local storage.
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Create thread contexts for DuckDB scan threads
+- `src/op/scan/duckdb_scan_task.cpp` — Thread context for scan task execution
+- `test/cpp/scan/test_scan_executor.cpp` — Test thread context
+
+### TaskScheduler
+
+**Header**: `duckdb/parallel/task_scheduler.hpp`
+**Signature**:
+```cpp
+class TaskScheduler {
+public:
+    static TaskScheduler &GetScheduler(ClientContext &context);
+    idx_t NumberOfThreads();
+    void ExecuteForever(atomic<bool> *marker);
+};
+```
+
+**Description**: DuckDB's global task scheduler for parallel execution.
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Access scheduler for parallel scan coordination
+
+### TaskExecutor
+
+**Header**: `duckdb/parallel/task_executor.hpp`
+**Signature**:
+```cpp
+class TaskExecutor {
+public:
+    TaskExecutor(ClientContext &context);
+    void ExecuteTask();
+    bool HasError();
+};
+```
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Execute DuckDB tasks for parallel scanning
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `Pipeline` | `pipeline.hpp` | DuckDB's pipeline execution framework (Sirius has its own) |
+| `MetaPipeline` | `meta_pipeline.hpp` | Pipeline dependency management |
+| `Event` | `event.hpp` | Pipeline execution events |
+| `InterruptState` | `interrupt.hpp` | Query interruption handling |

--- a/.claude/skills/module-discover/docs/duckdb/modules/parser.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/parser.md
@@ -1,0 +1,73 @@
+# parser
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/parser/`
+**Headers we include**:
+- `duckdb/parser/parser.hpp`
+- `duckdb/parser/parsed_data/create_table_function_info.hpp`
+- `duckdb/parser/expression/constant_expression.hpp`
+- `duckdb/parser/expression/function_expression.hpp`
+- `duckdb/parser/tableref/table_function_ref.hpp`
+
+## Summary
+
+The `parser` module provides SQL parsing and unbound AST types. Sirius uses it to parse user SQL queries and to register table functions in the catalog.
+
+## API Reference
+
+### Parser
+
+**Header**: `duckdb/parser/parser.hpp`
+**Signature**:
+```cpp
+class Parser {
+public:
+    explicit Parser(ParserOptions options = ParserOptions());
+    void ParseQuery(const string &query);
+    vector<unique_ptr<SQLStatement>> statements;
+};
+```
+
+**Description**: SQL parser that produces a list of `SQLStatement` objects from a query string.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Parse the SQL string passed to `gpu_processing()`/`gpu_execution()`
+- `test/cpp/pipeline/test_modified_pipeline.cpp` — Parse test queries
+- `test/cpp/integration/test_tpcds_plan_translation.cpp` — Parse TPC-DS queries
+
+### CreateTableFunctionInfo
+
+**Header**: `duckdb/parser/parsed_data/create_table_function_info.hpp`
+**Signature**:
+```cpp
+struct CreateTableFunctionInfo : public CreateFunctionInfo {
+    explicit CreateTableFunctionInfo(TableFunction function);
+    explicit CreateTableFunctionInfo(TableFunctionSet set);
+    vector<TableFunction> functions;
+};
+```
+
+**Description**: Information needed to register a table function in the catalog.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Create registration info for `gpu_processing`, `gpu_execution`, `gpu_buffer_init`, profiling functions
+- `test/cpp/integration/test_tpcds_plan_translation.cpp` — Register test functions
+
+### ConstantExpression / FunctionExpression / TableFunctionRef
+
+**Headers**: `duckdb/parser/expression/*.hpp`, `duckdb/parser/tableref/table_function_ref.hpp`
+
+**Description**: Unbound (pre-planning) expression and table reference types. Used to programmatically construct queries.
+
+**Our usage**:
+- `test/cpp/scan/test_parquet_scan_task.cpp` — Construct parquet scan function calls programmatically
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `SelectStatement` | `statement/select_statement.hpp` | SELECT query AST |
+| `CreateStatement` | `statement/create_statement.hpp` | DDL CREATE AST |
+| `Transformer` | `transformer.hpp` | PG parse tree → DuckDB AST |
+| `QueryNode` | `query_node/` | Query structure (SELECT, UNION, etc.) |
+| `Constraints` | `constraints/` | Table constraint definitions |

--- a/.claude/skills/module-discover/docs/duckdb/modules/planner.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/planner.md
@@ -1,0 +1,269 @@
+# planner
+
+**Status**: USED
+**Path**: `duckdb/src/include/duckdb/planner/`
+**Headers we include**:
+- `duckdb/planner/planner.hpp`
+- `duckdb/planner/expression.hpp`
+- `duckdb/planner/expression/bound_aggregate_expression.hpp`
+- `duckdb/planner/expression/bound_between_expression.hpp`
+- `duckdb/planner/expression/bound_case_expression.hpp`
+- `duckdb/planner/expression/bound_cast_expression.hpp`
+- `duckdb/planner/expression/bound_comparison_expression.hpp`
+- `duckdb/planner/expression/bound_conjunction_expression.hpp`
+- `duckdb/planner/expression/bound_constant_expression.hpp`
+- `duckdb/planner/expression/bound_function_expression.hpp`
+- `duckdb/planner/expression/bound_operator_expression.hpp`
+- `duckdb/planner/expression/bound_parameter_expression.hpp`
+- `duckdb/planner/expression/bound_reference_expression.hpp`
+- `duckdb/planner/bound_result_modifier.hpp`
+- `duckdb/planner/filter/conjunction_filter.hpp`
+- `duckdb/planner/filter/constant_filter.hpp`
+- `duckdb/planner/filter/dynamic_filter.hpp`
+- `duckdb/planner/logical_operator.hpp`
+- `duckdb/planner/operator/logical_aggregate.hpp`
+- `duckdb/planner/operator/logical_comparison_join.hpp`
+- `duckdb/planner/operator/logical_cteref.hpp`
+- `duckdb/planner/operator/logical_get.hpp`
+- `duckdb/planner/operator/logical_order.hpp`
+- `duckdb/planner/table_filter.hpp`
+
+## Summary
+
+The `planner` module is the most heavily used DuckDB module in Sirius. It provides the bound expression hierarchy (the typed/resolved form of SQL expressions), logical operators (the logical plan tree), and table filters. Sirius walks these structures to translate DuckDB's query plan into GPU-executable operators and expressions.
+
+## API Reference
+
+### Planner
+
+**Header**: `duckdb/planner/planner.hpp`
+**Signature**:
+```cpp
+class Planner {
+public:
+    explicit Planner(ClientContext &context);
+    void CreatePlan(unique_ptr<SQLStatement> statement);
+    unique_ptr<LogicalOperator> plan;
+    vector<LogicalType> types;
+    vector<string> names;
+};
+```
+
+**Description**: Converts parsed SQL statements into a logical plan tree.
+
+**Our usage**:
+- `src/sirius_extension.cpp` — Creates logical plan from parsed SQL for GPU translation
+
+### LogicalOperator
+
+**Header**: `duckdb/planner/logical_operator.hpp`
+**Signature**:
+```cpp
+class LogicalOperator {
+public:
+    LogicalOperatorType type;
+    vector<unique_ptr<LogicalOperator>> children;
+    vector<unique_ptr<Expression>> expressions;
+    vector<LogicalType> types;
+    virtual vector<ColumnBinding> GetColumnBindings();
+    idx_t EstimateCardinality(ClientContext &context);
+};
+```
+
+**Description**: Base class for all logical operators in the query plan tree. Sirius walks this tree to decide which operators can run on GPU.
+
+**Our usage**:
+- `src/gpu_physical_plan_generator.cpp` — Walk logical plan to create GPU physical operators
+- `src/planner/sirius_physical_plan_generator.cpp` — Same for new code path
+- `src/fallback.cpp` — Inspect logical operators for fallback decisions
+
+### BoundReferenceExpression
+
+**Header**: `duckdb/planner/expression/bound_reference_expression.hpp`
+**Signature**:
+```cpp
+class BoundReferenceExpression : public Expression {
+public:
+    BoundReferenceExpression(LogicalType type, idx_t index);
+    idx_t index;      // Column index in the input
+    idx_t depth = 0;  // Subquery depth
+};
+```
+
+**Description**: References a column by index in the input. Most common expression type — every column access in a query creates one.
+
+**Our usage**:
+- Used in virtually every operator translation file to map column references to GPU column indices
+- `src/expression_executor/gpu_expression_translator.cpp` — Map to GPU column references
+- `src/operator/gpu_physical_hash_join.cpp` — Join key column indices
+- `src/plan/gpu_plan_get.cpp` — Table scan column indices
+
+### BoundComparisonExpression
+
+**Header**: `duckdb/planner/expression/bound_comparison_expression.hpp`
+**Signature**:
+```cpp
+class BoundComparisonExpression : public Expression {
+public:
+    BoundComparisonExpression(ExpressionType type, unique_ptr<Expression> left, unique_ptr<Expression> right);
+    unique_ptr<Expression> left;
+    unique_ptr<Expression> right;
+};
+```
+
+**Description**: Binary comparison (=, !=, <, >, <=, >=, IS DISTINCT FROM, etc.).
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Translate to GPU comparison operations
+- `test/cpp/operator/test_physical_filter.cpp` — Build test filter expressions
+
+### BoundConjunctionExpression
+
+**Header**: `duckdb/planner/expression/bound_conjunction_expression.hpp`
+**Signature**:
+```cpp
+class BoundConjunctionExpression : public Expression {
+public:
+    BoundConjunctionExpression(ExpressionType type);  // AND or OR
+    vector<unique_ptr<Expression>> children;
+};
+```
+
+**Description**: AND/OR combination of boolean expressions.
+
+**Our usage**:
+- `src/operator/gpu_physical_filter.cpp` — Decompose conjunction into individual filter conditions
+- `src/expression_executor/gpu_expression_translator.cpp` — Translate AND/OR to GPU
+
+### BoundConstantExpression
+
+**Header**: `duckdb/planner/expression/bound_constant_expression.hpp`
+**Signature**:
+```cpp
+class BoundConstantExpression : public Expression {
+public:
+    BoundConstantExpression(Value value);
+    Value value;
+};
+```
+
+**Description**: A constant literal value in an expression.
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Extract constant values for GPU scalar operations
+
+### BoundCastExpression
+
+**Header**: `duckdb/planner/expression/bound_cast_expression.hpp`
+**Signature**:
+```cpp
+class BoundCastExpression : public Expression {
+public:
+    unique_ptr<Expression> child;
+    LogicalType return_type;
+    bool try_cast;  // TRY_CAST vs CAST
+};
+```
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Translate type casts to cuDF cast operations
+
+### BoundFunctionExpression
+
+**Header**: `duckdb/planner/expression/bound_function_expression.hpp`
+**Signature**:
+```cpp
+class BoundFunctionExpression : public Expression {
+public:
+    ScalarFunction function;
+    vector<unique_ptr<Expression>> children;
+    unique_ptr<FunctionData> bind_info;
+    bool is_operator;
+};
+```
+
+**Description**: A bound scalar function call (e.g., `SUBSTRING`, `YEAR`, arithmetic operators).
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Map DuckDB scalar functions to GPU implementations
+- `src/expression_executor/specializations/` — Specialized GPU implementations for specific functions
+
+### BoundAggregateExpression
+
+**Header**: `duckdb/planner/expression/bound_aggregate_expression.hpp`
+**Signature**:
+```cpp
+class BoundAggregateExpression : public Expression {
+public:
+    AggregateFunction function;
+    vector<unique_ptr<Expression>> children;
+    unique_ptr<Expression> filter;
+    unique_ptr<BoundOrderModifier> order_bys;
+    AggregateType aggr_type;  // DISTINCT or NON_DISTINCT
+    bool IsDistinct() const;
+};
+```
+
+**Our usage**:
+- `src/plan/gpu_plan_aggregate.cpp` — Extract aggregate functions for GPU grouped/ungrouped aggregation
+- `src/operator/gpu_physical_grouped_aggregate.cpp` — Map aggregate functions to cuDF aggregation ops
+
+### BoundCaseExpression / BoundBetweenExpression / BoundOperatorExpression
+
+**Headers**: Respective `bound_*_expression.hpp`
+
+**Our usage**:
+- `src/expression_executor/gpu_expression_translator.cpp` — Translate CASE/WHEN, BETWEEN, and operators (COALESCE, NOT, IS NULL, IS NOT NULL) to GPU
+
+### TableFilterSet / ConstantFilter / ConjunctionFilter / DynamicFilter
+
+**Headers**: `duckdb/planner/table_filter.hpp`, `duckdb/planner/filter/constant_filter.hpp`, etc.
+**Signature**:
+```cpp
+class TableFilterSet {
+public:
+    unordered_map<idx_t, unique_ptr<TableFilter>> filters;  // column_index -> filter
+};
+
+class ConstantFilter : public TableFilter {
+public:
+    ExpressionType comparison_type;
+    Value constant;
+};
+```
+
+**Description**: Pushed-down filters for table scans. Sirius translates these to GPU filter operations that run during data loading.
+
+**Our usage**:
+- `src/operator/gpu_physical_table_scan.cpp` — Apply pushed-down filters during scan
+- `test/cpp/operator/test_physical_table_scan.cpp` — Test filter pushdown
+
+### Logical Operators (LogicalGet, LogicalAggregate, LogicalOrder, LogicalComparisonJoin, LogicalCTERef)
+
+**Headers**: `duckdb/planner/operator/logical_*.hpp`
+
+**Description**: Specific logical operator types in the plan tree. Sirius accesses their properties (e.g., `LogicalGet::table_filters`, `LogicalAggregate::groups`, `LogicalComparisonJoin::conditions`).
+
+**Our usage**:
+- `src/plan/gpu_plan_get.cpp` — Access `LogicalGet` for table scan configuration
+- `src/plan/gpu_plan_aggregate.cpp` — Access `LogicalAggregate` for grouping/aggregate info
+- `src/plan/gpu_plan_join.cpp` — Access `LogicalComparisonJoin` for join conditions
+- `src/plan/gpu_plan_recursive_cte.cpp` — Access `LogicalCTERef` for CTE handling
+
+### BoundResultModifier (BoundOrderModifier)
+
+**Header**: `duckdb/planner/bound_result_modifier.hpp`
+
+**Our usage**:
+- `test/cpp/operator/test_physical_top_n.cpp` — Build ORDER BY specifications for tests
+- `src/plan/gpu_plan_order.cpp` — Access sort specifications
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `BoundSubqueryExpression` | `expression/bound_subquery_expression.hpp` | Correlated/uncorrelated subqueries |
+| `BoundWindowExpression` | `expression/bound_window_expression.hpp` | Window function expressions |
+| `ExpressionBinder` | `expression_binder/` | Expression binding infrastructure |
+| `LogicalWindow` | `operator/logical_window.hpp` | Window function operator |
+| `LogicalSample` | `operator/logical_sample.hpp` | TABLESAMPLE operator |

--- a/.claude/skills/module-discover/docs/duckdb/modules/storage.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/storage.md
@@ -1,0 +1,33 @@
+# storage
+
+**Status**: USED (minimal)
+**Path**: `duckdb/src/include/duckdb/storage/`
+**Headers we include**:
+- `duckdb/storage/data_table.hpp`
+
+## Summary
+
+The `storage` module implements DuckDB's persistent storage engine. Sirius only uses `DataTable` — included in operator headers for table scan and grouped aggregate operators that reference DuckDB's in-storage table representation.
+
+## API Reference
+
+### DataTable
+
+**Header**: `duckdb/storage/data_table.hpp`
+
+**Description**: Represents a table's physical storage. Referenced by GPU physical operators that need access to table metadata.
+
+**Our usage**:
+- `src/include/operator/gpu_physical_table_scan.hpp` — Table scan references DataTable
+- `src/include/operator/gpu_physical_grouped_aggregate.hpp` — Grouped aggregate references DataTable
+- `src/include/op/sirius_physical_duckdb_scan.hpp` — New code path scan operator
+- `src/include/op/sirius_physical_grouped_aggregate.hpp` — New code path aggregate
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `StorageManager` | `storage_manager.hpp` | Database storage lifecycle |
+| `BufferManager` | `buffer/buffer_manager.hpp` | Buffer pool for disk blocks |
+| `ColumnSegment` | `segment/column_segment.hpp` | Columnar storage with compression |
+| `CheckpointManager` | `checkpoint/checkpoint_manager.hpp` | WAL and checkpointing |

--- a/.claude/skills/module-discover/docs/duckdb/modules/transaction.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/transaction.md
@@ -1,0 +1,17 @@
+# transaction
+
+**Status**: UNUSED
+**Path**: `duckdb/src/include/duckdb/transaction/`
+
+## Summary
+
+The `transaction` module provides MVCC transaction management — transaction lifecycle, conflict detection, undo buffers, and isolation levels.
+
+## Key APIs
+- `TransactionContext` — Per-connection transaction state (indirectly used via ClientContext)
+- `TransactionManager` — Global transaction coordination
+- `DuckTransaction` — Individual transaction instance
+
+## Potential Relevance
+
+Not directly relevant. Sirius runs read-only analytical queries and relies on DuckDB's transaction context implicitly through `ClientContext`. No direct transaction management is needed.

--- a/.claude/skills/module-discover/docs/duckdb/modules/verification.md
+++ b/.claude/skills/module-discover/docs/duckdb/modules/verification.md
@@ -1,0 +1,16 @@
+# verification
+
+**Status**: UNUSED
+**Path**: `duckdb/src/include/duckdb/verification/`
+
+## Summary
+
+The `verification` module provides DuckDB's internal query verification infrastructure — re-executes queries with different configurations to detect correctness bugs.
+
+## Key APIs
+- `StatementVerifier` — Runs queries multiple ways to verify consistency
+- `PhysicalVerifyVector` — Verifies vector data integrity
+
+## Potential Relevance
+
+Could be useful for testing Sirius correctness — verifying that GPU results match CPU results. Currently not used; Sirius has its own validation in `performance_test.py`.

--- a/.claude/skills/module-discover/docs/libkvikio/README.md
+++ b/.claude/skills/module-discover/docs/libkvikio/README.md
@@ -1,0 +1,42 @@
+# libkvikio — Module Reference
+
+**Version**: 26.02.00
+**Location**: `.pixi/envs/default/include/kvikio/`
+**Namespace**: `kvikio`
+**Conda package**: `libkvikio` (from rapidsai channel)
+
+## Overview
+
+KvikIO (pronounced "quick I/O") is a RAPIDS library providing GPU-accelerated file I/O. It wraps NVIDIA's cuFile/GDS (GPUDirect Storage) APIs with a C++ header-only interface that supports synchronous, asynchronous, parallel, and batched I/O between files and GPU memory. It also supports POSIX fallback, remote file access (S3, HTTP), and memory-mapped I/O.
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| file_io | UNUSED | Core file I/O via cuFile/GDS with sync, async, and parallel reads/writes | — |
+| batch | UNUSED | Batched cuFile I/O operations | — |
+| memory | UNUSED | GPU buffer registration and bounce buffer pools | — |
+| remote | UNUSED | Remote file access (S3, HTTP, WebHDFS) | — |
+| mmap | UNUSED | Memory-mapped file access | — |
+| config | UNUSED | Global defaults, compatibility mode, and driver configuration | — |
+| shim | UNUSED | Dynamic loading shims for CUDA and cuFile libraries | — |
+
+## Our Usage Summary
+
+We use **0 of 7 modules**. libkvikio is a **transitive dependency** — it is pulled in by libcudf via the RAPIDS conda ecosystem but is not directly referenced anywhere in the Sirius codebase (`src/`, `test/`, `cucascade/`, or CMake files).
+
+### Why it's installed
+- libcudf depends on libkvikio for its Parquet/ORC I/O subsystem (`cudf::io`)
+- The dependency is declared in the pixi lock file but not in our direct dependencies
+
+### Potential relevance
+- If Sirius ever needs to read Parquet files directly on GPU (bypassing DuckDB's scanner), kvikio's `FileHandle` could enable GDS-accelerated reads
+- The `RemoteHandle` module could enable direct GPU reads from S3/HTTP without staging through CPU
+
+## Files That Reference This Library
+
+| Source File | Context | Notes |
+|-------------|---------|-------|
+| `pixi.lock` | Transitive dependency | Pulled in by libcudf |
+| `test/tpch_performance/pixi.lock` | Transitive dependency | Same |
+| `cucascade/.clang-format` | Include ordering regex | Groups kvikio with other RAPIDS libs |

--- a/.claude/skills/module-discover/docs/libkvikio/modules/batch.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/batch.md
@@ -1,0 +1,17 @@
+# Batch I/O
+
+**Status**: UNUSED
+**Path**: `kvikio/batch.hpp`
+
+## Summary
+Provides batched cuFile I/O operations for submitting multiple read/write requests in a single call. Useful for reading many file regions into GPU memory with reduced overhead.
+
+## Key APIs
+- `BatchHandle` — Handle for batch I/O operations
+- `BatchOp` — Struct describing a single I/O operation (file, offset, size, device pointer)
+- `BatchHandle::submit()` — Submit a vector of `BatchOp` operations
+- `BatchHandle::status()` — Poll for completion events
+- `BatchHandle::cancel()` — Cancel pending operations
+
+## Potential Relevance
+Medium. Could be useful if Sirius implements its own Parquet reader that needs to read many row groups/column chunks in parallel from a single file.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/config.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/config.md
@@ -1,0 +1,24 @@
+# Configuration & Defaults
+
+**Status**: UNUSED
+**Path**: `kvikio/defaults.hpp`, `kvikio/compat_mode.hpp`, `kvikio/cufile/driver.hpp`, `kvikio/cufile/config.hpp`
+
+## Summary
+Global configuration singleton for kvikio. Controls compatibility mode (cuFile vs POSIX fallback), thread pool sizing, task sizes, GDS thresholds, bounce buffer sizes, HTTP settings, and Direct I/O behavior. Also provides cuFile driver property access.
+
+## Key APIs
+- `defaults` — Singleton with static getters/setters for all global settings
+- `CompatMode` — Enum: `OFF` (enforce cuFile), `ON` (enforce POSIX), `AUTO` (try cuFile, fall back)
+- `DriverProperties` — Query cuFile driver capabilities (GDS availability, version, cache sizes)
+- `DriverInitializer` — RAII wrapper to open/close cuFile driver
+- `getenv_or()` — Utility to read environment variables with defaults
+
+### Key environment variables (read by `defaults`):
+- `KVIKIO_COMPAT_MODE` — Set compatibility mode
+- `KVIKIO_NTHREADS` — Thread pool size
+- `KVIKIO_TASK_SIZE` — Default task size for parallel I/O
+- `KVIKIO_GDS_THRESHOLD` — Minimum size to use GDS (below uses POSIX)
+- `KVIKIO_BOUNCE_BUFFER_SIZE` — Bounce buffer size
+
+## Potential Relevance
+Low unless directly integrating kvikio for file I/O. The `CompatMode::AUTO` pattern is useful to know — it's how cudf's Parquet reader transparently uses GDS when available.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/file_io.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/file_io.md
@@ -1,0 +1,18 @@
+# File I/O
+
+**Status**: UNUSED
+**Path**: `kvikio/file_handle.hpp`, `kvikio/stream.hpp`
+
+## Summary
+Core module providing GPU-accelerated file I/O via NVIDIA cuFile/GDS. Supports synchronous, asynchronous (CUDA stream-based), and parallel (thread pool-based) reads and writes between files and device memory. Falls back to POSIX I/O when cuFile is unavailable (controlled by `CompatMode`).
+
+## Key APIs
+- `FileHandle` — Main file handle class; open files, read/write with sync/async/parallel modes
+- `FileHandle::read()` / `FileHandle::write()` — Synchronous GPU↔file transfers
+- `FileHandle::pread()` / `FileHandle::pwrite()` — Parallel I/O using thread pool, returns `std::future`
+- `FileHandle::read_async()` / `FileHandle::write_async()` — CUDA stream-based async I/O, returns `StreamFuture`
+- `StreamFuture` — Future for async I/O operations; `check_bytes_done()` synchronizes stream
+- `stream_register()` / `stream_deregister()` — Register CUDA streams with cuFile for async I/O
+
+## Potential Relevance
+High. If Sirius ever implements direct GPU file reading (bypassing DuckDB's CPU-based Parquet scanner), `FileHandle` with GDS could significantly reduce data loading latency by enabling direct storage-to-GPU transfers without CPU staging.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/memory.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/memory.md
@@ -1,0 +1,18 @@
+# Memory Management
+
+**Status**: UNUSED
+**Path**: `kvikio/buffer.hpp`, `kvikio/bounce_buffer.hpp`
+
+## Summary
+Provides GPU buffer registration with cuFile (required for GDS) and a thread-safe bounce buffer pool for staging I/O through pinned host memory. Multiple allocator strategies are available (page-aligned, CUDA pinned, or both).
+
+## Key APIs
+- `buffer_register()` / `buffer_deregister()` — Register device memory with cuFile for DMA
+- `memory_register()` / `memory_deregister()` — Register device memory allocations
+- `BounceBufferPool<Allocator>` — Singleton thread-safe pool of reusable bounce buffers
+- `BounceBufferPool::Buffer` — RAII wrapper for a borrowed bounce buffer
+- `CudaPinnedAllocator` — Allocates CUDA pinned host memory
+- `PageAlignedAllocator` — Allocates page-aligned host memory
+
+## Potential Relevance
+Low. Sirius already manages GPU memory via cuCascade/RMM. These APIs would only be relevant if integrating GDS directly.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/mmap.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/mmap.md
@@ -1,0 +1,15 @@
+# Memory-Mapped I/O
+
+**Status**: UNUSED
+**Path**: `kvikio/mmap.hpp`
+
+## Summary
+Provides memory-mapped file access with parallel read support. Maps file regions into memory for efficient sequential access, with thread pool-based parallel reads.
+
+## Key APIs
+- `MmapHandle` — Handle for memory-mapped files; supports sequential and parallel reads
+- `MmapHandle::read()` — Sequential read from mapped region
+- `MmapHandle::pread()` — Parallel read using thread pool
+
+## Potential Relevance
+Low. Memory-mapped I/O is CPU-oriented; Sirius's GPU execution model favors direct file-to-GPU transfers via GDS or explicit reads.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/remote.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/remote.md
@@ -1,0 +1,18 @@
+# Remote File Access
+
+**Status**: UNUSED
+**Path**: `kvikio/remote_handle.hpp`
+
+## Summary
+Enables reading remote files (S3, HTTP, WebHDFS) directly into GPU memory. Supports multiple endpoint types with auto-detection, parallel reads via thread pool, and configurable retry/timeout behavior.
+
+## Key APIs
+- `RemoteHandle` — Handle for remote file access; `read()` and `pread()` methods
+- `RemoteHandle::open()` — Factory method with auto-detection of endpoint type
+- `RemoteEndpointType` — Enum: `AUTO`, `S3`, `S3_PUBLIC`, `S3_PRESIGNED_URL`, `WEBHDFS`, `HTTP`
+- `S3Endpoint` — AWS S3 endpoint with credentials and region support
+- `HttpEndpoint` — Generic HTTP/HTTPS endpoint
+- `S3PublicEndpoint` — Public S3 bucket access (no credentials)
+
+## Potential Relevance
+Medium. Could enable Sirius to query Parquet files directly from S3/cloud storage with GPU-accelerated reads, avoiding the need to download data to local storage first.

--- a/.claude/skills/module-discover/docs/libkvikio/modules/shim.md
+++ b/.claude/skills/module-discover/docs/libkvikio/modules/shim.md
@@ -1,0 +1,18 @@
+# Shim Layer
+
+**Status**: UNUSED
+**Path**: `kvikio/shim/cuda.hpp`, `kvikio/shim/cufile.hpp`
+
+## Summary
+Dynamic loading shims for CUDA and cuFile C APIs. Loads library symbols at runtime via `dlopen`/`dlsym`, enabling kvikio to work even when cuFile is not installed (graceful degradation). Provides singleton access to all required CUDA driver and cuFile functions.
+
+## Key APIs
+- `cudaAPI` — Singleton wrapping CUDA driver API functions (context, memory, streams)
+- `cuFileAPI` — Singleton wrapping cuFile API functions (register, read, write, batch, async)
+- `is_cuda_available()` — Check if CUDA library can be loaded
+- `is_cufile_library_available()` — Check if cuFile library can be loaded
+- `is_cufile_available()` — Check if cuFile is both loadable and functional
+- `cufile_version()` — Get cuFile library version
+
+## Potential Relevance
+Not applicable to our use case. These are internal implementation details of kvikio's runtime library loading.

--- a/.claude/skills/module-discover/docs/rmm/README.md
+++ b/.claude/skills/module-discover/docs/rmm/README.md
@@ -1,0 +1,60 @@
+# RMM (RAPIDS Memory Manager) — Module Reference
+
+**Version**: 26.2.0
+**Location**: `.pixi/envs/default/include/rmm/`
+**Namespace**: `rmm`, `rmm::mr`
+**CMake target**: `rmm::rmm`
+
+## Module Map
+
+| Module | Status | Description | Key APIs Used |
+|--------|--------|-------------|---------------|
+| CUDA Streams | USED | CUDA stream wrappers (owning & non-owning) | `cuda_stream_view`, `cuda_stream`, `cuda_stream_default` |
+| Device Containers | USED | GPU memory containers (buffer, uvector) | `device_buffer`, `device_uvector` |
+| Memory Resources | USED | Polymorphic device memory allocators | `device_memory_resource`, `cuda_memory_resource`, `pool_memory_resource` |
+| Resource Refs | USED | Type-erased resource references (CCCL-based) | `device_async_resource_ref`, `to_device_async_resource_ref_checked` |
+| Per-Device Resources | USED | Global per-device resource management | `get_current_device_resource`, `get_current_device_resource_ref` |
+| Device Management | USED | CUDA device ID and queries | `cuda_device_id`, `get_current_cuda_device`, `available_device_memory` |
+| Alignment Utilities | USED | Memory alignment helpers | `align_up`, `CUDA_ALLOCATION_ALIGNMENT` |
+| Error Handling | USED | Exception types and CUDA error macros | `out_of_memory`, `bad_alloc`, `RMM_CUDA_TRY` |
+| Arena MR | UNUSED | Arena-based memory resource | — |
+| Async MRs | UNUSED | CUDA async memory resources (cudaMallocAsync) | — |
+| Managed Memory | UNUSED | Managed/unified memory resources | — |
+| Logging/Stats MRs | UNUSED | Logging, statistics, tracking adaptors | — |
+| Pinned Host Memory | UNUSED | Pinned host memory resource | — |
+| Other MR Adaptors | UNUSED | Binning, fixed-size, limiting, callback, etc. | — |
+| Prefetch | UNUSED | Memory prefetch utilities | — |
+| Exec Policy | UNUSED | Thrust execution policy with stream | — |
+| Device Scalar/Vector | UNUSED | Higher-level device containers | — |
+
+## Our Usage Summary
+
+We use **8 of 17** modules. Primary integration points:
+- **Stream management**: `rmm::cuda_stream_view` is the standard stream parameter type across all GPU operators, pipeline tasks, and expression executors
+- **Device memory**: `rmm::device_buffer` and `rmm::device_uvector` for GPU memory allocations in operators and CUDA kernels
+- **Memory resources**: `rmm::mr::pool_memory_resource<cuda_memory_resource>` in `GPUBufferManager` for the processing memory pool
+- **Resource refs**: `rmm::device_async_resource_ref` as the standard allocator parameter type in operators and kernels
+- **Error handling**: `rmm::out_of_memory` caught in pipeline OOM reschedule logic
+
+## Files That Reference This Library
+
+| Source File | Modules Used | Key APIs |
+|-------------|-------------|----------|
+| `src/gpu_buffer_manager.cpp` | Memory Resources, Alignment, Streams | `pool_memory_resource`, `cuda_memory_resource`, `align_up` |
+| `src/include/cudf/cudf_utils.hpp` | Device Mgmt, Memory Resources | `cuda_device_id`, `cuda_memory_resource`, `pool_memory_resource` |
+| `src/include/sirius_context.hpp` | Resource Refs | `device_async_resource_ref` |
+| `src/include/pipeline/sirius_pipeline_itask.hpp` | Streams | `cuda_stream_view` |
+| `src/include/memory/sirius_memory_reservation_manager.hpp` | Memory Resources | `device_memory_resource` |
+| `src/cuda/operator/empty_str_check.cu` | Containers, Resource Refs, Streams | `device_uvector`, `device_buffer`, `device_async_resource_ref` |
+| `src/cuda/operator/strlen_from_offsets.cu` | Containers, Resource Refs, Streams | `device_uvector`, `device_buffer` |
+| `src/expression_executor/specializations/gpu_execute_operator.cpp` | Containers | `device_uvector` |
+| `src/op/scan/prefetched_data_source.cpp` | Error Handling, Containers | `rmm::detail::error`, `device_buffer` |
+| `src/downgrade/downgrade_executor.cpp` | Streams | `cuda_stream` |
+| `src/pipeline/gpu_pipeline_executor.cpp` | Device Mgmt | `cuda_device_id` |
+| `src/data/host_parquet_representation_converters.cpp` | Device Mgmt, Streams, Resource Refs | `cuda_device_id`, `cuda_stream_view` |
+| `src/op/sirius_physical_top_n.cpp` | Containers, Resource Refs | `device_buffer` |
+| `src/op/sirius_physical_ungrouped_aggregate.cpp` | Resource Refs | `device_async_resource_ref` |
+| `src/op/sirius_physical_nested_loop_join.cpp` | Resource Refs | `device_async_resource_ref` |
+| `src/operator/gpu_physical_ungrouped_aggregate.cpp` | Streams | `cuda_stream_default` |
+| `src/operator/gpu_physical_result_collector.cpp` | Streams | `cuda_stream_default` |
+| `src/operator/gpu_physical_nested_loop_join.cpp` | Streams | `cuda_stream_default` |

--- a/.claude/skills/module-discover/docs/rmm/modules/alignment.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/alignment.md
@@ -1,0 +1,40 @@
+# Alignment Utilities
+
+**Status**: USED
+**Path**: `rmm/aligned.hpp`
+**Headers we include**: `<rmm/aligned.hpp>`
+
+## Summary
+
+Memory alignment helper functions and constants. Used by `GPUBufferManager` for ensuring proper CUDA memory alignment.
+
+## API Reference
+
+### `rmm::CUDA_ALLOCATION_ALIGNMENT`
+
+```cpp
+static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
+```
+
+**Description**: Default alignment for CUDA allocations (256 bytes).
+
+### `rmm::align_up()`
+
+```cpp
+std::size_t align_up(std::size_t value, std::size_t alignment) noexcept;
+```
+
+**Description**: Rounds `value` up to the nearest multiple of `alignment`.
+
+**Our usage**:
+- `src/gpu_buffer_manager.cpp:28` — Aligns buffer sizes for GPU memory allocations
+
+### Other functions
+
+| API | Brief Description |
+|-----|-------------------|
+| `align_down()` | Round down to alignment |
+| `is_aligned()` | Check if value is aligned |
+| `is_pow2()` | Check if power of 2 |
+| `is_supported_alignment()` | Check if valid alignment |
+| `is_pointer_aligned()` | Check pointer alignment |

--- a/.claude/skills/module-discover/docs/rmm/modules/cuda_streams.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/cuda_streams.md
@@ -1,0 +1,96 @@
+# CUDA Streams
+
+**Status**: USED
+**Path**: `rmm/cuda_stream.hpp`, `rmm/cuda_stream_view.hpp`
+**Headers we include**: `<rmm/cuda_stream.hpp>`, `<rmm/cuda_stream_view.hpp>`
+
+## Summary
+
+Provides strongly-typed CUDA stream wrappers. `cuda_stream_view` is a non-owning view (like `string_view`) used as the standard stream parameter across all Sirius GPU operations. `cuda_stream` is an owning RAII wrapper used when a dedicated stream is needed.
+
+## API Reference
+
+### `rmm::cuda_stream_view`
+
+**Header**: `<rmm/cuda_stream_view.hpp>`
+```cpp
+class cuda_stream_view {
+public:
+  cuda_stream_view() = default;
+  cuda_stream_view(cudaStream_t stream) noexcept;
+  cuda_stream_view(cuda::stream_ref stream) noexcept;
+
+  cudaStream_t value() const noexcept;
+  operator cudaStream_t() const noexcept;
+  operator cuda::stream_ref() const noexcept;
+
+  bool is_per_thread_default() const noexcept;
+  bool is_default() const noexcept;
+  void synchronize() const;
+  void synchronize_no_throw() const noexcept;
+};
+```
+
+**Description**: Non-owning view of a CUDA stream. Implicitly convertible to/from `cudaStream_t` and `cuda::stream_ref`. Default-constructed view wraps the null/default stream.
+
+**Our usage**:
+- `src/include/pipeline/sirius_pipeline_itask.hpp:25` — Stream parameter for pipeline task interface
+- `src/include/expression_executor/gpu_expression_executor.hpp:44` — Stream for GPU expression execution
+- `src/include/operator/empty_str_check.cuh:21` — Stream parameter for CUDA kernel launches
+- Virtually every operator and pipeline file uses this as the stream parameter type
+
+### `rmm::cuda_stream`
+
+**Header**: `<rmm/cuda_stream.hpp>`
+```cpp
+class cuda_stream {
+public:
+  enum class flags : unsigned int {
+    sync_default = cudaStreamDefault,
+    non_blocking = cudaStreamNonBlocking,
+  };
+
+  cuda_stream(flags f = flags::sync_default);
+  ~cuda_stream() = default;  // RAII cleanup
+  cuda_stream(cuda_stream&&) = default;
+  cuda_stream(cuda_stream const&) = delete;
+
+  bool is_valid() const;
+  cudaStream_t value() const;
+  explicit operator cudaStream_t() const noexcept;
+  cuda_stream_view view() const;
+  operator cuda_stream_view() const;  // implicit conversion
+  void synchronize() const;
+  void synchronize_no_throw() const noexcept;
+};
+```
+
+**Description**: RAII wrapper that creates and destroys a CUDA stream. Move-only. Implicitly converts to `cuda_stream_view`.
+
+**Our usage**:
+- `src/downgrade/downgrade_executor.cpp:22` — Owns streams for downgrade operations
+- `test/cpp/operator/test_host_table_chunk_reader.cpp:250` — Creates streams that must outlive data batches
+- `test/cpp/scan/test_parquet_scan_task.cpp:323` — Owns streams for scan test operations
+
+### `rmm::cuda_stream_default`
+
+**Header**: `<rmm/cuda_stream_view.hpp>`
+```cpp
+static constexpr cuda_stream_view cuda_stream_default{};
+```
+
+**Description**: Pre-defined view of the default CUDA stream (stream 0).
+
+**Our usage**:
+- `src/operator/gpu_physical_ungrouped_aggregate.cpp:109` — Default stream for legacy operator execution
+- `src/operator/gpu_physical_result_collector.cpp:338` — Default stream for result collection
+- `src/operator/gpu_physical_nested_loop_join.cpp:389` — Default stream for legacy NLJ
+- `test/cpp/data/test_host_parquet_representation.cpp:309` — Default stream for cloning in tests
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `cuda_stream_legacy` | `cuda_stream_view.hpp` | View of `cudaStreamLegacy` |
+| `cuda_stream_per_thread` | `cuda_stream_view.hpp` | View of `cudaStreamPerThread` |
+| `cuda_stream::flags::non_blocking` | `cuda_stream.hpp` | Create non-blocking stream |

--- a/.claude/skills/module-discover/docs/rmm/modules/device_containers.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/device_containers.md
@@ -1,0 +1,112 @@
+# Device Containers
+
+**Status**: USED
+**Path**: `rmm/device_buffer.hpp`, `rmm/device_uvector.hpp`
+**Headers we include**: `<rmm/device_buffer.hpp>`, `<rmm/device_uvector.hpp>`
+
+## Summary
+
+RAII containers for uninitialized device memory. `device_buffer` holds raw bytes; `device_uvector<T>` is a typed vector that skips initialization for performance. Both are move-only and stream-aware. These are used throughout Sirius for GPU data storage in operators and CUDA kernels.
+
+## API Reference
+
+### `rmm::device_buffer`
+
+**Header**: `<rmm/device_buffer.hpp>`
+```cpp
+class device_buffer {
+public:
+  device_buffer();  // empty buffer
+  explicit device_buffer(std::size_t size, cuda_stream_view stream,
+                         device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_buffer(void const* source_data, std::size_t size, cuda_stream_view stream,
+                device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_buffer(device_buffer const& other, cuda_stream_view stream,
+                device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_buffer(device_buffer&& other) noexcept;
+  device_buffer& operator=(device_buffer&& other) noexcept;
+  ~device_buffer() noexcept;
+
+  void reserve(std::size_t new_capacity, cuda_stream_view stream);
+  void resize(std::size_t new_size, cuda_stream_view stream);
+  void shrink_to_fit(cuda_stream_view stream);
+
+  void const* data() const noexcept;
+  void* data() noexcept;
+  std::size_t size() const noexcept;
+  std::int64_t ssize() const noexcept;
+  bool is_empty() const noexcept;
+  std::size_t capacity() const noexcept;
+  cuda_stream_view stream() const noexcept;
+  void set_stream(cuda_stream_view stream) noexcept;
+  device_async_resource_ref memory_resource() noexcept;
+};
+```
+
+**Description**: Untyped, uninitialized device memory with RAII. Supports host-to-device copy construction. Copy ctor/assignment deleted (must specify stream explicitly).
+
+**Our usage**:
+- `src/op/sirius_physical_top_n.cpp:175` — Creates null mask buffers: `std::make_unique<rmm::device_buffer>(std::move(new_mask))`
+- `src/cuda/operator/empty_str_check.cu:69` — Empty buffer for null mask: `rmm::device_buffer(0, stream, mr)`
+- `src/cuda/operator/strlen_from_offsets.cu:69` — Same pattern for column construction
+- `test/cpp/utils/data_utils.hpp:95` — Creates char buffers for string column construction
+- `test/cpp/operator/operator_test_utils.hpp:249` — Allocates char data for test string columns
+- `test/cpp/memory/test_host_table_utils.cpp:280` — Copies host mask to device
+
+### `rmm::device_uvector<T>`
+
+**Header**: `<rmm/device_uvector.hpp>`
+```cpp
+template <typename T>
+class device_uvector {
+  static_assert(std::is_trivially_copyable_v<T>);
+public:
+  explicit device_uvector(size_type size, cuda_stream_view stream,
+                          device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit device_uvector(device_uvector const& other, cuda_stream_view stream,
+                          device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_uvector(device_uvector&&) noexcept = default;
+  device_uvector() = delete;  // no default ctor
+
+  void set_element_async(size_type idx, value_type const& value, cuda_stream_view stream);
+  void set_element(size_type idx, T const& value, cuda_stream_view stream);
+  value_type element(size_type idx, cuda_stream_view stream) const;
+
+  void reserve(size_type new_capacity, cuda_stream_view stream);
+  void resize(size_type new_size, cuda_stream_view stream);
+  device_buffer release() noexcept;
+
+  pointer data() noexcept;
+  const_pointer data() const noexcept;
+  size_type size() const noexcept;
+  bool is_empty() const noexcept;
+  size_type capacity() const noexcept;
+
+  iterator begin() noexcept;
+  iterator end() noexcept;
+  // + const/reverse iterators
+
+  operator cuda::std::span<T>() noexcept;
+  operator cuda::std::span<T const>() const noexcept;
+  device_async_resource_ref memory_resource() noexcept;
+  cuda_stream_view stream() const noexcept;
+  void set_stream(cuda_stream_view stream) noexcept;
+};
+```
+
+**Description**: Typed, uninitialized device vector. Only supports trivially copyable types. Unlike `thrust::device_vector`, does not default-initialize elements (better performance). All allocation/copy ops take a stream parameter.
+
+**Our usage**:
+- `src/cuda/operator/empty_str_check.cu:56` — `rmm::device_uvector<bool> output(num_rows, stream, mr)` for kernel output
+- `src/cuda/operator/strlen_from_offsets.cu:56` — `rmm::device_uvector<int32_t> output(num_rows, stream, mr)` for string length calculation
+- `src/expression_executor/specializations/gpu_execute_operator.cpp:28` — Used in expression evaluation
+- `src/cuda/expression_executor/gpu_dispatch_materialize.cu:21` — Used in materialization kernels
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `device_uvector::front_element()` | `device_uvector.hpp` | Get first element (sync) |
+| `device_uvector::back_element()` | `device_uvector.hpp` | Get last element (sync) |
+| `device_uvector::set_element_to_zero_async()` | `device_uvector.hpp` | Optimized zero-set via memset |
+| `device_buffer::ssize()` | `device_buffer.hpp` | Signed size |

--- a/.claude/skills/module-discover/docs/rmm/modules/device_management.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/device_management.md
@@ -1,0 +1,71 @@
+# Device Management
+
+**Status**: USED
+**Path**: `rmm/cuda_device.hpp`
+**Headers we include**: `<rmm/cuda_device.hpp>`
+
+## Summary
+
+CUDA device identification and query utilities. `cuda_device_id` is a strong type wrapper for GPU device IDs. Utility functions query available memory and device count.
+
+## API Reference
+
+### `rmm::cuda_device_id`
+
+**Header**: `<rmm/cuda_device.hpp>`
+```cpp
+struct cuda_device_id {
+  using value_type = int;
+  cuda_device_id() noexcept;               // current device
+  explicit constexpr cuda_device_id(value_type dev_id) noexcept;
+  constexpr value_type value() const noexcept;
+  friend bool operator==(cuda_device_id const&, cuda_device_id const&) noexcept;
+  friend bool operator!=(cuda_device_id const&, cuda_device_id const&) noexcept;
+};
+```
+
+**Description**: Strong type for CUDA device IDs. Default constructor captures the current device.
+
+**Our usage**:
+- `src/include/cudf/cudf_utils.hpp:52` — Device management utilities
+- `src/pipeline/gpu_pipeline_executor.cpp:29` — Pipeline executor device management
+- `src/memory/sirius_memory_reservation_manager.cpp:24` — Memory reservation per device
+- `src/data/host_parquet_representation_converters.cpp:35` — Device queries during conversion
+- `src/op/scan/duckdb_scan_executor.cpp:34` — Scan executor device management
+
+### `rmm::get_current_cuda_device()`
+
+**Header**: `<rmm/cuda_device.hpp>`
+```cpp
+cuda_device_id get_current_cuda_device();
+```
+
+**Description**: Returns a `cuda_device_id` for the currently active CUDA device.
+
+### `rmm::available_device_memory()`
+
+**Header**: `<rmm/cuda_device.hpp>`
+```cpp
+std::pair<std::size_t, std::size_t> available_device_memory();
+```
+
+**Description**: Returns `{free_bytes, total_bytes}` for the current device.
+
+### `rmm::cuda_set_device_raii`
+
+**Header**: `<rmm/cuda_device.hpp>`
+```cpp
+struct cuda_set_device_raii {
+  explicit cuda_set_device_raii(cuda_device_id dev_id);
+  ~cuda_set_device_raii() noexcept;  // restores previous device
+};
+```
+
+**Description**: RAII guard that sets CUDA device on construction and restores the previous device on destruction.
+
+## APIs Available but Not Used
+
+| API | Brief Description |
+|-----|-------------------|
+| `get_num_cuda_devices()` | Return total number of CUDA devices |
+| `percent_of_free_device_memory()` | Calculate percentage of free GPU memory |

--- a/.claude/skills/module-discover/docs/rmm/modules/error_handling.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/error_handling.md
@@ -1,0 +1,42 @@
+# Error Handling
+
+**Status**: USED
+**Path**: `rmm/error.hpp`, `rmm/detail/error.hpp`
+**Headers we include**: `<rmm/detail/error.hpp>`, `<rmm/error.hpp>` (via `<rmm/device_buffer.hpp>`)
+
+## Summary
+
+Exception types for RMM errors and CUDA error checking macros. Sirius catches `rmm::out_of_memory` in the pipeline OOM reschedule logic and uses `rmm::detail::error.hpp` for the `RMM_CUDA_TRY` macro in scan code.
+
+## API Reference
+
+### Exception Types
+
+**Header**: `<rmm/error.hpp>`
+
+```cpp
+struct rmm::logic_error : public std::logic_error { ... };
+struct rmm::cuda_error : public std::runtime_error { ... };
+class  rmm::bad_alloc : public std::bad_alloc { ... };
+class  rmm::out_of_memory : public bad_alloc { ... };
+class  rmm::out_of_range : public std::out_of_range { ... };
+```
+
+**Our usage**:
+- `test/cpp/pipeline/test_oom_reschedule.cpp:138` — `catch (const rmm::out_of_memory&)` in OOM reschedule tests
+
+### Macros
+
+**Header**: `<rmm/detail/error.hpp>`
+
+| Macro | Description |
+|-------|-------------|
+| `RMM_EXPECTS(cond, msg [, exception])` | Throws if condition false (default: `logic_error`) |
+| `RMM_FAIL(msg [, exception])` | Always throws |
+| `RMM_CUDA_TRY(call [, exception])` | Checks CUDA return code, throws on error (default: `cuda_error`) |
+| `RMM_CUDA_TRY_ALLOC(call [, bytes])` | Like CUDA_TRY but throws `bad_alloc`/`out_of_memory` |
+| `RMM_ASSERT_CUDA_SUCCESS(call)` | Debug-only assert on CUDA errors |
+| `RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(call)` | Like above but allows `cudaErrorCudartUnloading` |
+
+**Our usage**:
+- `src/op/scan/prefetched_data_source.cpp:19` — Includes `<rmm/detail/error.hpp>` for error macros

--- a/.claude/skills/module-discover/docs/rmm/modules/memory_resources.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/memory_resources.md
@@ -1,0 +1,86 @@
+# Memory Resources
+
+**Status**: USED
+**Path**: `rmm/mr/device_memory_resource.hpp`, `rmm/mr/cuda_memory_resource.hpp`, `rmm/mr/pool_memory_resource.hpp`
+**Headers we include**: `<rmm/mr/device_memory_resource.hpp>`, `<rmm/mr/cuda_memory_resource.hpp>`, `<rmm/mr/pool_memory_resource.hpp>`
+
+## Summary
+
+Polymorphic memory resource classes for GPU memory allocation. Sirius uses `cuda_memory_resource` (raw cudaMalloc) as the upstream allocator and wraps it in `pool_memory_resource` for the GPU processing memory pool in `GPUBufferManager`.
+
+## API Reference
+
+### `rmm::mr::device_memory_resource`
+
+**Header**: `<rmm/mr/device_memory_resource.hpp>`
+```cpp
+class device_memory_resource {
+public:
+  virtual ~device_memory_resource() = default;
+
+  void* allocate(cuda_stream_view stream, std::size_t bytes,
+                 std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT);
+  void deallocate(cuda_stream_view stream, void* ptr, std::size_t bytes,
+                  std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT) noexcept;
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT);
+  void deallocate_sync(void* ptr, std::size_t bytes,
+                       std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT) noexcept;
+  bool is_equal(device_memory_resource const& other) const noexcept;
+};
+```
+
+**Description**: Abstract base class for all device memory allocators. Stream-ordered allocation API. **Important (v26.x)**: `allocate(stream, bytes)` and `deallocate(stream, ptr, bytes)` — stream is the FIRST parameter.
+
+**Our usage**:
+- `src/include/memory/sirius_memory_reservation_manager.hpp:20` — Type used for memory resource pointers
+- `src/gpu_buffer_manager.cpp` — Pool MR's upstream; `mr->deallocate(rmm::cuda_stream_view{}, ptr, size)`
+
+### `rmm::mr::cuda_memory_resource`
+
+**Header**: `<rmm/mr/cuda_memory_resource.hpp>`
+```cpp
+class cuda_memory_resource final : public device_memory_resource {
+public:
+  cuda_memory_resource() = default;
+  // Internally uses cudaMalloc / cudaFree
+};
+```
+
+**Description**: Simplest MR — wraps `cudaMalloc`/`cudaFree`. Stream argument is ignored (allocation is synchronous).
+
+**Our usage**:
+- `src/gpu_buffer_manager.cpp:171` — `cuda_mr = new rmm::mr::cuda_memory_resource()`
+- `test/cpp/data/test_host_parquet_representation.cpp:78` — Creates cuda MR in test setup
+
+### `rmm::mr::pool_memory_resource<Upstream>`
+
+**Header**: `<rmm/mr/pool_memory_resource.hpp>`
+```cpp
+template <typename Upstream>
+class pool_memory_resource final : public /* stream_ordered_memory_resource */ {
+public:
+  explicit pool_memory_resource(Upstream* upstream_mr,
+                                std::size_t initial_pool_size,
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt);
+  explicit pool_memory_resource(device_async_resource_ref upstream_mr,
+                                std::size_t initial_pool_size,
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt);
+  ~pool_memory_resource() override;  // releases all upstream memory
+
+  device_async_resource_ref get_upstream_resource() const noexcept;
+  std::size_t pool_size() const noexcept;
+};
+```
+
+**Description**: Coalescing best-fit suballocator. Allocates a large pool from upstream and sub-allocates from it. Thread-safe. Grows geometrically up to `maximum_pool_size`. On destruction, returns all memory to upstream.
+
+**Our usage**:
+- `src/gpu_buffer_manager.cpp:172` — `mr = new rmm::mr::pool_memory_resource(cuda_mr, processing_size_per_gpu, processing_size_per_gpu)` — Fixed-size pool for GPU processing memory
+
+## APIs Available but Not Used
+
+| API | Header | Brief Description |
+|-----|--------|-------------------|
+| `pool_memory_resource::pool_size()` | `pool_memory_resource.hpp` | Query current pool size |
+| `pool_memory_resource::get_upstream_resource()` | `pool_memory_resource.hpp` | Get upstream resource ref |
+| `device_memory_resource::allocate_sync()` | `device_memory_resource.hpp` | Synchronous allocation |

--- a/.claude/skills/module-discover/docs/rmm/modules/per_device_resource.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/per_device_resource.md
@@ -1,0 +1,46 @@
+# Per-Device Resources
+
+**Status**: USED
+**Path**: `rmm/mr/per_device_resource.hpp`
+**Headers we include**: `<rmm/mr/per_device_resource.hpp>`
+
+## Summary
+
+Global per-device resource management. Maps CUDA device IDs to default memory resources. Provides thread-safe get/set functions. The initial default for any device is a `cuda_memory_resource` (raw cudaMalloc).
+
+## API Reference
+
+### `rmm::mr::get_current_device_resource()`
+
+**Header**: `<rmm/mr/per_device_resource.hpp>`
+```cpp
+inline device_memory_resource* get_current_device_resource();
+```
+
+**Description**: Returns the `device_memory_resource*` for the current CUDA device. Thread-safe.
+
+**Our usage**:
+- `test/cpp/utils/data_utils.hpp:60` — Default MR for test data construction
+- `test/cpp/utils/test_validation_utility.hpp:220,277` — `auto mr = rmm::mr::get_current_device_resource()`
+
+### `rmm::mr::get_current_device_resource_ref()`
+
+**Header**: `<rmm/mr/per_device_resource.hpp>`
+```cpp
+inline device_async_resource_ref get_current_device_resource_ref();
+```
+
+**Description**: Returns a `device_async_resource_ref` for the current CUDA device. Thread-safe. This is the default `mr` parameter value for `device_buffer` and `device_uvector` constructors.
+
+**Our usage**:
+- Implicitly used as default parameter in `device_buffer` and `device_uvector` constructors throughout the codebase
+
+## APIs Available but Not Used
+
+| API | Brief Description |
+|-----|-------------------|
+| `set_current_device_resource()` | Set the default MR for current device |
+| `set_per_device_resource()` | Set MR for a specific device ID |
+| `get_per_device_resource()` | Get MR for a specific device ID |
+| `set_current_device_resource_ref()` | Set resource ref for current device |
+| `reset_current_device_resource_ref()` | Reset to initial cuda MR |

--- a/.claude/skills/module-discover/docs/rmm/modules/resource_refs.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/resource_refs.md
@@ -1,0 +1,68 @@
+# Resource Refs
+
+**Status**: USED
+**Path**: `rmm/resource_ref.hpp`
+**Headers we include**: `<rmm/resource_ref.hpp>`
+
+## Summary
+
+Type-erased resource reference types based on CCCL's `cuda::mr::resource_ref`. These are the modern way to pass memory resources without template parameters. `device_async_resource_ref` is the standard allocator parameter type throughout Sirius operators and kernels.
+
+## API Reference
+
+### `rmm::device_async_resource_ref`
+
+**Header**: `<rmm/resource_ref.hpp>`
+```cpp
+using device_async_resource_ref =
+  detail::cccl_async_resource_ref<cuda::mr::resource_ref<cuda::mr::device_accessible>>;
+```
+
+**Description**: Type-erased reference to an async device memory resource. Constructible from any `device_memory_resource*` or `device_memory_resource&`. This is the standard parameter type for passing allocators.
+
+**Our usage**:
+- `src/include/sirius_context.hpp:28` — Stored in `sirius_context` for operator access
+- `src/include/operator/empty_str_check.cuh:22` — Kernel parameter type
+- `src/include/operator/strlen_from_offsets.cuh:22` — Kernel parameter type
+- `src/include/expression_executor/gpu_dispatcher.hpp:23` — Expression executor allocator
+- `src/include/expression_executor/gpu_expression_executor.hpp:45` — Expression executor allocator
+- `src/op/sirius_physical_top_n.cpp:30` — Top-N operator allocator
+- `src/op/sirius_physical_ungrouped_aggregate.cpp:36` — Aggregate operator allocator
+- `src/op/sirius_physical_nested_loop_join.cpp:38` — NLJ operator allocator
+- `test/cpp/operator/operator_test_utils.hpp:86` — `get_resource_ref()` helper returns this type
+
+### `rmm::to_device_async_resource_ref_checked`
+
+**Header**: `<rmm/resource_ref.hpp>`
+```cpp
+template <class Resource>
+device_async_resource_ref to_device_async_resource_ref_checked(Resource* res);
+```
+
+**Description**: Converts a raw pointer to a memory resource into a `device_async_resource_ref`, throwing `std::logic_error` if the pointer is null.
+
+**Our usage**:
+- `test/cpp/operator/operator_test_utils.hpp:88` — `return rmm::to_device_async_resource_ref_checked(space.get_default_allocator())`
+- `test/cpp/expression_executor/test_gpu_expression_executor.cpp:78` — Same pattern
+
+### `rmm::host_device_async_resource_ref`
+
+**Header**: `<rmm/resource_ref.hpp>`
+```cpp
+using host_device_async_resource_ref = detail::cccl_async_resource_ref<
+  cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+```
+
+**Description**: Reference to a resource that provides both host and device accessible memory.
+
+**Our usage**:
+- `test/cpp/data/test_host_parquet_representation.cpp:484` — Used in parquet representation tests
+
+## Other Type Aliases (Available but Less Used)
+
+| API | Brief Description |
+|-----|-------------------|
+| `device_resource_ref` | Synchronous device resource reference |
+| `host_resource_ref` | Synchronous host resource reference |
+| `host_async_resource_ref` | Async host resource reference |
+| `host_device_resource_ref` | Synchronous host+device resource reference |

--- a/.claude/skills/module-discover/docs/rmm/modules/unused_modules.md
+++ b/.claude/skills/module-discover/docs/rmm/modules/unused_modules.md
@@ -1,0 +1,99 @@
+# Unused RMM Modules
+
+## Arena Memory Resource
+
+**Status**: UNUSED
+**Path**: `rmm/mr/arena_memory_resource.hpp`
+
+Arena-based GPU allocator that pre-allocates large arenas and sub-allocates from them. Uses a different strategy than `pool_memory_resource` — better for workloads with many similar-sized allocations.
+
+**Potential Relevance**: Could be an alternative to the pool MR for Sirius's processing memory if allocation patterns are uniform.
+
+## CUDA Async Memory Resources
+
+**Status**: UNUSED
+**Path**: `rmm/mr/cuda_async_memory_resource.hpp`, `rmm/mr/cuda_async_managed_memory_resource.hpp`, `rmm/mr/cuda_async_view_memory_resource.hpp`
+
+Wrappers around `cudaMallocAsync`/`cudaFreeAsync` (CUDA 11.2+). Leverages CUDA's built-in memory pool with stream-ordered semantics.
+
+**Potential Relevance**: Could simplify memory management if CUDA driver-level pooling is sufficient. May offer better performance than RMM's pool MR on newer drivers.
+
+## Managed Memory Resource
+
+**Status**: UNUSED
+**Path**: `rmm/mr/managed_memory_resource.hpp`, `rmm/mr/sam_headroom_memory_resource.hpp`, `rmm/mr/system_memory_resource.hpp`
+
+Managed (unified) memory resources using `cudaMallocManaged`. Includes System Addressable Memory (SAM) support.
+
+**Potential Relevance**: Not applicable — Sirius explicitly manages GPU/CPU tiers via cuCascade.
+
+## Logging/Statistics/Tracking MR Adaptors
+
+**Status**: UNUSED
+**Path**: `rmm/mr/logging_resource_adaptor.hpp`, `rmm/mr/statistics_resource_adaptor.hpp`, `rmm/mr/tracking_resource_adaptor.hpp`
+
+Wrapper MRs that log allocations, collect statistics, or track outstanding allocations.
+
+- `logging_resource_adaptor` — Logs every allocate/deallocate call
+- `statistics_resource_adaptor` — Tracks peak/current memory usage
+- `tracking_resource_adaptor` — Tracks outstanding allocations for leak detection
+
+**Potential Relevance**: Useful for debugging memory issues. Could wrap the pool MR to diagnose allocation patterns or detect leaks.
+
+## Other Unused MR Adaptors
+
+**Status**: UNUSED
+
+| Resource | Path | Description |
+|----------|------|-------------|
+| `aligned_resource_adaptor` | `rmm/mr/aligned_resource_adaptor.hpp` | Enforces alignment > 256 bytes |
+| `binning_memory_resource` | `rmm/mr/binning_memory_resource.hpp` | Routes allocations to size-specific pools |
+| `callback_memory_resource` | `rmm/mr/callback_memory_resource.hpp` | Delegates to user-provided callbacks |
+| `failure_callback_resource_adaptor` | `rmm/mr/failure_callback_resource_adaptor.hpp` | Calls a callback on allocation failure |
+| `fixed_size_memory_resource` | `rmm/mr/fixed_size_memory_resource.hpp` | Pool for fixed-size allocations |
+| `limiting_resource_adaptor` | `rmm/mr/limiting_resource_adaptor.hpp` | Enforces a maximum allocation limit |
+| `owning_wrapper` | `rmm/mr/owning_wrapper.hpp` | Wraps MR with ownership semantics |
+| `pinned_host_memory_resource` | `rmm/mr/pinned_host_memory_resource.hpp` | Pinned (page-locked) host memory |
+| `prefetch_resource_adaptor` | `rmm/mr/prefetch_resource_adaptor.hpp` | Prefetches managed memory to device |
+| `thread_safe_resource_adaptor` | `rmm/mr/thread_safe_resource_adaptor.hpp` | Adds mutex to non-thread-safe MR |
+| `thrust_allocator_adaptor` | `rmm/mr/thrust_allocator_adaptor.hpp` | Adapts MR for use with Thrust |
+| `polymorphic_allocator` | `rmm/mr/polymorphic_allocator.hpp` | C++ PMR-compatible allocator |
+
+**Potential Relevance**: `failure_callback_resource_adaptor` could be useful for OOM handling; `limiting_resource_adaptor` could enforce per-query memory budgets.
+
+## Prefetch
+
+**Status**: UNUSED
+**Path**: `rmm/prefetch.hpp`
+
+Utility for prefetching managed memory to a specific device.
+
+**Potential Relevance**: Not applicable — Sirius doesn't use managed memory.
+
+## Exec Policy
+
+**Status**: UNUSED
+**Path**: `rmm/exec_policy.hpp`
+
+Thrust execution policy that uses a specified CUDA stream.
+
+**Potential Relevance**: Useful if Sirius needs stream-aware Thrust operations (currently uses cudf's stream-aware APIs).
+
+## Device Scalar / Device Vector
+
+**Status**: UNUSED
+**Path**: `rmm/device_scalar.hpp`, `rmm/device_vector.hpp`
+
+- `device_scalar<T>` — Single value in device memory
+- `device_vector<T>` — Thrust-compatible device vector (initializes elements, unlike `device_uvector`)
+
+**Potential Relevance**: `device_scalar` could be useful for single-value GPU results; `device_vector` is generally superseded by `device_uvector` for performance.
+
+## CUDA Stream Pool
+
+**Status**: UNUSED
+**Path**: `rmm/cuda_stream_pool.hpp`
+
+Pool of reusable CUDA streams.
+
+**Potential Relevance**: Sirius manages its own stream-per-thread model in the GPU thread pool, so this is redundant.

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -26,7 +26,11 @@ This is the complete workflow: profile for GPU analysis, then run without profil
 
 **Step 1: Profiled run** (for GPU analysis data)
 ```bash
+# Profile against parquet files
 bash test/tpch_performance/nsys_report.sh --sf <scale_factor> [query_numbers...]
+
+# Profile against a DuckDB database file (native table scan path)
+bash test/tpch_performance/nsys_report.sh --db-path <path_to.duckdb> [query_numbers...]
 ```
 
 **Step 2: Non-profiled timing run** (for accurate cold/hot times)
@@ -49,6 +53,7 @@ The non-profiled run produces per-query `timings.csv` files with accurate cold/h
 
 **Full options for the profiled run:**
 ```bash
+# Parquet scan profiling
 bash test/tpch_performance/nsys_report.sh \
     --sf <scale_factor> \
     --output-dir ./reports \
@@ -57,7 +62,19 @@ bash test/tpch_performance/nsys_report.sh \
     --query-timeout 120 \
     --compare <baseline_report_dir> \
     [query_numbers...]
+
+# DuckDB native table scan profiling
+bash test/tpch_performance/nsys_report.sh \
+    --db-path <path_to.duckdb> \
+    --output-dir ./reports \
+    --label <custom_name> \
+    --iterations 4 \
+    --query-timeout 120 \
+    --compare <baseline_report_dir> \
+    [query_numbers...]
 ```
+
+The `--db-path` option uses `profile_tpch_nsys_duckdb_native.sh` to profile against native DuckDB tables instead of parquet views. This exercises the `duckdb_scan_task` scan path rather than the `parquet_scan_task` path.
 
 **Output directory structure (profiled):**
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,47 @@ export SIRIUS_LOG_LEVEL=debug            # Levels: trace, debug, info, warn, err
 
 ## Development Guidelines
 
-Unsupported operations (data types, operators, row counts exceeding cuDF limits) fall back to DuckDB CPU execution via `src/fallback.cpp`.
+### Loading Library Context for Implementation Tasks
+
+**Before implementing new features, operators, or significant bug fixes**, always run `/module-context <task description>` first. This loads the relevant API documentation for cudf, rmm, duckdb, cucascade, and libkvikio modules so you have accurate function signatures, parameter types, and existing usage patterns. The module docs live in `.claude/skills/module-discover/docs/` and contain detailed API references extracted from the actual library headers.
+
+This is especially important for tasks involving:
+- GPU operators (joins, aggregations, sorting, filters, projections)
+- Memory management (reservations, pools, streams, spilling)
+- Data I/O (parquet scanning, datasources)
+- Expression evaluation (AST, unary/binary ops, type casting)
+- Pipeline execution (tasks, executors, data batches)
+
+### Fallback Strategy
+
+Sirius gracefully falls back to DuckDB CPU execution when:
+- Data size exceeds GPU memory regions (caching or processing)
+- Unsupported data types (nested types, some temporal types)
+- Unsupported operators (window functions, ASOF JOIN, etc.)
+- libcudf row count limitations (~2B rows due to int32_t row IDs)
+
+The fallback mechanism is implemented in `src/fallback.cpp` and integrates with DuckDB's execution engine.
+
+### Supported Features
+
+**Data types:** INTEGER, BIGINT, FLOAT, DOUBLE, VARCHAR, DATE, TIMESTAMP, DECIMAL
+**Operators:** FILTER, PROJECTION, JOIN (Hash/Nested Loop/Delim), GROUP BY, ORDER BY, AGGREGATION, TOP-N, LIMIT, CTE, TABLE SCAN
+**Join types:** INNER, LEFT, RIGHT, OUTER (implemented via cudf::left_join, cudf::inner_join, etc.)
+
+### Code Organization
+
+- GPU kernels (`.cu` files) are in `src/cuda/` and subdirectories
+- CPU-side logic (`.cpp` files) coordinates GPU execution
+- Header files (`.hpp`) in `src/include/` mirror source structure
+- Each operator has both a DuckDB-facing interface (`operator/`) and cuDF implementation (`cuda/operator/`)
+
+### Adding New Operators
+
+1. Create header in `src/include/operator/gpu_physical_<operator>.hpp`
+2. Implement DuckDB integration in `src/operator/gpu_physical_<operator>.cpp`
+3. Add cuDF/CUDA implementation in `src/cuda/operator/<operator>.cu`
+4. Register in physical plan generator (`src/gpu_physical_plan_generator.cpp`)
+5. Add tests in `test/cpp/operator/` and `test/sql/`
 
 ### CMake Notes
 
@@ -189,6 +229,8 @@ Sirius includes Claude Code skills for performance analysis and dataset manageme
 | Dataset Manager | `/dataset-manager` | Manages TPC-H parquet datasets — generate at any scale factor, consolidate files, inspect layout, optimize row groups. |
 | Optimization Advisor | `/optimization-advisor` | Maps GPU hotspots from nsys profiles to source functions, detects efficiency bottlenecks, sync overhead, and parallelism opportunities. |
 | TPC-DS Benchmark | `/tpcds-benchmark` | Runs TPC-DS benchmarks on Legacy Sirius, Super Sirius, or DuckDB CPU baseline — generate data, execute queries, and compare results. |
+| Module Context | `/module-context` | **Auto-loaded before implementation tasks.** Identifies which dependency modules are relevant to a task and loads their API docs (signatures, descriptions, usage examples). |
+| Module Discover | `/module-discover` | Analyzes a dependency library, divides it into modules, and generates LLM-consumable API documentation. Run once per library to populate docs. |
 
 **Useful debugging tools:**
 - `tools/parse_pipeline_log.py`: Parses Sirius pipeline logs to show per-operator row counts for debugging incorrect query results.


### PR DESCRIPTION
## Summary                                                                                                                                
                                                                                                                                            
  - Adds `module-context` and `module-discover` skills for loading dependency API documentation (cudf, rmm, duckdb, cucascade, libkvikio)   
  into Claude Code context before implementation tasks                                                                                      
  - Adds `profile-analyzer` skill for general-purpose nsys GPU performance analysis                                                         
  - Updates CLAUDE.md development guidelines with `/module-context` usage instructions                                                      
  - Minor `bisect` skill tweak                                                                                                              
                                                                                                                                            
  Cherry-picked from `improvement/duckdbscan` (commits e218585, 4956e86) — these are the non-scan-related skill additions from that branch. 
                                                                                                                                            
  ## Test plan                                                                                                                              
                                                                                                                                            
  - [x] Verify skill files are properly formatted with frontmatter                                                                       
  - [ ] Verify `/module-context`, `/module-discover`, and `/profile-analyzer` are recognized by Claude Code