### PR TITLE
Added some initial microbenchmarks

### DIFF
--- a/.github/workflows/gpu-microbench.yml
+++ b/.github/workflows/gpu-microbench.yml
@@ -1,6 +1,11 @@
 # NOTICE - Actions permissions policy (see .github/workflows/test.yml header).
 # Pinned third-party actions must use full commit SHAs per org policy.
+# If using org action allowlists, allow: benchmark-action/github-action-benchmark@*
 name: GPU microbench
+
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:
@@ -19,6 +24,11 @@ on:
           - daily
           - weekly
           - full
+      fail_on_regression:
+        description: "Fail the job if a benchmark regresses vs the gh-pages baseline (see alert-threshold)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -115,6 +125,35 @@ jobs:
               if rt is not None:
                   print(f"| `{name}` | {rt:.3f} {unit} | {it} |")
           PY
+
+      - name: Configure benchmark regression gate
+        if: success()
+        id: bench_flags
+        run: |
+          fail_on_alert=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ "${{ github.event.inputs.fail_on_regression }}" = "true" ]; then
+            fail_on_alert=true
+          fi
+          echo "fail_on_alert=$fail_on_alert" >> "$GITHUB_OUTPUT"
+
+      # Charts + history on gh-pages; compares to last run and warns on regression.
+      - name: Store benchmark result (github-action-benchmark)
+        if: success()
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+        with:
+          name: Sirius GPU Microbench (${{ steps.profile.outputs.name }})
+          tool: googlecpp
+          output-file-path: ${{ github.workspace }}/runs/microbench/ci_${{ github.run_id }}_${{ steps.profile.outputs.name }}/benchmark.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/gpu-microbench/${{ steps.profile.outputs.name }}
+          alert-threshold: "125%"
+          comment-on-alert: true
+          summary-always: true
+          max-items-in-chart: 50
+          fail-on-alert: ${{ steps.bench_flags.outputs.fail_on_alert == 'true' }}
 
       - name: Upload results
         if: success()

--- a/.github/workflows/gpu-microbench.yml
+++ b/.github/workflows/gpu-microbench.yml
@@ -61,12 +61,23 @@ jobs:
           CUDAARCHS: "75"
         run: pixi run make
 
+      - name: Prepare Parquet test data (TPC-H SF1)
+        if: steps.profile.outputs.name == 'full'
+        run: |
+          ./setup_test_datasets.sh
+          chmod -R a+r test_datasets/
+          mkdir -p test_datasets/tpch_parquet_sf1
+          ./build/release/duckdb -f scripts/tpch_to_parquet.sql
+
       - name: Run microbench
         id: run
         run: |
           chmod +x tools/microbench/run_microbench_sweep.sh
           OUT_DIR="$GITHUB_WORKSPACE/runs/microbench/ci_${{ github.run_id }}_${{ steps.profile.outputs.name }}"
           mkdir -p "$OUT_DIR"
+          if [ "${{ steps.profile.outputs.name }}" = "full" ]; then
+            export SIRIUS_MICROBENCH_PARQUET_FILE="$GITHUB_WORKSPACE/test_datasets/tpch_parquet_sf1/lineitem.parquet"
+          fi
           SIRIUS_MICROBENCH_RUN_DIR="$OUT_DIR" \
           SIRIUS_MICROBENCH_OUT="$OUT_DIR/benchmark.json" \
             ./tools/microbench/run_microbench_sweep.sh "${{ steps.profile.outputs.name }}"

--- a/.github/workflows/gpu-microbench.yml
+++ b/.github/workflows/gpu-microbench.yml
@@ -1,0 +1,115 @@
+# NOTICE - Actions permissions policy (see .github/workflows/test.yml header).
+# Pinned third-party actions must use full commit SHAs per org policy.
+name: GPU microbench
+
+on:
+  schedule:
+    # Daily Mon–Sat 06:15 UTC (Sundays use weekly only)
+    - cron: "15 6 * * 1-6"
+    # Weekly — Sundays 07:15 UTC (more repetitions in microbench_sweep.json)
+    - cron: "15 7 * * 0"
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "Sweep profile (daily / weekly / full)"
+        required: true
+        default: daily
+        type: choice
+        options:
+          - daily
+          - weekly
+          - full
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  microbench:
+    # Build and run on a GPU host (same pool as extension tests).
+    runs-on: [self-hosted, ubuntu-22.04, cuda-13, gpu-t4]
+    timeout-minutes: 120
+    env:
+      SCCACHE_GHA_ENABLED: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+        with:
+          cache: false
+          pixi-version: v0.65.0
+          activate-environment: true
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Select profile
+        id: profile
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.profile }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "schedule" ] && \
+               [ "${{ github.event.schedule }}" = "15 7 * * 0" ]; then
+            echo "name=weekly" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=daily" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        env:
+          CUDAARCHS: "75"
+        run: pixi run make
+
+      - name: Run microbench
+        id: run
+        run: |
+          chmod +x tools/microbench/run_microbench_sweep.sh
+          OUT_DIR="$GITHUB_WORKSPACE/runs/microbench/ci_${{ github.run_id }}_${{ steps.profile.outputs.name }}"
+          mkdir -p "$OUT_DIR"
+          SIRIUS_MICROBENCH_RUN_DIR="$OUT_DIR" \
+          SIRIUS_MICROBENCH_OUT="$OUT_DIR/benchmark.json" \
+            ./tools/microbench/run_microbench_sweep.sh "${{ steps.profile.outputs.name }}"
+
+      - name: Step summary
+        if: success()
+        env:
+          BENCH_JSON: ${{ github.workspace }}/runs/microbench/ci_${{ github.run_id }}_${{ steps.profile.outputs.name }}/benchmark.json
+          PROFILE: ${{ steps.profile.outputs.name }}
+        run: |
+          python3 << 'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import os
+          path = os.environ.get("BENCH_JSON", "")
+          profile = os.environ.get("PROFILE", "?")
+          if not path or not os.path.isfile(path):
+              print("## GPU microbench")
+              print()
+              print("_No benchmark JSON found at `" + path + "`._")
+              raise SystemExit(0)
+          with open(path) as f:
+              doc = json.load(f)
+          benches = doc.get("benchmarks", [])
+          print(f"## GPU microbench ({profile})")
+          print()
+          print("| Benchmark | real time | iterations |")
+          print("|-----------|-----------|------------|")
+          for b in benches:
+              if not isinstance(b, dict):
+                  continue
+              name = str(b.get("name", "?")).replace("|", "\\|")
+              rt = b.get("real_time")
+              it = b.get("iterations")
+              unit = b.get("time_unit", "")
+              if rt is not None:
+                  print(f"| `{name}` | {rt:.3f} {unit} | {it} |")
+          PY
+
+      - name: Upload results
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gpu-microbench-${{ steps.profile.outputs.name }}-${{ github.run_id }}
+          path: runs/microbench/ci_${{ github.run_id }}_${{ steps.profile.outputs.name }}/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/gpu-microbench.yml
+++ b/.github/workflows/gpu-microbench.yml
@@ -6,8 +6,17 @@ name: GPU microbench
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 on:
+  # Reuse `sirius-build-release` from the Test workflow (same self-hosted CUDA 13 / sm_75 build as gpu-t4).
+  workflow_run:
+    workflows:
+      - Test
+    types:
+      - completed
+    branches:
+      - dev
   schedule:
     # Daily Mon–Sat 06:15 UTC (Sundays use weekly only)
     - cron: "15 6 * * 1-6"
@@ -37,6 +46,7 @@ concurrency:
 jobs:
   microbench:
     # Build and run on a GPU host (same pool as extension tests).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, ubuntu-22.04, cuda-13, gpu-t4]
     timeout-minutes: 120
     env:
@@ -45,6 +55,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
@@ -57,7 +68,9 @@ jobs:
       - name: Select profile
         id: profile
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "name=daily" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "name=${{ inputs.profile }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "schedule" ] && \
                [ "${{ github.event.schedule }}" = "15 7 * * 0" ]; then
@@ -66,7 +79,51 @@ jobs:
             echo "name=daily" >> "$GITHUB_OUTPUT"
           fi
 
+      # Reuse Test workflow artifact when it matches this checkout (same CUDA/sm_75 build as gpu-t4).
+      - name: Resolve Test workflow run for current commit
+        id: test_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="${GITHUB_REF_NAME}"
+          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/test.yml/runs?branch=${BRANCH}&status=success&per_page=50"
+          RUN_ID=$(curl -sS -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$API" | jq -r --arg sha "$GITHUB_SHA" \
+            '.workflow_runs[] | select(.head_sha==$sha) | .id' | head -1)
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "run_id=" >> "$GITHUB_OUTPUT"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No successful Test run with artifact for commit ${GITHUB_SHA} on ${BRANCH}; will compile."
+          else
+            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Using Test workflow run $RUN_ID for commit ${GITHUB_SHA}."
+          fi
+
+      - name: Download sirius-build-release
+        id: dl_test_build
+        if: steps.test_run.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sirius-build-release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.test_run.outputs.run_id }}
+
+      - name: Extract Test build
+        if: steps.test_run.outputs.found == 'true' && steps.dl_test_build.outcome == 'success'
+        run: tar -xf build.tar
+
       - name: Build
+        if: steps.test_run.outputs.found != 'true' || steps.dl_test_build.outcome != 'success'
         env:
           CUDAARCHS: "75"
         run: pixi run make

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ cufile.log
 envs/
 compile_commands.json
 .cache
+# Local GPU microbench sweep outputs
+runs/microbench/
 
 # Zed editor settings
 .zed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ endif()
 option(ENABLE_STREAM_CHECK
        "Enable stream check library for debugging default stream usage" OFF)
 
+option(
+  SIRIUS_BUILD_GPU_MICROBENCH
+  "Build sirius_gpu_microbench (Google Benchmark libcudf operator microbench suite)"
+  OFF)
+
 # In the vcpkg build, vcpkg headers must take priority over: 1) conda's CCCL
 # 3.1.4 (injected via CXXFLAGS as -I.../include/cccl) 2) DuckDB's bundled fmt
 # 6.1.2 (uses duckdb_fmt namespace, incompatible with spdlog) Fix: strip conda
@@ -431,3 +436,7 @@ target_compile_definitions(
     $<BUILD_INTERFACE:SIRIUS_DEFAULT_LOG_DIR="${CMAKE_BINARY_DIR}/log">
     $<BUILD_INTERFACE:SIRIUS_UNITTEST_LOG_DIR="${CMAKE_CURRENT_BINARY_DIR}/test/cpp/log">
     $<BUILD_INTERFACE:SIRIUS_PROJECT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}">)
+
+if(SIRIUS_BUILD_GPU_MICROBENCH)
+  add_subdirectory(test/cpp/microbench)
+endif()

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -86,7 +86,8 @@
     {
       "binaryDir": "${sourceDir}/../build/release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "SIRIUS_BUILD_GPU_MICROBENCH": "ON"
       },
       "displayName": "GCC Release",
       "inherits": "base",

--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -29,6 +29,7 @@ Super Sirius is the new task-based GPU execution engine in Sirius, invoked via `
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
+| [GPU microbench](gpu-microbench.md) | `sirius_gpu_microbench`: libcudf benches, sweep scripts, CI artifacts |
 
 ## Suggested Reading Order
 

--- a/docs/super-sirius/gpu-microbench.md
+++ b/docs/super-sirius/gpu-microbench.md
@@ -1,6 +1,8 @@
 # GPU microbench (`sirius_gpu_microbench`)
 
-libcudf-focused Google Benchmark binaries live next to the extension tests. They time hash join, group-by sum, sort keys, boolean filter, and an optional Parquet column read.
+libcudf-focused Google Benchmark binaries live next to the extension tests. They time hash join, group-by sum, sort keys, boolean filter, and an optional **full-table** Parquet read with **cold** vs **warm** OS page cache.
+
+**Timing:** all benchmarks use **wall-clock (real) time** in **milliseconds** (`UseRealTime`, `Unit(kMillisecond)`), not CPU time.
 
 ## Build
 
@@ -59,32 +61,42 @@ YAML is not parsed by the scripts; if you prefer YAML for hand-editing, mirror t
 
 ### Benchmark parameters (P0)
 
-| Benchmark            | Args / meaning |
-|----------------------|----------------|
-| `BM_HashJoin`        | `build_rows`, `probe_rows` |
-| `BM_GroupBySum`      | `rows`, `num_groups` (NDV) |
-| `BM_SortKeys`        | `rows` |
-| `BM_FilterMask`      | `rows`, `permille_true` (approximate selectivity ×1000) |
-| `BM_ParquetReadColumn` | `max_rows` |
+| Benchmark | Args / meaning |
+|-----------|----------------|
+| `BM_HashJoin` | `build_rows`, `probe_rows` |
+| `BM_GroupBySum` | `rows`, `num_groups` (NDV) |
+| `BM_SortKeys` | `rows` |
+| `BM_FilterMask` | `rows`, `permille_true` (approximate selectivity ×1000) |
+| `BM_ParquetReadTable_Cold` | none — full file, all columns; **fadvise** excluded from timed section |
+| `BM_ParquetReadTable_Warm` | none — full file, all columns; no cache drop |
 
-### Optional Parquet read
+### Optional Parquet table read
+
+Prepare TPC-H SF1 Parquet (same as CI / `test.yml`):
 
 ```bash
-export SIRIUS_MICROBENCH_PARQUET_FILE=/path/to/file.parquet
-export SIRIUS_MICROBENCH_PARQUET_COLUMN=column_name
+./setup_test_datasets.sh
+mkdir -p test_datasets/tpch_parquet_sf1
+./build/release/duckdb -f scripts/tpch_to_parquet.sql
+export SIRIUS_MICROBENCH_PARQUET_FILE=$PWD/test_datasets/tpch_parquet_sf1/lineitem.parquet
 ```
 
-The `full` profile runs all benchmarks (`--benchmark_filter=.*`), including `BM_ParquetReadColumn`; without the env vars that case may skip or error in the report.
+- **Cold:** before each timed read, the benchmark calls `posix_fadvise(..., POSIX_FADV_DONTNEED)` on the file **outside** the timed section (`PauseTiming` / `ResumeTiming`) to encourage dropping clean page-cache pages (Linux only; best-effort).
+- **Warm:** no fadvise; measures reads with whatever pages the kernel keeps cached.
+
+The `full` sweep profile runs all benchmarks, including the Parquet pair, when `SIRIUS_MICROBENCH_PARQUET_FILE` is set (CI sets it to `lineitem.parquet`).
 
 ## CI
 
 Workflow: `.github/workflows/gpu-microbench.yml`
 
+- **Data (full profile only):** `setup_test_datasets.sh` + `scripts/tpch_to_parquet.sql` → `test_datasets/tpch_parquet_sf1/lineitem.parquet`.
+- **Env:** for `full`, `SIRIUS_MICROBENCH_PARQUET_FILE` is set to that `lineitem.parquet` path before the sweep script runs (`daily` / `weekly` skip dataset prep and omit the env var).
 - **Schedule:** Mon–Sat `daily` profile; Sunday `weekly` profile (UTC).
 - **Manual:** `workflow_dispatch` with profile choice.
 - **Artifacts:** JSON under `runs/microbench/ci_<run_id>_<profile>/` (30-day retention).
-- **Summary:** Markdown table of benchmark real time written to the job summary.
+- **Summary:** Markdown table of benchmark **real** time written to the job summary.
 
 ## Interpreting artifacts
 
-Download the artifact zip and open `benchmark.json`. Google Benchmark's schema lists one object per row in `benchmarks` with `name`, `real_time`, `cpu_time`, `iterations`, and `time_unit`. Compare runs by matching `name` strings (they include argument packs).
+Download the artifact zip and open `benchmark.json`. With `UseRealTime` and millisecond units, `real_time` and `time_unit` are the primary wall-clock metrics. `cpu_time` may still appear in the schema; prefer **`real_time`** for these benchmarks.

--- a/docs/super-sirius/gpu-microbench.md
+++ b/docs/super-sirius/gpu-microbench.md
@@ -1,0 +1,90 @@
+# GPU microbench (`sirius_gpu_microbench`)
+
+libcudf-focused Google Benchmark binaries live next to the extension tests. They time hash join, group-by sum, sort keys, boolean filter, and an optional Parquet column read.
+
+## Build
+
+From the repo root (Pixi environment):
+
+```bash
+pixi run build
+# or: pixi run make
+```
+
+Incremental rebuild of only the microbench target:
+
+```bash
+pixi run build-microbench
+```
+
+The binary is written to:
+
+`build/release/extension/sirius/test/cpp/sirius_gpu_microbench`
+
+Enable/disable is controlled by CMake (`SIRIUS_BUILD_GPU_MICROBENCH`); the release preset turns it on.
+
+## Run locally
+
+```bash
+pixi run microbench -- --benchmark_format=json
+pixi run microbench -- --benchmark_filter='BM_HashJoin|BM_GroupBySum'
+```
+
+Or invoke the binary directly:
+
+```bash
+./build/release/extension/sirius/test/cpp/sirius_gpu_microbench --benchmark_format=json
+```
+
+### Sweep profiles (JSON)
+
+`tools/microbench/microbench_sweep.json` defines `daily`, `weekly`, and `full` profiles (filter regex + extra Google Benchmark flags). Run (Pixi):
+
+```bash
+pixi run microbench-daily
+pixi run microbench-sweep weekly
+pixi run microbench-sweep full
+```
+
+Or run the scripts directly (ensure they are executable):
+
+```bash
+./tools/microbench/run_microbench_daily.sh
+./tools/microbench/run_microbench_sweep.sh weekly
+```
+
+Outputs default to `runs/microbench/<UTC-timestamp>_<profile>/benchmark.json`. Override with `SIRIUS_MICROBENCH_OUT`, `SIRIUS_MICROBENCH_RUN_DIR`, or `SIRIUS_GPU_MICROBENCH_BIN`.
+
+YAML is not parsed by the scripts; if you prefer YAML for hand-editing, mirror the same structure as the JSON `profiles` map.
+
+### Benchmark parameters (P0)
+
+| Benchmark            | Args / meaning |
+|----------------------|----------------|
+| `BM_HashJoin`        | `build_rows`, `probe_rows` |
+| `BM_GroupBySum`      | `rows`, `num_groups` (NDV) |
+| `BM_SortKeys`        | `rows` |
+| `BM_FilterMask`      | `rows`, `permille_true` (approximate selectivity ×1000) |
+| `BM_ParquetReadColumn` | `max_rows` |
+
+### Optional Parquet read
+
+```bash
+export SIRIUS_MICROBENCH_PARQUET_FILE=/path/to/file.parquet
+export SIRIUS_MICROBENCH_PARQUET_COLUMN=column_name
+```
+
+The `full` profile runs all benchmarks (`--benchmark_filter=.*`), including `BM_ParquetReadColumn`; without the env vars that case may skip or error in the report.
+
+## CI
+
+Workflow: `.github/workflows/gpu-microbench.yml`
+
+- **Schedule:** Mon–Sat `daily` profile; Sunday `weekly` profile (UTC).
+- **Manual:** `workflow_dispatch` with profile choice.
+- **Artifacts:** JSON under `runs/microbench/ci_<run_id>_<profile>/` (30-day retention).
+- **Summary:** Markdown table of benchmark real time written to the job summary.
+
+## Interpreting artifacts
+
+Download the artifact zip and open `benchmark.json`. Google Benchmark's schema lists one object per row in `benchmarks` with `name`, `real_time`, `cpu_time`, `iterations`, and `time_unit`. Compare runs by matching `name` strings (they include argument packs).

--- a/docs/super-sirius/gpu-microbench.md
+++ b/docs/super-sirius/gpu-microbench.md
@@ -97,6 +97,31 @@ Workflow: `.github/workflows/gpu-microbench.yml`
 - **Artifacts:** JSON under `runs/microbench/ci_<run_id>_<profile>/` (30-day retention).
 - **Summary:** Markdown table of benchmark **real** time written to the job summary.
 
+### Continuous benchmark (charts + regression warnings)
+
+The workflow runs **[github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark)** (`tool: googlecpp`) after each successful sweep. It:
+
+- **Stores** history and **pushes** JSON + generated pages to the **`gh-pages`** branch under
+  `dev/bench/gpu-microbench/<profile>/` (separate paths for `daily`, `weekly`, and `full`).
+- **Visualizes** trends (interactive charts on GitHub Pages once enabled).
+- **Warns** on regressions: default **`alert-threshold: 125%`** (alert if a case is **>1.25× slower** than the baseline stored on `gh-pages`).
+  - **`summary-always: true`** adds a comparison to the **Actions job summary** (works for scheduled runs).
+  - **`comment-on-alert: true`** can comment on PRs when that workflow is triggered from a PR with the same action (optional future hook-up).
+
+**One-time repo setup**
+
+1. **Allow the action** (if the org uses an action allowlist): add `benchmark-action/github-action-benchmark@*` (see `.github/workflows/test.yml` NOTICE).
+2. **GitHub Pages:** Settings → Pages → Build and deployment → deploy from branch **`gh-pages`**, folder **`/ (root)`** (or follow your org standard). After the first successful run, open:
+
+   `https://<owner>.github.io/<repo>/dev/bench/gpu-microbench/daily/`
+   (replace `daily` with `weekly` or `full` as needed.)
+
+**Optional: fail the job on regression**
+
+Manual runs only: set workflow input **`fail_on_regression`** to **true**. That sets **`fail-on-alert: true`** so the job fails if any benchmark exceeds **`alert-threshold`** vs the last stored baseline. Scheduled runs do **not** fail by default (noise + runner variance).
+
+Tune **`alert-threshold`** in `.github/workflows/gpu-microbench.yml` if 125% is too tight for GPU variance on self-hosted hardware.
+
 ## Interpreting artifacts
 
 Download the artifact zip and open `benchmark.json`. With `UseRealTime` and millisecond units, `real_time` and `time_unit` are the primary wall-clock metrics. `cpu_time` may still appear in the schema; prefer **`real_time`** for these benchmarks.

--- a/docs/super-sirius/gpu-microbench.md
+++ b/docs/super-sirius/gpu-microbench.md
@@ -90,6 +90,17 @@ The `full` sweep profile runs all benchmarks, including the Parquet pair, when `
 
 Workflow: `.github/workflows/gpu-microbench.yml`
 
+### Reusing the Test workflow build
+
+- **`Test`** uploads **`sirius-build-release`** (`build.tar` of `build/release/`) from **self-hosted** `ubuntu-22.04` / **CUDA 13** with **`CUDAARCHS=75`** — aligned with the **gpu-t4** microbench runner. The artifact is kept **7 days** so **weekly** cron can still download it if `dev` was quiet for a few days.
+- **All** microbench triggers try reuse first:
+  - **`workflow_run`** (after **Test** on **`dev`**): uses that run's id directly; profile forced to **daily**.
+  - **Schedule** and **`workflow_dispatch`**: queries the GitHub API for a **successful** **Test** run on the **current branch** whose **`head_sha`** equals **`GITHUB_SHA`**, then downloads **`sirius-build-release`** from that run.
+- If **no** matching Test run exists, the **artifact expired**, or **download** fails → **`pixi run make`** on the GPU runner (fallback).
+- **`Check`** does not publish a GPU-aligned build; it is not used here.
+
+### Other CI notes
+
 - **Data (full profile only):** `setup_test_datasets.sh` + `scripts/tpch_to_parquet.sql` → `test_datasets/tpch_parquet_sf1/lineitem.parquet`.
 - **Env:** for `full`, `SIRIUS_MICROBENCH_PARQUET_FILE` is set to that `lineitem.parquet` path before the sweep script runs (`daily` / `weekly` skip dataset prep and omit the env var).
 - **Schedule:** Mon–Sat `daily` profile; Sunday `weekly` profile (UTC).

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,6 +34,18 @@ spdlog = "1.8.*"
 sqlite = ">=3.52.0,<4"
 
 [tasks]
+# Full Sirius + DuckDB build (same as running `make` from this env).
+build = "make"
+
+# Build only the libcudf GPU microbench binary (after initial `pixi run build` configure).
+build-microbench = "bash -c 'cd \"$PIXI_PROJECT_ROOT/duckdb\" && cmake --build --preset release --target sirius_gpu_microbench'"
+
+# Run Google Benchmark binary; append args after `--`, e.g. `pixi run microbench -- --benchmark_filter=BM_HashJoin`.
+microbench = "./build/release/extension/sirius/test/cpp/sirius_gpu_microbench"
+
+# JSON sweep profiles from tools/microbench/microbench_sweep.json
+microbench-daily = "bash \"$PIXI_PROJECT_ROOT/tools/microbench/run_microbench_daily.sh\""
+microbench-sweep = "bash \"$PIXI_PROJECT_ROOT/tools/microbench/run_microbench_sweep.sh\""
 
 # CUDA version features: use `pixi run -e cuda12` for CUDA 12.x systems
 [feature.cuda13.system-requirements]

--- a/test/cpp/microbench/CMakeLists.txt
+++ b/test/cpp/microbench/CMakeLists.txt
@@ -1,0 +1,36 @@
+# =============================================================================
+# sirius_gpu_microbench — libcudf GPU microbenchmarks (Google Benchmark). Enable
+# with -DSIRIUS_BUILD_GPU_MICROBENCH=ON (release preset sets this ON).
+#
+# Reuses Google Benchmark from cuCascade (FetchContent in cucascade/benchmark);
+# do not FetchContent benchmark again here — target names would collide.
+# =============================================================================
+
+if(NOT TARGET benchmark::benchmark_main)
+  message(FATAL_ERROR "sirius_gpu_microbench needs Google Benchmark targets. "
+                      "Ensure CUCASCADE_BUILD_BENCHMARKS is ON (default).")
+endif()
+
+add_executable(sirius_gpu_microbench sirius_gpu_microbench.cpp
+                                     microbench_data.cpp)
+
+target_include_directories(
+  sirius_gpu_microbench PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+target_link_libraries(
+  sirius_gpu_microbench PRIVATE cudf::cudf rmm::rmm benchmark::benchmark_main
+                                CUDA::cudart)
+
+get_filename_component(_SIRIUS_MICROBENCH_BIN_DIR
+                       "${CMAKE_CURRENT_BINARY_DIR}/.." ABSOLUTE)
+set_target_properties(
+  sirius_gpu_microbench
+  PROPERTIES CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             RUNTIME_OUTPUT_DIRECTORY "${_SIRIUS_MICROBENCH_BIN_DIR}")
+
+if(VCPKG_BUILD)
+  set_target_properties(sirius_gpu_microbench PROPERTIES NO_SYSTEM_FROM_IMPORTED
+                                                         ON)
+  target_include_directories(sirius_gpu_microbench BEFORE PRIVATE ${_VCPKG_INC})
+endif()

--- a/test/cpp/microbench/microbench_data.cpp
+++ b/test/cpp/microbench/microbench_data.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ */
+
+#include "microbench_data.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+namespace sirius::microbench {
+
+namespace {
+
+void throw_if_cuda_error(char const* ctx)
+{
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(ctx) + ": " + cudaGetErrorString(err));
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<cudf::column> make_modulo_int32_keys(cudf::size_type num_rows,
+                                                     std::int32_t num_groups,
+                                                     rmm::cuda_stream_view stream)
+{
+  if (num_rows <= 0 || num_groups <= 0) {
+    throw std::invalid_argument("make_modulo_int32_keys: num_rows and num_groups must be positive");
+  }
+  std::vector<std::int32_t> host(static_cast<std::size_t>(num_rows));
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    host[static_cast<std::size_t>(i)] =
+      static_cast<std::int32_t>(static_cast<std::int64_t>(i) % num_groups);
+  }
+  auto col          = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       num_rows,
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       rmm::mr::get_current_device_resource());
+  auto mutable_view = col->mutable_view();
+  cudaMemcpyAsync(mutable_view.data<std::int32_t>(),
+                  host.data(),
+                  host.size() * sizeof(std::int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+  throw_if_cuda_error("make_modulo_int32_keys HtoD");
+  return col;
+}
+
+std::unique_ptr<cudf::column> make_int64_ones(cudf::size_type num_rows,
+                                              rmm::cuda_stream_view stream)
+{
+  if (num_rows <= 0) { throw std::invalid_argument("make_int64_ones: num_rows must be positive"); }
+  std::vector<std::int64_t> host(static_cast<std::size_t>(num_rows), 1);
+  auto col          = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT64},
+                                       num_rows,
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       rmm::mr::get_current_device_resource());
+  auto mutable_view = col->mutable_view();
+  cudaMemcpyAsync(mutable_view.data<std::int64_t>(),
+                  host.data(),
+                  host.size() * sizeof(std::int64_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+  throw_if_cuda_error("make_int64_ones HtoD");
+  return col;
+}
+
+std::unique_ptr<cudf::column> make_sparse_bool_mask(cudf::size_type num_rows,
+                                                    int permille_true,
+                                                    rmm::cuda_stream_view stream)
+{
+  if (num_rows <= 0 || permille_true < 0 || permille_true > 1000) {
+    throw std::invalid_argument("make_sparse_bool_mask: invalid args");
+  }
+  // BOOL8 columns use one byte per element (0/1), same as elsewhere in Sirius.
+  std::vector<std::uint8_t> host(static_cast<std::size_t>(num_rows));
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    std::uint64_t const h             = static_cast<std::uint64_t>(i) * 7919ULL;
+    bool const keep                   = static_cast<int>(h % 1000) < permille_true;
+    host[static_cast<std::size_t>(i)] = keep ? std::uint8_t{1} : std::uint8_t{0};
+  }
+  auto col          = cudf::make_numeric_column(cudf::data_type{cudf::type_id::BOOL8},
+                                       num_rows,
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream,
+                                       rmm::mr::get_current_device_resource());
+  auto mutable_view = col->mutable_view();
+  cudaMemcpyAsync(mutable_view.data<std::uint8_t>(),
+                  host.data(),
+                  host.size() * sizeof(std::uint8_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+  throw_if_cuda_error("make_sparse_bool_mask HtoD");
+  return col;
+}
+
+std::optional<std::unique_ptr<cudf::column>> try_read_parquet_column(
+  std::string const& parquet_file,
+  std::string const& column_name,
+  cudf::size_type max_rows,
+  rmm::cuda_stream_view stream)
+{
+  if (max_rows <= 0) { return std::nullopt; }
+  {
+    std::ifstream f(parquet_file.c_str(), std::ios::binary);
+    if (!f) { return std::nullopt; }
+  }
+  try {
+    cudf::io::parquet_reader_options opts =
+      cudf::io::parquet_reader_options::builder(cudf::io::source_info{parquet_file})
+        .column_names({column_name})
+        .build();
+    cudf::io::table_with_metadata tw = cudf::io::read_parquet(opts, stream);
+    stream.synchronize();
+    if (!tw.tbl || tw.tbl->num_columns() < 1 || tw.tbl->num_rows() == 0) { return std::nullopt; }
+    cudf::size_type const n = std::min(max_rows, tw.tbl->num_rows());
+    if (n <= 0) { return std::nullopt; }
+    if (tw.tbl->num_rows() == n) {
+      return std::make_unique<cudf::column>(tw.tbl->view().column(0), stream);
+    }
+    auto sliced = cudf::slice(tw.tbl->view(), {0, n}, stream);
+    if (sliced.empty()) { return std::nullopt; }
+    return std::make_unique<cudf::column>(sliced.front().column(0), stream);
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+}  // namespace sirius::microbench

--- a/test/cpp/microbench/microbench_data.cpp
+++ b/test/cpp/microbench/microbench_data.cpp
@@ -8,19 +8,23 @@
 #include "microbench_data.hpp"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/copying.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/mr/per_device_resource.hpp>
 
 #include <cuda_runtime.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <stdexcept>
 #include <vector>
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace sirius::microbench {
 
@@ -35,6 +39,19 @@ void throw_if_cuda_error(char const* ctx)
 }
 
 }  // namespace
+
+void discard_os_page_cache_for_file(std::string const& parquet_path)
+{
+#if defined(__linux__)
+  int const fd = ::open(parquet_path.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0) { return; }
+  // len == 0 => from offset to EOF (Linux).
+  (void)::posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+  ::close(fd);
+#else
+  (void)parquet_path;
+#endif
+}
 
 std::unique_ptr<cudf::column> make_modulo_int32_keys(cudf::size_type num_rows,
                                                      std::int32_t num_groups,
@@ -115,33 +132,20 @@ std::unique_ptr<cudf::column> make_sparse_bool_mask(cudf::size_type num_rows,
   return col;
 }
 
-std::optional<std::unique_ptr<cudf::column>> try_read_parquet_column(
-  std::string const& parquet_file,
-  std::string const& column_name,
-  cudf::size_type max_rows,
-  rmm::cuda_stream_view stream)
+std::optional<std::unique_ptr<cudf::table>> try_read_parquet_table(std::string const& parquet_file,
+                                                                   rmm::cuda_stream_view stream)
 {
-  if (max_rows <= 0) { return std::nullopt; }
   {
     std::ifstream f(parquet_file.c_str(), std::ios::binary);
     if (!f) { return std::nullopt; }
   }
   try {
-    cudf::io::parquet_reader_options opts =
-      cudf::io::parquet_reader_options::builder(cudf::io::source_info{parquet_file})
-        .column_names({column_name})
-        .build();
+    cudf::io::parquet_reader_options const opts =
+      cudf::io::parquet_reader_options::builder(cudf::io::source_info{parquet_file}).build();
     cudf::io::table_with_metadata tw = cudf::io::read_parquet(opts, stream);
     stream.synchronize();
     if (!tw.tbl || tw.tbl->num_columns() < 1 || tw.tbl->num_rows() == 0) { return std::nullopt; }
-    cudf::size_type const n = std::min(max_rows, tw.tbl->num_rows());
-    if (n <= 0) { return std::nullopt; }
-    if (tw.tbl->num_rows() == n) {
-      return std::make_unique<cudf::column>(tw.tbl->view().column(0), stream);
-    }
-    auto sliced = cudf::slice(tw.tbl->view(), {0, n}, stream);
-    if (sliced.empty()) { return std::nullopt; }
-    return std::make_unique<cudf::column>(sliced.front().column(0), stream);
+    return std::move(tw.tbl);
   } catch (...) {
     return std::nullopt;
   }

--- a/test/cpp/microbench/microbench_data.hpp
+++ b/test/cpp/microbench/microbench_data.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace sirius::microbench {
+
+/// Keys `int32(i % num_groups)` — TPC-H–like bounded key cardinality (e.g. NDV).
+[[nodiscard]] std::unique_ptr<cudf::column> make_modulo_int32_keys(cudf::size_type num_rows,
+                                                                   std::int32_t num_groups,
+                                                                   rmm::cuda_stream_view stream);
+
+/// Payload column of INT64 ones (for sum aggregate microbench).
+[[nodiscard]] std::unique_ptr<cudf::column> make_int64_ones(cudf::size_type num_rows,
+                                                            rmm::cuda_stream_view stream);
+
+/// Pseudorandom sparse BOOL8 mask; approximately `permille_true / 1000` fraction true.
+[[nodiscard]] std::unique_ptr<cudf::column> make_sparse_bool_mask(cudf::size_type num_rows,
+                                                                  int permille_true,
+                                                                  rmm::cuda_stream_view stream);
+
+/// Read up to `max_rows` from a single Parquet file column (first row group only if small).
+/// Returns nullopt if the file cannot be read or the column is missing.
+[[nodiscard]] std::optional<std::unique_ptr<cudf::column>> try_read_parquet_column(
+  std::string const& parquet_file,
+  std::string const& column_name,
+  cudf::size_type max_rows,
+  rmm::cuda_stream_view stream);
+
+}  // namespace sirius::microbench

--- a/test/cpp/microbench/microbench_data.hpp
+++ b/test/cpp/microbench/microbench_data.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cudf/column/column.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -32,12 +33,13 @@ namespace sirius::microbench {
                                                                   int permille_true,
                                                                   rmm::cuda_stream_view stream);
 
-/// Read up to `max_rows` from a single Parquet file column (first row group only if small).
-/// Returns nullopt if the file cannot be read or the column is missing.
-[[nodiscard]] std::optional<std::unique_ptr<cudf::column>> try_read_parquet_column(
-  std::string const& parquet_file,
-  std::string const& column_name,
-  cudf::size_type max_rows,
-  rmm::cuda_stream_view stream);
+/// Best-effort drop of clean page-cache pages for a file (Linux: `POSIX_FADV_DONTNEED`).
+/// No-op on non-Linux. Open/read handles held elsewhere may keep cache warm.
+void discard_os_page_cache_for_file(std::string const& parquet_path);
+
+/// Read the full Parquet file (all columns, all row groups) into a `cudf::table`.
+/// Returns nullopt if the file cannot be read.
+[[nodiscard]] std::optional<std::unique_ptr<cudf::table>> try_read_parquet_table(
+  std::string const& parquet_file, rmm::cuda_stream_view stream);
 
 }  // namespace sirius::microbench

--- a/test/cpp/microbench/sirius_gpu_microbench.cpp
+++ b/test/cpp/microbench/sirius_gpu_microbench.cpp
@@ -5,15 +5,18 @@
  * use this file except in compliance with the License.
  *
  * libcudf GPU microbenchmarks (Google Benchmark). Timed regions mirror hot
- * operator paths: hash join, groupby sum, sort keys, boolean filter, optional Parquet read.
+ * operator paths: hash join, groupby sum, sort keys, boolean filter, optional
+ * full-table Parquet read (cold vs warm page cache).
+ *
+ * All benchmarks use wall-clock time (`UseRealTime`) in milliseconds.
  *
  * Run:
  *   sirius_gpu_microbench --benchmark_format=json
  *   sirius_gpu_microbench --benchmark_filter='BM_HashJoin|BM_GroupBySum'
  *
- * TPC-H–style Parquet column read (optional):
+ * Optional full Parquet table read (Linux cold mode uses POSIX_FADV_DONTNEED
+ * outside the timed section):
  *   export SIRIUS_MICROBENCH_PARQUET_FILE=$PWD/test_datasets/tpch_parquet_sf1/lineitem.parquet
- *   export SIRIUS_MICROBENCH_PARQUET_COLUMN=l_orderkey
  */
 
 #include "microbench_data.hpp"
@@ -121,20 +124,37 @@ void BM_FilterMask(benchmark::State& state)
   state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
-void BM_ParquetReadColumn(benchmark::State& state)
+void BM_ParquetReadTable_Cold(benchmark::State& state)
 {
   char const* path = std::getenv("SIRIUS_MICROBENCH_PARQUET_FILE");
-  char const* col  = std::getenv("SIRIUS_MICROBENCH_PARQUET_COLUMN");
-  if (path == nullptr || col == nullptr) {
-    state.SkipWithError("Set SIRIUS_MICROBENCH_PARQUET_FILE and SIRIUS_MICROBENCH_PARQUET_COLUMN");
+  if (path == nullptr || path[0] == '\0') {
+    state.SkipWithError("Set SIRIUS_MICROBENCH_PARQUET_FILE to a Parquet file path");
     return;
   }
 
   rmm::cuda_stream stream;
-  auto const max_rows = static_cast<cudf::size_type>(state.range(0));
-
   for (auto _ : state) {
-    auto opt = sirius::microbench::try_read_parquet_column(path, col, max_rows, stream);
+    state.PauseTiming();
+    sirius::microbench::discard_os_page_cache_for_file(path);
+    state.ResumeTiming();
+
+    auto opt = sirius::microbench::try_read_parquet_table(path, stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(opt);
+  }
+}
+
+void BM_ParquetReadTable_Warm(benchmark::State& state)
+{
+  char const* path = std::getenv("SIRIUS_MICROBENCH_PARQUET_FILE");
+  if (path == nullptr || path[0] == '\0') {
+    state.SkipWithError("Set SIRIUS_MICROBENCH_PARQUET_FILE to a Parquet file path");
+    return;
+  }
+
+  rmm::cuda_stream stream;
+  for (auto _ : state) {
+    auto opt = sirius::microbench::try_read_parquet_table(path, stream);
     stream.synchronize();
     benchmark::DoNotOptimize(opt);
   }
@@ -142,14 +162,14 @@ void BM_ParquetReadColumn(benchmark::State& state)
 
 }  // namespace
 
-// All parameter packs registered here; daily CI uses --benchmark_filter to run a subset.
 BENCHMARK(BM_HashJoin)
   ->Args({1 << 16, 1 << 20})
   ->Args({1 << 17, 1 << 21})
   ->Args({1 << 18, 1 << 22})
   ->Args({1 << 19, 1 << 23})
   ->ArgNames({"build_rows", "probe_rows"})
-  ->Unit(benchmark::kMillisecond);
+  ->Unit(benchmark::kMillisecond)
+  ->UseRealTime();
 
 BENCHMARK(BM_GroupBySum)
   ->Args({1 << 20, 100000})
@@ -157,14 +177,16 @@ BENCHMARK(BM_GroupBySum)
   ->Args({1 << 21, 500000})
   ->Args({1 << 23, 800000})
   ->ArgNames({"rows", "num_groups"})
-  ->Unit(benchmark::kMillisecond);
+  ->Unit(benchmark::kMillisecond)
+  ->UseRealTime();
 
 BENCHMARK(BM_SortKeys)
   ->Arg(1 << 20)
   ->Arg(1 << 22)
   ->Arg(1 << 23)
   ->ArgName("rows")
-  ->Unit(benchmark::kMillisecond);
+  ->Unit(benchmark::kMillisecond)
+  ->UseRealTime();
 
 BENCHMARK(BM_FilterMask)
   ->Args({1 << 20, 50})
@@ -172,10 +194,10 @@ BENCHMARK(BM_FilterMask)
   ->Args({1 << 23, 100})
   ->Args({1 << 22, 200})
   ->ArgNames({"rows", "permille_true"})
-  ->Unit(benchmark::kMillisecond);
+  ->Unit(benchmark::kMillisecond)
+  ->UseRealTime();
 
-BENCHMARK(BM_ParquetReadColumn)
-  ->Arg(1 << 20)
-  ->Arg(1 << 22)
-  ->ArgName("max_rows")
-  ->Unit(benchmark::kMillisecond);
+// Full-file read; cold uses fadvise outside timed section. Few iterations — large I/O.
+BENCHMARK(BM_ParquetReadTable_Cold)->Unit(benchmark::kMillisecond)->UseRealTime()->Iterations(1);
+
+BENCHMARK(BM_ParquetReadTable_Warm)->Unit(benchmark::kMillisecond)->UseRealTime();

--- a/test/cpp/microbench/sirius_gpu_microbench.cpp
+++ b/test/cpp/microbench/sirius_gpu_microbench.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * libcudf GPU microbenchmarks (Google Benchmark). Timed regions mirror hot
+ * operator paths: hash join, groupby sum, sort keys, boolean filter, optional Parquet read.
+ *
+ * Run:
+ *   sirius_gpu_microbench --benchmark_format=json
+ *   sirius_gpu_microbench --benchmark_filter='BM_HashJoin|BM_GroupBySum'
+ *
+ * TPC-H–style Parquet column read (optional):
+ *   export SIRIUS_MICROBENCH_PARQUET_FILE=$PWD/test_datasets/tpch_parquet_sf1/lineitem.parquet
+ *   export SIRIUS_MICROBENCH_PARQUET_COLUMN=l_orderkey
+ */
+
+#include "microbench_data.hpp"
+
+#include <cudf/aggregation.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/join/hash_join.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/stream_compaction.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream.hpp>
+
+#include <benchmark/benchmark.h>
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+namespace {
+
+void BM_HashJoin(benchmark::State& state)
+{
+  rmm::cuda_stream stream;
+  auto const build_n     = static_cast<cudf::size_type>(state.range(0));
+  auto const probe_n     = static_cast<cudf::size_type>(state.range(1));
+  std::int32_t const ndv = std::max(
+    std::int32_t{1}, std::min(static_cast<std::int32_t>(std::min(build_n, probe_n)), 1 << 20));
+
+  auto build_key = sirius::microbench::make_modulo_int32_keys(build_n, ndv, stream);
+  auto probe_key = sirius::microbench::make_modulo_int32_keys(probe_n, ndv, stream);
+  cudf::table_view const build_tv{{build_key->view()}};
+  cudf::table_view const probe_tv{{probe_key->view()}};
+
+  for (auto _ : state) {
+    cudf::hash_join hj(build_tv, cudf::null_equality::UNEQUAL, stream);
+    stream.synchronize();
+    auto joined = hj.inner_join(probe_tv, std::nullopt, stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(joined.first);
+    benchmark::DoNotOptimize(joined.second);
+  }
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(probe_n));
+}
+
+void BM_GroupBySum(benchmark::State& state)
+{
+  rmm::cuda_stream stream;
+  auto const n   = static_cast<cudf::size_type>(state.range(0));
+  auto const ndv = std::max(std::int32_t{1}, static_cast<std::int32_t>(state.range(1)));
+  auto keys      = sirius::microbench::make_modulo_int32_keys(n, ndv, stream);
+  auto vals      = sirius::microbench::make_int64_ones(n, stream);
+
+  cudf::groupby::aggregation_request req;
+  req.values = vals->view();
+  req.aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+  std::vector<cudf::groupby::aggregation_request> reqs;
+  reqs.push_back(std::move(req));
+
+  for (auto _ : state) {
+    cudf::groupby::groupby gb(cudf::table_view{{keys->view()}}, cudf::null_policy::INCLUDE);
+    auto out = gb.aggregate(cudf::host_span<cudf::groupby::aggregation_request const>(
+                              reqs.data(), static_cast<std::size_t>(reqs.size())),
+                            stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(out.first);
+    benchmark::DoNotOptimize(out.second);
+  }
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
+}
+
+void BM_SortKeys(benchmark::State& state)
+{
+  rmm::cuda_stream stream;
+  auto const n = static_cast<cudf::size_type>(state.range(0));
+  std::int32_t const ndv =
+    std::max(std::int32_t{1}, std::min(static_cast<std::int32_t>(n), 1 << 18));
+  auto keys = sirius::microbench::make_modulo_int32_keys(n, ndv, stream);
+  cudf::table_view const key_tbl{{keys->view()}};
+  std::vector<cudf::order> const orders{cudf::order::ASCENDING};
+  std::vector<cudf::null_order> const null_orders{cudf::null_order::AFTER};
+
+  for (auto _ : state) {
+    auto sorted_ix = cudf::sorted_order(key_tbl, orders, null_orders, stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(sorted_ix);
+  }
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
+}
+
+void BM_FilterMask(benchmark::State& state)
+{
+  rmm::cuda_stream stream;
+  auto const n       = static_cast<cudf::size_type>(state.range(0));
+  int const permille = static_cast<int>(state.range(1));
+  auto payload       = sirius::microbench::make_modulo_int32_keys(n, 100000, stream);
+  auto mask          = sirius::microbench::make_sparse_bool_mask(n, permille, stream);
+  cudf::table_view const tbl{{payload->view()}};
+
+  for (auto _ : state) {
+    auto out = cudf::apply_boolean_mask(tbl, mask->view(), stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(out);
+  }
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
+}
+
+void BM_ParquetReadColumn(benchmark::State& state)
+{
+  char const* path = std::getenv("SIRIUS_MICROBENCH_PARQUET_FILE");
+  char const* col  = std::getenv("SIRIUS_MICROBENCH_PARQUET_COLUMN");
+  if (path == nullptr || col == nullptr) {
+    state.SkipWithError("Set SIRIUS_MICROBENCH_PARQUET_FILE and SIRIUS_MICROBENCH_PARQUET_COLUMN");
+    return;
+  }
+
+  rmm::cuda_stream stream;
+  auto const max_rows = static_cast<cudf::size_type>(state.range(0));
+
+  for (auto _ : state) {
+    auto opt = sirius::microbench::try_read_parquet_column(path, col, max_rows, stream);
+    stream.synchronize();
+    benchmark::DoNotOptimize(opt);
+  }
+}
+
+}  // namespace
+
+// All parameter packs registered here; daily CI uses --benchmark_filter to run a subset.
+BENCHMARK(BM_HashJoin)
+  ->Args({1 << 16, 1 << 20})
+  ->Args({1 << 17, 1 << 21})
+  ->Args({1 << 18, 1 << 22})
+  ->Args({1 << 19, 1 << 23})
+  ->ArgNames({"build_rows", "probe_rows"})
+  ->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_GroupBySum)
+  ->Args({1 << 20, 100000})
+  ->Args({1 << 22, 200000})
+  ->Args({1 << 21, 500000})
+  ->Args({1 << 23, 800000})
+  ->ArgNames({"rows", "num_groups"})
+  ->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_SortKeys)
+  ->Arg(1 << 20)
+  ->Arg(1 << 22)
+  ->Arg(1 << 23)
+  ->ArgName("rows")
+  ->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_FilterMask)
+  ->Args({1 << 20, 50})
+  ->Args({1 << 22, 50})
+  ->Args({1 << 23, 100})
+  ->Args({1 << 22, 200})
+  ->ArgNames({"rows", "permille_true"})
+  ->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_ParquetReadColumn)
+  ->Arg(1 << 20)
+  ->Arg(1 << 22)
+  ->ArgName("max_rows")
+  ->Unit(benchmark::kMillisecond);

--- a/tools/microbench/microbench_sweep.json
+++ b/tools/microbench/microbench_sweep.json
@@ -1,0 +1,30 @@
+{
+  "profiles": {
+    "daily": {
+      "benchmark_filter": "BM_HashJoin|BM_GroupBySum|BM_SortKeys|BM_FilterMask",
+      "extra_args": [
+        "--benchmark_format=json",
+        "--benchmark_out_format=json",
+        "--benchmark_min_time=0.05"
+      ]
+    },
+    "full": {
+      "benchmark_filter": ".*",
+      "extra_args": [
+        "--benchmark_format=json",
+        "--benchmark_out_format=json",
+        "--benchmark_min_time=0.05"
+      ]
+    },
+    "weekly": {
+      "benchmark_filter": "BM_HashJoin|BM_GroupBySum|BM_SortKeys|BM_FilterMask",
+      "extra_args": [
+        "--benchmark_format=json",
+        "--benchmark_out_format=json",
+        "--benchmark_min_time=0.1",
+        "--benchmark_repetitions=3",
+        "--benchmark_report_aggregates_only=true"
+      ]
+    }
+  }
+}

--- a/tools/microbench/read_profile.py
+++ b/tools/microbench/read_profile.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2025, Sirius Contributors.
+# SPDX-License-Identifier: Apache-2.0
+"""Load microbench_sweep.json and print eval-safe shell exports for bash."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shlex
+import sys
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("config", type=pathlib.Path, help="Path to microbench_sweep.json")
+    p.add_argument("profile", help="Profile name (e.g. daily, weekly, full)")
+    args = p.parse_args()
+
+    cfg = json.loads(args.config.read_text())
+    try:
+        prof = cfg["profiles"][args.profile]
+    except KeyError:
+        print(f"Unknown profile {args.profile!r}", file=sys.stderr)
+        return 1
+
+    filt = prof.get("benchmark_filter", ".*")
+    extra = prof.get("extra_args") or []
+    if not isinstance(extra, list) or not all(isinstance(x, str) for x in extra):
+        print("extra_args must be a list of strings", file=sys.stderr)
+        return 1
+
+    print(f"SIRIUS_MICROBENCH_FILTER={shlex.quote(filt)}")
+    # Bash array assignment
+    print("SIRIUS_MICROBENCH_EXTRA_ARGS=(")
+    for a in extra:
+        print(f"  {shlex.quote(a)}")
+    print(")")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/microbench/run_microbench_daily.sh
+++ b/tools/microbench/run_microbench_daily.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright 2025, Sirius Contributors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Convenience wrapper: run the "daily" microbench profile.
+# See run_microbench_sweep.sh for options and environment variables.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/run_microbench_sweep.sh" daily

--- a/tools/microbench/run_microbench_sweep.sh
+++ b/tools/microbench/run_microbench_sweep.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2025, Sirius Contributors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run sirius_gpu_microbench using a profile from microbench_sweep.json.
+#
+# Usage:
+#   ./tools/microbench/run_microbench_sweep.sh [profile]
+#   SIRIUS_GPU_MICROBENCH_BIN=... ./tools/microbench/run_microbench_sweep.sh weekly
+#
+# Environment:
+#   SIRIUS_GPU_MICROBENCH_BIN  — path to binary (default: build/release/.../sirius_gpu_microbench)
+#   SIRIUS_MICROBENCH_CONFIG   — path to microbench_sweep.json
+#   SIRIUS_MICROBENCH_OUT      — output JSON path (default: under runs/microbench/)
+#   SIRIUS_MICROBENCH_PARQUET_FILE / SIRIUS_MICROBENCH_PARQUET_COLUMN — optional Parquet bench
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROFILE="${1:-daily}"
+CONFIG="${SIRIUS_MICROBENCH_CONFIG:-$ROOT/tools/microbench/microbench_sweep.json}"
+DEFAULT_BIN="$ROOT/build/release/extension/sirius/test/cpp/sirius_gpu_microbench"
+BIN="${SIRIUS_GPU_MICROBENCH_BIN:-$DEFAULT_BIN}"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "Config not found: $CONFIG" >&2
+  exit 1
+fi
+if [[ ! -f "$BIN" ]]; then
+  echo "Microbench binary not found: $BIN (build with: pixi run make)" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+eval "$(python3 "$ROOT/tools/microbench/read_profile.py" "$CONFIG" "$PROFILE")"
+
+STAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+OUT_DIR="${SIRIUS_MICROBENCH_RUN_DIR:-$ROOT/runs/microbench/${STAMP}_${PROFILE}}"
+mkdir -p "$OUT_DIR"
+OUT_JSON="${SIRIUS_MICROBENCH_OUT:-$OUT_DIR/benchmark.json}"
+
+set -x
+"$BIN" \
+  --benchmark_filter="$SIRIUS_MICROBENCH_FILTER" \
+  "${SIRIUS_MICROBENCH_EXTRA_ARGS[@]}" \
+  --benchmark_out="$OUT_JSON"
+set +x
+
+echo "Wrote $OUT_JSON"
+echo "SIRIUS_MICROBENCH_LAST_OUT=$OUT_JSON"
+echo "SIRIUS_MICROBENCH_LAST_DIR=$OUT_DIR"


### PR DESCRIPTION
The benchmarks preferably generate their own data (or use test data that already exists in the repo), and in the end it would be nice if we can run them with default parameters every day and perform a parameter sweep once per week in CI.