### PR TITLE
Fix substrait submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	branch = main
 [submodule "substrait"]
 	path = substrait
-	url = https://github.com/duckdb/substrait.git
+	url = https://github.com/sirius-db/duckdb-substrait-extension.git
 	branch = main
 [submodule "cucascade"]
 	path = cucascade


### PR DESCRIPTION
We are using [a commit](https://github.com/sirius-db/duckdb-substrait-extension/commit/ac2464531d9feeaddacf8654ed8eaec4f2995a7c) from our fork (with 1.5.1 support).
