### PR TITLE
Add script to run TPC-H on duckdb files instead of parquet

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -92,8 +92,7 @@ Scripts are in `test/tpch_performance/`.
 
 ## TPC-H Query Files
 
-- **Sirius (GPU):** `test/tpch_performance/tpch_queries/gpu/q*.sql` — wrapped with `call gpu_execution('...');`
-- **DuckDB (CPU):** `test/tpch_performance/tpch_queries/orig/q*.sql` — plain SQL
+- **Sirius and DuckDB runners:** `test/tpch_performance/tpch_queries/orig/q*.sql` — plain TPC-H SQL (used by `run_tpch_parquet.sh`, `run_tpch_duckdb.sh`, `benchmark_and_validate.sh`)
 
 ## Workflow H-A: Generate TPC-H Data
 

--- a/test/tpch_performance/benchmark_and_validate.sh
+++ b/test/tpch_performance/benchmark_and_validate.sh
@@ -20,16 +20,18 @@
 #     timings.csv
 #
 # Before running benchmarks, a tiny read-only filesystem benchmark is run on the
-# input parquet directory and results are recorded in run_info.txt.
+# input location (parquet directory or DuckDB database file) and recorded in run_info.txt.
 #
 # Usage:
 #   export SIRIUS_CONFIG_FILE=...
 #   ./test/tpch_performance/benchmark_and_validate.sh <scale_factor>
+#   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --report <run_dir>
 #   ./test/tpch_performance/benchmark_and_validate.sh --duckdb-results <run_dir> <scale_factor>
 #
 # Example:
 #   ./test/tpch_performance/benchmark_and_validate.sh 1
+#   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb --duckdb-file ./performance_test.duckdb 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --report runs/2026-03-10_12-00-00_sf1_2iter
 #   ./test/tpch_performance/benchmark_and_validate.sh --duckdb-results runs/2026-03-10_12-00-00_sf1_2iter 1
 
@@ -37,6 +39,8 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Set by --data-source (default: parquet → run_tpch_parquet.sh).
+DATA_SOURCE="parquet"
 RUN_SCRIPT="$SCRIPT_DIR/run_tpch_parquet.sh"
 
 # ---------------------------------------------------------------------------
@@ -267,12 +271,29 @@ fi
 
 # Parse optional flags
 DUCKDB_RESULTS_DIR=""
+DUCKDB_FILE=""
 MULTI_SESSION=false
 CACHE_LEVEL=""
 while [ $# -gt 1 ]; do
     case "$1" in
         --config)
             export SIRIUS_CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --data-source)
+            case "$2" in
+                parquet | duckdb)
+                    DATA_SOURCE="$2"
+                    ;;
+                *)
+                    echo "ERROR: --data-source must be 'parquet' or 'duckdb' (got: $2)"
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
+        --duckdb-file)
+            DUCKDB_FILE="$2"
             shift 2
             ;;
         --parquet-dir)
@@ -313,11 +334,15 @@ NUM_ITERATIONS="${NUM_ITERATIONS:-2}"
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-1200}"
 
 if [ $# -ne 1 ]; then
-    echo "Usage: $0 [--config <config_file>] [--parquet-dir <path>] [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>] [--multi-session] <scale_factor>"
+    echo "Usage: $0 [--config <config_file>] [--data-source parquet|duckdb] [--parquet-dir <path>] [--duckdb-file <path>]"
+    echo "          [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>] [--multi-session] <scale_factor>"
     echo "       $0 --report <run_dir>"
+    echo "  --data-source parquet  (default) → run_tpch_parquet.sh + test_datasets/tpch_parquet_sf<SF> or --parquet-dir"
+    echo "  --data-source duckdb             → run_tpch_duckdb.sh + performance_test.duckdb or --duckdb-file"
     echo "Example: $0 --config ~/.sirius/sirius.yaml --engines sirius --iterations 3 --timeout 120 1000"
     echo "         $0 --duckdb-results runs/2026-03-10_sf1_2iter 1   # reuse stored DuckDB results for validation"
     echo "         $0 --multi-session --engines duckdb 100            # run DuckDB with fresh process per query"
+    echo "         $0 --data-source duckdb --duckdb-file ./performance_test.duckdb 1"
     exit 1
 fi
 
@@ -378,9 +403,35 @@ if [ -n "$DUCKDB_RESULTS_DIR" ]; then
 fi
 
 RUN_INFO_FILE="$RUN_DIR/run_info.txt"
-PARQUET_DIR="${PARQUET_DIR:-$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}}"
+
+if [ "$DATA_SOURCE" = "duckdb" ]; then
+    RUN_SCRIPT="$SCRIPT_DIR/run_tpch_duckdb.sh"
+    if [ ! -f "$RUN_SCRIPT" ]; then
+        echo "ERROR: DuckDB run script not found: $RUN_SCRIPT"
+        exit 1
+    fi
+    DUCKDB_FILE="${DUCKDB_FILE:-$PROJECT_DIR/performance_test.duckdb}"
+    DUCKDB_FILE="$(cd "$(dirname "$DUCKDB_FILE")" && pwd)/$(basename "$DUCKDB_FILE")"
+    if [ ! -f "$DUCKDB_FILE" ]; then
+        echo "ERROR: DuckDB database not found: $DUCKDB_FILE"
+        exit 1
+    fi
+else
+    RUN_SCRIPT="$SCRIPT_DIR/run_tpch_parquet.sh"
+    if [ ! -f "$RUN_SCRIPT" ]; then
+        echo "ERROR: Parquet run script not found: $RUN_SCRIPT"
+        exit 1
+    fi
+    PARQUET_DIR="${PARQUET_DIR:-$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}}"
+fi
 
 echo "Scale factor: SF${SF}   Iterations: ${NUM_ITERATIONS} (1 cold + $((NUM_ITERATIONS - 1)) warm)"
+echo "Data source: $DATA_SOURCE   Run script: $(basename "$RUN_SCRIPT")"
+if [ "$DATA_SOURCE" = "duckdb" ]; then
+    echo "DuckDB file: $DUCKDB_FILE"
+else
+    echo "Parquet dir: $PARQUET_DIR"
+fi
 echo "Run directory: $RUN_DIR"
 if [ -n "${DUCKDB_RESULTS_DIR:-}" ]; then
     echo "DuckDB results: reusing from $DUCKDB_RESULTS_DIR"
@@ -410,6 +461,15 @@ echo "=== Collecting run info and filesystem benchmark ==="
         echo "source: $DUCKDB_RESULTS_DIR (copied, not re-run)"
         echo ""
     fi
+
+    echo "--- Benchmark input ---"
+    echo "data_source: $DATA_SOURCE"
+    if [ "$DATA_SOURCE" = "duckdb" ]; then
+        echo "duckdb_file: $DUCKDB_FILE"
+    else
+        echo "parquet_dir: $PARQUET_DIR"
+    fi
+    echo ""
 
     echo "--- Git ---"
     if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree &>/dev/null; then
@@ -478,7 +538,28 @@ echo "=== Collecting run info and filesystem benchmark ==="
     echo ""
 
     echo "--- Filesystem benchmark (read-only, input location) ---"
-    if [ -d "$PARQUET_DIR" ]; then
+    if [ "$DATA_SOURCE" = "duckdb" ]; then
+        if [ -f "$DUCKDB_FILE" ]; then
+            SIZE_BYTES=$(stat -c %s "$DUCKDB_FILE" 2>/dev/null || stat -f %z "$DUCKDB_FILE" 2>/dev/null)
+            SIZE_MB=$((SIZE_BYTES / 1048576))
+            READ_MB=$((SIZE_MB < 100 ? SIZE_MB : 100))
+            echo "file: $DUCKDB_FILE"
+            echo "read_size_mb: $READ_MB"
+            START=$(date +%s.%N)
+            dd if="$DUCKDB_FILE" of=/dev/null bs=1M count="$READ_MB" 2>/dev/null
+            END=$(date +%s.%N)
+            ELAPSED=$(echo "$END - $START" | bc 2>/dev/null || echo "?")
+            if [ "$ELAPSED" != "?" ] && [ "$(echo "$ELAPSED > 0" | bc 2>/dev/null)" -eq 1 ]; then
+                THROUGHPUT=$(echo "scale=2; $READ_MB / $ELAPSED" | bc 2>/dev/null)
+                echo "elapsed_s: $ELAPSED"
+                echo "throughput_mb_s: $THROUGHPUT"
+            else
+                echo "elapsed_s: $ELAPSED (could not compute throughput)"
+            fi
+        else
+            echo "duckdb file not found: $DUCKDB_FILE (benchmark skipped)"
+        fi
+    elif [ -d "$PARQUET_DIR" ]; then
         FIRST_PARQUET=""
         for f in "$PARQUET_DIR"/lineitem.parquet \
                  "$PARQUET_DIR"/lineitem_*.parquet \
@@ -523,7 +604,9 @@ for engine in $ENGINES; do
     echo ""
     echo "=== Running $engine ==="
     EXTRA_ARGS=()
-    if [ -n "${PARQUET_DIR:-}" ]; then
+    if [ "$DATA_SOURCE" = "duckdb" ]; then
+        EXTRA_ARGS+=(--duckdb-file "$DUCKDB_FILE")
+    elif [ -n "${PARQUET_DIR:-}" ]; then
         EXTRA_ARGS+=(--parquet-dir "$PARQUET_DIR")
     fi
     EXTRA_ARGS+=(--iterations "$NUM_ITERATIONS")

--- a/test/tpch_performance/run_tpch_duckdb.sh
+++ b/test/tpch_performance/run_tpch_duckdb.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Run TPC-H GPU queries against TPC-H tables stored in a DuckDB database file
+# (default: performance_test.duckdb in the project root).
+#
+# Same session model as run_tpch_parquet.sh: single DuckDB process by default,
+# optional --multi-session for CPU baselines.
+#
+# Output layout matches run_tpch_parquet.sh (OUTPUT_DIR, TIMING_CSV, markers).
+#
+# Usage:
+#   export SIRIUS_CONFIG_FILE=...
+#   ./test/tpch_performance/run_tpch_duckdb.sh [options] <engine> <scale_factor> <query_numbers...>
+# with engine = [sirius/duckdb]
+#
+# Options:
+#   --duckdb-file <path>  Path to DuckDB file (default: <project>/performance_test.duckdb)
+#   --iterations <N>      Number of iterations per query (default: 2)
+#   --timeout <seconds>   Kill DuckDB session after N seconds (default: 1200)
+#   --cache-level <lvl>   Default Sirius scan_cache_level (sirius only)
+#   --multi-session       Run each query in its own DuckDB process
+#
+# Example:
+#   ./test/tpch_performance/run_tpch_duckdb.sh sirius 1 `seq 1 22`
+#   ./test/tpch_performance/run_tpch_duckdb.sh --duckdb-file ./data/perf.duckdb duckdb 1 1 6
+#
+# The scale_factor argument is kept for compatibility with benchmark drivers
+# (output filenames, logs). It does not select data inside performance_test.duckdb —
+# that file must already contain the TPC-H tables (customer, lineitem, ...).
+#
+# Environment variables:
+#   SIRIUS_CONFIG_FILE - path to Sirius config file (required for sirius engine)
+#   OUTPUT_DIR         - directory to save per-query results (optional)
+#   TIMING_CSV         - path to write per-query timing CSV (optional)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SIRIUS_DUCKDB="$PROJECT_DIR/build/release/duckdb"
+
+DUCKDB_FILE=""
+NUM_ITERATIONS=2
+SESSION_TIMEOUT=1200
+SCAN_CACHE_LEVEL=""
+MULTI_SESSION=false
+while [ "${1:-}" = "--duckdb-file" ] || [ "${1:-}" = "--iterations" ] || [ "${1:-}" = "--timeout" ] || [ "${1:-}" = "--cache-level" ] || [ "${1:-}" = "--multi-session" ]; do
+    if [ "$1" = "--duckdb-file" ]; then
+        DUCKDB_FILE="$2"
+        shift 2
+    elif [ "$1" = "--iterations" ]; then
+        NUM_ITERATIONS="$2"
+        shift 2
+    elif [ "$1" = "--timeout" ]; then
+        SESSION_TIMEOUT="$2"
+        shift 2
+    elif [ "$1" = "--cache-level" ]; then
+        SCAN_CACHE_LEVEL="$2"
+        shift 2
+    elif [ "$1" = "--multi-session" ]; then
+        MULTI_SESSION=true
+        shift
+    fi
+done
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 [--duckdb-file <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] <engine> <scale_factor> <query_numbers...>"
+    echo "Example: $0 sirius 1 \`seq 1 22\`"
+    echo "  Default database: \$PROJECT_DIR/performance_test.duckdb"
+    echo "  --iterations N    Number of iterations per query (default: 2, 1 cold + N-1 warm)"
+    echo "  --timeout N       Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
+    echo "  --multi-session   Run each query in its own DuckDB process (fresh state per query)"
+    exit 1
+fi
+
+ENGINE="$1"
+shift
+SF="$1"
+shift
+QUERIES=("$@")
+
+if [ -z "$DUCKDB_FILE" ]; then
+    DUCKDB_FILE="$PROJECT_DIR/performance_test.duckdb"
+fi
+
+# Resolve to absolute path (stable if cwd changes).
+DUCKDB_FILE="$(cd "$(dirname "$DUCKDB_FILE")" && pwd)/$(basename "$DUCKDB_FILE")"
+
+if [ "$ENGINE" != "sirius" ] && [ "$ENGINE" != "duckdb" ]; then
+    echo "Unknown engine, please use sirius or duckdb"
+    exit 1
+fi
+DUCKDB="$SIRIUS_DUCKDB"
+QUERY_DIR="$PROJECT_DIR/test/tpch_performance/tpch_queries/orig"
+if [ "$ENGINE" != "sirius" ]; then
+    export SIRIUS_DISABLE=1
+fi
+
+if [ ! -f "$DUCKDB_FILE" ]; then
+    echo "DuckDB database not found: $DUCKDB_FILE"
+    echo "Create it with TPC-H tables (customer, lineitem, nation, orders, part, partsupp, region, supplier),"
+    echo "or pass --duckdb-file <path> to an existing file."
+    exit 1
+fi
+
+if [ -n "${TIMING_CSV:-}" ]; then
+    echo "query,seconds" > "$TIMING_CSV"
+fi
+
+CACHE_CONFIG="$SCRIPT_DIR/scan_cache_levels.conf"
+declare -A QUERY_CACHE_LEVEL
+if [ "$SF" -ge 1000 ] 2>/dev/null && [ -f "$CACHE_CONFIG" ]; then
+    while IFS=' ' read -r qnum level; do
+        [[ -z "$qnum" || "$qnum" == \#* ]] && continue
+        QUERY_CACHE_LEVEL[$qnum]="$level"
+    done < "$CACHE_CONFIG"
+fi
+
+VALID_QUERIES=()
+for q in "${QUERIES[@]}"; do
+    QUERY_FILE="$QUERY_DIR/q${q}.sql"
+    if [ ! -f "$QUERY_FILE" ]; then
+        echo "WARNING: Query file not found: $QUERY_FILE, skipping Q${q}"
+        continue
+    fi
+    VALID_QUERIES+=("$q")
+done
+
+SESSION_MODE="single (all queries in one process)"
+if [ "$MULTI_SESSION" = true ]; then
+    SESSION_MODE="multi (fresh process per query)"
+fi
+
+echo "Running TPC-H queries from DuckDB file (sf label: ${SF})"
+echo "Engine: $ENGINE"
+echo "Database: $DUCKDB_FILE"
+echo "Session: $SESSION_MODE"
+echo "Iterations: $NUM_ITERATIONS (1 cold + $((NUM_ITERATIONS - 1)) warm)"
+echo "Queries: ${QUERIES[*]}"
+if [ "$SESSION_TIMEOUT" -gt 0 ] 2>/dev/null; then
+    echo "Session timeout: ${SESSION_TIMEOUT}s"
+else
+    echo "Session timeout: disabled"
+fi
+echo "=========================================="
+
+run_single_session() {
+    local MARKER_PREFIX="__TPCH_MARKER__"
+    local END_MARKER="__TPCH_END__"
+
+    local TEMP_SQL
+    TEMP_SQL=$(mktemp /tmp/tpch_all_XXXXXX.sql)
+    echo ".timer on" >> "$TEMP_SQL"
+
+    for q in "${VALID_QUERIES[@]}"; do
+        local QUERY_FILE="$QUERY_DIR/q${q}.sql"
+        if [ "$ENGINE" = "sirius" ]; then
+            local qlevel="${SCAN_CACHE_LEVEL:-${QUERY_CACHE_LEVEL[$q]:-table_gpu}}"
+            printf ".timer off\nSET scan_cache_level = '%s';\n.timer on\n" "$qlevel" >> "$TEMP_SQL"
+        fi
+        echo ".print ${MARKER_PREFIX} ${q}" >> "$TEMP_SQL"
+        for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do
+            cat "$QUERY_FILE" >> "$TEMP_SQL"
+            printf '\n' >> "$TEMP_SQL"
+        done
+    done
+    echo ".print ${END_MARKER}" >> "$TEMP_SQL"
+
+    if [ -n "${OUTPUT_DIR:-}" ]; then
+        mkdir -p "$OUTPUT_DIR"
+        cp "$TEMP_SQL" "$OUTPUT_DIR/all_queries.sql"
+    fi
+
+    echo ""
+    echo "Running all queries in a single DuckDB session..."
+    local START_TIME END_TIME FULL_OUTPUT SESSION_EXIT TOTAL_ELAPSED
+    START_TIME=$(date +%s.%N)
+    if [ "$SESSION_TIMEOUT" -gt 0 ] 2>/dev/null; then
+        if [ -n "${OUTPUT_DIR:-}" ]; then
+            FULL_OUTPUT=$(timeout "$SESSION_TIMEOUT" env SIRIUS_LOG_DIR="$OUTPUT_DIR" "$DUCKDB" "$DUCKDB_FILE" -f "$TEMP_SQL" 2>&1)
+        else
+            FULL_OUTPUT=$(timeout "$SESSION_TIMEOUT" "$DUCKDB" "$DUCKDB_FILE" -f "$TEMP_SQL" 2>&1)
+        fi
+    else
+        if [ -n "${OUTPUT_DIR:-}" ]; then
+            FULL_OUTPUT=$(SIRIUS_LOG_DIR="$OUTPUT_DIR" "$DUCKDB" "$DUCKDB_FILE" -f "$TEMP_SQL" 2>&1)
+        else
+            FULL_OUTPUT=$("$DUCKDB" "$DUCKDB_FILE" -f "$TEMP_SQL" 2>&1)
+        fi
+    fi
+    SESSION_EXIT=$?
+    END_TIME=$(date +%s.%N)
+
+    TOTAL_ELAPSED=$(echo "$END_TIME - $START_TIME" | bc)
+    echo "Total wall-clock time: ${TOTAL_ELAPSED}s"
+
+    if [ "$SESSION_EXIT" -eq 124 ]; then
+        echo "SESSION TIMEOUT: DuckDB was killed after ${SESSION_TIMEOUT}s"
+    elif [ "$SESSION_EXIT" -ne 0 ]; then
+        echo "SESSION FAILED: DuckDB exited with code $SESSION_EXIT"
+    fi
+
+    rm -f "$TEMP_SQL"
+
+    local TEMP_OUTPUT
+    TEMP_OUTPUT=$(mktemp /tmp/tpch_output_XXXXXX.txt)
+    echo "$FULL_OUTPUT" > "$TEMP_OUTPUT"
+
+    for q in "${VALID_QUERIES[@]}"; do
+        local RESULT_FILE TIMING_FILE
+        if [ -n "${OUTPUT_DIR:-}" ]; then
+            local Q_DIR="$OUTPUT_DIR/q${q}"
+            mkdir -p "$Q_DIR"
+            RESULT_FILE="$Q_DIR/result.txt"
+            TIMING_FILE="$Q_DIR/timings.csv"
+            cp "$QUERY_DIR/q${q}.sql" "$Q_DIR/query.sql"
+        else
+            RESULT_FILE="$PROJECT_DIR/result_${ENGINE}_sf${SF}_q${q}.txt"
+            TIMING_FILE="$PROJECT_DIR/timings_${ENGINE}_sf${SF}_q${q}.csv"
+        fi
+
+        echo ""
+        echo "========== Q${q} =========="
+
+        local SECTION
+        SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" \
+                      -v prefix="${MARKER_PREFIX}" \
+                      -v end="${END_MARKER}" '
+            $0 == start                                   { cap = 1; next }
+            cap && ($0 == end || index($0, prefix) == 1)  { exit }
+            cap                                           { print }
+        ' "$TEMP_OUTPUT")
+
+        if [ -z "$SECTION" ]; then
+            echo "  NO OUTPUT (session may have timed out or crashed before this query)"
+            echo "no output" > "$RESULT_FILE"
+            {
+                echo "step,runtime_s"
+                for ((i = 0; i < NUM_ITERATIONS; i++)); do
+                    echo "iter_$((i + 1)),N/A"
+                done
+            } > "$TIMING_FILE"
+            echo "  Timings written to $TIMING_FILE"
+            continue
+        fi
+
+        awk -v n="$NUM_ITERATIONS" '
+            /Run Time \(s\):/ { tc++; next }
+            tc == (n - 1)     { print }
+        ' <<< "$SECTION" > "$RESULT_FILE"
+
+        local TIMES
+        readarray -t TIMES < <(grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+' <<< "$SECTION")
+
+        {
+            echo "step,runtime_s"
+            for ((i = 0; i < ${#TIMES[@]}; i++)); do
+                echo "iter_$((i + 1)),${TIMES[$i]}"
+            done
+        } > "$TIMING_FILE"
+
+        local cold="${TIMES[0]:-N/A}"
+        local warm="N/A"
+        for ((i = 1; i < ${#TIMES[@]}; i++)); do
+            if [ "$warm" = "N/A" ] || (( $(echo "${TIMES[$i]} < $warm" | bc -l) )); then
+                warm="${TIMES[$i]}"
+            fi
+        done
+        echo "  Cold: ${cold}s   Warm(best): ${warm}s   (${#TIMES[@]} iterations)"
+
+        if [ -n "${TIMING_CSV:-}" ] && [ "$cold" != "N/A" ]; then
+            echo "${q},${cold}" >> "$TIMING_CSV"
+        fi
+
+        echo "  Timings written to $TIMING_FILE"
+    done
+
+    rm -f "$TEMP_OUTPUT"
+}
+
+run_multi_session() {
+    for q in "${VALID_QUERIES[@]}"; do
+        local QUERY_FILE="$QUERY_DIR/q${q}.sql"
+
+        local RESULT_FILE TIMING_FILE
+        if [ -n "${OUTPUT_DIR:-}" ]; then
+            local Q_DIR="$OUTPUT_DIR/q${q}"
+            mkdir -p "$Q_DIR"
+            RESULT_FILE="$Q_DIR/result.txt"
+            TIMING_FILE="$Q_DIR/timings.csv"
+            cp "$QUERY_DIR/q${q}.sql" "$Q_DIR/query.sql"
+        else
+            RESULT_FILE="$PROJECT_DIR/result_${ENGINE}_sf${SF}_q${q}.txt"
+            TIMING_FILE="$PROJECT_DIR/timings_${ENGINE}_sf${SF}_q${q}.csv"
+        fi
+
+        echo ""
+        echo "========== Q${q} =========="
+
+        local TEMP_SQL
+        TEMP_SQL=$(mktemp /tmp/tpch_q${q}_XXXXXX.sql)
+        {
+            if [ "$ENGINE" = "sirius" ]; then
+                local qlevel="${SCAN_CACHE_LEVEL:-${QUERY_CACHE_LEVEL[$q]:-table_gpu}}"
+                printf "SET scan_cache_level = '%s';\n" "$qlevel"
+            fi
+            printf ".timer on\n"
+            for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do
+                cat "$QUERY_FILE"
+                printf '\n'
+            done
+        } > "$TEMP_SQL"
+
+        local OUTPUT=""
+        local Q_EXIT=0
+        local RUN_ENV=("$DUCKDB" "$DUCKDB_FILE" -f "$TEMP_SQL")
+        if [ "$ENGINE" = "sirius" ] && [ -n "${Q_DIR:-}" ]; then
+            RUN_ENV=(env SIRIUS_LOG_DIR="$Q_DIR" "${RUN_ENV[@]}")
+        fi
+        if [ "$SESSION_TIMEOUT" -gt 0 ] 2>/dev/null; then
+            OUTPUT=$(timeout "$SESSION_TIMEOUT" "${RUN_ENV[@]}" 2>&1) || Q_EXIT=$?
+        else
+            OUTPUT=$("${RUN_ENV[@]}" 2>&1) || Q_EXIT=$?
+        fi
+
+        rm -f "$TEMP_SQL"
+
+        if [ "$Q_EXIT" -eq 124 ]; then
+            echo "  TIMEOUT: killed after ${SESSION_TIMEOUT}s"
+        elif [ "$Q_EXIT" -ne 0 ]; then
+            echo "  FAILED: DuckDB exited with code $Q_EXIT"
+        fi
+
+        local HAS_ERROR
+        HAS_ERROR=$(echo "$OUTPUT" | grep -ci "error" || true)
+
+        if [ "$HAS_ERROR" -gt 0 ] && [ "$Q_EXIT" -ne 0 ]; then
+            local ERROR_MSG
+            ERROR_MSG=$(echo "$OUTPUT" | grep -i "error" | head -1)
+            echo "  Error: $ERROR_MSG"
+            echo "error: $ERROR_MSG" > "$RESULT_FILE"
+            {
+                echo "step,runtime_s"
+                for ((i = 0; i < NUM_ITERATIONS; i++)); do
+                    echo "iter_$((i + 1)),N/A"
+                done
+            } > "$TIMING_FILE"
+            echo "  Timings written to $TIMING_FILE"
+            continue
+        fi
+
+        awk -v n="$NUM_ITERATIONS" '
+            /Run Time \(s\):/ { tc++; next }
+            tc == (n - 1)     { print }
+        ' <<< "$OUTPUT" > "$RESULT_FILE"
+
+        local TIMES
+        readarray -t TIMES < <(grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+' <<< "$OUTPUT")
+
+        {
+            echo "step,runtime_s"
+            for ((i = 0; i < ${#TIMES[@]}; i++)); do
+                echo "iter_$((i + 1)),${TIMES[$i]}"
+            done
+        } > "$TIMING_FILE"
+
+        local cold="${TIMES[0]:-N/A}"
+        local warm="N/A"
+        for ((i = 1; i < ${#TIMES[@]}; i++)); do
+            if [ "$warm" = "N/A" ] || (( $(echo "${TIMES[$i]} < $warm" | bc -l) )); then
+                warm="${TIMES[$i]}"
+            fi
+        done
+        echo "  Cold: ${cold}s   Warm(best): ${warm}s   (${#TIMES[@]} iterations)"
+
+        if [ -n "${TIMING_CSV:-}" ] && [ "$cold" != "N/A" ]; then
+            echo "${q},${cold}" >> "$TIMING_CSV"
+        fi
+
+        echo "  Timings written to $TIMING_FILE"
+    done
+}
+
+if [ "$MULTI_SESSION" = true ]; then
+    run_multi_session
+else
+    run_single_session
+fi
+
+if [ "$ENGINE" = "sirius" ] && [ "$MULTI_SESSION" = false ] && [ -n "${OUTPUT_DIR:-}" ] && [ ${#VALID_QUERIES[@]} -gt 0 ]; then
+    LOG_FILE=""
+    for f in "$OUTPUT_DIR"/sirius*.log; do
+        [ -f "$f" ] && LOG_FILE="$f"
+    done
+    if [ -n "$LOG_FILE" ]; then
+        echo ""
+        echo "Splitting Sirius log per query (${NUM_ITERATIONS} iterations per query)..."
+        readarray -t QB_LINES < <(grep -n 'QueryBegin: call' "$LOG_FILE" | cut -d: -f1)
+        TOTAL_LOG_LINES=$(wc -l < "$LOG_FILE")
+
+        for ((i = 0; i < ${#VALID_QUERIES[@]}; i++)); do
+            q="${VALID_QUERIES[$i]}"
+            start_idx=$((i * NUM_ITERATIONS))
+            next_idx=$(((i + 1) * NUM_ITERATIONS))
+
+            [ "$start_idx" -ge "${#QB_LINES[@]}" ] && continue
+            start_line="${QB_LINES[$start_idx]}"
+
+            if [ "$next_idx" -lt "${#QB_LINES[@]}" ]; then
+                end_line=$((QB_LINES[$next_idx] - 1))
+            else
+                end_line="$TOTAL_LOG_LINES"
+            fi
+
+            sed -n "${start_line},${end_line}p" "$LOG_FILE" > "$OUTPUT_DIR/q${q}/sirius.log"
+            echo "  Q${q}: lines ${start_line}-${end_line} -> q${q}/sirius.log"
+        done
+    fi
+fi
+
+echo ""
+echo "=========================================="
+echo "All queries complete."
+if [ -n "${OUTPUT_DIR:-}" ]; then
+    echo "Results saved under $OUTPUT_DIR"
+else
+    echo "Results saved as result_${ENGINE}_sf${SF}_q*.txt"
+    echo "Timings saved as timings_${ENGINE}_sf${SF}_q*.csv"
+fi


### PR DESCRIPTION
The scripts behaves the same as the existing parquet script, and can be called from benchmark_and_validate.sh with a new --data-source flag.
What it doesn't do is ensure the data exists and is of the proper scale factor; it assumes the user generated it into the expected performance_test.duckdb file. And the user needs to pass the proper scale factor of that file to the script.