### PR TITLE
feat: aarch64 build support for Doris integration layer

### DIFF
--- a/.planning/phases/01-build-and-runtime/01-01-SUMMARY.md
+++ b/.planning/phases/01-build-and-runtime/01-01-SUMMARY.md
@@ -1,0 +1,109 @@
+---
+phase: 01-build-and-runtime
+plan: 01
+subsystem: infra
+tags: [pixi, conda, aarch64, arm, cuda, nixl, sysroot, ld-library-path]
+
+# Dependency graph
+requires: []
+provides:
+  - pixi doris environment resolves on aarch64 (sysroot_linux-aarch64 platform-conditional dep)
+  - nixl-build meson CUDA paths use CUDA_TARGET variable (sbsa-linux on aarch64)
+  - sirius-be and sirius-be-2 tasks compute LIB_ARCH dynamically at runtime
+affects:
+  - 01-02 (Rust build scripts and nixl-test build.rs changes in plan 02)
+  - 02-documentation (build guide correctness depends on these pixi.toml task definitions)
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Pixi platform-conditional deps: [feature.X.target.PLATFORM.dependencies] for arch-specific package names"
+    - "Inline uname -m detection in pixi bash tasks: CUDA_TARGET=$([ $(uname -m) = aarch64 ] && echo sbsa-linux || echo x86_64-linux)"
+    - "exec env pattern for dynamic LD_LIBRARY_PATH inside bash -c tasks"
+
+key-files:
+  created: []
+  modified:
+    - pixi.toml
+
+key-decisions:
+  - "sbsa-linux is the correct CUDA target dir for aarch64 data center (Grace Hopper, etc.); Tegra uses aarch64-linux which would be wrong"
+  - "Remove env = { LD_LIBRARY_PATH } blocks and move LD_LIBRARY_PATH inside bash -c using exec env — pixi env blocks do not evaluate $() subshells"
+  - "Platform-conditional sysroot in [feature.doris.target.linux-aarch64.dependencies] rather than runtime workaround"
+
+patterns-established:
+  - "Pattern: arch detection in pixi tasks uses [ $(uname -m) = aarch64 ] && echo ARCH_VALUE || echo x86_64_VALUE"
+  - "Pattern: CUDA toolkit target dir maps as uname aarch64 -> sbsa-linux, x86_64 -> x86_64-linux"
+
+requirements-completed: [BUILD-01, BUILD-02, RUNTIME-01]
+
+# Metrics
+duration: 12min
+completed: 2026-04-07
+---
+
+# Phase 01 Plan 01: pixi.toml aarch64 Architecture Fixes Summary
+
+**Platform-conditional sysroot and dynamic arch detection in pixi.toml so the doris environment resolves, nixl builds with sbsa-linux CUDA paths, and sirius-be starts with correct LD_LIBRARY_PATH on aarch64**
+
+## Performance
+
+- **Duration:** ~12 min
+- **Started:** 2026-04-07T00:15:00Z
+- **Completed:** 2026-04-07T00:27:45Z
+- **Tasks:** 3 (2 with code changes, 1 verification)
+- **Files modified:** 1
+
+## Accomplishments
+
+- Removed `sysroot_linux-64` from global `[feature.doris.dependencies]` and added platform-conditional `[feature.doris.target.linux-64.dependencies]` and `[feature.doris.target.linux-aarch64.dependencies]` sections (BUILD-01)
+- Added `CUDA_TARGET` arch detection in nixl-build task using `uname -m`; replaced all 3 hardcoded `targets/x86_64-linux/` meson flags with `targets/$CUDA_TARGET/` (BUILD-02)
+- Replaced both sirius-be and sirius-be-2 `env = { LD_LIBRARY_PATH }` blocks with `bash -c` + `LIB_ARCH` detection + `exec env LD_LIBRARY_PATH` pattern (RUNTIME-01)
+- Validated TOML syntax and confirmed all x86_64 fallback branches produce identical values to originals
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Platform-conditional sysroot and arch-aware nixl-build CUDA paths** - `4a7d461` (feat)
+2. **Task 2: Fix sirius-be and sirius-be-2 LD_LIBRARY_PATH for aarch64** - `068c091` (feat)
+3. **Task 3: Verify pixi.toml is valid TOML and x86_64 regression** - no commit (verification only, no code changes)
+
+## Files Created/Modified
+
+- `pixi.toml` - Platform-conditional sysroot, arch-aware nixl-build CUDA paths, arch-aware sirius-be LD_LIBRARY_PATH
+
+## Decisions Made
+
+- Used `sbsa-linux` (not `aarch64-linux`) for aarch64 CUDA target directory — confirmed by conda activation script and existing `.pixi/envs/default/targets/sbsa-linux/` directory on this machine; `aarch64-linux` is for Tegra/Jetson, not data center GPUs
+- Removed `env = { LD_LIBRARY_PATH }` pixi blocks entirely and moved LD_LIBRARY_PATH setup inside `bash -c` using `exec env` — pixi's env block expands `$VAR` references but does NOT evaluate `$()` subshell commands, making the old approach unusable for dynamic arch detection
+- Added platform-conditional deps using pixi's native `[feature.X.target.PLATFORM.dependencies]` syntax rather than any runtime workaround
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- Worktree branch was created from an older base commit; `git reset --soft` to the correct base was required, and the working tree's `pixi.toml` had to be restored from the committed HEAD version before applying changes.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- pixi.toml is ready: `pixi install -e doris` should now succeed on aarch64 (unblocks all subsequent build steps)
+- Plan 02 can proceed: nixl-test/build.rs CUDA stubs path fix and nixl-sys crate patch remain as the next set of changes
+
+## Self-Check: PASSED
+
+- FOUND: .planning/phases/01-build-and-runtime/01-01-SUMMARY.md
+- FOUND: 4a7d461 (Task 1 commit — feat: platform-conditional sysroot + nixl CUDA paths)
+- FOUND: 068c091 (Task 2 commit — feat: arch-aware LD_LIBRARY_PATH for sirius-be tasks)
+- FOUND: 3c42d99 (SUMMARY commit)
+
+---
+*Phase: 01-build-and-runtime*
+*Completed: 2026-04-07*

--- a/.planning/phases/01-build-and-runtime/01-02-SUMMARY.md
+++ b/.planning/phases/01-build-and-runtime/01-02-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: 01-build-and-runtime
+plan: 02
+subsystem: rust-build-scripts
+tags: [aarch64, cuda, nixl, build-scripts, cargo]
+dependency_graph:
+  requires: []
+  provides: [BUILD-03, BUILD-04]
+  affects: [doris/crates/nixl-test, doris/Cargo.toml, doris/thirdparty/nixl]
+tech_stack:
+  added: []
+  patterns:
+    - "cfg!(target_arch) compile-time arch detection in Rust build.rs"
+    - "[patch.crates-io] Cargo workspace override for local crate substitution"
+key_files:
+  created: []
+  modified:
+    - doris/crates/nixl-test/build.rs
+    - doris/Cargo.toml
+    - doris/thirdparty/nixl/src/bindings/rust/build.rs
+decisions:
+  - "Use cfg!(target_arch = \"aarch64\") to select sbsa-linux vs x86_64-linux CUDA target at compile time (D-03)"
+  - "Override crates.io nixl-sys 0.10.0 with local submodule via [patch.crates-io] to apply one-line fix (D-07 extended)"
+  - "One-line fix to nixl submodule build.rs line 114: use arch variable instead of hardcoded x86_64-linux-gnu"
+metrics:
+  duration: "~5 minutes"
+  completed_date: "2026-04-07"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 3
+---
+
+# Phase 01 Plan 02: Rust Build Script aarch64 Fixes Summary
+
+Arch-aware CUDA stubs and nixl lib path in Rust build scripts using `cfg!(target_arch)` compile-time detection and `[patch.crates-io]` to redirect the published nixl-sys crate to the local submodule.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Fix nixl-test/build.rs CUDA stubs path for aarch64 | 22b0d16 | doris/crates/nixl-test/build.rs |
+| 2 | Patch nixl-sys to use local submodule and fix hardcoded lib path | 3086a3a | doris/Cargo.toml, doris/thirdparty/nixl/src/bindings/rust/build.rs |
+
+## What Was Built
+
+**Task 1 — nixl-test/build.rs:**
+Replaced the hardcoded `targets/x86_64-linux/lib/stubs` path on line 9 with a `cfg!(target_arch = "aarch64")` conditional that selects `sbsa-linux` (aarch64 SBSA data center ARM) or `x86_64-linux` (x86_64). The x86_64 path is identical to the original, preserving backward compatibility. Comments explain the sbsa-linux convention.
+
+**Task 2 — doris/Cargo.toml + nixl submodule build.rs:**
+- Added `[patch.crates-io]` section to `doris/Cargo.toml` pointing `nixl-sys` to `thirdparty/nixl/src/bindings/rust` (the local submodule). This overrides the published crates.io version (which has the same hardcoded bug) with our patched copy.
+- Fixed line 114 of the nixl submodule's `build.rs`: replaced `x86_64-linux-gnu` literal with `{}-linux-gnu", nixl_root_path, arch` using the `arch` variable already defined on line 103 via `get_arch()`. On x86_64 this produces `lib/x86_64-linux-gnu` (identical to original); on aarch64 it produces `lib/aarch64-linux-gnu` (correct for ARM).
+- Committed the one-line fix inside the submodule first (detached HEAD), then committed the submodule pointer update together with `Cargo.toml` in the parent repo.
+
+## Verification Results
+
+All 5 plan verification checks passed:
+1. `cfg!(target_arch = "aarch64")` present in nixl-test/build.rs
+2. `sbsa-linux` string present in nixl-test/build.rs
+3. `[patch.crates-io]` section present in doris/Cargo.toml
+4. `{}-linux-gnu", nixl_root_path, arch` pattern found in nixl submodule build.rs
+5. `x86_64-linux-gnu.*nixl_root_path` (hardcoded) NOT present in nixl submodule build.rs
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — plan executed exactly as written.
+
+### Procedural Note
+
+The nixl submodule (`doris/thirdparty/nixl`) is a nested git repository. Staging `doris/thirdparty/nixl/src/bindings/rust/build.rs` directly from the parent repo fails with "Pathspec is in submodule" error. The correct procedure (applied here):
+1. `cd` into submodule, `git add`, `git commit` to capture the one-line fix
+2. Return to parent repo, `git add doris/thirdparty/nixl` to update the submodule pointer
+3. Commit parent repo with `doris/Cargo.toml` and the updated submodule pointer together
+
+This is standard git submodule workflow. Not a deviation from plan intent — the plan correctly called this a "one-line submodule fix".
+
+## Known Stubs
+
+None — no stub patterns, placeholder text, or unwired data sources exist in the modified files.
+
+## Threat Flags
+
+None — modified files are Rust build scripts (linker search path configuration). No network endpoints, auth paths, file access patterns at trust boundaries, or schema changes introduced.
+
+## Self-Check: PASSED
+
+Files exist:
+- FOUND: doris/crates/nixl-test/build.rs
+- FOUND: doris/Cargo.toml
+- FOUND: doris/thirdparty/nixl/src/bindings/rust/build.rs
+
+Commits exist:
+- FOUND: 22b0d16 (Task 1 — feat(01-02): arch-aware CUDA stubs path)
+- FOUND: 3086a3a (Task 2 — feat(01-02): patch nixl-sys and fix arch-aware lib path)

--- a/.planning/phases/01-build-and-runtime/01-HUMAN-UAT.md
+++ b/.planning/phases/01-build-and-runtime/01-HUMAN-UAT.md
@@ -1,0 +1,36 @@
+---
+status: partial
+phase: 01-build-and-runtime
+source: [01-VERIFICATION.md]
+started: 2026-04-07T00:30:00Z
+updated: 2026-04-07T00:30:00Z
+---
+
+## Current Test
+
+[awaiting human testing]
+
+## Tests
+
+### 1. pixi install on aarch64
+expected: pixi install -e doris completes without errors; sysroot_linux-aarch64 resolves from conda-forge
+result: [pending]
+
+### 2. cargo build on aarch64 (BUILD-03, BUILD-04)
+expected: pixi run -e doris doris-build completes; nixl-test links against CUDA stubs at sbsa-linux path; nixl Rust bindings link against aarch64-linux-gnu
+result: [pending]
+
+### 3. sirius-be startup on aarch64 (RUNTIME-01)
+expected: pixi run -e doris sirius-be starts without missing library errors; LD_LIBRARY_PATH includes aarch64-linux-gnu
+result: [pending]
+
+## Summary
+
+total: 3
+passed: 0
+issues: 0
+pending: 3
+skipped: 0
+blocked: 0
+
+## Gaps

--- a/doris/Cargo.toml
+++ b/doris/Cargo.toml
@@ -29,3 +29,6 @@ clap = { version = "4", features = ["derive"] }
 mysql_async = { version = "0.34", default-features = false, features = ["default-rustls"] }
 duckdb = { version = "=1.10501.0", features = ["bundled", "appender-arrow"] }
 cudarc = { version = "0.19.4", default-features = false, features = ["std", "driver", "runtime", "dynamic-loading", "cuda-version-from-build-system"] }
+
+[patch.crates-io]
+nixl-sys = { path = "thirdparty/nixl/src/bindings/rust" }

--- a/doris/crates/nixl-test/build.rs
+++ b/doris/crates/nixl-test/build.rs
@@ -3,11 +3,18 @@ fn main() {
     // On NixOS, libcuda.so lives in /run/opengl-driver/lib/.
     println!("cargo:rustc-link-search=native=/run/opengl-driver/lib");
 
-    // CUDA toolkit stubs (conda env provides libcuda.so stub for linking)
+    // CUDA toolkit stubs (conda env provides libcuda.so stub for linking).
+    // sbsa-linux is the CUDA target dir for aarch64 SBSA (data center ARM, e.g. Grace Hopper).
+    // x86_64-linux is used for standard x86_64 systems.
     if let Ok(prefix) = std::env::var("CONDA_PREFIX") {
+        let cuda_target = if cfg!(target_arch = "aarch64") {
+            "sbsa-linux"
+        } else {
+            "x86_64-linux"
+        };
         println!(
-            "cargo:rustc-link-search=native={}/targets/x86_64-linux/lib/stubs",
-            prefix
+            "cargo:rustc-link-search=native={}/targets/{}/lib/stubs",
+            prefix, cuda_target
         );
     }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -66,13 +66,14 @@ rust = ">=1.85"
 libprotobuf = ">=5"
 thrift-compiler = ">=0.22"
 clangdev = "*"
-sysroot_linux-64 = ">=2.32"
 
 [feature.doris.tasks]
 substrait-build = { cmd = "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make release", cwd = "substrait", description = "Build DuckDB substrait extension" }
 doris-check = { cmd = "cargo check", cwd = "doris", description = "Check doris workspace" }
 nixl-build = { cmd = """bash -c 'set -e
   NIXL_SRC=$PIXI_PROJECT_ROOT/doris/thirdparty/nixl
+  # sbsa-linux = aarch64 SBSA (data center ARM, e.g. Grace Hopper); x86_64-linux = standard x86_64
+  CUDA_TARGET=$([ $(uname -m) = aarch64 ] && echo sbsa-linux || echo x86_64-linux)
 
   if [ -f "$CONDA_PREFIX/lib/libnixl.so" ]; then
     echo "nixl already installed in conda prefix"
@@ -89,9 +90,9 @@ nixl-build = { cmd = """bash -c 'set -e
   rm -rf builddir
   meson setup builddir --prefix="$CONDA_PREFIX" --libdir=lib --buildtype=release \
     -Ducx_path=$CONDA_PREFIX \
-    -Dcudapath_inc=$CONDA_PREFIX/targets/x86_64-linux/include \
-    -Dcudapath_lib=$CONDA_PREFIX/targets/x86_64-linux/lib \
-    -Dcudapath_stub=$CONDA_PREFIX/targets/x86_64-linux/lib/stubs \
+    -Dcudapath_inc=$CONDA_PREFIX/targets/$CUDA_TARGET/include \
+    -Dcudapath_lib=$CONDA_PREFIX/targets/$CUDA_TARGET/lib \
+    -Dcudapath_stub=$CONDA_PREFIX/targets/$CUDA_TARGET/lib/stubs \
     -Drust=false \
     -Denable_plugins=UCX \
     -Dbuild_tests=false \
@@ -106,8 +107,29 @@ nixl-build = { cmd = """bash -c 'set -e
 doris-build = { cmd = "NIXL_PREFIX=$CONDA_PREFIX NIXL_NO_STUBS_FALLBACK=1 cargo build --release", cwd = "doris", depends-on = ["nixl-build"], description = "Build doris workspace (with nixl)" }
 doris-test = { cmd = "cargo test", cwd = "doris", description = "Test doris workspace" }
 # Start Sirius GPU BEs with offset ports (for running alongside regular Doris BE)
-sirius-be = { cmd = "doris/target/release/sirius-doris-be --heartbeat-port 19050 --be-port 19060 --brpc-port 18060 --http-port 18040 --arrow-flight-port 18071 --gpu-cache-size 2GB --gpu-processing-size 2GB --fe 127.0.0.1:9030", env = { LD_LIBRARY_PATH = "$CONDA_PREFIX/lib:$CONDA_PREFIX/lib/x86_64-linux-gnu" }, description = "Run Sirius GPU BE 1 (ports 19xxx/18xxx)" }
-sirius-be-2 = { cmd = "bash -c 'mkdir -p /tmp/sirius-be-2/.sirius && cp -n ~/.sirius/sirius.cfg /tmp/sirius-be-2/.sirius/ 2>/dev/null; HOME=/tmp/sirius-be-2 exec doris/target/release/sirius-doris-be --heartbeat-port 29050 --be-port 29060 --brpc-port 28060 --http-port 28040 --arrow-flight-port 28071 --gpu-cache-size 2GB --gpu-processing-size 2GB --advertise-host 127.0.0.3 --fe 127.0.0.1:9030'", env = { LD_LIBRARY_PATH = "$CONDA_PREFIX/lib:$CONDA_PREFIX/lib/x86_64-linux-gnu" }, description = "Run Sirius GPU BE 2 (ports 29xxx/28xxx, separate HOME for lock)" }
+sirius-be = { cmd = """bash -c '
+  LIB_ARCH=$([ $(uname -m) = aarch64 ] && echo aarch64-linux-gnu || echo x86_64-linux-gnu)
+  exec env LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$CONDA_PREFIX/lib/$LIB_ARCH" \
+    doris/target/release/sirius-doris-be \
+    --heartbeat-port 19050 --be-port 19060 --brpc-port 18060 --http-port 18040 \
+    --arrow-flight-port 18071 --gpu-cache-size 2GB --gpu-processing-size 2GB \
+    --fe 127.0.0.1:9030
+'""", description = "Run Sirius GPU BE 1 (ports 19xxx/18xxx)" }
+sirius-be-2 = { cmd = """bash -c '
+  LIB_ARCH=$([ $(uname -m) = aarch64 ] && echo aarch64-linux-gnu || echo x86_64-linux-gnu)
+  mkdir -p /tmp/sirius-be-2/.sirius && cp -n ~/.sirius/sirius.cfg /tmp/sirius-be-2/.sirius/ 2>/dev/null
+  HOME=/tmp/sirius-be-2 exec env LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$CONDA_PREFIX/lib/$LIB_ARCH" \
+    doris/target/release/sirius-doris-be \
+    --heartbeat-port 29050 --be-port 29060 --brpc-port 28060 --http-port 28040 \
+    --arrow-flight-port 28071 --gpu-cache-size 2GB --gpu-processing-size 2GB \
+    --advertise-host 127.0.0.3 --fe 127.0.0.1:9030
+'""", description = "Run Sirius GPU BE 2 (ports 29xxx/28xxx, separate HOME for lock)" }
+
+[feature.doris.target.linux-64.dependencies]
+sysroot_linux-64 = ">=2.32"
+
+[feature.doris.target.linux-aarch64.dependencies]
+sysroot_linux-aarch64 = ">=2.32"
 
 # Doris FE feature: build & run Doris Frontend from source for testing
 [feature.doris-fe.dependencies]


### PR DESCRIPTION
## Summary

- **pixi.toml**: Platform-conditional sysroot (`sysroot_linux-aarch64` for ARM, `sysroot_linux-64` for x86), arch-detecting CUDA target paths (`sbsa-linux` / `x86_64-linux` via `uname -m`), and dynamic `LD_LIBRARY_PATH` for both `sirius-be` tasks
- **doris/crates/nixl-test/build.rs**: Compile-time `cfg\!(target_arch = "aarch64")` detection for CUDA stubs path (`sbsa-linux` vs `x86_64-linux`)
- **doris/Cargo.toml**: `[patch.crates-io]` to route `nixl-sys` to local submodule with the arch fix
- **doris/thirdparty/nixl/src/bindings/rust/build.rs**: One-line fix — use existing `arch` variable instead of hardcoded `x86_64-linux-gnu` (line 114)

All changes preserve exact x86_64 behavior via `else`/`||` branches that produce the original hardcoded values.

## Test plan

- [ ] `pixi install -e doris` on aarch64 — confirm `sysroot_linux-aarch64` resolves
- [ ] `pixi run -e doris doris-build` on aarch64 — confirm cargo build succeeds, nixl links correctly
- [ ] `pixi run -e doris sirius-be` on aarch64 — confirm BE starts without missing library errors
- [ ] Verify x86_64 build still works unchanged (regression check)
- [x] TOML syntax validated (`tomllib.load`)
- [x] Shell arch-detection logic verified on aarch64 machine (`sbsa-linux`, `aarch64-linux-gnu`)
- [x] Zero hardcoded `x86_64-linux` paths remain in CUDA meson flags
- [x] Zero hardcoded `x86_64-linux-gnu` paths remain in LD_LIBRARY_PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)