### PR TITLE
feat: enable sccache cache sharing across git worktrees

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,9 @@ requires-pixi = ">=0.59"
 [activation]
 scripts = ["scripts/pixi_activate.sh"]
 
+[activation.env]
+SCCACHE_BASEDIRS = "$PIXI_PROJECT_ROOT:$CONDA_PREFIX"
+
 [dependencies]
 bc = "*"
 cmake = "4.1.*"
@@ -15,7 +18,7 @@ cuda-nvml-dev = "*"
 cxx-compiler = "*"
 make = "*"
 ninja = "*"
-sccache = "*"
+sccache = ">=0.14"
 unzip = "*"
 clang = ">=21,<22"
 wget = "*"


### PR DESCRIPTION
## Summary
- Set `SCCACHE_BASEDIRS` to `$PIXI_PROJECT_ROOT:$CONDA_PREFIX` via `[activation.env]` in `pixi.toml`, enabling sccache cache hits across git worktrees by stripping base directory prefixes from paths before computing cache keys
- Pin `sccache >= 0.14` for [`SCCACHE_BASEDIRS` support](https://github.com/mozilla/sccache/commit/7e02a2f4f067e2fb5a438be6b4dc2d7534e3ddd9)

## Test plan
- [x] Verify `SCCACHE_BASEDIRS` is set correctly after `pixi shell` (`echo $SCCACHE_BASEDIRS`)
- [x] Build in main checkout, then build in a worktree and confirm sccache cache hits via `sccache --show-stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)