### PR TITLE
ci: add required `check` summary job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,3 +114,15 @@ jobs:
         run: |
           pixi run -e vcpkg cmake -S duckdb --preset vcpkg-release
           pixi run -e vcpkg cmake --build build/vcpkg-release
+
+  check:
+    runs-on: ubuntu-slim
+    needs: [lint, build]
+    if: always()
+    steps:
+      - name: All checks ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some checks failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds a `check` job to the Check workflow that depends on `lint` and `build`, providing a single required status check for branch protection rules.

## Test plan
- [x] Verify the `check` job passes when all matrix jobs succeed
- [ ] Verify the `check` job fails when any matrix job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)