### PR TITLE
CI: Fail merge_group runs when there are errors with TPC-H sf1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,3 +99,10 @@ jobs:
             cat "$RUN_DIR/comparison.txt"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          ERRORS=$(tail -n +2 "$RUN_DIR/validation.csv" | grep -cE ',error$' || true)
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::TPC-H snapshot: $ERRORS queries errored"
+            if [ "${{ github.event_name }}" = "merge_group" ]; then
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
Depends on #670

Right now the performance comparison of TPC-H sf1 runs at the end of the GPU test, but it does not fail if any of the queries fail. This changes our approach to fail only on `merge_group` runs if there are any detected query errors. This should help prevent future PRs that break the TPC-H test