### PR TITLE
fix: prevent concurrent boundary computation in sort_sample

### DIFF
--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -71,7 +71,7 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   size_t get_num_partitions() const { return _num_partitions; }
 
   //! Whether boundaries have been computed
-  bool boundaries_computed() const { return _boundaries_computed.load(); }
+  bool boundaries_computed() const { return _boundary_state.load(std::memory_order_acquire) == 2; }
 
   //! Override the maximum bytes per partition (0 = use default GPU memory-based calculation)
   void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
@@ -86,8 +86,10 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Number of partitions computed from the sample
   size_t _num_partitions = 1;
 
-  //! Whether partition boundaries have been computed
-  std::atomic<bool> _boundaries_computed{false};
+  //! Boundary computation state: 0 = not started, 1 = computing, 2 = done.
+  //! compare_exchange on this elects exactly one task as the winner; all others
+  //! passthrough without blocking.
+  std::atomic<int> _boundary_state{0};
 
   //! Override for max partition bytes (0 = use default GPU memory-based calculation)
   size_t _max_partition_bytes_override = 0;

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -51,7 +51,7 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(
 std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hint()
 {
   // If boundaries already computed, use default behavior (process batches as they arrive)
-  if (_boundaries_computed.load()) { return sirius_physical_operator::get_next_task_hint(); }
+  if (_boundary_state.load(std::memory_order_acquire) == 2) { return sirius_physical_operator::get_next_task_hint(); }
 
   // Need to wait for N batches before computing boundaries
   auto port_ids = get_port_ids();
@@ -82,8 +82,18 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
   const auto& input_batches = input.get_data_batches();
 
-  // After boundaries are computed, just pass through
-  if (_boundaries_computed.load()) {
+  // Fast path: boundaries already computed — just pass through.
+  if (_boundary_state.load(std::memory_order_acquire) == 2) {
+    SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
+    return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
+  }
+
+  // Elect exactly one winner via CAS (0=not started → 1=computing).
+  // The task_creator's while loop dispatches one task per batch, so multiple tasks
+  // can be in-flight simultaneously. Losers passthrough without blocking — they don't
+  // need the boundaries themselves; sort_partition accesses them in a later pipeline.
+  int expected = 0;
+  if (!_boundary_state.compare_exchange_strong(expected, 1, std::memory_order_acq_rel)) {
     SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
     return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
@@ -102,7 +112,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   }
 
   if (valid_batches.empty() || !space) {
-    _boundaries_computed.store(true);
+    _boundary_state.store(2, std::memory_order_release);
     return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
 
@@ -237,10 +247,14 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                                          cudf::out_of_bounds_policy::DONT_CHECK,
                                          stream,
                                          space->get_default_allocator());
-    _num_partitions       = num_parts;
+    _num_partitions = num_parts;
   }
 
-  _boundaries_computed.store(true);
+  // Pipeline framework calls stream.synchronize() after execute() returns, before
+  // publish_output(). Pipeline C only starts after all Pipeline B tasks complete,
+  // so _partition_boundaries is fully materialized on the GPU before sort_partition
+  // ever reads it. No explicit sync needed here.
+  _boundary_state.store(2, std::memory_order_release);
 
   auto end      = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -51,7 +51,9 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(
 std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hint()
 {
   // If boundaries already computed, use default behavior (process batches as they arrive)
-  if (_boundary_state.load(std::memory_order_acquire) == 2) { return sirius_physical_operator::get_next_task_hint(); }
+  if (_boundary_state.load(std::memory_order_acquire) == 2) {
+    return sirius_physical_operator::get_next_task_hint();
+  }
 
   // Need to wait for N batches before computing boundaries
   auto port_ids = get_port_ids();
@@ -115,6 +117,10 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     _boundary_state.store(2, std::memory_order_release);
     return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
   }
+
+  // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory),
+  // reset state to NOT_STARTED so the rescheduled task can win the CAS and retry.
+  try {
 
   // 2. Concatenate all sample batches into one table
   std::vector<cudf::table_view> sample_views;
@@ -247,7 +253,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                                          cudf::out_of_bounds_policy::DONT_CHECK,
                                          stream,
                                          space->get_default_allocator());
-    _num_partitions = num_parts;
+    _num_partitions       = num_parts;
   }
 
   // Pipeline framework calls stream.synchronize() after execute() returns, before
@@ -255,6 +261,13 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   // so _partition_boundaries is fully materialized on the GPU before sort_partition
   // ever reads it. No explicit sync needed here.
   _boundary_state.store(2, std::memory_order_release);
+
+  } catch (...) {
+    // Reset to NOT_STARTED so the rescheduled task (or another in-flight task) can
+    // win the CAS election and retry boundary computation.
+    _boundary_state.store(0, std::memory_order_release);
+    throw;
+  }
 
   auto end      = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -121,146 +121,145 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory),
   // reset state to NOT_STARTED so the rescheduled task can win the CAS and retry.
   try {
-
-  // 2. Concatenate all sample batches into one table
-  std::vector<cudf::table_view> sample_views;
-  size_t total_sample_bytes = 0;
-  sample_views.reserve(valid_batches.size());
-  for (auto const& batch : valid_batches) {
-    auto view = get_cudf_table_view(*batch);
-    sample_views.push_back(view);
-    total_sample_bytes += batch->get_data()->get_size_in_bytes();
-  }
-
-  auto concat_table = cudf::concatenate(sample_views, stream, space->get_default_allocator());
-
-  // 3. Build cudf order vectors from BoundOrderByNode
-  std::vector<int> order_key_idx;
-  std::vector<cudf::order> column_order;
-  std::vector<cudf::null_order> null_precedence;
-  order_key_idx.reserve(orders.size());
-  column_order.reserve(orders.size());
-  null_precedence.reserve(orders.size());
-
-  for (auto const& ord : orders) {
-    if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
-      throw not_implemented_exception("Sort sample only supports bound reference expressions");
+    // 2. Concatenate all sample batches into one table
+    std::vector<cudf::table_view> sample_views;
+    size_t total_sample_bytes = 0;
+    sample_views.reserve(valid_batches.size());
+    for (auto const& batch : valid_batches) {
+      auto view = get_cudf_table_view(*batch);
+      sample_views.push_back(view);
+      total_sample_bytes += batch->get_data()->get_size_in_bytes();
     }
-    auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
-    order_key_idx.push_back(idx);
-    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                    : cudf::order::DESCENDING);
-    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                                ? cudf::null_order::BEFORE
-                                : cudf::null_order::AFTER);
-  }
 
-  // 4. Sort the concatenated sample by sort keys
-  std::vector<cudf::column_view> sort_cols;
-  for (int idx : order_key_idx) {
-    sort_cols.push_back(concat_table->view().column(idx));
-  }
-  auto sorted_indices = cudf::sorted_order(cudf::table_view(sort_cols),
-                                           column_order,
-                                           null_precedence,
+    auto concat_table = cudf::concatenate(sample_views, stream, space->get_default_allocator());
+
+    // 3. Build cudf order vectors from BoundOrderByNode
+    std::vector<int> order_key_idx;
+    std::vector<cudf::order> column_order;
+    std::vector<cudf::null_order> null_precedence;
+    order_key_idx.reserve(orders.size());
+    column_order.reserve(orders.size());
+    null_precedence.reserve(orders.size());
+
+    for (auto const& ord : orders) {
+      if (ord.expression->expression_class != duckdb::ExpressionClass::BOUND_REF) {
+        throw not_implemented_exception("Sort sample only supports bound reference expressions");
+      }
+      auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
+      order_key_idx.push_back(idx);
+      column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
+                                                                      : cudf::order::DESCENDING);
+      null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
+                                  ? cudf::null_order::BEFORE
+                                  : cudf::null_order::AFTER);
+    }
+
+    // 4. Sort the concatenated sample by sort keys
+    std::vector<cudf::column_view> sort_cols;
+    for (int idx : order_key_idx) {
+      sort_cols.push_back(concat_table->view().column(idx));
+    }
+    auto sorted_indices = cudf::sorted_order(cudf::table_view(sort_cols),
+                                             column_order,
+                                             null_precedence,
+                                             stream,
+                                             space->get_default_allocator());
+
+    auto sorted_table = cudf::gather(concat_table->view(),
+                                     sorted_indices->view(),
+                                     cudf::out_of_bounds_policy::DONT_CHECK,
+                                     stream,
+                                     space->get_default_allocator());
+
+    // 5. Compute number of partitions
+    size_t total_rows      = static_cast<size_t>(sorted_table->num_rows());
+    size_t avg_batch_bytes = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
+    size_t avg_rows_per_batch = valid_batches.empty() ? 0 : total_rows / valid_batches.size();
+    size_t num_parts          = 1;
+    if (estimated_cardinality == 0 || avg_rows_per_batch == 0) {
+      SIRIUS_LOG_WARN(
+        "Sort sample: estimated_cardinality={} or avg_rows_per_batch={} is zero, "
+        "defaulting to 1 partition",
+        estimated_cardinality,
+        avg_rows_per_batch);
+    } else {
+      size_t total_batch_count =
+        (estimated_cardinality + avg_rows_per_batch - 1) / avg_rows_per_batch;
+      size_t estimated_total_bytes = avg_batch_bytes * total_batch_count;
+      size_t available_memory      = space->get_available_memory(stream);
+      size_t max_partition_bytes   = _max_partition_bytes_override > 0
+                                       ? _max_partition_bytes_override
+                                       : static_cast<size_t>(static_cast<double>(available_memory) *
+                                                           MAX_PARTITION_MEMORY_FRACTION);
+
+      if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
+        num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;
+      }
+
+      SIRIUS_LOG_DEBUG(
+        "Sort sample: estimated_cardinality={}, total_rows={}, avg_rows_per_batch={}, "
+        "avg_batch_bytes={}, total_batch_count={}, "
+        "estimated_total_bytes={}, available_memory={}, max_partition_bytes={}, num_partitions={}",
+        estimated_cardinality,
+        total_rows,
+        avg_rows_per_batch,
+        avg_batch_bytes,
+        total_batch_count,
+        estimated_total_bytes,
+        available_memory,
+        max_partition_bytes,
+        num_parts);
+    }
+
+    // 6. Pick P-1 evenly-spaced boundary rows from the sorted sample (sort key columns only)
+    if (num_parts <= 1 || total_rows == 0) {
+      // Single partition — no boundaries needed
+      _num_partitions = 1;
+      _partition_boundaries.reset();
+    } else {
+      // Compute boundary row indices: [total_rows/P, 2*total_rows/P, ..., (P-1)*total_rows/P]
+      size_t num_boundaries = num_parts - 1;
+      std::vector<int32_t> boundary_indices_host;
+      boundary_indices_host.reserve(num_boundaries);
+      for (size_t i = 1; i <= num_boundaries; i++) {
+        auto idx = static_cast<int32_t>((i * total_rows) / num_parts);
+        if (idx >= static_cast<int32_t>(total_rows)) { idx = static_cast<int32_t>(total_rows) - 1; }
+        boundary_indices_host.push_back(idx);
+      }
+
+      // Create a device column with the boundary indices
+      auto indices_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                                   static_cast<cudf::size_type>(num_boundaries),
+                                                   cudf::mask_state::UNALLOCATED,
+                                                   stream,
+                                                   space->get_default_allocator());
+      CUDF_CUDA_TRY(cudaMemcpyAsync(indices_col->mutable_view().data<int32_t>(),
+                                    boundary_indices_host.data(),
+                                    num_boundaries * sizeof(int32_t),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+
+      // Extract only the sort key columns from sorted table for the boundaries
+      std::vector<cudf::column_view> sort_key_cols;
+      for (int idx : order_key_idx) {
+        sort_key_cols.push_back(sorted_table->view().column(idx));
+      }
+      cudf::table_view sort_keys_view(sort_key_cols);
+
+      // Gather boundary rows
+      _partition_boundaries = cudf::gather(sort_keys_view,
+                                           indices_col->view(),
+                                           cudf::out_of_bounds_policy::DONT_CHECK,
                                            stream,
                                            space->get_default_allocator());
-
-  auto sorted_table = cudf::gather(concat_table->view(),
-                                   sorted_indices->view(),
-                                   cudf::out_of_bounds_policy::DONT_CHECK,
-                                   stream,
-                                   space->get_default_allocator());
-
-  // 5. Compute number of partitions
-  size_t total_rows         = static_cast<size_t>(sorted_table->num_rows());
-  size_t avg_batch_bytes    = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
-  size_t avg_rows_per_batch = valid_batches.empty() ? 0 : total_rows / valid_batches.size();
-  size_t num_parts          = 1;
-  if (estimated_cardinality == 0 || avg_rows_per_batch == 0) {
-    SIRIUS_LOG_WARN(
-      "Sort sample: estimated_cardinality={} or avg_rows_per_batch={} is zero, "
-      "defaulting to 1 partition",
-      estimated_cardinality,
-      avg_rows_per_batch);
-  } else {
-    size_t total_batch_count =
-      (estimated_cardinality + avg_rows_per_batch - 1) / avg_rows_per_batch;
-    size_t estimated_total_bytes = avg_batch_bytes * total_batch_count;
-    size_t available_memory      = space->get_available_memory(stream);
-    size_t max_partition_bytes   = _max_partition_bytes_override > 0
-                                     ? _max_partition_bytes_override
-                                     : static_cast<size_t>(static_cast<double>(available_memory) *
-                                                         MAX_PARTITION_MEMORY_FRACTION);
-
-    if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
-      num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;
+      _num_partitions       = num_parts;
     }
 
-    SIRIUS_LOG_DEBUG(
-      "Sort sample: estimated_cardinality={}, total_rows={}, avg_rows_per_batch={}, "
-      "avg_batch_bytes={}, total_batch_count={}, "
-      "estimated_total_bytes={}, available_memory={}, max_partition_bytes={}, num_partitions={}",
-      estimated_cardinality,
-      total_rows,
-      avg_rows_per_batch,
-      avg_batch_bytes,
-      total_batch_count,
-      estimated_total_bytes,
-      available_memory,
-      max_partition_bytes,
-      num_parts);
-  }
-
-  // 6. Pick P-1 evenly-spaced boundary rows from the sorted sample (sort key columns only)
-  if (num_parts <= 1 || total_rows == 0) {
-    // Single partition — no boundaries needed
-    _num_partitions = 1;
-    _partition_boundaries.reset();
-  } else {
-    // Compute boundary row indices: [total_rows/P, 2*total_rows/P, ..., (P-1)*total_rows/P]
-    size_t num_boundaries = num_parts - 1;
-    std::vector<int32_t> boundary_indices_host;
-    boundary_indices_host.reserve(num_boundaries);
-    for (size_t i = 1; i <= num_boundaries; i++) {
-      auto idx = static_cast<int32_t>((i * total_rows) / num_parts);
-      if (idx >= static_cast<int32_t>(total_rows)) { idx = static_cast<int32_t>(total_rows) - 1; }
-      boundary_indices_host.push_back(idx);
-    }
-
-    // Create a device column with the boundary indices
-    auto indices_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
-                                                 static_cast<cudf::size_type>(num_boundaries),
-                                                 cudf::mask_state::UNALLOCATED,
-                                                 stream,
-                                                 space->get_default_allocator());
-    CUDF_CUDA_TRY(cudaMemcpyAsync(indices_col->mutable_view().data<int32_t>(),
-                                  boundary_indices_host.data(),
-                                  num_boundaries * sizeof(int32_t),
-                                  cudaMemcpyHostToDevice,
-                                  stream.value()));
-
-    // Extract only the sort key columns from sorted table for the boundaries
-    std::vector<cudf::column_view> sort_key_cols;
-    for (int idx : order_key_idx) {
-      sort_key_cols.push_back(sorted_table->view().column(idx));
-    }
-    cudf::table_view sort_keys_view(sort_key_cols);
-
-    // Gather boundary rows
-    _partition_boundaries = cudf::gather(sort_keys_view,
-                                         indices_col->view(),
-                                         cudf::out_of_bounds_policy::DONT_CHECK,
-                                         stream,
-                                         space->get_default_allocator());
-    _num_partitions       = num_parts;
-  }
-
-  // Pipeline framework calls stream.synchronize() after execute() returns, before
-  // publish_output(). Pipeline C only starts after all Pipeline B tasks complete,
-  // so _partition_boundaries is fully materialized on the GPU before sort_partition
-  // ever reads it. No explicit sync needed here.
-  _boundary_state.store(2, std::memory_order_release);
+    // Pipeline framework calls stream.synchronize() after execute() returns, before
+    // publish_output(). Pipeline C only starts after all Pipeline B tasks complete,
+    // so _partition_boundaries is fully materialized on the GPU before sort_partition
+    // ever reads it. No explicit sync needed here.
+    _boundary_state.store(2, std::memory_order_release);
 
   } catch (...) {
     // Reset to NOT_STARTED so the rescheduled task (or another in-flight task) can


### PR DESCRIPTION
Closes #593

The `task_creator` exhausts all available batches in a while loop, dispatching one task per batch for sort_sample before any of them run. On the pipeline executor's thread pool, multiple tasks could enter `execute()` simultaneously with `_boundary_state=0` (not started), each racing to write _partition_boundaries via an async `cudf::gather`. The second writer frees the first task's GPU allocation mid-gather, producing corrupt boundary data. sort_partition then passes these corrupt boundaries to `cudf::lower_bound`, yielding non-monotone split positions whose slice index pairs have end < begin, triggering the below cuDF assertion
```
End index cannot be smaller than the starting index
```

Fix with a lock-free 3-state atomic (0=not started, 1=computing, 2=done): a compare_exchange elects exactly one winner; all other tasks pass-through without blocking. The pipeline framework's own `stream.synchronize()` (called after `execute()` returns) guarantees _partition_boundaries is fully materialized before Pipeline C and sort_partition start, so no explicit sync is needed in execute().

🤖 Created by Claude
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>