### PR TITLE
MINOR fix for hash_join::get_next_task_hint

### DIFF
--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -440,8 +440,8 @@ std::optional<task_creation_hint> sirius_physical_hash_join::get_next_task_hint(
         return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, producer};
       }
     } else {
-      throw std::runtime_error(
-        "Invalid hash table build state in sirius_physical_hash_join::get_next_task_hint");
+      // If we are here, then this operator is actually complete.
+      return std::nullopt;
     }
   } else {
     return sirius_physical_operator::get_next_task_hint();


### PR DESCRIPTION
The recent PR https://github.com/sirius-db/sirius/pull/590 makes it so that get_next_task_hint can be called on an operator which has already finished. When that happens to a hash_join operator it will throw an error and the query will crash. This PR fixes that