### PR TITLE
Fix for Q21 deadlock

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -71,6 +71,10 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 
   const auto& pipelines = query.get_pipelines();
   for (const auto& pipeline : pipelines) {
+    // Give each pipeline a pointer to this task_creator so that when a pipeline
+    // finishes (including via downstream notification), it can schedule output consumers.
+    pipeline->set_task_creator(this);
+
     auto source_operator = pipeline->get_source();
     if (source_operator == nullptr) { continue; }
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -27,10 +27,13 @@
 #include "duckdb/parallel/pipeline.hpp"
 
 #include <nvtx3/nvtx3.hpp>
-
 namespace sirius {
 
 class sirius_engine;
+
+namespace creator {
+class task_creator;
+}  // namespace creator
 
 namespace op {
 class sirius_physical_operator;
@@ -129,6 +132,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   std::vector<op::sirius_physical_operator*> get_output_consumers() const;
 
+  //! Notifies downstream pipelines to re-evaluate their status after this pipeline finishes
+  void notify_downstream_pipelines();
+
   //! Returns whether any of the operators in the pipeline care about preserving order
   bool is_order_dependent() const;
 
@@ -149,6 +155,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
 
   void mark_task_created();
   void mark_task_completed();
+
+  //! Set the task_creator pointer so this pipeline can schedule downstream consumers on finish.
+  void set_task_creator(sirius::creator::task_creator* tc);
 
  private:
   //! Whether or not the pipeline has been readied
@@ -181,6 +190,9 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   bool launch_scan_tasks(duckdb::shared_ptr<duckdb::Event>& event, duckdb::idx_t max_threads);
 
   bool schedule_parallel(duckdb::shared_ptr<duckdb::Event>& event);
+
+  //! Task creator pointer for scheduling downstream consumers when this pipeline finishes
+  sirius::creator::task_creator* _task_creator{nullptr};
 
   //! The unique ID of this pipeline (assigned based on new_scheduled order)
   size_t pipeline_id = 0;

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -16,6 +16,7 @@
 
 #include "pipeline/sirius_pipeline.hpp"
 
+#include "creator/task_creator.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
@@ -277,6 +278,23 @@ bool sirius_pipeline::is_pipeline_finished() const
   return pipeline_finished.load();
 }
 
+void sirius_pipeline::set_task_creator(sirius::creator::task_creator* tc) { _task_creator = tc; }
+
+void sirius_pipeline::notify_downstream_pipelines()
+{
+  // Schedule output consumers via the task_creator so downstream pipelines
+  // whose FULL-barrier ports are now unblocked will get tasks created.
+  if (_task_creator) {
+    for (auto* consumer : get_output_consumers()) {
+      _task_creator->schedule(consumer);
+    }
+  }
+
+  for (auto* parent : get_parents()) {
+    parent->update_pipeline_status();
+  }
+}
+
 void sirius_pipeline::update_pipeline_status()
 {
   auto end_nvtx_range_if_finished = [this]() {
@@ -285,19 +303,26 @@ void sirius_pipeline::update_pipeline_status()
     }
   };
 
+  // Skip if already finished — avoids redundant re-evaluation and re-notification.
+  if (pipeline_finished.load()) { return; }
+
   if (get_source()->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
     auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
     if (table_scan.exhausted) {  // WSM amin TODO: can we use exhausted? how about we use
                                  // get_next_task_hint() to check if the source is ready?
       pipeline_finished.store(true);
       end_nvtx_range_if_finished();
+      notify_downstream_pipelines();
       return;
     }
   } else if (get_source()->type == op::SiriusPhysicalOperatorType::PARQUET_SCAN) {
     auto& parquet_scan = get_source()->Cast<op::sirius_physical_parquet_scan>();
     if (!parquet_scan.has_more_partitions) {
-      if (tasks_created.load() == tasks_completed.load()) { pipeline_finished = true; }
-      end_nvtx_range_if_finished();
+      if (tasks_created.load() == tasks_completed.load()) {
+        pipeline_finished = true;
+        end_nvtx_range_if_finished();
+        notify_downstream_pipelines();
+      }
       return;
     }
   } else {
@@ -325,9 +350,11 @@ void sirius_pipeline::update_pipeline_status()
         for (auto& op : get_operators()) {
           op.get().finalize_operator();
         }
+        end_nvtx_range_if_finished();
+        notify_downstream_pipelines();
       }
     }
-    end_nvtx_range_if_finished();
+    if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
   }
 }
 


### PR DESCRIPTION
When testing on SF100 on RTC 6000 (ADA), Q21 would deadlock. This PR fixes the issue.

During task scheduing or task creation for a scan task, it would determine that the pipeline was complete and most of the code assumes that setting a pipeline to complete is something that only happens right after a task is complete. Similarly new task creation and scheduling was only happening when a task is complete. Due to memory barriers (pipeline breakers), some tasks can only be scheduled after the previous pipeline is set to complete. So if a pipeline is set to complete during the scheduling phase, this has to propagate to other pipelines being set to complete and trigger new task scheduling which this PR does.

So this PR adds some code which will propagate a check to see if a pipeline is complete on downstream pipelines. If it does propagate, it also tries to schedule tasks for the following pipeline