### PR TITLE
doris: Fix std::bad_cast crash on concurrent GPU-cached exchange table scans

### DIFF
--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -600,11 +600,13 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
         // Use exhausted flag as a mutex — first thread wins.
         bool expected = false;
         if (!g_state._op.exhausted.compare_exchange_strong(expected, true)) {
-          // Another thread already claimed this — return empty (not nullptr!
-          // because the scan executor dereferences the return value).
+          // Another thread already claimed this — return empty pipelineable_operator_data
+          // (not bare operator_data, which would cause std::bad_cast in publish_output
+          // when dynamic_cast<pipelineable_operator_data&> fails).
           l_state._local_state_drained = true;
           g_state.decrement_local_states();
-          return std::make_unique<op::operator_data>();
+          return std::make_unique<op::pipelineable_operator_data>(
+            std::vector<std::shared_ptr<cucascade::data_batch>>{});
         }
 
         SIRIUS_LOG_INFO("[duckdb_scan_task] table '{}' already GPU-resident ({} rows) — producing GPU batch directly",

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -88,7 +88,9 @@ void log_operator_data(const op::sirius_physical_operator& op,
                        const char* label,
                        const std::string& extra_info = "")
 {
-  auto& pipelineable_data = dynamic_cast<const op::pipelineable_operator_data&>(data);
+  auto* pipelineable_ptr = dynamic_cast<const op::pipelineable_operator_data*>(&data);
+  if (!pipelineable_ptr) { return; }
+  auto& pipelineable_data = *pipelineable_ptr;
   std::string batch_rows  = "";
   size_t total_bytes      = 0;
   for (auto& batch : pipelineable_data.get_data_batches()) {


### PR DESCRIPTION
When two scan threads race to read the same GPU-cached exchange table
(e.g., a 1-row scalar subquery result like min(ps_supplycost) in TPC-H
Q2), the losing thread returned bare operator_data instead of
pipelineable_operator_data. Downstream, publish_output() and
log_operator_data() used dynamic_cast<pipelineable_operator_data&> on
this, throwing std::bad_cast and killing the query.

Root cause: duckdb_scan_task.cpp:607 returned std::make_unique<operator_data>()
for the thread that lost the compare_exchange_strong race on the exhausted
flag. This type is not a pipelineable_operator_data, so:
  - duckdb_scan_task::publish_output() (line 726) crashes
  - gpu_pipeline_task::log_operator_data() (line 91) crashes

Fix:
  - Return pipelineable_operator_data with an empty batch vector instead of bare operator_data, matching the type contract of publish_output.
  - Harden log_operator_data to use pointer dynamic_cast with early return instead of throwing reference dynamic_cast (defense in depth).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>