### PR TITLE
refactor: replace DuckDB utility types in pipeline headers (Phase 5)

### DIFF
--- a/src/include/common/optional_ptr.hpp
+++ b/src/include/common/optional_ptr.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+namespace sirius {
+
+//! Non-owning nullable pointer wrapper. Identical API to duckdb::optional_ptr but depends only on
+//! standard headers. Throws std::runtime_error on null dereference via operator* / operator->.
+template <class T>
+class optional_ptr {  // NOLINT: mimic std casing
+ public:
+  optional_ptr() noexcept : ptr(nullptr) {}
+  optional_ptr(T* ptr_p) : ptr(ptr_p) {}  // NOLINT: allow implicit creation from pointer
+  optional_ptr(T& ref) : ptr(&ref) {}     // NOLINT: allow implicit creation from reference
+
+  explicit operator bool() const { return ptr; }
+
+  T& operator*()
+  {
+    check_valid();
+    return *ptr;
+  }
+  const T& operator*() const
+  {
+    check_valid();
+    return *ptr;
+  }
+  T* operator->()
+  {
+    check_valid();
+    return ptr;
+  }
+  const T* operator->() const
+  {
+    check_valid();
+    return ptr;
+  }
+
+  T* get() { return ptr; }              // NOLINT: mimic std casing
+  const T* get() const { return ptr; }  // NOLINT: mimic std casing
+  // Returns mutable pointer even from a const optional_ptr — mirrors duckdb::optional_ptr behavior
+  T* get_mutable() const { return ptr; }  // NOLINT: mimic std casing
+
+  bool operator==(const optional_ptr& rhs) const { return ptr == rhs.ptr; }
+  bool operator!=(const optional_ptr& rhs) const { return ptr != rhs.ptr; }
+
+ private:
+  T* ptr;
+
+  void check_valid() const
+  {
+    if (!ptr) { throw std::runtime_error("Dereferencing null optional_ptr"); }
+  }
+};
+
+}  // namespace sirius

--- a/src/include/common/reference_map.hpp
+++ b/src/include/common/reference_map.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace sirius {
+
+//! Hash by object identity (address of the referenced object).
+template <class T>
+struct ReferenceHashFunction {
+  uint64_t operator()(const std::reference_wrapper<T>& ref) const
+  {
+    return std::hash<void*>()((void*)&ref.get());
+  }
+};
+
+//! Equality by object identity.
+template <class T>
+struct ReferenceEquality {
+  bool operator()(const std::reference_wrapper<T>& a, const std::reference_wrapper<T>& b) const
+  {
+    return &a.get() == &b.get();
+  }
+};
+
+//! Unordered map keyed by reference identity. Drop-in replacement for duckdb::reference_map_t.
+template <typename K, typename V>
+using reference_map_t =
+  std::unordered_map<std::reference_wrapper<K>, V, ReferenceHashFunction<K>, ReferenceEquality<K>>;
+
+//! Unordered set keyed by reference identity. Drop-in replacement for duckdb::reference_set_t.
+template <typename K>
+using reference_set_t =
+  std::unordered_set<std::reference_wrapper<K>, ReferenceHashFunction<K>, ReferenceEquality<K>>;
+
+}  // namespace sirius

--- a/src/include/pipeline/sirius_meta_pipeline.hpp
+++ b/src/include/pipeline/sirius_meta_pipeline.hpp
@@ -79,7 +79,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! Recursively gets the last child added
   sirius_meta_pipeline& get_last_child();
   //! Get the dependencies (within this sirius_meta_pipeline) of the given Pipeline
-  const std::vector<std::reference_wrapper<sirius_pipeline>>* get_dependencies(
+  const duckdb::vector<std::reference_wrapper<sirius_pipeline>>* get_dependencies(
     sirius_pipeline& dependent) const;
   //! Whether the sink of this pipeline is a join build
   MetaPipelineType Type() const;
@@ -141,7 +141,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! All pipelines with a different source, but the same sink
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines;
   //! Dependencies within this sirius_meta_pipeline
-  sirius::reference_map_t<sirius_pipeline, std::vector<std::reference_wrapper<sirius_pipeline>>>
+  sirius::reference_map_t<sirius_pipeline, duckdb::vector<std::reference_wrapper<sirius_pipeline>>>
     dependencies;
   //! Other MetaPipelines that this sirius_meta_pipeline depends on
   duckdb::vector<duckdb::shared_ptr<sirius_meta_pipeline>> children;

--- a/src/include/pipeline/sirius_meta_pipeline.hpp
+++ b/src/include/pipeline/sirius_meta_pipeline.hpp
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include "duckdb/common/reference_map.hpp"
+#include "common/optional_ptr.hpp"
+#include "common/reference_map.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
@@ -55,7 +56,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! Create a sirius_meta_pipeline with the given sink
   sirius_meta_pipeline(sirius_engine& engine,
                        sirius_pipeline_build_state& state,
-                       duckdb::optional_ptr<op::sirius_physical_operator> sink);
+                       sirius::optional_ptr<op::sirius_physical_operator> sink);
 
  public:
   //! Get the gpu_executor for this sirius_meta_pipeline
@@ -63,9 +64,9 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! Get the pipeline_build_state for this sirius_meta_pipeline
   sirius_pipeline_build_state& get_state() const;
   //! Get the sink operator for this sirius_meta_pipeline
-  duckdb::optional_ptr<op::sirius_physical_operator> get_sink() const;
+  sirius::optional_ptr<op::sirius_physical_operator> get_sink() const;
   //! Get the parent pipeline
-  duckdb::optional_ptr<sirius_pipeline> get_parent() const;
+  sirius::optional_ptr<sirius_pipeline> get_parent() const;
 
   //! Get the initial pipeline of this sirius_meta_pipeline
   duckdb::shared_ptr<sirius_pipeline>& get_base_pipeline();
@@ -78,7 +79,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! Recursively gets the last child added
   sirius_meta_pipeline& get_last_child();
   //! Get the dependencies (within this sirius_meta_pipeline) of the given Pipeline
-  duckdb::optional_ptr<const duckdb::vector<duckdb::reference<sirius_pipeline>>> get_dependencies(
+  const std::vector<std::reference_wrapper<sirius_pipeline>>* get_dependencies(
     sirius_pipeline& dependent) const;
   //! Whether the sink of this pipeline is a join build
   MetaPipelineType Type() const;
@@ -101,7 +102,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! Whether the pipeline needs its own PipelineFinishEvent
   bool has_finish_event(sirius_pipeline& pipeline) const;
   //! Whether this pipeline is part of a PipelineFinishEvent
-  duckdb::optional_ptr<sirius_pipeline> get_finish_group(sirius_pipeline& pipeline) const;
+  sirius::optional_ptr<sirius_pipeline> get_finish_group(sirius_pipeline& pipeline) const;
 
   void build_sirius_pipelines(op::sirius_physical_operator& node, sirius_pipeline& current);
 
@@ -130,9 +131,9 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! The pipeline_build_state for all MetaPipelines in the query plan
   sirius_pipeline_build_state& state;
   //! Parent pipeline (optional)
-  duckdb::optional_ptr<sirius_pipeline> parent;
+  sirius::optional_ptr<sirius_pipeline> parent;
   //! The sink of all pipelines within this sirius_meta_pipeline
-  duckdb::optional_ptr<op::sirius_physical_operator> sink;
+  sirius::optional_ptr<op::sirius_physical_operator> sink;
   //! The type of this MetaPipeline (regular, join build)
   MetaPipelineType type;
   //! Whether this sirius_meta_pipeline is a the recursive pipeline of a recursive CTE
@@ -140,7 +141,7 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   //! All pipelines with a different source, but the same sink
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipelines;
   //! Dependencies within this sirius_meta_pipeline
-  duckdb::reference_map_t<sirius_pipeline, duckdb::vector<duckdb::reference<sirius_pipeline>>>
+  sirius::reference_map_t<sirius_pipeline, std::vector<std::reference_wrapper<sirius_pipeline>>>
     dependencies;
   //! Other MetaPipelines that this sirius_meta_pipeline depends on
   duckdb::vector<duckdb::shared_ptr<sirius_meta_pipeline>> children;
@@ -148,9 +149,9 @@ class sirius_meta_pipeline : public duckdb::enable_shared_from_this<sirius_meta_
   std::size_t next_batch_index;
   //! Pipelines (other than the base pipeline) that need their own PipelineFinishEvent (e.g., for
   //! IEJoin)
-  duckdb::reference_set_t<sirius_pipeline> finish_pipelines;
+  sirius::reference_set_t<sirius_pipeline> finish_pipelines;
   //! Mapping from pipeline (e.g., child or union) to finish pipeline
-  duckdb::reference_map_t<sirius_pipeline, sirius_pipeline&> finish_map;
+  sirius::reference_map_t<sirius_pipeline, sirius_pipeline&> finish_map;
 };
 
 }  // namespace pipeline

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -67,7 +67,7 @@ class sirius_pipeline_build_state {
                          std::size_t sink_pipeline_count);
   void set_pipeline_operators(
     sirius_pipeline& pipeline,
-    std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators);
+    duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>> operators);
   void add_pipeline_operator(sirius_pipeline& pipeline, op::sirius_physical_operator& op);
   duckdb::shared_ptr<sirius_pipeline> create_child_pipeline(sirius_engine& engine,
                                                             sirius_pipeline& pipeline,
@@ -75,7 +75,7 @@ class sirius_pipeline_build_state {
 
   sirius::optional_ptr<op::sirius_physical_operator> get_pipeline_source(sirius_pipeline& pipeline);
   sirius::optional_ptr<op::sirius_physical_operator> get_pipeline_sink(sirius_pipeline& pipeline);
-  std::vector<std::reference_wrapper<op::sirius_physical_operator>> get_pipeline_operators(
+  duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>> get_pipeline_operators(
     sirius_pipeline& pipeline);
 };
 
@@ -116,8 +116,8 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   // const;
 
   //! Returns a list of all operators (including source and sink) involved in this pipeline
-  std::vector<std::reference_wrapper<op::sirius_physical_operator>> get_operators();
-  std::vector<std::reference_wrapper<const op::sirius_physical_operator>> get_operators() const;
+  duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>> get_operators();
+  duckdb::vector<std::reference_wrapper<const op::sirius_physical_operator>> get_operators() const;
 
   sirius::optional_ptr<op::sirius_physical_operator> get_sink() { return sink; }
 
@@ -171,7 +171,7 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! The source of this pipeline
   sirius::optional_ptr<op::sirius_physical_operator> source;
   //! The chain of intermediate operators
-  std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators;
+  duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>> operators;
   //! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
   sirius::optional_ptr<op::sirius_physical_operator> sink;
 

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -17,13 +17,14 @@
 #pragma once
 
 #include "duckdb/common/atomic.hpp"
-#include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "op/sirius_physical_operator.hpp"
 // #include "duckdb/parallel/executor_task.hpp"
+#include "common/optional_ptr.hpp"
+#include "common/reference_map.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 
 #include <nvtx3/nvtx3.hpp>
@@ -51,28 +52,30 @@ class sirius_pipeline_build_state {
 
  public:
   //! Duplicate eliminated join scan dependencies
-  duckdb::reference_map_t<const op::sirius_physical_operator, duckdb::reference<sirius_pipeline>>
+  sirius::reference_map_t<const op::sirius_physical_operator,
+                          std::reference_wrapper<sirius_pipeline>>
     delim_join_dependencies;
   //! Materialized CTE scan dependencies
-  duckdb::reference_map_t<const op::sirius_physical_operator, duckdb::reference<sirius_pipeline>>
+  sirius::reference_map_t<const op::sirius_physical_operator,
+                          std::reference_wrapper<sirius_pipeline>>
     cte_dependencies;
 
  public:
   void set_pipeline_source(sirius_pipeline& pipeline, op::sirius_physical_operator& op);
   void set_pipeline_sink(sirius_pipeline& pipeline,
-                         duckdb::optional_ptr<op::sirius_physical_operator> op,
+                         sirius::optional_ptr<op::sirius_physical_operator> op,
                          std::size_t sink_pipeline_count);
   void set_pipeline_operators(
     sirius_pipeline& pipeline,
-    duckdb::vector<duckdb::reference<op::sirius_physical_operator>> operators);
+    std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators);
   void add_pipeline_operator(sirius_pipeline& pipeline, op::sirius_physical_operator& op);
   duckdb::shared_ptr<sirius_pipeline> create_child_pipeline(sirius_engine& engine,
                                                             sirius_pipeline& pipeline,
                                                             op::sirius_physical_operator& op);
 
-  duckdb::optional_ptr<op::sirius_physical_operator> get_pipeline_source(sirius_pipeline& pipeline);
-  duckdb::optional_ptr<op::sirius_physical_operator> get_pipeline_sink(sirius_pipeline& pipeline);
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_pipeline_operators(
+  sirius::optional_ptr<op::sirius_physical_operator> get_pipeline_source(sirius_pipeline& pipeline);
+  sirius::optional_ptr<op::sirius_physical_operator> get_pipeline_sink(sirius_pipeline& pipeline);
+  std::vector<std::reference_wrapper<op::sirius_physical_operator>> get_pipeline_operators(
     sirius_pipeline& pipeline);
 };
 
@@ -113,16 +116,16 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   // const;
 
   //! Returns a list of all operators (including source and sink) involved in this pipeline
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> get_operators();
-  duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> get_operators() const;
+  std::vector<std::reference_wrapper<op::sirius_physical_operator>> get_operators();
+  std::vector<std::reference_wrapper<const op::sirius_physical_operator>> get_operators() const;
 
-  duckdb::optional_ptr<op::sirius_physical_operator> get_sink() { return sink; }
+  sirius::optional_ptr<op::sirius_physical_operator> get_sink() { return sink; }
 
-  duckdb::optional_ptr<op::sirius_physical_operator> get_sink() const noexcept { return sink; }
+  sirius::optional_ptr<op::sirius_physical_operator> get_sink() const noexcept { return sink; }
 
-  duckdb::optional_ptr<op::sirius_physical_operator> get_source() { return source; }
+  sirius::optional_ptr<op::sirius_physical_operator> get_source() { return source; }
 
-  duckdb::optional_ptr<op::sirius_physical_operator> get_source() const noexcept { return source; }
+  sirius::optional_ptr<op::sirius_physical_operator> get_source() const noexcept { return source; }
 
   //! Set the pipeline ID
   void set_pipeline_id(size_t id) { pipeline_id = id; }
@@ -166,11 +169,11 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Whether or not the pipeline has been initialized
   std::atomic<bool> initialized;
   //! The source of this pipeline
-  duckdb::optional_ptr<op::sirius_physical_operator> source;
+  sirius::optional_ptr<op::sirius_physical_operator> source;
   //! The chain of intermediate operators
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> operators;
+  std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators;
   //! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
-  duckdb::optional_ptr<op::sirius_physical_operator> sink;
+  sirius::optional_ptr<op::sirius_physical_operator> sink;
 
   //! The global source state
   duckdb::unique_ptr<duckdb::GlobalSourceState> source_state;

--- a/src/pipeline/sirius_meta_pipeline.cpp
+++ b/src/pipeline/sirius_meta_pipeline.cpp
@@ -79,8 +79,8 @@ sirius_meta_pipeline& sirius_meta_pipeline::get_last_child()
   return *current_children.get().back();
 }
 
-const std::vector<std::reference_wrapper<sirius_pipeline>>* sirius_meta_pipeline::get_dependencies(
-  sirius_pipeline& dependent) const
+const duckdb::vector<std::reference_wrapper<sirius_pipeline>>*
+sirius_meta_pipeline::get_dependencies(sirius_pipeline& dependent) const
 {
   auto it = dependencies.find(dependent);
   if (it == dependencies.end()) {
@@ -149,7 +149,7 @@ void sirius_meta_pipeline::add_dependencies_from(sirius_pipeline& dependent,
   if (!including) { it++; }
 
   // collect pipelines that were created from then
-  std::vector<std::reference_wrapper<pipeline::sirius_pipeline>> created_pipelines;
+  duckdb::vector<std::reference_wrapper<pipeline::sirius_pipeline>> created_pipelines;
   for (; it != pipelines.end(); it++) {
     if (duckdb::RefersToSameObject(**it, dependent)) {
       // cannot depend on itself

--- a/src/pipeline/sirius_meta_pipeline.cpp
+++ b/src/pipeline/sirius_meta_pipeline.cpp
@@ -22,7 +22,7 @@ namespace pipeline {
 sirius_meta_pipeline::sirius_meta_pipeline(
   sirius_engine& engine,
   sirius_pipeline_build_state& state_p,
-  duckdb::optional_ptr<op::sirius_physical_operator> sink_p)
+  sirius::optional_ptr<op::sirius_physical_operator> sink_p)
   : engine(engine), state(state_p), sink(sink_p), recursive_cte(false), next_batch_index(0)
 {
   create_pipeline();
@@ -32,12 +32,12 @@ sirius_engine& sirius_meta_pipeline::get_engine() const { return engine; }
 
 sirius_pipeline_build_state& sirius_meta_pipeline::get_state() const { return state; }
 
-duckdb::optional_ptr<op::sirius_physical_operator> sirius_meta_pipeline::get_sink() const
+sirius::optional_ptr<op::sirius_physical_operator> sirius_meta_pipeline::get_sink() const
 {
   return sink;
 }
 
-duckdb::optional_ptr<sirius_pipeline> sirius_meta_pipeline::get_parent() const { return parent; }
+sirius::optional_ptr<sirius_pipeline> sirius_meta_pipeline::get_parent() const { return parent; }
 
 duckdb::shared_ptr<sirius_pipeline>& sirius_meta_pipeline::get_base_pipeline()
 {
@@ -71,7 +71,7 @@ void sirius_meta_pipeline::get_meta_pipelines(
 sirius_meta_pipeline& sirius_meta_pipeline::get_last_child()
 {
   if (children.empty()) { return *this; }
-  duckdb::reference<const duckdb::vector<duckdb::shared_ptr<sirius_meta_pipeline>>>
+  std::reference_wrapper<const duckdb::vector<duckdb::shared_ptr<sirius_meta_pipeline>>>
     current_children = children;
   while (!current_children.get().back()->children.empty()) {
     current_children = current_children.get().back()->children;
@@ -79,8 +79,8 @@ sirius_meta_pipeline& sirius_meta_pipeline::get_last_child()
   return *current_children.get().back();
 }
 
-duckdb::optional_ptr<const duckdb::vector<duckdb::reference<sirius_pipeline>>>
-sirius_meta_pipeline::get_dependencies(sirius_pipeline& dependent) const
+const std::vector<std::reference_wrapper<sirius_pipeline>>* sirius_meta_pipeline::get_dependencies(
+  sirius_pipeline& dependent) const
 {
   auto it = dependencies.find(dependent);
   if (it == dependencies.end()) {
@@ -149,7 +149,7 @@ void sirius_meta_pipeline::add_dependencies_from(sirius_pipeline& dependent,
   if (!including) { it++; }
 
   // collect pipelines that were created from then
-  duckdb::vector<duckdb::reference<pipeline::sirius_pipeline>> created_pipelines;
+  std::vector<std::reference_wrapper<pipeline::sirius_pipeline>> created_pipelines;
   for (; it != pipelines.end(); it++) {
     if (duckdb::RefersToSameObject(**it, dependent)) {
       // cannot depend on itself
@@ -222,7 +222,7 @@ bool sirius_meta_pipeline::has_finish_event(sirius_pipeline& pipeline) const
   return finish_pipelines.find(pipeline) != finish_pipelines.end();
 }
 
-duckdb::optional_ptr<sirius_pipeline> sirius_meta_pipeline::get_finish_group(
+sirius::optional_ptr<sirius_pipeline> sirius_meta_pipeline::get_finish_group(
   sirius_pipeline& pipeline) const
 {
   auto it = finish_map.find(pipeline);

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -152,15 +152,16 @@ void sirius_pipeline::add_dependency(duckdb::shared_ptr<sirius_pipeline>& pipeli
 //   return result;
 // }
 
-std::vector<std::reference_wrapper<op::sirius_physical_operator>> sirius_pipeline::get_operators()
+duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>>
+sirius_pipeline::get_operators()
 {
   return operators;
 }
 
-std::vector<std::reference_wrapper<const op::sirius_physical_operator>>
+duckdb::vector<std::reference_wrapper<const op::sirius_physical_operator>>
 sirius_pipeline::get_operators() const
 {
-  std::vector<std::reference_wrapper<const op::sirius_physical_operator>> result;
+  duckdb::vector<std::reference_wrapper<const op::sirius_physical_operator>> result;
   result.reserve(operators.size());
   for (const auto& ref : operators) {
     result.push_back(ref.get());
@@ -254,7 +255,7 @@ sirius::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::
 
 void sirius_pipeline_build_state::set_pipeline_operators(
   sirius_pipeline& pipeline,
-  std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators)
+  duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>> operators)
 {
   pipeline.operators = std::move(operators);
 }
@@ -265,7 +266,7 @@ duckdb::shared_ptr<sirius_pipeline> sirius_pipeline_build_state::create_child_pi
   return engine.create_child_pipeline(pipeline, op);
 }
 
-std::vector<std::reference_wrapper<op::sirius_physical_operator>>
+duckdb::vector<std::reference_wrapper<op::sirius_physical_operator>>
 sirius_pipeline_build_state::get_pipeline_operators(sirius_pipeline& pipeline)
 {
   return pipeline.operators;

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -152,15 +152,15 @@ void sirius_pipeline::add_dependency(duckdb::shared_ptr<sirius_pipeline>& pipeli
 //   return result;
 // }
 
-duckdb::vector<duckdb::reference<op::sirius_physical_operator>> sirius_pipeline::get_operators()
+std::vector<std::reference_wrapper<op::sirius_physical_operator>> sirius_pipeline::get_operators()
 {
   return operators;
 }
 
-duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>>
+std::vector<std::reference_wrapper<const op::sirius_physical_operator>>
 sirius_pipeline::get_operators() const
 {
-  duckdb::vector<duckdb::const_reference<op::sirius_physical_operator>> result;
+  std::vector<std::reference_wrapper<const op::sirius_physical_operator>> result;
   result.reserve(operators.size());
   for (const auto& ref : operators) {
     result.push_back(ref.get());
@@ -221,7 +221,7 @@ void sirius_pipeline_build_state::set_pipeline_source(sirius_pipeline& pipeline,
 
 void sirius_pipeline_build_state::set_pipeline_sink(
   sirius_pipeline& pipeline,
-  duckdb::optional_ptr<op::sirius_physical_operator> op,
+  sirius::optional_ptr<op::sirius_physical_operator> op,
   std::size_t sink_pipeline_count)
 {
   pipeline.sink = op;
@@ -240,13 +240,13 @@ void sirius_pipeline_build_state::add_pipeline_operator(sirius_pipeline& pipelin
   pipeline.operators.push_back(op);
 }
 
-duckdb::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::get_pipeline_source(
+sirius::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::get_pipeline_source(
   sirius_pipeline& pipeline)
 {
   return pipeline.source;
 }
 
-duckdb::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::get_pipeline_sink(
+sirius::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::get_pipeline_sink(
   sirius_pipeline& pipeline)
 {
   return pipeline.sink;
@@ -254,7 +254,7 @@ duckdb::optional_ptr<op::sirius_physical_operator> sirius_pipeline_build_state::
 
 void sirius_pipeline_build_state::set_pipeline_operators(
   sirius_pipeline& pipeline,
-  duckdb::vector<duckdb::reference<op::sirius_physical_operator>> operators)
+  std::vector<std::reference_wrapper<op::sirius_physical_operator>> operators)
 {
   pipeline.operators = std::move(operators);
 }
@@ -265,7 +265,7 @@ duckdb::shared_ptr<sirius_pipeline> sirius_pipeline_build_state::create_child_pi
   return engine.create_child_pipeline(pipeline, op);
 }
 
-duckdb::vector<duckdb::reference<op::sirius_physical_operator>>
+std::vector<std::reference_wrapper<op::sirius_physical_operator>>
 sirius_pipeline_build_state::get_pipeline_operators(sirius_pipeline& pipeline)
 {
   return pipeline.operators;


### PR DESCRIPTION
Closes #554

## Summary

- Adds `sirius::optional_ptr<T>` (`src/include/common/optional_ptr.hpp`) and `sirius::reference_map_t`/`reference_set_t` (`src/include/common/reference_map.hpp`) as std-only drop-in replacements for their DuckDB equivalents — removes `duckdb/common/reference_map.hpp` from both target headers with zero call-site changes
- Replaces `duckdb::reference<T>` / `duckdb::const_reference<T>` with `std::reference_wrapper<T>` throughout `sirius_pipeline.hpp`, `sirius_meta_pipeline.hpp` and their `.cpp` files
- Replaces `duckdb::optional_ptr<T>` with `sirius::optional_ptr<T>` in all pipeline headers and implementations

### Why own the definitions rather than use raw std equivalents
These types are not used at the Sirius/DuckDB interface boundary — they appear only as private members wrapping Sirius-internal types. Owning the definitions costs two small headers and produces zero call-site changes. Using `T*` or `std::unordered_map<K*, V>` would have required mechanical churn with no semantic benefit.

### Types replaced
| DuckDB type | Replacement | Functional difference |
|---|---|---|
| `duckdb::reference<T>` | `std::reference_wrapper<T>` | None — was already `using reference = std::reference_wrapper<T>` |
| `duckdb::const_reference<T>` | `std::reference_wrapper<const T>` | None — same alias |
| `duckdb::optional_ptr<T>` | `sirius::optional_ptr<T>` | Throws `std::runtime_error` instead of `duckdb::InternalException`; no implicit construction from smart pointers (no such call sites in scope) |
| `duckdb::reference_map_t<K,V>` | `sirius::reference_map_t<K,V>` | None — identical identity-based hash/equality |
| `duckdb::reference_set_t<T>` | `sirius::reference_set_t<T>` | None |

### Punted — blocked by Phase 3 (shared_ptr migration)
- `duckdb::enable_shared_from_this<T>`: `duckdb::shared_ptr::__enable_weak_this` only initialises `duckdb::enable_shared_from_this`, not the std version. Switching the base class while objects are managed by `duckdb::shared_ptr` causes `shared_from_this()` to throw `std::bad_weak_ptr` at runtime.
- `duckdb::weak_ptr<T>`: `std::weak_ptr<T>` cannot be constructed from `duckdb::shared_ptr<T>` (no implicit conversion; `.internal` is private).

## Test plan
- [x] Full build: 108/108 targets, zero errors
- [x] pre-commit hooks: all passed (clang-format, codespell, cmake-format, cmake-lint)
- [x] C++ unit tests: 833 test cases, 78,785,874 assertions — all passed
- [x] SQL end-to-end (tpch-sirius.test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)