### PR TITLE
Enable decimals in the expression translator

### DIFF
--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -569,40 +569,31 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
         _resource_ref);
     }
     // cudf decimal type uses negative scale
-    /// TODO: Uncomment the decimal code once the following bug fix is released in cuDF and we
-    /// update to that version:
-    /// https://github.com/rapidsai/cudf/pull/21447
-    /// For now, fallthrough to default case to return nullopt and effectively disallow decimal
-    /// types.
     case cudf::type_id::DECIMAL32: {
-      // return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal32>>(
-      //   expr.value.GetValueUnsafe<typename numeric::decimal32::rep>(),
-      //   numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-      //   true,
-      //   _stream,
-      //   _resource_ref);
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal32>>(
+        expr.value.GetValueUnsafe<typename numeric::decimal32::rep>(),
+        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
+        true,
+        _stream,
+        _resource_ref);
     }
     case cudf::type_id::DECIMAL64: {
-      // return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal64>>(
-      //   expr.value.GetValueUnsafe<typename numeric::decimal64::rep>(),
-      //   numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-      //   true,
-      //   _stream,
-      //   _resource_ref);
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal64>>(
+        expr.value.GetValueUnsafe<typename numeric::decimal64::rep>(),
+        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
+        true,
+        _stream,
+        _resource_ref);
     }
     case cudf::type_id::DECIMAL128: {
-      // duckdb::hugeint_t const value = expr.value.GetValueUnsafe<duckdb::hugeint_t>();
-      // __int128_t rep                = (static_cast<__int128_t>(value.upper) << 64) | value.lower;
-      // return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal128>>(
-      //   rep,
-      //   numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-      //   true,
-      //   _stream,
-      //   _resource_ref);
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] DECIMAL types are not supported in expression translator due to "
-        "cuDF bug");
-      return std::nullopt;
+      duckdb::hugeint_t const value = expr.value.GetValueUnsafe<duckdb::hugeint_t>();
+      __int128_t rep                = (static_cast<__int128_t>(value.upper) << 64) | value.lower;
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal128>>(
+        rep,
+        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
+        true,
+        _stream,
+        _resource_ref);
     }
     default: {
       SIRIUS_LOG_DEBUG("[expression_translator] Unsupported constant type_id: {}",
@@ -710,16 +701,6 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
 std::optional<expr_ref> gpu_expression_translator::add_expression(
   duckdb::BoundReferenceExpression const& expr, cudf::ast::table_reference const table_src)
 {
-  // We need to disable DECIMAL types in the expression translator for now because of cuDF bug.
-  auto const cudf_type = GetCudfType(expr.return_type);
-  if (cudf_type.id() == cudf::type_id::DECIMAL32 || cudf_type.id() == cudf::type_id::DECIMAL64 ||
-      cudf_type.id() == cudf::type_id::DECIMAL128) {
-    SIRIUS_LOG_DEBUG(
-      "[expression_translator] DECIMAL types are not supported in expression translator due to "
-      "cuDF bug");
-    return std::nullopt;
-  }
-
   if (_column_name_resolver) {
     return _ast_tree.emplace<cudf::ast::column_name_reference>(_column_name_resolver(expr.index));
   }

--- a/test/cpp/expression_executor/test_gpu_expression_translator.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_translator.cpp
@@ -27,6 +27,7 @@
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
@@ -185,6 +186,57 @@ std::unique_ptr<cudf::table> make_float32_table(std::vector<float> const& values
     cudf::data_type{cudf::type_id::FLOAT32}, n, cudf::mask_state::UNALLOCATED, stream, mr);
   cudaMemcpy(
     col->mutable_view().data<float>(), values.data(), sizeof(float) * n, cudaMemcpyHostToDevice);
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// Build a single-column DECIMAL32 table from host int32 rep values.
+std::unique_ptr<cudf::table> make_decimal32_table(std::vector<int32_t> const& rep_values,
+                                                  int32_t scale)
+{
+  auto const n = static_cast<cudf::size_type>(rep_values.size());
+  auto col     = cudf::make_fixed_point_column(
+    cudf::data_type{cudf::type_id::DECIMAL32, scale}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+  cudaMemcpy(col->mutable_view().data<int32_t>(),
+             rep_values.data(),
+             sizeof(int32_t) * n,
+             cudaMemcpyHostToDevice);
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// Build a single-column DECIMAL64 table from host int64 rep values.
+std::unique_ptr<cudf::table> make_decimal64_table(std::vector<int64_t> const& rep_values,
+                                                  int32_t scale)
+{
+  auto const n = static_cast<cudf::size_type>(rep_values.size());
+  auto col     = cudf::make_fixed_point_column(
+    cudf::data_type{cudf::type_id::DECIMAL64, scale}, n, cudf::mask_state::UNALLOCATED, stream, mr);
+  cudaMemcpy(col->mutable_view().data<int64_t>(),
+             rep_values.data(),
+             sizeof(int64_t) * n,
+             cudaMemcpyHostToDevice);
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// Build a single-column DECIMAL128 table from host __int128_t rep values.
+std::unique_ptr<cudf::table> make_decimal128_table(std::vector<__int128_t> const& rep_values,
+                                                   int32_t scale)
+{
+  auto const n = static_cast<cudf::size_type>(rep_values.size());
+  auto col     = cudf::make_fixed_point_column(cudf::data_type{cudf::type_id::DECIMAL128, scale},
+                                           n,
+                                           cudf::mask_state::UNALLOCATED,
+                                           stream,
+                                           mr);
+  cudaMemcpy(col->mutable_view().data<__int128_t>(),
+             rep_values.data(),
+             sizeof(__int128_t) * n,
+             cudaMemcpyHostToDevice);
   std::vector<std::unique_ptr<cudf::column>> cols;
   cols.push_back(std::move(col));
   return std::make_unique<cudf::table>(std::move(cols));
@@ -1734,30 +1786,143 @@ TEST_CASE("translator: 100-row table with complex expression", "[expression_tran
 }
 
 //===----------------------------------------------------------------------===//
-// Test: Decimal constants are disabled
+// Test: Decimal constant translation
 //===----------------------------------------------------------------------===//
 
-TEST_CASE("translator: decimal constants return nullopt", "[expression_translator]")
+TEST_CASE("translator: DECIMAL32 constant translates successfully", "[expression_translator]")
 {
-  // DECIMAL32 (small precision)
-  {
-    auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(42, 5, 2));
-    auto translator = make_translator();
-    auto ast_tree   = translator.translate_expression(*expr);
-    REQUIRE_FALSE(ast_tree.has_value());
+  auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(42, 5, 2));
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+}
+
+TEST_CASE("translator: DECIMAL64 constant translates successfully", "[expression_translator]")
+{
+  auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(12345, 12, 4));
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+}
+
+TEST_CASE("translator: DECIMAL128 constant translates successfully", "[expression_translator]")
+{
+  auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(99999, 30, 6));
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+}
+
+TEST_CASE("translator: DECIMAL128 constant with large hugeint value", "[expression_translator]")
+{
+  duckdb::hugeint_t big_val;
+  big_val.upper = 1;
+  big_val.lower = 0;  // 2^64
+
+  auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(big_val, 30, 6));
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+}
+
+//===----------------------------------------------------------------------===//
+// Test: Decimal column reference translation
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("translator: DECIMAL64 column reference translates successfully",
+          "[expression_translator]")
+{
+  auto expr       = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(18, 2), 0);
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+}
+
+//===----------------------------------------------------------------------===//
+// Test: Decimal comparison (column vs constant) — end-to-end
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("translator: DECIMAL64 comparison col(0) > constant", "[expression_translator]")
+{
+  // col values in rep: 100, 250, 350, 500 (i.e., 1.00, 2.50, 3.50, 5.00)
+  // constant: 200 (i.e., 2.00)
+  // expected: false, true, true, true
+  std::vector<int64_t> col_reps = {100, 250, 350, 500};
+  int32_t const scale           = -2;
+  auto table                    = make_decimal64_table(col_reps, scale);
+  auto tv                       = table->view();
+
+  auto left = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(18, 2), 0);
+  auto right =
+    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(static_cast<int64_t>(200), 18, 2));
+  auto expr = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
+
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+
+  auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
+  auto host_vals = copy_bool_column_to_host(result->view());
+
+  std::vector<uint8_t> expected;
+  for (auto rep : col_reps) {
+    expected.push_back(rep > 200 ? 1U : 0U);
   }
-  // DECIMAL64 (medium precision)
-  {
-    auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(12345, 12, 4));
-    auto translator = make_translator();
-    auto ast_tree   = translator.translate_expression(*expr);
-    REQUIRE_FALSE(ast_tree.has_value());
+  REQUIRE(host_vals == expected);
+}
+
+TEST_CASE("translator: DECIMAL32 comparison col(0) == constant", "[expression_translator]")
+{
+  // col values in rep: 100, 200, 300, 200, 500
+  // constant: 200 (i.e., 2.00)
+  // expected: false, true, false, true, false
+  std::vector<int32_t> col_reps = {100, 200, 300, 200, 500};
+  int32_t const scale           = -2;
+  auto table                    = make_decimal32_table(col_reps, scale);
+  auto tv                       = table->view();
+
+  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(5, 2), 0);
+  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(200, 5, 2));
+  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
+
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+
+  auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
+  auto host_vals = copy_bool_column_to_host(result->view());
+
+  std::vector<uint8_t> expected;
+  for (auto rep : col_reps) {
+    expected.push_back(rep == 200 ? 1U : 0U);
   }
-  // DECIMAL128 (large precision)
-  {
-    auto expr       = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(99999, 30, 6));
-    auto translator = make_translator();
-    auto ast_tree   = translator.translate_expression(*expr);
-    REQUIRE_FALSE(ast_tree.has_value());
+  REQUIRE(host_vals == expected);
+}
+
+TEST_CASE("translator: DECIMAL128 comparison col(0) <= constant", "[expression_translator]")
+{
+  std::vector<__int128_t> col_reps = {100000, 200000, 300000, 400000};
+  int32_t const scale              = -6;
+  auto table                       = make_decimal128_table(col_reps, scale);
+  auto tv                          = table->view();
+
+  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(30, 6), 0);
+  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(200000, 30, 6));
+  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left), std::move(right));
+
+  auto translator = make_translator();
+  auto ast_tree   = translator.translate_expression(*expr);
+  REQUIRE(ast_tree.has_value());
+
+  auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
+  auto host_vals = copy_bool_column_to_host(result->view());
+
+  std::vector<uint8_t> expected;
+  for (auto rep : col_reps) {
+    expected.push_back(rep <= 200000 ? 1U : 0U);
   }
+  REQUIRE(host_vals == expected);
 }


### PR DESCRIPTION
now we've updated libcudf to version 26.04, a critical bug has been fixed and we can use decimals in expressions.