### PR TITLE
Use static cudart in vcpkg extension build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if(VCPKG_BUILD)
   string(REGEX REPLACE "-I[^ ]*/include/cccl" "" CMAKE_CUDA_FLAGS
                        "${CMAKE_CUDA_FLAGS}")
 
+  # The loadable extension must not depend on libcudart.so in the vcpkg build.
+  # Set the CUDA language default to the static runtime before any CUDA targets
+  # are created.
+  set(CMAKE_CUDA_RUNTIME_LIBRARY Static)
+
   # Strip conda-injected -Wl,-rpath flags from linker flags and disable CMake's
   # RPATH mechanism so binaries don't carry a hardcoded path to the pixi/conda
   # env. All deps are statically linked, so no RPATH is needed. FORCE is
@@ -90,6 +95,37 @@ set(WARNINGS_AS_ERRORS
     OFF
     CACHE BOOL "" FORCE)
 add_subdirectory(cucascade "${CMAKE_BINARY_DIR}/cucascade" EXCLUDE_FROM_ALL)
+
+if(VCPKG_BUILD AND TARGET CUDA::cudart_static)
+  function(sirius_prefer_static_cudart target_name)
+    foreach(_prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+      get_target_property(_libs "${target_name}" "${_prop}")
+      if(NOT _libs OR _libs STREQUAL "_libs-NOTFOUND")
+        continue()
+      endif()
+
+      set(_patched_libs "${_libs}")
+      list(TRANSFORM _patched_libs REPLACE "^CUDA::cudart$"
+                   "CUDA::cudart_static")
+      list(TRANSFORM _patched_libs REPLACE "^\\$<LINK_ONLY:CUDA::cudart>$"
+                   "$<LINK_ONLY:CUDA::cudart_static>")
+
+      if(NOT _patched_libs STREQUAL _libs)
+        set_target_properties("${target_name}" PROPERTIES "${_prop}"
+                                                         "${_patched_libs}")
+      endif()
+    endforeach()
+
+    set_target_properties("${target_name}" PROPERTIES CUDA_RUNTIME_LIBRARY
+                                                         Static)
+  endfunction()
+
+  foreach(_target cucascade_objects cucascade_static cucascade_shared)
+    if(TARGET "${_target}")
+      sirius_prefer_static_cudart("${_target}")
+    endif()
+  endforeach()
+endif()
 
 # cmake-format: off
 set(EXTENSION_SOURCES
@@ -251,6 +287,10 @@ foreach(_target sirius_extension sirius_loadable_extension)
                CUDA_STANDARD_REQUIRED ON
                CUDA_SEPARABLE_COMPILATION ON
                CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+
+  if(VCPKG_BUILD)
+    set_target_properties(${_target} PROPERTIES CUDA_RUNTIME_LIBRARY Static)
+  endif()
 
   # In the vcpkg build, vcpkg include dir must be searched before DuckDB's
   # bundled fmt (which uses duckdb_fmt namespace, incompatible with spdlog).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,18 +106,18 @@ if(VCPKG_BUILD AND TARGET CUDA::cudart_static)
 
       set(_patched_libs "${_libs}")
       list(TRANSFORM _patched_libs REPLACE "^CUDA::cudart$"
-                   "CUDA::cudart_static")
+                                           "CUDA::cudart_static")
       list(TRANSFORM _patched_libs REPLACE "^\\$<LINK_ONLY:CUDA::cudart>$"
-                   "$<LINK_ONLY:CUDA::cudart_static>")
+                                           "$<LINK_ONLY:CUDA::cudart_static>")
 
       if(NOT _patched_libs STREQUAL _libs)
         set_target_properties("${target_name}" PROPERTIES "${_prop}"
-                                                         "${_patched_libs}")
+                                                          "${_patched_libs}")
       endif()
     endforeach()
 
     set_target_properties("${target_name}" PROPERTIES CUDA_RUNTIME_LIBRARY
-                                                         Static)
+                                                      Static)
   endfunction()
 
   foreach(_target cucascade_objects cucascade_static cucascade_shared)

--- a/vcpkg_ports/rmm/portfile.cmake
+++ b/vcpkg_ports/rmm/portfile.cmake
@@ -55,6 +55,7 @@ vcpkg_cmake_configure(
   -DBUILD_TESTS=OFF
   -DBUILD_BENCHMARKS=OFF
   -DCMAKE_CUDA_ARCHITECTURES=RAPIDS
+  -DCMAKE_CUDA_RUNTIME_LIBRARY=Static
   "-DCMAKE_CXX_FLAGS=-I${CURRENT_INSTALLED_DIR}/include"
   "-DCMAKE_CUDA_FLAGS=-I${CURRENT_INSTALLED_DIR}/include")
 
@@ -94,6 +95,19 @@ execute_process(
     "${CURRENT_PACKAGES_DIR}/share/rapids_logger/rapids_logger-targets.cmake")
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME rmm CONFIG_PATH lib/cmake/rmm)
+
+# RMM still exports shared CUDA::cudart in its installed target file even when
+# built as a static library. That pulls libcudart.so into the final Sirius
+# loadable extension alongside libcudart_static.a. Rewrite the exported target
+# to prefer the static CUDA runtime for vcpkg consumers.
+file(READ "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake" _rmm_targets)
+string(
+  REGEX REPLACE "CUDA::cudart([;\">])"
+                "CUDA::cudart_static\\1"
+                _rmm_targets
+                "${_rmm_targets}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake"
+     "${_rmm_targets}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/vcpkg_ports/rmm/portfile.cmake
+++ b/vcpkg_ports/rmm/portfile.cmake
@@ -101,11 +101,8 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME rmm CONFIG_PATH lib/cmake/rmm)
 # loadable extension alongside libcudart_static.a. Rewrite the exported target
 # to prefer the static CUDA runtime for vcpkg consumers.
 file(READ "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake" _rmm_targets)
-string(
-  REGEX REPLACE "CUDA::cudart([;\">])"
-                "CUDA::cudart_static\\1"
-                _rmm_targets
-                "${_rmm_targets}")
+string(REGEX REPLACE "CUDA::cudart([;\">])" "CUDA::cudart_static\\1"
+                     _rmm_targets "${_rmm_targets}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake"
      "${_rmm_targets}")
 


### PR DESCRIPTION
## Summary

- Statically link the CUDA runtime (`cudart_static`) instead of dynamically linking
  `libcudart.so` in the vcpkg extension build, so the loadable extension has no runtime
  dependency on a system CUDA installation.
- Set `CMAKE_CUDA_RUNTIME_LIBRARY=Static` globally for CUDA targets, pass it through to
  the RMM vcpkg port, and patch RMM's exported CMake targets to reference
  `CUDA::cudart_static` instead of `CUDA::cudart`.
- Add a `sirius_prefer_static_cudart()` CMake function that rewrites cucascade target
  link libraries from shared to static cudart after `add_subdirectory`.

## Test plan

- [x] Verify vcpkg build succeeds: `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make`
- [x] Confirm the loadable extension has no `libcudart.so` dependency:
      `ldd build/release/extension/sirius/sirius_loadable.duckdb_extension | grep cudart`
- [x] Run SQL logic tests: `make test`

🤖 Created by Claude