### PR TITLE
Temporarily disable nightly job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,12 +67,12 @@ jobs:
             environment: vcpkg
             cudf-channel: stable
             variant: super
-          - arch: arm64
-            compiler: gcc
-            build-type: release
-            environment: default
-            cudf-channel: nightly
-            variant: super
+          #- arch: arm64
+          #  compiler: gcc
+          #  build-type: release
+          #  environment: default
+          #  cudf-channel: nightly
+          #  variant: super
           - arch: x64
             compiler: gcc
             build-type: release


### PR DESCRIPTION
Let's temporarily disable our nightly job until we support building with nightly again.