### PR TITLE
Refactor operator_data into generic base with pipelineable_operator_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ cufile.log
 # Generated nightly environment
 envs/
 compile_commands.json
+.cache
 
 # Zed editor settings
 .zed

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -371,7 +371,10 @@ void task_creator::manager_loop()
             pipeline->mark_task_created();
 
             auto input_data = node->get_next_task_input_data();
-            if (!input_data || input_data->get_data_batches().empty()) {
+            auto* pipelineable_input =
+              dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
+            if (!input_data ||
+                (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
               // No data was available (e.g., another thread already consumed it).
               // Balance the counter. mark_task_completed() calls update_pipeline_status()
               // which is correct: if all ports are truly empty and all real tasks have

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -105,6 +105,15 @@ class pipelineable_operator_data : public operator_data {
   }
 
   /**
+   * @brief Move the data batches out of this container, leaving it empty.
+   * @return Vector of data batch pointers (moved out).
+   */
+  std::vector<std::shared_ptr<::cucascade::data_batch>> release_data_batches()
+  {
+    return std::move(_data_batches);
+  }
+
+  /**
    * @brief Lock all data batches for processing in the requested memory space.
    *
    * Iterates over all batches and locks (or converts then locks) each one into the

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -62,23 +62,40 @@ struct task_creation_hint {
 };
 
 /**
- * @brief Container for operator data batches.
+ * @brief Generic base class for operator input/output data.
  *
- * Wraps a collection of data batches that can be passed between operators.
+ * This is an intentionally minimal base class with no opinion on what the
+ * data should be. Derived classes define the concrete data representation.
  */
 class operator_data {
  public:
-  operator_data() = default;
-  explicit operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>> data_batches)
+  operator_data()          = default;
+  virtual ~operator_data() = default;
+
+  operator_data(const operator_data&)            = default;
+  operator_data& operator=(const operator_data&) = default;
+  operator_data(operator_data&&)                 = default;
+  operator_data& operator=(operator_data&&)      = default;
+};
+
+/**
+ * @brief Operator data carrying a collection of data batches for pipeline execution.
+ *
+ * This is the standard data container used by pipeline operators. It wraps a
+ * vector of data batches that flow between operators in a pipeline.
+ */
+class pipelineable_operator_data : public operator_data {
+ public:
+  pipelineable_operator_data() = default;
+  explicit pipelineable_operator_data(
+    std::vector<std::shared_ptr<::cucascade::data_batch>> data_batches)
     : _data_batches(std::move(data_batches))
   {
   }
 
-  virtual ~operator_data() = default;
-
   /**
-   * @brief Get mutable data batches.
-   * @return Mutable reference to vector of data batch pointers
+   * @brief Get the data batches.
+   * @return Const reference to vector of data batch pointers
    */
   [[nodiscard]] const std::vector<std::shared_ptr<::cucascade::data_batch>>& get_data_batches()
     const
@@ -91,16 +108,17 @@ class operator_data {
 };
 
 /**
- * @brief Container for partitioned operator data.
+ * @brief Operator data with partition index for partitioned pipeline execution.
  *
- * Extends operator_data to include partition index information.
+ * Extends pipelineable_operator_data to include partition index information,
+ * used by partition-aware operators (partition, concat, etc.).
  */
-class partitioned_operator_data : public operator_data {
+class partitioned_operator_data : public pipelineable_operator_data {
  public:
   partitioned_operator_data() = default;
   partitioned_operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>> data_batches,
                             std::size_t partition_idx)
-    : operator_data(std::move(data_batches)), _partition_idx(partition_idx)
+    : pipelineable_operator_data(std::move(data_batches)), _partition_idx(partition_idx)
   {
   }
 

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 namespace sirius {
 
@@ -102,6 +103,25 @@ class pipelineable_operator_data : public operator_data {
   {
     return _data_batches;
   }
+
+  /**
+   * @brief Lock all data batches for processing in the requested memory space.
+   *
+   * Iterates over all batches and locks (or converts then locks) each one into the
+   * requested memory space. Returns the processing handles that keep the batches locked
+   * until they go out of scope.
+   *
+   * Returns std::nullopt if any batch fails to lock (triggers a retry/reschedule).
+   * Propagates rmm::out_of_memory so the caller can record metrics and reschedule.
+   *
+   * @param requested_memory_space  Target memory space; may be nullptr to use each batch's
+   *                                current space.
+   * @param stream                  CUDA stream used for any data-movement kernels.
+   * @return Processing handles for all batches, or std::nullopt on lock failure.
+   */
+  virtual std::optional<std::vector<::cucascade::data_batch_processing_handle>>
+  prepare_for_processing(const ::cucascade::memory::memory_space* requested_memory_space,
+                         rmm::cuda_stream_view stream);
 
  private:
   std::vector<std::shared_ptr<::cucascade::data_batch>> _data_batches;

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -69,7 +69,7 @@ inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_ba
   while (!lock_result.success && lock_result.status == status::memory_space_mismatch) {
     try {
       auto& registry = sirius::converter_registry::get();
-      switch (requested_memory_space->get_tier()) {
+      switch (target_space->get_tier()) {
         case cucascade::memory::Tier::GPU: {
           auto prev_state = batch->get_state();
           if (!batch->try_to_lock_for_in_transit()) {
@@ -84,8 +84,7 @@ inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_ba
             return std::nullopt;
           }
           try {
-            batch->convert_to<cucascade::gpu_table_representation>(
-              registry, requested_memory_space, stream);
+            batch->convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
           } catch (...) {
             batch->try_to_release_in_transit();
             throw;
@@ -100,8 +99,7 @@ inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_ba
             return std::nullopt;
           }
           try {
-            batch->convert_to<cucascade::host_data_representation>(
-              registry, requested_memory_space, stream);
+            batch->convert_to<cucascade::host_data_representation>(registry, target_space, stream);
           } catch (...) {
             batch->try_to_release_in_transit();
             throw;
@@ -112,7 +110,7 @@ inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_ba
         default: cancel_task_if_needed(); return std::nullopt;
       }
 
-      lock_result = batch->try_to_lock_for_processing(requested_memory_space->get_id());
+      lock_result = batch->try_to_lock_for_processing(target_space->get_id());
     } catch (...) {
       throw;
     }

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "log/logging.hpp"
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <data/sirius_converter_registry.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace sirius {
+namespace pipeline {
+
+/**
+ * @brief Lock or prepare a single data batch for processing in the requested memory space.
+ *
+ * If the batch is already in the requested memory space it is locked in place. If it resides
+ * elsewhere the batch is first converted (moved) to the requested space and then locked.
+ *
+ * @param batch                   The batch to lock/prepare.
+ * @param requested_memory_space  Target memory space; may be nullptr to use the batch's current
+ *                                space.
+ * @param stream                  CUDA stream used for any data-movement kernels.
+ * @return A processing handle that keeps the batch locked, or std::nullopt on failure.
+ * @throws rmm::out_of_memory  If a GPU memory allocation fails during the conversion.
+ */
+inline std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
+  const std::shared_ptr<cucascade::data_batch>& batch,
+  const cucascade::memory::memory_space* requested_memory_space,
+  rmm::cuda_stream_view stream)
+{
+  using status = cucascade::lock_for_processing_status;
+  const auto* target_space =
+    requested_memory_space != nullptr ? requested_memory_space : batch->get_memory_space();
+  if (target_space == nullptr) { return std::nullopt; }
+
+  // NOTE: only works in single gpu setup
+  // wait for processing in case a shared batch is in transit in another thread.
+  auto lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
+
+  auto cancel_task_if_needed = []() {
+    SIRIUS_LOG_ERROR(
+      "gpu_pipeline_task: failed to lock batch for processing and cannot prepare batch for "
+      "processing. This likely means the batch is in transit and there is a bug in "
+      "the in-transit locking logic. Cancelling task to avoid deadlock.");
+  };
+
+  while (!lock_result.success && lock_result.status == status::memory_space_mismatch) {
+    try {
+      auto& registry = sirius::converter_registry::get();
+      switch (requested_memory_space->get_tier()) {
+        case cucascade::memory::Tier::GPU: {
+          auto prev_state = batch->get_state();
+          if (!batch->try_to_lock_for_in_transit()) {
+            auto current_state = batch->get_state();
+            if (current_state == cucascade::batch_state::in_transit) {
+              // If another thread has taken the in_transit lock, wait to acquire the processing
+              // lock.
+              lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
+              continue;
+            }
+            cancel_task_if_needed();
+            return std::nullopt;
+          }
+          try {
+            batch->convert_to<cucascade::gpu_table_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
+          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
+          break;
+        }
+        case cucascade::memory::Tier::HOST: {
+          auto prev_state = batch->get_state();
+          if (!batch->try_to_lock_for_in_transit()) {
+            cancel_task_if_needed();
+            return std::nullopt;
+          }
+          try {
+            batch->convert_to<cucascade::host_data_representation>(
+              registry, requested_memory_space, stream);
+          } catch (...) {
+            batch->try_to_release_in_transit();
+            throw;
+          }
+          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
+          break;
+        }
+        default: cancel_task_if_needed(); return std::nullopt;
+      }
+
+      lock_result = batch->try_to_lock_for_processing(requested_memory_space->get_id());
+    } catch (...) {
+      throw;
+    }
+  }
+
+  if (!lock_result.success) {
+    cancel_task_if_needed();
+    return std::nullopt;
+  }
+
+  return std::move(lock_result.handle);
+}
+
+}  // namespace pipeline
+}  // namespace sirius

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -97,8 +97,10 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
   {
     if (_estimation_basis) { return *_estimation_basis; }
     std::size_t input_size = 0;
-    if (_input_data) {
-      for (const auto& batch : _input_data->get_data_batches()) {
+    auto* pipelineable_input =
+      dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
+    if (pipelineable_input) {
+      for (const auto& batch : pipelineable_input->get_data_batches()) {
         if (batch && batch->get_data()) {
           input_size += batch->get_data()->get_uncompressed_data_size_in_bytes();
         }
@@ -111,8 +113,10 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
   [[nodiscard]] std::size_t get_estimated_bytes_to_materialize_input() const
   {
     std::size_t input_size = 0;
-    if (_input_data) {
-      for (const auto& batch : _input_data->get_data_batches()) {
+    auto* pipelineable_input =
+      dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
+    if (pipelineable_input) {
+      for (const auto& batch : pipelineable_input->get_data_batches()) {
         if (batch && batch->get_data() &&
             batch->get_data()->get_current_tier() != cucascade::memory::Tier::GPU) {
           input_size += batch->get_data()->get_uncompressed_data_size_in_bytes();

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -191,10 +191,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
         throw std::runtime_error("Scan results for query not cached");
       }
       auto batches = entry->batches[entry->batch_index++];
-      return std::make_unique<op::operator_data>(clone_batches(std::move(batches), stream));
+      return std::make_unique<op::pipelineable_operator_data>(
+        clone_batches(std::move(batches), stream));
     } else {
-      auto scan_output = task->compute_task(stream);
-      entry->batches.push_back(clone_batches(scan_output->get_data_batches(), stream));
+      auto scan_output               = task->compute_task(stream);
+      auto& pipelineable_scan_output = dynamic_cast<op::pipelineable_operator_data&>(*scan_output);
+      entry->batches.push_back(clone_batches(pipelineable_scan_output.get_data_batches(), stream));
       return scan_output;
     }
   }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -613,10 +613,9 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
 
 void duckdb_scan_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
 {
-  const auto& pipelineable_output =
-    dynamic_cast<const op::pipelineable_operator_data&>(output_data);
-  for (const auto& batch : pipelineable_output.get_data_batches()) {
-    _data_repo->add_data_batch(batch);
+  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
+  for (auto& batch : pipelineable_output.release_data_batches()) {
+    _data_repo->add_data_batch(std::move(batch));
   }
 }
 

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -613,10 +613,11 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
 
 void duckdb_scan_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
 {
-  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
-  std::for_each(std::make_move_iterator(pipelineable_output.get_data_batches().begin()),
-                std::make_move_iterator(pipelineable_output.get_data_batches().end()),
-                [this](auto batch) { this->_data_repo->add_data_batch(std::move(batch)); });
+  const auto& pipelineable_output =
+    dynamic_cast<const op::pipelineable_operator_data&>(output_data);
+  for (const auto& batch : pipelineable_output.get_data_batches()) {
+    _data_repo->add_data_batch(batch);
+  }
 }
 
 std::size_t duckdb_scan_task::get_estimated_reservation_size() const

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -536,8 +536,9 @@ void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
   // Record memory metrics for future reservation estimates.
   // Scan tasks don't have peak memory tracking, so use output size as proxy.
   if (auto output_data = compute_task(stream); output_data) {
-    std::size_t output_bytes = 0;
-    for (const auto& batch : output_data->get_data_batches()) {
+    auto& pipelineable_output_data = dynamic_cast<op::pipelineable_operator_data&>(*output_data);
+    std::size_t output_bytes       = 0;
+    for (const auto& batch : pipelineable_output_data.get_data_batches()) {
       if (batch && batch->get_data()) { output_bytes += batch->get_data()->get_size_in_bytes(); }
     }
     auto& g_state = _global_state->cast<duckdb_scan_task_global_state>();
@@ -602,17 +603,19 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
 
   // Make data batch and push to repository
   if (l_state._row_offset > 0) {
-    return std::make_unique<op::operator_data>(
+    return std::make_unique<op::pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{l_state.make_data_batch()});
   }
 
-  return std::make_unique<op::operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+  return std::make_unique<op::pipelineable_operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{});
 }
 
 void duckdb_scan_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
 {
-  std::for_each(std::make_move_iterator(output_data.get_data_batches().begin()),
-                std::make_move_iterator(output_data.get_data_batches().end()),
+  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
+  std::for_each(std::make_move_iterator(pipelineable_output.get_data_batches().begin()),
+                std::make_move_iterator(pipelineable_output.get_data_batches().end()),
                 [this](auto batch) { this->_data_repo->add_data_batch(std::move(batch)); });
 }
 

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -614,9 +614,10 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
 void parquet_scan_task::publish_output(op::operator_data& output_data,
                                        rmm::cuda_stream_view /* stream */)
 {
-  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
-  for (auto& batch : pipelineable_output.get_data_batches()) {
-    _data_repo->add_data_batch(std::move(batch));
+  const auto& pipelineable_output =
+    dynamic_cast<const op::pipelineable_operator_data&>(output_data);
+  for (const auto& batch : pipelineable_output.get_data_batches()) {
+    _data_repo->add_data_batch(batch);
   }
 }
 

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -468,8 +468,9 @@ void parquet_scan_task::execute(rmm::cuda_stream_view stream)
   // Record memory metrics for future reservation estimates.
   // Parquet scan tasks don't have peak memory tracking, so use output size as proxy.
   if (auto output_data = compute_task(stream); output_data) {
-    std::size_t output_bytes = 0;
-    for (const auto& batch : output_data->get_data_batches()) {
+    auto& pipelineable_output_data = dynamic_cast<op::pipelineable_operator_data&>(*output_data);
+    std::size_t output_bytes       = 0;
+    for (const auto& batch : pipelineable_output_data.get_data_batches()) {
       if (batch && batch->get_data()) { output_bytes += batch->get_data()->get_size_in_bytes(); }
     }
     auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
@@ -592,7 +593,7 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
                                                       std::move(parquet_representation));
     }
   }
-  auto result = std::make_unique<op::operator_data>(
+  auto result = std::make_unique<op::pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(batch)});
 
   auto const task_end = std::chrono::high_resolution_clock::now();
@@ -613,7 +614,8 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
 void parquet_scan_task::publish_output(op::operator_data& output_data,
                                        rmm::cuda_stream_view /* stream */)
 {
-  for (auto& batch : output_data.get_data_batches()) {
+  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
+  for (auto& batch : pipelineable_output.get_data_batches()) {
     _data_repo->add_data_batch(std::move(batch));
   }
 }

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -614,10 +614,9 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
 void parquet_scan_task::publish_output(op::operator_data& output_data,
                                        rmm::cuda_stream_view /* stream */)
 {
-  const auto& pipelineable_output =
-    dynamic_cast<const op::pipelineable_operator_data&>(output_data);
-  for (const auto& batch : pipelineable_output.get_data_batches()) {
-    _data_repo->add_data_batch(batch);
+  auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
+  for (auto& batch : pipelineable_output.release_data_batches()) {
+    _data_repo->add_data_batch(std::move(batch));
   }
 }
 

--- a/src/op/sirius_physical_column_data_scan.cpp
+++ b/src/op/sirius_physical_column_data_scan.cpp
@@ -104,7 +104,8 @@ std::unique_ptr<operator_data> sirius_physical_column_data_scan::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_column_data_scan::execute"};
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_data_batches());
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_cte.cpp
+++ b/src/op/sirius_physical_cte.cpp
@@ -78,7 +78,8 @@ std::unique_ptr<operator_data> sirius_physical_cte::execute(const operator_data&
                                                             rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_cte::execute"};
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_data_batches());
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -155,7 +155,8 @@ std::unique_ptr<operator_data> sirius_physical_right_delim_join::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_right_delim_join::execute"};
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_data_batches());
 }
 
 void sirius_physical_right_delim_join::sink(const operator_data& input_data,
@@ -183,7 +184,8 @@ std::unique_ptr<operator_data> sirius_physical_left_delim_join::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_left_delim_join::execute"};
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_data_batches());
 }
 
 void sirius_physical_left_delim_join::sink(const operator_data& input_data,

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -50,7 +50,8 @@ std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_da
                                                                rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_filter::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   // The executor uses the data_batch API to filter rows according to `expression`.
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*expression.get());
@@ -63,7 +64,7 @@ std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_da
     auto filtered_batch = gpu_expression_executor.select(batch, stream);
     if (filtered_batch) { output_batches.push_back(std::move(filtered_batch)); }
   }
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -170,7 +170,8 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_grouped_aggregate::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   std::vector<std::shared_ptr<::cucascade::data_batch>> results;
   for (auto& input_batch : input_batches) {
     auto result = gpu_aggregate_impl::local_grouped_aggregate(input_batch,
@@ -182,7 +183,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
                                                               *input_batch->get_memory_space());
     results.push_back(std::move(result));
   }
-  return std::make_unique<operator_data>(results);
+  return std::make_unique<pipelineable_operator_data>(results);
 }
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -184,7 +184,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::get_next
     }
     current_partition_index++;
     if (input_batch.empty()) { return nullptr; }
-    return std::make_unique<operator_data>(input_batch);
+    return std::make_unique<pipelineable_operator_data>(input_batch);
   } else {
     return nullptr;
   }
@@ -194,7 +194,8 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_grouped_aggregate_merge::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (input_batches.size() == 0) {
     throw std::runtime_error(
       "We expect at least one input batch for grouped aggregate merge operator");
@@ -202,7 +203,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 
   // Fast path: single batch with no post-processing needed
   if (input_batches.size() == 1 && !has_avg && !has_count_distinct) {
-    return std::make_unique<operator_data>(input_data);
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
   // Merge multiple batches, or use single batch directly if only one
@@ -219,7 +220,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 
   // If no post-processing needed, return merged result directly
   if (!has_avg && !has_count_distinct) {
-    return std::make_unique<operator_data>(
+    return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<::cucascade::data_batch>>{merged});
   }
 
@@ -287,7 +288,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 
   auto output_table = std::make_unique<cudf::table>(std::move(output_cols), stream, mr);
   auto result       = sirius::make_data_batch(std::move(output_table), *space);
-  return std::make_unique<operator_data>(
+  return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{result});
 }
 }  // namespace op

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -474,7 +474,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
     input_batch.push_back(std::move(probe_batch));
     input_batch.push_back(std::move(build_batch));
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::SCHEDULED;
-    return std::make_unique<operator_data>(input_batch);
+    return std::make_unique<pipelineable_operator_data>(input_batch);
 
   } else if (_hash_table_build_state == BUILD_HASH_TABLE_STATE::BUILT) {
     if (probe_port->repo->num_partitions() != 1) {
@@ -495,7 +495,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
         "batch from the default port but got none in operator " +
         std::to_string(this->get_operator_id()));
     }
-    return std::make_unique<operator_data>(input_batch);
+    return std::make_unique<pipelineable_operator_data>(input_batch);
   } else {
     SIRIUS_LOG_WARN(fmt::format(
       "In sirius_physical_hash_join:get_next_task_input_data_for_build_probe: invalid hash table "
@@ -564,7 +564,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::get_next_task_input_da
             input_batch.push_back(ports["build"]->repo->get_data_batch_by_id(
               right_batch_id, cucascade::batch_state::task_created, partition_idx));
           }
-          return std::make_unique<operator_data>(input_batch);
+          return std::make_unique<pipelineable_operator_data>(input_batch);
         }
         right_counter++;
         counter++;
@@ -697,8 +697,9 @@ static std::unique_ptr<operator_data> gather_join_output(
   }
 
   auto output_cudf_table = std::make_unique<cudf::table>(std::move(out_cols), stream);
-  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-    make_data_batch(std::move(output_cudf_table), memory_space)});
+  return std::make_unique<pipelineable_operator_data>(
+    std::vector<std::shared_ptr<::cucascade::data_batch>>{
+      make_data_batch(std::move(output_cudf_table), memory_space)});
 }
 
 /// @brief the MARK join output from the semi_join matching row indices.
@@ -757,15 +758,17 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
 
   mark_out_cols.push_back(std::move(mark_column));
   auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
-  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{
-    make_data_batch(std::move(output_cudf_table), *left_batch->get_memory_space())});
+  return std::make_unique<pipelineable_operator_data>(
+    std::vector<std::shared_ptr<::cucascade::data_batch>>{
+      make_data_batch(std::move(output_cudf_table), *left_batch->get_memory_space())});
 }
 
 std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator_data& input_data,
                                                                   rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_hash_join::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   if (is_all_inequality_join) {
     throw std::runtime_error(

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -68,7 +68,8 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_streaming_limit::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   if (limit_val.Type() != duckdb::LimitNodeType::CONSTANT_VALUE) {
     throw duckdb::NotImplementedException("Streaming limit with non-constant limit value");
@@ -123,7 +124,7 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
     _limit_exhausted.store(true, std::memory_order_release);
   }
 
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::get_next_task_input_d
                      all_batches.size(),
                      _current_partition_index - 1);
     if (all_batches.empty()) { return nullptr; }
-    return std::make_unique<operator_data>(all_batches);
+    return std::make_unique<pipelineable_operator_data>(all_batches);
   }
   return nullptr;
 }
@@ -80,7 +80,8 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_merge_sort::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   // Collect valid batches and find memory space
   std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
@@ -92,7 +93,8 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
   }
 
   if (valid_batches.empty() || !space) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   // Helper lambda to apply final projection to a batch (removes sort-key-only columns)
@@ -114,7 +116,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
   if (valid_batches.size() == 1) {
     std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
     outputs.push_back(apply_final_projection(valid_batches[0]));
-    return std::make_unique<operator_data>(outputs);
+    return std::make_unique<pipelineable_operator_data>(outputs);
   }
 
   // Build cudf order vectors from BoundOrderByNode
@@ -143,7 +145,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
 
   std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
   if (merged_batch) { outputs.push_back(apply_final_projection(std::move(merged_batch))); }
-  return std::make_unique<operator_data>(outputs);
+  return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -323,7 +323,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::get_next_task_i
             input_batch.push_back(build_port->repo->get_data_batch_by_id(
               right_batch_id, cucascade::batch_state::task_created, partition_idx));
           }
-          return std::make_unique<operator_data>(input_batch);
+          return std::make_unique<pipelineable_operator_data>(input_batch);
         }
         right_counter++;
         counter++;
@@ -384,7 +384,8 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_nested_loop_join::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   size_t pipeline_id = (this->get_pipeline() != nullptr) ? this->get_pipeline()->get_pipeline_id()
                                                          : static_cast<size_t>(-1);
   SIRIUS_LOG_DEBUG(
@@ -401,7 +402,8 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
 
   if (!left_batch || !right_batch) {
     SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 0 output batches", pipeline_id);
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   cudf::table_view left  = get_cudf_table_view(*left_batch);
@@ -412,7 +414,8 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     SIRIUS_LOG_DEBUG(
       "Pipeline {}: nested loop join, 0 output batches because left batch had no memory space",
       pipeline_id);
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto mr = space->get_default_allocator();
@@ -432,8 +435,9 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     }
     auto empty_table = std::make_unique<cudf::table>(std::move(empty_cols), stream, mr);
     SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 empty output batches", pipeline_id);
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{
-      make_data_batch(std::move(empty_table), *space)});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{
+        make_data_batch(std::move(empty_table), *space)});
   }
 
   std::unique_ptr<cudf::table> result_table;
@@ -592,8 +596,9 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         auto gathered =
           cudf::gather(left, left_map, cudf::out_of_bounds_policy::NULLIFY, stream, mr);
         SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 output batches", pipeline_id);
-        return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{
-          make_data_batch(std::move(gathered), *space)});
+        return std::make_unique<pipelineable_operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{
+            make_data_batch(std::move(gathered), *space)});
       }
       case duckdb::JoinType::ANTI: {
         auto left_indices = cudf::conditional_left_anti_join(
@@ -608,8 +613,9 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
         auto gathered =
           cudf::gather(left, left_map, cudf::out_of_bounds_policy::NULLIFY, stream, mr);
         SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 output batches", pipeline_id);
-        return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{
-          make_data_batch(std::move(gathered), *space)});
+        return std::make_unique<pipelineable_operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>{
+            make_data_batch(std::move(gathered), *space)});
       }
       case duckdb::JoinType::OUTER:
         join_result =
@@ -663,8 +669,9 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
   }
 
   SIRIUS_LOG_DEBUG("Pipeline {}: nested loop join, 1 output batches", pipeline_id);
-  return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{
-    make_data_batch(std::move(result_table), *space)});
+  return std::make_unique<pipelineable_operator_data>(
+    std::vector<std::shared_ptr<cucascade::data_batch>>{
+      make_data_batch(std::move(result_table), *space)});
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -17,15 +17,55 @@
 #include "op/sirius_physical_operator.hpp"
 
 #include "gpu_executor.hpp"
+#include "log/logging.hpp"
+#include "pipeline/batch_lock_utils.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/memory/error.hpp>
 
 #include <optional>
 
 namespace sirius {
 namespace op {
+
+//===--------------------------------------------------------------------===//
+// pipelineable_operator_data
+//===--------------------------------------------------------------------===//
+
+std::optional<std::vector<::cucascade::data_batch_processing_handle>>
+pipelineable_operator_data::prepare_for_processing(
+  const ::cucascade::memory::memory_space* requested_memory_space, rmm::cuda_stream_view stream)
+{
+  std::vector<::cucascade::data_batch_processing_handle> handles;
+  handles.reserve(_data_batches.size());
+
+  for (const auto& batch : _data_batches) {
+    std::optional<::cucascade::data_batch_processing_handle> handle;
+    try {
+      handle = pipeline::lock_or_prepare_batch(batch, requested_memory_space, stream);
+    } catch (const rmm::out_of_memory&) {
+      SIRIUS_LOG_ERROR(
+        "pipelineable_operator_data: OOM at batch {} preparing for processing, state: {}",
+        batch->get_batch_id(),
+        static_cast<int>(batch->get_state()));
+      throw;
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_ERROR(
+        "pipelineable_operator_data: Unknown error at batch {} preparing for processing, "
+        "state: {}: {}",
+        batch->get_batch_id(),
+        static_cast<int>(batch->get_state()),
+        e.what());
+      throw;
+    }
+    if (!handle) { return std::nullopt; }
+    handles.emplace_back(std::move(*handle));
+  }
+
+  return handles;
+}
 
 //===--------------------------------------------------------------------===//
 // Operator

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -42,6 +42,10 @@ pipelineable_operator_data::prepare_for_processing(
   handles.reserve(_data_batches.size());
 
   for (const auto& batch : _data_batches) {
+    if (!batch) {
+      SIRIUS_LOG_ERROR("pipelineable_operator_data: null batch encountered, skipping");
+      return std::nullopt;
+    }
     std::optional<::cucascade::data_batch_processing_handle> handle;
     try {
       handle = pipeline::lock_or_prepare_batch(batch, requested_memory_space, stream);

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -192,7 +192,8 @@ sirius_physical_operator::port* sirius_physical_operator::get_port(std::string_v
 
 void sirius_physical_operator::sink(const operator_data& output_data, rmm::cuda_stream_view stream)
 {
-  for (auto& batch : output_data.get_data_batches()) {
+  auto& pipelineable_output = dynamic_cast<const pipelineable_operator_data&>(output_data);
+  for (auto& batch : pipelineable_output.get_data_batches()) {
     for (auto& next_port_info : next_port_after_sink) {
       next_port_info.next_operator->push_data_batch(next_port_info.next_operator_port_name, batch);
     }
@@ -203,7 +204,8 @@ std::unique_ptr<operator_data> sirius_physical_operator::execute(const operator_
                                                                  rmm::cuda_stream_view stream)
 {
   // not doing anything for now
-  return std::make_unique<operator_data>(std::vector<std::shared_ptr<::cucascade::data_batch>>{});
+  return std::make_unique<pipelineable_operator_data>(
+    std::vector<std::shared_ptr<::cucascade::data_batch>>{});
 }
 
 void sirius_physical_operator::push_data_batch(std::string_view port_id,
@@ -276,7 +278,7 @@ std::unique_ptr<operator_data> sirius_physical_operator::get_next_task_input_dat
     if (batch_and_handle) { input_batch.push_back(std::move(batch_and_handle)); }
   }
   if (input_batch.empty()) { return nullptr; }
-  return std::make_unique<operator_data>(input_batch);
+  return std::make_unique<pipelineable_operator_data>(input_batch);
 }
 
 bool sirius_physical_operator::all_ports_empty()

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -41,7 +41,8 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
                                                               rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_order::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   // Build cudf order vectors from BoundOrderByNode
   std::vector<int> order_key_idx;
@@ -79,7 +80,7 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
     if (sorted_batch) { output_batches.push_back(std::move(sorted_batch)); }
   }
 
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -153,7 +153,8 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
                                                                   rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_partition::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (input_batches.size() != 1) {
     throw std::runtime_error("We expect only one input batch for partition operator " +
                              std::to_string(this->get_operator_id()));
@@ -163,7 +164,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
                              std::to_string(this->get_operator_id()));
   }
   if (_num_partitions.value() < 2 || _partition_keys.empty()) {
-    return std::make_unique<operator_data>(input_data);
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
   auto input_batch = input_batches[0];
@@ -190,13 +191,14 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
       throw std::runtime_error("Unsupported partition type: " +
                                partition_type_to_string(_partition_type));
   }
-  return std::make_unique<operator_data>(partitioned_results);
+  return std::make_unique<pipelineable_operator_data>(partitioned_results);
 }
 
 void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_partition::sink"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& pipelineable_input  = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = pipelineable_input.get_data_batches();
   (void)stream;  // sink does not use stream for push_data_batch_partitioned
   int partition_id = 0;
   for (auto& batch : input_batches) {

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -37,7 +37,8 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_projection::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(select_list);
 
@@ -49,7 +50,7 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
     auto projected_batch = gpu_expression_executor.execute(batch, stream);
     if (projected_batch) { output_batches.push_back(std::move(projected_batch)); }
   }
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -59,7 +59,8 @@ std::unique_ptr<operator_data> sirius_physical_result_collector::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_result_collector::execute"};
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(
+    dynamic_cast<const pipelineable_operator_data&>(input_data).get_data_batches());
 }
 
 duckdb::vector<duckdb::const_reference<sirius_physical_operator>>
@@ -114,7 +115,8 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
                                                   rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_materialized_collector::sink"};
-  const auto& input_batches     = input_data.get_data_batches();
+  auto& pipelineable_input      = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches     = pipelineable_input.get_data_batches();
   using host_table_chunk_reader = ::sirius::op::result::host_table_chunk_reader;
 
   if (input_batches.empty()) {

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -53,14 +53,15 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_sort_partition::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   // If no sample operator or only 1 partition, pass through
   if (!_sample_op || !_sample_op->boundaries_computed() || _sample_op->get_num_partitions() <= 1) {
     SIRIUS_LOG_DEBUG("Sort partition: passthrough ({} batches, {} partitions)",
                      input_batches.size(),
                      _sample_op ? _sample_op->get_num_partitions() : 1);
-    return std::make_unique<operator_data>(input_data);
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
   auto start           = std::chrono::high_resolution_clock::now();
@@ -161,7 +162,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
     num_parts,
     duration.count() / 1000.0);
 
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 void sirius_physical_sort_partition::finalize_operator()

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -78,12 +78,13 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                                                                     rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_sort_sample::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
 
   // After boundaries are computed, just pass through
   if (_boundaries_computed.load()) {
     SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
-    return std::make_unique<operator_data>(input_data);
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
   SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches",
@@ -101,7 +102,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
 
   if (valid_batches.empty() || !space) {
     _boundaries_computed.store(true);
-    return std::make_unique<operator_data>(input_data);
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
   // 2. Concatenate all sample batches into one table
@@ -248,7 +249,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                    _partition_boundaries ? _partition_boundaries->num_rows() : 0,
                    duration.count() / 1000.0);
 
-  return std::make_unique<operator_data>(input_data);
+  return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   // parquet_scan_task and the host_parquet_representation converters.
   // Also, only parquet file tails are small due to the partitioning logic, so batch concatenation
   // is not needed.
-  if (passthrough) { return std::make_unique<operator_data>(raw_input_batches); }
+  if (passthrough) { return std::make_unique<pipelineable_operator_data>(raw_input_batches); }
 
   // Build the column_ids index → batch position mapping once.
   // Both filter expression construction and post-filter projection use this.

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -96,14 +96,15 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::get_next_task_input_d
     }
   }
   if (input_batch.empty()) { return nullptr; }
-  return std::make_unique<operator_data>(input_batch);
+  return std::make_unique<pipelineable_operator_data>(input_batch);
 }
 
 std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operator_data& input_data,
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_table_scan::execute"};
-  const auto& raw_input_batches = input_data.get_data_batches();
+  auto& input                   = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& raw_input_batches = input.get_data_batches();
 
   // For parquet scan pipelines, filter and projection are already applied in
   // parquet_scan_task and the host_parquet_representation converters.
@@ -140,7 +141,9 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   // After concatenation (or if only one batch), work with a single batch.
   const auto& batch_ref =
     single_batch ? single_batch : (!raw_input_batches.empty() ? raw_input_batches[0] : nullptr);
-  if (!batch_ref || !batch_ref->get_data()) { return std::make_unique<operator_data>(); }
+  if (!batch_ref || !batch_ref->get_data()) {
+    return std::make_unique<pipelineable_operator_data>();
+  }
 
   // Apply table filters as a GPU expression if present.
   std::shared_ptr<cucascade::data_batch> output_batch;
@@ -153,7 +156,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   if (filter_expr != nullptr) {
     duckdb::sirius::GpuExpressionExecutor gpu_expression_executor(*filter_expr);
     output_batch = gpu_expression_executor.select(batch_ref, stream);
-    if (!output_batch) { return std::make_unique<operator_data>(); }
+    if (!output_batch) { return std::make_unique<pipelineable_operator_data>(); }
   } else {
     output_batch = batch_ref;
   }
@@ -212,7 +215,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.push_back(std::move(output_batch));
-  return std::make_unique<operator_data>(output_batches);
+  return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -150,9 +150,11 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
                                                               rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (limit == 0) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::shared_ptr<cucascade::data_batch> input_batch;
@@ -165,12 +167,14 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     }
   }
   if (!input_batch) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto* space = input_batch->get_memory_space();
   if (space == nullptr) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto& input_table =
@@ -183,7 +187,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
     std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
-  return std::make_unique<operator_data>(outputs);
+  return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
 sirius_physical_top_n_merge::sirius_physical_top_n_merge(sirius_physical_top_n* top_n)
@@ -218,9 +222,11 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
                                                                     rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n_merge::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (limit == 0) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   // Use the memory space from the first valid batch (all batches are expected to share the same
@@ -233,7 +239,8 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     }
   }
   if (space == nullptr) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   // std::vector<std::unique_ptr<cudf::table>> owned_tables;
@@ -245,7 +252,8 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   }
 
   if (concat_views.empty()) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::unique_ptr<cudf::table> combined;
@@ -273,7 +281,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
     std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
-  return std::make_unique<operator_data>(outputs);
+  return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
 std::unique_ptr<operator_data> sirius_physical_top_n_merge::get_next_task_input_data()
@@ -293,7 +301,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::get_next_task_input_
     }
   }
   if (input_batch.empty()) { return nullptr; }
-  return std::make_unique<operator_data>(input_batch);
+  return std::make_unique<pipelineable_operator_data>(input_batch);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -326,9 +326,11 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_ungrouped_aggregate::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (aggregates.empty()) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto layout = build_aggregate_layout(aggregates);
@@ -443,7 +445,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
     outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
   }
 
-  return std::make_unique<operator_data>(outputs);
+  return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
 // Helper to deep copy Expression vector (same as in grouped_aggregate)
@@ -489,9 +491,11 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_ungrouped_aggregate_merge::execute"};
-  const auto& input_batches = input_data.get_data_batches();
+  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  const auto& input_batches = input.get_data_batches();
   if (aggregates.empty()) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> valid_batches;
@@ -500,12 +504,14 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
     if (batch) { valid_batches.push_back(batch); }
   }
   if (valid_batches.empty()) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   cucascade::memory::memory_space* space = valid_batches[0]->get_memory_space();
   if (space == nullptr) {
-    return std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{});
+    return std::make_unique<pipelineable_operator_data>(
+      std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto layout = build_aggregate_layout(aggregates);
@@ -518,7 +524,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   }
 
   if (!layout.has_avg) {
-    return std::make_unique<operator_data>(
+    return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(merged_batch)});
   }
 
@@ -547,7 +553,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   auto const batch_id = ::sirius::get_next_batch_id();
   auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
 
-  return std::make_unique<operator_data>(
+  return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(output_batch)});
 }
 
@@ -568,7 +574,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::get_ne
     }
   }
   if (input_batch.empty()) { return nullptr; }
-  return std::make_unique<operator_data>(input_batch);
+  return std::make_unique<pipelineable_operator_data>(input_batch);
 }
 
 }  // namespace op

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -201,8 +201,10 @@ void gpu_pipeline_executor::manager_loop()
           // Operator outputs are in idle state; transition to task_created so
           // lock_or_prepare_batch() can lock them for the rescheduled task.
           auto intermediate_data = oom.release_intermediate_data();
-          if (intermediate_data) {
-            for (auto& batch : intermediate_data->get_data_batches()) {
+          auto* pipelineable_intermediate =
+            dynamic_cast<op::pipelineable_operator_data*>(intermediate_data.get());
+          if (pipelineable_intermediate) {
+            for (auto& batch : pipelineable_intermediate->get_data_batches()) {
               if (batch) { batch->try_to_create_task(); }
             }
           }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -126,8 +126,10 @@ void validate_operator_output_types(const op::operator_data* data,
                                     const op::sirius_physical_operator& op)
 {
   if (data == nullptr) { return; }
+  auto* pipelineable_data = dynamic_cast<const op::pipelineable_operator_data*>(data);
+  if (pipelineable_data == nullptr) { return; }
   const auto& expected_types = op.get_types();
-  const auto& batches        = data->get_data_batches();
+  const auto& batches        = pipelineable_data->get_data_batches();
   for (size_t batch_index = 0; batch_index < batches.size(); batch_index++) {
     const auto& batch = batches[batch_index];
     if (!batch) { continue; }
@@ -170,9 +172,10 @@ void log_operator_data(const op::sirius_physical_operator& op,
                        const char* label,
                        const std::string& extra_info = "")
 {
-  std::string batch_rows = "";
-  size_t total_bytes     = 0;
-  for (auto& batch : data.get_data_batches()) {
+  auto& pipelineable_data = dynamic_cast<const op::pipelineable_operator_data&>(data);
+  std::string batch_rows  = "";
+  size_t total_bytes      = 0;
+  for (auto& batch : pipelineable_data.get_data_batches()) {
     auto view = get_cudf_table_view(*batch);
     batch_rows += std::to_string(view.num_rows()) + "  ";
     total_bytes += batch->get_data()->get_size_in_bytes();
@@ -184,7 +187,7 @@ void log_operator_data(const op::sirius_physical_operator& op,
     op.get_name(),
     op.get_operator_id(),
     label,
-    data.get_data_batches().size(),
+    pipelineable_data.get_data_batches().size(),
     batch_rows,
     total_bytes,
     static_cast<double>(total_bytes) / (1024.0 * 1024.0),
@@ -395,9 +398,15 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   if (!local_state._input_data) {
     throw std::runtime_error("gpu_pipeline_task::execute: input_data is null");
   }
-  processing_handles.reserve(local_state._input_data->get_data_batches().size());
+  auto* pipelineable_input =
+    dynamic_cast<const op::pipelineable_operator_data*>(local_state._input_data.get());
+  if (!pipelineable_input) {
+    throw std::runtime_error(
+      "gpu_pipeline_task::execute: input_data is not pipelineable_operator_data");
+  }
+  processing_handles.reserve(pipelineable_input->get_data_batches().size());
 
-  for (const auto& batch : local_state._input_data->get_data_batches()) {
+  for (const auto& batch : pipelineable_input->get_data_batches()) {
     auto* resident_space = batch->get_memory_space();
     if (requested_memory_space && resident_space &&
         resident_space->get_id() != requested_memory_space->get_id()) {
@@ -476,8 +485,12 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       peak_bytes = 0;
     }
     std::size_t output_bytes = 0;
-    for (const auto& batch : output_data->get_data_batches()) {
-      if (batch && batch->get_data()) { output_bytes += batch->get_data()->get_size_in_bytes(); }
+    auto* pipelineable_output =
+      dynamic_cast<const op::pipelineable_operator_data*>(output_data.get());
+    if (pipelineable_output) {
+      for (const auto& batch : pipelineable_output->get_data_batches()) {
+        if (batch && batch->get_data()) { output_bytes += batch->get_data()->get_size_in_bytes(); }
+      }
     }
     auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
     global.get_memory_history().record({input_basis, peak_bytes, output_bytes});
@@ -502,7 +515,10 @@ std::size_t gpu_pipeline_task::get_input_size() const
   auto& local_state      = _local_state->cast<gpu_pipeline_task_local_state>();
   std::size_t input_size = 0;
   if (!local_state._input_data) { return 0; }
-  for (const auto& batch : local_state._input_data->get_data_batches()) {
+  auto* pipelineable_input =
+    dynamic_cast<const op::pipelineable_operator_data*>(local_state._input_data.get());
+  if (!pipelineable_input) { return 0; }
+  for (const auto& batch : pipelineable_input->get_data_batches()) {
     if (!batch || !batch->get_data()) { continue; }
     input_size += batch->get_data()->get_size_in_bytes();
   }

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -24,14 +24,11 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <absl/cleanup/cleanup.h>
-#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_repository.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/error.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <data/data_batch_utils.hpp>
-#include <data/sirius_converter_registry.hpp>
 
 #include <format>
 #include <optional>
@@ -40,87 +37,6 @@ namespace sirius {
 namespace pipeline {
 
 namespace {
-
-std::optional<cucascade::data_batch_processing_handle> lock_or_prepare_batch(
-  const std::shared_ptr<cucascade::data_batch>& batch,
-  const cucascade::memory::memory_space* requested_memory_space,
-  rmm::cuda_stream_view stream)
-{
-  using status = cucascade::lock_for_processing_status;
-  const auto* target_space =
-    requested_memory_space != nullptr ? requested_memory_space : batch->get_memory_space();
-  if (target_space == nullptr) { return std::nullopt; }
-
-  // NOTE: only works in single gpu setup
-  // wait for processing in case a shared batch is in transit in another thread.
-  auto lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
-
-  auto cancel_task_if_needed = []() {
-    SIRIUS_LOG_ERROR(
-      "gpu_pipeline_task: failed to lock batch for processing and cannot prepare batch for "
-      "processing. This likely means the batch is in transit and there is a bug in "
-      "the in-transit locking logic. Cancelling task to avoid deadlock.");
-  };
-
-  while (!lock_result.success && lock_result.status == status::memory_space_mismatch) {
-    try {
-      auto& registry = sirius::converter_registry::get();
-      switch (requested_memory_space->get_tier()) {
-        case cucascade::memory::Tier::GPU: {
-          auto prev_state = batch->get_state();
-          if (!batch->try_to_lock_for_in_transit()) {
-            auto current_state = batch->get_state();
-            if (current_state == cucascade::batch_state::in_transit) {
-              // If another thread has taken the in_transit lock, wait to acquire the processing
-              // lock.
-              lock_result = batch->wait_to_lock_for_processing(target_space->get_id());
-              continue;
-            }
-            cancel_task_if_needed();
-            return std::nullopt;
-          }
-          try {
-            batch->convert_to<cucascade::gpu_table_representation>(
-              registry, requested_memory_space, stream);
-          } catch (...) {
-            batch->try_to_release_in_transit();
-            throw;
-          }
-          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
-          break;
-        }
-        case cucascade::memory::Tier::HOST: {
-          auto prev_state = batch->get_state();
-          if (!batch->try_to_lock_for_in_transit()) {
-            cancel_task_if_needed();
-            return std::nullopt;
-          }
-          try {
-            batch->convert_to<cucascade::host_data_representation>(
-              registry, requested_memory_space, stream);
-          } catch (...) {
-            batch->try_to_release_in_transit();
-            throw;
-          }
-          batch->try_to_release_in_transit(std::optional<cucascade::batch_state>{prev_state});
-          break;
-        }
-        default: cancel_task_if_needed(); return std::nullopt;
-      }
-
-      lock_result = batch->try_to_lock_for_processing(requested_memory_space->get_id());
-    } catch (...) {
-      throw;
-    }
-  }
-
-  if (!lock_result.success) {
-    cancel_task_if_needed();
-    return std::nullopt;
-  }
-
-  return std::move(lock_result.handle);
-}
 
 void validate_operator_output_types(const op::operator_data* data,
                                     const op::sirius_physical_operator& op)
@@ -394,67 +310,43 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     allocator->reset_stream_reservation(stream);
   };
 
-  std::vector<cucascade::data_batch_processing_handle> processing_handles;
   if (!local_state._input_data) {
     throw std::runtime_error("gpu_pipeline_task::execute: input_data is null");
   }
   auto* pipelineable_input =
-    dynamic_cast<const op::pipelineable_operator_data*>(local_state._input_data.get());
+    dynamic_cast<op::pipelineable_operator_data*>(local_state._input_data.get());
   if (!pipelineable_input) {
     throw std::runtime_error(
       "gpu_pipeline_task::execute: input_data is not pipelineable_operator_data");
   }
-  processing_handles.reserve(pipelineable_input->get_data_batches().size());
 
-  for (const auto& batch : pipelineable_input->get_data_batches()) {
-    auto* resident_space = batch->get_memory_space();
-    if (requested_memory_space && resident_space &&
-        resident_space->get_id() != requested_memory_space->get_id()) {
-      SIRIUS_LOG_TRACE(
-        "Pipeline {}: fetching batch {} from tier {} to tier {} for operator {} (id={})",
-        pipeline->get_pipeline_id(),
-        batch->get_batch_id(),
-        static_cast<int>(resident_space->get_tier()),
-        static_cast<int>(requested_memory_space->get_tier()),
-        first_op.get_name(),
-        first_op.get_operator_id());
-    }
-    std::optional<cucascade::data_batch_processing_handle> handle;
-    try {
-      handle = lock_or_prepare_batch(batch, requested_memory_space, stream);
-    } catch (const rmm::out_of_memory& oom) {
-      auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
-      auto input_basis = local_state.get_task_consumption_basis();
-      auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
-      global.get_memory_history().record_on_failure(input_basis, peak_bytes);
+  std::optional<std::vector<cucascade::data_batch_processing_handle>> handles_opt;
+  try {
+    handles_opt = pipelineable_input->prepare_for_processing(requested_memory_space, stream);
+  } catch (const rmm::out_of_memory& oom) {
+    auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
+    auto input_basis = local_state.get_task_consumption_basis();
+    auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
+    global.get_memory_history().record_on_failure(input_basis, peak_bytes);
 
-      SIRIUS_LOG_ERROR("Pipeline {}: OOM at batch {} preparing for processing, state: {}",
-                       pipeline->get_pipeline_id(),
-                       batch->get_batch_id(),
-                       static_cast<int>(batch->get_state()));
-      throw oom_reschedule_exception(std::move(local_state._input_data),
-                                     0,
-                                     "Failed to lock or prepare batch " +
-                                       std::to_string(batch->get_batch_id()) + " for processing");
-    } catch (const std::exception& e) {
-      SIRIUS_LOG_ERROR(
-        "Unknown error: {};  in lock or prepare for pipeline {}, batch {}, state: {}",
-        e.what(),
-        pipeline->get_pipeline_id(),
-        batch->get_batch_id(),
-        static_cast<int>(batch->get_state()));
-      throw;
-    }
-    if (!handle) {
-      // trick to retry the task
-      throw oom_reschedule_exception(std::move(local_state._input_data),
-                                     0,
-                                     "Failed to lock or prepare batch " +
-                                       std::to_string(batch->get_batch_id()) + " for processing");
-      return;
-    }
-    processing_handles.emplace_back(std::move(*handle));
+    SIRIUS_LOG_ERROR("Pipeline {}: OOM preparing batches for processing",
+                     pipeline->get_pipeline_id());
+    throw oom_reschedule_exception(
+      std::move(local_state._input_data),
+      0,
+      std::string("OOM while preparing batches for processing: ") + oom.what());
+  } catch (const std::exception& e) {
+    SIRIUS_LOG_ERROR("Unknown error in prepare_for_processing for pipeline {}: {}",
+                     pipeline->get_pipeline_id(),
+                     e.what());
+    throw;
   }
+
+  if (!handles_opt) {
+    throw oom_reschedule_exception(
+      std::move(local_state._input_data), 0, "Failed to lock or prepare batches for processing");
+  }
+  std::vector<cucascade::data_batch_processing_handle> processing_handles = std::move(*handles_opt);
 
   auto const prepare_end = std::chrono::high_resolution_clock::now();
   auto const prepare_duration =

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp
@@ -84,15 +84,18 @@ TEMPLATE_TEST_CASE(
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+  auto outputs =
+    grouped_aggregator.execute(pipelineable_operator_data({input_batch}), default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs->get_data_batches()[0], expected_table->view(), true);
+    dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0],
+    expected_table->view(),
+    true);
   REQUIRE(tables_match);
 }
 
@@ -137,12 +140,14 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate grouped aggregates with AV
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  auto outputs =
+    grouped_aggregator.execute(pipelineable_operator_data({input_batch}), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // The local operator outputs expanded columns: group_key, min, max, count, sum, count_valid
   // (AVG decomposed into SUM + COUNT_VALID). Verify column count = 1 group + 5 aggregates.
-  auto& output_table = outputs->get_data_batches()[0]
+  auto& output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                         .get_data_batches()[0]
                          ->get_data()
                          ->cast<cucascade::gpu_table_representation>()
                          .get_table();
@@ -198,14 +203,17 @@ TEMPLATE_TEST_CASE(
                                                        std::move(agg_result.groups),
                                                        num_groups);
 
-  auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+  auto outputs =
+    grouped_aggregator.execute(pipelineable_operator_data({input_batch}), default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs->get_data_batches()[0], expected_table->view(), true);
+    dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0],
+    expected_table->view(),
+    true);
   REQUIRE(tables_match);
 }

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
@@ -93,10 +93,10 @@ std::unique_ptr<cudf::table> make_count_distinct_expected(const std::vector<int3
 std::shared_ptr<data_batch> run_local(sirius_physical_grouped_aggregate& local_op,
                                       std::shared_ptr<data_batch> input)
 {
-  auto out = local_op.execute(operator_data(std::vector<std::shared_ptr<data_batch>>{input}),
-                              default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
-  return out->get_data_batches()[0];
+  auto out = local_op.execute(
+    pipelineable_operator_data(std::vector<std::shared_ptr<data_batch>>{input}), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
+  return dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches()[0];
 }
 
 }  // namespace
@@ -148,11 +148,15 @@ TEST_CASE("count distinct: single batch, basic correctness",
 
   // Merge post-processes LIST → INT64 count, even for a single batch
   auto final_out = merge_op.execute(
-    operator_data(std::vector<std::shared_ptr<data_batch>>{local_out}), default_stream());
-  REQUIRE(final_out->get_data_batches().size() == 1);
+    pipelineable_operator_data(std::vector<std::shared_ptr<data_batch>>{local_out}),
+    default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches().size() ==
+          1);
 
   bool match = sirius::test::expect_data_batch_equivalent_to_table(
-    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+    dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches()[0],
+    expected_table->view(),
+    true /*sort*/);
   REQUIRE(match);
 }
 
@@ -235,11 +239,14 @@ TEMPLATE_TEST_CASE("count distinct: multiple batches, randomly striped",
   }
 
   // Merge all local results
-  auto final_out = merge_op.execute(operator_data(local_results), default_stream());
-  REQUIRE(final_out->get_data_batches().size() == 1);
+  auto final_out = merge_op.execute(pipelineable_operator_data(local_results), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches().size() ==
+          1);
 
   bool match = sirius::test::expect_data_batch_equivalent_to_table(
-    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+    dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches()[0],
+    expected_table->view(),
+    true /*sort*/);
   REQUIRE(match);
 }
 
@@ -306,11 +313,14 @@ TEST_CASE("count distinct: cross-batch duplicate deduplication within a partitio
   local_results.push_back(run_local(local_op, batch2));
   local_results.push_back(run_local(local_op, batch3));
 
-  auto final_out = merge_op.execute(operator_data(local_results), default_stream());
-  REQUIRE(final_out->get_data_batches().size() == 1);
+  auto final_out = merge_op.execute(pipelineable_operator_data(local_results), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches().size() ==
+          1);
 
   bool match = sirius::test::expect_data_batch_equivalent_to_table(
-    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+    dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches()[0],
+    expected_table->view(),
+    true /*sort*/);
   REQUIRE(match);
 }
 
@@ -429,11 +439,15 @@ TEST_CASE("count distinct: mixed with regular aggregations, multiple batches",
   auto local2 = run_local(local_op, batch2);
 
   auto final_out = merge_op.execute(
-    operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}), default_stream());
-  REQUIRE(final_out->get_data_batches().size() == 1);
+    pipelineable_operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}),
+    default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches().size() ==
+          1);
 
   bool match = sirius::test::expect_data_batch_equivalent_to_table(
-    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/);
+    dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches()[0],
+    expected_table->view(),
+    true /*sort*/);
   REQUIRE(match);
 }
 
@@ -509,24 +523,30 @@ TEST_CASE("count distinct: multiple partitions with multiple batches per partiti
   for (auto& split : splits0) {
     local_p0.push_back(run_local(local_op, sirius::make_data_batch(std::move(split), *space)));
   }
-  auto result_p0 = merge_op.execute(operator_data(local_p0), default_stream());
-  REQUIRE(result_p0->get_data_batches().size() == 1);
+  auto result_p0 = merge_op.execute(pipelineable_operator_data(local_p0), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result_p0).get_data_batches().size() ==
+          1);
 
   auto expected_p0 = make_count_distinct_expected({0, 1, 2}, {4, 4, 4}, stream, mr);
   REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
-    result_p0->get_data_batches()[0], expected_p0->view(), true /*sort*/));
+    dynamic_cast<const pipelineable_operator_data&>(*result_p0).get_data_batches()[0],
+    expected_p0->view(),
+    true /*sort*/));
 
   // --- Process partition 1 (separate execute() call) ---
   std::vector<std::shared_ptr<data_batch>> local_p1;
   for (auto& split : splits1) {
     local_p1.push_back(run_local(local_op, sirius::make_data_batch(std::move(split), *space)));
   }
-  auto result_p1 = merge_op.execute(operator_data(local_p1), default_stream());
-  REQUIRE(result_p1->get_data_batches().size() == 1);
+  auto result_p1 = merge_op.execute(pipelineable_operator_data(local_p1), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result_p1).get_data_batches().size() ==
+          1);
 
   auto expected_p1 = make_count_distinct_expected({3, 4}, {4, 4}, stream, mr);
   REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
-    result_p1->get_data_batches()[0], expected_p1->view(), true /*sort*/));
+    dynamic_cast<const pipelineable_operator_data&>(*result_p1).get_data_batches()[0],
+    expected_p1->view(),
+    true /*sort*/));
 }
 
 // ===========================================================================
@@ -598,9 +618,13 @@ TEST_CASE("count distinct: multi-column struct expression",
   auto local2 = run_local(local_op, batch2);
 
   auto final_out = merge_op.execute(
-    operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}), default_stream());
-  REQUIRE(final_out->get_data_batches().size() == 1);
+    pipelineable_operator_data(std::vector<std::shared_ptr<data_batch>>{local1, local2}),
+    default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches().size() ==
+          1);
 
   REQUIRE(sirius::test::expect_data_batch_equivalent_to_table(
-    final_out->get_data_batches()[0], expected_table->view(), true /*sort*/));
+    dynamic_cast<const pipelineable_operator_data&>(*final_out).get_data_batches()[0],
+    expected_table->view(),
+    true /*sort*/));
 }

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_merge.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_merge.cpp
@@ -86,16 +86,18 @@ TEST_CASE("sirius_physical_grouped_aggregate_merge grouped aggregates single dat
   auto input_table = std::make_unique<cudf::table>(expected_table->view());
   auto input_batch = sirius::make_data_batch(std::move(input_table), *space);
 
-  auto outputs =
-    grouped_aggregate_merger.execute(operator_data({std::move(input_batch)}), default_stream());
+  auto outputs = grouped_aggregate_merger.execute(
+    pipelineable_operator_data({std::move(input_batch)}), default_stream());
 
   // Verify we got one output batch
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // Compare output with expected using the validation utility
   // Dont Sort both tables before comparison since they should be identical
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs->get_data_batches()[0], expected_table->view(), false);
+    dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0],
+    expected_table->view(),
+    false);
   REQUIRE(tables_match);
 }
 
@@ -170,15 +172,19 @@ TEMPLATE_TEST_CASE(
     std::shared_ptr<data_batch> input_batch =
       sirius::make_data_batch(std::move(input_table), *space);
 
-    auto outputs = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
+    auto outputs =
+      grouped_aggregator.execute(pipelineable_operator_data({input_batch}), default_stream());
 
     // Verify we got one output batch
-    REQUIRE(outputs->get_data_batches().size() == 1);
-    agg_outputs.push_back(outputs->get_data_batches()[0]);
+    REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() ==
+            1);
+    agg_outputs.push_back(
+      dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
   }
 
-  auto outputs = grouped_aggregate_merger.execute(operator_data(agg_outputs), default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  auto outputs =
+    grouped_aggregate_merger.execute(pipelineable_operator_data(agg_outputs), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // need to cast the expected table column 4 (which is the count column) to int64_t since at the
   // merge stage, we end up doing a sum of int32_t which becomes an int64_t
@@ -200,7 +206,9 @@ TEMPLATE_TEST_CASE(
   // Compare output with expected using the validation utility
   // Sort both tables before comparison since aggregation order is not guaranteed
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs->get_data_batches()[0], expected_table->view(), true);
+    dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0],
+    expected_table->view(),
+    true);
   REQUIRE(tables_match);
 }
 
@@ -261,14 +269,18 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate_merge end-to-end with AVG"
   std::vector<std::shared_ptr<data_batch>> agg_outputs;
   for (auto& split_table : input_tables) {
     auto input_batch = sirius::make_data_batch(std::move(split_table), *space);
-    auto outputs     = grouped_aggregator.execute(operator_data({input_batch}), default_stream());
-    REQUIRE(outputs->get_data_batches().size() == 1);
-    agg_outputs.push_back(outputs->get_data_batches()[0]);
+    auto outputs =
+      grouped_aggregator.execute(pipelineable_operator_data({input_batch}), default_stream());
+    REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() ==
+            1);
+    agg_outputs.push_back(
+      dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
   }
 
   // Run merge with AVG projection
-  auto outputs = grouped_aggregate_merger.execute(operator_data(agg_outputs), default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  auto outputs =
+    grouped_aggregate_merger.execute(pipelineable_operator_data(agg_outputs), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
   // Cast expected count column from int32 to int64 (merge sums int32 counts -> int64)
   auto expected_columns = expected_table->release();
@@ -279,6 +291,8 @@ TEMPLATE_TEST_CASE("sirius_physical_grouped_aggregate_merge end-to-end with AVG"
   expected_table = std::make_unique<cudf::table>(std::move(expected_columns));
 
   bool tables_match = sirius::test::expect_data_batch_equivalent_to_table(
-    outputs->get_data_batches()[0], expected_table->view(), true);
+    dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0],
+    expected_table->view(),
+    true);
   REQUIRE(tables_match);
 }

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -36,6 +36,7 @@ using namespace sirius::op;
 using namespace cucascade;
 using namespace cucascade::memory;
 using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 
 namespace {
 
@@ -197,8 +198,9 @@ TEMPLATE_TEST_CASE("sirius_physical_concat concatenates multiple data_batches",
   auto outputs = concat_op.execute(partitioned_operator_data(input_batches, 0), default_stream());
 
   // Verify: single output batch with correct total rows
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto& out_table = outputs->get_data_batches()[0]
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto& out_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                      .get_data_batches()[0]
                       ->get_data()
                       ->cast<cucascade::gpu_table_representation>()
                       .get_table();
@@ -229,9 +231,10 @@ TEST_CASE("sirius_physical_concat returns single batch as-is", "[physical_concat
 
   auto outputs = concat_op.execute(partitioned_operator_data({input_batch}, 0), default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
   // Single batch should be the same pointer (passthrough)
-  REQUIRE(outputs->get_data_batches()[0].get() == input_batch.get());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0].get() ==
+          input_batch.get());
 }
 
 TEST_CASE("sirius_physical_concat handles empty input", "[physical_concat]")
@@ -244,7 +247,7 @@ TEST_CASE("sirius_physical_concat handles empty input", "[physical_concat]")
     partitioned_operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}, 0),
     default_stream());
 
-  REQUIRE(outputs->get_data_batches().empty());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().empty());
 }
 
 TEST_CASE("sirius_physical_concat filters null batches", "[physical_concat]")
@@ -265,8 +268,9 @@ TEST_CASE("sirius_physical_concat filters null batches", "[physical_concat]")
   std::vector<std::shared_ptr<data_batch>> input = {batch1, nullptr, batch2, nullptr};
   auto outputs = concat_op.execute(partitioned_operator_data(input, 0), default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto& out_table = outputs->get_data_batches()[0]
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto& out_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                      .get_data_batches()[0]
                       ->get_data()
                       ->cast<cucascade::gpu_table_representation>()
                       .get_table();
@@ -426,15 +430,18 @@ TEST_CASE("sirius_physical_concat stops concatenating at concat_batch_bytes thre
   // First call: should return some batches but not all (threshold exceeded)
   auto result1 = concat_op.get_next_task_input_data();
   REQUIRE(result1 != nullptr);
-  REQUIRE(result1->get_data_batches().size() < static_cast<std::size_t>(num_batches));
-  REQUIRE(result1->get_data_batches().size() >= 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result1).get_data_batches().size() <
+          static_cast<std::size_t>(num_batches));
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result1).get_data_batches().size() >= 1);
 
   // Collect total batches returned across multiple calls
-  std::size_t total_batches_returned = result1->get_data_batches().size();
+  std::size_t total_batches_returned =
+    dynamic_cast<const pipelineable_operator_data&>(*result1).get_data_batches().size();
   while (true) {
     auto result = concat_op.get_next_task_input_data();
     if (!result) { break; }
-    total_batches_returned += result->get_data_batches().size();
+    total_batches_returned +=
+      dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches().size();
   }
 
   // All batches should eventually be consumed
@@ -477,7 +484,8 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   // With concat_all=true, all batches in the partition should be returned in one call
   auto result = concat_op.get_next_task_input_data();
   REQUIRE(result != nullptr);
-  REQUIRE(result->get_data_batches().size() == static_cast<std::size_t>(num_batches));
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches().size() ==
+          static_cast<std::size_t>(num_batches));
 
   // No more batches remaining
   auto result2 = concat_op.get_next_task_input_data();
@@ -606,7 +614,8 @@ TEST_CASE("sirius_physical_concat get_next_task_input_batch is thread-safe", "[p
       if (!result) { break; }
       total_calls.fetch_add(1, std::memory_order_relaxed);
       std::lock_guard<std::mutex> lg(collected_mutex);
-      for (auto& batch : result->get_data_batches()) {
+      for (auto& batch :
+           dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches()) {
         if (batch) { collected_batch_ids.push_back(batch->get_batch_id()); }
       }
     }
@@ -678,7 +687,8 @@ TEST_CASE("sirius_physical_concat execute is thread-safe with independent stream
       // Synchronize the stream before accessing results
       cudaStreamSynchronize(raw_stream);
 
-      thread_outputs[thread_id] = std::move(outputs->get_data_batches());
+      thread_outputs[thread_id] =
+        dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches();
 
       cudaStreamDestroy(raw_stream);
     } catch (const std::exception& e) {

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -92,10 +92,13 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = filter.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto outputs = filter.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view    = output_table.view();
   auto host_vals   = copy_column_to_host<typename Traits::type>(out_view.column(1));
   auto host_filter = copy_column_to_host<int64_t>(out_view.column(0));

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -98,10 +98,13 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
     std::move(types), std::move(limit_node), std::move(offset_node), values.size(), false);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = limiter.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto outputs = limiter.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto host_vals = copy_column_to_host<typename Traits::type>(output_table.view().column(0));
 
   std::vector<typename Traits::type> expected = {values[2], values[3], values[4]};
@@ -151,8 +154,9 @@ TEST_CASE("streaming_limit caps total rows across multiple batches",
   sirius_physical_streaming_limit limiter(
     std::move(types), duckdb::BoundLimitNode::ConstantValue(5), duckdb::BoundLimitNode(), 30, true);
 
-  auto outputs = limiter.execute(operator_data(batches), cudf::get_default_stream());
-  auto rows    = collect_all_rows(outputs->get_data_batches());
+  auto outputs = limiter.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  auto rows =
+    collect_all_rows(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches());
 
   // Should return exactly 5 rows: [0, 1, 2, 3, 4]
   std::vector<int64_t> expected{0, 1, 2, 3, 4};
@@ -180,8 +184,9 @@ TEST_CASE("streaming_limit spans across two batches returning correct data",
                                           300,
                                           true);
 
-  auto outputs = limiter.execute(operator_data(batches), cudf::get_default_stream());
-  auto rows    = collect_all_rows(outputs->get_data_batches());
+  auto outputs = limiter.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  auto rows =
+    collect_all_rows(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches());
 
   // Should return exactly 200 rows: all 150 from batch 1, plus first 50 from batch 2
   REQUIRE(rows.size() == 200);
@@ -213,8 +218,9 @@ TEST_CASE("streaming_limit offset spans across multiple batches", "[physical_lim
                                           30,
                                           true);
 
-  auto outputs = limiter.execute(operator_data(batches), cudf::get_default_stream());
-  auto rows    = collect_all_rows(outputs->get_data_batches());
+  auto outputs = limiter.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  auto rows =
+    collect_all_rows(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches());
 
   // Should return [15, 16, 17, 18, 19]
   std::vector<int64_t> expected{15, 16, 17, 18, 19};
@@ -237,13 +243,15 @@ TEST_CASE("streaming_limit with separate execute calls enforces global limit",
 
   // First call with batch [0..9]
   std::vector<std::shared_ptr<data_batch>> batch1{make_range_batch(*space, 0, 10)};
-  auto out1  = limiter.execute(operator_data(batch1), cudf::get_default_stream());
-  auto rows1 = collect_all_rows(out1->get_data_batches());
+  auto out1 = limiter.execute(pipelineable_operator_data(batch1), cudf::get_default_stream());
+  auto rows1 =
+    collect_all_rows(dynamic_cast<const pipelineable_operator_data&>(*out1).get_data_batches());
 
   // Second call with batch [10..19] — limit should already be exhausted
   std::vector<std::shared_ptr<data_batch>> batch2{make_range_batch(*space, 10, 10)};
-  auto out2  = limiter.execute(operator_data(batch2), cudf::get_default_stream());
-  auto rows2 = collect_all_rows(out2->get_data_batches());
+  auto out2 = limiter.execute(pipelineable_operator_data(batch2), cudf::get_default_stream());
+  auto rows2 =
+    collect_all_rows(dynamic_cast<const pipelineable_operator_data&>(*out2).get_data_batches());
 
   // Total across both calls should be exactly 5
   REQUIRE(rows1.size() + rows2.size() == 5);

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -117,11 +117,16 @@ TEST_CASE("sirius_physical_hash_join mark join - partial match", "[physical_mark
 
   auto f = create_mark_join();
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
-  auto outputs = f.hash_join->execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto out_view =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table().view();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                    .get_data_batches()[0]
+                    ->get_data()
+                    ->cast<gpu_table_representation>()
+                    .get_table()
+                    .view();
   REQUIRE(out_view.num_columns() == 3);
   REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
 
@@ -147,11 +152,16 @@ TEST_CASE("sirius_physical_hash_join mark join - all rows match", "[physical_mar
 
   auto f = create_mark_join();
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
-  auto outputs = f.hash_join->execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto out_view =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table().view();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                    .get_data_batches()[0]
+                    ->get_data()
+                    ->cast<gpu_table_representation>()
+                    .get_table()
+                    .view();
   REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
 
   REQUIRE(copy_column_to_host<int32_t>(out_view.column(0)) == left_ids);
@@ -175,11 +185,16 @@ TEST_CASE("sirius_physical_hash_join mark join - no rows match", "[physical_mark
 
   auto f = create_mark_join();
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
-  auto outputs = f.hash_join->execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto out_view =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table().view();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                    .get_data_batches()[0]
+                    ->get_data()
+                    ->cast<gpu_table_representation>()
+                    .get_table()
+                    .view();
   REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
 
   REQUIRE(copy_column_to_host<int32_t>(out_view.column(0)) == left_ids);
@@ -203,11 +218,16 @@ TEST_CASE("sirius_physical_hash_join mark join - empty right side", "[physical_m
 
   auto f = create_mark_join();
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
-  auto outputs = f.hash_join->execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto out_view =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table().view();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                    .get_data_batches()[0]
+                    ->get_data()
+                    ->cast<gpu_table_representation>()
+                    .get_table()
+                    .view();
   REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
 
   REQUIRE(copy_column_to_host<int32_t>(out_view.column(0)) == left_ids);
@@ -232,11 +252,16 @@ TEST_CASE("sirius_physical_hash_join mark join - duplicate keys on right side",
 
   auto f = create_mark_join();
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
-  auto outputs = f.hash_join->execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto out_view =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table().view();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                    .get_data_batches()[0]
+                    ->get_data()
+                    ->cast<gpu_table_representation>()
+                    .get_table()
+                    .view();
   REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
 
   REQUIRE(copy_column_to_host<int32_t>(out_view.column(0)) == left_ids);

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -23,6 +23,7 @@
 
 using namespace sirius::op;
 using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 using namespace cucascade;
 using namespace cucascade::memory;
 using namespace sirius::test::operator_utils;
@@ -92,9 +93,9 @@ std::shared_ptr<data_batch> sort_batch(const std::shared_ptr<data_batch>& batch,
                                  copy_orders(orders),
                                  duckdb::vector<duckdb::idx_t>(projections),
                                  0);
-  auto result = order_op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(result->get_data_batches().size() == 1);
-  return result->get_data_batches()[0];
+  auto result = order_op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches().size() == 1);
+  return dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches()[0];
 }
 
 }  // namespace
@@ -124,11 +125,15 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 1-column batches ascending
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{1, 2, 3, 4, 5, 6, 7, 8};
   REQUIRE(col0 == expected);
@@ -155,11 +160,16 @@ TEST_CASE("sirius_physical_merge_sort merges 3 sorted 1-column batches descendin
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2, batch3}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out =
+    op.execute(pipelineable_operator_data({batch1, batch2, batch3}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{9, 8, 7, 6, 5, 4, 3, 2, 1};
   REQUIRE(col0 == expected);
@@ -191,11 +201,15 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 2-column batches by col0 a
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -235,11 +249,15 @@ TEST_CASE("sirius_physical_merge_sort merges 2-column batches sorted by 2 keys",
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
 
-  auto out = op.execute(operator_data({sorted1, sorted2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({sorted1, sorted2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -275,11 +293,15 @@ TEST_CASE("sirius_physical_merge_sort merges 3-column batches sorted by col0, re
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -322,11 +344,15 @@ TEST_CASE("sirius_physical_merge_sort 3 columns sorted by col0 asc + col1 desc",
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
 
-  auto out = op.execute(operator_data({sorted1, sorted2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({sorted1, sorted2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -360,11 +386,15 @@ TEST_CASE("sirius_physical_merge_sort single batch passthrough", "[physical_merg
 
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3});
 }
 
@@ -388,11 +418,15 @@ TEST_CASE("sirius_physical_merge_sort skips null batches", "[physical_merge_sort
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch1, nullptr, batch2, nullptr};
-  auto out = op.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
 }
 
@@ -410,8 +444,8 @@ TEST_CASE("sirius_physical_merge_sort returns empty for all-null inputs", "[phys
   sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
-  auto out = op.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().empty());
+  auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().empty());
 }
 
 TEST_CASE("sirius_physical_merge_sort constructed from sirius_physical_order",
@@ -439,10 +473,14 @@ TEST_CASE("sirius_physical_merge_sort constructed from sirius_physical_order",
 
   sirius_physical_merge_sort op(&order_op);
 
-  auto out = op.execute(operator_data({batch1, batch2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3, 4, 5, 6});
 }

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -22,6 +22,7 @@
 
 using namespace sirius::op;
 using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 using namespace cucascade;
 using namespace cucascade::memory;
 using namespace sirius::test::operator_utils;
@@ -105,11 +106,15 @@ TEST_CASE("sirius_physical_order sorts 1 column ascending", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{1, 2, 3, 5, 7, 8, 9};
   REQUIRE(col0 == expected);
@@ -133,11 +138,15 @@ TEST_CASE("sirius_physical_order sorts 1 column descending", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
 
   std::vector<int64_t> expected{9, 8, 7, 5, 3, 2, 1};
   REQUIRE(col0 == expected);
@@ -167,11 +176,15 @@ TEST_CASE("sirius_physical_order sorts by col0, returns both columns", "[physica
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -203,11 +216,15 @@ TEST_CASE("sirius_physical_order sorts by 2 keys (asc, desc)", "[physical_order]
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
 
@@ -237,11 +254,15 @@ TEST_CASE("sirius_physical_order projects only col1 when sorting by col0", "[phy
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view = table.view();
   REQUIRE(view.num_columns() == 1);
 
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
@@ -273,11 +294,15 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc, return all", "[phy
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -317,11 +342,15 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc + col1 desc, return
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view   = table.view();
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
   auto out_c1 = copy_column_to_host<int64_t>(view.column(1));
   auto out_c2 = copy_column_to_host<int64_t>(view.column(2));
@@ -352,11 +381,15 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0, project col1 and col2 
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view = table.view();
   REQUIRE(view.num_columns() == 2);
 
   auto out_c0 = copy_column_to_host<int64_t>(view.column(0));
@@ -389,15 +422,23 @@ TEST_CASE("sirius_physical_order handles multiple batches", "[physical_order]")
 
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
-  auto out = op.execute(operator_data({batch1, batch2}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 2);
+  auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 2);
 
   // Each batch is independently sorted
-  auto t1   = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto t1 = dynamic_cast<const pipelineable_operator_data&>(*out)
+              .get_data_batches()[0]
+              ->get_data()
+              ->cast<gpu_table_representation>()
+              .get_table();
   auto col1 = copy_column_to_host<int64_t>(t1.view().column(0));
   REQUIRE(col1 == std::vector<int64_t>{1, 3, 5});
 
-  auto t2   = out->get_data_batches()[1]->get_data()->cast<gpu_table_representation>().get_table();
+  auto t2 = dynamic_cast<const pipelineable_operator_data&>(*out)
+              .get_data_batches()[1]
+              ->get_data()
+              ->cast<gpu_table_representation>()
+              .get_table();
   auto col2 = copy_column_to_host<int64_t>(t2.view().column(0));
   REQUIRE(col2 == std::vector<int64_t>{2, 4, 6});
 }
@@ -421,11 +462,15 @@ TEST_CASE("sirius_physical_order handles null input batches", "[physical_order]"
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch, nullptr};
-  auto out = op.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto col0  = copy_column_to_host<int64_t>(table.view().column(0));
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto col0 = copy_column_to_host<int64_t>(table.view().column(0));
   REQUIRE(col0 == std::vector<int64_t>{1, 2, 3});
 }
 
@@ -443,6 +488,6 @@ TEST_CASE("sirius_physical_order returns empty for all-null inputs", "[physical_
   sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
-  auto out = op.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().empty());
+  auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().empty());
 }

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -28,6 +28,7 @@
 using namespace duckdb;
 using namespace sirius::op;
 using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 using namespace cucascade;
 using namespace cucascade::memory;
 
@@ -145,15 +146,17 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
     static_cast<int>(std::max(std::size_t(1), estimated_cardinality_bytes / partition_size));
   partitioner.set_num_partitions(num_partitions);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
+  auto outputs = partitioner.execute(pipelineable_operator_data({input_batch}), default_stream());
 
   std::size_t expected_num_partitions = static_cast<std::size_t>(num_partitions);
 
-  REQUIRE(outputs->get_data_batches().size() == expected_num_partitions);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() ==
+          expected_num_partitions);
 
   // count the number of rows in each output and make sure it's the same and the initial inputs
   std::size_t total_num_rows = 0;
-  for (auto& output : outputs->get_data_batches()) {
+  for (auto& output :
+       dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()) {
     total_num_rows += output->get_data()->cast<gpu_table_representation>().get_table().num_rows();
   }
   REQUIRE(total_num_rows == num_values);
@@ -276,15 +279,17 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
     static_cast<int>(std::max(std::size_t(1), estimated_cardinality_bytes / partition_size));
   partitioner.set_num_partitions(num_partitions);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
+  auto outputs = partitioner.execute(pipelineable_operator_data({input_batch}), default_stream());
 
   std::size_t expected_num_partitions = static_cast<std::size_t>(num_partitions);
 
-  REQUIRE(outputs->get_data_batches().size() == expected_num_partitions);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() ==
+          expected_num_partitions);
 
   // count the number of rows in each output and make sure it's the same and the initial inputs
   std::size_t total_num_rows = 0;
-  for (auto& output : outputs->get_data_batches()) {
+  for (auto& output :
+       dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()) {
     std::size_t num_rows_out =
       output->get_data()->cast<gpu_table_representation>().get_table().num_rows();
     REQUIRE(num_rows_out % prime_repeater ==
@@ -361,9 +366,10 @@ TEST_CASE(
     std::size_t(1), estimated_cardinality_bytes / sirius::config::DEFAULT_HASH_PARTITION_BYTES));
   partitioner.set_num_partitions(num_partitions);
 
-  auto outputs = partitioner.execute(operator_data({input_batch}), default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  REQUIRE(outputs->get_data_batches()[0]
+  auto outputs = partitioner.execute(pipelineable_operator_data({input_batch}), default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs)
+            .get_data_batches()[0]
             ->get_data()
             ->cast<gpu_table_representation>()
             .get_table()

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -85,10 +85,13 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view = output_table.view();
 
   auto host_data = copy_column_to_host<typename Traits::type>(out_view.column(0));
@@ -130,9 +133,10 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table = outputs->get_data_batches()[0]
+  auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
                         ->get_data()
                         ->template cast<gpu_table_representation>()
                         .get_table();
@@ -178,9 +182,10 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = projection.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table = outputs->get_data_batches()[0]
+  auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
                         ->get_data()
                         ->template cast<gpu_table_representation>()
                         .get_table();

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -56,7 +56,7 @@
 using namespace sirius;
 using namespace cucascade;
 using namespace cucascade::memory;
-using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 
 namespace {
 
@@ -247,7 +247,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
-  collector.sink(operator_data({batch}), cudf::get_default_stream());
+  collector.sink(pipelineable_operator_data({batch}), cudf::get_default_stream());
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -313,7 +313,7 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
-  collector.sink(operator_data({batch}), stream);
+  collector.sink(pipelineable_operator_data({batch}), stream);
   duckdb::GlobalSinkState sink_state;
   auto result = collector.get_result(sink_state);
   REQUIRE(result != nullptr);
@@ -419,7 +419,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
         std::this_thread::yield();
       }
       try {
-        collector.sink(operator_data({batches[static_cast<size_t>(thread_idx)]}),
+        collector.sink(pipelineable_operator_data({batches[static_cast<size_t>(thread_idx)]}),
                        cudf::get_default_stream());
       } catch (...) {
         exceptions[static_cast<size_t>(thread_idx)] = std::current_exception();

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -122,10 +122,13 @@ TEMPLATE_TEST_CASE(
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view    = output_table.view();
   auto host_vals   = copy_column_to_host<typename Traits::type>(out_view.column(1));
   auto host_filter = copy_column_to_host<int64_t>(out_view.column(0));
@@ -192,11 +195,14 @@ TEST_CASE("sirius_physical_table_scan with no filters passes through data", "[ph
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view = output_table.view();
 
   // Verify all data passes through unchanged
@@ -264,11 +270,14 @@ TEST_CASE("sirius_physical_table_scan with multiple filters", "[physical_table_s
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view = output_table.view();
 
   auto host_col0 = copy_column_to_host<int64_t>(out_view.column(0));
@@ -334,11 +343,14 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
                                         std::move(virtual_columns));
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
 
-  REQUIRE(outputs->get_data_batches().size() == 1);
-  auto table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
   auto view = table.view();
   REQUIRE(view.num_columns() == 2);
   REQUIRE(view.num_rows() == 0);

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -416,11 +416,14 @@ TEST_CASE("parquet_scan with translatable filter sets table_scan passthrough",
 
   // In passthrough mode, execute() returns input data unchanged
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view    = output_table.view();
   auto host_filter = copy_column_to_host<int64_t>(out_view.column(0));
   auto host_data   = copy_column_to_host<int32_t>(out_view.column(1));
@@ -520,11 +523,14 @@ TEST_CASE("parquet_scan with decimal filter does not set passthrough",
 
   // execute() should apply the filter (col0 > 3.00 keeps rows 5.00 and 7.00)
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
-  auto outputs = table_scan.execute(operator_data(inputs), cudf::get_default_stream());
-  REQUIRE(outputs->get_data_batches().size() == 1);
+  auto outputs = table_scan.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
 
-  auto output_table =
-    outputs->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto output_table = dynamic_cast<const pipelineable_operator_data&>(*outputs)
+                        .get_data_batches()[0]
+                        ->get_data()
+                        ->cast<gpu_table_representation>()
+                        .get_table();
   auto out_view  = output_table.view();
   auto host_dec  = copy_column_to_host<int64_t>(out_view.column(0));
   auto host_data = copy_column_to_host<int32_t>(out_view.column(1));

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -23,7 +23,7 @@
 #include <op/sirius_physical_top_n_merge.hpp>
 
 using namespace sirius::op;
-using sirius::op::operator_data;
+using sirius::op::pipelineable_operator_data;
 using namespace cucascade;
 using namespace cucascade::memory;
 using namespace sirius::test::operator_utils;
@@ -87,11 +87,15 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
                              nullptr,
                              0);
 
-  auto out = topn.execute(operator_data({batches[0]}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = topn.execute(pipelineable_operator_data({batches[0]}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view        = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
 
@@ -127,11 +131,15 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
                              nullptr,
                              0);
 
-  auto out = topn.execute(operator_data({batches[0]}), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = topn.execute(pipelineable_operator_data({batches[0]}), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view        = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
 
@@ -167,11 +175,15 @@ TEST_CASE("sirius_physical_top_n_merge applies offset and limit", "[physical_top
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = topn_merge.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
-  auto view  = table.view();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
+  auto view        = table.view();
   auto orders_out  = copy_column_to_host<int64_t>(view.column(0));
   auto payload_out = copy_column_to_host<int64_t>(view.column(1));
 
@@ -205,8 +217,8 @@ TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_to
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().empty());
+  auto out = topn_merge.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().empty());
 }
 
 TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_merge]")
@@ -232,9 +244,13 @@ TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_
                                          nullptr,
                                          0);
 
-  auto out = topn_merge.execute(operator_data(batches), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = topn_merge.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table = out->get_data_batches()[0]->get_data()->cast<gpu_table_representation>().get_table();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->cast<gpu_table_representation>()
+                 .get_table();
   REQUIRE(table.num_rows() == 0);
 }

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -181,10 +181,12 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1         = local_op.execute(operator_data({b1}), cudf::get_default_stream());
-  auto local_out2         = local_op.execute(operator_data({b2}), cudf::get_default_stream());
-  auto local_out1_batches = local_out1->get_data_batches();
-  auto local_out2_batches = local_out2->get_data_batches();
+  auto local_out1 = local_op.execute(pipelineable_operator_data({b1}), cudf::get_default_stream());
+  auto local_out2 = local_op.execute(pipelineable_operator_data({b2}), cudf::get_default_stream());
+  auto local_out1_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*local_out1).get_data_batches();
+  auto local_out2_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*local_out2).get_data_batches();
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1_batches.begin()),
@@ -192,11 +194,14 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out2_batches.begin()),
                       std::make_move_iterator(local_out2_batches.end()));
-  auto out = merge_op.execute(operator_data(merge_inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = merge_op.execute(pipelineable_operator_data(merge_inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table =
-    out->get_data_batches()[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->template cast<gpu_table_representation>()
+                 .get_table();
   auto view = table.view();
 
   REQUIRE(view.num_columns() == 5);
@@ -306,10 +311,12 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
 
-  auto local_out1         = local_op.execute(operator_data({b1}), cudf::get_default_stream());
-  auto local_out2         = local_op.execute(operator_data({b2}), cudf::get_default_stream());
-  auto local_out1_batches = local_out1->get_data_batches();
-  auto local_out2_batches = local_out2->get_data_batches();
+  auto local_out1 = local_op.execute(pipelineable_operator_data({b1}), cudf::get_default_stream());
+  auto local_out2 = local_op.execute(pipelineable_operator_data({b2}), cudf::get_default_stream());
+  auto local_out1_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*local_out1).get_data_batches();
+  auto local_out2_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*local_out2).get_data_batches();
   std::vector<std::shared_ptr<data_batch>> merge_inputs;
   merge_inputs.insert(merge_inputs.end(),
                       std::make_move_iterator(local_out1_batches.begin()),
@@ -318,11 +325,14 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
                       std::make_move_iterator(local_out2_batches.begin()),
                       std::make_move_iterator(local_out2_batches.end()));
 
-  auto out = merge_op.execute(operator_data(merge_inputs), cudf::get_default_stream());
-  REQUIRE(out->get_data_batches().size() == 1);
+  auto out = merge_op.execute(pipelineable_operator_data(merge_inputs), cudf::get_default_stream());
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
 
-  auto table =
-    out->get_data_batches()[0]->get_data()->template cast<gpu_table_representation>().get_table();
+  auto table = dynamic_cast<const pipelineable_operator_data&>(*out)
+                 .get_data_batches()[0]
+                 ->get_data()
+                 ->template cast<gpu_table_representation>()
+                 .get_table();
   auto view = table.view();
   REQUIRE(view.num_columns() == 1);
   REQUIRE(view.num_rows() == 1);

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -183,7 +183,7 @@ TEST_CASE("GPU pipeline executor uses task requests to schedule GPU tasks",
       if (!request) { break; }
 
       auto local_state = std::make_unique<test_gpu_pipeline_task_local_state>(
-        std::make_unique<sirius::op::operator_data>(
+        std::make_unique<sirius::op::pipelineable_operator_data>(
           std::vector<std::shared_ptr<cucascade::data_batch>>{}));
       auto task = std::make_unique<sirius_pipeline_task>(
         static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed)),

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -206,12 +206,13 @@ stub_operator::execute_fn make_allocating_execute_fn(cucascade::memory::memory_s
     REQUIRE(mr != nullptr);
     void* scratch = mr->allocate(s, exec_size);
 
+    auto& pipelineable_input = dynamic_cast<const sirius::op::pipelineable_operator_data&>(input);
     std::vector<std::shared_ptr<cucascade::data_batch>> pass_through;
-    pass_through.reserve(input.get_data_batches().size());
-    for (auto const& batch : input.get_data_batches()) {
+    pass_through.reserve(pipelineable_input.get_data_batches().size());
+    for (auto const& batch : pipelineable_input.get_data_batches()) {
       if (batch) { pass_through.push_back(batch); }
     }
-    auto out = std::make_unique<sirius::op::operator_data>(std::move(pass_through));
+    auto out = std::make_unique<sirius::op::pipelineable_operator_data>(std::move(pass_through));
     s.synchronize();
     mr->deallocate(s, scratch, exec_size);
     s.synchronize();
@@ -232,7 +233,7 @@ std::unique_ptr<sirius::pipeline::gpu_pipeline_task> create_pipeline_task(
 {
   std::vector<std::shared_ptr<cucascade::data_batch>> batches;
   batches.push_back(std::move(batch));
-  auto op_data = std::make_unique<sirius::op::operator_data>(std::move(batches));
+  auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(std::move(batches));
 
   auto local_state =
     std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data));

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -362,7 +362,7 @@ TEST_CASE("GPU pipeline executor reschedules tasks on OOM", "[gpu_pipeline_execu
       if (!request) { break; }
 
       auto local_state = std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(
-        std::make_unique<sirius::op::operator_data>(
+        std::make_unique<sirius::op::pipelineable_operator_data>(
           std::vector<std::shared_ptr<cucascade::data_batch>>{}));
       auto task = std::make_unique<oom_test_task>(
         static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed)),
@@ -465,7 +465,7 @@ TEST_CASE("GPU pipeline executor fails after max OOM retries",
 
       auto id          = static_cast<uint64_t>(dispatched.load(std::memory_order_relaxed));
       auto local_state = std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(
-        std::make_unique<sirius::op::operator_data>(
+        std::make_unique<sirius::op::pipelineable_operator_data>(
           std::vector<std::shared_ptr<cucascade::data_batch>>{}));
 
       std::unique_ptr<sirius::parallel::itask> task;

--- a/test/cpp/pipeline/test_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_pipeline_executor.cpp
@@ -52,8 +52,8 @@ class mock_gpu_pipeline_task_global_state : public gpu_pipeline_task_global_stat
 class mock_gpu_pipeline_task_local_state : public gpu_pipeline_task_local_state {
  public:
   mock_gpu_pipeline_task_local_state(int task_id, int expected_gpu_id)
-    : gpu_pipeline_task_local_state(
-        std::make_unique<operator_data>(std::vector<std::shared_ptr<cucascade::data_batch>>{})),
+    : gpu_pipeline_task_local_state(std::make_unique<pipelineable_operator_data>(
+        std::vector<std::shared_ptr<cucascade::data_batch>>{})),
       _task_id(task_id),
       _expected_gpu_id(expected_gpu_id)
   {


### PR DESCRIPTION
## Summary
- Split `operator_data` into a generic empty base class and a derived `pipelineable_operator_data` that carries the data batch vector
- `partitioned_operator_data` now derives from `pipelineable_operator_data` instead of `operator_data`
- All operator implementations, pipeline tasks, scan tasks, and tests updated to use `pipelineable_operator_data` for batch-based data flow

## Motivation
The previous `operator_data` class was tightly coupled to the data-batch representation. This refactoring creates a clean extension point: future operator data types can derive from the generic `operator_data` base without being forced into the batch model.

### New hierarchy
```
operator_data                    (empty generic base)
  └── pipelineable_operator_data (vector<data_batch> + get_data_batches())
       └── partitioned_operator_data (adds partition_idx)
```

## Test plan
- [x] Full build compiles cleanly
- [x] All 741 unit tests pass (78.8M assertions)
- [x] Pre-commit hooks (clang-format, codespell, etc.) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)