### PR TITLE
scan: support nested column projection in metadata scan

### DIFF
--- a/src/include/op/scan/parquet_schema_mapping.hpp
+++ b/src/include/op/scan/parquet_schema_mapping.hpp
@@ -40,8 +40,14 @@ namespace sirius::op::scan::detail {
  * the named top-level column — e.g. a STRUCT with three fields yields three
  * leaf indices, all sharing the same path_in_schema[0].
  *
- * Matching is case-sensitive; parquet writers and cuDF's reader treat column
- * names as case-sensitive identifiers.
+ * Matching is case-sensitive by design. @p column_name is expected to come
+ * from DuckDB's parquet bind, which already extracted the name verbatim from
+ * the file's schema — so we are comparing a file-schema name to itself and
+ * exact equality is sufficient. DuckDB's SQL-layer case-insensitivity is
+ * resolved upstream of this call and is not relevant here. Parquet and cuDF
+ * both treat column names as case-sensitive, so broadening the match would
+ * silently collapse the pathological (but legal) case of two file-schema
+ * columns differing only in case.
  *
  * Returns an empty vector if @p metadata has no row groups (the file is empty
  * and has no chunk-ordering information to report).

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -18,7 +18,7 @@
 #include <log/logging.hpp>
 #include <op/scan/hive_partition.hpp>  // build_partition_inject_fn
 #include <op/scan/parquet_scan_operator_data.hpp>
-#include <op/scan/parquet_scan_task.hpp>  // detail::make_selected_column_indices, detail::projected_columns_are_flat
+#include <op/scan/parquet_scan_task.hpp>       // detail::make_selected_column_indices
 #include <op/scan/parquet_schema_mapping.hpp>  // detail::leaf_indices_for_column
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_parquet_scan_operator.hpp>
@@ -247,12 +247,6 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
       cudf::host_span<uint8_t const>(footer_buffer->data(), footer_buffer->size()),
       *result->reader_options);
     auto metadata = reader.parquet_metadata();
-    if (_is_projected && !detail::projected_columns_are_flat(metadata, _projected_column_names)) {
-      /// TODO: Support nested column schemas with projection.
-      throw std::runtime_error(
-        "[sirius_parquet_metadata_scan_operator] Parquet scans with projections currently only "
-        "support flat projected columns.");
-    }
 
     //===----------Resolve selected DuckDB columns to parquet column chunk indices----------===//
     // row_group.columns is indexed in parquet schema-leaf order (preorder), which can differ from
@@ -261,19 +255,18 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
     std::vector<std::size_t> selected_chunk_indices;
     std::unordered_set<std::size_t> pure_filter_chunk_indices;
     if (_is_projected) {
-      selected_chunk_indices.reserve(_projected_column_names.size());
       for (std::size_t k = 0; k < _projected_column_names.size(); ++k) {
         auto leaves = detail::leaf_indices_for_column(metadata, _projected_column_names[k]);
-        // projected_columns_are_flat (checked above) guarantees exactly one leaf per name.
-        if (leaves.size() != 1) {
-          throw std::runtime_error(
-            "[sirius_parquet_metadata_scan_operator] Projected column '" +
-            _projected_column_names[k] +
-            "' did not resolve to exactly one parquet leaf in file: " + file_path);
+        if (leaves.empty()) {
+          throw std::runtime_error("[sirius_parquet_metadata_scan_operator] Projected column '" +
+                                   _projected_column_names[k] +
+                                   "' not found in parquet file: " + file_path);
         }
-        selected_chunk_indices.push_back(leaves.front());
-        if (_pure_filter_column_indices.contains(_selected_column_indices[k])) {
-          pure_filter_chunk_indices.insert(leaves.front());
+        bool const is_pure_filter =
+          _pure_filter_column_indices.contains(_selected_column_indices[k]);
+        for (auto const leaf : leaves) {
+          selected_chunk_indices.push_back(leaf);
+          if (is_pure_filter) { pure_filter_chunk_indices.insert(leaf); }
         }
       }
     }

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -1040,59 +1040,7 @@ TEST_CASE("two-pipeline scan - pure filter column pruning",
   REQUIRE(total_rows == 500);
 }
 
-TEST_CASE("two-pipeline scan - DECIMAL filter falls back to DuckDB expression executor",
-          "[two_pipeline_scan][filter][fallback][shared_context]")
-{
-  auto memory_manager = initialize_memory_manager();
-  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
-  REQUIRE(gpu_space);
-
-  auto [db_owner, con]           = sirius::make_test_db_and_connection();
-  constexpr std::size_t NUM_ROWS = 500;
-  create_diverse_table(con, "decimal_fallback", NUM_ROWS);
-  auto path = write_parquet(con, "decimal_fallback", 200);
-  parquet_file_cleanup cleanup{{path}};
-
-  // Schema: id(0) INTEGER, value(1) BIGINT, price(2) DECIMAL(12,2), label(3) VARCHAR, created(4)
-  // DATE. A filter on the DECIMAL column will fail cudf AST translation (DECIMAL types are
-  // disabled due to a cudf bug), so the DuckDB expression executor fallback path is exercised.
-  auto schema                    = diverse_table_schema();
-  std::vector<std::string> files = {path.string()};
-  duckdb::vector<duckdb::idx_t> no_projection;
-
-  // Filter: price < 100.00  (price_cents = i*100+1, so price = i + 0.01; id < 100 → 100 rows)
-  auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  table_filters->PushFilter(
-    duckdb::ColumnIndex(2),
-    duckdb::make_uniq<duckdb::ConstantFilter>(duckdb::ExpressionType::COMPARE_LESSTHAN,
-                                              duckdb::Value::DECIMAL(10000, 12, 2)));
-
-  auto batches = run_two_pipeline_scan(files,
-                                       schema.types,
-                                       schema.types,
-                                       schema.column_ids,
-                                       no_projection,
-                                       schema.names,
-                                       1024 * 1024,
-                                       *gpu_space,
-                                       std::move(table_filters));
-
-  std::size_t total_rows = 0;
-  for (auto const& batch : batches) {
-    auto table = sirius::get_cudf_table_view(*batch);
-    REQUIRE(table.num_columns() == 5);
-    auto ids = copy_int32_column(table.column(0));
-    for (auto id : ids) {
-      REQUIRE(id < 100);
-    }
-    total_rows += table.num_rows();
-  }
-  REQUIRE(total_rows == 100);
-}
-
 //===----------------------------------------------------------------------===//
-// Nested column support (PR #663)
-//
 // Two-pipeline scan tests for parquet files containing STRUCT and LIST
 // columns.  cuDF reassembles nested columns into a single top-level
 // cudf::column when the parent name is passed via parquet_reader_options::set_column_names, so the
@@ -1653,6 +1601,66 @@ TEST_CASE("two-pipeline scan - flat filter with nested projection",
     total_rows += view.num_rows();
   }
   REQUIRE(total_rows == NUM_ROWS - FILTER_MIN);
+}
+
+TEST_CASE("two-pipeline scan - filter on nested column throws cleanly",
+          "[two_pipeline_scan][nested][filter][negative][shared_context]")
+{
+  // cuDF's AST has no operand support for STRUCT or LIST in comparison or
+  // binary ops, so a filter pushed directly against a nested column cannot be
+  // pushed down or evaluated post-scan.  The scan must surface this as an
+  // exception rather than a crash.  This test pins down the "throws cleanly"
+  // contract; the precise layer that throws (filter-to-expression conversion,
+  // AST translation, or the post-scan expression executor fallback) is left
+  // unspecified.
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "filter_on_nested";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': 'v'} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
+                                                   duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
+
+  // Push a constant filter against the STRUCT column.  The constant value type
+  // is unimportant — the point is that the filtered column is nested.
+  auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
+  table_filters->PushFilter(duckdb::ColumnIndex(1),
+                            duckdb::make_uniq<duckdb::ConstantFilter>(
+                              duckdb::ExpressionType::COMPARE_EQUAL, duckdb::Value::INTEGER(0)));
+
+  std::vector<std::string> files = {path.string()};
+  REQUIRE_THROWS(run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space,
+                                       std::move(table_filters)));
 }
 
 //---------- Edge cases ----------//

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -41,6 +41,7 @@
 #include <duckdb/planner/table_filter.hpp>
 
 // standard library
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <string>
@@ -1094,10 +1095,9 @@ TEST_CASE("two-pipeline scan - DECIMAL filter falls back to DuckDB expression ex
 //
 // Two-pipeline scan tests for parquet files containing STRUCT and LIST
 // columns.  cuDF reassembles nested columns into a single top-level
-// cudf::column when the parent name is passed via set_columns, so the
-// metadata-scan operator need only (a) push every leaf chunk into
-// selected_chunk_indices for byte accounting and (b) accept that a single
-// DuckDB column may resolve to multiple parquet leaves.
+// cudf::column when the parent name is passed via parquet_reader_options::set_column_names, so the
+// metadata-scan operator need only (a) push every leaf chunk into selected_chunk_indices for byte
+// accounting and (b) accept that a single DuckDB column may resolve to multiple parquet leaves.
 //
 // Out of scope (not tested here):
 //   - Filter on a sub-field (e.g. WHERE s.a > 10): requires a
@@ -1153,15 +1153,35 @@ TEST_CASE("two-pipeline scan - project STRUCT column",
                                        *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
+  std::vector<int32_t> all_a;
   std::size_t total_rows = 0;
   for (auto const& batch : batches) {
     auto view = sirius::get_cudf_table_view(*batch);
     REQUIRE(view.num_columns() == 1);
-    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
-    REQUIRE(view.column(0).num_children() == 2);
+    auto const struct_col = view.column(0);
+    REQUIRE(struct_col.type().id() == cudf::type_id::STRUCT);
+    REQUIRE(struct_col.num_children() == 2);
+    REQUIRE(struct_col.child(0).type().id() == cudf::type_id::INT32);
+    REQUIRE(struct_col.child(1).type().id() == cudf::type_id::STRING);
+
+    // Child values must be paired: s.b == "row_" || cast(s.a AS VARCHAR).
+    auto a = copy_int32_column(struct_col.child(0));
+    auto b = copy_string_column(struct_col.child(1));
+    REQUIRE(a.size() == b.size());
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      REQUIRE(b[i] == "row_" + std::to_string(a[i]));
+    }
+    all_a.insert(all_a.end(), a.begin(), a.end());
     total_rows += view.num_rows();
   }
   REQUIRE(total_rows == NUM_ROWS);
+
+  // Every expected id must appear exactly once across batches.
+  std::sort(all_a.begin(), all_a.end());
+  REQUIRE(all_a.size() == NUM_ROWS);
+  for (std::size_t i = 0; i < NUM_ROWS; ++i) {
+    REQUIRE(all_a[i] == static_cast<int32_t>(i));
+  }
 }
 
 TEST_CASE("two-pipeline scan - project LIST column", "[two_pipeline_scan][nested][shared_context]")

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -1250,9 +1250,8 @@ TEST_CASE("two-pipeline scan - table with nested column, project flat only",
   duckdb::vector<duckdb::idx_t> projection_ids{0, 2};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
                                                    duckdb::LogicalType::INTEGER};
-  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
-                                                     duckdb::LogicalType::STRUCT({}),
-                                                     duckdb::LogicalType::INTEGER};
+  duckdb::vector<duckdb::LogicalType> returned_types{
+    duckdb::LogicalType::INTEGER, duckdb::LogicalType::STRUCT({}), duckdb::LogicalType::INTEGER};
 
   std::vector<std::string> files = {path.string()};
   auto batches                   = run_two_pipeline_scan(files,

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -1088,3 +1088,575 @@ TEST_CASE("two-pipeline scan - DECIMAL filter falls back to DuckDB expression ex
   }
   REQUIRE(total_rows == 100);
 }
+
+//===----------------------------------------------------------------------===//
+// Nested column support (PR #663)
+//
+// Two-pipeline scan tests for parquet files containing STRUCT and LIST
+// columns.  cuDF reassembles nested columns into a single top-level
+// cudf::column when the parent name is passed via set_columns, so the
+// metadata-scan operator need only (a) push every leaf chunk into
+// selected_chunk_indices for byte accounting and (b) accept that a single
+// DuckDB column may resolve to multiple parquet leaves.
+//
+// Out of scope (not tested here):
+//   - Filter on a sub-field (e.g. WHERE s.a > 10): requires a
+//     duckdb::Expression referencing a struct field rather than a column-level
+//     TableFilter, and depends on GpuExpressionExecutor sub-field support.
+//   - Pure-filter nested columns: TableFilter does not naturally express a
+//     filter on a STRUCT/LIST column at the column level.
+//===----------------------------------------------------------------------===//
+
+//---------- Basic nested projection ----------//
+
+TEST_CASE("two-pipeline scan - project STRUCT column",
+          "[two_pipeline_scan][nested][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 300;
+
+  std::string const table = "nested_struct_scan";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': 'row_' || cast(i AS VARCHAR)} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
+    REQUIRE(view.column(0).num_children() == 2);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - project LIST column", "[two_pipeline_scan][nested][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 300;
+
+  std::string const table = "nested_list_scan";
+  auto create             = con.Query("CREATE TABLE " + table + " (id INTEGER, l INTEGER[])");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert =
+    con.Query("INSERT INTO " + table + " SELECT i, [i, i+1, i+2] FROM generate_series(0, " +
+              std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "l"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{
+    duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::LIST);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - table with nested column, project flat only",
+          "[two_pipeline_scan][nested][shared_context]")
+{
+  // Regression: the mere presence of a STRUCT column in the table's schema
+  // should not affect a scan that projects only flat columns.
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 200;
+
+  std::string const table = "mixed_nested_scan";
+  auto create             = con.Query("CREATE TABLE " + table +
+                          " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR), tail INTEGER)");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': 'x'}, i * 2 "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{
+    duckdb::ColumnIndex(0), duckdb::ColumnIndex(1), duckdb::ColumnIndex(2)};
+  duckdb::vector<std::string> names{"id", "s", "tail"};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 2};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
+                                                   duckdb::LogicalType::INTEGER};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 2);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::INT32);
+    REQUIRE(view.column(1).type().id() == cudf::type_id::INT32);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+//---------- Mixed and multi-file ----------//
+
+TEST_CASE("two-pipeline scan - mixed flat and nested projection",
+          "[two_pipeline_scan][nested][shared_context]")
+{
+  // Project one flat column alongside one nested column.  Verifies that
+  // output-column ordering is preserved when the projection spans both.
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 200;
+
+  std::string const table = "mixed_flat_nested";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': 'v'} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
+                                                   duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 2);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::INT32);
+    REQUIRE(view.column(1).type().id() == cudf::type_id::STRUCT);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - nested column across multiple files",
+          "[two_pipeline_scan][nested][multi_file][shared_context]")
+{
+  // Two files with identical schemas; name-based resolution must work per file.
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]            = sirius::make_test_db_and_connection();
+  constexpr std::size_t ROWS_EACH = 150;
+
+  std::vector<std::filesystem::path> paths;
+  for (auto const& name : {"multi_nested_a", "multi_nested_b"}) {
+    auto create = con.Query(std::string("CREATE TABLE ") + name +
+                            " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+    REQUIRE(create);
+    REQUIRE(!create->HasError());
+
+    auto insert = con.Query(std::string("INSERT INTO ") + name +
+                            " SELECT i, {'a': i, 'b': 'y'} "
+                            "FROM generate_series(0, " +
+                            std::to_string(ROWS_EACH - 1) + ") t(i)");
+    REQUIRE(insert);
+    REQUIRE(!insert->HasError());
+
+    paths.push_back(write_parquet(con, name, 50));
+  }
+  parquet_file_cleanup cleanup{paths};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files;
+  for (auto const& p : paths) {
+    files.push_back(p.string());
+  }
+
+  auto batches = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == 2 * ROWS_EACH);
+}
+
+//---------- Deeper nesting ----------//
+
+TEST_CASE("two-pipeline scan - STRUCT inside STRUCT", "[two_pipeline_scan][nested][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "struct_in_struct";
+  auto create             = con.Query("CREATE TABLE " + table +
+                          " (id INTEGER, s STRUCT(a INTEGER, b STRUCT(c INTEGER, d VARCHAR)))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': {'c': i * 10, 'd': 'inner'}} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
+    REQUIRE(view.column(0).num_children() == 2);
+    REQUIRE(view.column(0).child(1).type().id() == cudf::type_id::STRUCT);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - LIST of LIST", "[two_pipeline_scan][nested][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "list_of_list";
+  auto create             = con.Query("CREATE TABLE " + table + " (id INTEGER, ll INTEGER[][])");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, [[i, i+1], [i+2]] "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "ll"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{
+    duckdb::LogicalType::LIST(duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER))};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::LIST);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - LIST inside STRUCT", "[two_pipeline_scan][nested][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "list_in_struct";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, l INTEGER[]))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'l': [i, i+1, i+2]} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
+    REQUIRE(view.column(0).num_children() == 2);
+    REQUIRE(view.column(0).child(1).type().id() == cudf::type_id::LIST);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+//---------- Filter interaction ----------//
+
+TEST_CASE("two-pipeline scan - flat filter with nested projection",
+          "[two_pipeline_scan][nested][filter][shared_context]")
+{
+  // Filter pushdown on a flat column while the projection includes a nested
+  // column.  The filter runs at scan time; the nested column is projected as
+  // a single top-level cudf::column.
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 500;
+  constexpr int32_t FILTER_MIN   = 100;
+
+  std::string const table = "filter_with_nested";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, {'a': i, 'b': 'v'} "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table, 100);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
+                                                   duckdb::LogicalType::STRUCT({})};
+
+  auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
+  table_filters->PushFilter(
+    duckdb::ColumnIndex(0),
+    duckdb::make_uniq<duckdb::ConstantFilter>(duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO,
+                                              duckdb::Value::INTEGER(FILTER_MIN)));
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space,
+                                       std::move(table_filters));
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 2);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::INT32);
+    REQUIRE(view.column(1).type().id() == cudf::type_id::STRUCT);
+    auto ids = copy_int32_column(view.column(0));
+    for (auto id : ids) {
+      REQUIRE(id >= FILTER_MIN);
+    }
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS - FILTER_MIN);
+}
+
+//---------- Edge cases ----------//
+
+TEST_CASE("two-pipeline scan - LIST with empty and populated rows",
+          "[two_pipeline_scan][nested][edge][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "empty_list_scan";
+  auto create             = con.Query("CREATE TABLE " + table + " (id INTEGER, l INTEGER[])");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, CASE WHEN i % 2 = 0 THEN [] ELSE [i, i+1] END "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "l"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{
+    duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::LIST);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}
+
+TEST_CASE("two-pipeline scan - STRUCT with NULL rows",
+          "[two_pipeline_scan][nested][edge][shared_context]")
+{
+  auto memory_manager = initialize_memory_manager();
+  auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
+  REQUIRE(gpu_space);
+
+  auto [db_owner, con]           = sirius::make_test_db_and_connection();
+  constexpr std::size_t NUM_ROWS = 100;
+
+  std::string const table = "null_struct_scan";
+  auto create =
+    con.Query("CREATE TABLE " + table + " (id INTEGER, s STRUCT(a INTEGER, b VARCHAR))");
+  REQUIRE(create);
+  REQUIRE(!create->HasError());
+
+  auto insert = con.Query("INSERT INTO " + table +
+                          " SELECT i, CASE WHEN i % 3 = 0 THEN NULL ELSE {'a': i, 'b': 'v'} END "
+                          "FROM generate_series(0, " +
+                          std::to_string(NUM_ROWS - 1) + ") t(i)");
+  REQUIRE(insert);
+  REQUIRE(!insert->HasError());
+
+  auto path = write_parquet(con, table);
+  parquet_file_cleanup cleanup{{path}};
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<std::string> names{"id", "s"};
+  duckdb::vector<duckdb::idx_t> projection_ids{1};
+  duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+
+  std::vector<std::string> files = {path.string()};
+  auto batches                   = run_two_pipeline_scan(
+    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+
+  REQUIRE_FALSE(batches.empty());
+  std::size_t total_rows = 0;
+  for (auto const& batch : batches) {
+    auto view = sirius::get_cudf_table_view(*batch);
+    REQUIRE(view.num_columns() == 1);
+    REQUIRE(view.column(0).type().id() == cudf::type_id::STRUCT);
+    total_rows += view.num_rows();
+  }
+  REQUIRE(total_rows == NUM_ROWS);
+}

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -1139,10 +1139,18 @@ TEST_CASE("two-pipeline scan - project STRUCT column",
   duckdb::vector<std::string> names{"id", "s"};
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1184,10 +1192,18 @@ TEST_CASE("two-pipeline scan - project LIST column", "[two_pipeline_scan][nested
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{
     duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
+  duckdb::vector<duckdb::LogicalType> returned_types{
+    duckdb::LogicalType::INTEGER, duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1234,10 +1250,19 @@ TEST_CASE("two-pipeline scan - table with nested column, project flat only",
   duckdb::vector<duckdb::idx_t> projection_ids{0, 2};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
                                                    duckdb::LogicalType::INTEGER};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({}),
+                                                     duckdb::LogicalType::INTEGER};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1286,10 +1311,18 @@ TEST_CASE("two-pipeline scan - mixed flat and nested projection",
   duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
                                                    duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1336,14 +1369,22 @@ TEST_CASE("two-pipeline scan - nested column across multiple files",
   duckdb::vector<std::string> names{"id", "s"};
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files;
   for (auto const& p : paths) {
     files.push_back(p.string());
   }
 
-  auto batches = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1387,10 +1428,18 @@ TEST_CASE("two-pipeline scan - STRUCT inside STRUCT", "[two_pipeline_scan][neste
   duckdb::vector<std::string> names{"id", "s"};
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1434,10 +1483,19 @@ TEST_CASE("two-pipeline scan - LIST of LIST", "[two_pipeline_scan][nested][share
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{
     duckdb::LogicalType::LIST(duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER))};
+  duckdb::vector<duckdb::LogicalType> returned_types{
+    duckdb::LogicalType::INTEGER,
+    duckdb::LogicalType::LIST(duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER))};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1479,10 +1537,18 @@ TEST_CASE("two-pipeline scan - LIST inside STRUCT", "[two_pipeline_scan][nested]
   duckdb::vector<std::string> names{"id", "s"};
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1534,6 +1600,8 @@ TEST_CASE("two-pipeline scan - flat filter with nested projection",
   duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::INTEGER,
                                                    duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
   table_filters->PushFilter(
@@ -1544,6 +1612,7 @@ TEST_CASE("two-pipeline scan - flat filter with nested projection",
   std::vector<std::string> files = {path.string()};
   auto batches                   = run_two_pipeline_scan(files,
                                        output_types,
+                                       returned_types,
                                        column_ids,
                                        projection_ids,
                                        names,
@@ -1599,10 +1668,18 @@ TEST_CASE("two-pipeline scan - LIST with empty and populated rows",
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{
     duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
+  duckdb::vector<duckdb::LogicalType> returned_types{
+    duckdb::LogicalType::INTEGER, duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;
@@ -1645,10 +1722,18 @@ TEST_CASE("two-pipeline scan - STRUCT with NULL rows",
   duckdb::vector<std::string> names{"id", "s"};
   duckdb::vector<duckdb::idx_t> projection_ids{1};
   duckdb::vector<duckdb::LogicalType> output_types{duckdb::LogicalType::STRUCT({})};
+  duckdb::vector<duckdb::LogicalType> returned_types{duckdb::LogicalType::INTEGER,
+                                                     duckdb::LogicalType::STRUCT({})};
 
   std::vector<std::string> files = {path.string()};
-  auto batches                   = run_two_pipeline_scan(
-    files, output_types, column_ids, projection_ids, names, 1024 * 1024, *gpu_space);
+  auto batches                   = run_two_pipeline_scan(files,
+                                       output_types,
+                                       returned_types,
+                                       column_ids,
+                                       projection_ids,
+                                       names,
+                                       1024 * 1024,
+                                       *gpu_space);
 
   REQUIRE_FALSE(batches.empty());
   std::size_t total_rows = 0;


### PR DESCRIPTION
## Summary

Extends the parquet metadata-scan pipeline to support projection of **STRUCT** and **LIST** columns in addition to flat primitives. Builds on #662's name-based DuckDB→parquet column mapping by generalizing the metadata scan's single-leaf-per-column assumption to a multi-leaf-per-column one.

## Motivation

Before this PR, the metadata-scan pipeline enforced a flat-schema guard (`"Parquet scans with projections currently only support flat projected columns."`) because each projected DuckDB column was assumed to map to exactly one parquet column chunk. That breaks for:

- **STRUCT** — one DuckDB column maps to N parquet leaf chunks (one per field), all sharing `path_in_schema[0]`.
- **LIST** — parquet's 3-level list encoding produces leaves at a deeper path (`.list.element` etc.); again, one DuckDB column → one or more leaves.

Any projection of a nested column fell back to DuckDB CPU.

## Changes

1. **Drop the flat-schema guard** in the metadata scan `execute()` path.
2. **Multi-leaf expansion**: for each selected column, call `leaf_indices_for_column` (already generalized to `std::vector<size_t>` in #662) and push every leaf index — including pure-filter leaves — into the chunk-index sets.
3. **No post-read reassembly needed** — cuDF's parquet reader, given a top-level column name, materializes the nested `cudf::column` natively (option (a) from design). `execute()` downstream projection is unchanged.

## Tests

11 new C++ unit tests in `test/cpp/scan/test_metadata_gpu_scan_operators.cpp` (tagged `[two_pipeline_scan][nested]`, 572 assertions):

- Project STRUCT / LIST / STRUCT-inside-STRUCT / LIST-of-LIST / LIST-inside-STRUCT
- Mixed flat + nested projection
- Nested column across multiple files
- Table with nested column but flat-only projection (regression guard)
- Flat filter pushdown alongside nested projection
- Edge cases: LIST with empty rows, STRUCT with NULL rows

## Known gaps (not addressed here)

- **Legacy `parquet_scan_task` path still has the flat-only guard** (`src/op/scan/parquet_scan_task.cpp:466`).
- No SQLLogic / end-to-end `gpu_execution` test — the new tests drive the operators directly.
- No negative test for *filter on a nested column*. The expression executor is known to error rather than crash, but that behavior isn't locked in by a test.

## Out of scope

- **MAP** — not present in `sirius::type_id`.
- **DECIMAL128 in nested contexts.**
- **Nested columns as hive partition columns** — hive key parser only handles scalars.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
