### PR TITLE
ci: add legacy Sirius build to check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,7 @@ jobs:
         environment: [default]
         cudf-channel:
           - stable
+        variant: [super]
         exclude:
           - compiler: gcc
             build-type: debug
@@ -70,6 +71,12 @@ jobs:
             build-type: release
             environment: default
             cudf-channel: nightly
+          - arch: x64
+            compiler: gcc
+            build-type: release
+            environment: default
+            cudf-channel: stable
+            variant: legacy
       fail-fast: false
     runs-on: >-
       ${{ matrix.environment == 'vcpkg'
@@ -104,7 +111,7 @@ jobs:
           key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json', 'vcpkg/versions/baseline.json', 'vcpkg_ports/**') }}
           restore-keys: vcpkg-${{ runner.os }}-${{ runner.arch }}-
 
-      - run: ${{ case(matrix.cudf-channel == 'nightly', 'pixi run -e nightly-runner nightly-run', '') }} make ${{ case(matrix.compiler == 'gcc', matrix.build-type, format('clang-{0}', matrix.build-type)) }} -j$(nproc)
+      - run: ${{ case(matrix.cudf-channel == 'nightly', 'pixi run -e nightly-runner nightly-run', '') }} make ${{ matrix.variant == 'legacy' && format('legacy-{0}', matrix.build-type) || case(matrix.compiler == 'gcc', matrix.build-type, format('clang-{0}', matrix.build-type)) }} -j$(nproc)
         if: matrix.environment != 'vcpkg'
         env:
           CUDAARCHS: "100"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,11 +66,13 @@ jobs:
             build-type: release
             environment: vcpkg
             cudf-channel: stable
+            variant: super
           - arch: arm64
             compiler: gcc
             build-type: release
             environment: default
             cudf-channel: nightly
+            variant: super
           - arch: x64
             compiler: gcc
             build-type: release

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ TEST_PATH_RELWITHDEBINFO ?= build/relwithdebinfo/test/unittest
 TEST_BUILD_TARGET ?= unittest
 
 .PHONY: all release debug reldebug relwithdebinfo debug-release \
+	legacy-release \
 	clang-release clang-debug clang-relwithdebinfo \
 	test test_release test_debug test_reldebug clean list-presets
 
@@ -59,6 +60,9 @@ relwithdebinfo: build/relwithdebinfo/build.ninja
 ifneq ($(TEST_BUILD_TARGET),)
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset relwithdebinfo --target $(TEST_BUILD_TARGET)
 endif
+
+legacy-release: build/legacy-release/build.ninja
+	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset legacy-release
 
 clang-release: build/clang-release/build.ninja
 	cd $(DUCKDB_DIR) && $(CMAKE) --build --preset clang-release

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -25,6 +25,10 @@
       "name": "clang-relwithdebinfo"
     },
     {
+      "configurePreset": "legacy-release",
+      "name": "legacy-release"
+    },
+    {
       "configurePreset": "vcpkg-debug",
       "name": "vcpkg-debug"
     },
@@ -130,6 +134,14 @@
       "displayName": "Clang RelWithDebInfo",
       "inherits": "base-clang",
       "name": "clang-relwithdebinfo"
+    },
+    {
+      "binaryDir": "${sourceDir}/../build/legacy-release",
+      "cacheVariables": {
+        "ENABLE_LEGACY_SIRIUS": "ON"
+      },
+      "inherits": "release",
+      "name": "legacy-release"
     },
     {
       "cacheVariables": {


### PR DESCRIPTION
## Summary
- Add a `legacy-release` CMake preset (inherits `release`, enables `ENABLE_LEGACY_SIRIUS=ON`)
- Add corresponding `legacy-release` Makefile target
- Wire into CI build matrix via a `variant` dimension (`super`/`legacy`) so the legacy code path is compiled on every PR

## Test plan
- [x] CI `build (x64, gcc, release, default, stable, legacy)` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)