### PR TITLE
refactor: remove DuckDB execution state types from sirius_physical_operator base class

### DIFF
--- a/src/include/helper/types.hpp
+++ b/src/include/helper/types.hpp
@@ -22,4 +22,6 @@ enum class OrderByType { ASCENDING, DESCENDING };
 
 enum class AggregationType { SUM, MIN, MAX, COUNT, COUNT_STAR, AVERAGE, FIRST, COUNT_DISTINCT };
 
+enum class OrderPreservationType { INSERTION_ORDER, NO_ORDER, FIXED_ORDER };
+
 }  // namespace sirius

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -56,9 +56,9 @@ class sirius_physical_delim_join : public sirius_physical_operator {
 
   bool is_sink() const override { return true; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::NO_ORDER;
+    return sirius::OrderPreservationType::NO_ORDER;
   }
   bool sink_order_dependent() const override { return false; }
 };

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -98,9 +98,9 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
   // Source interface
   bool is_source() const override { return true; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::NO_ORDER;
+    return sirius::OrderPreservationType::NO_ORDER;
   }
 
   // Sink interface

--- a/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
@@ -115,9 +115,9 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
   // Source interface
   bool is_source() const override { return true; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::NO_ORDER;
+    return sirius::OrderPreservationType::NO_ORDER;
   }
 
   // Sink interface

--- a/src/include/op/sirius_physical_merge_sort.hpp
+++ b/src/include/op/sirius_physical_merge_sort.hpp
@@ -50,9 +50,9 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
   // Source interface
   bool is_source() const override { return true; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
  public:

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -19,7 +19,6 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
-#include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -19,12 +19,9 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
-#include "duckdb/common/enums/order_preservation_type.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/execution/execution_context.hpp"
-#include "duckdb/execution/physical_operator.hpp"
-#include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "helper/types.hpp"
 #include "op/sirius_physical_operator_type.hpp"
@@ -193,11 +190,7 @@ class sirius_physical_operator {
   //! The unique ID of this operator (auto-incremented at creation)
   size_t operator_id;
 
-  //! The global sink state of this operator
-  duckdb::unique_ptr<duckdb::GlobalSinkState> sink_state;
-  //! The global state of this operator
-  duckdb::unique_ptr<duckdb::GlobalOperatorState> op_state;
-  //! Lock for (re)setting any of the operator states
+  //! Lock for concurrent access to operator state
   std::mutex lock;
 
  public:
@@ -223,45 +216,27 @@ class sirius_physical_operator {
 
  public:
   // Operator interface
-  virtual duckdb::unique_ptr<duckdb::OperatorState> get_operator_state(
-    duckdb::ExecutionContext& context) const;
-
-  virtual duckdb::unique_ptr<duckdb::GlobalOperatorState> get_global_operator_state(
-    duckdb::ClientContext& context) const;
-
   virtual std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                                  rmm::cuda_stream_view stream);
 
   //! The influence the operator has on order (insertion order means no influence)
-  virtual duckdb::OrderPreservationType operator_order() const
+  virtual sirius::OrderPreservationType operator_order() const
   {
-    return duckdb::OrderPreservationType::INSERTION_ORDER;
+    return sirius::OrderPreservationType::INSERTION_ORDER;
   }
 
  public:
   // Source interface
-  virtual duckdb::unique_ptr<duckdb::LocalSourceState> get_local_source_state(
-    duckdb::ExecutionContext& context, duckdb::GlobalSourceState& gstate) const;
-
-  virtual duckdb::unique_ptr<duckdb::GlobalSourceState> get_global_source_state(
-    duckdb::ClientContext& context) const;
-
   virtual bool is_source() const { return false; }
 
   //! The type of order emitted by the operator (as a source)
-  virtual duckdb::OrderPreservationType source_order() const
+  virtual sirius::OrderPreservationType source_order() const
   {
-    return duckdb::OrderPreservationType::INSERTION_ORDER;
+    return sirius::OrderPreservationType::INSERTION_ORDER;
   }
 
  public:
   // Sink interface
-  virtual duckdb::unique_ptr<duckdb::LocalSinkState> get_local_sink_state(
-    duckdb::ExecutionContext& context) const;
-
-  virtual duckdb::unique_ptr<duckdb::GlobalSinkState> get_global_sink_state(
-    duckdb::ClientContext& context) const;
-
   virtual void sink(const operator_data& input_data, rmm::cuda_stream_view stream);
 
   virtual bool is_sink() const { return false; }

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -53,9 +53,9 @@ class sirius_physical_order : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,

--- a/src/include/op/sirius_physical_result_collector.hpp
+++ b/src/include/op/sirius_physical_result_collector.hpp
@@ -53,8 +53,8 @@ class sirius_physical_result_collector : public sirius_physical_operator {
   duckdb::vector<std::string> names;
 
  public:
-  // //! The final method used to fetch the query result from this operator
-  virtual duckdb::unique_ptr<duckdb::QueryResult> get_result(duckdb::GlobalSinkState& state) = 0;
+  //! The final method used to fetch the query result from this operator
+  virtual duckdb::unique_ptr<duckdb::QueryResult> get_result() = 0;
 
   bool is_sink() const override { return true; }
 
@@ -76,10 +76,9 @@ class sirius_physical_materialized_collector : public sirius_physical_result_col
   /**
    * @brief Fetch the final query result from the result collection
    *
-   * @param[in] state The global sink state (currently unused)
    * @return The query result
    */
-  duckdb::unique_ptr<duckdb::QueryResult> get_result(duckdb::GlobalSinkState& state) override;
+  duckdb::unique_ptr<duckdb::QueryResult> get_result() override;
 
   /**
    * @brief Sink a data batch into the result collection

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -46,9 +46,9 @@ class sirius_physical_sort_partition : public sirius_physical_operator {
   // Source interface
   bool is_source() const override { return true; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
  public:

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -53,9 +53,9 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   bool is_sink() const override { return true; }
   bool sink_order_dependent() const override { return false; }
 
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -53,9 +53,9 @@ class sirius_physical_top_n : public sirius_physical_operator {
 
  public:
   bool is_source() const override { return true; }
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
  public:

--- a/src/include/op/sirius_physical_top_n_merge.hpp
+++ b/src/include/op/sirius_physical_top_n_merge.hpp
@@ -54,9 +54,9 @@ class sirius_physical_top_n_merge : public sirius_physical_operator {
 
  public:
   bool is_source() const override { return true; }
-  duckdb::OrderPreservationType source_order() const override
+  sirius::OrderPreservationType source_order() const override
   {
-    return duckdb::OrderPreservationType::FIXED_ORDER;
+    return sirius::OrderPreservationType::FIXED_ORDER;
   }
 
  public:

--- a/src/include/planner/sirius_physical_plan_generator.hpp
+++ b/src/include/planner/sirius_physical_plan_generator.hpp
@@ -72,7 +72,7 @@ class sirius_physical_plan_generator {
                                        sirius::op::sirius_physical_operator& plan);
   //! The order preservation type of the given operator decided by recursively looking at its
   //! children
-  static duckdb::OrderPreservationType order_preservation_recursive(
+  static sirius::OrderPreservationType order_preservation_recursive(
     sirius::op::sirius_physical_operator& op);
 
   static bool has_equality(duckdb::vector<duckdb::JoinCondition>& conds, std::size_t& range_count);

--- a/src/op/sirius_physical_cte.cpp
+++ b/src/op/sirius_physical_cte.cpp
@@ -51,8 +51,6 @@ void sirius_physical_cte::build_pipelines(pipeline::sirius_pipeline& current,
                                           pipeline::sirius_meta_pipeline& meta_pipeline)
 {
   D_ASSERT(children.size() == 2);
-  op_state.reset();
-  sink_state.reset();
 
   auto& state = meta_pipeline.get_state();
 

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -107,9 +107,6 @@ sirius_physical_left_delim_join::sirius_physical_left_delim_join(
 void sirius_physical_left_delim_join::build_pipelines(pipeline::sirius_pipeline& current,
                                                       pipeline::sirius_meta_pipeline& meta_pipeline)
 {
-  op_state.reset();
-  sink_state.reset();
-
   auto& child_meta_pipeline = meta_pipeline.create_child_meta_pipeline(current, *this);
   child_meta_pipeline.build(*children[0]);
 
@@ -130,9 +127,6 @@ void sirius_physical_left_delim_join::build_pipelines(pipeline::sirius_pipeline&
 void sirius_physical_right_delim_join::build_pipelines(
   pipeline::sirius_pipeline& current, pipeline::sirius_meta_pipeline& meta_pipeline)
 {
-  op_state.reset();
-  sink_state.reset();
-
   auto& child_meta_pipeline = meta_pipeline.create_child_meta_pipeline(current, *this);
   child_meta_pipeline.build(*children[0]);
 

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -316,9 +316,6 @@ void sirius_physical_hash_join::build_join_pipelines(pipeline::sirius_pipeline& 
                                                      sirius_physical_operator& op,
                                                      bool build_rhs)
 {
-  op.op_state.reset();
-  op.sink_state.reset();
-
   auto& state = meta_pipeline.get_state();
   state.add_pipeline_operator(current, op);
 

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -211,9 +211,6 @@ void sirius_physical_nested_loop_join::build_join_pipelines(
   sirius_physical_operator& op,
   bool build_rhs)
 {
-  op.op_state.reset();
-  op.sink_state.reset();
-
   auto& state = meta_pipeline.get_state();
   state.add_pipeline_operator(current, op);
 

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -71,51 +71,6 @@ pipelineable_operator_data::prepare_for_processing(
   return handles;
 }
 
-//===--------------------------------------------------------------------===//
-// Operator
-//===--------------------------------------------------------------------===//
-// LCOV_EXCL_START
-duckdb::unique_ptr<duckdb::OperatorState> sirius_physical_operator::get_operator_state(
-  duckdb::ExecutionContext& context) const
-{
-  return duckdb::make_uniq<duckdb::OperatorState>();
-}
-
-duckdb::unique_ptr<duckdb::GlobalOperatorState> sirius_physical_operator::get_global_operator_state(
-  duckdb::ClientContext& context) const
-{
-  return duckdb::make_uniq<duckdb::GlobalOperatorState>();
-}
-
-//===--------------------------------------------------------------------===//
-// Source
-//===--------------------------------------------------------------------===//
-duckdb::unique_ptr<duckdb::LocalSourceState> sirius_physical_operator::get_local_source_state(
-  duckdb::ExecutionContext& context, duckdb::GlobalSourceState& gstate) const
-{
-  return duckdb::make_uniq<duckdb::LocalSourceState>();
-}
-
-duckdb::unique_ptr<duckdb::GlobalSourceState> sirius_physical_operator::get_global_source_state(
-  duckdb::ClientContext& context) const
-{
-  return duckdb::make_uniq<duckdb::GlobalSourceState>();
-}
-//===--------------------------------------------------------------------===//
-// Sink
-//===--------------------------------------------------------------------===//
-duckdb::unique_ptr<duckdb::LocalSinkState> sirius_physical_operator::get_local_sink_state(
-  duckdb::ExecutionContext& context) const
-{
-  return duckdb::make_uniq<duckdb::LocalSinkState>();
-}
-
-duckdb::unique_ptr<duckdb::GlobalSinkState> sirius_physical_operator::get_global_sink_state(
-  duckdb::ClientContext& context) const
-{
-  return duckdb::make_uniq<duckdb::GlobalSinkState>();
-}
-
 std::string sirius_physical_operator::get_name() const
 {
   return SiriusPhysicalOperatorToString(type);
@@ -141,12 +96,9 @@ sirius_physical_operator::get_children() const
 void sirius_physical_operator::build_pipelines(pipeline::sirius_pipeline& current,
                                                pipeline::sirius_meta_pipeline& meta_pipeline)
 {
-  op_state.reset();
-
   auto& state = meta_pipeline.get_state();
   if (is_sink()) {
     // operator is a sink, build a pipeline
-    sink_state.reset();
     D_ASSERT(children.size() == 1);
 
     // single operator: the operator becomes the data source of the current pipeline

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -75,8 +75,6 @@ void sirius_physical_result_collector::build_pipelines(
   pipeline::sirius_pipeline& current, pipeline::sirius_meta_pipeline& meta_pipeline)
 {
   // operator is a sink, build a pipeline
-  sink_state.reset();
-
   D_ASSERT(children.empty());
 
   // single operator: the operator becomes the data source of the current pipeline
@@ -96,11 +94,8 @@ sirius_physical_materialized_collector::sirius_physical_materialized_collector(
 {
 }
 
-duckdb::unique_ptr<duckdb::QueryResult> sirius_physical_materialized_collector::get_result(
-  duckdb::GlobalSinkState& state)
+duckdb::unique_ptr<duckdb::QueryResult> sirius_physical_materialized_collector::get_result()
 {
-  (void)state;  // Silence unused parameter warning
-
   auto props = _client_ctx.GetClientProperties();
 
   std::lock_guard<std::mutex> guard(lock);

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -44,13 +44,13 @@ bool sirius_pipeline::is_order_dependent() const
 {
   if (source) {
     auto source_order = source->source_order();
-    if (source_order == duckdb::OrderPreservationType::FIXED_ORDER) { return true; }
-    if (source_order == duckdb::OrderPreservationType::NO_ORDER) { return false; }
+    if (source_order == sirius::OrderPreservationType::FIXED_ORDER) { return true; }
+    if (source_order == sirius::OrderPreservationType::NO_ORDER) { return false; }
   }
   for (auto& op_ref : operators) {
     auto& op = op_ref.get();
-    if (op.operator_order() == duckdb::OrderPreservationType::NO_ORDER) { return false; }
-    if (op.operator_order() == duckdb::OrderPreservationType::FIXED_ORDER) { return true; }
+    if (op.operator_order() == sirius::OrderPreservationType::NO_ORDER) { return false; }
+    if (op.operator_order() == sirius::OrderPreservationType::FIXED_ORDER) { return true; }
   }
   if (!duckdb::Settings::Get<duckdb::PreserveInsertionOrderSetting>(engine.context)) {
     return false;

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -35,7 +35,7 @@ sirius_physical_plan_generator::sirius_physical_plan_generator(duckdb::ClientCon
 
 sirius_physical_plan_generator::~sirius_physical_plan_generator() {}
 
-duckdb::OrderPreservationType sirius_physical_plan_generator::order_preservation_recursive(
+sirius::OrderPreservationType sirius_physical_plan_generator::order_preservation_recursive(
   sirius::op::sirius_physical_operator& op)
 {
   if (op.is_source()) { return op.source_order(); }
@@ -48,23 +48,23 @@ duckdb::OrderPreservationType sirius_physical_plan_generator::order_preservation
       continue;
     }
     auto child_preservation = order_preservation_recursive(*child);
-    if (child_preservation != duckdb::OrderPreservationType::INSERTION_ORDER) {
+    if (child_preservation != sirius::OrderPreservationType::INSERTION_ORDER) {
       return child_preservation;
     }
     child_idx++;
   }
-  return duckdb::OrderPreservationType::INSERTION_ORDER;
+  return sirius::OrderPreservationType::INSERTION_ORDER;
 }
 
 bool sirius_physical_plan_generator::preserve_insertion_order(
   duckdb::ClientContext& context, sirius::op::sirius_physical_operator& plan)
 {
   auto preservation_type = order_preservation_recursive(plan);
-  if (preservation_type == duckdb::OrderPreservationType::FIXED_ORDER) {
+  if (preservation_type == sirius::OrderPreservationType::FIXED_ORDER) {
     // always need to maintain preservation order
     return true;
   }
-  if (preservation_type == duckdb::OrderPreservationType::NO_ORDER) {
+  if (preservation_type == sirius::OrderPreservationType::NO_ORDER) {
     // never need to preserve order
     return false;
   }

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -177,9 +177,7 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_engine::get_result()
     throw invalid_input_exception("sirius_physical_plan is NULL");
   auto& result_collector =
     sirius_physical_plan.get()->Cast<op::sirius_physical_materialized_collector>();
-  result_collector.sink_state = result_collector.get_global_sink_state(context);
-  duckdb::unique_ptr<duckdb::QueryResult> res =
-    result_collector.get_result(*(result_collector.sink_state));
+  duckdb::unique_ptr<duckdb::QueryResult> res = result_collector.get_result();
   return res;
 }
 

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -248,8 +248,7 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
   collector.sink(pipelineable_operator_data({batch}), cudf::get_default_stream());
-  duckdb::GlobalSinkState sink_state;
-  auto result = collector.get_result(sink_state);
+  auto result = collector.get_result();
   REQUIRE(result != nullptr);
 
   size_t row_base = 0;
@@ -314,8 +313,7 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
 
   collector.sink(pipelineable_operator_data({batch}), stream);
-  duckdb::GlobalSinkState sink_state;
-  auto result = collector.get_result(sink_state);
+  auto result = collector.get_result();
   REQUIRE(result != nullptr);
 
   size_t row_base = 0;
@@ -450,8 +448,7 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
     }
   }
 
-  duckdb::GlobalSinkState sink_state;
-  auto result = collector.get_result(sink_state);
+  auto result = collector.get_result();
   REQUIRE(result != nullptr);
 
   std::vector<row_t> actual_rows;


### PR DESCRIPTION
Closes #553

Part of the broader DuckDB decoupling initiative (#545).

## Summary

- Removed `duckdb/execution/` includes (`execution_context.hpp`, `physical_operator.hpp`,
  `physical_operator_states.hpp`) and `order_preservation_type.hpp` from
  `sirius_physical_operator.hpp` — these headers pulled the entire DuckDB client-context
  chain into every operator
- Dropped `sink_state`/`op_state` member fields and 6 virtual DuckDB state methods from
  the base class; none were overridden in Super Sirius
- Added `sirius::OrderPreservationType` to `helper/types.hpp` to replace
  `duckdb::OrderPreservationType` across the operator hierarchy
- Simplified `get_result()` to take no arguments (the `duckdb::GlobalSinkState&` param
  was always unused)

## Test plan
- [x] Full build passes
- [x] All 833 C++ unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)