### PR TITLE
feat: replace GPUBufferManager with cuCascade for exchange path in Doris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(EXTENSION_SOURCES
     src/expression_executor/specializations/gpu_execute_constant.cpp
     src/expression_executor/specializations/gpu_execute_function.cpp
     src/expression_executor/specializations/gpu_execute_operator.cpp
+    src/exchange_memory_manager.cpp
     src/expression_executor/specializations/gpu_execute_reference.cpp
     src/fallback.cpp
     src/gpu_buffer_manager.cpp

--- a/doris/crates/sirius-doris-be/src/main.rs
+++ b/doris/crates/sirius-doris-be/src/main.rs
@@ -156,49 +156,44 @@ fn main() {
         )
             .map(|a| std::sync::Arc::new(a))
     };
-    // Allocate TWO staging buffers via C++ cudaMalloc:
+    // Get pre-allocated exchange staging buffers from cuCascade (allocated during SiriusContext init).
     // 1. Send staging: used by C++ cudf::chunked_pack to pack outgoing GPU data
     // 2. Receive staging: registered with nixl, used for incoming GPU transfers
     // They must be separate because the receiver's exchange table data (in receive
     // staging) is read by the GPU scan while the sender packs new data (in send staging).
-    if let (Some(ref agent), Some(ref eng), Some(size)) = (&nixl_agent, &engine, staging_size) {
-        let half = size / 2;
+    if let (Some(ref agent), Some(ref eng)) = (&nixl_agent, &engine) {
         let eng_guard = eng.lock().unwrap();
 
         // Send staging: C++ packs outgoing data here via cudf::chunked_pack.
         // Registered with nixl so it can transfer to remote BEs.
-        let send_ok = match eng_guard.cuda_alloc(half) {
-            Ok(addr) => {
-                info!(addr = format_args!("0x{addr:x}"), size_mb = half / (1024 * 1024),
-                      "allocated SEND staging via C++ cudaMalloc");
-                if let Err(e) = eng_guard.set_staging_buffer(addr, half) {
-                    warn!(error = %e, "failed to set send staging");
-                }
-                // Register send buffer with nixl (sender reads from here).
-                if let Err(e) = agent.register_send_staging(addr, half) {
+        let send_ok = match eng_guard.get_exchange_staging("send") {
+            Ok((addr, size)) => {
+                info!(addr = format_args!("0x{addr:x}"), size_mb = size / (1024 * 1024),
+                      "got SEND staging from cuCascade");
+                if let Err(e) = agent.register_send_staging(addr, size) {
                     warn!(error = %e, "failed to register send staging with nixl");
                 }
                 true
             }
-            Err(e) => { warn!(error = %e, "send staging alloc failed"); false }
+            Err(e) => { warn!(error = %e, "send staging get failed"); false }
         };
 
         // Receive staging: nixl writes incoming transfers here.
-        // Exchange tables point into this buffer (via registerExternalTable).
-        let recv_ok = match eng_guard.cuda_alloc(half) {
-            Ok(addr) => {
-                info!(addr = format_args!("0x{addr:x}"), size_mb = half / (1024 * 1024),
-                      "allocated RECV staging via C++ cudaMalloc");
-                match agent.register_staging_from_addr(addr, half) {
+        // Exchange tables point into this buffer (via registerExternalTablePacked).
+        let recv_ok = match eng_guard.get_exchange_staging("recv") {
+            Ok((addr, size)) => {
+                info!(addr = format_args!("0x{addr:x}"), size_mb = size / (1024 * 1024),
+                      "got RECV staging from cuCascade");
+                match agent.register_staging_from_addr(addr, size) {
                     Ok(()) => { info!("recv staging registered with nixl"); true }
                     Err(e) => { warn!(error = %e, "recv staging nixl registration failed"); false }
                 }
             }
-            Err(e) => { warn!(error = %e, "recv staging alloc failed"); false }
+            Err(e) => { warn!(error = %e, "recv staging get failed"); false }
         };
 
         if send_ok && recv_ok {
-            info!("dual staging buffers ready (send + recv, {}MB each)", half / (1024 * 1024));
+            info!("dual staging buffers ready (send + recv)");
         }
 
         drop(eng_guard);

--- a/doris/crates/sirius-ffi/src/lib.rs
+++ b/doris/crates/sirius-ffi/src/lib.rs
@@ -1112,6 +1112,26 @@ impl SiriusEngine {
         let addr: i64 = row.get(0).map_err(|e| EngineError::ExecFailed(e.to_string()))?;
         Ok(addr as usize)
     }
+
+    /// Get a pre-allocated exchange staging buffer address.
+    ///
+    /// Staging buffers are allocated from cuCascade's GPU pool during SiriusContext
+    /// initialization. This function returns the address and size for the specified
+    /// role ("send" or "recv").
+    pub fn get_exchange_staging(&self, role: &str) -> Result<(usize, usize), EngineError> {
+        let sql = format!("SELECT * FROM sirius_get_exchange_staging('{}')", role);
+        let mut stmt = self.conn
+            .prepare(&sql)
+            .map_err(|e| EngineError::ExecFailed(e.to_string()))?;
+        let mut rows = stmt.query([])
+            .map_err(|e| EngineError::ExecFailed(e.to_string()))?;
+        let row = rows.next()
+            .map_err(|e| EngineError::ExecFailed(e.to_string()))?
+            .ok_or_else(|| EngineError::ExecFailed("sirius_get_exchange_staging: no result".into()))?;
+        let addr: i64 = row.get(0).map_err(|e| EngineError::ExecFailed(e.to_string()))?;
+        let size: i64 = row.get(1).map_err(|e| EngineError::ExecFailed(e.to_string()))?;
+        Ok((addr as usize, size as usize))
+    }
 }
 
 /// Owned exchange result artifact returned by the modern GPU exchange path.

--- a/src/exchange_memory_manager.cpp
+++ b/src/exchange_memory_manager.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exchange_memory_manager.hpp"
+#include "last_gpu_buffers.hpp"
+#include "log/logging.hpp"
+
+#include <cudf/concatenate.hpp>
+#include <cudf/contiguous_split.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace duckdb {
+
+// ---------------------------------------------------------------------------
+// ExchangeTable
+// ---------------------------------------------------------------------------
+
+void ExchangeTable::finalize_pending_views()
+{
+  if (pending_views.empty()) { return; }
+
+  SIRIUS_LOG_INFO("[finalize_pending_views] finalizing {} pending views, {} total rows",
+                  pending_views.size(), pending_total_rows);
+
+  // Re-unpack from stored metadata + gpu_ptrs to get fresh table_views.
+  // The stored pending_views may have corrupted column_view pointers if
+  // the vector reallocated.
+  if (pending_gpu_ptrs.size() == pending_views.size() &&
+      pending_metadata.size() == pending_views.size()) {
+    pending_views.clear();
+    for (size_t i = 0; i < pending_metadata.size(); i++) {
+      auto* md_ptr = reinterpret_cast<const uint8_t*>(pending_metadata[i].data());
+      auto view    = cudf::unpack(md_ptr, pending_gpu_ptrs[i]);
+      if (i < pending_projection_indices.size() && !pending_projection_indices[i].empty()) {
+        std::vector<cudf::column_view> projected;
+        projected.reserve(pending_projection_indices[i].size());
+        for (auto idx : pending_projection_indices[i]) {
+          projected.push_back(view.column(idx));
+        }
+        view = cudf::table_view(projected);
+      }
+      pending_views.push_back(view);
+    }
+  }
+
+  auto merged = cudf::concatenate(pending_views);
+  finalized   = std::shared_ptr<cudf::table>(merged.release());
+
+  pending_views.clear();
+  pending_metadata.clear();
+  pending_gpu_ptrs.clear();
+  pending_projection_indices.clear();
+  if (finalized) {
+    pending_total_rows = static_cast<size_t>(finalized->num_rows());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ExchangeMemoryManager
+// ---------------------------------------------------------------------------
+
+std::atomic<ExchangeMemoryManager*> ExchangeMemoryManager::active_{nullptr};
+
+namespace {
+
+cudf::table_view apply_projection_indices(cudf::table_view view,
+                                          const std::vector<int32_t>& projection_indices)
+{
+  if (projection_indices.empty()) { return view; }
+
+  std::vector<cudf::column_view> projected;
+  projected.reserve(projection_indices.size());
+  for (auto idx : projection_indices) {
+    if (idx < 0 || idx >= view.num_columns()) {
+      throw std::runtime_error("projection index " + std::to_string(idx) +
+                               " out of range for packed table with " +
+                               std::to_string(view.num_columns()) + " columns");
+    }
+    projected.push_back(view.column(idx));
+  }
+  return cudf::table_view(projected);
+}
+
+}  // namespace
+
+ExchangeMemoryManager::ExchangeMemoryManager(const sirius::exchange_params& params)
+{
+  // cudf device resource is already set to cuCascade by sirius_memory_reservation_manager.
+  auto* mr        = rmm::mr::get_current_device_resource();
+  send_staging_ptr_  = mr->allocate(rmm::cuda_stream_view{}, params.send_staging_size);
+  recv_staging_ptr_  = mr->allocate(rmm::cuda_stream_view{}, params.recv_staging_size);
+  send_staging_size_ = params.send_staging_size;
+  recv_staging_size_ = params.recv_staging_size;
+
+  SIRIUS_LOG_INFO("[ExchangeMemoryManager] allocated send staging: 0x{:x} ({} MB), "
+                  "recv staging: 0x{:x} ({} MB)",
+                  reinterpret_cast<uintptr_t>(send_staging_ptr_),
+                  send_staging_size_ / (1024 * 1024),
+                  reinterpret_cast<uintptr_t>(recv_staging_ptr_),
+                  recv_staging_size_ / (1024 * 1024));
+
+  // Tell LastGPUBuffers about the send staging address so the result collector
+  // knows where to pack GPU data via cudf::chunked_pack.
+  LastGPUBuffers::GetInstance().SetStagingBuffer(
+    reinterpret_cast<uintptr_t>(send_staging_ptr_), send_staging_size_);
+
+  active_.store(this, std::memory_order_release);
+}
+
+ExchangeMemoryManager::~ExchangeMemoryManager()
+{
+  active_.store(nullptr, std::memory_order_release);
+
+  auto* mr = rmm::mr::get_current_device_resource();
+  if (send_staging_ptr_) {
+    mr->deallocate(rmm::cuda_stream_view{}, send_staging_ptr_, send_staging_size_);
+  }
+  if (recv_staging_ptr_) {
+    mr->deallocate(rmm::cuda_stream_view{}, recv_staging_ptr_, recv_staging_size_);
+  }
+  SIRIUS_LOG_INFO("[ExchangeMemoryManager] destroyed, staging freed");
+}
+
+ExchangeMemoryManager* ExchangeMemoryManager::GetActive()
+{
+  return active_.load(std::memory_order_acquire);
+}
+
+std::pair<uintptr_t, size_t> ExchangeMemoryManager::GetSendStaging() const
+{
+  return {reinterpret_cast<uintptr_t>(send_staging_ptr_), send_staging_size_};
+}
+
+std::pair<uintptr_t, size_t> ExchangeMemoryManager::GetRecvStaging() const
+{
+  return {reinterpret_cast<uintptr_t>(recv_staging_ptr_), recv_staging_size_};
+}
+
+void ExchangeMemoryManager::registerExternalTablePacked(
+  const std::string& table_name,
+  uint8_t* gpu_data,
+  size_t gpu_size,
+  std::string metadata,
+  const std::vector<int32_t>& projection_indices,
+  int& out_num_cols,
+  int& out_num_rows)
+{
+  std::string up = table_name;
+  std::transform(up.begin(), up.end(), up.begin(), ::toupper);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = tables_.find(up);
+  if (it != tables_.end()) {
+    // Append to existing table.
+    auto& tbl = it->second;
+    tbl->pending_metadata.push_back(std::move(metadata));
+
+    auto& stored_md = tbl->pending_metadata.back();
+    auto* md_ptr    = reinterpret_cast<const uint8_t*>(stored_md.data());
+    auto raw_view   = cudf::unpack(md_ptr, gpu_data);
+    auto view       = apply_projection_indices(raw_view, projection_indices);
+
+    tbl->pending_views.push_back(view);
+    tbl->pending_gpu_ptrs.push_back(gpu_data);
+    tbl->pending_projection_indices.push_back(projection_indices);
+    tbl->pending_total_rows += static_cast<size_t>(view.num_rows());
+
+    out_num_cols = view.num_columns();
+    out_num_rows = static_cast<int>(tbl->pending_total_rows);
+
+    SIRIUS_LOG_INFO("[registerExternalTablePacked] appended '{}': {} rows this view, "
+                    "{} total ({} views)",
+                    up, view.num_rows(), tbl->pending_total_rows,
+                    tbl->pending_views.size());
+    return;
+  }
+
+  // First registration: create ExchangeTable, store metadata, unpack.
+  auto tbl = std::make_shared<ExchangeTable>();
+  tbl->pending_metadata.push_back(std::move(metadata));
+
+  auto& stored_md = tbl->pending_metadata.back();
+  auto* md_ptr    = reinterpret_cast<const uint8_t*>(stored_md.data());
+  auto raw_view   = cudf::unpack(md_ptr, gpu_data);
+  auto view       = apply_projection_indices(raw_view, projection_indices);
+
+  tbl->pending_views.push_back(view);
+  tbl->pending_gpu_ptrs.push_back(gpu_data);
+  tbl->pending_projection_indices.push_back(projection_indices);
+  tbl->pending_total_rows = static_cast<size_t>(view.num_rows());
+
+  tables_[up] = tbl;
+
+  out_num_cols = view.num_columns();
+  out_num_rows = static_cast<int>(view.num_rows());
+
+  SIRIUS_LOG_INFO("[registerExternalTablePacked] registered '{}': {} cols, {} rows",
+                  up, view.num_columns(), view.num_rows());
+}
+
+void ExchangeMemoryManager::finalizeExchangeTable(const std::string& table_name)
+{
+  std::string up = table_name;
+  std::transform(up.begin(), up.end(), up.begin(), ::toupper);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = tables_.find(up);
+  if (it == tables_.end() || !it->second || it->second->pending_views.empty()) { return; }
+
+  SIRIUS_LOG_INFO("[finalizeExchangeTable] finalizing '{}': {} pending views, {} total rows",
+                  up, it->second->pending_views.size(), it->second->pending_total_rows);
+  try {
+    it->second->finalize_pending_views();
+    SIRIUS_LOG_INFO("[finalizeExchangeTable] '{}' finalized: {} cols, {} rows",
+                    up, it->second->finalized->num_columns(),
+                    it->second->finalized->num_rows());
+  } catch (const std::exception& e) {
+    SIRIUS_LOG_ERROR("[finalizeExchangeTable] failed for '{}': {}", up, e.what());
+  }
+}
+
+void ExchangeMemoryManager::finalizeExchangeTables()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  for (auto& [name, tbl] : tables_) {
+    if (name.find("__EXCH_") != std::string::npos && tbl && !tbl->pending_views.empty()) {
+      SIRIUS_LOG_INFO("[finalizeExchangeTables] finalizing '{}'", name);
+      try {
+        tbl->finalize_pending_views();
+      } catch (const std::exception& e) {
+        SIRIUS_LOG_ERROR("[finalizeExchangeTables] failed for '{}': {}", name, e.what());
+      }
+    }
+  }
+}
+
+std::shared_ptr<ExchangeTable> ExchangeMemoryManager::findTable(const std::string& name) const
+{
+  std::string up = name;
+  std::transform(up.begin(), up.end(), up.begin(), ::toupper);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = tables_.find(up);
+  if (it != tables_.end()) { return it->second; }
+  return nullptr;
+}
+
+}  // namespace duckdb

--- a/src/include/exchange_memory_manager.hpp
+++ b/src/include/exchange_memory_manager.hpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sirius_config.hpp"
+
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace duckdb {
+
+/// Lightweight exchange table representation.
+/// Replaces GPUIntermediateRelation for the exchange path — holds only
+/// pending cudf::table_views (from cudf::unpack) and a finalized cudf::table
+/// (from cudf::concatenate). No legacy GPUColumn vector.
+struct ExchangeTable {
+  /// Finalized cudf::table (after finalize_pending_views).
+  /// Shared ownership allows multiple scan operators in the same fragment
+  /// to reuse the same read-only GPU table.
+  std::shared_ptr<cudf::table> finalized;
+
+  /// Pending table_views accumulated from multiple senders (zero-copy).
+  /// Each view points into a packed/staging buffer that stays alive until
+  /// finalize_pending_views() concatenates them.
+  std::vector<cudf::table_view> pending_views;
+
+  /// Keeps metadata buffers alive — cudf::unpack creates table_views that
+  /// reference the host metadata buffer internally (for STRING child column pointers).
+  std::vector<std::string> pending_metadata;
+
+  /// GPU data pointers for re-unpack during finalization.
+  std::vector<uint8_t*> pending_gpu_ptrs;
+
+  /// Per-view projection indices for re-unpack during finalization.
+  std::vector<std::vector<int32_t>> pending_projection_indices;
+
+  /// Total rows across all pending views (before finalization).
+  size_t pending_total_rows = 0;
+
+  [[nodiscard]] bool has_data() const { return finalized || pending_total_rows > 0; }
+
+  [[nodiscard]] size_t num_rows() const
+  {
+    return finalized ? static_cast<size_t>(finalized->num_rows()) : pending_total_rows;
+  }
+
+  /// Concatenate all pending views into a single owned cudf::table.
+  /// Always uses cudf::concatenate (even for single view) because
+  /// cudf::table(column_view) deep copy fails for string columns from cudf::unpack.
+  void finalize_pending_views();
+};
+
+/// Manages exchange staging buffers and the exchange table registry.
+/// Owned by SiriusContext. Allocates staging from the cudf device resource
+/// (which is already set to cuCascade by sirius_memory_reservation_manager).
+///
+/// For the C API edge case (sirius_exchange_c_api.cpp), provides a
+/// process-level accessor via GetActive() (same pattern as LastGPUBuffers).
+class ExchangeMemoryManager {
+ public:
+  explicit ExchangeMemoryManager(const sirius::exchange_params& params);
+  ~ExchangeMemoryManager();
+
+  ExchangeMemoryManager(const ExchangeMemoryManager&)            = delete;
+  ExchangeMemoryManager& operator=(const ExchangeMemoryManager&) = delete;
+
+  /// Process-level accessor for C API (not a singleton — SiriusContext owns lifetime).
+  static ExchangeMemoryManager* GetActive();
+
+  /// Staging buffer access. Returns (address, size).
+  [[nodiscard]] std::pair<uintptr_t, size_t> GetSendStaging() const;
+  [[nodiscard]] std::pair<uintptr_t, size_t> GetRecvStaging() const;
+
+  /// Register a packed cudf buffer from NIXL. Stores metadata, calls cudf::unpack,
+  /// pushes the resulting table_view to pending_views.
+  void registerExternalTablePacked(const std::string& table_name,
+                                   uint8_t* gpu_data,
+                                   size_t gpu_size,
+                                   std::string metadata,
+                                   const std::vector<int32_t>& projection_indices,
+                                   int& out_num_cols,
+                                   int& out_num_rows);
+
+  /// Finalize a single exchange table (cudf::concatenate pending views).
+  void finalizeExchangeTable(const std::string& table_name);
+
+  /// Finalize all exchange tables with __EXCH_ prefix.
+  void finalizeExchangeTables();
+
+  /// Look up an exchange table by name. Returns nullptr if not found.
+  [[nodiscard]] std::shared_ptr<ExchangeTable> findTable(const std::string& name) const;
+
+ private:
+  void* send_staging_ptr_  = nullptr;
+  void* recv_staging_ptr_  = nullptr;
+  size_t send_staging_size_ = 0;
+  size_t recv_staging_size_ = 0;
+
+  std::map<std::string, std::shared_ptr<ExchangeTable>> tables_;
+  mutable std::mutex mutex_;
+
+  static std::atomic<ExchangeMemoryManager*> active_;
+};
+
+}  // namespace duckdb

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -35,7 +35,17 @@ constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES       = 512ULL * 1024 * 1024;  /
 constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES         = 512ULL * 1024 * 1024;  // 512 MB
 constexpr uint64_t DEFAULT_MAX_BUILD_HASH_TABLE_BYTES = 500ULL * 1024 * 1024;  // 500 MB
 
+constexpr uint64_t DEFAULT_EXCHANGE_SEND_STAGING_SIZE = 1ULL << 30;  // 1 GB
+constexpr uint64_t DEFAULT_EXCHANGE_RECV_STAGING_SIZE = 1ULL << 30;  // 1 GB
+
 }  // namespace config
+
+/// Parameters controlling exchange staging buffer sizes.
+/// Set via the .yaml file under the sirius.exchange section.
+struct exchange_params {
+  uint64_t send_staging_size = config::DEFAULT_EXCHANGE_SEND_STAGING_SIZE;
+  uint64_t recv_staging_size = config::DEFAULT_EXCHANGE_RECV_STAGING_SIZE;
+};
 
 /// Parameters controlling operator-level resource sizing.
 /// These can be set via the .yaml file under the sirius.operator_params section
@@ -111,6 +121,11 @@ struct sirius_config {
 
   [[nodiscard]] operator_params& get_operator_params() noexcept { return _operator_params; }
 
+  [[nodiscard]] const exchange_params& get_exchange_params() const noexcept
+  {
+    return _exchange_params;
+  }
+
  private:
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
@@ -121,6 +136,7 @@ struct sirius_config {
   exec::downgrade_executor_config _downgrade_executor_config;
   op::scan::scan_executor_config _scan_executor_config;
   operator_params _operator_params;
+  exchange_params _exchange_params;
 };
 
 }  // namespace sirius

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -18,6 +18,7 @@
 
 #include "creator/task_creator.hpp"
 #include "downgrade/downgrade_executor.hpp"
+#include "exchange_memory_manager.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "pipeline/pipeline_executor.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -140,6 +141,9 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] sirius::creator::task_creator& get_task_creator();
   [[nodiscard]] const sirius::creator::task_creator& get_task_creator() const;
 
+  [[nodiscard]] ExchangeMemoryManager& get_exchange_manager();
+  [[nodiscard]] const ExchangeMemoryManager& get_exchange_manager() const;
+
   /// \brief Start a query with its pipelines.
   /// \param pipelines The ordered pipelines for the query.
   void create_query(
@@ -164,6 +168,7 @@ class SiriusContext : public ClientContextState {
   sirius::sirius_config config_;
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager_;
   // Destroyed before memory_manager_ (declared after it — reverse destruction order).
+  std::unique_ptr<ExchangeMemoryManager> exchange_manager_;
   std::unique_ptr<cucascade::memory::small_pinned_host_memory_resource> small_pinned_allocator_;
   // Previous cuDF pinned resource and threshold — restored in terminate() before
   // small_pinned_allocator_ is destroyed to prevent dangling references.

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -36,7 +36,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/bit.hpp>
 
-// sirius GPU cache
+// sirius GPU cache and exchange
+#include <exchange_memory_manager.hpp>
 #include <gpu_buffer_manager.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 
@@ -675,12 +676,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   auto& l_state = this->_local_state->cast<duckdb_scan_task_local_state>();
   auto& g_state = this->_global_state->cast<duckdb_scan_task_global_state>();
 
-  // Check if the table is already GPU-resident in GPUBufferManager::tables.
+  // Check if the table is already GPU-resident in ExchangeMemoryManager.
   // This happens when exchange data was received via nixl and registered via
-  // cudf::unpack + registerExternalTable (zero-copy from staging buffer).
+  // cudf::unpack + registerExternalTablePacked (zero-copy from staging buffer).
   // In this case, skip the DuckDB scan entirely — the data is already on GPU.
   {
-    auto& bm = duckdb::GPUBufferManager::GetInstance();
+    auto& emgr = g_state._sirius_ctx->get_exchange_manager();
     duckdb::TableFunctionToStringInput tf_input(g_state._op.function, g_state._op.bind_data.get());
     auto to_string = g_state._op.function.to_string(tf_input);
     std::string table_name;
@@ -695,15 +696,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
       if (last_dot != std::string::npos) {
         up = up.substr(last_dot + 1);
       }
-      auto it = bm.tables.find(up);
-      SIRIUS_LOG_INFO("[duckdb_scan_task] GPU-resident check: table='{}' found={} cols={} len={}",
-                      up, it != bm.tables.end(),
-                      (it != bm.tables.end() && it->second) ? it->second->columns.size() : 0,
-                      (it != bm.tables.end() && it->second && !it->second->columns.empty() && it->second->columns[0])
-                        ? it->second->columns[0]->column_length : 0);
-      if (it != bm.tables.end() && !it->second->columns.empty() &&
-          it->second->columns[0]->column_length > 0) {
-        auto num_cached_rows = it->second->columns[0]->column_length;
+      auto exchange_table = emgr.findTable(up);
+      SIRIUS_LOG_INFO("[duckdb_scan_task] GPU-resident check: table='{}' found={} rows={}",
+                      up, exchange_table != nullptr,
+                      exchange_table ? exchange_table->num_rows() : 0);
+      if (exchange_table && exchange_table->has_data()) {
+        auto num_cached_rows = exchange_table->num_rows();
 
         // Only one thread should produce the cached batch for this scan
         // operator. Multiple scan operators may still read the same cached
@@ -722,16 +720,16 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
                         table_name, num_cached_rows);
 
         // Finalize pending views (concatenate multi-sender data) if not yet done.
-        if (!it->second->pending_views.empty()) {
+        if (!exchange_table->pending_views.empty()) {
           try {
-            it->second->finalize_pending_views();
+            exchange_table->finalize_pending_views();
           } catch (const std::exception& e) {
             SIRIUS_LOG_ERROR("[duckdb_scan_task] finalize_pending_views failed: {}", e.what());
           }
         }
-        auto cached_table = it->second->packed_cudf_table;
+        auto cached_table = exchange_table->finalized;
         if (!cached_table) {
-          SIRIUS_LOG_WARN("[duckdb_scan_task] no packed_cudf_table — returning empty cached scan result");
+          SIRIUS_LOG_WARN("[duckdb_scan_task] no finalized exchange table — returning empty cached scan result");
           l_state._local_state_drained = true;
           l_state._defer_drain_until_publish = true;
           return std::make_unique<op::pipelineable_operator_data>(
@@ -762,7 +760,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
 
           // Instead of creating a gpu_table_representation directly (which causes
           // same-device GPU→GPU conversion assertion failures), we populate the
-          // GPUBufferManager cache and let the normal DuckDB scan produce dummy rows.
+          // exchange table cache and let the normal DuckDB scan produce dummy rows.
           // The TABLE_SCAN will find columns cached (via checkIfColumnCached) and skip H2D.
           //
           // This means we DO need the DuckDB table to have rows. Since it's schema-only,
@@ -772,7 +770,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
           // returns 0 rows → pipeline hangs. We need real rows in DuckDB.
           //
           // For now: just log and fall through — the exchange table registration
-          // already put data in GPUBufferManager. We need to also populate DuckDB.
+          // already put data in the exchange table. We need to also populate DuckDB.
           // Ensure CUDA context on this thread (needed to access RMM-allocated GPU data).
           cudaSetDevice(0);
 
@@ -782,8 +780,11 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
             gpu_rep = std::make_unique<cucascade::gpu_table_representation>(
               std::move(owned_table), *gpu_space);
           } else {
+            // cached_table is shared — create a deep copy as unique_ptr for gpu_table_representation.
+            auto owned_copy = std::make_unique<cudf::table>(
+              cached_table->view(), stream, gpu_space->get_default_allocator());
             gpu_rep = std::make_unique<cucascade::gpu_table_representation>(
-              std::move(cached_table), *gpu_space);
+              std::move(owned_copy), *gpu_space);
           }
           static std::atomic<int64_t> cached_batch_id{1000000};
           auto batch = std::make_shared<cucascade::data_batch>(

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -92,6 +92,14 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.reject_unknown();
 }
 
+static void from_yaml(const YAML::Node& node, exchange_params& opt)
+{
+  yaml::reader r(node, "exchange");
+  r.optional("send_staging_size", yaml::bytes(opt.send_staging_size));
+  r.optional("recv_staging_size", yaml::bytes(opt.recv_staging_size));
+  r.reject_unknown();
+}
+
 static void from_yaml(const YAML::Node& node, op::scan::scan_executor_config& opt)
 {
   yaml::reader r(node, "duckdb_scan");
@@ -331,6 +339,9 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
 
     // Operator params
     if (auto n = r.optional_node("operator_params")) { sirius::from_yaml(*n, _operator_params); }
+
+    // Exchange params
+    if (auto n = r.optional_node("exchange")) { sirius::from_yaml(*n, _exchange_params); }
 
     // Explicit space configs (low-level API)
     std::vector<cucascade::memory::gpu_memory_space_config> gpu_space_configs;

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -169,6 +169,10 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   memory_manager_ = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
     config_.get_memory_space_configs());
 
+  // Allocate exchange staging buffers from the cuCascade GPU pool.
+  // Must be after memory_manager_ creation (which sets cudf device resource).
+  exchange_manager_ = std::make_unique<ExchangeMemoryManager>(config_.get_exchange_params());
+
   // Configure cuDF to use our pinned slab allocator for small internal host buffers
   // (e.g. column_device_view metadata arrays in cudf::concatenate).  This eliminates
   // the pageable H2D transfers that cuDF issues by default.
@@ -300,6 +304,9 @@ void SiriusContext::terminate()
   }
   spdlog::info("SiriusContext::terminate: query and repositories reset");
 
+  // Release exchange staging before shutting down the memory pool.
+  exchange_manager_.reset();
+
   spdlog::info("SiriusContext::terminate: shutting down memory manager");
   memory_manager_->shutdown();
   memory_manager_.reset();
@@ -319,6 +326,18 @@ const sirius::memory::sirius_memory_reservation_manager& SiriusContext::get_memo
 {
   throw_if_not_initialized();
   return *memory_manager_;
+}
+
+ExchangeMemoryManager& SiriusContext::get_exchange_manager()
+{
+  throw_if_not_initialized();
+  return *exchange_manager_;
+}
+
+const ExchangeMemoryManager& SiriusContext::get_exchange_manager() const
+{
+  throw_if_not_initialized();
+  return *exchange_manager_;
 }
 
 cucascade::shared_data_repository_manager& SiriusContext::get_data_repository_manager()

--- a/src/sirius_exchange_c_api.cpp
+++ b/src/sirius_exchange_c_api.cpp
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <gpu_buffer_manager.hpp>
+#include <exchange_memory_manager.hpp>
 #include <last_gpu_buffers.hpp>
 #include <sirius_exchange_c_api.hpp>
-#include <sirius_extension.hpp>
 
 #include <exception>
 #include <memory>
@@ -66,8 +65,9 @@ const char* sirius_exchange_last_error() {
 
 int sirius_finalize_exchange_tables_direct() {
   return with_error_boundary([]() -> int {
-    duckdb::SiriusExtension::EnsureExchangeBufferManager();
-    duckdb::GPUBufferManager::GetInstance().finalizeExchangeTables();
+    auto* emgr = duckdb::ExchangeMemoryManager::GetActive();
+    if (!emgr) { throw std::runtime_error("exchange manager not initialized"); }
+    emgr->finalizeExchangeTables();
     return 1;
   });
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1231,12 +1231,58 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
   CreateTableFunctionInfo gpu_allocate_buffers_info(gpu_allocate_buffers);
   catalog.CreateTableFunction(transaction, gpu_allocate_buffers_info);
 
+  // Keep sirius_cuda_alloc for backward compat (legacy callers).
   TableFunction cuda_alloc("sirius_cuda_alloc",
                             {LogicalType::BIGINT},
                             CudaAllocFunction,
                             CudaAllocBind);
   CreateTableFunctionInfo cuda_alloc_info(cuda_alloc);
   catalog.CreateTableFunction(transaction, cuda_alloc_info);
+
+  // sirius_get_exchange_staging(role VARCHAR) — returns pre-allocated staging address.
+  // role is "send" or "recv". Staging is allocated by ExchangeMemoryManager in SiriusContext.
+  {
+    struct ExchStagingData : public TableFunctionData {
+      uintptr_t addr = 0;
+      size_t size = 0;
+      bool finished = false;
+    };
+    auto bind = [](ClientContext& ctx, TableFunctionBindInput& input,
+                    vector<LogicalType>& return_types, vector<string>& names)
+      -> unique_ptr<FunctionData> {
+      return_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+      names = {"addr", "size"};
+      auto result = make_uniq<ExchStagingData>();
+      auto role = input.inputs[0].GetValue<string>();
+      auto sirius_ctx = ctx.registered_state->Get<SiriusContext>("sirius_state");
+      auto& emgr = sirius_ctx->get_exchange_manager();
+      if (role == "send") {
+        auto [addr, sz] = emgr.GetSendStaging();
+        result->addr = addr;
+        result->size = sz;
+      } else if (role == "recv") {
+        auto [addr, sz] = emgr.GetRecvStaging();
+        result->addr = addr;
+        result->size = sz;
+      } else {
+        throw IOException("sirius_get_exchange_staging: role must be 'send' or 'recv', got '%s'", role);
+      }
+      SIRIUS_LOG_INFO("[sirius_get_exchange_staging] role={} addr=0x{:x} size={}", role, result->addr, result->size);
+      return std::move(result);
+    };
+    auto func = [](ClientContext&, TableFunctionInput& data_p, DataChunk& output) {
+      auto& data = data_p.bind_data->CastNoConst<ExchStagingData>();
+      if (data.finished) { output.SetCardinality(0); return; }
+      output.SetCardinality(1);
+      output.SetValue(0, 0, Value::BIGINT(static_cast<int64_t>(data.addr)));
+      output.SetValue(1, 0, Value::BIGINT(static_cast<int64_t>(data.size)));
+      data.finished = true;
+    };
+    TableFunction exch_staging("sirius_get_exchange_staging",
+                                {LogicalType::VARCHAR}, func, bind);
+    CreateTableFunctionInfo exch_staging_info(exch_staging);
+    catalog.CreateTableFunction(transaction, exch_staging_info);
+  }
 
   // sirius_register_packed_table(table_name VARCHAR, gpu_addr BIGINT, gpu_size BIGINT, metadata BLOB)
   // sirius_register_projected_packed_table(..., projection_indices INTEGER[])
@@ -1268,22 +1314,22 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
                       table_name, gpu_addr, gpu_size, md_blob.size(), projection_indices.size());
 
       int num_cols = 0, num_rows_out = 0;
-      SiriusExtension::EnsureExchangeBufferManager();
-      auto& mgr = GPUBufferManager::GetInstance();
-      mgr.registerExternalTablePacked(table_name,
-                                      gpu_ptr,
-                                      gpu_size,
-                                      std::move(md_blob),
-                                      projection_indices,
-                                      num_cols,
-                                      num_rows_out);
+      auto sirius_ctx = ctx.registered_state->Get<SiriusContext>("sirius_state");
+      auto& emgr = sirius_ctx->get_exchange_manager();
+      emgr.registerExternalTablePacked(table_name,
+                                       gpu_ptr,
+                                       gpu_size,
+                                       std::move(md_blob),
+                                       projection_indices,
+                                       num_cols,
+                                       num_rows_out);
 
       cudf::table_view view;
       string up = table_name;
       transform(up.begin(), up.end(), up.begin(), ::toupper);
-      auto it = mgr.tables.find(up);
-      if (it != mgr.tables.end() && !it->second->pending_views.empty()) {
-        view = it->second->pending_views.back();
+      auto exch_table = emgr.findTable(up);
+      if (exch_table && !exch_table->pending_views.empty()) {
+        view = exch_table->pending_views.back();
         num_cols = view.num_columns();
       }
 
@@ -1346,22 +1392,22 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
                       table_name, gpu_addr, gpu_size, md_blob.size(), projection_indices.size());
 
       int num_cols = 0, num_rows_out = 0;
-      SiriusExtension::EnsureExchangeBufferManager();
-      auto& mgr = GPUBufferManager::GetInstance();
-      mgr.registerExternalTablePacked(table_name,
-                                      gpu_ptr,
-                                      gpu_size,
-                                      std::move(md_blob),
-                                      projection_indices,
-                                      num_cols,
-                                      num_rows_out);
+      auto sirius_ctx = ctx.registered_state->Get<SiriusContext>("sirius_state");
+      auto& emgr = sirius_ctx->get_exchange_manager();
+      emgr.registerExternalTablePacked(table_name,
+                                       gpu_ptr,
+                                       gpu_size,
+                                       std::move(md_blob),
+                                       projection_indices,
+                                       num_cols,
+                                       num_rows_out);
 
       cudf::table_view view;
       string up = table_name;
       transform(up.begin(), up.end(), up.begin(), ::toupper);
-      auto it = mgr.tables.find(up);
-      if (it != mgr.tables.end() && !it->second->pending_views.empty()) {
-        view = it->second->pending_views.back();
+      auto exch_table = emgr.findTable(up);
+      if (exch_table && !exch_table->pending_views.empty()) {
+        view = exch_table->pending_views.back();
         num_cols = view.num_columns();
       }
 
@@ -1469,12 +1515,12 @@ void SiriusExtension::RegisterGPUFunctions(DatabaseInstance& instance)
       result->table_name = input.inputs[0].GetValue<string>();
       return std::move(result);
     };
-    auto func = [](ClientContext&, TableFunctionInput& data_p, DataChunk& output) {
+    auto func = [](ClientContext& ctx, TableFunctionInput& data_p, DataChunk& output) {
       auto& data = data_p.bind_data->CastNoConst<FinalizeOneData>();
       if (data.finished) { output.SetCardinality(0); return; }
       data.finished = true;
-      SiriusExtension::EnsureExchangeBufferManager();
-      GPUBufferManager::GetInstance().finalizeExchangeTable(data.table_name);
+      auto sirius_ctx = ctx.registered_state->Get<SiriusContext>("sirius_state");
+      sirius_ctx->get_exchange_manager().finalizeExchangeTable(data.table_name);
       output.SetValue(0, 0, Value("finalized"));
       output.SetCardinality(1);
     };


### PR DESCRIPTION
## Summary

- Replace `GPUBufferManager::GetInstance()` in the NIXL exchange path with `ExchangeMemoryManager`, a new `SiriusContext` component that allocates staging buffers from cuCascade's GPU memory pool
- Introduce lightweight `ExchangeTable` struct (replaces `GPUIntermediateRelation` for exchange) — holds only `cudf::table_view` pending views and a finalized `cudf::table`
- Exchange staging sizes configurable via `sirius.yaml` (`sirius.exchange.send_staging_size` / `recv_staging_size`, default 1GB each)

### Why

The exchange path was bypassing cuCascade by creating a separate `GPUBufferManager` with its own RMM pool. This pool's init (`cudf::set_current_device_resource(mr)`) overwrote cuCascade's device resource, creating two competing GPU memory pools. Now exchange operations use the same cuCascade pool as query execution.

### Changes

**New files:**
- `src/include/exchange_memory_manager.hpp` — `ExchangeTable` + `ExchangeMemoryManager` class
- `src/exchange_memory_manager.cpp` — staging allocation, table registry, register/finalize methods

**C++ changes:**
- `sirius_config` — added `exchange_params` struct with YAML parsing
- `SiriusContext` — owns `ExchangeMemoryManager`, created in `initialize()`, destroyed in `terminate()`
- `sirius_extension.cpp` — exchange table functions use `SiriusContext::get_exchange_manager()` instead of `GPUBufferManager`; new `sirius_get_exchange_staging` table function
- `sirius_exchange_c_api.cpp` — uses `ExchangeMemoryManager::GetActive()` with null guard
- `duckdb_scan_task.cpp` — GPU-resident table lookup via `ExchangeMemoryManager` (also fixes pre-existing `shared_ptr`/`unique_ptr` build error)

**Rust changes:**
- `sirius-ffi` — added `get_exchange_staging()` method
- `main.rs` — replaced `cuda_alloc` + `set_staging_buffer` with `get_exchange_staging`

## Test plan

- [x] C++ build passes (`pixi run make release`)
- [x] Rust build passes (`pixi run -e doris doris-build`)
- [x] C++ unit tests compile
- [ ] Run 2-BE cluster with exchange queries (`run-tpch.sh --queries 1,6,14`)
- [ ] Verify staging allocated from cuCascade pool (check logs for `ExchangeMemoryManager` messages)
- [ ] Test YAML config override (`sirius.exchange.send_staging_size`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)