### PR TITLE
refactor: introduce sirius-native type system (logical_type / type_id)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 # cmake-format: off
 set(EXTENSION_SOURCES
     src/config.cpp
+    src/helper/type_conversions.cpp
     src/cpu_cache.cpp
     src/debug_utils.cpp
     src/creator/task_creator.cpp
@@ -353,6 +354,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/expression_executor/test_gpu_expression_executor.cpp
     test/cpp/expression_executor/test_gpu_expression_translator.cpp
+    test/cpp/helper/test_logical_type.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/memory/test_host_table_utils.cpp

--- a/src/cuda/cudf/cudf_join.cu
+++ b/src/cuda/cudf/cudf_join.cu
@@ -55,11 +55,11 @@ void cudf_hash_inner_join(vector<shared_ptr<GPUColumn>>& probe_keys,
     if (build_key_cudf.type().id() == probe_key_cudf.type().id()) {
       build_keys_cudf.push_back(build_key_cudf);
       probe_keys_cudf.push_back(probe_key_cudf);
-    } else if (IsCudfTypeDecimal(build_key_cudf.type()) &&
-               IsCudfTypeDecimal(probe_key_cudf.type())) {
+    } else if (sirius::IsCudfTypeDecimal(build_key_cudf.type()) &&
+               sirius::IsCudfTypeDecimal(probe_key_cudf.type())) {
       // Cast for decimal join key
-      int build_decimal_size = GetCudfDecimalTypeSize(build_key_cudf.type());
-      int probe_decimal_size = GetCudfDecimalTypeSize(probe_key_cudf.type());
+      int build_decimal_size = sirius::GetCudfDecimalTypeSize(build_key_cudf.type());
+      int probe_decimal_size = sirius::GetCudfDecimalTypeSize(probe_key_cudf.type());
       if (build_decimal_size < probe_decimal_size) {
         // Cast for build side to probe side
         keys_cast.push_back(cudf::cast(build_key_cudf,
@@ -294,11 +294,11 @@ void cudf_hash_left_join(vector<shared_ptr<GPUColumn>>& probe_keys,
     if (build_key_cudf.type().id() == probe_key_cudf.type().id()) {
       build_keys_cudf.push_back(build_key_cudf);
       probe_keys_cudf.push_back(probe_key_cudf);
-    } else if (IsCudfTypeDecimal(build_key_cudf.type()) &&
-               IsCudfTypeDecimal(probe_key_cudf.type())) {
+    } else if (sirius::IsCudfTypeDecimal(build_key_cudf.type()) &&
+               sirius::IsCudfTypeDecimal(probe_key_cudf.type())) {
       // Cast for decimal join key
-      int build_decimal_size = GetCudfDecimalTypeSize(build_key_cudf.type());
-      int probe_decimal_size = GetCudfDecimalTypeSize(probe_key_cudf.type());
+      int build_decimal_size = sirius::GetCudfDecimalTypeSize(build_key_cudf.type());
+      int probe_decimal_size = sirius::GetCudfDecimalTypeSize(probe_key_cudf.type());
       if (build_decimal_size < probe_decimal_size) {
         // Cast for build side to probe side
         keys_cast.push_back(cudf::cast(build_key_cudf,
@@ -382,10 +382,10 @@ void cudf_hash_full_join(vector<shared_ptr<GPUColumn>>& probe_keys,
     if (build_key_cudf.type().id() == probe_key_cudf.type().id()) {
       build_keys_cudf.push_back(build_key_cudf);
       probe_keys_cudf.push_back(probe_key_cudf);
-    } else if (IsCudfTypeDecimal(build_key_cudf.type()) &&
-               IsCudfTypeDecimal(probe_key_cudf.type())) {
-      int build_decimal_size = GetCudfDecimalTypeSize(build_key_cudf.type());
-      int probe_decimal_size = GetCudfDecimalTypeSize(probe_key_cudf.type());
+    } else if (sirius::IsCudfTypeDecimal(build_key_cudf.type()) &&
+               sirius::IsCudfTypeDecimal(probe_key_cudf.type())) {
+      int build_decimal_size = sirius::GetCudfDecimalTypeSize(build_key_cudf.type());
+      int probe_decimal_size = sirius::GetCudfDecimalTypeSize(probe_key_cudf.type());
       if (build_decimal_size < probe_decimal_size) {
         keys_cast.push_back(cudf::cast(build_key_cudf,
                                        probe_key_cudf.type(),

--- a/src/helper/type_conversions.cpp
+++ b/src/helper/type_conversions.cpp
@@ -80,7 +80,9 @@ duckdb::LogicalType to_duckdb(const logical_type& t)
     case type_id::TIMESTAMP_NS: return LogicalType::TIMESTAMP_NS;
     case type_id::VARCHAR: return LogicalType::VARCHAR;
     case type_id::STRUCT: return LogicalType::STRUCT({});
-    case type_id::LIST: return LogicalType::LIST(LogicalType::SQLNULL);
+    case type_id::LIST:
+      throw duckdb::InvalidInputException(
+        "to_duckdb: LIST conversion requires nested element metadata and is not supported");
     case type_id::INVALID:
       throw duckdb::InvalidInputException("to_duckdb: INVALID type has no DuckDB equivalent");
     case type_id::DECIMAL: return LogicalType::DECIMAL(t.decimal_precision(), t.decimal_scale());

--- a/src/helper/type_conversions.cpp
+++ b/src/helper/type_conversions.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "helper/type_conversions.hpp"
+
+#include <duckdb/common/exception.hpp>
+#include <duckdb/common/types/decimal.hpp>
+
+namespace sirius {
+
+logical_type from_duckdb(const duckdb::LogicalType& t)
+{
+  using duckdb::LogicalTypeId;
+  switch (t.id()) {
+    case LogicalTypeId::SQLNULL: return logical_type::make(type_id::SQLNULL);
+    case LogicalTypeId::BOOLEAN: return logical_type::make(type_id::BOOLEAN);
+    case LogicalTypeId::TINYINT: return logical_type::make(type_id::TINYINT);
+    case LogicalTypeId::SMALLINT: return logical_type::make(type_id::SMALLINT);
+    case LogicalTypeId::INTEGER: return logical_type::make(type_id::INTEGER);
+    case LogicalTypeId::BIGINT: return logical_type::make(type_id::BIGINT);
+    case LogicalTypeId::HUGEINT: return logical_type::make(type_id::HUGEINT);
+    case LogicalTypeId::UTINYINT: return logical_type::make(type_id::UTINYINT);
+    case LogicalTypeId::USMALLINT: return logical_type::make(type_id::USMALLINT);
+    case LogicalTypeId::UINTEGER: return logical_type::make(type_id::UINTEGER);
+    case LogicalTypeId::UBIGINT: return logical_type::make(type_id::UBIGINT);
+    case LogicalTypeId::UHUGEINT: return logical_type::make(type_id::UHUGEINT);
+    case LogicalTypeId::FLOAT: return logical_type::make(type_id::FLOAT);
+    case LogicalTypeId::DOUBLE: return logical_type::make(type_id::DOUBLE);
+    case LogicalTypeId::DATE: return logical_type::make(type_id::DATE);
+    case LogicalTypeId::TIMESTAMP_SEC: return logical_type::make(type_id::TIMESTAMP_SEC);
+    case LogicalTypeId::TIMESTAMP_MS: return logical_type::make(type_id::TIMESTAMP_MS);
+    case LogicalTypeId::TIMESTAMP: return logical_type::make(type_id::TIMESTAMP);
+    case LogicalTypeId::TIMESTAMP_NS: return logical_type::make(type_id::TIMESTAMP_NS);
+    case LogicalTypeId::VARCHAR: return logical_type::make(type_id::VARCHAR);
+    case LogicalTypeId::STRUCT: return logical_type::make(type_id::STRUCT);
+    case LogicalTypeId::LIST: return logical_type::make(type_id::LIST);
+    case LogicalTypeId::DECIMAL:
+      return logical_type::make_decimal(duckdb::DecimalType::GetWidth(t),
+                                        duckdb::DecimalType::GetScale(t));
+    default:
+      throw duckdb::InvalidInputException("from_duckdb: Unsupported DuckDB type: %s", t.ToString());
+  }
+}
+
+duckdb::LogicalType to_duckdb(const logical_type& t)
+{
+  using duckdb::LogicalType;
+  switch (t.id()) {
+    case type_id::SQLNULL: return LogicalType::SQLNULL;
+    case type_id::BOOLEAN: return LogicalType::BOOLEAN;
+    case type_id::TINYINT: return LogicalType::TINYINT;
+    case type_id::SMALLINT: return LogicalType::SMALLINT;
+    case type_id::INTEGER: return LogicalType::INTEGER;
+    case type_id::BIGINT: return LogicalType::BIGINT;
+    case type_id::HUGEINT: return LogicalType::HUGEINT;
+    case type_id::UTINYINT: return LogicalType::UTINYINT;
+    case type_id::USMALLINT: return LogicalType::USMALLINT;
+    case type_id::UINTEGER: return LogicalType::UINTEGER;
+    case type_id::UBIGINT: return LogicalType::UBIGINT;
+    case type_id::UHUGEINT: return LogicalType::UHUGEINT;
+    case type_id::FLOAT: return LogicalType::FLOAT;
+    case type_id::DOUBLE: return LogicalType::DOUBLE;
+    case type_id::DATE: return LogicalType::DATE;
+    case type_id::TIMESTAMP_SEC: return LogicalType::TIMESTAMP_S;
+    case type_id::TIMESTAMP_MS: return LogicalType::TIMESTAMP_MS;
+    case type_id::TIMESTAMP: return LogicalType::TIMESTAMP;
+    case type_id::TIMESTAMP_NS: return LogicalType::TIMESTAMP_NS;
+    case type_id::VARCHAR: return LogicalType::VARCHAR;
+    case type_id::STRUCT: return LogicalType::STRUCT({});
+    case type_id::LIST: return LogicalType::LIST(LogicalType::SQLNULL);
+    case type_id::INVALID:
+      throw duckdb::InvalidInputException("to_duckdb: INVALID type has no DuckDB equivalent");
+    case type_id::DECIMAL: return LogicalType::DECIMAL(t.decimal_precision(), t.decimal_scale());
+    default:
+      throw duckdb::InvalidInputException("to_duckdb: Unsupported sirius type: %s", t.to_string());
+  }
+}
+
+duckdb::vector<logical_type> from_duckdb_vec(const duckdb::vector<duckdb::LogicalType>& types)
+{
+  duckdb::vector<logical_type> result;
+  result.reserve(types.size());
+  for (const auto& t : types) {
+    result.push_back(from_duckdb(t));
+  }
+  return result;
+}
+
+duckdb::vector<duckdb::LogicalType> to_duckdb_vec(const duckdb::vector<logical_type>& types)
+{
+  duckdb::vector<duckdb::LogicalType> result;
+  result.reserve(types.size());
+  for (const auto& t : types) {
+    result.push_back(to_duckdb(t));
+  }
+  return result;
+}
+
+}  // namespace sirius

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -41,6 +41,9 @@
 #if CUDF_VERSION_NUM >= 2604
 #include <cudf/reduction/distinct_count.hpp>
 #endif
+#include "helper/logical_type.hpp"
+#include "sirius/exception.hpp"
+
 #include <cudf/round.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
@@ -58,9 +61,10 @@
 #include <duckdb/common/types.hpp>
 
 #include <memory>
+#include <string>
 #include <vector>
 
-namespace duckdb {
+namespace sirius {
 
 inline bool IsCudfTypeDecimal(const cudf::data_type& type)
 {
@@ -73,9 +77,63 @@ inline int GetCudfDecimalTypeSize(const cudf::data_type& type)
   if (type.id() == cudf::type_id::DECIMAL32) { return sizeof(int32_t); }
   if (type.id() == cudf::type_id::DECIMAL64) { return sizeof(int64_t); }
   if (type.id() == cudf::type_id::DECIMAL128) { return sizeof(__int128_t); }
-  throw InternalException("Non decimal cudf type called in `GetCudfDecimalTypeSize`: %d",
-                          static_cast<int>(type.id()));
+  throw internal_exception("Non decimal cudf type called in GetCudfDecimalTypeSize: " +
+                           std::to_string(static_cast<int>(type.id())));
 }
+
+/**
+ * @brief Map a sirius::logical_type to its corresponding cudf::data_type.
+ *
+ * Mirrors duckdb::GetCudfType() but operates on the Sirius-native type system.
+ * This overload is used by GPU operators that have been decoupled from DuckDB.
+ *
+ * @throws duckdb::InvalidInputException if the type is unsupported.
+ */
+inline cudf::data_type get_cudf_type(const logical_type& t)
+{
+  switch (t.id()) {
+    case type_id::TINYINT: return cudf::data_type(cudf::type_id::INT8);
+    case type_id::SMALLINT: return cudf::data_type(cudf::type_id::INT16);
+    case type_id::INTEGER: return cudf::data_type(cudf::type_id::INT32);
+    case type_id::BIGINT:
+    case type_id::HUGEINT:  // FIXME: unsafe conversion from HUGEINT to INT64 (no INT128 in cuDF)
+      return cudf::data_type(cudf::type_id::INT64);
+    case type_id::UTINYINT: return cudf::data_type(cudf::type_id::UINT8);
+    case type_id::USMALLINT: return cudf::data_type(cudf::type_id::UINT16);
+    case type_id::UINTEGER: return cudf::data_type(cudf::type_id::UINT32);
+    case type_id::UBIGINT:
+    case type_id::UHUGEINT: return cudf::data_type(cudf::type_id::UINT64);
+    case type_id::FLOAT: return cudf::data_type(cudf::type_id::FLOAT32);
+    case type_id::DOUBLE: return cudf::data_type(cudf::type_id::FLOAT64);
+    case type_id::BOOLEAN: return cudf::data_type(cudf::type_id::BOOL8);
+    case type_id::DATE: return cudf::data_type(cudf::type_id::TIMESTAMP_DAYS);
+    case type_id::TIMESTAMP_SEC: return cudf::data_type(cudf::type_id::TIMESTAMP_SECONDS);
+    case type_id::TIMESTAMP_MS: return cudf::data_type(cudf::type_id::TIMESTAMP_MILLISECONDS);
+    case type_id::TIMESTAMP: return cudf::data_type(cudf::type_id::TIMESTAMP_MICROSECONDS);
+    case type_id::TIMESTAMP_NS: return cudf::data_type(cudf::type_id::TIMESTAMP_NANOSECONDS);
+    case type_id::VARCHAR: return cudf::data_type(cudf::type_id::STRING);
+    case type_id::STRUCT: return cudf::data_type(cudf::type_id::STRUCT);
+    case type_id::LIST:
+    case type_id::SQLNULL:
+    case type_id::INVALID:
+      throw duckdb::InvalidInputException("sirius::get_cudf_type: Type %s cannot be mapped to cuDF",
+                                          t.to_string());
+    case type_id::DECIMAL: {
+      // cuDF uses negative scale convention; precision determines the storage width.
+      auto const neg_scale = static_cast<int32_t>(-t.decimal_scale());
+      if (t.decimal_precision() <= 9) return cudf::data_type(cudf::type_id::DECIMAL32, neg_scale);
+      if (t.decimal_precision() <= 18) return cudf::data_type(cudf::type_id::DECIMAL64, neg_scale);
+      return cudf::data_type(cudf::type_id::DECIMAL128, neg_scale);
+    }
+    default:
+      throw duckdb::InvalidInputException("sirius::get_cudf_type: Unsupported type: %s",
+                                          t.to_string());
+  }
+}
+
+}  // namespace sirius
+
+namespace duckdb {
 
 /**
  * @brief Type switch from duckdb LogicalType to cudf data_type

--- a/src/include/cudf/cudf_utils.hpp
+++ b/src/include/cudf/cudf_utils.hpp
@@ -95,14 +95,19 @@ inline cudf::data_type get_cudf_type(const logical_type& t)
     case type_id::TINYINT: return cudf::data_type(cudf::type_id::INT8);
     case type_id::SMALLINT: return cudf::data_type(cudf::type_id::INT16);
     case type_id::INTEGER: return cudf::data_type(cudf::type_id::INT32);
-    case type_id::BIGINT:
-    case type_id::HUGEINT:  // FIXME: unsafe conversion from HUGEINT to INT64 (no INT128 in cuDF)
+    case type_id::BIGINT: return cudf::data_type(cudf::type_id::INT64);
+    case type_id::HUGEINT:
+      // FIXME: unsafe 128→64-bit narrowing: DuckDB HUGEINT is INT128 but cuDF has no INT128.
+      // Values outside INT64 range are silently corrupted. Matches legacy duckdb::GetCudfType().
       return cudf::data_type(cudf::type_id::INT64);
     case type_id::UTINYINT: return cudf::data_type(cudf::type_id::UINT8);
     case type_id::USMALLINT: return cudf::data_type(cudf::type_id::UINT16);
     case type_id::UINTEGER: return cudf::data_type(cudf::type_id::UINT32);
-    case type_id::UBIGINT:
-    case type_id::UHUGEINT: return cudf::data_type(cudf::type_id::UINT64);
+    case type_id::UBIGINT: return cudf::data_type(cudf::type_id::UINT64);
+    case type_id::UHUGEINT:
+      // FIXME: unsafe 128→64-bit narrowing: DuckDB UHUGEINT is UINT128 but cuDF has no UINT128.
+      // Values outside UINT64 range are silently corrupted. Matches legacy duckdb::GetCudfType().
+      return cudf::data_type(cudf::type_id::UINT64);
     case type_id::FLOAT: return cudf::data_type(cudf::type_id::FLOAT32);
     case type_id::DOUBLE: return cudf::data_type(cudf::type_id::FLOAT64);
     case type_id::BOOLEAN: return cudf::data_type(cudf::type_id::BOOL8);
@@ -121,8 +126,15 @@ inline cudf::data_type get_cudf_type(const logical_type& t)
     case type_id::DECIMAL: {
       // cuDF uses negative scale convention; precision determines the storage width.
       auto const neg_scale = static_cast<int32_t>(-t.decimal_scale());
-      if (t.decimal_precision() <= 9) return cudf::data_type(cudf::type_id::DECIMAL32, neg_scale);
-      if (t.decimal_precision() <= 18) return cudf::data_type(cudf::type_id::DECIMAL64, neg_scale);
+      if (t.decimal_precision() <= logical_type::decimal_max_precision_int16)
+        throw duckdb::InvalidInputException(
+          "sirius::get_cudf_type: DECIMAL with precision <= %d is stored as INT16 in DuckDB "
+          "and has no direct cuDF equivalent — use DuckDB CPU fallback",
+          logical_type::decimal_max_precision_int16);
+      if (t.decimal_precision() <= logical_type::decimal_max_precision_int32)
+        return cudf::data_type(cudf::type_id::DECIMAL32, neg_scale);
+      if (t.decimal_precision() <= logical_type::decimal_max_precision_int64)
+        return cudf::data_type(cudf::type_id::DECIMAL64, neg_scale);
       return cudf::data_type(cudf::type_id::DECIMAL128, neg_scale);
     }
     default:

--- a/src/include/helper/logical_type.hpp
+++ b/src/include/helper/logical_type.hpp
@@ -77,6 +77,20 @@ enum class type_id : uint8_t {
 class logical_type {
  public:
   //===--------------------------------------------------------------------===//
+  // DECIMAL precision thresholds
+  //
+  // Maximum number of decimal digits representable in each signed integer width.
+  // These mirror duckdb::Decimal::MAX_WIDTH_INT{16,32,64,128} and determine
+  // the physical storage type (INT16/32/64/128) for a given DECIMAL precision.
+  //===--------------------------------------------------------------------===//
+  static constexpr uint8_t decimal_max_precision_int16 =
+    4;  ///< INT16  (2B): up to 4 digits (max 9,999)
+  static constexpr uint8_t decimal_max_precision_int32 =
+    9;  ///< INT32  (4B): up to 9 digits (max 999,999,999)
+  static constexpr uint8_t decimal_max_precision_int64  = 18;  ///< INT64  (8B): up to 18 digits
+  static constexpr uint8_t decimal_max_precision_int128 = 38;  ///< INT128 (16B): up to 38 digits
+
+  //===--------------------------------------------------------------------===//
   // Constructors / factories
   //===--------------------------------------------------------------------===//
 
@@ -202,10 +216,10 @@ class logical_type {
       case type_id::TIMESTAMP:
       case type_id::TIMESTAMP_NS: return 8;
       case type_id::DECIMAL:
-        if (_precision <= 9) return 4;   // DECIMAL32
-        if (_precision <= 18) return 8;  // DECIMAL64
-        return 16;                       // DECIMAL128
-      case type_id::VARCHAR: return 0;   // variable-length
+        if (_precision <= decimal_max_precision_int32) return 4;  // DECIMAL32
+        if (_precision <= decimal_max_precision_int64) return 8;  // DECIMAL64
+        return 16;                                                // DECIMAL128
+      case type_id::VARCHAR: return 0;                            // variable-length
       case type_id::LIST:
       case type_id::STRUCT:
       case type_id::SQLNULL:

--- a/src/include/helper/logical_type.hpp
+++ b/src/include/helper/logical_type.hpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace sirius {
+
+//===----------------------------------------------------------------------===//
+// type_id
+//===----------------------------------------------------------------------===//
+
+/**
+ * @brief Sirius SQL type identifiers — independent of DuckDB and cuDF.
+ *
+ * Covers all SQL types currently supported by the Sirius GPU engine.
+ * For DECIMAL, precision and scale are carried separately in logical_type.
+ */
+enum class type_id : uint8_t {
+  INVALID = 0,
+  SQLNULL,
+  BOOLEAN,
+  TINYINT,
+  SMALLINT,
+  INTEGER,
+  BIGINT,
+  HUGEINT,
+  UTINYINT,
+  USMALLINT,
+  UINTEGER,
+  UBIGINT,
+  UHUGEINT,
+  FLOAT,
+  DOUBLE,
+  DATE,
+  TIMESTAMP_SEC,
+  TIMESTAMP_MS,
+  TIMESTAMP,  ///< microsecond precision (default SQL TIMESTAMP)
+  TIMESTAMP_NS,
+  VARCHAR,
+  STRUCT,
+  LIST,
+  DECIMAL,
+};
+
+//===----------------------------------------------------------------------===//
+// logical_type
+//===----------------------------------------------------------------------===//
+
+/**
+ * @brief Sirius-native SQL type descriptor.
+ *
+ * A lightweight, copyable value type that carries:
+ * - The base SQL type via sirius::type_id
+ * - For DECIMAL: precision (total significant digits) and scale (fractional digits)
+ *
+ * No DuckDB or cuDF headers are required. Use type_conversions.hpp at the
+ * DuckDB boundaries (plan generator entry / result collector exit).
+ */
+class logical_type {
+ public:
+  //===--------------------------------------------------------------------===//
+  // Constructors / factories
+  //===--------------------------------------------------------------------===//
+
+  /// Default-constructs a SQLNULL type (used as a sentinel/placeholder).
+  logical_type() : _id(type_id::SQLNULL), _precision(0), _scale(0) {}
+
+  /**
+   * @brief Construct a non-DECIMAL logical type.
+   * @param id  The SQL type identifier (must not be DECIMAL).
+   */
+  static logical_type make(type_id id) { return logical_type(id, 0, 0); }
+
+  /**
+   * @brief Construct a DECIMAL logical type with full precision and scale.
+   * @param precision  Total significant digits (1–38).
+   * @param scale      Fractional digits (0–precision).
+   */
+  static logical_type make_decimal(uint8_t precision, uint8_t scale)
+  {
+    return logical_type(type_id::DECIMAL, precision, scale);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Type inspection
+  //===--------------------------------------------------------------------===//
+
+  /// Returns the base SQL type identifier.
+  type_id id() const noexcept { return _id; }
+
+  /// Returns true if this is a DECIMAL type.
+  bool is_decimal() const noexcept { return _id == type_id::DECIMAL; }
+
+  /// Returns true if this is a VARCHAR (variable-length string) type.
+  bool is_varchar() const noexcept { return _id == type_id::VARCHAR; }
+
+  /// Returns true if this is an integer type (signed or unsigned, including HUGEINT variants).
+  bool is_integer() const noexcept
+  {
+    switch (_id) {
+      case type_id::TINYINT:
+      case type_id::SMALLINT:
+      case type_id::INTEGER:
+      case type_id::BIGINT:
+      case type_id::HUGEINT:
+      case type_id::UTINYINT:
+      case type_id::USMALLINT:
+      case type_id::UINTEGER:
+      case type_id::UBIGINT:
+      case type_id::UHUGEINT: return true;
+      default: return false;
+    }
+  }
+
+  /// Returns true if this is a numeric type (integer, float, double, or decimal).
+  bool is_numeric() const noexcept
+  {
+    return is_integer() || _id == type_id::FLOAT || _id == type_id::DOUBLE ||
+           _id == type_id::DECIMAL;
+  }
+
+  /// Returns true if this is a date or timestamp type (any precision).
+  bool is_temporal() const noexcept
+  {
+    switch (_id) {
+      case type_id::DATE:
+      case type_id::TIMESTAMP_SEC:
+      case type_id::TIMESTAMP_MS:
+      case type_id::TIMESTAMP:
+      case type_id::TIMESTAMP_NS: return true;
+      default: return false;
+    }
+  }
+
+  /**
+   * @brief Returns true for types with a fixed, known storage size.
+   *
+   * All types except VARCHAR (variable-length), STRUCT (nested), SQLNULL, and INVALID.
+   * Unlike fixed_width_byte_size(), this does NOT throw — safe to use in predicates.
+   */
+  bool is_fixed_width() const noexcept
+  {
+    return _id != type_id::VARCHAR && _id != type_id::STRUCT && _id != type_id::LIST &&
+           _id != type_id::SQLNULL && _id != type_id::INVALID;
+  }
+
+  /**
+   * @brief Returns the total number of significant digits for a DECIMAL type.
+   * @note Only meaningful when is_decimal() == true.
+   */
+  uint8_t decimal_precision() const noexcept { return _precision; }
+
+  /**
+   * @brief Returns the number of fractional digits for a DECIMAL type.
+   * @note Only meaningful when is_decimal() == true.
+   */
+  uint8_t decimal_scale() const noexcept { return _scale; }
+
+  /**
+   * @brief Returns the storage size in bytes for fixed-width types.
+   *
+   * Replaces `duckdb::GetTypeIdSize(type.InternalType())` for fixed-width dispatch.
+   * Returns 0 for VARCHAR (variable-length). Throws for STRUCT, INVALID, and SQLNULL.
+   */
+  std::size_t fixed_width_byte_size() const
+  {
+    switch (_id) {
+      case type_id::BOOLEAN:
+      case type_id::TINYINT:
+      case type_id::UTINYINT: return 1;
+      case type_id::SMALLINT:
+      case type_id::USMALLINT: return 2;
+      case type_id::INTEGER:
+      case type_id::UINTEGER:
+      case type_id::FLOAT:
+      case type_id::DATE: return 4;
+      case type_id::BIGINT:
+      case type_id::UBIGINT:
+      case type_id::HUGEINT:   // cuDF maps HUGEINT → INT64
+      case type_id::UHUGEINT:  // cuDF maps UHUGEINT → UINT64
+      case type_id::DOUBLE:
+      case type_id::TIMESTAMP_SEC:
+      case type_id::TIMESTAMP_MS:
+      case type_id::TIMESTAMP:
+      case type_id::TIMESTAMP_NS: return 8;
+      case type_id::DECIMAL:
+        if (_precision <= 9) return 4;   // DECIMAL32
+        if (_precision <= 18) return 8;  // DECIMAL64
+        return 16;                       // DECIMAL128
+      case type_id::VARCHAR: return 0;   // variable-length
+      case type_id::LIST:
+      case type_id::STRUCT:
+      case type_id::SQLNULL:
+      case type_id::INVALID:
+      default:
+        throw std::runtime_error("fixed_width_byte_size: not applicable for type " + to_string());
+    }
+  }
+
+  /// Returns a human-readable name for the type (for error messages / logging).
+  std::string to_string() const
+  {
+    switch (_id) {
+      case type_id::INVALID: return "INVALID";
+      case type_id::SQLNULL: return "NULL";
+      case type_id::BOOLEAN: return "BOOLEAN";
+      case type_id::TINYINT: return "TINYINT";
+      case type_id::SMALLINT: return "SMALLINT";
+      case type_id::INTEGER: return "INTEGER";
+      case type_id::BIGINT: return "BIGINT";
+      case type_id::HUGEINT: return "HUGEINT";
+      case type_id::UTINYINT: return "UTINYINT";
+      case type_id::USMALLINT: return "USMALLINT";
+      case type_id::UINTEGER: return "UINTEGER";
+      case type_id::UBIGINT: return "UBIGINT";
+      case type_id::UHUGEINT: return "UHUGEINT";
+      case type_id::FLOAT: return "FLOAT";
+      case type_id::DOUBLE: return "DOUBLE";
+      case type_id::DATE: return "DATE";
+      case type_id::TIMESTAMP_SEC: return "TIMESTAMP_S";
+      case type_id::TIMESTAMP_MS: return "TIMESTAMP_MS";
+      case type_id::TIMESTAMP: return "TIMESTAMP";
+      case type_id::TIMESTAMP_NS: return "TIMESTAMP_NS";
+      case type_id::VARCHAR: return "VARCHAR";
+      case type_id::STRUCT: return "STRUCT";
+      case type_id::LIST: return "LIST";
+      case type_id::DECIMAL:
+        return "DECIMAL(" + std::to_string(_precision) + "," + std::to_string(_scale) + ")";
+      default: return "UNKNOWN";
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Comparison
+  //===--------------------------------------------------------------------===//
+
+  bool operator==(const logical_type& other) const noexcept
+  {
+    return _id == other._id && _precision == other._precision && _scale == other._scale;
+  }
+
+  bool operator!=(const logical_type& other) const noexcept { return !(*this == other); }
+
+ private:
+  explicit logical_type(type_id id, uint8_t precision, uint8_t scale)
+    : _id(id), _precision(precision), _scale(scale)
+  {
+  }
+
+  type_id _id;
+  uint8_t _precision{0};  ///< Meaningful only for DECIMAL: total significant digits (1–38)
+  uint8_t _scale{0};      ///< Meaningful only for DECIMAL: fractional digits (0–precision)
+};
+
+}  // namespace sirius

--- a/src/include/helper/type_conversions.hpp
+++ b/src/include/helper/type_conversions.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// This header is intentionally included ONLY at DuckDB boundaries:
+//   - src/planner/  (entry: duckdb::LogicalType → sirius::logical_type)
+//   - src/op/result/ (exit: sirius::logical_type → duckdb::LogicalType)
+// Do NOT include from operator headers or GPU kernel headers.
+
+#include "helper/logical_type.hpp"
+
+#include <duckdb/common/types.hpp>
+#include <duckdb/common/vector.hpp>
+
+namespace sirius {
+
+/**
+ * @brief Convert a DuckDB logical type to a Sirius logical type.
+ *
+ * Used at the plan-generator entry boundary to convert types from the DuckDB
+ * logical plan into Sirius operator types. DECIMAL precision and scale are
+ * fully preserved.
+ *
+ * @throws duckdb::InvalidInputException if the type is unsupported.
+ */
+logical_type from_duckdb(const duckdb::LogicalType& t);
+
+/**
+ * @brief Convert a Sirius logical type back to a DuckDB logical type.
+ *
+ * Used at the result-collector exit boundary to reconstruct DuckDB types for
+ * DataChunk initialization and ColumnDataCollection. DECIMAL precision and
+ * scale are fully preserved.
+ *
+ * @throws duckdb::InvalidInputException if the type is unsupported.
+ */
+duckdb::LogicalType to_duckdb(const logical_type& t);
+
+/**
+ * @brief Batch-convert a DuckDB type vector to a Sirius type vector.
+ *
+ * Convenience wrapper over from_duckdb() for operator constructor call sites
+ * in the planner. Returns duckdb::vector to preserve bounds-checking on
+ * subsequent operator[] accesses.
+ */
+duckdb::vector<logical_type> from_duckdb_vec(const duckdb::vector<duckdb::LogicalType>& types);
+
+/**
+ * @brief Batch-convert a Sirius type vector to a DuckDB type vector.
+ *
+ * Convenience wrapper over to_duckdb() for result-collector call sites that
+ * need a duckdb::vector<duckdb::LogicalType> (e.g. DataChunk::Initialize,
+ * ColumnDataCollection). Accepts duckdb::vector via base-class reference.
+ */
+duckdb::vector<duckdb::LogicalType> to_duckdb_vec(const duckdb::vector<logical_type>& types);
+
+}  // namespace sirius

--- a/src/include/memory/host_table_utils.hpp
+++ b/src/include/memory/host_table_utils.hpp
@@ -69,14 +69,14 @@ struct metadata_node {
  * @param null_mask_offset The byte offset of the null mask within a compact allocation.
  * @return metadata_node The constructed metadata node.
  */
-inline metadata_node make_flat_metadata_node(duckdb::LogicalType type,
+inline metadata_node make_flat_metadata_node(sirius::logical_type type,
                                              cudf::size_type size,
                                              cudf::size_type null_count,
                                              int64_t data_offset,
                                              int64_t null_mask_offset)
 {
   return metadata_node{
-    duckdb::GetCudfType(type), size, null_count, data_offset, null_mask_offset, {}};
+    sirius::get_cudf_type(type), size, null_count, data_offset, null_mask_offset, {}};
 }
 
 /**

--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 // sirius
+#include <helper/logical_type.hpp>
 #include <helper/utils.hpp>
 #include <memory/multiple_blocks_allocation_accessor.hpp>
 
@@ -137,7 +138,7 @@ class host_table_chunk_reader {
    */
   host_table_chunk_reader(duckdb::ClientContext& client_ctx,
                           cucascade::host_data_representation const& host_table,
-                          duckdb::vector<duckdb::LogicalType> const& types);
+                          duckdb::vector<sirius::logical_type> const& types);
   ~host_table_chunk_reader() = default;
 
   /**

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -191,7 +191,7 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
     static constexpr uint8_t FULL_MASK = 0xFF;  ///< Byte mask with all bits set
 
     //===----------Fields----------===//
-    duckdb::LogicalType type;  ///< DuckDB logical type of the column
+    sirius::logical_type type;  ///< Sirius logical type of the column
     size_t type_size;  ///< Size of the column data type in bytes (for VARCHAR, just data size)
     size_t total_data_bytes =
       0;  ///< Total number of data bytes written for this column (only needed for VARCHAR)
@@ -215,7 +215,7 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
      * @param[in] t The DuckDB logical type of the column.
      * @param[in] default_varchar_size The default size to use for VARCHAR data.
      */
-    column_builder(duckdb::LogicalType t, size_t default_varchar_size);
+    column_builder(sirius::logical_type t, size_t default_varchar_size);
 
     // no copying
     column_builder(const column_builder&)            = delete;

--- a/src/include/op/scan/scan_utils.hpp
+++ b/src/include/op/scan/scan_utils.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"
+
 // duckdb
 #include <duckdb/common/types.hpp>
 #include <duckdb/planner/table_filter.hpp>
@@ -48,7 +51,7 @@ std::vector<duckdb::idx_t> build_batch_column_map(
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
-  const duckdb::vector<duckdb::LogicalType>& returned_types,
+  const duckdb::vector<sirius::logical_type>& returned_types,
   const std::vector<duckdb::idx_t>& batch_column_map);
 
 }  // namespace sirius::op

--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -71,7 +71,7 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
    * @param estimated_cardinality  Estimated row count.
    * @param gpu_memory_space       GPU memory space for allocating output tables.
    */
-  sirius_gpu_parquet_scan_operator(duckdb::vector<duckdb::LogicalType> types,
+  sirius_gpu_parquet_scan_operator(duckdb::vector<sirius::logical_type> types,
                                    duckdb::idx_t estimated_cardinality,
                                    cucascade::memory::memory_space& gpu_memory_space);
 

--- a/src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp
+++ b/src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp
@@ -97,7 +97,7 @@ class sirius_parquet_metadata_scan_operator : public sirius_physical_operator {
    *         (column names are required for both projection and filter pushdown).
    */
   sirius_parquet_metadata_scan_operator(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::idx_t estimated_cardinality,
     std::vector<std::string> const& file_paths,
     duckdb::vector<duckdb::ColumnIndex> const& column_ids,

--- a/src/include/op/sirius_physical_column_data_scan.hpp
+++ b/src/include/op/sirius_physical_column_data_scan.hpp
@@ -37,12 +37,12 @@ class sirius_physical_column_data_scan : public sirius_physical_operator {
 
  public:
   sirius_physical_column_data_scan(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     SiriusPhysicalOperatorType op_type,
     std::size_t estimated_cardinality,
     duckdb::optionally_owned_ptr<duckdb::ColumnDataCollection> collection);
 
-  sirius_physical_column_data_scan(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_column_data_scan(duckdb::vector<sirius::logical_type> types,
                                    SiriusPhysicalOperatorType op_type,
                                    std::size_t estimated_cardinality,
                                    std::size_t cte_index);

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -34,7 +34,7 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::CONCAT;
 
   explicit sirius_physical_concat(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     std::size_t estimated_cardinality,
     sirius_physical_operator* parent_op,
     bool is_build,

--- a/src/include/op/sirius_physical_cte.hpp
+++ b/src/include/op/sirius_physical_cte.hpp
@@ -38,7 +38,7 @@ class sirius_physical_cte : public sirius_physical_operator {
  public:
   sirius_physical_cte(std::string ctename,
                       std::size_t table_index,
-                      duckdb::vector<duckdb::LogicalType> types,
+                      duckdb::vector<sirius::logical_type> types,
                       duckdb::unique_ptr<sirius_physical_operator> top,
                       duckdb::unique_ptr<sirius_physical_operator> bottom,
                       std::size_t estimated_cardinality);

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -39,7 +39,7 @@ class sirius_physical_delim_join : public sirius_physical_operator {
  public:
   sirius_physical_delim_join(
     SiriusPhysicalOperatorType type,
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::unique_ptr<sirius_physical_operator> original_join,
     duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
     std::size_t estimated_cardinality,
@@ -72,7 +72,7 @@ class sirius_physical_right_delim_join : public sirius_physical_delim_join {
 
  public:
   sirius_physical_right_delim_join(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::unique_ptr<sirius_physical_operator> original_join,
     duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
     std::size_t estimated_cardinality,
@@ -98,7 +98,7 @@ class sirius_physical_left_delim_join : public sirius_physical_delim_join {
 
  public:
   sirius_physical_left_delim_join(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::unique_ptr<sirius_physical_operator> original_join,
     duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
     std::size_t estimated_cardinality,

--- a/src/include/op/sirius_physical_duckdb_scan.hpp
+++ b/src/include/op/sirius_physical_duckdb_scan.hpp
@@ -36,10 +36,10 @@ class sirius_physical_duckdb_scan : public sirius_physical_operator {
 
   //! Table scan that immediately projects out filter columns that are unused in the remainder of
   //! the query plan
-  sirius_physical_duckdb_scan(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_duckdb_scan(duckdb::vector<sirius::logical_type> types,
                               duckdb::TableFunction function,
                               duckdb::unique_ptr<duckdb::FunctionData> bind_data,
-                              duckdb::vector<duckdb::LogicalType> returned_types,
+                              duckdb::vector<sirius::logical_type> returned_types,
                               duckdb::vector<duckdb::ColumnIndex> column_ids,
                               duckdb::vector<std::size_t> projection_ids,
                               duckdb::vector<std::string> names,
@@ -60,7 +60,7 @@ class sirius_physical_duckdb_scan : public sirius_physical_operator {
   //! Bind data of the function
   duckdb::unique_ptr<duckdb::FunctionData> bind_data;
   //! The types of ALL columns that can be returned by the table function
-  duckdb::vector<duckdb::LogicalType> returned_types;
+  duckdb::vector<sirius::logical_type> returned_types;
   //! The column ids used within the table function
   duckdb::vector<duckdb::ColumnIndex> column_ids;
   //! The projected-out column ids
@@ -92,7 +92,7 @@ class sirius_physical_duckdb_scan : public sirius_physical_operator {
 
   //! Types of the columns that DuckDB will output after projection.
   //! Includes ROW_ID (as BIGINT) when the plan requires it.
-  duckdb::vector<duckdb::LogicalType> scanned_types;
+  duckdb::vector<sirius::logical_type> scanned_types;
 
   duckdb::unique_ptr<duckdb::TableFilterSet> fake_table_filters;
 

--- a/src/include/op/sirius_physical_dummy_scan.hpp
+++ b/src/include/op/sirius_physical_dummy_scan.hpp
@@ -27,7 +27,7 @@ class sirius_physical_dummy_scan : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::DUMMY_SCAN;
 
  public:
-  explicit sirius_physical_dummy_scan(duckdb::vector<duckdb::LogicalType> types,
+  explicit sirius_physical_dummy_scan(duckdb::vector<sirius::logical_type> types,
                                       std::size_t estimated_cardinality)
     : sirius_physical_operator(
         SiriusPhysicalOperatorType::DUMMY_SCAN, std::move(types), estimated_cardinality)

--- a/src/include/op/sirius_physical_empty_result.hpp
+++ b/src/include/op/sirius_physical_empty_result.hpp
@@ -27,7 +27,7 @@ class sirius_physical_empty_result : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::EMPTY_RESULT;
 
  public:
-  explicit sirius_physical_empty_result(duckdb::vector<duckdb::LogicalType> types,
+  explicit sirius_physical_empty_result(duckdb::vector<sirius::logical_type> types,
                                         std::size_t estimated_cardinality)
     : sirius_physical_operator(
         SiriusPhysicalOperatorType::EMPTY_RESULT, std::move(types), estimated_cardinality)

--- a/src/include/op/sirius_physical_filter.hpp
+++ b/src/include/op/sirius_physical_filter.hpp
@@ -29,7 +29,7 @@ class sirius_physical_filter : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::FILTER;
 
  public:
-  sirius_physical_filter(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_filter(duckdb::vector<sirius::logical_type> types,
                          duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
                          std::size_t estimated_cardinality);
 

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -41,14 +41,14 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
  public:
   sirius_physical_grouped_aggregate(
     duckdb::ClientContext& context,
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups,
     std::size_t estimated_cardinality);
 
   sirius_physical_grouped_aggregate(
     duckdb::ClientContext& context,
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups,
     duckdb::vector<duckdb::GroupingSet> grouping_sets,
@@ -68,7 +68,7 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
   // duckdb::vector<duckdb::HashAggregateGroupingData> groupings;
   // duckdb::unique_ptr<duckdb::DistinctAggregateCollectionInfo> distinct_collection_info;
   // //! A recreation of the input chunk, with nulls for everything that isn't a group
-  // duckdb::vector<duckdb::LogicalType> input_group_types;
+  // duckdb::vector<sirius::logical_type> input_group_types;
 
   // // Filters given to sink and friends
   // duckdb::unsafe_vector<std::size_t> non_distinct_filter;

--- a/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate_merge.hpp
@@ -44,7 +44,7 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
   sirius_physical_grouped_aggregate_merge(sirius_physical_grouped_aggregate* grouped_aggregate);
 
   sirius_physical_grouped_aggregate_merge(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     std::vector<int> group_idx,
     std::vector<cudf::aggregation::Kind> cudf_aggregates,
     std::vector<int> cudf_aggregate_idx,
@@ -56,14 +56,14 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
 
   sirius_physical_grouped_aggregate_merge(
     duckdb::ClientContext& context,
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups,
     std::size_t estimated_cardinality);
 
   sirius_physical_grouped_aggregate_merge(
     duckdb::ClientContext& context,
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups,
     duckdb::vector<duckdb::GroupingSet> grouping_sets,
@@ -80,7 +80,7 @@ class sirius_physical_grouped_aggregate_merge : public sirius_physical_partition
   duckdb::vector<duckdb::HashAggregateGroupingData> groupings;
   duckdb::unique_ptr<duckdb::DistinctAggregateCollectionInfo> distinct_collection_info;
   //! A recreation of the input chunk, with nulls for everything that isn't a group
-  duckdb::vector<duckdb::LogicalType> input_group_types;
+  duckdb::vector<sirius::logical_type> input_group_types;
 
   // Filters given to sink and friends
   duckdb::unsafe_vector<std::size_t> non_distinct_filter;

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -55,7 +55,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   struct join_projection_columns {
     std::vector<cudf::size_type> col_idxs;
-    duckdb::vector<duckdb::LogicalType> col_types;
+    duckdb::vector<sirius::logical_type> col_types;
   };
 
  public:
@@ -67,7 +67,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
     duckdb::JoinType join_type,
     const duckdb::vector<std::size_t>& left_projection_map,
     const duckdb::vector<std::size_t>& right_projection_map,
-    duckdb::vector<duckdb::LogicalType> delim_types,
+    duckdb::vector<sirius::logical_type> delim_types,
     std::size_t estimated_cardinality,
     duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info,
     uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES);
@@ -88,7 +88,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   void initialize_hash_table(duckdb::ClientContext& context) const;
 
   //! The types of the join keys
-  duckdb::vector<duckdb::LogicalType> condition_types;
+  duckdb::vector<sirius::logical_type> condition_types;
   //! The type of the join
   duckdb::JoinType join_type;
 
@@ -100,7 +100,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   join_projection_columns rhs_output_columns;
 
   //! Duplicate eliminated types; only used for delim_joins (i.e. correlated subqueries)
-  duckdb::vector<duckdb::LogicalType> delim_types;
+  duckdb::vector<sirius::logical_type> delim_types;
 
   mutable bool unique_build_keys = false;
 

--- a/src/include/op/sirius_physical_iceberg_scan.hpp
+++ b/src/include/op/sirius_physical_iceberg_scan.hpp
@@ -46,10 +46,10 @@ class sirius_physical_iceberg_scan : public sirius_physical_parquet_scan {
   explicit sirius_physical_iceberg_scan(sirius_physical_table_scan* table_scan);
 
   /// Full-parameter constructor (mirrors sirius_physical_parquet_scan).
-  sirius_physical_iceberg_scan(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_iceberg_scan(duckdb::vector<sirius::logical_type> types,
                                duckdb::TableFunction function,
                                duckdb::unique_ptr<duckdb::FunctionData> bind_data,
-                               duckdb::vector<duckdb::LogicalType> returned_types,
+                               duckdb::vector<sirius::logical_type> returned_types,
                                duckdb::vector<duckdb::ColumnIndex> column_ids,
                                duckdb::vector<std::size_t> projection_ids,
                                duckdb::vector<std::string> names,

--- a/src/include/op/sirius_physical_limit.hpp
+++ b/src/include/op/sirius_physical_limit.hpp
@@ -32,7 +32,7 @@ class sirius_physical_streaming_limit : public sirius_physical_operator {
     SiriusPhysicalOperatorType::STREAMING_LIMIT;
 
  public:
-  sirius_physical_streaming_limit(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_streaming_limit(duckdb::vector<sirius::logical_type> types,
                                   duckdb::BoundLimitNode limit_val_p,
                                   duckdb::BoundLimitNode offset_val_p,
                                   std::size_t estimated_cardinality,

--- a/src/include/op/sirius_physical_merge_sort.hpp
+++ b/src/include/op/sirius_physical_merge_sort.hpp
@@ -32,7 +32,7 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
  public:
   sirius_physical_merge_sort(sirius_physical_order* order_by);
 
-  sirius_physical_merge_sort(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_merge_sort(duckdb::vector<sirius::logical_type> types,
                              duckdb::vector<duckdb::BoundOrderByNode> orders,
                              duckdb::vector<std::size_t> projections_p,
                              std::size_t estimated_cardinality,
@@ -68,7 +68,7 @@ class sirius_physical_merge_sort : public sirius_physical_operator {
 
   //! Set the final output projection (applied after merge, to remove sort-key-only columns)
   void set_final_projections(duckdb::vector<std::size_t> proj,
-                             duckdb::vector<duckdb::LogicalType> output_types)
+                             duckdb::vector<sirius::logical_type> output_types)
   {
     _final_projections = std::move(proj);
     types              = std::move(output_types);

--- a/src/include/op/sirius_physical_nested_loop_join.hpp
+++ b/src/include/op/sirius_physical_nested_loop_join.hpp
@@ -69,19 +69,19 @@ class sirius_physical_nested_loop_join : public sirius_physical_partition_consum
 
   duckdb::vector<duckdb::JoinCondition> conditions;
   //! The types of the join keys
-  duckdb::vector<duckdb::LogicalType> condition_types;
+  duckdb::vector<sirius::logical_type> condition_types;
   //! The type of the join
   duckdb::JoinType join_type;
 
   //! The indices for getting the payload columns
   duckdb::vector<std::size_t> payload_column_idxs;
   //! The types of the payload columns
-  duckdb::vector<duckdb::LogicalType> payload_types;
+  duckdb::vector<sirius::logical_type> payload_types;
 
   //! Positions of the RHS columns that need to output
   duckdb::vector<std::size_t> rhs_output_columns;
   //! The types of the output
-  duckdb::vector<duckdb::LogicalType> rhs_output_types;
+  duckdb::vector<sirius::logical_type> rhs_output_types;
 
   //! Output column order: indices into left table columns (empty = identity 0,1,...,left_cols-1)
   duckdb::vector<std::size_t> left_output_col_idxs;
@@ -89,7 +89,7 @@ class sirius_physical_nested_loop_join : public sirius_physical_partition_consum
   duckdb::vector<std::size_t> right_output_col_idxs;
 
   //! Duplicate eliminated types; only used for delim_joins (i.e. correlated subqueries)
-  duckdb::vector<duckdb::LogicalType> delim_types;
+  duckdb::vector<sirius::logical_type> delim_types;
 
   duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> filter_pushdown;
 
@@ -116,7 +116,7 @@ class sirius_physical_nested_loop_join : public sirius_physical_partition_consum
 
  public:
   //! Returns a list of the types of the join conditions
-  duckdb::vector<duckdb::LogicalType> get_join_types() const;
+  duckdb::vector<sirius::logical_type> get_join_types() const;
 
   std::unique_ptr<operator_data> get_next_task_input_data() override;
 

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -22,6 +22,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
+#include "helper/logical_type.hpp"
 #include "helper/types.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "sirius/exception.hpp"
@@ -167,7 +168,7 @@ class sirius_physical_operator {
 
  public:
   sirius_physical_operator(SiriusPhysicalOperatorType type,
-                           duckdb::vector<duckdb::LogicalType> types,
+                           duckdb::vector<sirius::logical_type> types,
                            std::size_t estimated_cardinality)
     : type(type),
       types(std::move(types)),
@@ -183,7 +184,7 @@ class sirius_physical_operator {
   //! The set of children of the operator
   duckdb::vector<duckdb::unique_ptr<sirius_physical_operator>> children;
   //! The types returned by this physical operator
-  duckdb::vector<duckdb::LogicalType> types;
+  duckdb::vector<sirius::logical_type> types;
   //! The estimated cardinality of this physical operator
   std::size_t estimated_cardinality;
   //! The unique ID of this operator (auto-incremented at creation)
@@ -204,7 +205,7 @@ class sirius_physical_operator {
   virtual duckdb::vector<duckdb::const_reference<sirius_physical_operator>> get_children() const;
 
   //! Return a vector of the types that will be returned by this operator
-  const duckdb::vector<duckdb::LogicalType>& get_types() const { return types; }
+  const duckdb::vector<sirius::logical_type>& get_types() const { return types; }
 
   //! Get the unique operator ID
   size_t get_operator_id() const { return operator_id; }

--- a/src/include/op/sirius_physical_order.hpp
+++ b/src/include/op/sirius_physical_order.hpp
@@ -38,7 +38,7 @@ class sirius_physical_order : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::ORDER_BY;
 
-  sirius_physical_order(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_order(duckdb::vector<sirius::logical_type> types,
                         duckdb::vector<duckdb::BoundOrderByNode> orders,
                         duckdb::vector<std::size_t> projections_p,
                         std::size_t estimated_cardinality,

--- a/src/include/op/sirius_physical_parquet_scan.hpp
+++ b/src/include/op/sirius_physical_parquet_scan.hpp
@@ -40,10 +40,10 @@ class sirius_physical_parquet_scan : public sirius_physical_operator {
 
   //! Table scan that immediately projects out filter columns that are unused in the remainder of
   //! the query plan
-  sirius_physical_parquet_scan(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_parquet_scan(duckdb::vector<sirius::logical_type> types,
                                duckdb::TableFunction function,
                                duckdb::unique_ptr<duckdb::FunctionData> bind_data,
-                               duckdb::vector<duckdb::LogicalType> returned_types,
+                               duckdb::vector<sirius::logical_type> returned_types,
                                duckdb::vector<duckdb::ColumnIndex> column_ids,
                                duckdb::vector<std::size_t> projection_ids,
                                duckdb::vector<std::string> names,
@@ -65,7 +65,7 @@ class sirius_physical_parquet_scan : public sirius_physical_operator {
   //! Bind data of the function
   duckdb::unique_ptr<duckdb::FunctionData> bind_data;
   //! The types of ALL columns that can be returned by the table function
-  duckdb::vector<duckdb::LogicalType> returned_types;
+  duckdb::vector<sirius::logical_type> returned_types;
   //! The column ids used within the table function
   duckdb::vector<duckdb::ColumnIndex> column_ids;
   //! The projected-out column ids
@@ -95,7 +95,7 @@ class sirius_physical_parquet_scan : public sirius_physical_operator {
 
   bool* already_cached;
 
-  duckdb::vector<duckdb::LogicalType> scanned_types;
+  duckdb::vector<sirius::logical_type> scanned_types;
 
   duckdb::vector<std::size_t> scanned_ids;
 

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -49,7 +49,7 @@ class sirius_physical_partition : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::PARTITION;
 
   explicit sirius_physical_partition(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     std::size_t estimated_cardinality,
     sirius_physical_operator* parent_op,
     bool is_build                 = false,

--- a/src/include/op/sirius_physical_partition_consumer_operator.hpp
+++ b/src/include/op/sirius_physical_partition_consumer_operator.hpp
@@ -26,7 +26,7 @@ namespace op {
 class sirius_physical_partition_consumer_operator : public sirius_physical_operator {
  public:
   sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType type,
-                                              duckdb::vector<duckdb::LogicalType> types,
+                                              duckdb::vector<sirius::logical_type> types,
                                               std::size_t estimated_cardinality)
     : sirius_physical_operator(type, std::move(types), estimated_cardinality)
   {

--- a/src/include/op/sirius_physical_projection.hpp
+++ b/src/include/op/sirius_physical_projection.hpp
@@ -27,7 +27,7 @@ class sirius_physical_projection : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::PROJECTION;
 
  public:
-  sirius_physical_projection(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_projection(duckdb::vector<sirius::logical_type> types,
                              duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
                              std::size_t estimated_cardinality);
 

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -33,7 +33,7 @@ class sirius_physical_sort_partition : public sirius_physical_operator {
  public:
   sirius_physical_sort_partition(sirius_physical_order* order_by);
 
-  sirius_physical_sort_partition(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_sort_partition(duckdb::vector<sirius::logical_type> types,
                                  duckdb::vector<duckdb::BoundOrderByNode> orders,
                                  duckdb::vector<std::size_t> projections_p,
                                  std::size_t estimated_cardinality);

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -37,7 +37,7 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
 
   sirius_physical_sort_sample(sirius_physical_order* order_by);
 
-  sirius_physical_sort_sample(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_sort_sample(duckdb::vector<sirius::logical_type> types,
                               duckdb::vector<duckdb::BoundOrderByNode> orders,
                               std::size_t estimated_cardinality,
                               std::size_t num_sample_batches = DEFAULT_NUM_SAMPLE_BATCHES);

--- a/src/include/op/sirius_physical_table_scan.hpp
+++ b/src/include/op/sirius_physical_table_scan.hpp
@@ -58,10 +58,10 @@ class sirius_physical_table_scan : public sirius_physical_operator {
  public:
   //! Table scan that immediately projects out filter columns that are unused in the remainder of
   //! the query plan
-  sirius_physical_table_scan(duckdb::vector<duckdb::LogicalType> types,
+  sirius_physical_table_scan(duckdb::vector<sirius::logical_type> types,
                              duckdb::TableFunction function,
                              duckdb::unique_ptr<duckdb::FunctionData> bind_data,
-                             duckdb::vector<duckdb::LogicalType> returned_types,
+                             duckdb::vector<sirius::logical_type> returned_types,
                              duckdb::vector<duckdb::ColumnIndex> column_ids,
                              duckdb::vector<std::size_t> projection_ids,
                              duckdb::vector<std::string> names,
@@ -76,7 +76,7 @@ class sirius_physical_table_scan : public sirius_physical_operator {
   //! Bind data of the function
   duckdb::unique_ptr<duckdb::FunctionData> bind_data;
   //! The types of ALL columns that can be returned by the table function
-  duckdb::vector<duckdb::LogicalType> returned_types;
+  duckdb::vector<sirius::logical_type> returned_types;
   //! The column ids used within the table function
   duckdb::vector<duckdb::ColumnIndex> column_ids;
   //! The projected-out column ids
@@ -106,7 +106,7 @@ class sirius_physical_table_scan : public sirius_physical_operator {
 
   bool* already_cached;
 
-  duckdb::vector<duckdb::LogicalType> scanned_types;
+  duckdb::vector<sirius::logical_type> scanned_types;
 
   duckdb::vector<std::size_t> scanned_ids;
 

--- a/src/include/op/sirius_physical_top_n.hpp
+++ b/src/include/op/sirius_physical_top_n.hpp
@@ -37,7 +37,7 @@ class sirius_physical_top_n : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::TOP_N;
 
  public:
-  sirius_physical_top_n(duckdb::vector<duckdb::LogicalType> types_p,
+  sirius_physical_top_n(duckdb::vector<sirius::logical_type> types_p,
                         duckdb::vector<duckdb::BoundOrderByNode> orders,
                         std::size_t limit,
                         std::size_t offset,

--- a/src/include/op/sirius_physical_top_n_merge.hpp
+++ b/src/include/op/sirius_physical_top_n_merge.hpp
@@ -36,7 +36,7 @@ class sirius_physical_top_n_merge : public sirius_physical_operator {
  public:
   sirius_physical_top_n_merge(sirius_physical_top_n* top_n);
 
-  sirius_physical_top_n_merge(duckdb::vector<duckdb::LogicalType> types_p,
+  sirius_physical_top_n_merge(duckdb::vector<sirius::logical_type> types_p,
                               duckdb::vector<duckdb::BoundOrderByNode> orders,
                               std::size_t limit,
                               std::size_t offset,

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -33,7 +33,7 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
 
  public:
   sirius_physical_ungrouped_aggregate(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
     std::size_t estimated_cardinality,
     duckdb::TupleDataValidityType distinct_validity);

--- a/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
@@ -37,7 +37,7 @@ class sirius_physical_ungrouped_aggregate_merge : public sirius_physical_operato
     sirius_physical_ungrouped_aggregate* ungrouped_aggregate);
 
   sirius_physical_ungrouped_aggregate_merge(
-    duckdb::vector<duckdb::LogicalType> types,
+    duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
     std::size_t estimated_cardinality,
     duckdb::TupleDataValidityType distinct_validity);

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -15,6 +15,7 @@
  */
 
 // sirius
+#include <helper/type_conversions.hpp>
 #include <helper/utils.hpp>
 #include <op/result/host_table_chunk_reader.hpp>
 
@@ -221,8 +222,10 @@ void host_table_chunk_reader::column_reader::copy_string(
 host_table_chunk_reader::host_table_chunk_reader(
   duckdb::ClientContext& client_ctx,
   cucascade::host_data_representation const& host_table,
-  duckdb::vector<duckdb::LogicalType> const& types_p)
-  : _client_ctx(client_ctx), _allocation(host_table.get_host_table()->allocation), _types(types_p)
+  duckdb::vector<sirius::logical_type> const& types_p)
+  : _client_ctx(client_ctx),
+    _allocation(host_table.get_host_table()->allocation),
+    _types(sirius::to_duckdb_vec(types_p))
 {
   if (!host_table.get_host_table().get()) {
     throw std::runtime_error(

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -21,6 +21,7 @@
 #include <cudf/cudf_utils.hpp>
 
 #include <data/data_batch_utils.hpp>
+#include <helper/type_conversions.hpp>
 #include <helper/utils.hpp>
 #include <log/logging.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
@@ -81,13 +82,11 @@ duckdb_scan_task_global_state::duckdb_scan_task_global_state(
 //===----------------------------------------------------------------------===//
 // duckdb_scan_task_local_state::column_builder
 //===----------------------------------------------------------------------===//
-duckdb_scan_task_local_state::column_builder::column_builder(duckdb::LogicalType t,
+duckdb_scan_task_local_state::column_builder::column_builder(sirius::logical_type t,
                                                              size_t default_varchar_size)
   : type(t)
 {
-  type_size = t.InternalType() == duckdb::PhysicalType::VARCHAR
-                ? default_varchar_size
-                : duckdb::GetTypeIdSize(t.InternalType());
+  type_size = t.is_varchar() ? default_varchar_size : t.fixed_width_byte_size();
 }
 
 void duckdb_scan_task_local_state::column_builder::initialize_accessors(
@@ -98,7 +97,7 @@ void duckdb_scan_task_local_state::column_builder::initialize_accessors(
   assert(allocation != nullptr);
   assert(!allocation->get_blocks().empty());
 
-  if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+  if (type.is_varchar()) {
     // Initialize offset accessor
     offset_blocks_accessor.initialize(byte_offset, allocation);
     // Write the initial offset value of 0
@@ -123,7 +122,7 @@ bool duckdb_scan_task_local_state::column_builder::sufficient_space_for_column(
   duckdb::Vector& vec, duckdb::ValidityMask const& validity, size_t num_rows)
 {
   size_t data_bytes = 0;
-  if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+  if (type.is_varchar()) {
     auto const* str_data = reinterpret_cast<duckdb::string_t const*>(vec.GetData());
     for (size_t row = 0; row < num_rows; ++row) {
       if (validity.RowIsValid(row)) { data_bytes += str_data[row].GetSize(); }
@@ -227,7 +226,7 @@ void duckdb_scan_task_local_state::column_builder::process_column(
   std::unique_ptr<multiple_blocks_allocation>& allocation)
 {
   // PRECONDITION: Vector must be flattened
-  if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+  if (type.is_varchar()) {
     size_t data_bytes    = 0;
     auto const* str_data = reinterpret_cast<duckdb::string_t const*>(vec.GetData());
     for (size_t row = 0; row < num_rows; ++row) {
@@ -263,7 +262,7 @@ duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_ro
 {
   using cucascade::memory::column_metadata;
 
-  if (type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+  if (type.is_varchar()) {
     // VARCHAR column: data buffer + offsets child
     column_metadata offsets_child{};
     offsets_child.type_id          = cudf::type_id::INT32;
@@ -292,7 +291,7 @@ duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_ro
     return col;
   } else {
     // Fixed-width column
-    auto cudf_type = duckdb::GetCudfType(type);
+    auto cudf_type = sirius::get_cudf_type(type);
 
     column_metadata col{};
     col.type_id          = cudf_type.id();
@@ -378,11 +377,11 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_duckd
   for (size_t i = 0; i < _num_columns; ++i) {
     auto const col_type = op.scanned_types[i];
     _column_builders.emplace_back(col_type, _default_varchar_size);
-    if (col_type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+    if (col_type.is_varchar()) {
       _varchar_indices.push_back(i);
       estimated_row_bytes += (sizeof(int32_t) + _default_varchar_size);  // offset + data + mask
     } else {
-      estimated_row_bytes += duckdb::GetTypeIdSize(col_type.InternalType());  // data + mask
+      estimated_row_bytes += col_type.fixed_width_byte_size();  // data + mask
     }
   }
 
@@ -411,7 +410,7 @@ void duckdb_scan_task_local_state::initialize_builders()
     byte_offset = (byte_offset + 7) & ~size_t{7};
     _column_builders[i].initialize_accessors(_estimated_rows_per_batch, byte_offset, _allocation);
     // Update byte_offset for next column
-    if (_column_builders[i].type.InternalType() == duckdb::PhysicalType::VARCHAR) {
+    if (_column_builders[i].type.is_varchar()) {
       // VARCHAR column (offsets + data + mask)
       byte_offset += (_estimated_rows_per_batch + 1) * sizeof(int32_t) +
                      _estimated_rows_per_batch * _default_varchar_size +
@@ -560,7 +559,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   // Initialize the data chunk with scanned_types (all projected columns, including ROW_ID).
   // This matches the column_ids and projection_ids passed to DuckDB's init functions.
   l_state._chunk.Initialize(duckdb::Allocator::Get(l_state._exec_ctx.client),
-                            g_state._op.scanned_types);
+                            sirius::to_duckdb_vec(g_state._op.scanned_types));
 
   // Enter the scan loop to accumulate a data batch
   while (get_next_chunk(l_state, g_state)) {

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -17,6 +17,7 @@
 // sirius
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <helper/type_conversions.hpp>
 #include <log/logging.hpp>
 #include <op/scan/scan_utils.hpp>
 
@@ -55,7 +56,7 @@ std::vector<duckdb::idx_t> build_batch_column_map(
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
-  const duckdb::vector<duckdb::LogicalType>& returned_types,
+  const duckdb::vector<sirius::logical_type>& returned_types,
   const std::vector<duckdb::idx_t>& batch_column_map)
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> filter_expressions;
@@ -85,7 +86,7 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
     SIRIUS_LOG_DEBUG("TABLE_SCAN filter: column_index={}, primary_idx={}, type={}, filter_type={}",
                      column_index,
                      primary_idx,
-                     col_type.ToString(),
+                     col_type.to_string(),
                      static_cast<int>(filter->filter_type));
 
     auto batch_column_index = batch_column_map[column_index];
@@ -96,8 +97,8 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
 
     SIRIUS_LOG_DEBUG("TABLE_SCAN filter: batch_column_index={}", batch_column_index);
 
-    auto column_ref =
-      duckdb::make_uniq<duckdb::BoundReferenceExpression>(col_type, batch_column_index);
+    auto column_ref = duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+      sirius::to_duckdb(col_type), batch_column_index);
     auto expr = filter->ToExpression(*column_ref);
     filter_expressions.push_back(std::move(expr));
   }

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -39,7 +39,7 @@ namespace sirius::op::scan {
 // Constructor
 //===----------------------------------------------------------------------===//
 sirius_gpu_parquet_scan_operator::sirius_gpu_parquet_scan_operator(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::idx_t estimated_cardinality,
   cucascade::memory::memory_space& gpu_memory_space)
   : sirius_physical_operator(

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<cudf::io::datasource::buffer> fetch_footer_to_host_fallback(
 // Constructor
 //===----------------------------------------------------------------------===//
 sirius_parquet_metadata_scan_operator::sirius_parquet_metadata_scan_operator(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::idx_t estimated_cardinality,
   std::vector<std::string> const& file_paths,
   duckdb::vector<duckdb::ColumnIndex> const& column_ids,

--- a/src/op/sirius_physical_column_data_scan.cpp
+++ b/src/op/sirius_physical_column_data_scan.cpp
@@ -28,7 +28,7 @@ namespace sirius {
 namespace op {
 
 sirius_physical_column_data_scan::sirius_physical_column_data_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   SiriusPhysicalOperatorType op_type,
   std::size_t estimated_cardinality,
   duckdb::optionally_owned_ptr<duckdb::ColumnDataCollection> collection_p)
@@ -39,7 +39,7 @@ sirius_physical_column_data_scan::sirius_physical_column_data_scan(
 }
 
 sirius_physical_column_data_scan::sirius_physical_column_data_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   SiriusPhysicalOperatorType op_type,
   std::size_t estimated_cardinality,
   std::size_t cte_index)

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -25,7 +25,7 @@
 namespace sirius {
 namespace op {
 
-sirius_physical_concat::sirius_physical_concat(duckdb::vector<duckdb::LogicalType> types,
+sirius_physical_concat::sirius_physical_concat(duckdb::vector<sirius::logical_type> types,
                                                std::size_t estimated_cardinality,
                                                sirius_physical_operator* parent_op,
                                                bool is_build,

--- a/src/op/sirius_physical_cte.cpp
+++ b/src/op/sirius_physical_cte.cpp
@@ -29,7 +29,7 @@ namespace op {
 
 sirius_physical_cte::sirius_physical_cte(std::string ctename,
                                          std::size_t table_index,
-                                         duckdb::vector<duckdb::LogicalType> types,
+                                         duckdb::vector<sirius::logical_type> types,
                                          duckdb::unique_ptr<sirius_physical_operator> top,
                                          duckdb::unique_ptr<sirius_physical_operator> bottom,
                                          std::size_t estimated_cardinality)

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -43,7 +43,7 @@ class sirius_right_delim_join_local_state : public duckdb::LocalSinkState {
 
 sirius_physical_delim_join::sirius_physical_delim_join(
   SiriusPhysicalOperatorType type,
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::unique_ptr<sirius_physical_operator> original_join,
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
   std::size_t estimated_cardinality,
@@ -57,7 +57,7 @@ sirius_physical_delim_join::sirius_physical_delim_join(
 }
 
 sirius_physical_right_delim_join::sirius_physical_right_delim_join(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::unique_ptr<sirius_physical_operator> original_join,
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
   std::size_t estimated_cardinality,
@@ -77,7 +77,7 @@ sirius_physical_right_delim_join::sirius_physical_right_delim_join(
 }
 
 sirius_physical_left_delim_join::sirius_physical_left_delim_join(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::unique_ptr<sirius_physical_operator> original_join,
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans,
   std::size_t estimated_cardinality,

--- a/src/op/sirius_physical_duckdb_scan.cpp
+++ b/src/op/sirius_physical_duckdb_scan.cpp
@@ -52,10 +52,10 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(sirius_physical_table_s
 }
 
 sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::TableFunction function_p,
   duckdb::unique_ptr<duckdb::FunctionData> bind_data_p,
-  duckdb::vector<duckdb::LogicalType> returned_types_p,
+  duckdb::vector<sirius::logical_type> returned_types_p,
   duckdb::vector<duckdb::ColumnIndex> column_ids_p,
   duckdb::vector<std::size_t> projection_ids_p,
   duckdb::vector<std::string> names_p,
@@ -100,7 +100,7 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
     for (auto pid : projection_ids) {
       auto col_idx = column_ids[pid].GetPrimaryIndex();
       if (column_ids[pid].IsRowIdColumn()) {
-        scanned_types.push_back(duckdb::LogicalType::BIGINT);
+        scanned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
       } else {
         scanned_types.push_back(returned_types[col_idx]);
       }
@@ -110,7 +110,7 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
     for (std::size_t i = 0; i < num_cols; i++) {
       auto col_idx = column_ids[i].GetPrimaryIndex();
       if (column_ids[i].IsRowIdColumn()) {
-        scanned_types.push_back(duckdb::LogicalType::BIGINT);
+        scanned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
       } else {
         scanned_types.push_back(returned_types[col_idx]);
       }
@@ -118,7 +118,7 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(
   }
 
   if (scanned_types.empty()) {
-    scanned_types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
+    scanned_types.push_back(sirius::logical_type::make(sirius::type_id::BIGINT));
   }
 
   fake_table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -28,7 +28,7 @@ namespace sirius {
 namespace op {
 
 sirius_physical_filter::sirius_physical_filter(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
   std::size_t estimated_cardinality)
   : sirius_physical_operator(

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -48,7 +48,7 @@ namespace op {
 
 sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   duckdb::ClientContext& context,
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups_p,
   std::size_t estimated_cardinality)
@@ -73,7 +73,7 @@ sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
 // grouping set and the second level is the indexes to the groupby expression for that set.
 sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   duckdb::ClientContext& context,
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups_p,
   duckdb::vector<duckdb::GroupingSet> grouping_sets_p,

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -15,6 +15,7 @@
  */
 #include "op/sirius_physical_grouped_aggregate_merge.hpp"
 
+#include "cudf/cudf_utils.hpp"
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "op/aggregate/aggregate_op_util.hpp"
@@ -94,7 +95,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
 }
 
 sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   std::vector<int> group_idx,
   std::vector<cudf::aggregation::Kind> cudf_aggregates,
   std::vector<int> cudf_aggregate_idx,
@@ -117,7 +118,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
 
 sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge(
   duckdb::ClientContext& context,
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups_p,
   std::size_t estimated_cardinality)
@@ -142,7 +143,7 @@ sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge
 // grouping set and the second level is the indexes to the groupby expression for that set.
 sirius_physical_grouped_aggregate_merge::sirius_physical_grouped_aggregate_merge(
   duckdb::ClientContext& context,
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups_p,
   duckdb::vector<duckdb::GroupingSet> grouping_sets_p,
@@ -249,9 +250,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
       auto count_view = merged_cols[count_col_idx]->view();
 
       std::unique_ptr<cudf::column> avg_col;
-      bool is_decimal = (slot.output_type.id() == cudf::type_id::DECIMAL32 ||
-                         slot.output_type.id() == cudf::type_id::DECIMAL64 ||
-                         slot.output_type.id() == cudf::type_id::DECIMAL128);
+      bool is_decimal = sirius::IsCudfTypeDecimal(slot.output_type);
       if (is_decimal) {
         // DECIMAL: divide directly in fixed-point to preserve precision
         avg_col = cudf::binary_operation(

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -30,6 +30,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "expression_executor/gpu_expression_translator.hpp"
+#include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -156,12 +157,13 @@ sirius_physical_hash_join::sirius_physical_hash_join(
   duckdb::JoinType join_type,
   const duckdb::vector<std::size_t>& left_projection_map,
   const duckdb::vector<std::size_t>& right_projection_map,
-  duckdb::vector<duckdb::LogicalType> delim_types,
+  duckdb::vector<sirius::logical_type> delim_types,
   std::size_t estimated_cardinality,
   duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p,
   uint64_t max_build_hash_table_bytes)
-  : sirius_physical_partition_consumer_operator(
-      SiriusPhysicalOperatorType::HASH_JOIN, op.types, estimated_cardinality),
+  : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::HASH_JOIN,
+                                                sirius::from_duckdb_vec(op.types),
+                                                estimated_cardinality),
     conditions(std::move(cond)),
     join_type(join_type),
     delim_types(std::move(delim_types))

--- a/src/op/sirius_physical_iceberg_scan.cpp
+++ b/src/op/sirius_physical_iceberg_scan.cpp
@@ -37,10 +37,10 @@ sirius_physical_iceberg_scan::sirius_physical_iceberg_scan(sirius_physical_table
 }
 
 sirius_physical_iceberg_scan::sirius_physical_iceberg_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::TableFunction function_p,
   duckdb::unique_ptr<duckdb::FunctionData> bind_data_p,
-  duckdb::vector<duckdb::LogicalType> returned_types_p,
+  duckdb::vector<sirius::logical_type> returned_types_p,
   duckdb::vector<duckdb::ColumnIndex> column_ids_p,
   duckdb::vector<std::size_t> projection_ids_p,
   duckdb::vector<std::string> names_p,

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -29,7 +29,7 @@ namespace sirius {
 namespace op {
 
 sirius_physical_streaming_limit::sirius_physical_streaming_limit(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::BoundLimitNode limit_val_p,
   duckdb::BoundLimitNode offset_val_p,
   std::size_t estimated_cardinality,

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -39,7 +39,7 @@ sirius_physical_merge_sort::sirius_physical_merge_sort(sirius_physical_order* or
 }
 
 sirius_physical_merge_sort::sirius_physical_merge_sort(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   duckdb::vector<std::size_t> projections_p,
   std::size_t estimated_cardinality,

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "expression_executor/gpu_expression_executor_state.hpp"
+#include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
@@ -87,8 +88,9 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   duckdb::vector<duckdb::JoinCondition> cond,
   duckdb::JoinType join_type,
   std::size_t estimated_cardinality)
-  : sirius_physical_partition_consumer_operator(
-      SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, op.types, estimated_cardinality),
+  : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
+                                                sirius::from_duckdb_vec(op.types),
+                                                estimated_cardinality),
     join_type(join_type),
     conditions(std::move(cond))
 {
@@ -116,8 +118,9 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   duckdb::JoinType join_type,
   std::size_t estimated_cardinality,
   duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p)
-  : sirius_physical_partition_consumer_operator(
-      SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, op.types, estimated_cardinality),
+  : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
+                                                sirius::from_duckdb_vec(op.types),
+                                                estimated_cardinality),
     join_type(join_type),
     conditions(std::move(cond))
 {
@@ -146,8 +149,9 @@ sirius_physical_nested_loop_join::sirius_physical_nested_loop_join(
   std::size_t estimated_cardinality,
   duckdb::vector<std::size_t> left_projection_map,
   duckdb::vector<std::size_t> right_projection_map)
-  : sirius_physical_partition_consumer_operator(
-      SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, op.types, estimated_cardinality),
+  : sirius_physical_partition_consumer_operator(SiriusPhysicalOperatorType::NESTED_LOOP_JOIN,
+                                                sirius::from_duckdb_vec(op.types),
+                                                estimated_cardinality),
     join_type(join_type),
     conditions(std::move(cond))
 {
@@ -193,11 +197,11 @@ bool sirius_physical_nested_loop_join::is_supported(
   return true;
 }
 
-duckdb::vector<duckdb::LogicalType> sirius_physical_nested_loop_join::get_join_types() const
+duckdb::vector<sirius::logical_type> sirius_physical_nested_loop_join::get_join_types() const
 {
-  duckdb::vector<duckdb::LogicalType> result;
+  duckdb::vector<sirius::logical_type> result;
   for (auto& op : conditions) {
-    result.push_back(op.right->return_type);
+    result.push_back(sirius::from_duckdb(op.right->return_type));
   }
   return result;
 }

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -25,7 +25,7 @@
 namespace sirius {
 namespace op {
 
-sirius_physical_order::sirius_physical_order(duckdb::vector<duckdb::LogicalType> types,
+sirius_physical_order::sirius_physical_order(duckdb::vector<sirius::logical_type> types,
                                              duckdb::vector<duckdb::BoundOrderByNode> orders,
                                              duckdb::vector<std::size_t> projections_p,
                                              std::size_t estimated_cardinality,

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -54,10 +54,10 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(sirius_physical_table
 }
 
 sirius_physical_parquet_scan::sirius_physical_parquet_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::TableFunction function_p,
   duckdb::unique_ptr<duckdb::FunctionData> bind_data_p,
-  duckdb::vector<duckdb::LogicalType> returned_types_p,
+  duckdb::vector<sirius::logical_type> returned_types_p,
   duckdb::vector<duckdb::ColumnIndex> column_ids_p,
   duckdb::vector<std::size_t> projection_ids_p,
   duckdb::vector<std::string> names_p,

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -50,7 +50,7 @@ std::optional<std::size_t> extract_bound_ref_index(const duckdb::Expression& exp
 
 }  // namespace
 
-sirius_physical_partition::sirius_physical_partition(duckdb::vector<duckdb::LogicalType> types,
+sirius_physical_partition::sirius_physical_partition(duckdb::vector<sirius::logical_type> types,
                                                      std::size_t estimated_cardinality,
                                                      sirius_physical_operator* parent_op,
                                                      bool is_build,

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -27,7 +27,7 @@ namespace sirius {
 namespace op {
 
 sirius_physical_projection::sirius_physical_projection(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list,
   std::size_t estimated_cardinality)
   : sirius_physical_operator(

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -19,6 +19,7 @@
 #include <nvtx3/nvtx3.hpp>
 
 #include <data/sirius_converter_registry.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/result/host_table_chunk_reader.hpp>
 #include <op/sirius_physical_result_collector.hpp>
 #include <pipeline/sirius_meta_pipeline.hpp>
@@ -47,14 +48,15 @@ namespace op {
 
 sirius_physical_result_collector::sirius_physical_result_collector(
   ::sirius::sirius_prepared_statement_data& data)
-  : sirius_physical_operator(
-      SiriusPhysicalOperatorType::RESULT_COLLECTOR, {duckdb::LogicalType::BOOLEAN}, 0),
+  : sirius_physical_operator(SiriusPhysicalOperatorType::RESULT_COLLECTOR,
+                             {sirius::logical_type::make(sirius::type_id::BOOLEAN)},
+                             0),
     statement_type(data.prepared->statement_type),
     properties(data.prepared->properties),
     plan(*data.sirius_physical_plan),
     names(data.prepared->names)
 {
-  this->types = data.prepared->types;
+  this->types = sirius::from_duckdb_vec(data.prepared->types);
 }
 
 std::unique_ptr<operator_data> sirius_physical_result_collector::execute(
@@ -90,7 +92,8 @@ sirius_physical_materialized_collector::sirius_physical_materialized_collector(
   ::sirius::sirius_prepared_statement_data& data, duckdb::ClientContext& client_ctx)
   : sirius_physical_result_collector(data),
     _client_ctx(client_ctx),
-    result_collection(duckdb::make_uniq<duckdb::ColumnDataCollection>(client_ctx, types))
+    result_collection(
+      duckdb::make_uniq<duckdb::ColumnDataCollection>(client_ctx, sirius::to_duckdb_vec(types)))
 {
 }
 
@@ -101,7 +104,8 @@ duckdb::unique_ptr<duckdb::QueryResult> sirius_physical_materialized_collector::
   std::lock_guard<std::mutex> guard(lock);
   // Return an empty result collection if the result_collection is null (from a move)
   if (!result_collection) {
-    result_collection = duckdb::make_uniq<duckdb::ColumnDataCollection>(_client_ctx, types);
+    result_collection =
+      duckdb::make_uniq<duckdb::ColumnDataCollection>(_client_ctx, sirius::to_duckdb_vec(types));
   }
 
   return duckdb::make_uniq<duckdb::MaterializedQueryResult>(
@@ -190,7 +194,8 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       std::lock_guard<std::mutex> guard(lock);
       // Initialize result collection if it is null (from a move)
       if (!result_collection) {
-        result_collection = duckdb::make_uniq<duckdb::ColumnDataCollection>(_client_ctx, types);
+        result_collection = duckdb::make_uniq<duckdb::ColumnDataCollection>(
+          _client_ctx, sirius::to_duckdb_vec(types));
       }
       result_collection->Append(chunk);
     }

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -39,7 +39,7 @@ sirius_physical_sort_partition::sirius_physical_sort_partition(sirius_physical_o
 }
 
 sirius_physical_sort_partition::sirius_physical_sort_partition(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   duckdb::vector<std::size_t> projections_p,
   std::size_t estimated_cardinality)

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -37,7 +37,7 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* 
 }
 
 sirius_physical_sort_sample::sirius_physical_sort_sample(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   std::size_t estimated_cardinality,
   std::size_t num_sample_batches)

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -34,17 +34,16 @@
 namespace sirius {
 namespace op {
 
-uint64_t get_chunk_data_byte_size(duckdb::LogicalType type, std::size_t cardinality)
+uint64_t get_chunk_data_byte_size(sirius::logical_type type, std::size_t cardinality)
 {
-  auto physical_size = duckdb::GetTypeIdSize(type.InternalType());
-  return cardinality * physical_size;
+  return cardinality * type.fixed_width_byte_size();
 }
 
 sirius_physical_table_scan::sirius_physical_table_scan(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::TableFunction function_p,
   duckdb::unique_ptr<duckdb::FunctionData> bind_data_p,
-  duckdb::vector<duckdb::LogicalType> returned_types_p,
+  duckdb::vector<sirius::logical_type> returned_types_p,
   duckdb::vector<duckdb::ColumnIndex> column_ids_p,
   duckdb::vector<std::size_t> projection_ids_p,
   duckdb::vector<std::string> names_p,

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<cudf::table> compute_top_n_table(
 }  // namespace
 
 sirius_physical_top_n::sirius_physical_top_n(
-  duckdb::vector<duckdb::LogicalType> types_p,
+  duckdb::vector<sirius::logical_type> types_p,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   std::size_t limit,
   std::size_t offset,
@@ -202,7 +202,7 @@ sirius_physical_top_n_merge::sirius_physical_top_n_merge(sirius_physical_top_n* 
 }
 
 sirius_physical_top_n_merge::sirius_physical_top_n_merge(
-  duckdb::vector<duckdb::LogicalType> types_p,
+  duckdb::vector<sirius::logical_type> types_p,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   std::size_t limit,
   std::size_t offset,

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -49,7 +49,7 @@ namespace sirius {
 namespace op {
 
 sirius_physical_ungrouped_aggregate::sirius_physical_ungrouped_aggregate(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   std::size_t estimated_cardinality,
   duckdb::TupleDataValidityType distinct_validity)
@@ -233,9 +233,7 @@ std::unique_ptr<cudf::column> make_avg_column(const cudf::column_view& sum_view,
   // The sum column type may differ from the return type (e.g., sum is DECIMAL64 but
   // DuckDB's avg return type is DOUBLE).
   long double sum_host = 0.0L;
-  bool sum_is_decimal =
-    (sum_type.id() == cudf::type_id::DECIMAL32 || sum_type.id() == cudf::type_id::DECIMAL64 ||
-     sum_type.id() == cudf::type_id::DECIMAL128);
+  bool sum_is_decimal  = sirius::IsCudfTypeDecimal(sum_type);
   if (sum_is_decimal) {
     auto denom = std::pow(10.0L, static_cast<long double>(-sum_type.scale()));
     switch (sum_type.id()) {
@@ -396,9 +394,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
           // cuDF requires output type == input type for fixed-point (decimal) reductions.
           // For AVG we use input type and apply return type in the merge step (SUM/COUNT).
           // For SUM we widen (expected by duckdb) before the aggregation to avoid overflow.
-          bool is_decimal = (col.type().id() == cudf::type_id::DECIMAL32 ||
-                             col.type().id() == cudf::type_id::DECIMAL64 ||
-                             col.type().id() == cudf::type_id::DECIMAL128);
+          bool is_decimal = sirius::IsCudfTypeDecimal(col.type());
 
           std::unique_ptr<cudf::column> casted_col;
           if (spec.kind == aggregate_kind::SUM) {
@@ -473,7 +469,7 @@ sirius_physical_ungrouped_aggregate_merge::sirius_physical_ungrouped_aggregate_m
 }
 
 sirius_physical_ungrouped_aggregate_merge::sirius_physical_ungrouped_aggregate_merge(
-  duckdb::vector<duckdb::LogicalType> types,
+  duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> expressions,
   std::size_t estimated_cardinality,
   duckdb::TupleDataValidityType distinct_validity)

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -64,7 +64,7 @@ void validate_operator_output_types(const op::operator_data* data,
       return;
     }
     for (cudf::size_type c = 0; c < tbl.num_columns(); c++) {
-      cudf::data_type expected_cudf = duckdb::GetCudfType(expected_types[c]);
+      cudf::data_type expected_cudf = sirius::get_cudf_type(expected_types[c]);
       cudf::data_type actual        = tbl.column(c).type();
       if (actual != expected_cudf) {
         SIRIUS_LOG_WARN(

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -512,7 +512,7 @@ void sirius_pipeline_converter::split_order_by_sink(
       }
     }
     if (!is_identity) {
-      duckdb::vector<duckdb::LogicalType> output_types;
+      duckdb::vector<sirius::logical_type> output_types;
       for (auto idx : original_projections) {
         output_types.push_back(order_ptr->types[idx]);
       }

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_grouped_aggregate.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_table_scan.hpp"
@@ -270,7 +271,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     if (can_use_simple_aggregation) {
       auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
                                              sirius::op::sirius_physical_ungrouped_aggregate>(
-        op.types, std::move(op.expressions), op.estimated_cardinality, op.distinct_validity);
+        sirius::from_duckdb_vec(op.types),
+        std::move(op.expressions),
+        op.estimated_cardinality,
+        op.distinct_validity);
       group_by->children.push_back(std::move(plan));
       return group_by;
     }
@@ -296,7 +300,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
                                            sirius::op::sirius_physical_grouped_aggregate>(
       context,
-      op.types,
+      sirius::from_duckdb_vec(op.types),
       std::move(op.expressions),
       std::move(op.groups),
       std::move(op.grouping_sets),
@@ -318,7 +322,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
     auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
                                            sirius::op::sirius_physical_grouped_aggregate>(
       context,
-      op.types,
+      sirius::from_duckdb_vec(op.types),
       std::move(op.expressions),
       std::move(op.groups),
       std::move(op.grouping_sets),
@@ -333,7 +337,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalAggregate& op)
   auto group_by = duckdb::make_uniq_base<sirius::op::sirius_physical_operator,
                                          sirius::op::sirius_physical_grouped_aggregate>(
     context,
-    op.types,
+    sirius::from_duckdb_vec(op.types),
     std::move(op.expressions),
     std::move(op.groups),
     std::move(op.grouping_sets),
@@ -390,7 +394,7 @@ sirius_physical_plan_generator::extract_aggregate_expressions(
   }
   if (expressions.empty()) { return child; }
   auto projection = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
-    std::move(types), std::move(expressions), child->estimated_cardinality);
+    sirius::from_duckdb_vec(types), std::move(expressions), child->estimated_cardinality);
   projection->children.push_back(std::move(child));
   return std::move(projection);
 }

--- a/src/planner/sirius_plan_column_data_get.cpp
+++ b/src/planner/sirius_plan_column_data_get.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -27,7 +28,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalColumnDataGet& op)
   D_ASSERT(op.collection);
 
   return duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-    op.types,
+    sirius::from_duckdb_vec(op.types),
     sirius::op::SiriusPhysicalOperatorType::COLUMN_DATA_SCAN,
     op.estimated_cardinality,
     std::move(op.collection));

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_nested_loop_join.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
@@ -318,7 +319,7 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       op.join_type,
       op.left_projection_map,
       op.right_projection_map,
-      std::move(op.mark_types),
+      sirius::from_duckdb_vec(op.mark_types),
       op.estimated_cardinality,
       std::move(op.filter_pushdown),
       op_params.max_build_hash_table_bytes);

--- a/src/planner/sirius_plan_delim_get.cpp
+++ b/src/planner/sirius_plan_delim_get.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_delim_get.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -27,7 +28,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalDelimGet& op)
 
   // create a PhysicalChunkScan without an owned_collection, the collection will be added later
   auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-    op.types,
+    sirius::from_duckdb_vec(op.types),
     sirius::op::SiriusPhysicalOperatorType::DELIM_SCAN,
     op.estimated_cardinality,
     nullptr);

--- a/src/planner/sirius_plan_delim_join.cpp
+++ b/src/planner/sirius_plan_delim_join.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "op/sirius_physical_delim_join.hpp"
@@ -76,14 +77,14 @@ sirius_physical_plan_generator::plan_delim_join(duckdb::LogicalComparisonJoin& o
   duckdb::unique_ptr<sirius::op::sirius_physical_delim_join> delim_join;
   if (op.delim_flipped) {
     delim_join = duckdb::make_uniq<sirius::op::sirius_physical_right_delim_join>(
-      op.types,
+      sirius::from_duckdb_vec(op.types),
       std::move(plan),
       delim_scans,
       op.estimated_cardinality,
       duckdb::optional_idx(this->delim_index));
   } else {
     delim_join = duckdb::make_uniq<sirius::op::sirius_physical_left_delim_join>(
-      op.types,
+      sirius::from_duckdb_vec(op.types),
       std::move(plan),
       delim_scans,
       op.estimated_cardinality,
@@ -93,7 +94,7 @@ sirius_physical_plan_generator::plan_delim_join(duckdb::LogicalComparisonJoin& o
   // chunk
   delim_join->distinct = duckdb::make_uniq<sirius::op::sirius_physical_grouped_aggregate>(
     context,
-    delim_types,
+    sirius::from_duckdb_vec(delim_types),
     std::move(distinct_expressions),
     std::move(distinct_groups),
     op.estimated_cardinality);

--- a/src/planner/sirius_plan_dummy_scan.cpp
+++ b/src/planner/sirius_plan_dummy_scan.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_dummy_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -24,8 +25,8 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalDummyScan& op)
 {
   D_ASSERT(op.children.size() == 0);
-  return duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(op.types,
-                                                                   op.estimated_cardinality);
+  return duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(
+    sirius::from_duckdb_vec(op.types), op.estimated_cardinality);
 }
 
 }  // namespace sirius::planner

--- a/src/planner/sirius_plan_empty_result.cpp
+++ b/src/planner/sirius_plan_empty_result.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_empty_result.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_empty_result.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -24,8 +25,8 @@ duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::create_plan(duckdb::LogicalEmptyResult& op)
 {
   D_ASSERT(op.children.size() == 0);
-  return duckdb::make_uniq<sirius::op::sirius_physical_empty_result>(op.types,
-                                                                     op.estimated_cardinality);
+  return duckdb::make_uniq<sirius::op::sirius_physical_empty_result>(
+    sirius::from_duckdb_vec(op.types), op.estimated_cardinality);
 }
 
 }  // namespace sirius::planner

--- a/src/planner/sirius_plan_expression_get.cpp
+++ b/src/planner/sirius_plan_expression_get.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_expression_get.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -48,7 +49,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalExpressionGet& op)
   }
 
   auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-    op.types,
+    sirius::from_duckdb_vec(op.types),
     sirius::op::SiriusPhysicalOperatorType::COLUMN_DATA_SCAN,
     op.expressions.size(),
     std::move(collection));

--- a/src/planner/sirius_plan_filter.cpp
+++ b/src/planner/sirius_plan_filter.cpp
@@ -16,6 +16,7 @@
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_filter.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
@@ -43,7 +44,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalFilter& op)
         duckdb::make_uniq<duckdb::BoundReferenceExpression>(op.types[i], op.projection_map[i]));
     }
     auto proj = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
-      op.types, std::move(select_list), op.estimated_cardinality);
+      sirius::from_duckdb_vec(op.types), std::move(select_list), op.estimated_cardinality);
     proj->children.push_back(std::move(plan));
     plan = std::move(proj);
   }

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -16,6 +16,7 @@
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_filter.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "op/sirius_physical_table_scan.hpp"
@@ -126,26 +127,26 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
         filter_types.push_back(op.returned_types[column_id]);
       }
       filter = duckdb::make_uniq<sirius::op::sirius_physical_filter>(
-        filter_types, std::move(select_list), op.estimated_cardinality);
+        sirius::from_duckdb_vec(filter_types), std::move(select_list), op.estimated_cardinality);
     }
   }
   op.ResolveOperatorTypes();
   // create the table scan node
   if (!op.function.projection_pushdown) {
     // function does not support projection pushdown
-    auto node =
-      duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(op.returned_types,
-                                                                op.function,
-                                                                std::move(op.bind_data),
-                                                                op.returned_types,
-                                                                column_ids,
-                                                                duckdb::vector<duckdb::column_t>(),
-                                                                op.names,
-                                                                std::move(table_filters),
-                                                                op.estimated_cardinality,
-                                                                std::move(op.extra_info),
-                                                                std::move(op.parameters),
-                                                                std::move(op.virtual_columns));
+    auto node = duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(
+      sirius::from_duckdb_vec(op.returned_types),
+      op.function,
+      std::move(op.bind_data),
+      sirius::from_duckdb_vec(op.returned_types),
+      column_ids,
+      duckdb::vector<duckdb::column_t>(),
+      op.names,
+      std::move(table_filters),
+      op.estimated_cardinality,
+      std::move(op.extra_info),
+      std::move(op.parameters),
+      std::move(op.virtual_columns));
     // first check if an additional projection is necessary
     if (column_ids.size() == op.returned_types.size()) {
       bool projection_necessary = false;
@@ -180,7 +181,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     }
     duckdb::unique_ptr<sirius::op::sirius_physical_projection> projection =
       duckdb::make_uniq<sirius::op::sirius_physical_projection>(
-        std::move(types), std::move(expressions), op.estimated_cardinality);
+        sirius::from_duckdb_vec(types), std::move(expressions), op.estimated_cardinality);
     if (filter) {
       filter->children.push_back(std::move(node));
       projection->children.push_back(std::move(filter));
@@ -191,10 +192,10 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
   }
 
   auto node = duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(
-    original_types,  // Use original types, not modified
+    sirius::from_duckdb_vec(original_types),  // Use original types, not modified
     op.function,
     std::move(op.bind_data),
-    op.returned_types,
+    sirius::from_duckdb_vec(op.returned_types),
     column_ids,
     op.projection_ids,
     op.names,

--- a/src/planner/sirius_plan_limit.cpp
+++ b/src/planner/sirius_plan_limit.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_limit.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_limit.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -61,12 +62,12 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalLimit& op)
     default:
       // GPU pipeline compares all limits at the end, so insertion order does not matter.
       // Always use parallel streaming limit.
-      limit =
-        duckdb::make_uniq<sirius::op::sirius_physical_streaming_limit>(op.types,
-                                                                       std::move(op.limit_val),
-                                                                       std::move(op.offset_val),
-                                                                       op.estimated_cardinality,
-                                                                       true);
+      limit = duckdb::make_uniq<sirius::op::sirius_physical_streaming_limit>(
+        sirius::from_duckdb_vec(op.types),
+        std::move(op.limit_val),
+        std::move(op.offset_val),
+        op.estimated_cardinality,
+        true);
       break;
   }
 

--- a/src/planner/sirius_plan_order.cpp
+++ b/src/planner/sirius_plan_order.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_order.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_order.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -35,8 +36,11 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOrder& op)
         projection_map.push_back(i);
       }
     }
-    auto order = duckdb::make_uniq<sirius::op::sirius_physical_order>(
-      op.types, std::move(op.orders), std::move(projection_map), op.estimated_cardinality);
+    auto order =
+      duckdb::make_uniq<sirius::op::sirius_physical_order>(sirius::from_duckdb_vec(op.types),
+                                                           std::move(op.orders),
+                                                           std::move(projection_map),
+                                                           op.estimated_cardinality);
     order->children.push_back(std::move(plan));
     plan = std::move(order);
   }

--- a/src/planner/sirius_plan_projection.cpp
+++ b/src/planner/sirius_plan_projection.cpp
@@ -16,6 +16,7 @@
 
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_projection.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -53,7 +54,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalProjection& op)
   }
 
   auto projection = duckdb::make_uniq<sirius::op::sirius_physical_projection>(
-    op.types, std::move(op.expressions), op.estimated_cardinality);
+    sirius::from_duckdb_vec(op.types), std::move(op.expressions), op.estimated_cardinality);
   projection->children.push_back(std::move(plan));
   return std::move(projection);
 }

--- a/src/planner/sirius_plan_recursive_cte.cpp
+++ b/src/planner/sirius_plan_recursive_cte.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_cteref.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -34,7 +35,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
   // If this check fails, this is a reference to a materialized recursive CTE.
   if (materialized_cte != materialized_ctes.end()) {
     auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-      op.chunk_types,
+      sirius::from_duckdb_vec(op.chunk_types),
       sirius::op::SiriusPhysicalOperatorType::CTE_SCAN,
       op.estimated_cardinality,
       op.cte_index);
@@ -79,7 +80,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalCTERef& op)
                       ? sirius::op::SiriusPhysicalOperatorType::RECURSIVE_RECURRING_CTE_SCAN
                       : sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN;
   auto chunk_scan = duckdb::make_uniq<sirius::op::sirius_physical_column_data_scan>(
-    cte->second.get()->Types(),
+    sirius::from_duckdb_vec(cte->second.get()->Types()),
     sirius::op::SiriusPhysicalOperatorType::RECURSIVE_CTE_SCAN,
     op.estimated_cardinality,
     op.cte_index);

--- a/src/planner/sirius_plan_top_n.cpp
+++ b/src/planner/sirius_plan_top_n.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "duckdb/planner/operator/logical_top_n.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_top_n.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
@@ -28,7 +29,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalTopN& op)
   auto plan = create_plan(*op.children[0]);
 
   auto top_n = duckdb::make_uniq<sirius::op::sirius_physical_top_n>(
-    op.types,
+    sirius::from_duckdb_vec(op.types),
     std::move(op.orders),
     duckdb::NumericCast<std::size_t>(op.limit),
     duckdb::NumericCast<std::size_t>(op.offset),

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -345,7 +345,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
 
   // NOTE: dead code preserved for operator ID numbering stability
   auto invalid_op = make_uniq<op::sirius_physical_operator>(
-    op::SiriusPhysicalOperatorType::INVALID, duckdb::vector<duckdb::LogicalType>{}, 0);
+    op::SiriusPhysicalOperatorType::INVALID, duckdb::vector<sirius::logical_type>{}, 0);
 
   // Collect all pipelines for progress tracking
   root_pipeline->get_pipelines(sirius_pipelines, true);

--- a/src/sirius_interface.cpp
+++ b/src/sirius_interface.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "helper/type_conversions.hpp"
 #include "log/logging.hpp"
 
 namespace sirius {
@@ -167,7 +168,7 @@ duckdb::unique_ptr<duckdb::PendingQueryResult> sirius_interface::sirius_pending_
       duckdb::ErrorData("Error in sirius_pending_statement_internal"));
   }
   D_ASSERT(sirius_collector->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR);
-  auto types = sirius_collector->get_types();
+  auto types = sirius::to_duckdb_vec(sirius_collector->get_types());
   D_ASSERT(types == statement.types);
   engine.initialize(std::move(sirius_collector));
 

--- a/test/cpp/helper/test_logical_type.cpp
+++ b/test/cpp/helper/test_logical_type.cpp
@@ -32,8 +32,9 @@ using sirius::logical_type;
 using sirius::type_id;
 
 // ============================================================================
-// Helpers — full list of every GPU-processable sirius type_id (excludes
-// INVALID / SQLNULL / LIST which are meta / unsupported-GPU types).
+// Helpers — all type_id values except DECIMAL (precision/scale tested
+// separately via make_decimal()). Includes INVALID, SQLNULL, LIST, and STRUCT
+// so predicate edge-cases (e.g. is_fixed_width()) are exercised for them too.
 // ============================================================================
 
 static const std::vector<type_id> k_all_type_ids = {
@@ -409,9 +410,12 @@ TEST_CASE("type_conversions - to_duckdb round-trip for all GPU-processable types
   }
 }
 
-TEST_CASE("type_conversions - to_duckdb throws for INVALID", "[logical_type]")
+TEST_CASE("type_conversions - to_duckdb throws for non-GPU types", "[logical_type]")
 {
   REQUIRE_THROWS(sirius::to_duckdb(logical_type::make(type_id::INVALID)));
+  REQUIRE_THROWS(sirius::to_duckdb(logical_type::make(type_id::LIST)));
+  // STRUCT maps to LogicalType::STRUCT({}) — cuDF supports STRUCT columns
+  REQUIRE_NOTHROW(sirius::to_duckdb(logical_type::make(type_id::STRUCT)));
 }
 
 TEST_CASE("type_conversions - from_duckdb_vec / to_duckdb_vec round-trip", "[logical_type]")

--- a/test/cpp/helper/test_logical_type.cpp
+++ b/test/cpp/helper/test_logical_type.cpp
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for sirius::logical_type and the DuckDB boundary conversions.
+//
+// These tests verify that sirius::logical_type correctly emulates the behaviour
+// of duckdb::LogicalType for every type that Sirius supports, and that the
+// round-trip through from_duckdb() / to_duckdb() is lossless.
+
+#include "catch.hpp"
+#include "helper/logical_type.hpp"
+#include "helper/type_conversions.hpp"
+
+#include <duckdb/common/types.hpp>
+
+#include <stdexcept>
+
+using sirius::logical_type;
+using sirius::type_id;
+
+// ============================================================================
+// Helpers — full list of every GPU-processable sirius type_id (excludes
+// INVALID / SQLNULL / LIST which are meta / unsupported-GPU types).
+// ============================================================================
+
+static const std::vector<type_id> k_all_type_ids = {
+  type_id::BOOLEAN,   type_id::TINYINT,      type_id::SMALLINT,      type_id::INTEGER,
+  type_id::BIGINT,    type_id::HUGEINT,      type_id::UTINYINT,      type_id::USMALLINT,
+  type_id::UINTEGER,  type_id::UBIGINT,      type_id::UHUGEINT,      type_id::FLOAT,
+  type_id::DOUBLE,    type_id::DATE,         type_id::TIMESTAMP_SEC, type_id::TIMESTAMP_MS,
+  type_id::TIMESTAMP, type_id::TIMESTAMP_NS, type_id::VARCHAR,       type_id::STRUCT,
+  type_id::LIST,      type_id::SQLNULL,      type_id::INVALID,
+  // DECIMAL tested separately via make_decimal()
+};
+
+// ============================================================================
+// Construction and factory
+// ============================================================================
+
+TEST_CASE("logical_type - default constructor yields SQLNULL", "[logical_type]")
+{
+  logical_type t;
+  REQUIRE(t.id() == type_id::SQLNULL);
+}
+
+TEST_CASE("logical_type - make() preserves type_id for every non-decimal type", "[logical_type]")
+{
+  for (auto id : k_all_type_ids) {
+    REQUIRE(logical_type::make(id).id() == id);
+  }
+}
+
+TEST_CASE("logical_type - make_decimal() stores precision and scale", "[logical_type]")
+{
+  auto t = logical_type::make_decimal(18, 6);
+  REQUIRE(t.id() == type_id::DECIMAL);
+  REQUIRE(t.decimal_precision() == 18);
+  REQUIRE(t.decimal_scale() == 6);
+}
+
+TEST_CASE("logical_type - make_decimal precision and scale boundary values", "[logical_type]")
+{
+  // Minimum
+  auto t_min = logical_type::make_decimal(1, 0);
+  REQUIRE(t_min.decimal_precision() == 1);
+  REQUIRE(t_min.decimal_scale() == 0);
+
+  // Max INT32 (precision <= 9)
+  auto t32 = logical_type::make_decimal(9, 4);
+  REQUIRE(t32.decimal_precision() == 9);
+  REQUIRE(t32.decimal_scale() == 4);
+
+  // Max INT64 (precision <= 18)
+  auto t64 = logical_type::make_decimal(18, 9);
+  REQUIRE(t64.decimal_precision() == 18);
+  REQUIRE(t64.decimal_scale() == 9);
+
+  // INT128 (precision > 18)
+  auto t128 = logical_type::make_decimal(38, 10);
+  REQUIRE(t128.decimal_precision() == 38);
+  REQUIRE(t128.decimal_scale() == 10);
+}
+
+// ============================================================================
+// Predicate methods
+// ============================================================================
+
+TEST_CASE("logical_type - is_decimal()", "[logical_type]")
+{
+  REQUIRE(logical_type::make_decimal(10, 2).is_decimal());
+  for (auto id : k_all_type_ids) {
+    REQUIRE_FALSE(logical_type::make(id).is_decimal());
+  }
+}
+
+TEST_CASE("logical_type - is_varchar()", "[logical_type]")
+{
+  REQUIRE(logical_type::make(type_id::VARCHAR).is_varchar());
+  for (auto id : k_all_type_ids) {
+    if (id == type_id::VARCHAR) continue;
+    REQUIRE_FALSE(logical_type::make(id).is_varchar());
+  }
+  REQUIRE_FALSE(logical_type::make_decimal(10, 2).is_varchar());
+}
+
+TEST_CASE("logical_type - is_integer()", "[logical_type]")
+{
+  const std::vector<type_id> integer_ids = {
+    type_id::TINYINT,
+    type_id::SMALLINT,
+    type_id::INTEGER,
+    type_id::BIGINT,
+    type_id::HUGEINT,
+    type_id::UTINYINT,
+    type_id::USMALLINT,
+    type_id::UINTEGER,
+    type_id::UBIGINT,
+    type_id::UHUGEINT,
+  };
+  for (auto id : integer_ids) {
+    REQUIRE(logical_type::make(id).is_integer());
+  }
+  // Non-integer types
+  for (auto id : {type_id::FLOAT,
+                  type_id::DOUBLE,
+                  type_id::BOOLEAN,
+                  type_id::DATE,
+                  type_id::VARCHAR,
+                  type_id::DECIMAL,
+                  type_id::SQLNULL}) {
+    if (id == type_id::DECIMAL) {
+      REQUIRE_FALSE(logical_type::make_decimal(10, 2).is_integer());
+    } else {
+      REQUIRE_FALSE(logical_type::make(id).is_integer());
+    }
+  }
+}
+
+TEST_CASE("logical_type - is_numeric()", "[logical_type]")
+{
+  // All integer types are numeric
+  for (auto id : {type_id::TINYINT,
+                  type_id::SMALLINT,
+                  type_id::INTEGER,
+                  type_id::BIGINT,
+                  type_id::HUGEINT,
+                  type_id::UTINYINT,
+                  type_id::USMALLINT,
+                  type_id::UINTEGER,
+                  type_id::UBIGINT,
+                  type_id::UHUGEINT,
+                  type_id::FLOAT,
+                  type_id::DOUBLE}) {
+    REQUIRE(logical_type::make(id).is_numeric());
+  }
+  REQUIRE(logical_type::make_decimal(10, 2).is_numeric());
+
+  // Non-numeric types
+  for (auto id : {type_id::BOOLEAN,
+                  type_id::DATE,
+                  type_id::TIMESTAMP,
+                  type_id::VARCHAR,
+                  type_id::STRUCT,
+                  type_id::LIST,
+                  type_id::SQLNULL}) {
+    REQUIRE_FALSE(logical_type::make(id).is_numeric());
+  }
+}
+
+TEST_CASE("logical_type - is_temporal()", "[logical_type]")
+{
+  for (auto id : {type_id::DATE,
+                  type_id::TIMESTAMP_SEC,
+                  type_id::TIMESTAMP_MS,
+                  type_id::TIMESTAMP,
+                  type_id::TIMESTAMP_NS}) {
+    REQUIRE(logical_type::make(id).is_temporal());
+  }
+  for (auto id :
+       {type_id::INTEGER, type_id::FLOAT, type_id::VARCHAR, type_id::BOOLEAN, type_id::SQLNULL}) {
+    REQUIRE_FALSE(logical_type::make(id).is_temporal());
+  }
+  REQUIRE_FALSE(logical_type::make_decimal(10, 2).is_temporal());
+}
+
+TEST_CASE("logical_type - is_fixed_width()", "[logical_type]")
+{
+  // Variable-length / unsupported types are NOT fixed-width
+  for (auto id :
+       {type_id::VARCHAR, type_id::STRUCT, type_id::LIST, type_id::SQLNULL, type_id::INVALID}) {
+    REQUIRE_FALSE(logical_type::make(id).is_fixed_width());
+  }
+  // All remaining types are fixed-width
+  for (auto id : {type_id::BOOLEAN,
+                  type_id::TINYINT,
+                  type_id::SMALLINT,
+                  type_id::INTEGER,
+                  type_id::BIGINT,
+                  type_id::HUGEINT,
+                  type_id::UTINYINT,
+                  type_id::USMALLINT,
+                  type_id::UINTEGER,
+                  type_id::UBIGINT,
+                  type_id::UHUGEINT,
+                  type_id::FLOAT,
+                  type_id::DOUBLE,
+                  type_id::DATE,
+                  type_id::TIMESTAMP_SEC,
+                  type_id::TIMESTAMP_MS,
+                  type_id::TIMESTAMP,
+                  type_id::TIMESTAMP_NS}) {
+    REQUIRE(logical_type::make(id).is_fixed_width());
+  }
+  REQUIRE(logical_type::make_decimal(10, 2).is_fixed_width());
+}
+
+// ============================================================================
+// fixed_width_byte_size
+// ============================================================================
+
+TEST_CASE("logical_type - fixed_width_byte_size() returns correct sizes", "[logical_type]")
+{
+  REQUIRE(logical_type::make(type_id::BOOLEAN).fixed_width_byte_size() == 1);
+  REQUIRE(logical_type::make(type_id::TINYINT).fixed_width_byte_size() == 1);
+  REQUIRE(logical_type::make(type_id::UTINYINT).fixed_width_byte_size() == 1);
+
+  REQUIRE(logical_type::make(type_id::SMALLINT).fixed_width_byte_size() == 2);
+  REQUIRE(logical_type::make(type_id::USMALLINT).fixed_width_byte_size() == 2);
+
+  REQUIRE(logical_type::make(type_id::INTEGER).fixed_width_byte_size() == 4);
+  REQUIRE(logical_type::make(type_id::UINTEGER).fixed_width_byte_size() == 4);
+  REQUIRE(logical_type::make(type_id::FLOAT).fixed_width_byte_size() == 4);
+  REQUIRE(logical_type::make(type_id::DATE).fixed_width_byte_size() == 4);
+
+  REQUIRE(logical_type::make(type_id::BIGINT).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::UBIGINT).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::HUGEINT).fixed_width_byte_size() == 8);   // mapped to INT64
+  REQUIRE(logical_type::make(type_id::UHUGEINT).fixed_width_byte_size() == 8);  // mapped to UINT64
+  REQUIRE(logical_type::make(type_id::DOUBLE).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_SEC).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_MS).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::TIMESTAMP).fixed_width_byte_size() == 8);
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_NS).fixed_width_byte_size() == 8);
+
+  // DECIMAL storage depends on precision
+  REQUIRE(logical_type::make_decimal(9, 2).fixed_width_byte_size() == 4);     // DECIMAL32
+  REQUIRE(logical_type::make_decimal(18, 4).fixed_width_byte_size() == 8);    // DECIMAL64
+  REQUIRE(logical_type::make_decimal(19, 4).fixed_width_byte_size() == 16);   // DECIMAL128
+  REQUIRE(logical_type::make_decimal(38, 10).fixed_width_byte_size() == 16);  // DECIMAL128
+
+  // VARCHAR is variable-length: sentinel value 0
+  REQUIRE(logical_type::make(type_id::VARCHAR).fixed_width_byte_size() == 0);
+}
+
+TEST_CASE("logical_type - fixed_width_byte_size() throws for non-scalar types", "[logical_type]")
+{
+  REQUIRE_THROWS(logical_type::make(type_id::STRUCT).fixed_width_byte_size());
+  REQUIRE_THROWS(logical_type::make(type_id::LIST).fixed_width_byte_size());
+  REQUIRE_THROWS(logical_type::make(type_id::SQLNULL).fixed_width_byte_size());
+  REQUIRE_THROWS(logical_type::make(type_id::INVALID).fixed_width_byte_size());
+}
+
+// ============================================================================
+// to_string
+// ============================================================================
+
+TEST_CASE("logical_type - to_string() returns expected names", "[logical_type]")
+{
+  REQUIRE(logical_type::make(type_id::INVALID).to_string() == "INVALID");
+  REQUIRE(logical_type::make(type_id::SQLNULL).to_string() == "NULL");
+  REQUIRE(logical_type::make(type_id::BOOLEAN).to_string() == "BOOLEAN");
+  REQUIRE(logical_type::make(type_id::TINYINT).to_string() == "TINYINT");
+  REQUIRE(logical_type::make(type_id::SMALLINT).to_string() == "SMALLINT");
+  REQUIRE(logical_type::make(type_id::INTEGER).to_string() == "INTEGER");
+  REQUIRE(logical_type::make(type_id::BIGINT).to_string() == "BIGINT");
+  REQUIRE(logical_type::make(type_id::HUGEINT).to_string() == "HUGEINT");
+  REQUIRE(logical_type::make(type_id::UTINYINT).to_string() == "UTINYINT");
+  REQUIRE(logical_type::make(type_id::USMALLINT).to_string() == "USMALLINT");
+  REQUIRE(logical_type::make(type_id::UINTEGER).to_string() == "UINTEGER");
+  REQUIRE(logical_type::make(type_id::UBIGINT).to_string() == "UBIGINT");
+  REQUIRE(logical_type::make(type_id::UHUGEINT).to_string() == "UHUGEINT");
+  REQUIRE(logical_type::make(type_id::FLOAT).to_string() == "FLOAT");
+  REQUIRE(logical_type::make(type_id::DOUBLE).to_string() == "DOUBLE");
+  REQUIRE(logical_type::make(type_id::DATE).to_string() == "DATE");
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_SEC).to_string() == "TIMESTAMP_S");
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_MS).to_string() == "TIMESTAMP_MS");
+  REQUIRE(logical_type::make(type_id::TIMESTAMP).to_string() == "TIMESTAMP");
+  REQUIRE(logical_type::make(type_id::TIMESTAMP_NS).to_string() == "TIMESTAMP_NS");
+  REQUIRE(logical_type::make(type_id::VARCHAR).to_string() == "VARCHAR");
+  REQUIRE(logical_type::make(type_id::STRUCT).to_string() == "STRUCT");
+  REQUIRE(logical_type::make(type_id::LIST).to_string() == "LIST");
+  REQUIRE(logical_type::make_decimal(18, 6).to_string() == "DECIMAL(18,6)");
+  REQUIRE(logical_type::make_decimal(9, 0).to_string() == "DECIMAL(9,0)");
+}
+
+// ============================================================================
+// Equality operators
+// ============================================================================
+
+TEST_CASE("logical_type - operator== and operator!=", "[logical_type]")
+{
+  // Same type compares equal
+  REQUIRE(logical_type::make(type_id::INTEGER) == logical_type::make(type_id::INTEGER));
+  REQUIRE(logical_type::make(type_id::VARCHAR) == logical_type::make(type_id::VARCHAR));
+  REQUIRE(logical_type::make(type_id::INVALID) == logical_type::make(type_id::INVALID));
+
+  // Different types compare unequal
+  REQUIRE(logical_type::make(type_id::INTEGER) != logical_type::make(type_id::BIGINT));
+  REQUIRE(logical_type::make(type_id::FLOAT) != logical_type::make(type_id::DOUBLE));
+
+  // DECIMAL: same precision + scale compare equal
+  REQUIRE(logical_type::make_decimal(10, 3) == logical_type::make_decimal(10, 3));
+
+  // DECIMAL: different precision compare unequal
+  REQUIRE(logical_type::make_decimal(10, 3) != logical_type::make_decimal(11, 3));
+
+  // DECIMAL: different scale compare unequal
+  REQUIRE(logical_type::make_decimal(10, 3) != logical_type::make_decimal(10, 4));
+
+  // DECIMAL vs non-DECIMAL
+  REQUIRE(logical_type::make_decimal(10, 0) != logical_type::make(type_id::INTEGER));
+
+  // Default (SQLNULL) equals explicit SQLNULL
+  REQUIRE(logical_type() == logical_type::make(type_id::SQLNULL));
+}
+
+// ============================================================================
+// DuckDB boundary conversions
+// ============================================================================
+
+TEST_CASE("type_conversions - from_duckdb covers all supported DuckDB types", "[logical_type]")
+{
+  using duckdb::LogicalType;
+  using duckdb::LogicalTypeId;
+
+  // Scalar types map to the matching sirius type_id
+  REQUIRE(sirius::from_duckdb(LogicalType::BOOLEAN).id() == type_id::BOOLEAN);
+  REQUIRE(sirius::from_duckdb(LogicalType::TINYINT).id() == type_id::TINYINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::SMALLINT).id() == type_id::SMALLINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::INTEGER).id() == type_id::INTEGER);
+  REQUIRE(sirius::from_duckdb(LogicalType::BIGINT).id() == type_id::BIGINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::HUGEINT).id() == type_id::HUGEINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::UTINYINT).id() == type_id::UTINYINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::USMALLINT).id() == type_id::USMALLINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::UINTEGER).id() == type_id::UINTEGER);
+  REQUIRE(sirius::from_duckdb(LogicalType::UBIGINT).id() == type_id::UBIGINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::UHUGEINT).id() == type_id::UHUGEINT);
+  REQUIRE(sirius::from_duckdb(LogicalType::FLOAT).id() == type_id::FLOAT);
+  REQUIRE(sirius::from_duckdb(LogicalType::DOUBLE).id() == type_id::DOUBLE);
+  REQUIRE(sirius::from_duckdb(LogicalType::DATE).id() == type_id::DATE);
+  REQUIRE(sirius::from_duckdb(LogicalType::TIMESTAMP_S).id() == type_id::TIMESTAMP_SEC);
+  REQUIRE(sirius::from_duckdb(LogicalType::TIMESTAMP_MS).id() == type_id::TIMESTAMP_MS);
+  REQUIRE(sirius::from_duckdb(LogicalType::TIMESTAMP).id() == type_id::TIMESTAMP);
+  REQUIRE(sirius::from_duckdb(LogicalType::TIMESTAMP_NS).id() == type_id::TIMESTAMP_NS);
+  REQUIRE(sirius::from_duckdb(LogicalType::VARCHAR).id() == type_id::VARCHAR);
+  REQUIRE(sirius::from_duckdb(LogicalType::STRUCT({})).id() == type_id::STRUCT);
+  REQUIRE(sirius::from_duckdb(LogicalType::LIST(LogicalType::INTEGER)).id() == type_id::LIST);
+
+  // DECIMAL: precision and scale are preserved
+  auto dec = sirius::from_duckdb(LogicalType::DECIMAL(18, 6));
+  REQUIRE(dec.id() == type_id::DECIMAL);
+  REQUIRE(dec.decimal_precision() == 18);
+  REQUIRE(dec.decimal_scale() == 6);
+}
+
+TEST_CASE("type_conversions - from_duckdb throws for unsupported DuckDB types", "[logical_type]")
+{
+  REQUIRE_THROWS(sirius::from_duckdb(duckdb::LogicalType::INTERVAL));
+  REQUIRE_THROWS(sirius::from_duckdb(duckdb::LogicalType::BLOB));
+  // JSON is a VARCHAR alias in DuckDB (LogicalTypeId::VARCHAR), so it maps to type_id::VARCHAR.
+  REQUIRE(sirius::from_duckdb(duckdb::LogicalType::JSON()).id() == sirius::type_id::VARCHAR);
+}
+
+TEST_CASE("type_conversions - to_duckdb round-trip for all GPU-processable types", "[logical_type]")
+{
+  // For every type that can go through to_duckdb → from_duckdb, the round-trip
+  // must recover the original sirius::logical_type.
+  const std::vector<logical_type> round_trip_types = {
+    logical_type::make(type_id::BOOLEAN),       logical_type::make(type_id::TINYINT),
+    logical_type::make(type_id::SMALLINT),      logical_type::make(type_id::INTEGER),
+    logical_type::make(type_id::BIGINT),        logical_type::make(type_id::HUGEINT),
+    logical_type::make(type_id::UTINYINT),      logical_type::make(type_id::USMALLINT),
+    logical_type::make(type_id::UINTEGER),      logical_type::make(type_id::UBIGINT),
+    logical_type::make(type_id::UHUGEINT),      logical_type::make(type_id::FLOAT),
+    logical_type::make(type_id::DOUBLE),        logical_type::make(type_id::DATE),
+    logical_type::make(type_id::TIMESTAMP_SEC), logical_type::make(type_id::TIMESTAMP_MS),
+    logical_type::make(type_id::TIMESTAMP),     logical_type::make(type_id::TIMESTAMP_NS),
+    logical_type::make(type_id::VARCHAR),       logical_type::make_decimal(9, 2),
+    logical_type::make_decimal(18, 9),          logical_type::make_decimal(38, 10),
+  };
+
+  for (const auto& t : round_trip_types) {
+    auto duckdb_type   = sirius::to_duckdb(t);
+    auto round_tripped = sirius::from_duckdb(duckdb_type);
+    REQUIRE(round_tripped == t);
+  }
+}
+
+TEST_CASE("type_conversions - to_duckdb throws for INVALID", "[logical_type]")
+{
+  REQUIRE_THROWS(sirius::to_duckdb(logical_type::make(type_id::INVALID)));
+}
+
+TEST_CASE("type_conversions - from_duckdb_vec / to_duckdb_vec round-trip", "[logical_type]")
+{
+  duckdb::vector<duckdb::LogicalType> duckdb_types = {
+    duckdb::LogicalType::INTEGER,
+    duckdb::LogicalType::VARCHAR,
+    duckdb::LogicalType::DECIMAL(15, 3),
+    duckdb::LogicalType::TIMESTAMP,
+  };
+
+  auto sirius_types    = sirius::from_duckdb_vec(duckdb_types);
+  auto recovered_types = sirius::to_duckdb_vec(sirius_types);
+
+  REQUIRE(sirius_types.size() == duckdb_types.size());
+  REQUIRE(recovered_types.size() == duckdb_types.size());
+
+  REQUIRE(sirius_types[0] == logical_type::make(type_id::INTEGER));
+  REQUIRE(sirius_types[1] == logical_type::make(type_id::VARCHAR));
+  REQUIRE(sirius_types[2] == logical_type::make_decimal(15, 3));
+  REQUIRE(sirius_types[3] == logical_type::make(type_id::TIMESTAMP));
+
+  REQUIRE(recovered_types[0] == duckdb::LogicalType::INTEGER);
+  REQUIRE(recovered_types[3] == duckdb::LogicalType::TIMESTAMP);
+}

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -21,6 +21,7 @@
 // sirius
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
+#include <helper/type_conversions.hpp>
 #include <helper/utils.hpp>
 #include <memory/host_table_utils.hpp>
 #include <memory/multiple_blocks_allocation_accessor.hpp>
@@ -391,9 +392,12 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
   duckdb::LogicalType str_type(duckdb::LogicalTypeId::VARCHAR);
   duckdb::LogicalType big_type(duckdb::LogicalTypeId::BIGINT);
 
-  duckdb_scan_task_local_state::column_builder int_builder(int_type, kDefaultVarcharSize);
-  duckdb_scan_task_local_state::column_builder str_builder(str_type, kDefaultVarcharSize);
-  duckdb_scan_task_local_state::column_builder big_builder(big_type, kDefaultVarcharSize);
+  duckdb_scan_task_local_state::column_builder int_builder(sirius::from_duckdb(int_type),
+                                                           kDefaultVarcharSize);
+  duckdb_scan_task_local_state::column_builder str_builder(sirius::from_duckdb(str_type),
+                                                           kDefaultVarcharSize);
+  duckdb_scan_task_local_state::column_builder big_builder(sirius::from_duckdb(big_type),
+                                                           kDefaultVarcharSize);
 
   size_t byte_offset = 0;
   int_builder.initialize_accessors(num_rows, byte_offset, allocation);
@@ -525,8 +529,10 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
   duckdb::LogicalType int_type(duckdb::LogicalTypeId::INTEGER);
   duckdb::LogicalType str_type(duckdb::LogicalTypeId::VARCHAR);
 
-  duckdb_scan_task_local_state::column_builder int_builder(int_type, kSmallVarcharSize);
-  duckdb_scan_task_local_state::column_builder str_builder(str_type, kSmallVarcharSize);
+  duckdb_scan_task_local_state::column_builder int_builder(sirius::from_duckdb(int_type),
+                                                           kSmallVarcharSize);
+  duckdb_scan_task_local_state::column_builder str_builder(sirius::from_duckdb(str_type),
+                                                           kSmallVarcharSize);
 
   size_t byte_offset = 0;
   int_builder.initialize_accessors(num_rows_expected, byte_offset, allocation);

--- a/test/cpp/operator/aggregate/aggregate_test_utils.hpp
+++ b/test/cpp/operator/aggregate/aggregate_test_utils.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "helper/type_conversions.hpp"
 #include "operator/operator_type_traits.hpp"
 #include "utils/data_utils.hpp"
 
@@ -42,7 +43,7 @@ namespace test {
  * @brief Result structure for create_aggregate_expressions
  */
 struct AggregateExpressionResult {
-  duckdb::vector<duckdb::LogicalType> output_types;
+  duckdb::vector<sirius::logical_type> output_types;
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups;
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> aggregates;
 };
@@ -84,18 +85,18 @@ AggregateExpressionResult create_aggregate_expressions(
 
   // Create output types: first the group by column types, then the aggregate result types
   for (std::size_t group_idx : group_indexes) {
-    result.output_types.push_back(Traits::logical_type());
+    result.output_types.push_back(sirius::from_duckdb(Traits::logical_type()));
   }
   for (std::size_t i = 0; i < aggregations.size(); ++i) {
     if (aggregations[i] == "avg") {
       // DECIMAL AVG preserves the DECIMAL type; non-DECIMAL AVG returns DOUBLE
       if constexpr (Traits::is_decimal) {
-        result.output_types.push_back(Traits::logical_type());
+        result.output_types.push_back(sirius::from_duckdb(Traits::logical_type()));
       } else {
-        result.output_types.push_back(duckdb::LogicalType::DOUBLE);
+        result.output_types.push_back(sirius::from_duckdb(duckdb::LogicalType::DOUBLE));
       }
     } else {
-      result.output_types.push_back(Traits::logical_type());
+      result.output_types.push_back(sirius::from_duckdb(Traits::logical_type()));
     }
   }
 
@@ -427,9 +428,9 @@ AggregateExpressionResult create_count_distinct_expressions(
 
   // Output types: one per group key column, then BIGINT for the distinct count
   for (std::size_t i = 0; i < group_indexes.size(); ++i) {
-    result.output_types.push_back(KeyTraits::logical_type());
+    result.output_types.push_back(sirius::from_duckdb(KeyTraits::logical_type()));
   }
-  result.output_types.push_back(duckdb::LogicalType::BIGINT);
+  result.output_types.push_back(sirius::from_duckdb(duckdb::LogicalType::BIGINT));
 
   // Group expressions
   for (std::size_t group_idx : group_indexes) {
@@ -475,9 +476,9 @@ inline AggregateExpressionResult create_count_distinct_struct_col_expressions(
 
   // Output types: one BIGINT count distinct result per group key
   for (const auto& [type, idx] : key_col_infos) {
-    result.output_types.push_back(type);
+    result.output_types.push_back(sirius::from_duckdb(type));
   }
-  result.output_types.push_back(duckdb::LogicalType::BIGINT);
+  result.output_types.push_back(sirius::from_duckdb(duckdb::LogicalType::BIGINT));
 
   // Group expressions
   for (const auto& [type, idx] : key_col_infos) {

--- a/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
+++ b/test/cpp/operator/aggregate/test_physical_grouped_aggregate_count_distinct.cpp
@@ -32,6 +32,7 @@
 #include "../operator_type_traits.hpp"
 #include "aggregate_test_utils.hpp"
 #include "data/data_batch_utils.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/sirius_physical_grouped_aggregate.hpp"
 #include "op/sirius_physical_grouped_aggregate_merge.hpp"
 #include "utils/data_utils.hpp"
@@ -373,11 +374,11 @@ TEST_CASE("count distinct: mixed with regular aggregations, multiple batches",
   auto expected_table = std::make_unique<cudf::table>(std::move(exp_cols));
 
   // Build expressions: [count(distinct col1), min(col1), count(col1)]
-  duckdb::vector<duckdb::LogicalType> output_types;
-  output_types.push_back(KeyTraits::logical_type());    // group key
-  output_types.push_back(duckdb::LogicalType::BIGINT);  // count distinct
-  output_types.push_back(ValTraits::logical_type());    // min
-  output_types.push_back(duckdb::LogicalType::BIGINT);  // count
+  duckdb::vector<sirius::logical_type> output_types;
+  output_types.push_back(sirius::from_duckdb(KeyTraits::logical_type()));    // group key
+  output_types.push_back(sirius::from_duckdb(duckdb::LogicalType::BIGINT));  // count distinct
+  output_types.push_back(sirius::from_duckdb(ValTraits::logical_type()));    // min
+  output_types.push_back(sirius::from_duckdb(duckdb::LogicalType::BIGINT));  // count
 
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups;
   groups.push_back(
@@ -414,7 +415,7 @@ TEST_CASE("count distinct: mixed with regular aggregations, multiple batches",
   }
 
   // Clone expressions for merge operator (it takes the same spec)
-  duckdb::vector<duckdb::LogicalType> output_types2 = output_types;
+  duckdb::vector<sirius::logical_type> output_types2 = output_types;
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> groups2;
   groups2.push_back(
     duckdb::make_uniq<duckdb::BoundReferenceExpression>(KeyTraits::logical_type(), 0));

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -20,6 +20,7 @@
 
 // sirius
 #include <data/data_batch_utils.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/result/host_table_chunk_reader.hpp>
 
 // cudf
@@ -277,7 +278,8 @@ TEST_CASE("host_table_chunk_reader produces correct DataChunks",
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
-  sirius::op::result::host_table_chunk_reader reader(*con.context, host_table, types);
+  sirius::op::result::host_table_chunk_reader reader(
+    *con.context, host_table, sirius::from_duckdb_vec(types));
 
   size_t row_base       = 0;
   auto const num_chunks = reader.calculate_num_chunks();
@@ -364,7 +366,8 @@ TEST_CASE("host_table_chunk_reader handles null masks",
   duckdb::vector<duckdb::LogicalType> types{duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT),
                                             duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
-  sirius::op::result::host_table_chunk_reader reader(*con.context, host_table, types);
+  sirius::op::result::host_table_chunk_reader reader(
+    *con.context, host_table, sirius::from_duckdb_vec(types));
 
   size_t row_base       = 0;
   auto const num_chunks = reader.calculate_num_chunks();

--- a/test/cpp/operator/test_physical_concat.cpp
+++ b/test/cpp/operator/test_physical_concat.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
 
@@ -75,11 +76,11 @@ hash_join_test_fixture create_test_hash_join(duckdb::JoinType join_type,
   // Create minimal child operators (need at least one type each for the hash join constructor)
   auto left_child = duckdb::make_uniq<sirius_physical_operator>(
     SiriusPhysicalOperatorType::PROJECTION,
-    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
     0);
   auto right_child = duckdb::make_uniq<sirius_physical_operator>(
     SiriusPhysicalOperatorType::PROJECTION,
-    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
     0);
 
   // Create a single equality join condition (column 0 = column 0)
@@ -97,11 +98,11 @@ hash_join_test_fixture create_test_hash_join(duckdb::JoinType join_type,
     std::move(right_child),
     std::move(conditions),
     join_type,
-    duckdb::vector<duckdb::idx_t>{},        // left_projection_map (empty = all)
-    duckdb::vector<duckdb::idx_t>{},        // right_projection_map (empty = all)
-    duckdb::vector<duckdb::LogicalType>{},  // delim_types
-    1000,                                   // estimated_cardinality
-    nullptr);                               // pushdown_info
+    duckdb::vector<duckdb::idx_t>{},  // left_projection_map (empty = all)
+    duckdb::vector<duckdb::idx_t>{},  // right_projection_map (empty = all)
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),  // delim_types
+    1000,                                                            // estimated_cardinality
+    nullptr);                                                        // pushdown_info
 
   return fixture;
 }
@@ -192,7 +193,11 @@ TEMPLATE_TEST_CASE("sirius_physical_concat concatenates multiple data_batches",
 
   // Create hash join fixture and concat operator
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {Traits::logical_type()});
-  sirius_physical_concat concat_op({Traits::logical_type()}, 1000, fixture.hash_join.get(), false);
+  sirius_physical_concat concat_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{Traits::logical_type()}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   // Execute
   auto outputs = concat_op.execute(partitioned_operator_data(input_batches, 0), default_stream());
@@ -227,7 +232,10 @@ TEST_CASE("sirius_physical_concat returns single batch as-is", "[physical_concat
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   auto outputs = concat_op.execute(partitioned_operator_data({input_batch}, 0), default_stream());
 
@@ -241,7 +249,10 @@ TEST_CASE("sirius_physical_concat handles empty input", "[physical_concat]")
 {
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   auto outputs = concat_op.execute(
     partitioned_operator_data(std::vector<std::shared_ptr<cucascade::data_batch>>{}, 0),
@@ -262,7 +273,10 @@ TEST_CASE("sirius_physical_concat filters null batches", "[physical_concat]")
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   // Mix valid and null batches
   std::vector<std::shared_ptr<data_batch>> input = {batch1, nullptr, batch2, nullptr};
@@ -303,11 +317,17 @@ TEST_CASE(
   // Create the concat operator
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   // Create a downstream partition consumer operator to receive the sink output
   sirius_physical_concat downstream_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   // Set up a data repository on the downstream operator's port
   auto downstream_repo           = std::make_unique<cucascade::shared_data_repository>();
@@ -348,13 +368,22 @@ TEST_CASE("sirius_physical_concat sink forwards to multiple downstream operators
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   // Create two downstream operators
   sirius_physical_concat downstream1(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
   sirius_physical_concat downstream2(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false);
 
   auto repo1           = std::make_unique<cucascade::shared_data_repository>();
   auto port1           = std::make_unique<sirius_physical_operator::port>();
@@ -404,7 +433,11 @@ TEST_CASE("sirius_physical_concat stops concatenating at concat_batch_bytes thre
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false, threshold);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
 
   // Set up a port with a data repository
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -459,7 +492,11 @@ TEST_CASE("sirius_physical_concat with concat_all=true ignores threshold", "[phy
   // LEFT join + is_build=true -> _concat_all = true
   auto fixture = create_test_hash_join(duckdb::JoinType::LEFT, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true, threshold);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    true,
+    threshold);
 
   // Set up a port with a data repository
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -503,11 +540,17 @@ TEST_CASE("sirius_physical_concat constructor sets concat_all for different join
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
     sirius_physical_concat concat_build(
-      {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true);
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      true);
     REQUIRE(concat_build.is_build_concat() == true);
 
     sirius_physical_concat concat_probe(
-      {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      false);
     REQUIRE(concat_probe.is_build_concat() == false);
   }
 
@@ -515,7 +558,10 @@ TEST_CASE("sirius_physical_concat constructor sets concat_all for different join
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::LEFT, {duckdb::LogicalType::INTEGER});
     sirius_physical_concat concat_op(
-      {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true);
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      true);
     REQUIRE(concat_op.is_build_concat() == true);
   }
 
@@ -523,37 +569,55 @@ TEST_CASE("sirius_physical_concat constructor sets concat_all for different join
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::LEFT, {duckdb::LogicalType::INTEGER});
     sirius_physical_concat concat_op(
-      {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      false);
     REQUIRE(concat_op.is_build_concat() == false);
   }
 
   SECTION("RIGHT join constructs successfully")
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::RIGHT, {duckdb::LogicalType::INTEGER});
-    REQUIRE_NOTHROW(
-      sirius_physical_concat({duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), true));
+    REQUIRE_NOTHROW(sirius_physical_concat(
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      true));
   }
 
   SECTION("SEMI join constructs successfully")
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::SEMI, {duckdb::LogicalType::INTEGER});
-    REQUIRE_NOTHROW(
-      sirius_physical_concat({duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false));
+    REQUIRE_NOTHROW(sirius_physical_concat(
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      false));
   }
 
   SECTION("OUTER join throws unsupported join type")
   {
     auto fixture = create_test_hash_join(duckdb::JoinType::OUTER, {duckdb::LogicalType::INTEGER});
-    REQUIRE_NOTHROW(
-      sirius_physical_concat({duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false));
+    REQUIRE_NOTHROW(sirius_physical_concat(
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000,
+      fixture.hash_join.get(),
+      false));
   }
 
   SECTION("Non-hash-join parent throws")
   {
     sirius_physical_operator non_join_op(
-      SiriusPhysicalOperatorType::PROJECTION, {duckdb::LogicalType::INTEGER}, 1000);
+      SiriusPhysicalOperatorType::PROJECTION,
+      sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+      1000);
     REQUIRE_THROWS_AS(
-      sirius_physical_concat({duckdb::LogicalType::INTEGER}, 1000, &non_join_op, false),
+      sirius_physical_concat(
+        sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        1000,
+        &non_join_op,
+        false),
       std::runtime_error);
   }
 }
@@ -572,7 +636,11 @@ TEST_CASE("sirius_physical_concat get_next_task_input_batch is thread-safe", "[p
 
   auto fixture = create_test_hash_join(duckdb::JoinType::INNER, {duckdb::LogicalType::INTEGER});
   sirius_physical_concat concat_op(
-    {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false, threshold);
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000,
+    fixture.hash_join.get(),
+    false,
+    threshold);
 
   // Set up a port with a data repository containing many batches across partitions
   auto repo = std::make_unique<cucascade::shared_data_repository>();
@@ -674,7 +742,10 @@ TEST_CASE("sirius_physical_concat execute is thread-safe with independent stream
   auto worker = [&](int thread_id) {
     try {
       sirius_physical_concat concat_op(
-        {duckdb::LogicalType::INTEGER}, 1000, fixture.hash_join.get(), false);
+        sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+        1000,
+        fixture.hash_join.get(),
+        false);
 
       // Create a dedicated CUDA stream for this thread
       cudaStream_t raw_stream;

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
@@ -89,7 +90,8 @@ TEMPLATE_TEST_CASE("sirius_physical_filter executes on data_batch for multiple n
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));  // filter column
   types.push_back(Traits::logical_type());
 
-  sirius_physical_filter filter(std::move(types), std::move(exprs), filter_vals.size());
+  sirius_physical_filter filter(
+    sirius::from_duckdb_vec(types), std::move(exprs), filter_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = filter.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());

--- a/test/cpp/operator/test_physical_limit.cpp
+++ b/test/cpp/operator/test_physical_limit.cpp
@@ -18,6 +18,7 @@
 #include "operator_type_traits.hpp"
 
 #include <catch.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/sirius_physical_limit.hpp>
 
 #include <numeric>
@@ -94,8 +95,11 @@ TEMPLATE_TEST_CASE("sirius_physical_streaming_limit limits rows in data_batch",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(Traits::logical_type());
 
-  sirius_physical_streaming_limit limiter(
-    std::move(types), std::move(limit_node), std::move(offset_node), values.size(), false);
+  sirius_physical_streaming_limit limiter(sirius::from_duckdb_vec(std::move(types)),
+                                          std::move(limit_node),
+                                          std::move(offset_node),
+                                          values.size(),
+                                          false);
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = limiter.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -151,8 +155,11 @@ TEST_CASE("streaming_limit caps total rows across multiple batches",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_streaming_limit limiter(
-    std::move(types), duckdb::BoundLimitNode::ConstantValue(5), duckdb::BoundLimitNode(), 30, true);
+  sirius_physical_streaming_limit limiter(sirius::from_duckdb_vec(std::move(types)),
+                                          duckdb::BoundLimitNode::ConstantValue(5),
+                                          duckdb::BoundLimitNode(),
+                                          30,
+                                          true);
 
   auto outputs = limiter.execute(pipelineable_operator_data(batches), cudf::get_default_stream());
   auto rows =
@@ -178,7 +185,7 @@ TEST_CASE("streaming_limit spans across two batches returning correct data",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_streaming_limit limiter(std::move(types),
+  sirius_physical_streaming_limit limiter(sirius::from_duckdb_vec(std::move(types)),
                                           duckdb::BoundLimitNode::ConstantValue(200),
                                           duckdb::BoundLimitNode(),
                                           300,
@@ -212,7 +219,7 @@ TEST_CASE("streaming_limit offset spans across multiple batches", "[physical_lim
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
   // offset=15 skips all of batch 1 (10 rows) + 5 rows of batch 2, limit=5
-  sirius_physical_streaming_limit limiter(std::move(types),
+  sirius_physical_streaming_limit limiter(sirius::from_duckdb_vec(std::move(types)),
                                           duckdb::BoundLimitNode::ConstantValue(5),
                                           duckdb::BoundLimitNode::ConstantValue(15),
                                           30,
@@ -238,8 +245,11 @@ TEST_CASE("streaming_limit with separate execute calls enforces global limit",
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
   // limit=5 shared across multiple execute() calls (simulating concurrent tasks)
-  sirius_physical_streaming_limit limiter(
-    std::move(types), duckdb::BoundLimitNode::ConstantValue(5), duckdb::BoundLimitNode(), 30, true);
+  sirius_physical_streaming_limit limiter(sirius::from_duckdb_vec(std::move(types)),
+                                          duckdb::BoundLimitNode::ConstantValue(5),
+                                          duckdb::BoundLimitNode(),
+                                          30,
+                                          true);
 
   // First call with batch [0..9]
   std::vector<std::shared_ptr<data_batch>> batch1{make_range_batch(*space, 0, 10)};

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "operator_test_utils.hpp"
 
@@ -60,11 +61,12 @@ mark_join_fixture create_mark_join()
 
   auto left_child = duckdb::make_uniq<sirius_physical_operator>(
     SiriusPhysicalOperatorType::PROJECTION,
-    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER, duckdb::LogicalType::INTEGER},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER,
+                                                                duckdb::LogicalType::INTEGER}),
     0);
   auto right_child = duckdb::make_uniq<sirius_physical_operator>(
     SiriusPhysicalOperatorType::PROJECTION,
-    duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
     0);
 
   duckdb::vector<duckdb::JoinCondition> conditions;
@@ -80,9 +82,9 @@ mark_join_fixture create_mark_join()
     std::move(right_child),
     std::move(conditions),
     duckdb::JoinType::MARK,
-    duckdb::vector<duckdb::idx_t>{},        // left_projection_map (empty = all)
-    duckdb::vector<duckdb::idx_t>{},        // right_projection_map (not used by MARK)
-    duckdb::vector<duckdb::LogicalType>{},  // delim_types
+    duckdb::vector<duckdb::idx_t>{},  // left_projection_map (empty = all)
+    duckdb::vector<duckdb::idx_t>{},  // right_projection_map (not used by MARK)
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),  // delim_types
     1000,
     nullptr);
 

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 
 #include <catch.hpp>
@@ -89,10 +90,11 @@ std::shared_ptr<data_batch> sort_batch(const std::shared_ptr<data_batch>& batch,
                                        const duckdb::vector<duckdb::idx_t>& projections,
                                        const duckdb::vector<duckdb::LogicalType>& types)
 {
-  sirius_physical_order order_op(duckdb::vector<duckdb::LogicalType>(types),
-                                 copy_orders(orders),
-                                 duckdb::vector<duckdb::idx_t>(projections),
-                                 0);
+  sirius_physical_order order_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>(types)),
+    copy_orders(orders),
+    duckdb::vector<duckdb::idx_t>(projections),
+    0);
   auto result = order_op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches().size() == 1);
   return dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches()[0];
@@ -123,7 +125,8 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 1-column batches ascending
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -158,7 +161,8 @@ TEST_CASE("sirius_physical_merge_sort merges 3 sorted 1-column batches descendin
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out =
     op.execute(pipelineable_operator_data({batch1, batch2, batch3}), cudf::get_default_stream());
@@ -199,7 +203,8 @@ TEST_CASE("sirius_physical_merge_sort merges 2 sorted 2-column batches by col0 a
 
   duckdb::vector<duckdb::idx_t> projections{0, 1};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -244,7 +249,7 @@ TEST_CASE("sirius_physical_merge_sort merges 2-column batches sorted by 2 keys",
   auto sorted2 = sort_batch(raw2, orders, projections, types);
   // sorted2: (1,15), (2,1), (2,25), (3,35)
 
-  sirius_physical_merge_sort op(duckdb::vector<duckdb::LogicalType>(types),
+  sirius_physical_merge_sort op(sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>(types)),
                                 copy_orders(orders),
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
@@ -291,7 +296,8 @@ TEST_CASE("sirius_physical_merge_sort merges 3-column batches sorted by col0, re
 
   duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -339,7 +345,7 @@ TEST_CASE("sirius_physical_merge_sort 3 columns sorted by col0 asc + col1 desc",
   auto sorted2 = sort_batch(raw2, orders, projections, types);
   // sorted2: (1,25,500), (2,40,400), (2,5,600)
 
-  sirius_physical_merge_sort op(duckdb::vector<duckdb::LogicalType>(types),
+  sirius_physical_merge_sort op(sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>(types)),
                                 copy_orders(orders),
                                 duckdb::vector<duckdb::idx_t>(projections),
                                 0);
@@ -384,7 +390,8 @@ TEST_CASE("sirius_physical_merge_sort single batch passthrough", "[physical_merg
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -415,7 +422,8 @@ TEST_CASE("sirius_physical_merge_sort skips null batches", "[physical_merge_sort
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch1, nullptr, batch2, nullptr};
   auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -441,7 +449,8 @@ TEST_CASE("sirius_physical_merge_sort returns empty for all-null inputs", "[phys
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_merge_sort op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_merge_sort op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
   auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -466,10 +475,11 @@ TEST_CASE("sirius_physical_merge_sort constructed from sirius_physical_order",
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order order_op(duckdb::vector<duckdb::LogicalType>(types),
-                                 copy_orders(orders),
-                                 duckdb::vector<duckdb::idx_t>(projections),
-                                 0);
+  sirius_physical_order order_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>(types)),
+    copy_orders(orders),
+    duckdb::vector<duckdb::idx_t>(projections),
+    0);
 
   sirius_physical_merge_sort op(&order_op);
 

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 
 #include <catch.hpp>
@@ -104,7 +105,8 @@ TEST_CASE("sirius_physical_order sorts 1 column ascending", "[physical_order]")
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -136,7 +138,8 @@ TEST_CASE("sirius_physical_order sorts 1 column descending", "[physical_order]")
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -174,7 +177,8 @@ TEST_CASE("sirius_physical_order sorts by col0, returns both columns", "[physica
 
   duckdb::vector<duckdb::idx_t> projections{0, 1};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -214,7 +218,8 @@ TEST_CASE("sirius_physical_order sorts by 2 keys (asc, desc)", "[physical_order]
 
   duckdb::vector<duckdb::idx_t> projections{0, 1};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -252,7 +257,8 @@ TEST_CASE("sirius_physical_order projects only col1 when sorting by col0", "[phy
   // Only project col1 (payload), not col0 (sort key)
   duckdb::vector<duckdb::idx_t> projections{1};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -292,7 +298,8 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc, return all", "[phy
 
   duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -340,7 +347,8 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0 asc + col1 desc, return
 
   duckdb::vector<duckdb::idx_t> projections{0, 1, 2};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -379,7 +387,8 @@ TEST_CASE("sirius_physical_order 3 columns, sort by col0, project col1 and col2 
 
   duckdb::vector<duckdb::idx_t> projections{1, 2};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 1);
@@ -420,7 +429,8 @@ TEST_CASE("sirius_physical_order handles multiple batches", "[physical_order]")
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   auto out = op.execute(pipelineable_operator_data({batch1, batch2}), cudf::get_default_stream());
   REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*out).get_data_batches().size() == 2);
@@ -459,7 +469,8 @@ TEST_CASE("sirius_physical_order handles null input batches", "[physical_order]"
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, batch, nullptr};
   auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -485,7 +496,8 @@ TEST_CASE("sirius_physical_order returns empty for all-null inputs", "[physical_
 
   duckdb::vector<duckdb::idx_t> projections{0};
 
-  sirius_physical_order op(std::move(types), std::move(orders), std::move(projections), 0);
+  sirius_physical_order op(
+    sirius::from_duckdb_vec(std::move(types)), std::move(orders), std::move(projections), 0);
 
   std::vector<std::shared_ptr<data_batch>> inputs{nullptr, nullptr};
   auto out = op.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -123,7 +123,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
   );
 
   // Create partitioner types (copy of agg_output_types before moving)
-  duckdb::vector<duckdb::LogicalType> partitioner_types = agg_result.output_types;
+  duckdb::vector<sirius::logical_type> partitioner_types = agg_result.output_types;
 
   // Create the grouped aggregate merge operator
   sirius_physical_grouped_aggregate_merge grouped_aggregator(context,
@@ -132,11 +132,8 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
                                                              std::move(agg_result.groups),
                                                              estimated_cardinality);
 
-  sirius_physical_partition partitioner(std::move(partitioner_types),
-                                        estimated_cardinality,
-                                        &grouped_aggregator,
-                                        false,
-                                        partition_size);
+  sirius_physical_partition partitioner(
+    partitioner_types, estimated_cardinality, &grouped_aggregator, false, partition_size);
 
   // Compute num_partitions from estimated bytes: cardinality * bytes_per_row / partition_size
   // col0 is Traits::type, col1 is int32_t
@@ -256,7 +253,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
   );
 
   // Create partitioner types (copy of agg_output_types before moving)
-  duckdb::vector<duckdb::LogicalType> partitioner_types = agg_result.output_types;
+  duckdb::vector<sirius::logical_type> partitioner_types = agg_result.output_types;
 
   // Create the grouped aggregate merge operator
   sirius_physical_grouped_aggregate_merge grouped_aggregator(context,
@@ -265,11 +262,8 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
                                                              std::move(agg_result.groups),
                                                              estimated_cardinality);
 
-  sirius_physical_partition partitioner(std::move(partitioner_types),
-                                        estimated_cardinality,
-                                        &grouped_aggregator,
-                                        false,
-                                        partition_size);
+  sirius_physical_partition partitioner(
+    partitioner_types, estimated_cardinality, &grouped_aggregator, false, partition_size);
 
   // Compute num_partitions from estimated bytes: cardinality * bytes_per_row / partition_size
   // col0 is Traits::type, col1 and col2 are int32_t
@@ -346,7 +340,7 @@ TEST_CASE(
   );
 
   // Create partitioner types (copy of agg_output_types before moving)
-  duckdb::vector<duckdb::LogicalType> partitioner_types = agg_result.output_types;
+  duckdb::vector<sirius::logical_type> partitioner_types = agg_result.output_types;
 
   // Create the grouped aggregate merge operator
   sirius_physical_grouped_aggregate_merge grouped_aggregator(context,
@@ -356,7 +350,7 @@ TEST_CASE(
                                                              estimated_cardinality);
 
   sirius_physical_partition partitioner(
-    std::move(partitioner_types), estimated_cardinality, &grouped_aggregator, false);
+    partitioner_types, estimated_cardinality, &grouped_aggregator, false);
 
   // Compute num_partitions from estimated bytes: cardinality * bytes_per_row / partition_size
   // col0 and col1 are both int32_t; uses default partition size (512 MB)

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
 
@@ -82,7 +83,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection executes on data_batch for multip
   types.push_back(Traits::logical_type());
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(
+    sirius::from_duckdb_vec(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -130,7 +132,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can drop columns",
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(Traits::logical_type());
 
-  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(
+    sirius::from_duckdb_vec(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
@@ -179,7 +182,8 @@ TEMPLATE_TEST_CASE("sirius_physical_projection can duplicate/reorder columns",
   types.push_back(Traits::logical_type());
   types.push_back(duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT));
 
-  sirius_physical_projection projection(std::move(types), std::move(exprs), key_vals.size());
+  sirius_physical_projection projection(
+    sirius::from_duckdb_vec(types), std::move(exprs), key_vals.size());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> inputs{input_batch};
   auto outputs = projection.execute(pipelineable_operator_data(inputs), cudf::get_default_stream());

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -16,6 +16,7 @@
 
 // test
 #include <catch.hpp>
+#include <helper/type_conversions.hpp>
 #include <utils/utils.hpp>
 
 // sirius
@@ -242,7 +243,8 @@ TEST_CASE("sirius_physical_materialized_collector sink with host input",
     duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
   prepared->types = types;
   prepared->names = {"c0", "c1", "c2"};
-  auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
+  auto plan =
+    duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(sirius::from_duckdb_vec(types), 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
@@ -307,7 +309,8 @@ TEST_CASE("sirius_physical_materialized_collector sink converts GPU input",
     duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
   prepared->types = types;
   prepared->names = {"c0", "c1"};
-  auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
+  auto plan =
+    duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(sirius::from_duckdb_vec(types), 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);
@@ -399,7 +402,8 @@ TEST_CASE("sirius_physical_materialized_collector sink supports concurrent appen
     duckdb::make_shared_ptr<duckdb::PreparedStatementData>(duckdb::StatementType::SELECT_STATEMENT);
   prepared->types = types;
   prepared->names = {"c0", "c1"};
-  auto plan       = duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(types, 0);
+  auto plan =
+    duckdb::make_uniq<sirius::op::sirius_physical_dummy_scan>(sirius::from_duckdb_vec(types), 0);
   auto sirius_prepared =
     duckdb::make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(plan));
   sirius::op::sirius_physical_materialized_collector collector(*sirius_prepared, *con.context);

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
@@ -108,10 +109,10 @@ TEMPLATE_TEST_CASE(
   // Create a minimal table function (not used in this test but required by constructor)
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,  // bind_data
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),
@@ -181,10 +182,10 @@ TEST_CASE("sirius_physical_table_scan with no filters passes through data", "[ph
 
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),
@@ -256,10 +257,10 @@ TEST_CASE("sirius_physical_table_scan with multiple filters", "[physical_table_s
 
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),
@@ -329,10 +330,10 @@ TEST_CASE("sirius_physical_table_scan filters all rows", "[physical_table_scan]"
 
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),
@@ -393,10 +394,10 @@ TEST_CASE("parquet_scan with translatable filter sets table_scan passthrough",
 
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),
@@ -500,10 +501,10 @@ TEST_CASE("parquet_scan with decimal filter sets table_scan passthrough",
 
   duckdb::TableFunction table_function("test_scan", {}, nullptr, nullptr);
 
-  sirius_physical_table_scan table_scan(std::move(types),
+  sirius_physical_table_scan table_scan(sirius::from_duckdb_vec(types),
                                         std::move(table_function),
                                         nullptr,
-                                        std::move(returned_types),
+                                        sirius::from_duckdb_vec(returned_types),
                                         std::move(column_ids),
                                         std::move(projection_ids),
                                         std::move(names),

--- a/test/cpp/operator/test_physical_top_n.cpp
+++ b/test/cpp/operator/test_physical_top_n.cpp
@@ -19,6 +19,7 @@
 #include <catch.hpp>
 #include <duckdb/planner/bound_result_modifier.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/sirius_physical_top_n.hpp>
 #include <op/sirius_physical_top_n_merge.hpp>
 
@@ -80,7 +81,7 @@ TEST_CASE("sirius_physical_top_n single-key uses top_k per batch", "[physical_to
   duckdb::vector<duckdb::BoundOrderByNode> orders;
   orders.push_back(make_order(0, duckdb::OrderType::DESCENDING));
 
-  sirius_physical_top_n topn(std::move(types),
+  sirius_physical_top_n topn(sirius::from_duckdb_vec(types),
                              std::move(orders),
                              /*limit=*/3,
                              /*offset=*/0,
@@ -124,7 +125,7 @@ TEST_CASE("sirius_physical_top_n multi-key falls back to sort_by_key", "[physica
   orders.push_back(make_order(0, duckdb::OrderType::DESCENDING));
   orders.push_back(make_order(1, duckdb::OrderType::ASCENDING));
 
-  sirius_physical_top_n topn(std::move(types),
+  sirius_physical_top_n topn(sirius::from_duckdb_vec(types),
                              std::move(orders),
                              /*limit=*/4,
                              /*offset=*/0,
@@ -168,7 +169,7 @@ TEST_CASE("sirius_physical_top_n_merge applies offset and limit", "[physical_top
   duckdb::vector<duckdb::BoundOrderByNode> orders;
   orders.push_back(make_order(0, duckdb::OrderType::DESCENDING));
 
-  sirius_physical_top_n_merge topn_merge(std::move(types),
+  sirius_physical_top_n_merge topn_merge(sirius::from_duckdb_vec(types),
                                          std::move(orders),
                                          /*limit=*/5,
                                          /*offset=*/3,
@@ -210,7 +211,7 @@ TEST_CASE("sirius_physical_top_n_merge returns empty for limit 0", "[physical_to
   duckdb::vector<duckdb::BoundOrderByNode> orders;
   orders.push_back(make_order(0, duckdb::OrderType::DESCENDING));
 
-  sirius_physical_top_n_merge topn_merge(std::move(types),
+  sirius_physical_top_n_merge topn_merge(sirius::from_duckdb_vec(types),
                                          std::move(orders),
                                          /*limit=*/0,
                                          /*offset=*/2,
@@ -237,7 +238,7 @@ TEST_CASE("sirius_physical_top_n_merge handles empty batches", "[physical_top_n_
   duckdb::vector<duckdb::BoundOrderByNode> orders;
   orders.push_back(make_order(0, duckdb::OrderType::DESCENDING));
 
-  sirius_physical_top_n_merge topn_merge(std::move(types),
+  sirius_physical_top_n_merge topn_merge(sirius::from_duckdb_vec(types),
                                          std::move(orders),
                                          /*limit=*/3,
                                          /*offset=*/0,

--- a/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+++ b/test/cpp/operator/test_physical_ungrouped_aggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
 
@@ -171,12 +172,12 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate computes SUM/MIN/MAX/COU
   auto merge_aggregates = make_aggregates(merge_types);
 
   sirius_physical_ungrouped_aggregate local_op(
-    std::move(local_types),
+    sirius::from_duckdb_vec(local_types),
     std::move(local_aggregates),
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
   sirius_physical_ungrouped_aggregate_merge merge_op(
-    std::move(merge_types),
+    sirius::from_duckdb_vec(merge_types),
     std::move(merge_aggregates),
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
@@ -301,12 +302,12 @@ TEMPLATE_TEST_CASE("sirius_physical_ungrouped_aggregate resolves AVG in merge",
   auto merge_aggregates = make_avg_aggregates(merge_types);
 
   sirius_physical_ungrouped_aggregate local_op(
-    std::move(local_types),
+    sirius::from_duckdb_vec(local_types),
     std::move(local_aggregates),
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
   sirius_physical_ungrouped_aggregate_merge merge_op(
-    std::move(merge_types),
+    sirius::from_duckdb_vec(merge_types),
     std::move(merge_aggregates),
     0,
     duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -17,6 +17,7 @@
 #include "catch.hpp"
 #include "data/data_batch_utils.hpp"
 #include "data/sirius_converter_registry.hpp"
+#include "helper/type_conversions.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
@@ -57,8 +58,9 @@ class stub_operator : public sirius::op::sirius_physical_operator {
   using sink_fn    = std::function<void(const sirius::op::operator_data&, rmm::cuda_stream_view)>;
 
   stub_operator()
-    : sirius_physical_operator(
-        sirius::op::SiriusPhysicalOperatorType::FILTER, duckdb::vector<duckdb::LogicalType>{}, 0)
+    : sirius_physical_operator(sirius::op::SiriusPhysicalOperatorType::FILTER,
+                               sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),
+                               0)
   {
   }
 

--- a/test/cpp/scan/test_column_builder.cpp
+++ b/test/cpp/scan/test_column_builder.cpp
@@ -19,6 +19,7 @@
 #include <utils/utils.hpp>
 
 // sirius
+#include <helper/type_conversions.hpp>
 #include <helper/utils.hpp>
 #include <op/scan/duckdb_scan_task.hpp>
 
@@ -85,9 +86,10 @@ TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder][s
   SECTION("construct with INTEGER type")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
-    REQUIRE(builder.type.id() == duckdb::LogicalTypeId::INTEGER);
+    REQUIRE(builder.type.id() == sirius::type_id::INTEGER);
     REQUIRE(builder.type_size == sizeof(int32_t));
     REQUIRE(builder.total_data_bytes == 0);
     REQUIRE(builder.null_count == 0);
@@ -96,9 +98,10 @@ TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder][s
   SECTION("construct with BIGINT type")
   {
     auto bigint_type = duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT);
-    duckdb_scan_task_local_state::column_builder builder(bigint_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(bigint_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
-    REQUIRE(builder.type.id() == duckdb::LogicalTypeId::BIGINT);
+    REQUIRE(builder.type.id() == sirius::type_id::BIGINT);
     REQUIRE(builder.type_size == sizeof(int64_t));
     REQUIRE(builder.total_data_bytes == 0);
   }
@@ -106,9 +109,10 @@ TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder][s
   SECTION("construct with VARCHAR type")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
-    REQUIRE(builder.type.id() == duckdb::LogicalTypeId::VARCHAR);
+    REQUIRE(builder.type.id() == sirius::type_id::VARCHAR);
     REQUIRE(builder.total_data_bytes == 0);
     REQUIRE(builder.type_size ==
             DEFAULT_VARCHAR_SIZE);  // For VARCHAR, type_size is the default size
@@ -117,9 +121,10 @@ TEST_CASE("column_builder - construction", "[duckdb_scan_task][column_builder][s
   SECTION("construct with DOUBLE type")
   {
     auto double_type = duckdb::LogicalType(duckdb::LogicalTypeId::DOUBLE);
-    duckdb_scan_task_local_state::column_builder builder(double_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(double_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
-    REQUIRE(builder.type.id() == duckdb::LogicalTypeId::DOUBLE);
+    REQUIRE(builder.type.id() == sirius::type_id::DOUBLE);
     REQUIRE(builder.type_size == sizeof(double));
   }
 }
@@ -142,7 +147,8 @@ TEST_CASE("column_builder - accessor initialization",
   SECTION("initialize accessors for fixed-width type")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows = 100;
     // Calculate total size needed: data + mask
@@ -166,7 +172,8 @@ TEST_CASE("column_builder - accessor initialization",
   SECTION("initialize accessors for VARCHAR type")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows = 100;
     // Calculate total size needed: offsets + data + mask
@@ -208,7 +215,8 @@ TEST_CASE("column_builder - sufficient_space_for_column",
   SECTION("VARCHAR type space check - sufficient space")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
     // Allocate space for 100 rows with default VARCHAR size
     size_t num_rows   = 100;
@@ -241,7 +249,8 @@ TEST_CASE("column_builder - sufficient_space_for_column",
   SECTION("VARCHAR type space check - insufficient space")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 10);  // Small default size
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         10);  // Small default size
 
     // Allocate space for 10 rows with small VARCHAR size (10 bytes per row)
     size_t num_rows   = 10;
@@ -285,7 +294,7 @@ TEST_CASE("column_builder - process_mask_for_column",
   SECTION("byte-aligned mask processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -320,7 +329,7 @@ TEST_CASE("column_builder - process_mask_for_column",
   SECTION("byte-unaligned mask processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -351,7 +360,7 @@ TEST_CASE("column_builder - process_mask_for_column",
   SECTION("null_count reflects invalid rows in validity mask")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -375,7 +384,7 @@ TEST_CASE("column_builder - process_mask_for_column",
   SECTION("null_count remains zero when all rows are valid (mask pointer not null)")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -398,7 +407,7 @@ TEST_CASE("column_builder - process_mask_for_column",
   SECTION("null_count remains zero when validity mask data pointer is null")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -429,7 +438,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
   SECTION("INTEGER column processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -468,7 +477,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
   SECTION("BIGINT column processing")
   {
     auto bigint_type = duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT);
-    duckdb_scan_task_local_state::column_builder builder(bigint_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(bigint_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int64_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -505,7 +514,7 @@ TEST_CASE("column_builder - process_column for fixed-width types",
   SECTION("DOUBLE column processing")
   {
     auto double_type = duckdb::LogicalType(duckdb::LogicalTypeId::DOUBLE);
-    duckdb_scan_task_local_state::column_builder builder(double_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(double_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(double) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -545,7 +554,8 @@ TEST_CASE("column_builder - process_column for VARCHAR",
   SECTION("VARCHAR column processing with all valid rows")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows   = 10;
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
@@ -591,7 +601,8 @@ TEST_CASE("column_builder - process_column for VARCHAR",
   SECTION("VARCHAR column processing with NULL values")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, DEFAULT_VARCHAR_SIZE);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type),
+                                                         DEFAULT_VARCHAR_SIZE);
 
     size_t num_rows   = 10;
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
@@ -648,7 +659,7 @@ TEST_CASE("column_builder - multiple batch processing",
   SECTION("process multiple batches of INTEGER data")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -684,7 +695,7 @@ TEST_CASE("column_builder - multiple batch processing",
   SECTION("process multiple batches of VARCHAR data")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type), 256);
 
     size_t num_rows   = 20;
     size_t total_size = sizeof(int64_t) * (num_rows + 1) +    // offsets
@@ -729,7 +740,7 @@ TEST_CASE("column_builder - multiple batch processing",
   SECTION("process multiple batches with mixed NULL values")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -792,7 +803,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][sha
   SECTION("empty vector (0 rows)")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -813,7 +824,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][sha
   SECTION("all NULL vector")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 100;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -855,7 +866,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][sha
   SECTION("empty strings in VARCHAR")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type), 256);
 
     size_t num_rows      = 10;
     size_t max_data_size = 1024;
@@ -899,7 +910,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][sha
   SECTION("mixed empty and non-empty VARCHAR strings")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type), 256);
 
     size_t num_rows      = 10;
     size_t max_data_size = 1024;
@@ -948,7 +959,7 @@ TEST_CASE("column_builder - edge cases", "[duckdb_scan_task][column_builder][sha
   SECTION("single row processing")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     size_t num_rows   = 10;
     size_t total_size = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -992,8 +1003,9 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     auto int_type    = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
     auto bigint_type = duckdb::LogicalType(duckdb::LogicalTypeId::BIGINT);
 
-    duckdb_scan_task_local_state::column_builder int_builder(int_type, 256);
-    duckdb_scan_task_local_state::column_builder bigint_builder(bigint_type, 256);
+    duckdb_scan_task_local_state::column_builder int_builder(sirius::from_duckdb(int_type), 256);
+    duckdb_scan_task_local_state::column_builder bigint_builder(sirius::from_duckdb(bigint_type),
+                                                                256);
 
     size_t num_rows         = 10;
     size_t int_data_size    = sizeof(int32_t) * num_rows;
@@ -1057,8 +1069,9 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     auto int_type     = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 
-    duckdb_scan_task_local_state::column_builder int_builder(int_type, 256);
-    duckdb_scan_task_local_state::column_builder varchar_builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder int_builder(sirius::from_duckdb(int_type), 256);
+    duckdb_scan_task_local_state::column_builder varchar_builder(sirius::from_duckdb(varchar_type),
+                                                                 256);
 
     size_t num_rows            = 5;
     size_t int_data_size       = sizeof(int32_t) * num_rows;
@@ -1137,9 +1150,11 @@ TEST_CASE("column_builder - packed allocation multiple columns",
     auto double_type  = duckdb::LogicalType(duckdb::LogicalTypeId::DOUBLE);
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 
-    duckdb_scan_task_local_state::column_builder int_builder(int_type, 256);
-    duckdb_scan_task_local_state::column_builder double_builder(double_type, 256);
-    duckdb_scan_task_local_state::column_builder varchar_builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder int_builder(sirius::from_duckdb(int_type), 256);
+    duckdb_scan_task_local_state::column_builder double_builder(sirius::from_duckdb(double_type),
+                                                                256);
+    duckdb_scan_task_local_state::column_builder varchar_builder(sirius::from_duckdb(varchar_type),
+                                                                 256);
 
     size_t num_rows    = 8;
     size_t int_size    = sizeof(int32_t) * num_rows + sirius::utils::ceil_div_8(num_rows);
@@ -1240,7 +1255,8 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     duckdb_scan_task_local_state::column_builder builder(
-      varchar_type, 4);  // Small default size: 5 rows * 4 bytes = 20 bytes allocated
+      sirius::from_duckdb(varchar_type),
+      4);  // Small default size: 5 rows * 4 bytes = 20 bytes allocated
 
     size_t num_rows      = 5;
     size_t max_data_size = 20;  // Only 20 bytes of data space
@@ -1276,7 +1292,7 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
   SECTION("VARCHAR with all NULLs uses no data space")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type), 256);
 
     size_t num_rows      = 10;
     size_t max_data_size = 1024;
@@ -1313,7 +1329,7 @@ TEST_CASE("column_builder - VARCHAR space checking edge cases",
   SECTION("VARCHAR alternating NULL and valid pattern")
   {
     auto varchar_type = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    duckdb_scan_task_local_state::column_builder builder(varchar_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(varchar_type), 256);
 
     size_t num_rows      = 10;
     size_t max_data_size = 1024;
@@ -1368,7 +1384,7 @@ TEST_CASE("column_builder - NULL handling at boundaries",
   SECTION("NULLs at byte boundaries in mask")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     // Test with exactly 16 rows (2 mask bytes)
     size_t num_rows   = 16;
@@ -1413,7 +1429,7 @@ TEST_CASE("column_builder - NULL handling at boundaries",
   SECTION("all rows NULL across multiple mask bytes")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     // Test with 24 rows (3 mask bytes)
     size_t num_rows   = 24;
@@ -1442,7 +1458,7 @@ TEST_CASE("column_builder - NULL handling at boundaries",
   SECTION("no NULLs across multiple mask bytes")
   {
     auto int_type = duckdb::LogicalType(duckdb::LogicalTypeId::INTEGER);
-    duckdb_scan_task_local_state::column_builder builder(int_type, 256);
+    duckdb_scan_task_local_state::column_builder builder(sirius::from_duckdb(int_type), 256);
 
     // Test with 20 rows (3 mask bytes, last one partial)
     size_t num_rows   = 20;

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -21,6 +21,7 @@
 
 // sirius
 #include <data/data_batch_utils.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/scan/parquet_scan_operator_data.hpp>
 #include <op/scan/sirius_gpu_parquet_scan_operator.hpp>
 #include <op/scan/sirius_parquet_metadata_scan_operator.hpp>
@@ -179,16 +180,18 @@ std::vector<std::shared_ptr<cucascade::data_batch>> run_two_pipeline_scan(
   rmm::cuda_stream_view stream                             = cudf::get_default_stream())
 {
   // --- Pipeline 1: metadata scan ---
-  sirius::op::scan::sirius_parquet_metadata_scan_operator metadata_op(output_types,
-                                                                      0,
-                                                                      file_paths,
-                                                                      column_ids,
-                                                                      projection_ids,
-                                                                      names,
-                                                                      approximate_batch_size,
-                                                                      std::move(table_filters));
+  sirius::op::scan::sirius_parquet_metadata_scan_operator metadata_op(
+    sirius::from_duckdb_vec(output_types),
+    0,
+    file_paths,
+    column_ids,
+    projection_ids,
+    names,
+    approximate_batch_size,
+    std::move(table_filters));
 
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(output_types, 0, gpu_space);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(output_types), 0, gpu_space);
 
   // Execute all metadata tasks and sink results into the GPU operator.
   while (!metadata_op.all_ports_empty()) {
@@ -280,8 +283,13 @@ TEST_CASE("metadata_scan_operator - source interface dispatches all files",
   std::vector<std::string> files = {path.string()};
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_parquet_metadata_scan_operator op(
-    schema.types, 0, files, schema.column_ids, no_projection, schema.names, 1024 * 1024);
+  sirius::op::scan::sirius_parquet_metadata_scan_operator op(sirius::from_duckdb_vec(schema.types),
+                                                             0,
+                                                             files,
+                                                             schema.column_ids,
+                                                             no_projection,
+                                                             schema.names,
+                                                             1024 * 1024);
 
   REQUIRE(op.is_source());
   REQUIRE_FALSE(op.all_ports_empty());
@@ -312,8 +320,13 @@ TEST_CASE("metadata_scan_operator - execute produces partitioned metadata",
   std::vector<std::string> files = {path.string()};
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_parquet_metadata_scan_operator op(
-    schema.types, 0, files, schema.column_ids, no_projection, schema.names, 1024 * 1024);
+  sirius::op::scan::sirius_parquet_metadata_scan_operator op(sirius::from_duckdb_vec(schema.types),
+                                                             0,
+                                                             files,
+                                                             schema.column_ids,
+                                                             no_projection,
+                                                             schema.names,
+                                                             1024 * 1024);
 
   auto input = op.get_next_task_input_data();
   REQUIRE(input);
@@ -656,7 +669,8 @@ TEST_CASE("gpu_scan_operator - sink and finalize lifecycle", "[gpu_scan_operator
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::INTEGER);
-  sirius::op::scan::sirius_gpu_parquet_scan_operator op(types, 0, *gpu_space);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator op(
+    sirius::from_duckdb_vec(types), 0, *gpu_space);
 
   REQUIRE(op.is_sink());
   REQUIRE(op.is_source());

--- a/test/cpp/scan/test_parquet_scan_task.cpp
+++ b/test/cpp/scan/test_parquet_scan_task.cpp
@@ -21,6 +21,7 @@
 
 // sirius
 #include <exec/config.hpp>
+#include <helper/type_conversions.hpp>
 #include <op/scan/duckdb_scan_task_queue.hpp>
 #include <op/scan/parquet_scan_task.hpp>
 #include <op/sirius_physical_parquet_scan.hpp>
@@ -200,19 +201,20 @@ static std::unique_ptr<sirius::op::sirius_physical_parquet_scan> make_parquet_sc
     }
   }
 
-  return std::make_unique<sirius::op::sirius_physical_parquet_scan>(output_types,
-                                                                    table_function,
-                                                                    std::move(bind_data),
-                                                                    return_types,
-                                                                    std::move(column_ids),
-                                                                    std::move(projection_ids),
-                                                                    std::move(names),
-                                                                    std::move(table_filters),
-                                                                    0,
-                                                                    std::move(extra_info),
-                                                                    duckdb::vector<duckdb::Value>(),
-                                                                    std::move(virtual_columns),
-                                                                    nullptr);
+  return std::make_unique<sirius::op::sirius_physical_parquet_scan>(
+    sirius::from_duckdb_vec(output_types),
+    table_function,
+    std::move(bind_data),
+    sirius::from_duckdb_vec(return_types),
+    std::move(column_ids),
+    std::move(projection_ids),
+    std::move(names),
+    std::move(table_filters),
+    0,
+    std::move(extra_info),
+    duckdb::vector<duckdb::Value>(),
+    std::move(virtual_columns),
+    nullptr);
 }
 
 static duckdb::unique_ptr<duckdb::TableFilterSet> make_id_constant_filter(

--- a/test/cpp/scan/test_scan_executor.cpp
+++ b/test/cpp/scan/test_scan_executor.cpp
@@ -20,6 +20,7 @@
 #include <utils/utils.hpp>
 
 // sirius
+#include <helper/type_conversions.hpp>
 #include <op/scan/duckdb_scan_executor.hpp>
 #include <op/scan/duckdb_scan_task.hpp>
 #include <pipeline/pipeline_executor.hpp>
@@ -91,11 +92,11 @@ static std::unique_ptr<sirius::op::sirius_physical_duckdb_scan> make_physical_ta
 
   // Create sirius_physical_duckdb_scan with all required parameters
   auto physical_scan = std::make_unique<sirius::op::sirius_physical_duckdb_scan>(
-    table_catalog_entry.GetTypes(),   // types
-    table_scan_function,              // function
-    std::move(bind_data),             // bind_data
-    table_catalog_entry.GetTypes(),   // returned_types
-    std::move(column_ids),            // column_ids
+    sirius::from_duckdb_vec(table_catalog_entry.GetTypes()),  // types
+    table_scan_function,                                      // function
+    std::move(bind_data),                                     // bind_data
+    sirius::from_duckdb_vec(table_catalog_entry.GetTypes()),  // returned_types
+    std::move(column_ids),                                    // column_ids
     std::move(projection_ids),        // projection_ids (maps output to internal columns)
     std::move(column_names),          // names
     nullptr,                          // table_filters


### PR DESCRIPTION
Replace `duckdb::LogicalType` throughout the Sirius GPU engine with a new lightweight `sirius::logical_type` (carrying type_id + DECIMAL precision/scale). DuckDB types are now converted at the plan boundary via `from_duckdb_vec()` / `to_duckdb_vec()` in `type_conversions.cpp` and never flow into operator internals.

- Add `type_id` enum + `logical_type` class with predicates (is_integer, is_numeric, is_temporal, is_fixed_width, etc.)
- Add `from_duckdb` / `to_duckdb` boundary converters including LIST support
- Cleaning w.r.t `sirius::get_cudf_type(const logical_type&)` to cudf_utils.hpp; merge duplicate namespace sirius blocks; exhaustive explicit throws for non-GPU types
- Replace `duckdb::vector<duckdb::LogicalType>` with `duckdb::vector<sirius::logical_type>` across all operators
- Remove dead fn `from_duckdb_expr_return_types()` (zero call sites)
- Add `test/cpp/helper/test_logical_type.cpp` covering all predicates, byte sizes, to_string, equality, and conversion round-trips for all 24 type_id values

Closes #555