### PR TITLE
Fix race condition in metadata scan -> gpu scan handoff

### DIFF
--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -26,7 +26,6 @@
 #include <cucascade/memory/memory_space.hpp>
 
 // standard library
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -121,8 +120,8 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
    * @brief Signal that no more metadata will arrive.
    *
    * Must be called exactly once, after all accumulate_metadata() calls have returned.
-   * Invoked from metadata_scan.finalize_operator(). Sets _finalized with release
-   * semantics so get_next_task_hint() can return std::nullopt once the partition
+   * Invoked from metadata_scan.finalize_operator(). Sets _finalized under
+   * _metadata_mutex so get_next_task_hint() can return std::nullopt once the partition
    * index is fully drained instead of continuing to defer to the upstream pipeline.
    */
   void finalize_partitions();
@@ -208,13 +207,13 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
   //                         metadata's row_group_partitions.
   //   _next_partition_idx— counter of the next unclaimed entry; advanced under
   //                         _metadata_mutex by get_next_task_input_data().
-  //   _finalized         — set once by finalize_partitions() with release semantics
+  //   _finalized         — set once by finalize_partitions() under _metadata_mutex
   //                         to signal that no more accumulate_metadata() calls will
-  //                         arrive. Read with acquire semantics by
-  //                         get_next_task_hint() to decide nullopt vs. WAITING.
+  //                         arrive. Read by get_next_task_hint() under _metadata_mutex
+  //                         to decide nullopt vs. WAITING.
   // ===----------------------------------------------------------------------===//
   std::mutex _metadata_mutex;
-  std::atomic<bool> _finalized{false};
+  bool _finalized{false};
   partition_inject_fn_t _hive_partition_inject_fn;
 
   struct partition_entry {

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -63,7 +63,8 @@ void sirius_gpu_parquet_scan_operator::accumulate_metadata(
 
 void sirius_gpu_parquet_scan_operator::finalize_partitions()
 {
-  _finalized.store(true, std::memory_order_release);
+  std::lock_guard<std::mutex> lock(_metadata_mutex);
+  _finalized = true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -71,27 +72,26 @@ void sirius_gpu_parquet_scan_operator::finalize_partitions()
 //===----------------------------------------------------------------------===//
 std::optional<task_creation_hint> sirius_gpu_parquet_scan_operator::get_next_task_hint()
 {
-  // 1. Work available right now? Dispatch immediately, even if metadata pipeline
-  //    is still producing. Hold the mutex so size() is consistent with
-  //    accumulate_metadata()'s growth.
   {
     std::lock_guard<std::mutex> lock(_metadata_mutex);
+
+    // 1. Work available? Dispatch immediately, even if metadata pipeline
+    //    is still producing.
     if (_next_partition_idx < _partition_index.size()) {
       return task_creation_hint{TaskCreationHint::READY, this};
     }
+
+    // 2. No work and metadata pipeline is done — we are finished.
+    if (_finalized) { return std::nullopt; }
   }
 
-  // 2. No work right now. If metadata pipeline is still running, defer to it.
-  if (!_finalized.load(std::memory_order_acquire)) {
-    auto it = ports.find("handoff");
-    if (it != ports.end() && it->second && it->second->src_pipeline) {
-      if (auto upstream = it->second->src_pipeline->get_source()) {
-        return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, upstream.get()};
-      }
+  // 3. Metadata pipeline is still running — defer to it.
+  auto it = ports.find("handoff");
+  if (it != ports.end() && it->second && it->second->src_pipeline) {
+    if (auto upstream = it->second->src_pipeline->get_source()) {
+      return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, upstream.get()};
     }
   }
-
-  // 3. Finalized and exhausted (or no upstream) — done.
   return std::nullopt;
 }
 


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition in `sirius_gpu_parquet_scan_operator::get_next_task_hint()` that could silently drop parquet row-group partitions, producing incorrect query results.

## Problem

`get_next_task_hint()` made two checks in sequence **without holding the mutex across both**:

1. **Under mutex**: any unclaimed partitions in `_partition_index`? → no → release mutex
2. **Without mutex**: is `_finalized` true? → yes → return `nullopt` (done)

Between steps 1 and 2, an upstream metadata pipeline thread could call both `accumulate_metadata()` (appending new partitions) and `finalize_partitions()` (setting `_finalized = true`). When the GPU scan thread resumed at step 2, it observed `_finalized = true` and concluded the scan was complete — but the partitions added in the gap were never processed.

**Symptoms:**
- Non-deterministic wrong query results (different rows dropped each run)
- Only manifested in long sessions with many prior queries (timing-dependent)
- Disappeared with `SIRIUS_LOG_LEVEL=debug` (logging changed thread scheduling)
- Cold execution wrong, warm execution correct (different timing patterns)
- Observed as TPC-H Q10 validation failure at SF100

## Fix

Hold `_metadata_mutex` across both the partition check and the `_finalized` check in `get_next_task_hint()`, and acquire the mutex in `finalize_partitions()` before setting `_finalized`. Since all access to `_finalized` is now guarded by the mutex, it is changed from `std::atomic<bool>` to a plain `bool`.

## Changes

- `src/op/scan/sirius_gpu_parquet_scan_operator.cpp`: Restructure `get_next_task_hint()` to hold the lock across both checks; acquire mutex in `finalize_partitions()`
- `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`: `_finalized` from `std::atomic<bool>` to `bool`; remove unused `#include <atomic>`; update docstrings

## Test plan

- [x] TPC-H SF100 full benchmark (all 22 queries × 2 iterations, single session): 21/22 pass, 1 benign FP rounding diff (Q1 `avg_price` last digit)
- [x] Q10 validation passes (previously failed with wrong top-20 customers and revenue values)
- [x] Existing unit tests pass (`sirius_unittest`)

Get [Outlook for Android](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Faka.ms%2FAAb9ysg&data=05%7C02%7Ckkristensen%40nvidia.com%7Cc4cb06ddc58d4cc7da3008dea0a2d38a%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C639124818386027419%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=7NBSerF2QYeu8zfOnom26ZgrXdESqw8TmVa72dzSb6g%3D&reserved=0)