### PR TITLE
Support dynamic table filters

### DIFF
--- a/.codespell_words
+++ b/.codespell_words
@@ -1,5 +1,6 @@
 aktion
 ans
 foto
+fpr
 ist
 thirdparty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ set(EXTENSION_SOURCES
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_utils.cpp
     src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+    src/op/sirius_dynamic_filter.cpp
     src/op/sirius_physical_column_data_scan.cpp
     src/op/sirius_physical_cpu_source.cpp
     src/op/sirius_physical_concat.cpp
@@ -371,6 +372,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_table_scan.cpp
     test/cpp/operator/test_physical_top_n.cpp
     test/cpp/operator/test_physical_ungrouped_aggregate.cpp
+    test/cpp/operator/test_sirius_dynamic_filter.cpp
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp

--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -1,0 +1,249 @@
+# Dynamic Filters
+
+A **dynamic filter** is a predicate that is computed at query runtime by one operator (the *producer*) and consumed by another (the *consumer*) to prune data. The producer sees data, learns something about it, emits a filter; the consumer uses that filter to do less work — ideally before paying the cost of materialization.
+
+This is a category, not a single feature. It spans:
+
+- **Dynamic table-filter pushdown** — a hash-join build pushes a filter into a downstream parquet scan, so row-group pruning and post-decode filtering can happen against the actual build-side keys instead of the static predicates.
+- **Sideways information passing (SIP)** — a hash-join build pushes a filter into another join's probe input, so the second join can reject probe-side rows that can't possibly match.
+- **Aggregation-driven pushdown** — a `GROUP BY` or `DISTINCT` exposes its distinct-value set to downstream consumers.
+- **Sort- or top-N-driven pruning** — a post-sort min/max is exact and free; a top-N's current threshold tightens upstream filters.
+- **Adaptive runtime predicates** — operators that observe data and refine filters over the lifetime of a pipeline.
+
+This document describes the general dynamic-filter framework in Sirius and the phased plan for delivering it. **The current PR adds the framework scaffolding only — no producers, no consumers, no behavior change.** Phase 1 is the first concrete use case (dynamic table-filter pushdown) and lands in follow-up PRs that plug into the scaffolding introduced here.
+
+## How the phases generalize
+
+The framework has four axes of generality. Each phase opens one axis:
+
+| Axis | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
+|------|---------|---------|---------|---------|
+| Filter kind | zone map → bloom → IN-list | (reuses Phase 1's filter zoo) | (reuses) | (reuses) |
+| Consumer kind | parquet metadata scan only | + hash-join probe | + any operator with a column input | (unchanged) |
+| Producer kind | hash-join build only | (unchanged) | + agg, sort, filter | (unchanged) |
+| Coordination | implicit (meta-pipeline ordering) | explicit readiness for non-implicit pairs | (unchanged) | streaming / incremental refinement |
+
+Anything implemented in Phase 1 is reused unchanged by later phases. We do not replace DuckDB's static table-filter pushdown — static filters continue to flow through the existing translator path and are AND-merged with dynamic filters at the consumer.
+
+## Generalized architecture
+
+The framework has four pieces, all designed to be filter-kind, producer-kind, and consumer-kind agnostic:
+
+1. **`sirius_dynamic_filter`** — polymorphic base class for runtime-computed filters. Each subclass knows how to lower itself to a cuDF AST fragment, to a runtime apply pass, or both.
+2. **`sirius_dynamic_filter_set`** — thread-safe append-only channel that connects producers and consumers. Keyed by the consumer's column index in its output schema.
+3. **Filter router** *(future)* — keeps a map of channels keyed by a *route key*, so multiple operators can attach to the same channel during plan construction.
+4. **Producer / consumer roles** *(future)* — concrete operators that push filters into channels (producers) or read them out (consumers). An operator can be both for different channels.
+
+Pieces 1 and 2 (and the `merge_ast_dynamic_filters_into_tree` helper) are introduced in the scaffolding PR. Pieces 3 and 4 land with the first producer and consumer (Phase 1.1).
+
+```
+   PRODUCERS                     CHANNEL                          CONSUMERS
+  ─────────────              ───────────────                     ─────────────
+  hash join build            sirius_dynamic_                     parquet metadata
+  agg / distinct               filter_set                          scan       (AST)
+  sort                                                           hash join probe
+  filter (narrowed)          push_filter(col, f)                   (apply)
+  …                          filters_for_column(col)             expression exec
+                             [ready signal — Phase 4]              (AST)
+                                                                 post-decode filter
+                                                                   (apply)
+
+  Filter zoo (subclasses of sirius_dynamic_filter):
+    sirius_dynamic_zone_map_filter       to_ast Y    apply Y (Phase 1.2 add)
+    sirius_dynamic_bloom_filter          to_ast N    apply Y (Phase 1.3 add)
+    sirius_dynamic_in_list_filter        to_ast Y    apply Y (Phase 1.4 add)
+```
+
+### Filter polymorphism (filter kind axis)
+
+`sirius_dynamic_filter` is the base for every dynamic filter kind. The base carries only the kind tag — concrete consumer-side capabilities (AST lowering today, runtime apply in Phase 1.2) live on separate **capability mixin** interfaces that filters inherit alongside the base. This avoids forcing a filter to implement a path it cannot satisfy: a bloom filter, which has no meaningful AST representation, simply does not inherit from `sirius_ast_lowerable`.
+
+```cpp
+class sirius_dynamic_filter {                  // base — kind tag only
+ public:
+  virtual ~sirius_dynamic_filter() = default;
+  [[nodiscard]] virtual sirius_dynamic_filter_kind kind() const = 0;
+};
+
+class sirius_ast_lowerable {                   // capability: AST lowering
+ public:
+  virtual ~sirius_ast_lowerable() = default;
+  [[nodiscard]] virtual cudf::ast::expression const& to_ast(
+    cudf::ast::tree& tree, cudf::ast::expression const& column_ref) const = 0;
+};
+
+class sirius_dynamic_zone_map_filter
+  : public sirius_dynamic_filter, public sirius_ast_lowerable { /* both */ };
+```
+
+**Consumer-side dispatch** is by `dynamic_cast` from a `sirius_dynamic_filter` pointer to the capability the consumer needs. The `merge_ast_dynamic_filters_into_tree` helper performs the AST-capability cast internally and silently skips filters that lack it, so consumers building an AST tree don't need any per-call-site logic. `sirius_dynamic_filter::kind()` remains for cases where the consumer needs filter-kind-specific behavior beyond what a capability mixin describes (e.g., a parquet reader that natively understands bloom filters via a path other than `apply`).
+
+**AST lowering** — for consumers that build a `cudf::ast::tree` (parquet reader `set_filter`, expression executor). Tree nodes are owned by `tree`; device scalars referenced by literals are owned by the filter instance.
+
+**Runtime apply lowering** *(Phase 1.2)* — for consumers that evaluate a filter against a materialized `cudf::column_view`. Lands as a sibling capability mixin with the same shape.
+
+### Channel — `sirius_dynamic_filter_set` (decoupling axis)
+
+A `sirius_dynamic_filter_set` is the rendezvous between producers and a consumer. It owns the filters and is co-owned via `shared_ptr` by every operator that holds either end.
+
+Properties:
+
+- **Append-only.** `push_filter(col_idx, f)` adds; nothing removes.
+- **Thread-safe.** A mutex guards the underlying map.
+- **Keyed by consumer column index.** Producers push for a column index in the *consumer's* output schema. Multiple producers targeting the same column AND-conjoin at the consumer.
+- **N producers, M consumers.** The channel does not distinguish between them.
+- **Filters are co-owned via `shared_ptr<filter const>`.** Producers may push the same filter object into multiple channels (fan-out — a single bloom filter from a hash-join build can prune both a parquet scan and a downstream join probe without cloning device scalars).
+
+Consumer access is via `filters_for_column(col_idx)` and `filtered_columns()`. The free helper `merge_ast_dynamic_filters_into_tree(tree, existing_root, set, resolver)` walks the channel, lowers every AST-capable filter, AND-conjoins the per-column and cross-column fragments, and returns `AND(existing_root, dynamic_root)` — or `existing_root` unchanged if no filter contributed.
+
+### Filter router — plan-gen channel map (routing axis)
+
+*Introduced in Phase 1.1.* During plan construction, multiple operators must find each other and agree on a shared channel. The router lives on `sirius_physical_plan_generator` and maps a *route key* to a channel:
+
+```cpp
+// Phase 1.1
+std::unordered_map<
+  const duckdb::DynamicTableFilterSet*,
+  std::shared_ptr<sirius::op::sirius_dynamic_filter_set>
+> dynamic_filter_channels;
+```
+
+The route key in Phase 1.1 is `const duckdb::DynamicTableFilterSet*` — DuckDB's optimizer creates a `DynamicTableFilterSet` and references it from both the join's `JoinFilterPushdownInfo::probe_info` and the target `LogicalGet`'s `dynamic_filters`. The pointer is the identity that pairs them.
+
+For Phase 2 (SIP) and Phase 3 (other producers), there is no DuckDB-supplied pointer — Sirius creates the pairing itself, and the route key generalizes to a variant covering Sirius-owned producer/consumer ID pairs. The router's logic is unchanged: find or create a channel for a route key, attach to producer, attach to consumer. Only the key set grows.
+
+### Producer / consumer wiring
+
+*Introduced in Phase 1.1.* A **producer** holds the channel via a per-target struct that also carries the column-index translation from its own schema to the consumer's:
+
+```cpp
+// Phase 1.1, on sirius_physical_hash_join
+struct probe_target {
+  std::shared_ptr<sirius_dynamic_filter_set> filter_set;
+  std::vector<std::size_t> probe_col_idx;   // build-key idx -> consumer col idx
+};
+std::vector<probe_target> probe_targets;
+```
+
+At finalization, the producer iterates over its targets, computes a filter for each join key, and pushes into the corresponding channel.
+
+A **consumer** holds the channel directly via `std::shared_ptr<sirius_dynamic_filter_set> sirius_dynamic_filters` and reads from it during execution.
+
+## Lifetimes and ordering
+
+**Channel lifetime.** The `sirius_dynamic_filter_set` is co-owned via `shared_ptr` by every operator that references it.
+
+**Scalar lifetime.** Scalars referenced by AST literals or apply kernels are owned by the filter instance, which is owned by the set. The set must outlive any AST tree or apply invocation built from filters it contains.
+
+**Producer-consumer ordering.** The consumer must not read filters until every producer has pushed. In Phases 1-3 this is guaranteed implicitly by meta-pipeline structure: the consumer is downstream of the producer in the engine's pipeline graph, so the producer's finalization runs before the consumer's task executes. This is an invariant of the engine, not of the framework. Phase 4 adds explicit readiness signals (`signal_ready` / `wait_ready`) for patterns where this implicit ordering does not hold; Phases 1-3 do not call them.
+
+## Static + dynamic filter mixing at the consumer
+
+A parquet partition's static filter is a `shared_ptr<duckdb::Expression>` (`parquet_scan_operator_data::filter_expression`). At execute time, `sirius_gpu_parquet_scan_operator` calls `gpu_expression_translator::translate_expression_with_names` to lower it to a cuDF AST. The translation outcome is what the dynamic-filter merge has to interleave with:
+
+- **No static filter.** The consumer builds an AST tree containing only the dynamic-filter fragments and installs it via `reader_options::set_filter`.
+- **Static filter, translation succeeds.** The consumer takes the translated AST, calls `merge_ast_dynamic_filters_into_tree(tree, static_root, set, resolver)` to AND-conjoin every dynamic fragment into it, and installs the resulting root via `set_filter`. Parquet row-group pruning sees the combined predicate.
+- **Static filter, translation fails.** The static filter falls through to post-decode evaluation by `gpu_expression_executor`. **AST-path dynamic pushdown is skipped** here — we cannot mix an AST fragment with a DuckDB expression in `reader_options::set_filter`. Phase 1.2's runtime apply path lifts this restriction for filter kinds that support `apply`.
+
+This mixing rule is a property of the consumer (parquet metadata scan), not the framework. Other consumers (hash-join probe in Phase 2) have their own merge rules.
+
+---
+
+## Phase 1 — Dynamic table-filter pushdown
+
+**Goal:** establish the framework end-to-end against a single (producer, consumer) pair — hash-join build → parquet scan — and exercise filter-kind polymorphism via progressively richer filters.
+
+**Producer:** hash-join build side.
+**Consumer:** parquet scan task (`parquet_scan_task_global_state`).
+**Routing:** DuckDB-paired (`DynamicTableFilterSet*` route key).
+**Coordination:** implicit (meta-pipeline ordering).
+
+### 1.1 Foundational wiring
+
+Wires the scaffolding into operators end-to-end against a degenerate single-zone (N=1) zone-map filter — equivalent to a global min/max bound. Validates the channel + router + consumer-merge plumbing in a real query.
+
+What this PR adds:
+
+- `sirius_physical_plan_generator::dynamic_filter_channels` map (the router)
+- `sirius_physical_table_scan::sirius_dynamic_filters` field (consumer endpoint)
+- `sirius_physical_parquet_scan::sirius_dynamic_filters` field (consumer endpoint, propagated from table_scan)
+- `sirius_physical_hash_join::probe_target` struct + `probe_targets` vector (producer endpoint)
+- Plan-gen wiring in `sirius_plan_get.cpp` and `sirius_plan_comparison_join.cpp`
+- Producer-side push in `sirius_physical_hash_join::finalize_operator()`: `cudf::reduce` to compute global (min, max) per join key, emit a single-zone `sirius_dynamic_zone_map_filter`, push into each probe target's channel
+- Consumer-side merge in `parquet_scan_task_global_state`: replace the current "Dynamic table filters are not supported" `throw` with a call to `merge_ast_dynamic_filters_into_tree`, AND-conjoin with the static filter, install via `reader_options::set_filter`
+- E2E TPC-H test (Q14, Q19) verifying row-group pruning fires
+
+### 1.2 Multi-zone zone maps
+
+Producer keeps per-build-partition bounds rather than reducing to a global min/max. Same filter class (`sirius_dynamic_zone_map_filter`), now with N>1 zones. AST grows to `O(partitions)` per filter; the consumer adds a fallback-to-global threshold when AST size exceeds a budget.
+
+This sub-stage adds the runtime apply path (`sirius_dynamic_filter::apply`) so the next sub-stage (bloom) can plug in. No new filter kind here — the same zone-map filter gains a trivial `apply` implementation.
+
+### 1.3 Bloom filter
+
+`sirius_dynamic_bloom_filter`. Producer builds a GPU bloom over its build keys (sized by build cardinality and a target false-positive rate). Consumer applies post-decode via the 1.2 path.
+
+Bloom filters are runtime-only — there is no AST node that evaluates "is this hash in this bitset" without a custom kernel.
+
+**Build heuristic: only build the bloom if it fits in L2 cache.** A bloom probe is bandwidth-bound — every probed row issues a small number of random loads against the bitset. If the bitset fits in L2, those loads land in L2 and the probe runs at L2 bandwidth; if it spills, every probe pays full HBM bandwidth and the bloom is no longer worth its construction cost. The producer queries the GPU's L2 size at build time (`cudaDeviceGetAttribute(cudaDevAttrL2CacheSize)`) and skips bloom when the sized bitset would exceed it; if the FPR target cannot be met within that budget, it falls back to zone-map / IN-list filters.
+
+### 1.4 IN-list / hash set
+
+`sirius_dynamic_in_list_filter` with both lowering paths:
+
+- **Small set** (< N values, configurable; proposed N = 32): `to_ast` emits `OR(col = v_i)`. AST-pushable, prunes at parquet row-group level.
+- **Large set**: `apply` uses `cudf::contains(col, set_column)`. Post-decode only.
+
+The same filter object exposes both paths; the consumer picks based on the AST-size budget.
+
+---
+
+## Phase 2 — Sideways information passing
+
+**Goal:** generalize the *consumer* axis. The hash-join probe becomes a consumer, allowing a build-side filter to prune the probe input of a *different* join — essential for star-schema queries where filters from dimension joins should reach the fact-table scan via intermediate joins.
+
+**Producer:** hash-join build (same as Phase 1).
+**Consumer (new):** hash-join probe input.
+**Routing (new):** Sirius-owned `sirius_sip_route` route key.
+**Coordination:** implicit, where the producer's meta-pipeline is upstream of the consumer's; explicit readiness (Phase 4) otherwise.
+
+What changes:
+
+- **Route key variant.** `dynamic_filter_channels` becomes keyed by a variant including a Sirius-owned `sirius_sip_route`. Plan-gen in `sirius_plan_comparison_join.cpp` extends: a join can register itself as a *consumer* of filters from upstream join builds in addition to its existing producer role. Producer/consumer pairing is Sirius's responsibility — no DuckDB pointer to lean on.
+- **New consumer code path in hash-join probe.** Before hashing, the probe applies each filter from its incoming channel via `sirius_dynamic_filter::apply`. Reuses Phase 1.2's apply path; no new filter kinds, no AST path (AST is parquet-reader-only).
+
+The filter zoo, the channel type, and the producer side are unchanged.
+
+## Phase 3 — Beyond hash-join producers
+
+**Goal:** generalize the *producer* axis. Operators other than hash-join build can produce dynamic filters when they expose useful properties of their output.
+
+**Candidate producer kinds:**
+
+- **Aggregation / DISTINCT.** A `GROUP BY` exposes its distinct-key set; this is an exact IN-list (or large hash-set) for downstream consumers.
+- **Sort.** Post-sort, the min/max of the sort key is exact and available for free — strictly cheaper than the `cudf::reduce` path used by hash-join build.
+- **Filter (narrowed).** A filter operator that has been further narrowed at runtime (e.g., by an upstream agg pushing an exact set) can republish the narrowed predicate downstream.
+
+Each new producer type carries its own `probe_target`-shaped struct, registers via plan-gen, and adds a new route-key variant. The filter zoo, the channel, and the consumer side are unchanged.
+
+This phase is opportunistic — its value depends on where bottlenecks land after Phases 1 and 2. It is in the design so the producer side is not silently locked to "hash-join only" by Phase 1's choices.
+
+## Phase 4 — Dynamic refinement (speculative)
+
+**Goal:** generalize the *coordination* axis — producers update filters incrementally as they observe more data; consumers wait for finalization or apply progressively-tightening filters as they arrive. Use cases: streaming refinement, cross-pipeline channels with no implicit edge, adaptive runtime predicates.
+
+This adds explicit lifecycle methods on the channel (`signal_ready` / `wait_ready` / `ready`) and may version filters so consumers can opt into "latest" semantics. Phases 1-3 do not call any of this. The phase is speculative and included so the channel's lifecycle is not silently locked to "push once at finalization" by earlier phases. No work is planned until a concrete use case justifies it.
+
+---
+
+## Open questions
+
+1. **Meta-pipeline ordering verification.** Phase 1.1's correctness depends on the build pipeline finalizing before the scan task runs. We believe this holds for join → scan pushdown via meta-pipeline structure, but it has not been verified end-to-end. Phase 1.1's E2E test is the validation.
+2. **AST-size threshold for multi-zone maps.** Phase 1.2's fallback-to-global threshold should be tuned with a microbenchmark on TPC-H Q14 / Q19 once 1.2 lands.
+3. **Bloom build-cost gate.** Phase 1.3 sizes bloom against L2, but a separate lower bound on build cardinality (below which bloom is dominated by zone-map / IN-list) is unspecified. Candidate: skip bloom when build cardinality < 10k.
+
+## References
+
+- `src/include/op/sirius_dynamic_filter.hpp`, `src/op/sirius_dynamic_filter.cpp`, `test/cpp/operator/test_sirius_dynamic_filter.cpp` — framework API, implementation, and tests added by this PR
+- `src/include/expression_executor/gpu_expression_translator_internal.hpp` — existing AST construction patterns (`cudf::ast::tree::emplace`, scalar lifetime)
+- `duckdb/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp` — `JoinFilterPushdownInfo`, `JoinFilterPushdownFilter` (consumed by Phase 1.1)

--- a/src/include/op/sirius_dynamic_filter.hpp
+++ b/src/include/op/sirius_dynamic_filter.hpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// cudf
+#include <cudf/ast/ast_operator.hpp>
+#include <cudf/ast/expressions.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/types.hpp>
+
+// standard library
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace sirius::op {
+
+/**
+ * @brief Kind tag for @ref sirius_dynamic_filter subtypes.
+ *
+ * Extend this enum as new filter kinds (bloom, IN-list, etc.) are added in later phases.
+ * See @c docs/super-sirius/dynamic-filters.md for the staged rollout.
+ */
+enum class sirius_dynamic_filter_kind { ZONE_MAP };
+
+//===----------------------------------------------------------------------===//
+// sirius_dynamic_filter
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Polymorphic runtime-computed filter produced by one operator and consumed by another.
+ *
+ * Produced by some upstream operator (e.g., a hash-join build) and delivered to a downstream
+ * consumer (e.g., a parquet scan) through a @ref sirius_dynamic_filter_set.
+ *
+ * Concrete filters expose their consumer-side capabilities by inheriting from one or more
+ * capability mixins (today: @ref sirius_ast_lowerable; future: a runtime-apply mixin). The base
+ * class carries only the kind tag because not every filter kind supports every lowering path —
+ * for example, a bloom filter cannot produce a cuDF AST fragment. Consumers @c dynamic_cast a
+ * @ref sirius_dynamic_filter pointer to the capability they need; a failed cast means the filter
+ * does not support that path.
+ */
+class sirius_dynamic_filter {
+ public:
+  virtual ~sirius_dynamic_filter() = default;
+
+  /// The kind of this filter.
+  [[nodiscard]] virtual sirius_dynamic_filter_kind kind() const = 0;
+};
+
+//===----------------------------------------------------------------------===//
+// AST mix-in
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Capability mixin: filter can lower itself to a cuDF AST fragment.
+ *
+ * Filters inheriting from this interface support consumer paths that build a @c cudf::ast::tree
+ * (e.g., parquet reader @c set_filter, expression executor).
+ */
+class sirius_ast_lowerable {
+ public:
+  virtual ~sirius_ast_lowerable() = default;
+
+  /**
+   * @brief Lower the filter to a cuDF AST fragment rooted at a BOOL expression.
+   *
+   * The fragment, when AND-ed into the consumer's filter tree, rejects rows that this filter
+   * excludes. All nodes emitted are owned by @p tree; any device scalars referenced by literals
+   * are owned by the implementing filter and must outlive @p tree.
+   *
+   * @param tree        The consumer's AST tree; new nodes are emplaced into it.
+   * @param column_ref  An AST expression naming or referencing the column this filter applies to,
+   *                    already emplaced by the caller into @p tree.
+   * @return            Reference to the fragment's root expression (BOOL), owned by @p tree.
+   */
+  [[nodiscard]] virtual cudf::ast::expression const& to_ast(
+    cudf::ast::tree& tree, cudf::ast::expression const& column_ref) const = 0;
+
+  /**
+   * @brief Construct a fresh AST tree containing only this filter's fragment.
+   *
+   * Convenience wrapper around @ref to_ast for callers that don't have an existing tree to merge
+   * into. The factory emplaces whatever column reference the consumer needs (typically a
+   * @c cudf::ast::column_reference or @c cudf::ast::column_name_reference) into the fresh tree
+   * and returns it; the filter's fragment is then built on top.
+   *
+   * @param column_ref_factory Callback that emplaces and returns the column expression in the
+   *                           fresh tree. Invoked exactly once.
+   * @return                   A new AST tree owning the filter's fragment. The fragment root is
+   *                           @c tree.back(). Ownership transfers to the caller.
+   */
+  [[nodiscard]] cudf::ast::tree to_standalone_ast(
+    std::function<cudf::ast::expression const&(cudf::ast::tree&)> const& column_ref_factory) const;
+};
+
+/// One zone of a zone-map filter: bounds on the column over a contiguous range of rows.
+struct zone_map_entry {
+  /// Lower bound scalar on device. Owned by the enclosing filter.
+  std::unique_ptr<cudf::scalar> min;
+  /// Upper bound scalar on device. Owned by the enclosing filter.
+  std::unique_ptr<cudf::scalar> max;
+};
+
+//===----------------------------------------------------------------------===//
+// sirius_dynamic_zone_map_filter
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Multi-zone range filter that keeps rows where any zone's @c [min, max] contains them.
+ *
+ * Lowers to @c OR_i ( min_i ≤ col AND col ≤ max_i ) (or strict variants based on @c inclusive_*).
+ *
+ * @note A degenerate single-zone (N=1) filter is the simplest case and is equivalent to a
+ *       global min/max range. Multi-zone (N>1) filters retain per-block bounds and prune
+ *       more aggressively when build values cluster.
+ *
+ * @pre  At least one zone must be supplied; every zone's @c min and @c max must be non-null
+ *       and share the same @ref cudf::data_type as the column being filtered.
+ *
+ * @throws std::invalid_argument if zones is empty or any zone has a null bound.
+ */
+class sirius_dynamic_zone_map_filter final : public sirius_dynamic_filter,
+                                             public sirius_ast_lowerable {
+ public:
+  /**
+   * @brief Construct a zone-map filter.
+   *
+   * @param zones          One entry per zone (ownership transferred).
+   * @param inclusive_min  If true, the lower comparison is @c GREATER_EQUAL; else @c GREATER.
+   * @param inclusive_max  If true, the upper comparison is @c LESS_EQUAL; else @c LESS.
+   */
+  explicit sirius_dynamic_zone_map_filter(std::vector<zone_map_entry> zones,
+                                          bool inclusive_min = true,
+                                          bool inclusive_max = true);
+
+  [[nodiscard]] sirius_dynamic_filter_kind kind() const override
+  { return sirius_dynamic_filter_kind::ZONE_MAP; }
+
+  [[nodiscard]] cudf::ast::expression const& to_ast(
+    cudf::ast::tree& tree, cudf::ast::expression const& column_ref) const override;
+
+  [[nodiscard]] std::size_t num_zones() const noexcept { return _zones.size(); }
+  [[nodiscard]] std::vector<zone_map_entry> const& zones() const noexcept { return _zones; }
+  [[nodiscard]] bool inclusive_min() const noexcept { return _inclusive_min; }
+  [[nodiscard]] bool inclusive_max() const noexcept { return _inclusive_max; }
+
+ private:
+  std::vector<zone_map_entry> _zones;
+  bool _inclusive_min;
+  bool _inclusive_max;
+};
+
+//===----------------------------------------------------------------------===//
+// sirius_dynamic_filter_set
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Thread-safe append-only channel connecting one or more producer operators to a consumer.
+ *
+ * Filters are keyed by the column index in the consumer's output schema. Multiple producers may
+ * push filters for the same column. The set is append-only — once pushed, filters cannot be
+ * removed.
+ *
+ * @note A producer pushes filters for the consumer's column index — i.e. the column index in the
+ *       downstream operator's output schema, not the producer's. The plan-gen layer is
+ *       responsible for translating between the two when wiring producers and consumers.
+ */
+class sirius_dynamic_filter_set {
+ public:
+  /**
+   * @brief Register a filter for column @p col_idx. No-op if @p f is null.
+   *
+   * Thread-safe; may be called concurrently from multiple producer operators. The same
+   * @p f may be pushed into multiple channels and/or columns to fan-out a filter without
+   * cloning it; the channels co-own the filter.
+   */
+  void push_filter(std::size_t col_idx, std::shared_ptr<sirius_dynamic_filter const> f);
+
+  /**
+   * @brief Snapshot of filters for @p col_idx, in insertion order.
+   *
+   * The returned snapshots own a share of each filter; they remain valid even if the set
+   * itself is later destroyed. Subsequent @ref push_filter calls do not invalidate
+   * previously-returned snapshots.
+   */
+  [[nodiscard]] std::vector<std::shared_ptr<sirius_dynamic_filter const>> filters_for_column(
+    std::size_t col_idx) const;
+
+  /// Column indices with at least one registered filter. Order is unspecified.
+  [[nodiscard]] std::vector<std::size_t> filtered_columns() const;
+
+  /// True iff no filters have been pushed for any column.
+  [[nodiscard]] bool empty() const;
+
+ private:
+  mutable std::mutex _mu;
+  std::unordered_map<std::size_t, std::vector<std::shared_ptr<sirius_dynamic_filter const>>>
+    _filters;
+};
+
+/// Resolves a consumer column index to an AST expression already emplaced in the tree (typically
+/// a @c cudf::ast::column_reference or @c cudf::ast::column_name_reference).
+using column_ref_resolver_fn = std::function<cudf::ast::expression const&(std::size_t col_idx)>;
+
+/**
+ * @brief AND-conjoin @p set's AST-lowerable filters with @p existing_root in @p tree.
+ *
+ * For each column with filters, all AST-capable filters are AND-conjoined (multiple producers);
+ * across columns, the per-column conjunctions are AND-conjoined; the final dynamic root is then
+ * AND-ed with @p existing_root and that AND-node is returned.
+ *
+ * If @p set is empty, or every filter declines the AST capability, the function emplaces nothing
+ * and returns @p existing_root unchanged.
+ *
+ * @param tree                The AST tree the consumer is constructing. @p existing_root must
+ *                            already be emplaced in @p tree.
+ * @param existing_root       The root expression to AND with the dynamic filters' fragments.
+ *                            Returned unchanged if no filter contributes.
+ * @param set                 The dynamic filter channel.
+ * @param column_ref_resolver Callback that returns the AST column expression for a column index.
+ *                            Invoked at most once per column with at least one AST-capable filter.
+ *                            Must remain valid for the duration of this call.
+ * @return Reference to the new root, owned by @p tree. Stable across further @c emplace calls.
+ */
+[[nodiscard]] cudf::ast::expression const& merge_ast_dynamic_filters_into_tree(
+  cudf::ast::tree& tree,
+  cudf::ast::expression const& existing_root,
+  sirius_dynamic_filter_set const& set,
+  column_ref_resolver_fn const& column_ref_resolver);
+
+}  // namespace sirius::op

--- a/src/include/op/sirius_dynamic_filter.hpp
+++ b/src/include/op/sirius_dynamic_filter.hpp
@@ -149,7 +149,9 @@ class sirius_dynamic_zone_map_filter final : public sirius_dynamic_filter,
                                           bool inclusive_max = true);
 
   [[nodiscard]] sirius_dynamic_filter_kind kind() const override
-  { return sirius_dynamic_filter_kind::ZONE_MAP; }
+  {
+    return sirius_dynamic_filter_kind::ZONE_MAP;
+  }
 
   [[nodiscard]] cudf::ast::expression const& to_ast(
     cudf::ast::tree& tree, cudf::ast::expression const& column_ref) const override;

--- a/src/op/sirius_dynamic_filter.cpp
+++ b/src/op/sirius_dynamic_filter.cpp
@@ -34,12 +34,16 @@ namespace {
 cudf::ast::expression const& and_join(cudf::ast::tree& tree,
                                       cudf::ast::expression const& lhs,
                                       cudf::ast::expression const& rhs)
-{ return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_AND, lhs, rhs); }
+{
+  return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_AND, lhs, rhs);
+}
 
 cudf::ast::expression const& or_join(cudf::ast::tree& tree,
                                      cudf::ast::expression const& lhs,
                                      cudf::ast::expression const& rhs)
-{ return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_OR, lhs, rhs); }
+{
+  return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_OR, lhs, rhs);
+}
 
 // cudf::ast::literal only has typed constructors; dispatch on type_id to downcast a type-erased
 // cudf::scalar to the correct concrete subtype before emplacing.

--- a/src/op/sirius_dynamic_filter.cpp
+++ b/src/op/sirius_dynamic_filter.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// sirius
+#include <op/sirius_dynamic_filter.hpp>
+
+// cudf
+#include <cudf/ast/expressions.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/wrappers/timestamps.hpp>
+
+// standard library
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace sirius::op {
+
+namespace {
+
+cudf::ast::expression const& and_join(cudf::ast::tree& tree,
+                                      cudf::ast::expression const& lhs,
+                                      cudf::ast::expression const& rhs)
+{ return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_AND, lhs, rhs); }
+
+cudf::ast::expression const& or_join(cudf::ast::tree& tree,
+                                     cudf::ast::expression const& lhs,
+                                     cudf::ast::expression const& rhs)
+{ return tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::LOGICAL_OR, lhs, rhs); }
+
+// cudf::ast::literal only has typed constructors; dispatch on type_id to downcast a type-erased
+// cudf::scalar to the correct concrete subtype before emplacing.
+cudf::ast::expression const& emplace_literal_from_scalar(cudf::ast::tree& tree, cudf::scalar& s)
+{
+  switch (s.type().id()) {
+    case cudf::type_id::INT8:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<int8_t>&>(s));
+    case cudf::type_id::INT16:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<int16_t>&>(s));
+    case cudf::type_id::INT32:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<int32_t>&>(s));
+    case cudf::type_id::INT64:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<int64_t>&>(s));
+    case cudf::type_id::UINT8:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<uint8_t>&>(s));
+    case cudf::type_id::UINT16:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<uint16_t>&>(s));
+    case cudf::type_id::UINT32:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<uint32_t>&>(s));
+    case cudf::type_id::UINT64:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<uint64_t>&>(s));
+    case cudf::type_id::FLOAT32:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<float>&>(s));
+    case cudf::type_id::FLOAT64:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<double>&>(s));
+    case cudf::type_id::BOOL8:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::numeric_scalar<bool>&>(s));
+    case cudf::type_id::TIMESTAMP_DAYS:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::timestamp_scalar<cudf::timestamp_D>&>(s));
+    case cudf::type_id::TIMESTAMP_SECONDS:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::timestamp_scalar<cudf::timestamp_s>&>(s));
+    case cudf::type_id::TIMESTAMP_MILLISECONDS:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::timestamp_scalar<cudf::timestamp_ms>&>(s));
+    case cudf::type_id::TIMESTAMP_MICROSECONDS:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::timestamp_scalar<cudf::timestamp_us>&>(s));
+    case cudf::type_id::TIMESTAMP_NANOSECONDS:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::timestamp_scalar<cudf::timestamp_ns>&>(s));
+    case cudf::type_id::DECIMAL32:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::fixed_point_scalar<numeric::decimal32>&>(s));
+    case cudf::type_id::DECIMAL64:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::fixed_point_scalar<numeric::decimal64>&>(s));
+    case cudf::type_id::DECIMAL128:
+      return tree.emplace<cudf::ast::literal>(
+        static_cast<cudf::fixed_point_scalar<numeric::decimal128>&>(s));
+    case cudf::type_id::STRING:
+      return tree.emplace<cudf::ast::literal>(static_cast<cudf::string_scalar&>(s));
+    default:
+      throw std::runtime_error(
+        "[sirius_dynamic_zone_map_filter] Unsupported scalar type for AST literal");
+  }
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// AST mix-in
+//===----------------------------------------------------------------------===//
+cudf::ast::tree sirius_ast_lowerable::to_standalone_ast(
+  std::function<cudf::ast::expression const&(cudf::ast::tree&)> const& column_ref_factory) const
+{
+  cudf::ast::tree tree;
+  auto const& col_ref = column_ref_factory(tree);
+  (void)to_ast(tree, col_ref);
+  return tree;
+}
+
+//===----------------------------------------------------------------------===//
+// sirius_dynamic_zone_map_filter
+//===----------------------------------------------------------------------===//
+sirius_dynamic_zone_map_filter::sirius_dynamic_zone_map_filter(std::vector<zone_map_entry> zones,
+                                                               bool inclusive_min,
+                                                               bool inclusive_max)
+  : _zones(std::move(zones)), _inclusive_min(inclusive_min), _inclusive_max(inclusive_max)
+{
+  if (_zones.empty()) {
+    throw std::invalid_argument("[sirius_dynamic_zone_map_filter] At least one zone is required");
+  }
+  for (auto const& z : _zones) {
+    if (!z.min || !z.max) {
+      throw std::invalid_argument(
+        "[sirius_dynamic_zone_map_filter] Every zone must have non-null min and max");
+    }
+  }
+}
+
+cudf::ast::expression const& sirius_dynamic_zone_map_filter::to_ast(
+  cudf::ast::tree& tree, cudf::ast::expression const& column_ref) const
+{
+  auto const lower_op =
+    _inclusive_min ? cudf::ast::ast_operator::GREATER_EQUAL : cudf::ast::ast_operator::GREATER;
+  auto const upper_op =
+    _inclusive_max ? cudf::ast::ast_operator::LESS_EQUAL : cudf::ast::ast_operator::LESS;
+
+  cudf::ast::expression const* result = nullptr;
+  for (auto const& z : _zones) {
+    auto const& min_lit   = emplace_literal_from_scalar(tree, *z.min);
+    auto const& max_lit   = emplace_literal_from_scalar(tree, *z.max);
+    auto const& lo        = tree.emplace<cudf::ast::operation>(lower_op, column_ref, min_lit);
+    auto const& hi        = tree.emplace<cudf::ast::operation>(upper_op, column_ref, max_lit);
+    auto const& zone_pred = and_join(tree, lo, hi);
+    result                = (result == nullptr) ? &zone_pred : &or_join(tree, *result, zone_pred);
+  }
+  return *result;
+}
+
+//===----------------------------------------------------------------------===//
+// sirius_dynamic_filter_set
+//===----------------------------------------------------------------------===//
+void sirius_dynamic_filter_set::push_filter(std::size_t col_idx,
+                                            std::shared_ptr<sirius_dynamic_filter const> f)
+{
+  if (!f) { return; }
+  std::lock_guard<std::mutex> lk(_mu);
+  _filters[col_idx].push_back(std::move(f));
+}
+
+std::vector<std::shared_ptr<sirius_dynamic_filter const>>
+sirius_dynamic_filter_set::filters_for_column(std::size_t col_idx) const
+{
+  std::lock_guard<std::mutex> lk(_mu);
+  auto it = _filters.find(col_idx);
+  if (it == _filters.end()) { return {}; }
+  return it->second;
+}
+
+std::vector<std::size_t> sirius_dynamic_filter_set::filtered_columns() const
+{
+  std::lock_guard<std::mutex> lk(_mu);
+  std::vector<std::size_t> out;
+  out.reserve(_filters.size());
+  for (auto const& [k, _] : _filters) {
+    out.push_back(k);
+  }
+  return out;
+}
+
+bool sirius_dynamic_filter_set::empty() const
+{
+  std::lock_guard<std::mutex> lk(_mu);
+  return _filters.empty();
+}
+
+cudf::ast::expression const& merge_ast_dynamic_filters_into_tree(
+  cudf::ast::tree& tree,
+  cudf::ast::expression const& existing_root,
+  sirius_dynamic_filter_set const& set,
+  column_ref_resolver_fn const& column_ref_resolver)
+{
+  if (set.empty()) { return existing_root; }
+
+  auto cols = set.filtered_columns();
+  std::sort(cols.begin(), cols.end());
+
+  cudf::ast::expression const* dynamic_root = nullptr;
+  for (auto const col_idx : cols) {
+    auto filters = set.filters_for_column(col_idx);
+    if (filters.empty()) { continue; }
+
+    cudf::ast::expression const* column_ref = nullptr;
+    cudf::ast::expression const* per_col    = nullptr;
+    for (auto const& f : filters) {
+      auto const* lowerable = dynamic_cast<sirius_ast_lowerable const*>(f.get());
+      if (!lowerable) { continue; }
+      if (!column_ref) { column_ref = &column_ref_resolver(col_idx); }
+      auto const& fragment = lowerable->to_ast(tree, *column_ref);
+      per_col              = per_col ? &and_join(tree, *per_col, fragment) : &fragment;
+    }
+    if (!per_col) { continue; }
+    dynamic_root = dynamic_root ? &and_join(tree, *dynamic_root, *per_col) : per_col;
+  }
+  if (!dynamic_root) { return existing_root; }
+  return and_join(tree, existing_root, *dynamic_root);
+}
+
+}  // namespace sirius::op

--- a/test/cpp/operator/test_sirius_dynamic_filter.cpp
+++ b/test/cpp/operator/test_sirius_dynamic_filter.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/sirius_dynamic_filter.hpp"
+
+#include <catch.hpp>
+#include <cudf/ast/expressions.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using sirius::op::column_ref_resolver_fn;
+using sirius::op::merge_ast_dynamic_filters_into_tree;
+using sirius::op::sirius_ast_lowerable;
+using sirius::op::sirius_dynamic_filter;
+using sirius::op::sirius_dynamic_filter_kind;
+using sirius::op::sirius_dynamic_filter_set;
+using sirius::op::sirius_dynamic_zone_map_filter;
+using sirius::op::zone_map_entry;
+
+namespace {
+
+std::unique_ptr<cudf::scalar> make_int32_scalar(int32_t v)
+{
+  return std::make_unique<cudf::numeric_scalar<int32_t>>(
+    v, true, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
+}
+
+zone_map_entry make_zone(int32_t lo, int32_t hi)
+{
+  return zone_map_entry{make_int32_scalar(lo), make_int32_scalar(hi)};
+}
+
+std::unique_ptr<sirius_dynamic_zone_map_filter> make_single_zone_filter(int32_t lo, int32_t hi)
+{
+  std::vector<zone_map_entry> zones;
+  zones.push_back(make_zone(lo, hi));
+  return std::make_unique<sirius_dynamic_zone_map_filter>(std::move(zones));
+}
+
+// Stand-in for a runtime-only filter (e.g., bloom): inherits the base but NOT the AST mixin.
+// Lets us verify that the consumer-side merge skips filters lacking the AST capability.
+class stub_runtime_only_filter final : public sirius_dynamic_filter {
+ public:
+  [[nodiscard]] sirius_dynamic_filter_kind kind() const override
+  {
+    return sirius_dynamic_filter_kind::ZONE_MAP;
+  }
+};
+
+}  // namespace
+
+TEST_CASE("sirius_dynamic_filter_set is empty after construction", "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  REQUIRE(set.empty());
+  REQUIRE(set.filtered_columns().empty());
+  REQUIRE(set.filters_for_column(0).empty());
+}
+
+TEST_CASE("sirius_dynamic_filter_set::push_filter ignores null filters", "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(0, nullptr);
+  REQUIRE(set.empty());
+}
+
+TEST_CASE("sirius_dynamic_filter_set retains and exposes pushed filters", "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(3, make_single_zone_filter(0, 100));
+  set.push_filter(3, make_single_zone_filter(50, 150));
+  set.push_filter(7, make_single_zone_filter(-1, 1));
+
+  REQUIRE_FALSE(set.empty());
+
+  auto cols = set.filtered_columns();
+  std::sort(cols.begin(), cols.end());
+  REQUIRE(cols == std::vector<std::size_t>{3, 7});
+
+  REQUIRE(set.filters_for_column(3).size() == 2);
+  REQUIRE(set.filters_for_column(7).size() == 1);
+  REQUIRE(set.filters_for_column(99).empty());
+
+  REQUIRE(set.filters_for_column(3)[0]->kind() == sirius_dynamic_filter_kind::ZONE_MAP);
+}
+
+TEST_CASE("filters_for_column snapshot survives the set's destruction", "[dynamic_filter]")
+{
+  std::vector<std::shared_ptr<sirius_dynamic_filter const>> snapshot;
+  {
+    sirius_dynamic_filter_set set;
+    set.push_filter(0, make_single_zone_filter(0, 100));
+    snapshot = set.filters_for_column(0);
+  }
+  REQUIRE(snapshot.size() == 1);
+  REQUIRE(snapshot[0]->kind() == sirius_dynamic_filter_kind::ZONE_MAP);
+}
+
+TEST_CASE("the same filter can be co-owned by multiple channels (fan-out)", "[dynamic_filter]")
+{
+  std::shared_ptr<sirius_dynamic_filter const> shared_filter = make_single_zone_filter(0, 100);
+
+  sirius_dynamic_filter_set set_a;
+  sirius_dynamic_filter_set set_b;
+  set_a.push_filter(0, shared_filter);
+  set_b.push_filter(5, shared_filter);
+
+  auto const a_snapshot = set_a.filters_for_column(0);
+  auto const b_snapshot = set_b.filters_for_column(5);
+
+  REQUIRE(a_snapshot.size() == 1);
+  REQUIRE(b_snapshot.size() == 1);
+  REQUIRE(a_snapshot[0].get() == b_snapshot[0].get());
+}
+
+TEST_CASE("sirius_dynamic_filter_set::push_filter is thread-safe", "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+
+  constexpr int kThreads             = 8;
+  constexpr int kPushesPerThread     = 32;
+  constexpr std::size_t kColumnCount = 4;
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&set, t]() {
+      for (int i = 0; i < kPushesPerThread; ++i) {
+        auto col = static_cast<std::size_t>((t + i) % kColumnCount);
+        set.push_filter(col, make_single_zone_filter(t * 1000 + i, t * 1000 + i + 1));
+      }
+    });
+  }
+  for (auto& th : threads) { th.join(); }
+
+  std::size_t total = 0;
+  for (std::size_t col = 0; col < kColumnCount; ++col) {
+    total += set.filters_for_column(col).size();
+  }
+  REQUIRE(total == static_cast<std::size_t>(kThreads) * kPushesPerThread);
+}
+
+TEST_CASE("sirius_dynamic_zone_map_filter rejects empty zones", "[dynamic_filter]")
+{
+  REQUIRE_THROWS_AS(sirius_dynamic_zone_map_filter(std::vector<zone_map_entry>{}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("sirius_dynamic_zone_map_filter rejects null bounds", "[dynamic_filter]")
+{
+  std::vector<zone_map_entry> zones;
+  zones.push_back(zone_map_entry{nullptr, make_int32_scalar(10)});
+  REQUIRE_THROWS_AS(sirius_dynamic_zone_map_filter(std::move(zones)), std::invalid_argument);
+
+  std::vector<zone_map_entry> zones2;
+  zones2.push_back(zone_map_entry{make_int32_scalar(0), nullptr});
+  REQUIRE_THROWS_AS(sirius_dynamic_zone_map_filter(std::move(zones2)), std::invalid_argument);
+}
+
+TEST_CASE("sirius_dynamic_zone_map_filter::to_ast emits a single bounded conjunction for N=1",
+          "[dynamic_filter]")
+{
+  auto filter = make_single_zone_filter(0, 100);
+
+  cudf::ast::tree tree;
+  auto const& col_ref = tree.emplace<cudf::ast::column_reference>(0);
+  auto const& root    = filter->to_ast(tree, col_ref);
+
+  // For N=1 we expect: 2 literals + 2 comparisons + 1 AND = 5 new nodes,
+  // plus the column_reference already pushed = 6 total.
+  REQUIRE(tree.size() == 6);
+  // Root must be the AND node, which is the last node emplaced.
+  REQUIRE(&root == &tree.back());
+}
+
+TEST_CASE("sirius_dynamic_zone_map_filter::to_ast OR-conjoins multiple zones",
+          "[dynamic_filter]")
+{
+  std::vector<zone_map_entry> zones;
+  zones.push_back(make_zone(0, 10));
+  zones.push_back(make_zone(20, 30));
+  zones.push_back(make_zone(40, 50));
+  auto filter = std::make_unique<sirius_dynamic_zone_map_filter>(std::move(zones));
+
+  cudf::ast::tree tree;
+  auto const& col_ref = tree.emplace<cudf::ast::column_reference>(0);
+  auto const& root    = filter->to_ast(tree, col_ref);
+
+  // Each zone contributes 2 literals + 2 ops + 1 AND = 5 nodes.
+  // OR-conjoining N zones contributes (N - 1) OR ops on top.
+  // Plus the column_reference already pushed.
+  // Expected: 1 + N * 5 + (N - 1) = 1 + 15 + 2 = 18.
+  REQUIRE(tree.size() == 18);
+  REQUIRE(&root == &tree.back());
+  REQUIRE(filter->num_zones() == 3);
+}
+
+TEST_CASE("sirius_ast_lowerable::to_standalone_ast wraps to_ast in a fresh tree",
+          "[dynamic_filter]")
+{
+  auto filter = make_single_zone_filter(0, 100);
+
+  auto tree = filter->to_standalone_ast([](cudf::ast::tree& t) -> cudf::ast::expression const& {
+    return t.emplace<cudf::ast::column_reference>(0);
+  });
+
+  // Same node count as the in-place to_ast for N=1: 1 col_ref + 2 lit + 2 op + 1 AND = 6.
+  REQUIRE(tree.size() == 6);
+}
+
+TEST_CASE("merge_ast_dynamic_filters_into_tree returns existing_root unchanged for empty set",
+          "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  cudf::ast::tree tree;
+  auto const& base = tree.emplace<cudf::ast::column_reference>(99);
+
+  auto const& root = merge_ast_dynamic_filters_into_tree(
+    tree, base, set, [&tree](std::size_t) -> cudf::ast::expression const& {
+      return tree.emplace<cudf::ast::column_reference>(0);
+    });
+
+  REQUIRE(&root == &base);
+  REQUIRE(tree.size() == 1);
+}
+
+TEST_CASE("merge_ast_dynamic_filters_into_tree AND-conjoins per-column fragments with existing root",
+          "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(0, make_single_zone_filter(0, 100));
+  set.push_filter(1, make_single_zone_filter(-5, 5));
+
+  cudf::ast::tree tree;
+  auto const& base = tree.emplace<cudf::ast::column_reference>(99);
+
+  std::vector<std::size_t> resolved_cols;
+  auto const& root = merge_ast_dynamic_filters_into_tree(
+    tree, base, set, [&tree, &resolved_cols](std::size_t col_idx) -> cudf::ast::expression const& {
+      resolved_cols.push_back(col_idx);
+      return tree.emplace<cudf::ast::column_reference>(static_cast<cudf::size_type>(col_idx));
+    });
+
+  REQUIRE(&tree.back() == &root);
+
+  // Resolver should have been called once per column with AST-capable filters.
+  std::sort(resolved_cols.begin(), resolved_cols.end());
+  REQUIRE(resolved_cols == std::vector<std::size_t>{0, 1});
+
+  // 1 base col_ref + 2 cols × (1 col_ref + 2 lit + 2 op + 1 AND) + 1 cross-col AND
+  //   + 1 final AND with base = 1 + 12 + 1 + 1 = 15.
+  REQUIRE(tree.size() == 15);
+}
+
+TEST_CASE("merge_ast_dynamic_filters_into_tree AND-conjoins multiple filters per column",
+          "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(0, make_single_zone_filter(0, 100));
+  set.push_filter(0, make_single_zone_filter(10, 200));
+
+  cudf::ast::tree tree;
+  auto const& base = tree.emplace<cudf::ast::column_reference>(99);
+
+  auto const& root = merge_ast_dynamic_filters_into_tree(
+    tree, base, set, [&tree](std::size_t col_idx) -> cudf::ast::expression const& {
+      return tree.emplace<cudf::ast::column_reference>(static_cast<cudf::size_type>(col_idx));
+    });
+
+  REQUIRE(&tree.back() == &root);
+  // 1 base + (1 col_ref + 2*(2 lit + 2 op + 1 AND) + 1 AND combining filters)
+  //   + 1 final AND with base = 1 + 12 + 1 = 14.
+  REQUIRE(tree.size() == 14);
+}
+
+TEST_CASE("merge_ast_dynamic_filters_into_tree skips filters lacking the AST capability",
+          "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(0, std::make_unique<stub_runtime_only_filter>());
+
+  cudf::ast::tree tree;
+  auto const& base = tree.emplace<cudf::ast::column_reference>(99);
+
+  std::size_t resolver_calls = 0;
+  auto const& root           = merge_ast_dynamic_filters_into_tree(
+    tree, base, set, [&tree, &resolver_calls](std::size_t col_idx) -> cudf::ast::expression const& {
+      ++resolver_calls;
+      return tree.emplace<cudf::ast::column_reference>(static_cast<cudf::size_type>(col_idx));
+    });
+
+  REQUIRE(&root == &base);
+  REQUIRE(resolver_calls == 0);  // resolver is lazy; no AST-capable filter, no resolve
+  REQUIRE(tree.size() == 1);     // only the base remains
+}
+
+TEST_CASE("merge_ast_dynamic_filters_into_tree mixes AST-capable and non-capable filters per column",
+          "[dynamic_filter]")
+{
+  sirius_dynamic_filter_set set;
+  set.push_filter(0, std::make_unique<stub_runtime_only_filter>());
+  set.push_filter(0, make_single_zone_filter(0, 100));
+
+  cudf::ast::tree tree;
+  auto const& base = tree.emplace<cudf::ast::column_reference>(99);
+
+  auto const& root = merge_ast_dynamic_filters_into_tree(
+    tree, base, set, [&tree](std::size_t col_idx) -> cudf::ast::expression const& {
+      return tree.emplace<cudf::ast::column_reference>(static_cast<cudf::size_type>(col_idx));
+    });
+
+  REQUIRE(&tree.back() == &root);
+  // 1 base + 1 col_ref + 2 lit + 2 op + 1 AND (zone_map) + 1 final AND with base = 8.
+  REQUIRE(tree.size() == 8);
+}

--- a/test/cpp/operator/test_sirius_dynamic_filter.cpp
+++ b/test/cpp/operator/test_sirius_dynamic_filter.cpp
@@ -16,11 +16,12 @@
 
 #include "op/sirius_dynamic_filter.hpp"
 
-#include <catch.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+
+#include <catch.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -151,7 +152,9 @@ TEST_CASE("sirius_dynamic_filter_set::push_filter is thread-safe", "[dynamic_fil
       }
     });
   }
-  for (auto& th : threads) { th.join(); }
+  for (auto& th : threads) {
+    th.join();
+  }
 
   std::size_t total = 0;
   for (std::size_t col = 0; col < kColumnCount; ++col) {
@@ -193,8 +196,7 @@ TEST_CASE("sirius_dynamic_zone_map_filter::to_ast emits a single bounded conjunc
   REQUIRE(&root == &tree.back());
 }
 
-TEST_CASE("sirius_dynamic_zone_map_filter::to_ast OR-conjoins multiple zones",
-          "[dynamic_filter]")
+TEST_CASE("sirius_dynamic_zone_map_filter::to_ast OR-conjoins multiple zones", "[dynamic_filter]")
 {
   std::vector<zone_map_entry> zones;
   zones.push_back(make_zone(0, 10));
@@ -244,8 +246,9 @@ TEST_CASE("merge_ast_dynamic_filters_into_tree returns existing_root unchanged f
   REQUIRE(tree.size() == 1);
 }
 
-TEST_CASE("merge_ast_dynamic_filters_into_tree AND-conjoins per-column fragments with existing root",
-          "[dynamic_filter]")
+TEST_CASE(
+  "merge_ast_dynamic_filters_into_tree AND-conjoins per-column fragments with existing root",
+  "[dynamic_filter]")
 {
   sirius_dynamic_filter_set set;
   set.push_filter(0, make_single_zone_filter(0, 100));
@@ -314,8 +317,9 @@ TEST_CASE("merge_ast_dynamic_filters_into_tree skips filters lacking the AST cap
   REQUIRE(tree.size() == 1);     // only the base remains
 }
 
-TEST_CASE("merge_ast_dynamic_filters_into_tree mixes AST-capable and non-capable filters per column",
-          "[dynamic_filter]")
+TEST_CASE(
+  "merge_ast_dynamic_filters_into_tree mixes AST-capable and non-capable filters per column",
+  "[dynamic_filter]")
 {
   sirius_dynamic_filter_set set;
   set.push_filter(0, std::make_unique<stub_runtime_only_filter>());


### PR DESCRIPTION
## Summary
Scaffolds the dynamic-filter framework (polymorphic filter base, capability
mixin for AST lowering, thread-safe channel, AST-merge helper). No producers
or consumers are wired in — runtime behavior is unchanged.

Design and phasing: `docs/super-sirius/dynamic-filters.md`.

## What's in the diff
- `src/include/op/sirius_dynamic_filter.hpp` / `src/op/sirius_dynamic_filter.cpp`
  — `sirius_dynamic_filter` base, `sirius_ast_lowerable` mixin,
  `sirius_dynamic_zone_map_filter`, `sirius_dynamic_filter_set`,
  `merge_ast_dynamic_filters_into_tree`.
- `test/cpp/operator/test_sirius_dynamic_filter.cpp` — 16 tests covering
  channel mechanics, zone-map AST construction, merge behavior, capability
  dispatch, and thread-safety.
- `docs/super-sirius/dynamic-filters.md` — framework design + 4-phase plan.
- `CMakeLists.txt` — register the new source and test.

## Why this is safe
No existing operator or planner is touched. Every symbol added is unreferenced
by runtime code paths. Phase 1.1 (follow-up PR) wires it into hash-join build
and parquet scan; this PR cannot regress any existing query.
