### PR TITLE
fix: add memory reservations before host allocations

### DIFF
--- a/src/data/host_parquet_representation.cpp
+++ b/src/data/host_parquet_representation.cpp
@@ -17,6 +17,9 @@
 // sirius
 #include <data/host_parquet_representation.hpp>
 
+// cucascade
+#include <cucascade/memory/memory_reservation.hpp>
+
 namespace sirius {
 
 std::unique_ptr<cucascade::idata_representation> host_parquet_representation::clone(
@@ -28,8 +31,15 @@ std::unique_ptr<cucascade::idata_representation> host_parquet_representation::cl
     throw std::runtime_error("Cannot clone host_parquet_representation: no host memory resource");
   }
 
-  // Allocate new blocks for the copy
-  auto allocation_copy = host_mr->allocate_multiple_blocks(_size_in_bytes);
+  // Reserve memory before allocating to ensure proper memory tracking
+  auto reservation = get_memory_space().make_reservation_or_null(_size_in_bytes);
+  if (!reservation) {
+    throw std::runtime_error(
+      "Cannot clone host_parquet_representation: failed to reserve host memory");
+  }
+
+  // Allocate new blocks for the copy, tracked against the reservation
+  auto allocation_copy = host_mr->allocate_multiple_blocks(_size_in_bytes, reservation.get());
 
   // Copy data block by block
   const auto& src_blocks = _column_chunks->get_blocks();

--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -24,6 +24,7 @@
 // cucascade
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 // cudf
@@ -120,8 +121,16 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_host_pa
       "Target HOST memory_space does not have a fixed_size_host_memory_resource");
   }
 
+  // Reserve memory before allocating to ensure proper memory tracking
+  auto reservation = const_cast<cucascade::memory::memory_space*>(target_memory_space)
+                       ->make_reservation_or_null(data_size);
+  if (!reservation) {
+    throw std::runtime_error(
+      "Cannot corss-NUMA copy host_parquet_representation: failed to reserve host memory");
+  }
+
   auto const& src_allocation  = host_src.get_column_chunks();
-  auto dst_allocation         = mr->allocate_multiple_blocks(data_size);
+  auto dst_allocation         = mr->allocate_multiple_blocks(data_size, reservation.get());
   size_t src_block_index      = 0;
   size_t src_block_offset     = 0;
   size_t dst_block_index      = 0;
@@ -158,8 +167,8 @@ std::unique_ptr<cucascade::idata_representation> convert_host_parquet_to_host_pa
     std::move(dst_allocation),
     std::move(cloned_reader),
     host_src.get_reader_options(),
-    std::move(host_src.get_row_group_indices()),
-    std::move(host_src.get_column_chunk_byte_ranges()),
+    host_src.get_row_group_indices(),
+    host_src.get_column_chunk_byte_ranges(),
     data_size,
     host_src.get_uncompressed_data_size_in_bytes(),
     host_src.get_file_size(),

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -149,8 +149,9 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       // Convert to host representation.
       // Release the reservation before converting so the converter's internal allocation
       // can use the freed capacity (the converter cannot accept a reservation parameter).
-      auto& registry  = sirius::converter_registry::get();
-      auto* mem_space = const_cast<cucascade::memory::memory_space*>(&reservation->get_memory_space());
+      auto& registry = sirius::converter_registry::get();
+      auto* mem_space =
+        const_cast<cucascade::memory::memory_space*>(&reservation->get_memory_space());
       reservation.reset();
 
       auto& data_repo_mgr = sirius_ctx->get_data_repository_manager();

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -146,14 +146,18 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
           "[GPUPhysicalMaterializedCollector] Failed to reserve host memory for result collection");
       }
 
-      // Convert to host representation
-      auto& registry      = sirius::converter_registry::get();
-      auto& mem_space     = reservation->get_memory_space();
+      // Convert to host representation.
+      // Release the reservation before converting so the converter's internal allocation
+      // can use the freed capacity (the converter cannot accept a reservation parameter).
+      auto& registry  = sirius::converter_registry::get();
+      auto* mem_space = const_cast<cucascade::memory::memory_space*>(&reservation->get_memory_space());
+      reservation.reset();
+
       auto& data_repo_mgr = sirius_ctx->get_data_repository_manager();
       auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
       clone_batch         = input_batch->clone(next_batch_id, stream);
       // todo (bobbi) pass stream to sink
-      clone_batch->convert_to<cucascade::host_data_representation>(registry, &mem_space, stream);
+      clone_batch->convert_to<cucascade::host_data_representation>(registry, mem_space, stream);
       data = clone_batch->get_data();
     } else if (data->get_current_tier() != cucascade::memory::Tier::HOST) {
       // Data must be in HOST tier (i.e., cannot currently reside in DISK tier)

--- a/test/cpp/data/test_host_parquet_representation.cpp
+++ b/test/cpp/data/test_host_parquet_representation.cpp
@@ -430,8 +430,8 @@ TEST_CASE("host_parquet_representation clone fails when reservation unavailable"
   REQUIRE(repr != nullptr);
 
   // Exhaust remaining capacity by reserving nearly all available memory
-  auto available      = host_space->get_available_memory();
-  auto blocker        = host_space->make_reservation_or_null(available);
+  auto available = host_space->get_available_memory();
+  auto blocker   = host_space->make_reservation_or_null(available);
 
   // Clone should throw because reservation cannot be satisfied
   REQUIRE_THROWS_AS(repr->clone(rmm::cuda_stream_default), std::runtime_error);

--- a/test/cpp/data/test_host_parquet_representation.cpp
+++ b/test/cpp/data/test_host_parquet_representation.cpp
@@ -380,6 +380,63 @@ TEST_CASE("host_parquet_representation clone creates independent copy",
   }
 }
 
+TEST_CASE("host_parquet_representation clone uses reservation",
+          "[host_parquet_representation][clone][reservation]")
+{
+  sirius_memory_reservation_manager mgr(create_test_configs());
+  auto* host_space = const_cast<memory_space*>(mgr.get_memory_space(Tier::HOST, 0));
+  REQUIRE(host_space != nullptr);
+
+  parquet_test_fixture fixture;
+  fixture.setup(500, "clone_reservation");
+
+  auto repr = fixture.build_representation(host_space);
+  REQUIRE(repr != nullptr);
+
+  // Record reservation state before clone
+  auto reserved_before = host_space->get_total_reserved_memory();
+  auto count_before    = host_space->get_active_reservation_count();
+
+  // Clone creates and releases a reservation internally
+  auto cloned_base = repr->clone(rmm::cuda_stream_default);
+  REQUIRE(cloned_base != nullptr);
+
+  // After clone completes, the internal reservation should be released
+  auto reserved_after = host_space->get_total_reserved_memory();
+  auto count_after    = host_space->get_active_reservation_count();
+  REQUIRE(count_after == count_before);
+  REQUIRE(reserved_after == reserved_before);
+}
+
+TEST_CASE("host_parquet_representation clone fails when reservation unavailable",
+          "[host_parquet_representation][clone][reservation]")
+{
+  // Create a memory manager with very limited host capacity
+  reservation_manager_configurator builder;
+  builder.set_number_of_gpus(1)
+    .set_gpu_usage_limit(2048ull * 1024 * 1024)
+    .set_gpu_memory_resource_factory(
+      [](int, size_t) { return std::make_unique<rmm::mr::cuda_memory_resource>(); })
+    .use_host_per_gpu()
+    .set_per_host_capacity(1ull * 1024 * 1024);  // Only 1 MB
+  sirius_memory_reservation_manager mgr(builder.build());
+  auto* host_space = const_cast<memory_space*>(mgr.get_memory_space(Tier::HOST, 0));
+  REQUIRE(host_space != nullptr);
+
+  parquet_test_fixture fixture;
+  fixture.setup(500, "clone_fail");
+
+  auto repr = fixture.build_representation(host_space);
+  REQUIRE(repr != nullptr);
+
+  // Exhaust remaining capacity by reserving nearly all available memory
+  auto available      = host_space->get_available_memory();
+  auto blocker        = host_space->make_reservation_or_null(available);
+
+  // Clone should throw because reservation cannot be satisfied
+  REQUIRE_THROWS_AS(repr->clone(rmm::cuda_stream_default), std::runtime_error);
+}
+
 TEST_CASE("host_parquet_representation clone with small data",
           "[host_parquet_representation][clone]")
 {
@@ -673,6 +730,54 @@ TEST_CASE("host_parquet_representation clone then convert to GPU",
 //===----------------------------------------------------------------------===//
 // host_parquet_representation Cross-Host Copy Converter Tests
 //===----------------------------------------------------------------------===//
+
+TEST_CASE("host_parquet_representation cross-host copy uses reservation",
+          "[host_parquet_representation][converters][cross_host][reservation]")
+{
+  reservation_manager_configurator builder;
+  builder.set_number_of_gpus(2)
+    .set_gpu_usage_limit(2048ull * 1024 * 1024)
+    .set_gpu_memory_resource_factory(
+      [](int, size_t) { return std::make_unique<rmm::mr::cuda_memory_resource>(); })
+    .use_host_per_gpu()
+    .set_per_host_capacity(4096ull * 1024 * 1024);
+
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count < 2) {
+    SUCCEED("Fewer than 2 GPUs available; skipping cross-host reservation test");
+    return;
+  }
+
+  sirius_memory_reservation_manager mgr(builder.build());
+  cucascade::representation_converter_registry registry;
+  cucascade::register_builtin_converters(registry);
+  register_parquet_converters(registry);
+
+  auto* host_space_0 = const_cast<memory_space*>(mgr.get_memory_space(Tier::HOST, 0));
+  auto* host_space_1 = const_cast<memory_space*>(mgr.get_memory_space(Tier::HOST, 1));
+  REQUIRE(host_space_0 != nullptr);
+  REQUIRE(host_space_1 != nullptr);
+
+  parquet_test_fixture fixture;
+  fixture.setup(200, "cross_host_reservation");
+
+  auto repr = fixture.build_representation(host_space_0);
+  REQUIRE(repr != nullptr);
+
+  // Record reservation state on target space before conversion
+  auto reserved_before = host_space_1->get_total_reserved_memory();
+  auto count_before    = host_space_1->get_active_reservation_count();
+
+  rmm::cuda_stream stream;
+  auto result = registry.convert<host_parquet_representation>(*repr, host_space_1, stream);
+  REQUIRE(result != nullptr);
+
+  // The converter's internal reservation should be released after conversion
+  auto reserved_after = host_space_1->get_total_reserved_memory();
+  auto count_after    = host_space_1->get_active_reservation_count();
+  REQUIRE(count_after == count_before);
+  REQUIRE(reserved_after == reserved_before);
+}
 
 TEST_CASE("host_parquet_representation cross-host copy converter",
           "[host_parquet_representation][converters][cross_host]")


### PR DESCRIPTION
  Fixes #566                                                                                                                  
                                                                                                                              
  - **`host_parquet_representation::clone()`**: Added `make_reservation_or_null()` before `allocate_multiple_blocks()`, with a
   throw if the reservation fails. Previously allocated without any reservation tracking.                                     
  - **`convert_host_parquet_to_host_parquet` (cross-NUMA copy)**: Added `make_reservation_or_null()` before                   
  `allocate_multiple_blocks()`, passing the reservation to the allocator. Previously allocated without reservation tracking.  
  - **`sirius_physical_result_collector::sink()`**: Released the existing reservation before calling `convert_to`, so the     
  built-in converter's internal allocation can use the freed capacity. Previously the reservation held capacity that the      
  converter couldn't use (double-counting).                                                                                   
                                                                                                                              
  ## Test plan                                                                                                                
                                                                                                                              
  - [x] Added `"host_parquet_representation clone uses reservation"` — verifies reservation count returns to baseline after   
  clone                                                                                                                       
  - [x] Added `"host_parquet_representation clone fails when reservation unavailable"` — exhausts memory, confirms clone      
  throws                                                                                                                      
  - [x] Added `"host_parquet_representation cross-host copy uses reservation"` — verifies converter's reservation is released 
  after conversion                                                                                                            
  - [x] All 12 `[host_parquet_representation]` tests pass (265 assertions) 