### PR TITLE
Add config option to disable parquet row group pruning

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,6 +44,8 @@ uint64_t Config::DEFAULT_SCAN_TASK_VARCHAR_SIZE = 256ULL;
 
 uint64_t Config::MAX_SORT_PARTITION_BYTES = 0;  ///< 0 = auto (33% of available GPU memory)
 
+bool Config::ENABLE_ROW_GROUP_PRUNING = true;
+
 std::string Config::LOG_LEVEL = "info";
 std::string Config::LOG_DIR   = "log";
 int Config::LOG_FLUSH_SECONDS = 3;

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -67,6 +67,9 @@ struct Config {
   //  - max bytes per sort partition (0 = auto based on 33% GPU memory)
   static uint64_t MAX_SORT_PARTITION_BYTES;
 
+  // For parquet scan: whether to prune row groups using filter pushdown statistics
+  static bool ENABLE_ROW_GROUP_PRUNING;
+
   // Logging configuration
   static std::string LOG_LEVEL;
   static std::string LOG_DIR;

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -15,6 +15,7 @@
  */
 
 // sirius
+#include <config.hpp>
 #include <data/cached_data_representation.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/host_parquet_representation.hpp>
@@ -369,7 +370,7 @@ void parquet_scan_task_global_state::initialize_from_files()
   //===----------Row Group Partitioning for Task Generation----------===//
   for (std::size_t file_idx = 0; file_idx < _file_paths.size(); ++file_idx) {
     auto row_group_indices = readers[file_idx]->all_row_groups(_reader_options);
-    if (_translated_filter) {
+    if (_translated_filter && duckdb::Config::ENABLE_ROW_GROUP_PRUNING) {
       auto const row_groups_before_pruning = row_group_indices.size();
       // clang-format off
       SIRIUS_LOG_INFO("[parquet_scan_task_global_state] Row group pruning: file: {}\n" \

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -15,6 +15,7 @@
  */
 
 // sirius
+#include <config.hpp>
 #include <log/logging.hpp>
 #include <op/scan/parquet_scan_operator_data.hpp>
 #include <op/scan/parquet_scan_task.hpp>  // detail::make_selected_column_indices, detail::projected_columns_are_flat
@@ -272,7 +273,7 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
     //===----------Row Group Partitioning----------===//
     auto row_group_indices = reader.all_row_groups(*result->reader_options);
     // Row group pruning with filter pushdown using metadata statistics.
-    if (ast_filter) {
+    if (ast_filter && duckdb::Config::ENABLE_ROW_GROUP_PRUNING) {
       auto const row_groups_before_pruning = row_group_indices.size();
       // clang-format off
       SIRIUS_LOG_DEBUG("[sirius_parquet_metadata_scan_operator] Row group pruning: file: {}\n" \

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -16,6 +16,7 @@
 
 #include "op/sirius_physical_parquet_scan.hpp"
 
+#include "config.hpp"
 #include "expression_executor/gpu_expression_translator.hpp"
 #include "log/logging.hpp"
 #include "op/scan/scan_utils.hpp"
@@ -89,17 +90,23 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(
     auto duckdb_expression = convert_table_filters_to_expression(
       *table_filters, column_ids, returned_types, batch_column_map);
     if (duckdb_expression) {
-      gpu_expression_translator translator(rmm::cuda_stream_default,
-                                           cudf::get_current_device_resource_ref());
-      translated_filter =
-        translator.translate_expression_with_names(*duckdb_expression, name_resolver);
-      if (!translated_filter) {
-        SIRIUS_LOG_INFO(
-          "[sirius_physical_parquet_scan] Failed to translate filter expression for pushdown. "
-          "Filter will be applied in the table scan operator.");
+      if (duckdb::Config::ENABLE_ROW_GROUP_PRUNING) {
+        gpu_expression_translator translator(rmm::cuda_stream_default,
+                                             cudf::get_current_device_resource_ref());
+        translated_filter =
+          translator.translate_expression_with_names(*duckdb_expression, name_resolver);
+        if (!translated_filter) {
+          SIRIUS_LOG_INFO(
+            "[sirius_physical_parquet_scan] Failed to translate filter expression for pushdown. "
+            "Filter will be applied in the table scan operator.");
+        } else {
+          // Instruct the sirius_physical_table_scan operator to bypass execute()
+          if (table_scan) { table_scan->passthrough = true; }
+        }
       } else {
-        // Instruct the sirius_physical_table_scan operator to bypass execute()
-        if (table_scan) { table_scan->passthrough = true; }
+        SIRIUS_LOG_INFO(
+          "[sirius_physical_parquet_scan] Row group pruning disabled via "
+          "enable_row_group_pruning; filter will be applied in the table scan operator.");
       }
       // Move the duckdb_expression into the table scan
       if (table_scan) { table_scan->filter_expr = std::move(duckdb_expression); }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -772,6 +772,13 @@ static void SetModifiedPipeline(ClientContext& context, SetScope scope, Value& p
   SIRIUS_LOG_DEBUG("Updated config MODIFIED_PIPELINE to {}", Config::MODIFIED_PIPELINE);
 }
 
+static void SetEnableRowGroupPruning(ClientContext& context, SetScope scope, Value& parameter)
+{
+  Config::ENABLE_ROW_GROUP_PRUNING = BooleanValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config ENABLE_ROW_GROUP_PRUNING to {}",
+                   Config::ENABLE_ROW_GROUP_PRUNING);
+}
+
 static void SetCacheScanLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
@@ -955,6 +962,13 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::BOOLEAN,
                             Value::BOOLEAN(Config::MODIFIED_PIPELINE),
                             SetModifiedPipeline);
+
+  // Add in config option for parquet row group pruning
+  config.AddExtensionOption("enable_row_group_pruning",
+                            "Whether to prune parquet row groups using filter pushdown statistics",
+                            LogicalType::BOOLEAN,
+                            Value::BOOLEAN(Config::ENABLE_ROW_GROUP_PRUNING),
+                            SetEnableRowGroupPruning);
 
   // Add in config options for duckdb scan task
   // Default batch size


### PR DESCRIPTION
Introduces enable_row_group_pruning (default true) so users can opt out of the filter-pushdown stats-based row group pruning added in #363 