### PR TITLE
Simplify dataset-manager skill and add DuckDB format to TPC-H generation

### DIFF
--- a/.claude/skills/dataset-manager/SKILL.md
+++ b/.claude/skills/dataset-manager/SKILL.md
@@ -1,159 +1,79 @@
 ---
 name: dataset-manager
 description: >
-  Use this skill to generate TPC-H test data, consolidate parquet files, inspect dataset layout,
-  or optimize row group sizes. Trigger when the user needs test data at a specific scale factor,
-  wants to merge small parquet files, check dataset structure, or prepare data for benchmarks.
-  Auto-selects cudf (GPU) or pyarrow (CPU) with OOM fallback.
+  Use this skill to generate benchmark datasets (TPC-H, TPC-DS, etc.). Trigger when the user
+  needs test data at a specific scale factor for benchmarking or testing. Supports parquet and
+  duckdb output formats.
+argument-hint: "[benchmark] [scale_factor] [--format duckdb|parquet] [--output <path>]"
 ---
 
-# TPC-H Dataset Manager
+# Dataset Generator
 
-You are managing TPC-H parquet datasets for Sirius, a GPU-accelerated SQL query engine. Your job is to generate, inspect, consolidate, and optimize parquet files used for benchmarking and testing.
+Generate benchmark datasets by running the corresponding shell script under `test/<benchmark>_performance/`.
 
-## Backend Selection
+## Gather Parameters
 
-The `rewrite_parquet.py` script handles backend selection automatically:
-- If **cudf** is installed, it uses GPU-accelerated reads (much faster for large datasets)
-- If cudf is **not installed** or hits a **GPU out-of-memory** error, it falls back to **pyarrow** (CPU-only)
-- The fallback is per-table and per-batch — if a large table OOMs on the GPU mid-way, remaining batches continue with pyarrow
+Parse `$ARGUMENTS` for:
+- **Benchmark**: name from the registry below (first positional arg)
+- **Scale factor**: integer (second positional arg)
+- **Format**: `--format duckdb|parquet` (optional — each benchmark has a default)
+- **Output path**: `--output <path>` (optional — scripts have sensible defaults)
 
-No manual GPU memory check is needed. Just run the script.
+If any required parameter (benchmark, scale factor) is missing, ask the user.
 
-## TPC-H Tables
+## Benchmark Registry
 
-All 8 TPC-H tables: `customer`, `lineitem`, `nation`, `orders`, `part`, `partsupp`, `region`, `supplier`.
+Each entry follows the same structure: script location, command template, supported formats, defaults, and prerequisites.
 
-## Working Directory
+<!-- To add a new benchmark: copy an existing entry, fill in the fields, and update the description frontmatter. -->
 
-All commands run from the **project root** (the repository root).
-Scripts are in `test/tpch_performance/`.
-Datasets live under `test_datasets/`.
-The pixi environment for Python scripts: `cd test/tpch_performance && pixi run python ...`
+### TPC-H
 
-## Workflows
-
-### Workflow A: Generate TPC-H Data
-
-Use `generate_tpch_data.sh` which clones and builds [sirius-db/tpchgen-rs](https://github.com/sirius-db/tpchgen-rs) from source, then generates parquet files with optimized row groups, encodings, and compression.
-
-```bash
-cd test/tpch_performance
-pixi run bash generate_tpch_data.sh <scale_factor> [output_dir] [jobs]
-```
-
-Arguments:
-- `scale_factor` — TPC-H scale factor (e.g. 1, 10, 100)
-- `output_dir` — Output directory (default: `test_datasets/tpch_parquet_sf<SF>`)
-- `jobs` — Number of parallel jobs (default: `nproc`)
-
-Examples:
-```bash
-# Generate SF100 with default settings
-cd test/tpch_performance
-pixi run bash generate_tpch_data.sh 100
-
-# Generate SF10 to a custom location with 8 jobs
-cd test/tpch_performance
-pixi run bash generate_tpch_data.sh 10 ../../test_datasets/tpch_sf10_custom 8
-```
-
-The script:
-1. Clones `sirius-db/tpchgen-rs` to `test_datasets/tpchgen-rs/` (if not already present)
-2. Builds `tpchgen-cli` with native CPU optimizations (`RUSTFLAGS="-C target-cpu=native"`)
-3. Runs `scripts/generate_tpch.py` to produce parquet files
-
-If the output directory already exists, the script skips generation. Remove the directory to regenerate.
-
-### Workflow B: Consolidate / Optimize Parquet Files
-
-This is the most common operation. Takes parquet files and rewrites them with optimized row groups, compression, and file size limits. Automatically uses cudf if available, falls back to pyarrow on import failure or GPU OOM.
+| Field | Value |
+|-------|-------|
+| Script | `test/tpch_performance/generate_tpch_data.sh` |
+| Default format | `parquet` |
+| Formats | `parquet` (tpchgen-rs), `duckdb` (DuckDB `dbgen()`) |
+| Default output (parquet) | `test_datasets/tpch_parquet_sf<SF>` |
+| Default output (duckdb) | `test_datasets/tpch_sf<SF>.duckdb` |
+| Prerequisites | Parquet: pixi env (rust, python, pyarrow). DuckDB: `build/release/duckdb` |
 
 ```bash
-cd test/tpch_performance
-pixi run python rewrite_parquet.py <source_dir> <dest_dir> [row_group_rows] [max_file_gb]
+cd test/tpch_performance && pixi run bash generate_tpch_data.sh <SF> --format <FORMAT> [--output <path>]
 ```
 
-Parameters:
-- `source_dir` — Directory containing source parquet files
-- `dest_dir` — Output directory for rewritten files
-- `row_group_rows` — Rows per row group (default: 10,000,000)
-- `max_file_gb` — Maximum output file size in GB (default: 20). Tables exceeding this are split into numbered files (e.g., `lineitem_0000.parquet`, `lineitem_0001.parquet`)
+Notes:
+- If the parquet output directory already exists, the script skips generation
 
-Settings applied:
-- Snappy compression
-- Parquet V2 page headers
-- 8 MiB max page size
-- Dictionary encoding enabled
-- ROWGROUP-level statistics
-- Int32 downcasts for key columns to reduce memory footprint
+### TPC-DS
 
-Examples:
-```bash
-cd test/tpch_performance
-
-# Default: 10M-row row groups, 20 GB max file size
-pixi run python rewrite_parquet.py \
-    ../../test_datasets/tpch_parquet_sf100 \
-    ../../test_datasets/tpch_parquet_sf100_optimized
-
-# Custom: 2M-row row groups, 10 GB max file size
-pixi run python rewrite_parquet.py \
-    ../../test_datasets/tpch_parquet_sf100 \
-    ../../test_datasets/tpch_parquet_sf100_rg2m \
-    2000000 10
-```
-
-### Workflow C: Inspect Dataset
-
-Show the user what's in a dataset directory:
+| Field | Value |
+|-------|-------|
+| Script | `test/tpcds_performance/generate_tpcds_data.sh` |
+| Default format | `duckdb` |
+| Formats | `duckdb`, `parquet` |
+| Default output (duckdb) | `test_datasets/tpcds_sf<SF>.duckdb` |
+| Default output (parquet) | `test_datasets/tpcds_parquet_sf<SF>` |
+| Prerequisites | `build/release/duckdb` |
 
 ```bash
-# List files and sizes
-ls -lhS <dataset_dir>/*.parquet 2>/dev/null
-ls -lhS <dataset_dir>/**/*.parquet 2>/dev/null
+cd test/tpcds_performance && bash generate_tpcds_data.sh <SF> --format <FORMAT> [--output <path>]
 ```
 
-Then use Python to inspect parquet metadata:
+Notes:
+- Also extracts TPC-DS query files to `test/tpcds_performance/queries/q{1..99}.sql`
 
-```python
-import pyarrow.parquet as pq
+## Prerequisites
 
-for f in parquet_files:
-    meta = pq.read_metadata(f)
-    print(f"{f}: {meta.num_rows:,} rows, {meta.num_row_groups} row groups, {meta.num_columns} cols")
-    for i in range(meta.num_row_groups):
-        rg = meta.row_group(i)
-        print(f"  RG {i}: {rg.num_rows:,} rows")
+For any benchmark that requires the DuckDB binary, check before running:
+```bash
+test -x build/release/duckdb
 ```
+If missing, tell the user to build first: `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make`
 
-Report: table name, total rows, number of files, number of row groups, row group sizes, file sizes on disk, compression.
+## Report Results
 
-### Workflow D: Merge Specific Tables
-
-Sometimes the user wants to merge only specific tables (e.g., just lineitem). Edit the `TPCH_TABLES` list in `rewrite_parquet.py` or call `rewrite_table()` directly for the requested tables.
-
-## Key Considerations
-
-- **Memory safety**: For large datasets (SF100+), the script processes in batches automatically. If cudf OOMs, it falls back to pyarrow for remaining batches.
-- **Schema preservation**: Preserve original date32 and decimal types. cudf internally promotes date32 to timestamp; the script casts back before writing.
-- **File splitting**: Output files exceeding `max_file_gb` (default 20 GB) are automatically split into numbered files. Small tables that fit under the limit stay as single files (e.g., `customer.parquet`).
-- **File discovery**: The script handles three parquet layouts:
-  1. Single file: `<dir>/<table>.parquet`
-  2. Partitioned by suffix: `<dir>/<table>_*.parquet`
-  3. Subdirectory (tpchgen-rs): `<dir>/<table>/<table>.*.parquet`
-- **Row group sizing**: Default 10M rows. For small tables (nation, region), the full table is one row group. For large tables (lineitem at SF100 = ~600M rows), 10M row groups give ~60 row groups.
-- **Recommended sizes**: 2M-10M rows per row group for GPU workloads.
-
-## Before Running
-
-- **Ask the user** for source/destination paths if not clear from context.
-- Use the pixi environment: `cd test/tpch_performance && pixi run python ...`
-
-## Output
-
-Always report:
-- Backend used (cudf or pyarrow) — the script prints this automatically
-- Per-table: rows processed, source size, destination size, compression ratio, number of output files
-- Total time elapsed
-- Output directory location
+- Benchmark name
+- Output path
+- Format used
+- Whether generation was skipped (output already existed) or completed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ Sirius includes Claude Code skills for performance analysis and dataset manageme
 | Skill | Command | Description |
 |-------|---------|-------------|
 | Profile Analyzer | `/profile-analyzer` | Analyzes GPU performance from nsys profiles — kernel occupancy, memory bandwidth, operator attribution, and regression detection. |
-| Dataset Manager | `/dataset-manager` | Manages TPC-H parquet datasets — generate at any scale factor, consolidate files, inspect layout, optimize row groups. |
+| Dataset Manager | `/dataset-manager` | Generates benchmark datasets (TPC-H, TPC-DS, etc.) at any scale factor in parquet or duckdb format. |
 | Optimization Advisor | `/optimization-advisor` | Maps GPU hotspots from nsys profiles to source functions, detects efficiency bottlenecks, sync overhead, and parallelism opportunities. |
 | TPC-DS Benchmark | `/tpcds-benchmark` | Runs TPC-DS benchmarks on Legacy Sirius, Super Sirius, or DuckDB CPU baseline — generate data, execute queries, and compare results. |
 | Module Context | `/module-context` | **Auto-loaded before implementation tasks.** Identifies which dependency modules are relevant to a task and loads their API docs (signatures, descriptions, usage examples). |

--- a/test/tpch_performance/generate_tpch_data.sh
+++ b/test/tpch_performance/generate_tpch_data.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
-# Generate TPC-H parquet datasets using sirius-db/tpchgen-rs.
-#
-# Clones and builds tpchgen-cli from source (with native CPU optimizations),
-# then runs scripts/generate_tpch.py to produce partitioned parquet files
-# with optimized row groups, encodings, and compression.
+# Generate TPC-H datasets using tpchgen-rs (parquet) or DuckDB's dbgen (duckdb).
 #
 # Usage:
-#   ./generate_tpch_data.sh <scale_factor> [output_dir] [jobs]
+#   ./generate_tpch_data.sh <scale_factor> [--format duckdb|parquet] [--output <path>] [--jobs N]
+#   ./generate_tpch_data.sh <scale_factor> [output_dir] [jobs]     # backward-compatible
 #
 # Arguments:
 #   scale_factor  - TPC-H scale factor (e.g. 1, 10, 100)
-#   output_dir    - Output directory (default: test_datasets/tpch_parquet_sf<SF>)
-#   jobs          - Number of parallel jobs (default: nproc)
+#   --format      - Output format: 'parquet' (default) or 'duckdb'
+#   --output      - Output path (default depends on format)
+#   --jobs        - Number of parallel jobs for parquet generation (default: nproc)
 #
-# This script is intended to be run via pixi from test/tpch_performance/:
+# Parquet format uses tpchgen-rs for optimized row groups and compression.
+# DuckDB format uses DuckDB's built-in dbgen() extension.
+#
+# Examples:
 #   cd test/tpch_performance
 #   pixi run bash generate_tpch_data.sh 100
+#   pixi run bash generate_tpch_data.sh 100 --format duckdb
+#   pixi run bash generate_tpch_data.sh 100 --format parquet --output /data/tpch_sf100
 #
 # Or it can be called standalone if rust, python, and pyarrow are in PATH.
 
@@ -23,50 +26,118 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="$PROJECT_DIR/build/release/duckdb"
 
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <scale_factor> [output_dir] [jobs]"
-    echo "Example: $0 100"
+    echo "Usage: $0 <scale_factor> [--format duckdb|parquet] [--output <path>] [--jobs N]"
+    echo "Examples:"
+    echo "  $0 100                        # SF100, parquet (default)"
+    echo "  $0 100 --format duckdb        # SF100, duckdb database"
+    echo "  $0 100 --format parquet --output /data/tpch_sf100"
     exit 1
 fi
 
 SF="$1"
-OUTPUT_DIR="${2:-$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}}"
-JOBS="${3:-$(nproc)}"
-TPCHGEN_DIR="$PROJECT_DIR/test_datasets/tpchgen-rs"
+shift
 
-if [ -d "$OUTPUT_DIR" ]; then
-    echo "Output directory already exists: $OUTPUT_DIR"
-    echo "Skipping generation. Remove the directory to regenerate."
-    exit 0
+FORMAT="parquet"
+OUTPUT=""
+JOBS="$(nproc)"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --format)
+            FORMAT="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        --jobs)
+            JOBS="$2"
+            shift 2
+            ;;
+        *)
+            # Backward compatibility: positional [output_dir] [jobs]
+            if [ -z "$OUTPUT" ]; then
+                OUTPUT="$1"
+            else
+                JOBS="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ "$FORMAT" != "duckdb" ] && [ "$FORMAT" != "parquet" ]; then
+    echo "ERROR: format must be 'duckdb' or 'parquet', got: $FORMAT"
+    exit 1
 fi
 
-# Step 1: Clone tpchgen-rs if not present
-if [ ! -d "$TPCHGEN_DIR" ]; then
-    echo "Cloning sirius-db/tpchgen-rs..."
-    git clone https://github.com/sirius-db/tpchgen-rs.git "$TPCHGEN_DIR"
-else
-    echo "tpchgen-rs already cloned at $TPCHGEN_DIR"
+# --- Set default output path ---
+if [ -z "$OUTPUT" ]; then
+    if [ "$FORMAT" = "duckdb" ]; then
+        OUTPUT="$PROJECT_DIR/test_datasets/tpch_sf${SF}.duckdb"
+    else
+        OUTPUT="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+    fi
 fi
 
-# Step 2: Build tpchgen-cli from source (skip if already built)
-TPCHGEN_CLI="$TPCHGEN_DIR/target/release/tpchgen-cli"
-if [ ! -f "$TPCHGEN_CLI" ]; then
-    echo "Building tpchgen-cli with native CPU optimizations..."
-    (cd "$TPCHGEN_DIR" && RUSTFLAGS="-C target-cpu=native" cargo build --release -p tpchgen-cli)
-else
-    echo "tpchgen-cli already built at $TPCHGEN_CLI"
-fi
+# --- Generate data ---
+if [ "$FORMAT" = "parquet" ]; then
+    # Use tpchgen-rs for optimized parquet output
+    if [ -d "$OUTPUT" ]; then
+        echo "Output directory already exists: $OUTPUT"
+        echo "Skipping generation. Remove the directory to regenerate."
+        exit 0
+    fi
 
-# Step 3: Generate parquet data
-echo "Generating TPC-H SF${SF} parquet data with ${JOBS} parallel jobs..."
-echo "Output: $OUTPUT_DIR"
-python "$TPCHGEN_DIR/scripts/generate_tpch.py" \
-    -s "$SF" \
-    -f parquet \
-    -j "$JOBS" \
-    -o "$OUTPUT_DIR"
+    TPCHGEN_DIR="$PROJECT_DIR/test_datasets/tpchgen-rs"
+
+    # Step 1: Clone tpchgen-rs if not present
+    if [ ! -d "$TPCHGEN_DIR" ]; then
+        echo "Cloning sirius-db/tpchgen-rs..."
+        git clone https://github.com/sirius-db/tpchgen-rs.git "$TPCHGEN_DIR"
+    else
+        echo "tpchgen-rs already cloned at $TPCHGEN_DIR"
+    fi
+
+    # Step 2: Build tpchgen-cli from source (skip if already built)
+    TPCHGEN_CLI="$TPCHGEN_DIR/target/release/tpchgen-cli"
+    if [ ! -f "$TPCHGEN_CLI" ]; then
+        echo "Building tpchgen-cli with native CPU optimizations..."
+        (cd "$TPCHGEN_DIR" && RUSTFLAGS="-C target-cpu=native" cargo build --release -p tpchgen-cli)
+    else
+        echo "tpchgen-cli already built at $TPCHGEN_CLI"
+    fi
+
+    # Step 3: Generate parquet data
+    echo "Generating TPC-H SF${SF} parquet data with ${JOBS} parallel jobs..."
+    echo "Output: $OUTPUT"
+    python "$TPCHGEN_DIR/scripts/generate_tpch.py" \
+        -s "$SF" \
+        -f parquet \
+        -j "$JOBS" \
+        -o "$OUTPUT"
+
+elif [ "$FORMAT" = "duckdb" ]; then
+    # Use DuckDB's built-in dbgen() for DuckDB format
+    if [ ! -x "$DUCKDB" ]; then
+        echo "ERROR: DuckDB binary not found at $DUCKDB"
+        echo "Build first: CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make"
+        exit 1
+    fi
+
+    if [ -f "$OUTPUT" ]; then
+        echo "WARNING: Database file already exists, will overwrite tables"
+    fi
+
+    echo "Generating TPC-H SF${SF} data into $OUTPUT ..."
+    "$DUCKDB" "$OUTPUT" -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=${SF});"
+fi
 
 echo ""
 echo "TPC-H SF${SF} data generation complete."
-echo "Output: $OUTPUT_DIR"
+echo "  Format: $FORMAT"
+echo "  Output: $OUTPUT"


### PR DESCRIPTION
## Summary
- **Replace** the complex 4-workflow dataset-manager skill (generate, consolidate, inspect, merge) with a streamlined version that generates TPC-H or TPC-DS data via shell scripts
- **Add `--format duckdb|parquet`** to `generate_tpch_data.sh` — DuckDB format uses `dbgen()`, mirroring the TPC-DS script; parquet format keeps the existing tpchgen-rs path
- **Extensible benchmark registry** pattern in the skill makes it easy to add future benchmarks (copy a section, fill in the fields)
- Backward-compatible: existing callers using positional args (`generate_tpch_data.sh <SF> <output_dir>`) continue to work

## Test plan
- [x] Run `cd test/tpch_performance && pixi run bash generate_tpch_data.sh 1` (parquet, default)
- [x] Run `cd test/tpch_performance && pixi run bash generate_tpch_data.sh 1 --format duckdb` (new DuckDB path)
- [x] Run `cd test/tpcds_performance && bash generate_tpcds_data.sh 1 --format parquet`
- [x] Verify backward compat: `cd test/tpch_performance && pixi run bash generate_tpch_data.sh 1 /tmp/test_tpch`
- [x] Invoke `/dataset-manager` skill and confirm it prompts for benchmark type and scale factor

🤖 Generated with [Claude Code](https://claude.com/claude-code)