### PR TITLE
feat: enable DuckDB CPU fallback by default for gpu_execution

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -33,7 +33,7 @@ uint64_t Config::PRINT_GPU_TABLE_MAX_ROWS = 1000;
 
 bool Config::ENABLE_FALLBACK_CHECK = false;
 
-bool Config::ENABLE_DUCKDB_FALLBACK = false;
+bool Config::ENABLE_DUCKDB_FALLBACK = true;
 
 bool Config::ENABLE_REGEX_JIT_IMPL = true;
 


### PR DESCRIPTION
## Summary
- Enables `ENABLE_DUCKDB_FALLBACK` by default (`true` instead of `false`) so the `gpu_execution` path gracefully falls back to DuckDB CPU execution on plan generation or GPU execution errors.
- Matches the fallback behavior of the legacy `gpu_processing` path.
- Users can still disable at runtime via `SET enable_duckdb_fallback = false;`.

## Test plan
- [x] Pre-commit hooks pass
- [x] Full build succeeds
- [ ] Run TPC-H tests to verify no regressions
- [ ] Verify fallback triggers correctly on unsupported operations