### PR TITLE
Add generic /benchmark skill with TPC-H and TPC-DS support

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: benchmark
+description: >
+  Run TPC-H or TPC-DS benchmarks on Super Sirius or DuckDB CPU baseline — generate data, execute
+  queries, validate results, and compare timings. Trigger when the user mentions benchmarking,
+  TPC-DS, TPC-H, performance testing, query runtimes, or wants to compare Sirius vs DuckDB speed.
+disable-model-invocation: true
+---
+
+# Benchmark Runner
+
+You are running SQL benchmarks for Sirius, a GPU-accelerated SQL query engine built on DuckDB. This skill manages data generation, benchmark execution across two engines (Super Sirius, DuckDB CPU), and result comparison. Each benchmark suite is documented in its own section below — to add a new benchmark in the future, add a new section following the same pattern (tables, query files, data generation, workflows).
+
+## Supported Benchmarks
+
+| Benchmark | Queries | Tables | Scripts Directory | Best For |
+|-----------|---------|--------|-------------------|----------|
+| **TPC-H** | 22 | 8 | `test/tpch_performance/` | I/O-heavy joins, aggregations, standard analytics |
+| **TPC-DS** | 99 | 24 | `test/tpcds_performance/` | Broad SQL coverage (joins, aggregates, subqueries, window functions) |
+
+**Ask the user which benchmark to run if not specified.**
+
+## Two Engines
+
+| Engine | Entry Point | Config | TPC-H Scripts | TPC-DS Scripts |
+|--------|-------------|--------|---------------|----------------|
+| **Super Sirius** | `gpu_execution("...")` | **Requires** `SIRIUS_CONFIG_FILE` | `benchmark_and_validate.sh` / `run_tpch_parquet.sh` | `benchmark_and_validate.sh` / `run_tpcds_super.sh` |
+| **DuckDB CPU** | Raw SQL (no GPU wrapping) | Unsets `SIRIUS_CONFIG_FILE` | `benchmark_and_validate.sh` / `run_tpch_parquet.sh` | `benchmark_and_validate.sh` / `run_tpcds_duckdb.sh` |
+
+**Config file behavior:**
+- Super Sirius: `SIRIUS_CONFIG_FILE` must be set and point to a valid file — the scripts error if not
+- DuckDB CPU: `SIRIUS_CONFIG_FILE` is automatically unset — pure CPU baseline
+
+## Working Directory
+
+All commands run from the **project root**. TPC-H scripts are in `test/tpch_performance/`. TPC-DS scripts are in `test/tpcds_performance/`.
+
+## GPU-Compatible Queries
+
+A query is **GPU-compatible** when it meets both criteria:
+1. **Executes completely on Super Sirius** — every operator in the query plan runs on the GPU without falling back to DuckDB's CPU engine
+2. **Produces correct results** — the GPU output matches DuckDB CPU output exactly
+
+- **TPC-H:** All 22 queries (1-22) are GPU-compatible
+- **TPC-DS:** 15 queries are GPU-compatible: 3, 7, 22, 26, 32, 37, 42, 52, 55, 62, 82, 85, 92, 93, 97
+
+The TPC-DS GPU-compatible list grows as more queries gain full GPU support.
+
+## Identifying GPU Fallback and Errors
+
+When a query cannot run on GPU, Super Sirius produces distinct error messages (see `src/sirius_extension.cpp`). A query is considered **failing** if any of these conditions are true:
+1. The log contains a fallback or error message (query ran on CPU, not GPU)
+2. The timer output is missing (`-1` in timings.csv / `NO_TIMER` status) — indicates the query crashed or hung
+3. The timings.csv shows `FAILED` status
+
+**Super Sirius (`gpu_execution`) messages:**
+- `"Error in SiriusGeneratePhysicalPlan: <message>"` — plan generation failed; falls back if `ENABLE_DUCKDB_FALLBACK` is true
+- `"Error in SiriusExecuteQuery, fallback to DuckDB"` — plan or execution error with fallback enabled
+- `"SiriusExecuteQuery error: <message>"` — thrown when fallback is disabled
+
+**How to detect failures in benchmark logs:**
+```bash
+# Queries that fell back to DuckDB CPU
+grep -l "fallback to DuckDB" <output_dir>/log_q*.txt
+
+# Plan generation errors
+grep -l "Error in SiriusGeneratePhysicalPlan" <output_dir>/log_q*.txt
+
+# Execution errors
+grep -l "Error in SiriusExecuteQuery" <output_dir>/log_q*.txt
+
+# Queries that crashed or hung (no timer output)
+grep "NO_TIMER\|FAILED" <output_dir>/timings.csv
+
+# Queries that ran successfully on GPU
+for log in <output_dir>/log_q*.txt; do
+    if ! grep -q "fallback to DuckDB\|Error in.*PhysicalPlan\|Error in.*ExecuteQuery" "$log"; then
+        echo "$log"
+    fi
+done
+```
+
+---
+
+# TPC-H Benchmarks
+
+Scripts are in `test/tpch_performance/`.
+
+## TPC-H Tables
+
+8 tables: `customer`, `lineitem`, `nation`, `orders`, `part`, `partsupp`, `region`, `supplier`.
+
+## TPC-H Query Files
+
+- **Sirius (GPU):** `test/tpch_performance/tpch_queries/gpu/q*.sql` — wrapped with `call gpu_execution('...');`
+- **DuckDB (CPU):** `test/tpch_performance/tpch_queries/orig/q*.sql` — plain SQL
+
+## Workflow H-A: Generate TPC-H Data
+
+```bash
+cd test/tpch_performance
+pixi run bash generate_tpch_data.sh <scale_factor> [output_dir] [jobs]
+```
+
+- Builds `sirius-db/tpchgen-rs` from source, generates partitioned parquet files to `test_datasets/tpch_parquet_sf<SF>/`
+- **Auto-called** by `run_tpch_parquet.sh` if data is missing — no need to run separately in most cases
+
+## Workflow H-B: Full Benchmark with Validation (Recommended)
+
+Runs all 22 queries for both Sirius and DuckDB, compares results for correctness, and produces a timestamped run directory.
+
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+./test/tpch_performance/benchmark_and_validate.sh <scale_factor>
+```
+
+**Options:**
+- `--config <file>` — Override Sirius config file
+- `--parquet-dir <path>` — Custom parquet data location (default: `test_datasets/tpch_parquet_sf<SF>/`)
+- `--engines <engines>` — Space-separated list (default: `"sirius duckdb"`)
+- `--iterations <N>` — Iterations per query (default: 2 = 1 cold + 1 warm)
+- `--timeout <seconds>` — Session timeout (default: 1200)
+- `--multi-session` — Run each query in its own DuckDB process (fresh state per query, useful for DuckDB baselines)
+- `--duckdb-results <run_dir>` — Reuse previously stored DuckDB results (skip re-running DuckDB)
+- `--report <run_dir>` — Regenerate reports from existing run directory (no benchmarks run)
+
+**Examples:**
+```bash
+# Basic run at SF100
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+./test/tpch_performance/benchmark_and_validate.sh 100
+
+# 3 iterations, 5-minute timeout
+./test/tpch_performance/benchmark_and_validate.sh --config ~/my.cfg --iterations 3 --timeout 300 100
+
+# Reuse prior DuckDB results
+./test/tpch_performance/benchmark_and_validate.sh --duckdb-results runs/2026-03-10_12-00-00_sf100_2iter 100
+
+# Regenerate report from existing run
+./test/tpch_performance/benchmark_and_validate.sh --report runs/2026-03-10_12-00-00_sf100_2iter
+```
+
+**Output:** `runs/<timestamp>_sf<SF>_<N>iter/`
+- `run_info.txt` — git, hardware, build info
+- `sirius/` and `duckdb/` — per-engine: `q<N>/result.txt`, `q<N>/timings.csv`, `run.log`
+- `validation.csv` — per-query match/error status
+- `comparison.txt` — cold/warm timing table with speedup ratios
+- `timings.csv` — long-format: `engine,query,iteration,runtime_s`
+
+## Workflow H-C: Run Individual Queries
+
+For running specific queries or a single engine without the full orchestrator.
+
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+./test/tpch_performance/run_tpch_parquet.sh [options] <engine> <scale_factor> <query_numbers...>
+```
+
+**Options:** `--parquet-dir`, `--iterations`, `--timeout`, `--cache-level`, `--multi-session`
+
+**Examples:**
+```bash
+./test/tpch_performance/run_tpch_parquet.sh sirius 100 $(seq 1 22)
+./test/tpch_performance/run_tpch_parquet.sh duckdb 100 1 3 6
+./test/tpch_performance/run_tpch_parquet.sh --multi-session duckdb 100 $(seq 1 22)
+./test/tpch_performance/run_tpch_parquet.sh --iterations 5 --parquet-dir /data/tpch sirius 100 $(seq 1 22)
+```
+
+**SF>=1000 cache note:** At SF>=1000, queries 1, 7, 9, 10, 17, 18, 19, 21 automatically use `scan_cache_level = 'table_host'` (host memory caching). Override with `--cache-level`.
+
+---
+
+# TPC-DS Benchmarks
+
+Scripts are in `test/tpcds_performance/`.
+
+## TPC-DS Tables
+
+All 24 tables: `call_center`, `catalog_page`, `catalog_returns`, `catalog_sales`, `customer`, `customer_address`, `customer_demographics`, `date_dim`, `household_demographics`, `income_band`, `inventory`, `item`, `promotion`, `reason`, `ship_mode`, `store`, `store_returns`, `store_sales`, `time_dim`, `warehouse`, `web_page`, `web_returns`, `web_sales`, `web_site`.
+
+## TPC-DS Query Files
+
+Located at `test/tpcds_performance/queries/q1.sql` through `q99.sql`. Generated automatically by `generate_tpcds_data.sh` using DuckDB's `tpcds_queries()` function.
+
+## Workflow DS-A: Generate TPC-DS Data
+
+```bash
+bash test/tpcds_performance/generate_tpcds_data.sh <scale_factor> [--format parquet|duckdb] [--output <path>]
+```
+
+- Default format is `duckdb`; use `--format parquet` for Super Sirius
+- Output: `test_datasets/tpcds_sf<SF>.duckdb` or `test_datasets/tpcds_parquet_sf<SF>/`
+- Also generates query files `q1.sql` through `q99.sql`
+
+**Examples:**
+```bash
+bash test/tpcds_performance/generate_tpcds_data.sh 1
+bash test/tpcds_performance/generate_tpcds_data.sh 10 --format parquet
+```
+
+## Workflow DS-B: Full Benchmark with Validation (Recommended)
+
+Runs TPC-DS queries for both Super Sirius and DuckDB, compares results for correctness, and produces a timestamped run directory.
+
+**Ask the user which query set to run:**
+
+| Option | Flag | Queries | Description |
+|--------|------|---------|-------------|
+| **GPU-compatible only** | `--gpu-only` | 15 queries | Only queries that execute completely on Super Sirius and produce correct results matching DuckDB CPU. All should succeed. This list grows as more queries gain GPU support. |
+| **All 99 queries** | *(default)* | 99 queries | Runs every TPC-DS query. Some will fall back to DuckDB CPU or error — useful for discovering which queries work and measuring coverage. |
+
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+
+# GPU-compatible queries only (recommended for benchmarking)
+./test/tpcds_performance/benchmark_and_validate.sh --gpu-only <scale_factor>
+
+# All 99 queries (some may fall back to CPU or error)
+./test/tpcds_performance/benchmark_and_validate.sh <scale_factor>
+```
+
+**Options:**
+- `--config <file>` — Override Sirius config file
+- `--parquet-dir <path>` — Custom parquet data location (default: `test_datasets/tpcds_parquet_sf<SF>/`)
+- `--engines <engines>` — Space-separated list (default: `"sirius duckdb"`)
+- `--gpu-only` — Run only the GPU-compatible query subset
+- `--queries <N...> --` — Specific query numbers (use `--` before scale_factor)
+- `--duckdb-results <run_dir>` — Reuse previously stored DuckDB results
+- `--report <run_dir>` — Regenerate reports from existing run directory
+
+**Examples:**
+```bash
+# GPU-compatible queries at SF1
+export SIRIUS_CONFIG_FILE=~/sirius_config.cfg
+./test/tpcds_performance/benchmark_and_validate.sh --gpu-only 1
+
+# All 99 queries at SF10
+./test/tpcds_performance/benchmark_and_validate.sh 10
+
+# Specific queries
+./test/tpcds_performance/benchmark_and_validate.sh --queries 3 7 42 -- 1
+
+# Reuse prior DuckDB results
+./test/tpcds_performance/benchmark_and_validate.sh --duckdb-results runs/tpcds_2026-04-05_sf1 --gpu-only 1
+
+# Regenerate report from existing run
+./test/tpcds_performance/benchmark_and_validate.sh --report runs/tpcds_2026-04-05_sf1
+```
+
+**Output:** `runs/tpcds_<timestamp>_sf<SF>/`
+- `run_info.txt` — git, hardware, build info
+- `sirius/` and `duckdb/` — per-engine: `result_q<N>.txt`, `log_q<N>.txt`, `timings.csv`, `run.log`
+- `validation.csv` — per-query match/error status (`success` = results match, `validation` = diff found, `error` = query failed)
+- `comparison.txt` — cold/warm timing table with speedup ratios
+- `timings.csv` — long-format: `engine,query,iteration,runtime_s`
+
+## Workflow DS-C: Run Individual Engine
+
+For running a single engine without the full orchestrator.
+
+**Super Sirius:**
+```bash
+export SIRIUS_CONFIG_FILE=/path/to/config.cfg
+bash test/tpcds_performance/run_tpcds_super.sh <parquet_dir> [--queries N...] [--output-dir path]
+bash test/tpcds_performance/run_tpcds_super_gpu.sh <parquet_dir> [--output-dir path]  # GPU-compatible only
+```
+
+**DuckDB CPU:**
+```bash
+bash test/tpcds_performance/run_tpcds_duckdb.sh --parquet-dir <path> [--queries N...] [--output-dir path]
+bash test/tpcds_performance/run_tpcds_duckdb.sh --db <path> [--queries N...] [--output-dir path]
+```
+
+## Updating the GPU-Compatible Query List
+
+To discover which TPC-DS queries are GPU-compatible:
+1. Run all 99 queries: `./test/tpcds_performance/benchmark_and_validate.sh <SF>`
+2. Check `validation.csv` — queries with `success` status executed on GPU with correct results
+3. Cross-check logs for fallback: `grep -l "fallback to DuckDB" <run_dir>/sirius/log_q*.txt`
+4. Queries that show `success` in validation AND have no fallback in logs are GPU-compatible
+5. Update the `GPU_QUERIES` array in both `run_tpcds_super_gpu.sh` and `benchmark_and_validate.sh`
+
+---
+
+# Before Running
+
+- **Ask the user** for any paths you don't know. Do NOT assume paths.
+- **Ask which benchmark** (TPC-H or TPC-DS) if not specified.
+- **For TPC-DS**, ask which query set: GPU-compatible only (queries that fully execute on GPU with correct results) or all 99 queries (some may fall back to CPU or error).
+- Ensure the DuckDB binary is built: `pixi run -e clang make release`
+- For Super Sirius: ensure `SIRIUS_CONFIG_FILE` is set
+- For TPC-H: data is auto-generated if missing; query files are pre-existing in `tpch_queries/`
+- For TPC-DS: query files must exist in `test/tpcds_performance/queries/` — run `generate_tpcds_data.sh` first

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -166,8 +166,6 @@ export SIRIUS_CONFIG_FILE=/path/to/config.cfg
 ./test/tpch_performance/run_tpch_parquet.sh --iterations 5 --parquet-dir /data/tpch sirius 100 $(seq 1 22)
 ```
 
-**SF>=1000 cache note:** At SF>=1000, queries 1, 7, 9, 10, 17, 18, 19, 21 automatically use `scan_cache_level = 'table_host'` (host memory caching). Override with `--cache-level`.
-
 ---
 
 # TPC-DS Benchmarks
@@ -287,7 +285,6 @@ To discover which TPC-DS queries are GPU-compatible:
 - **Ask the user** for any paths you don't know. Do NOT assume paths.
 - **Ask which benchmark** (TPC-H or TPC-DS) if not specified.
 - **For TPC-DS**, ask which query set: GPU-compatible only (queries that fully execute on GPU with correct results) or all 99 queries (some may fall back to CPU or error).
+- **Ask about data**: Does the dataset already exist? If yes, ask for the parquet directory path. If no, confirm the user wants to generate it before proceeding — data generation can take significant time and disk space at large scale factors. Do NOT auto-generate without asking.
 - Ensure the DuckDB binary is built: `pixi run -e clang make release`
 - For Super Sirius: ensure `SIRIUS_CONFIG_FILE` is set
-- For TPC-H: data is auto-generated if missing; query files are pre-existing in `tpch_queries/`
-- For TPC-DS: query files must exist in `test/tpcds_performance/queries/` — run `generate_tpcds_data.sh` first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ Sirius includes Claude Code skills for performance analysis and dataset manageme
 | Profile Analyzer | `/profile-analyzer` | Analyzes GPU performance from nsys profiles — kernel occupancy, memory bandwidth, operator attribution, and regression detection. |
 | Dataset Manager | `/dataset-manager` | Manages TPC-H parquet datasets — generate at any scale factor, consolidate files, inspect layout, optimize row groups. |
 | Optimization Advisor | `/optimization-advisor` | Maps GPU hotspots from nsys profiles to source functions, detects efficiency bottlenecks, sync overhead, and parallelism opportunities. |
-| TPC-DS Benchmark | `/tpcds-benchmark` | Runs TPC-DS benchmarks on Legacy Sirius, Super Sirius, or DuckDB CPU baseline — generate data, execute queries, and compare results. |
+| Benchmark | `/benchmark` | Runs TPC-H or TPC-DS benchmarks on Super Sirius or DuckDB CPU baseline — generate data, execute queries, validate results, and compare timings. |
 | Module Context | `/module-context` | **Auto-loaded before implementation tasks.** Identifies which dependency modules are relevant to a task and loads their API docs (signatures, descriptions, usage examples). |
 | Module Discover | `/module-discover` | Analyzes a dependency library, divides it into modules, and generates LLM-consumable API documentation. Run once per library to populate docs. |
 

--- a/test/tpcds_performance/benchmark_and_validate.sh
+++ b/test/tpcds_performance/benchmark_and_validate.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# benchmark_and_validate.sh
+#
+# Runs TPC-DS queries for both sirius (Super Sirius) and duckdb, compares
+# results, and writes:
+#   validation.csv  - per-query match/error status
+#   comparison.txt  - results summary table (cold/warm timings, speedup)
+#   timings.csv     - long-format runtimes (engine,query,iteration,runtime_s)
+#
+# Each run gets its own timestamped directory under runs/:
+#   runs/tpcds_<timestamp>_sf<SF>/
+#     run_info.txt     - git, hardware, build info
+#     run_info.patch   - git diff when tree is dirty
+#     sirius_config.cfg
+#     sirius/          - result_q<N>.txt, log_q<N>.txt, timings.csv
+#     duckdb/          - result_q<N>.txt, log_q<N>.txt, timings.csv
+#     validation.csv
+#     comparison.txt
+#     timings.csv
+#
+# Usage:
+#   export SIRIUS_CONFIG_FILE=...
+#   ./test/tpcds_performance/benchmark_and_validate.sh <scale_factor>
+#   ./test/tpcds_performance/benchmark_and_validate.sh --gpu-only <scale_factor>
+#   ./test/tpcds_performance/benchmark_and_validate.sh --queries 3 7 42 -- <scale_factor>
+#   ./test/tpcds_performance/benchmark_and_validate.sh --report <run_dir>
+#   ./test/tpcds_performance/benchmark_and_validate.sh --duckdb-results <run_dir> <scale_factor>
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUPER_SCRIPT="$SCRIPT_DIR/run_tpcds_super.sh"
+DUCKDB_SCRIPT="$SCRIPT_DIR/run_tpcds_duckdb.sh"
+
+# TPC-DS queries confirmed to execute completely on Super Sirius with correct results.
+# This list grows as more queries gain full GPU support.
+GPU_QUERIES=(3 7 22 26 32 37 42 52 55 62 82 85 92 93 97)
+
+# ---------------------------------------------------------------------------
+# Report generation from an existing run directory.
+# ---------------------------------------------------------------------------
+generate_report() {
+    local RUN_DIR="$1"
+    local QUERIES=()
+
+    # Discover which queries are present by scanning sirius/ and duckdb/ result files.
+    for f in "$RUN_DIR"/sirius/result_q*.txt "$RUN_DIR"/duckdb/result_q*.txt; do
+        [ -f "$f" ] || continue
+        local base
+        base=$(basename "$f")
+        # Extract query number from result_q<N>.txt
+        local qnum="${base#result_q}"
+        qnum="${qnum%.txt}"
+        QUERIES+=("$qnum")
+    done
+    # Deduplicate and sort numerically.
+    readarray -t QUERIES < <(printf '%s\n' "${QUERIES[@]}" | sort -un)
+
+    if [ ${#QUERIES[@]} -eq 0 ]; then
+        echo "ERROR: no query result files found in $RUN_DIR"
+        return 1
+    fi
+
+    # Try to extract SF from the directory name (e.g. tpcds_..._sf10).
+    local SF="?"
+    local dir_base
+    dir_base=$(basename "$RUN_DIR")
+    if [[ "$dir_base" =~ _sf([0-9]+) ]]; then
+        SF="${BASH_REMATCH[1]}"
+    fi
+
+    local VALIDATION_CSV="$RUN_DIR/validation.csv"
+    local TIMINGS_CSV="$RUN_DIR/timings.csv"
+
+    # ---------- Validation ----------
+    echo ""
+    echo "=== Comparing results ==="
+    echo "=========================================="
+
+    has_error() {
+        local file="$1"
+        [[ ! -f "$file" ]] && return 0
+        [[ ! -s "$file" ]] && return 0
+        grep -qE "(Error|Segmentation fault)" "$file" 2>/dev/null
+    }
+
+    printf 'query,status\n' | tee "$VALIDATION_CSV"
+
+    local ok=0 validate=0 errors=0
+
+    for q in "${QUERIES[@]}"; do
+        local SIRIUS_FILE="$RUN_DIR/sirius/result_q${q}.txt"
+        local DUCKDB_FILE="$RUN_DIR/duckdb/result_q${q}.txt"
+        local status
+        if has_error "$SIRIUS_FILE"; then
+            status="error"
+            (( errors++ ))
+        elif [ ! -f "$DUCKDB_FILE" ]; then
+            status="error"
+            (( errors++ ))
+        elif diff -q "$SIRIUS_FILE" "$DUCKDB_FILE" >/dev/null 2>&1; then
+            status="success"
+            (( ok++ ))
+        else
+            status="validation"
+            (( validate++ ))
+        fi
+
+        printf 'Q%s,%s\n' "$q" "$status" | tee -a "$VALIDATION_CSV"
+    done
+
+    echo ""
+    echo "=========================================="
+    printf 'Summary: %d/%d success   %d validation   %d error\n' \
+        "$ok" "${#QUERIES[@]}" "$validate" "$errors"
+    echo "Validation CSV saved to $VALIDATION_CSV"
+
+    # ---------- Combined timings CSV ----------
+    echo ""
+    echo "=== Building combined timings CSV ==="
+
+    printf 'engine,query,iteration,runtime_s\n' > "$TIMINGS_CSV"
+
+    for engine in sirius duckdb; do
+        local ENGINE_TIMINGS="$RUN_DIR/$engine/timings.csv"
+        [[ ! -f "$ENGINE_TIMINGS" ]] && continue
+
+        # TPC-DS timings.csv format: query,run1_time,run1_status,run2_time,run2_status
+        awk -F',' -v engine="$engine" '
+            NR == 1 { next }
+            {
+                query = "Q" $1
+                if ($2 != "-1" && $3 != "SKIP" && $3 != "EMPTY") {
+                    printf "%s,%s,1,%s\n", engine, query, $2
+                }
+                if ($4 != "-1" && $5 != "SKIP" && $5 != "EMPTY") {
+                    printf "%s,%s,2,%s\n", engine, query, $4
+                }
+            }
+        ' "$ENGINE_TIMINGS" >> "$TIMINGS_CSV"
+    done
+
+    echo "Timings CSV saved to $TIMINGS_CSV"
+
+    # ---------- Comparison table ----------
+    {
+    echo ""
+    echo "============================================================"
+    printf "  TPC-DS Results Summary  (SF%s)\n" "$SF"
+    echo "============================================================"
+    echo ""
+
+    declare -A DC DW SC SW
+
+    for q in "${QUERIES[@]}"; do
+        local ENGINE_TIMINGS
+
+        # Parse DuckDB timings (wide format: query,run1_time,run1_status,run2_time,run2_status)
+        ENGINE_TIMINGS="$RUN_DIR/duckdb/timings.csv"
+        if [ -f "$ENGINE_TIMINGS" ]; then
+            DC[$q]=$(awk -F',' -v q="$q" '$1==q && $3=="OK"{print $2}' "$ENGINE_TIMINGS")
+            DW[$q]=$(awk -F',' -v q="$q" '$1==q && $5=="OK"{print $4}' "$ENGINE_TIMINGS")
+        fi
+
+        # Parse Sirius timings
+        ENGINE_TIMINGS="$RUN_DIR/sirius/timings.csv"
+        if [ -f "$ENGINE_TIMINGS" ]; then
+            SC[$q]=$(awk -F',' -v q="$q" '$1==q && $3=="OK"{print $2}' "$ENGINE_TIMINGS")
+            SW[$q]=$(awk -F',' -v q="$q" '$1==q && $5=="OK"{print $4}' "$ENGINE_TIMINGS")
+        fi
+    done
+
+    printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+        "Query" "DuckDB Cold" "DuckDB Warm" "Sirius Cold" "Sirius Warm" "Speedup (warm)"
+    printf "%-7s-+-%13s-+-%13s-+-%13s-+-%13s-+-%14s\n" \
+        "-------" "-------------" "-------------" "-------------" "-------------" "--------------"
+
+    local TOTAL_DC=0 TOTAL_DW=0 TOTAL_SC=0 TOTAL_SW=0
+
+    for q in "${QUERIES[@]}"; do
+        local dc="${DC[$q]:-N/A}" dw="${DW[$q]:-N/A}"
+        local sc="${SC[$q]:-N/A}" sw="${SW[$q]:-N/A}"
+
+        local speedup="N/A"
+        if [ "$dw" != "N/A" ] && [ -n "$dw" ] && [ "$sw" != "N/A" ] && [ -n "$sw" ]; then
+            speedup=$(echo "scale=2; $dw / $sw" | bc 2>/dev/null || echo "N/A")
+            [ "$speedup" != "N/A" ] && speedup="${speedup}x"
+        fi
+
+        local fmt_dc="N/A" fmt_dw="N/A" fmt_sc="N/A" fmt_sw="N/A"
+        [ "$dc" != "N/A" ] && [ -n "$dc" ] && fmt_dc=$(printf "%.2fs" "$dc")
+        [ "$dw" != "N/A" ] && [ -n "$dw" ] && fmt_dw=$(printf "%.2fs" "$dw")
+        [ "$sc" != "N/A" ] && [ -n "$sc" ] && fmt_sc=$(printf "%.2fs" "$sc")
+        [ "$sw" != "N/A" ] && [ -n "$sw" ] && fmt_sw=$(printf "%.2fs" "$sw")
+
+        printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+            "Q${q}" "$fmt_dc" "$fmt_dw" "$fmt_sc" "$fmt_sw" "$speedup"
+
+        [ "$dc" != "N/A" ] && [ -n "$dc" ] && TOTAL_DC=$(echo "$TOTAL_DC + $dc" | bc)
+        [ "$dw" != "N/A" ] && [ -n "$dw" ] && TOTAL_DW=$(echo "$TOTAL_DW + $dw" | bc)
+        [ "$sc" != "N/A" ] && [ -n "$sc" ] && TOTAL_SC=$(echo "$TOTAL_SC + $sc" | bc)
+        [ "$sw" != "N/A" ] && [ -n "$sw" ] && TOTAL_SW=$(echo "$TOTAL_SW + $sw" | bc)
+    done
+
+    local total_speedup="N/A"
+    if [ "$(echo "$TOTAL_SW > 0" | bc)" -eq 1 ]; then
+        total_speedup=$(echo "scale=2; $TOTAL_DW / $TOTAL_SW" | bc 2>/dev/null || echo "N/A")
+        [ "$total_speedup" != "N/A" ] && total_speedup="${total_speedup}x"
+    fi
+
+    printf "%-7s-+-%13s-+-%13s-+-%13s-+-%13s-+-%14s\n" \
+        "-------" "-------------" "-------------" "-------------" "-------------" "--------------"
+    printf "%-7s | %13s | %13s | %13s | %13s | %14s\n" \
+        "TOTAL" "$(printf '%.2fs' "$TOTAL_DC")" "$(printf '%.2fs' "$TOTAL_DW")" \
+        "$(printf '%.2fs' "$TOTAL_SC")" "$(printf '%.2fs' "$TOTAL_SW")" "$total_speedup"
+    echo ""
+    echo "============================================================"
+    echo "All output saved to $RUN_DIR"
+    } | tee "$RUN_DIR/comparison.txt"
+}
+
+# ---------------------------------------------------------------------------
+# --report mode: regenerate comparison/timings from an existing run directory
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--report" ]; then
+    if [ $# -ne 2 ]; then
+        echo "Usage: $0 --report <run_dir>"
+        exit 1
+    fi
+    RUN_DIR="$2"
+    if [ ! -d "$RUN_DIR" ] && [ -d "$PROJECT_DIR/runs/$RUN_DIR" ]; then
+        RUN_DIR="$PROJECT_DIR/runs/$RUN_DIR"
+    fi
+    if [ ! -d "$RUN_DIR" ]; then
+        echo "ERROR: run directory not found: $RUN_DIR"
+        exit 1
+    fi
+    generate_report "$RUN_DIR"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Normal benchmark mode
+# ---------------------------------------------------------------------------
+
+# Parse optional flags
+DUCKDB_RESULTS_DIR=""
+PARQUET_DIR=""
+ENGINES=""
+USER_QUERIES=()
+GPU_ONLY=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config)
+            export SIRIUS_CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --parquet-dir)
+            PARQUET_DIR="$2"
+            shift 2
+            ;;
+        --engines)
+            ENGINES="$2"
+            shift 2
+            ;;
+        --gpu-only)
+            GPU_ONLY=true
+            shift
+            ;;
+        --queries)
+            shift
+            while [ $# -gt 0 ] && [[ "$1" != --* ]] && [[ "$1" != [^0-9]* || "$1" =~ ^[0-9]+$ ]]; do
+                USER_QUERIES+=("$1")
+                shift
+            done
+            ;;
+        --duckdb-results)
+            DUCKDB_RESULTS_DIR="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 [options] <scale_factor>"
+    echo "       $0 --report <run_dir>"
+    echo ""
+    echo "Options:"
+    echo "  --config <file>           Override Sirius config file"
+    echo "  --parquet-dir <path>      Custom parquet data location"
+    echo "  --engines 'sirius duckdb' Space-separated engine list (default: 'sirius duckdb')"
+    echo "  --gpu-only                Run only the GPU-compatible query subset"
+    echo "  --queries <N...> --       Specific query numbers (use -- before scale_factor)"
+    echo "  --duckdb-results <dir>    Reuse previously stored DuckDB results"
+    echo ""
+    echo "Examples:"
+    echo "  $0 1"
+    echo "  $0 --gpu-only 10"
+    echo "  $0 --queries 3 7 42 -- 1"
+    echo "  $0 --duckdb-results runs/tpcds_2026-04-05_sf1 10"
+    exit 1
+fi
+
+SF="$1"
+
+# Determine query set
+if [ ${#USER_QUERIES[@]} -gt 0 ]; then
+    QUERIES=("${USER_QUERIES[@]}")
+elif [ "$GPU_ONLY" = true ]; then
+    QUERIES=("${GPU_QUERIES[@]}")
+else
+    QUERIES=($(seq 1 99))
+fi
+
+ENGINES="${ENGINES:-sirius duckdb}"
+
+RUN_DIR="$PROJECT_DIR/runs/tpcds_$(date +%Y-%m-%d_%H-%M-%S)_sf${SF}"
+mkdir -p "$RUN_DIR"
+
+# Resolve config — only required for sirius engine.
+if [[ " $ENGINES " == *" sirius "* ]]; then
+    if [ -z "${SIRIUS_CONFIG_FILE:-}" ]; then
+        export SIRIUS_CONFIG_FILE="$HOME/.sirius/sirius.cfg"
+    fi
+    if [ ! -f "$SIRIUS_CONFIG_FILE" ]; then
+        echo "ERROR: config file not found: $SIRIUS_CONFIG_FILE"
+        exit 1
+    fi
+    echo "Config file: $SIRIUS_CONFIG_FILE"
+    cp "$SIRIUS_CONFIG_FILE" "$RUN_DIR/sirius_config.cfg"
+fi
+
+# Resolve parquet directory
+PARQUET_DIR="${PARQUET_DIR:-$PROJECT_DIR/test_datasets/tpcds_parquet_sf${SF}}"
+
+# ---------------------------------------------------------------------------
+# --duckdb-results: reuse previously stored DuckDB results for validation.
+# ---------------------------------------------------------------------------
+if [ -n "$DUCKDB_RESULTS_DIR" ]; then
+    if [ ! -d "$DUCKDB_RESULTS_DIR" ] && [ -d "$PROJECT_DIR/runs/$DUCKDB_RESULTS_DIR" ]; then
+        DUCKDB_RESULTS_DIR="$PROJECT_DIR/runs/$DUCKDB_RESULTS_DIR"
+    fi
+    if [ -d "$DUCKDB_RESULTS_DIR/duckdb" ]; then
+        DUCKDB_RESULTS_DIR="$DUCKDB_RESULTS_DIR/duckdb"
+    fi
+    if [ ! -d "$DUCKDB_RESULTS_DIR" ]; then
+        echo "ERROR: DuckDB results directory not found: $DUCKDB_RESULTS_DIR"
+        exit 1
+    fi
+
+    DUCKDB_RESULT_COUNT=0
+    for f in "$DUCKDB_RESULTS_DIR"/result_q*.txt; do
+        [ -f "$f" ] && (( DUCKDB_RESULT_COUNT++ ))
+    done
+    if [ "$DUCKDB_RESULT_COUNT" -eq 0 ]; then
+        echo "ERROR: no query results (result_q*.txt) found in $DUCKDB_RESULTS_DIR"
+        exit 1
+    fi
+
+    echo "Using stored DuckDB results from: $DUCKDB_RESULTS_DIR ($DUCKDB_RESULT_COUNT queries)"
+    cp -a "$DUCKDB_RESULTS_DIR" "$RUN_DIR/duckdb"
+
+    ENGINES=$(echo "$ENGINES" | sed 's/\bduckdb\b//g' | xargs)
+fi
+
+RUN_INFO_FILE="$RUN_DIR/run_info.txt"
+
+QUERY_MODE="all 99"
+if [ "$GPU_ONLY" = true ]; then
+    QUERY_MODE="GPU-compatible (${#GPU_QUERIES[@]})"
+elif [ ${#USER_QUERIES[@]} -gt 0 ]; then
+    QUERY_MODE="custom (${#USER_QUERIES[@]})"
+fi
+
+echo "=========================================="
+echo "TPC-DS Benchmark"
+echo "=========================================="
+echo "Scale factor: SF${SF}"
+echo "Parquet dir:  $PARQUET_DIR"
+echo "Queries:      $QUERY_MODE — ${QUERIES[*]}"
+echo "Engines:      $ENGINES"
+echo "Run dir:      $RUN_DIR"
+if [ -n "${DUCKDB_RESULTS_DIR:-}" ]; then
+    echo "DuckDB:       reusing from $DUCKDB_RESULTS_DIR"
+fi
+echo "=========================================="
+echo ""
+
+# ---------- Run info and environment ----------
+echo "=== Collecting run info ==="
+{
+    echo "Run info — $(date -Iseconds)"
+    echo "================================"
+    echo ""
+
+    echo "--- Benchmark ---"
+    echo "suite: TPC-DS"
+    echo "scale_factor: $SF"
+    echo "query_mode: $QUERY_MODE"
+    echo "queries: ${QUERIES[*]}"
+    echo ""
+
+    if [ -n "${DUCKDB_RESULTS_DIR:-}" ]; then
+        echo "--- DuckDB results ---"
+        echo "source: $DUCKDB_RESULTS_DIR (copied, not re-run)"
+        echo ""
+    fi
+
+    echo "--- Git ---"
+    if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree &>/dev/null; then
+        echo "branch: $(git -C "$PROJECT_DIR" branch --show-current)"
+        echo "revision: $(git -C "$PROJECT_DIR" rev-parse --short HEAD)"
+        if git -C "$PROJECT_DIR" diff --quiet 2>/dev/null && git -C "$PROJECT_DIR" diff --cached --quiet 2>/dev/null; then
+            echo "tree: clean"
+        else
+            echo "tree: dirty (uncommitted changes, see run_info.patch)"
+            {
+                echo "=== git diff ==="
+                git -C "$PROJECT_DIR" diff
+                echo ""
+                echo "=== git diff --cached ==="
+                git -C "$PROJECT_DIR" diff --cached
+            } > "$RUN_DIR/run_info.patch"
+        fi
+    else
+        echo "not a git repository"
+    fi
+    echo ""
+
+    echo "--- Build ---"
+    DUCKDB_BIN="$PROJECT_DIR/build/release/duckdb"
+    if [ -f "$DUCKDB_BIN" ]; then
+        echo "duckdb binary: $DUCKDB_BIN"
+        echo "duckdb mtime:  $(stat -c %y "$DUCKDB_BIN" 2>/dev/null || stat -f '%Sm' "$DUCKDB_BIN" 2>/dev/null)"
+    else
+        echo "duckdb binary: not found ($DUCKDB_BIN)"
+    fi
+    echo ""
+
+    echo "--- Hardware ---"
+    echo "hostname: $(hostname)"
+    echo "memory:"
+    sed -n 's/^MemTotal:/  MemTotal: /p; s/^MemAvailable:/  MemAvailable: /p' /proc/meminfo 2>/dev/null || true
+    echo "num_cpus: $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo '?')"
+    echo ""
+    echo "GPUs:"
+    if command -v nvidia-smi &>/dev/null; then
+        nvidia-smi --query-gpu=index,name,memory.total,memory.free,memory.used --format=csv,noheader 2>/dev/null | while read -r line; do echo "  $line"; done || nvidia-smi
+    else
+        echo "  nvidia-smi not available"
+    fi
+} | tee "$RUN_INFO_FILE"
+
+echo ""
+echo "Run info saved to $RUN_INFO_FILE"
+echo "=========================================="
+
+# ---------- Run benchmarks ----------
+for engine in $ENGINES; do
+    ENGINE_DIR="$RUN_DIR/$engine"
+    mkdir -p "$ENGINE_DIR"
+
+    echo ""
+    echo "=== Running $engine ==="
+
+    if [ "$engine" = "sirius" ]; then
+        bash "$SUPER_SCRIPT" "$PARQUET_DIR" \
+            --queries "${QUERIES[@]}" \
+            --output-dir "$ENGINE_DIR" \
+            2>&1 | tee "$ENGINE_DIR/run.log" || true
+    elif [ "$engine" = "duckdb" ]; then
+        bash "$DUCKDB_SCRIPT" --parquet-dir "$PARQUET_DIR" \
+            --queries "${QUERIES[@]}" \
+            --output-dir "$ENGINE_DIR" \
+            2>&1 | tee "$ENGINE_DIR/run.log" || true
+    fi
+done
+
+generate_report "$RUN_DIR"

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -126,12 +126,16 @@ if [ -n "${TIMING_CSV:-}" ]; then
     echo "query,seconds" > "$TIMING_CSV"
 fi
 
-# Queries where scan results must be cached in host instead of GPU (too large to fit in GPU memory).
-# Only needed at SF1000+; at smaller scale factors everything fits in GPU memory.
-if [ "$SF" -ge 1000 ] 2>/dev/null; then
-    HOST_CACHE_QUERIES="1 7 9 10 17 18 19 21"
-else
-    HOST_CACHE_QUERIES=""
+# Load per-query scan cache level overrides from config file.
+# Format: <query_number> <cache_level> (one per line, # comments ignored).
+# Queries not listed use the default (table_gpu).
+CACHE_CONFIG="$SCRIPT_DIR/scan_cache_levels.conf"
+declare -A QUERY_CACHE_LEVEL
+if [ "$SF" -ge 1000 ] 2>/dev/null && [ -f "$CACHE_CONFIG" ]; then
+    while IFS=' ' read -r qnum level; do
+        [[ -z "$qnum" || "$qnum" == \#* ]] && continue
+        QUERY_CACHE_LEVEL[$qnum]="$level"
+    done < "$CACHE_CONFIG"
 fi
 
 # Build list of valid queries (those with existing SQL files).
@@ -183,14 +187,8 @@ run_single_session() {
         # Set per-query scan cache level.  Bracket the SET with .timer off/on
         # so it doesn't produce a spurious "Run Time" line in the output.
         if [ "$ENGINE" = "sirius" ]; then
-            if [ -n "$SCAN_CACHE_LEVEL" ]; then
-                # Explicit --cache-level overrides all per-query defaults
-                printf ".timer off\nSET scan_cache_level = '%s';\n.timer on\n" "$SCAN_CACHE_LEVEL" >> "$TEMP_SQL"
-            elif echo " $HOST_CACHE_QUERIES " | grep -q " $q "; then
-                printf ".timer off\nSET scan_cache_level = 'table_host';\n.timer on\n" >> "$TEMP_SQL"
-            else
-                printf ".timer off\nSET scan_cache_level = 'table_gpu';\n.timer on\n" >> "$TEMP_SQL"
-            fi
+            local qlevel="${SCAN_CACHE_LEVEL:-${QUERY_CACHE_LEVEL[$q]:-table_gpu}}"
+            printf ".timer off\nSET scan_cache_level = '%s';\n.timer on\n" "$qlevel" >> "$TEMP_SQL"
         fi
         echo ".print ${MARKER_PREFIX} ${q}" >> "$TEMP_SQL"
         # N iterations back-to-back — nothing between them.
@@ -346,14 +344,8 @@ run_multi_session() {
         {
             printf '%s\n' "$VIEW_SQL"
             if [ "$ENGINE" = "sirius" ]; then
-                if [ -n "$SCAN_CACHE_LEVEL" ]; then
-                    # Explicit --cache-level overrides all per-query defaults
-                    printf "SET scan_cache_level = '%s';\n" "$SCAN_CACHE_LEVEL"
-                elif echo " $HOST_CACHE_QUERIES " | grep -q " $q "; then
-                    printf "SET scan_cache_level = 'table_host';\n"
-                else
-                    printf "SET scan_cache_level = 'table_gpu';\n"
-                fi
+                local qlevel="${SCAN_CACHE_LEVEL:-${QUERY_CACHE_LEVEL[$q]:-table_gpu}}"
+                printf "SET scan_cache_level = '%s';\n" "$qlevel"
             fi
             printf ".timer on\n"
             for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do

--- a/test/tpch_performance/scan_cache_levels.conf
+++ b/test/tpch_performance/scan_cache_levels.conf
@@ -1,0 +1,17 @@
+# Per-query scan cache level overrides for Sirius engine.
+#
+# Format: <query_number> <cache_level>
+# Queries not listed here use the default: table_gpu
+# Valid levels: table_gpu, table_host
+#
+# These overrides are typically needed at large scale factors (SF>=1000)
+# where certain queries produce intermediate data too large for GPU memory.
+# Edit this file to change which queries use host vs GPU caching.
+1 table_host
+7 table_host
+9 table_host
+10 table_host
+17 table_host
+18 table_host
+19 table_host
+21 table_host


### PR DESCRIPTION
## Summary
- Replace the TPC-DS-only `/tpcds-benchmark` skill with a unified `/benchmark` skill that covers both **TPC-H** and **TPC-DS** benchmarks with Super Sirius and DuckDB CPU engines
- Create `test/tpcds_performance/benchmark_and_validate.sh` — a TPC-DS orchestrator (modeled after TPC-H's) that runs both engines, validates results, and produces comparison reports
- Define **GPU-compatible** as: executes completely on Super Sirius (no CPU fallback) AND produces results matching DuckDB CPU exactly
- Extensible structure for adding future benchmark suites (SSB, TPC-DI, etc.)

## New files
- `.claude/skills/benchmark/SKILL.md` — unified benchmark skill
- `test/tpcds_performance/benchmark_and_validate.sh` — TPC-DS benchmark orchestrator with `--gpu-only`, `--queries`, `--duckdb-results`, `--report` flags

## Modified files
- `CLAUDE.md` — updated skills table (`/tpcds-benchmark` → `/benchmark`)

## Test plan
- [x] Run `/benchmark` in Claude Code and verify it loads the new skill
- [x] Run `test/tpcds_performance/benchmark_and_validate.sh --gpu-only 1` at SF1 and verify validation.csv, comparison.txt, timings.csv are produced
- [x] Verify TPC-H workflows still work: `test/tpch_performance/benchmark_and_validate.sh 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)