### PR TITLE
Fix build warnings

### DIFF
--- a/src/expression_executor/regex/regex_playground.cpp
+++ b/src/expression_executor/regex/regex_playground.cpp
@@ -75,12 +75,13 @@ __device__ void extract_domain(cuda::std::optional<cudf::string_view>* out, cuda
 }
 )***";
 
-  return cudf::transform({input},
-                         udf,
-                         cudf::data_type{cudf::type_id::STRING},
-                         false,
-                         std::nullopt,
-                         cudf::null_aware::YES);
+  cudf::transform_input ti = input;
+  return cudf::transform_extended(std::span(&ti, 1),
+                                  udf,
+                                  cudf::data_type{cudf::type_id::STRING},
+                                  cudf::udf_source_type::CUDA,
+                                  std::nullopt,
+                                  cudf::null_aware::YES);
 }
 
 }  // namespace expression

--- a/test/cpp/exec/test_bounded_thread_pool.cpp
+++ b/test/cpp/exec/test_bounded_thread_pool.cpp
@@ -193,7 +193,7 @@ TEST_CASE("bounded_thread_pool interrupt wakes multiple blocked callers", "[boun
   std::vector<std::thread> threads;
   for (int i = 0; i < num_waiters; ++i) {
     threads.emplace_back([&pool, &woken] {
-      pool.reserve();  // blocks until a slot is available or interrupted
+      (void)pool.reserve();  // blocks until a slot is available or interrupted
       woken.fetch_add(1);
     });
   }


### PR DESCRIPTION
## Summary
- Replace deprecated `cudf::transform` with `cudf::transform_extended` in regex playground (`is_ptx` bool → `udf_source_type::CUDA` enum)
- Suppress `[[nodiscard]]` warning on `pool.reserve()` in bounded thread pool interrupt test where the slot is intentionally unused

## Test plan
- [x] Clean build completes with no new warnings from Sirius source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)