### PR TITLE
refactor: rename pipeline_executor to task_scheduler

### DIFF
--- a/.claude/skills/module-discover/docs/cucascade/README.md
+++ b/.claude/skills/module-discover/docs/cucascade/README.md
@@ -29,7 +29,7 @@ We use **2 of 3** modules. Primary integration points:
 | `src/sirius_context.cpp` | memory | `fixed_size_host_memory_resource`, `small_pinned_host_memory_resource` |
 | `src/sirius_config.cpp` | memory | `config`, `reservation_manager_configurator` |
 | `src/pipeline/gpu_pipeline_task.cpp` | data, memory | `data_batch`, `gpu_table_representation`, `cpu_data_representation`, `memory_space`, `reservation_aware_resource_adaptor` |
-| `src/pipeline/pipeline_executor.cpp` | memory | `memory_reservation`, `memory_space`, `common` |
+| `src/pipeline/task_scheduler.cpp` | memory | `memory_reservation`, `memory_space`, `common` |
 | `src/pipeline/gpu_pipeline_executor.cpp` | memory | `stream_pool`, `memory_reservation`, `memory_space` |
 | `src/memory/sirius_memory_reservation_manager.cpp` | memory | `memory_reservation_manager`, `Tier` |
 | `src/op/scan/duckdb_scan_task.cpp` | data, memory | `cpu_data_representation`, `data_batch`, `memory_space`, `memory_reservation` |

--- a/.claude/skills/module-discover/docs/cucascade/modules/memory.md
+++ b/.claude/skills/module-discover/docs/cucascade/modules/memory.md
@@ -420,7 +420,7 @@ public:
 
 **Our usage**:
 - `src/include/sirius_config.hpp:25` — sirius config uses topology for memory setup
-- `src/include/pipeline/pipeline_executor.hpp:33` — pipeline executor reads topology
+- `src/include/pipeline/task_scheduler.hpp:33` — task scheduler reads topology
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ set(EXTENSION_SOURCES
     src/parallel/task_executor.cpp
     src/pipeline/gpu_pipeline_executor.cpp
     src/pipeline/gpu_pipeline_task.cpp
-    src/pipeline/pipeline_executor.cpp
+    src/pipeline/task_scheduler.cpp
     src/pipeline/sirius_meta_pipeline.cpp
     src/pipeline/sirius_pipeline.cpp
     src/pipeline/sirius_pipeline_converter.cpp
@@ -400,7 +400,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
     test/cpp/pipeline/test_plan_printer.cpp
-    test/cpp/pipeline/test_pipeline_executor.cpp
+    test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/test_column_builder.cpp
     test/cpp/scan/test_metadata_gpu_scan_operators.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp

--- a/docs/super-sirius/architecture-overview.md
+++ b/docs/super-sirius/architecture-overview.md
@@ -10,7 +10,7 @@ graph TD
     EXT --> IFACE["sirius_interface"]
     IFACE --> ENGINE["sirius_engine"]
     ENGINE -->|"build pipelines"| PLANNER["sirius_physical_plan_generator"]
-    ENGINE -->|"execute"| PE["pipeline_executor"]
+    ENGINE -->|"execute"| PE["task_scheduler"]
 
     PE --> GPE["gpu_pipeline_executor(s)"]
     PE --> SE["duckdb_scan_executor"]
@@ -45,7 +45,7 @@ SiriusContext
 ├── sirius_memory_reservation_manager   # GPU/Host/Disk memory management via cuCascade
 ├── small_pinned_host_memory_resource   # Pinned host memory allocator
 ├── shared_data_repository_manager      # Central registry of all data repositories
-├── pipeline_executor                   # Top-level executor (owns GPU + scan executors)
+├── task_scheduler                      # Top-level executor (owns GPU + scan executors)
 ├── downgrade_executor[]                # Per-memory-space monitors for GPU→Host spilling
 ├── task_creator                        # Creates scan and GPU tasks based on data availability
 └── query                               # Current query context (pipeline hashmap)
@@ -67,7 +67,7 @@ Super Sirius uses multiple dedicated thread pools, each with a specific role:
 │  - Parses SQL, generates logical plan                           │
 │  - Calls sirius_interface → sirius_engine                       │
 │  - Builds pipelines (single-threaded)                           │
-│  - Calls pipeline_executor.start_query()                        │
+│  - Calls task_scheduler.start_query()                           │
 │  - Blocks on future until query completes                       │
 └─────────────────────────────────────────────────────────────────┘
 
@@ -119,8 +119,8 @@ A query through Super Sirius follows these steps:
    - Splits operators (TABLE_SCAN, joins, aggregates, sorts) into multiple pipelines
    - Injects PARTITION, CONCAT, MERGE operators at pipeline boundaries
    - Wires data repositories between pipelines with barrier types
-4. **Query Preparation** — `pipeline_executor::prepare_for_query()` drains leftover state, prepares scan cache, queues initial scan operators
-5. **Query Start** — `pipeline_executor::start_query()` creates a `completion_handler`, distributes it to all sub-executors, and schedules initial scan tasks
+4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state, prepares scan cache, queues initial scan operators
+5. **Query Start** — `task_scheduler::start_query()` creates a `completion_handler`, distributes it to all sub-executors, and schedules initial scan tasks
 6. **Scan Phase** — Scan executor pulls data from storage (DuckDB tables or Parquet files), converts to GPU-compatible format, and publishes to data repositories
 7. **Pipeline Execution** — GPU executor threads pull tasks from the queue, acquire memory reservations, and call `execute()` on every operator in the pipeline (source through sink) on CUDA streams, then call the sink's `sink()` to push results downstream
 8. **Task Creation** — After each task completes, the task creator is notified to schedule downstream consumers based on data availability in ports
@@ -137,7 +137,7 @@ A query through Super Sirius follows these steps:
 | `src/sirius_interface.cpp` | DuckDB-facing API, query lifecycle |
 | `src/sirius_engine.cpp` | Pipeline construction, execution orchestration |
 | `src/planner/sirius_physical_plan_generator.cpp` | Logical-to-physical plan translation |
-| `src/include/pipeline/pipeline_executor.hpp` | Top-level executor |
+| `src/include/pipeline/task_scheduler.hpp` | Top-level executor |
 | `src/include/pipeline/gpu_pipeline_executor.hpp` | Per-GPU task executor |
 | `src/include/creator/task_creator.hpp` | Task creation and scheduling |
 | `src/include/op/scan/duckdb_scan_executor.hpp` | Scan task executor |

--- a/docs/super-sirius/execution-flow.md
+++ b/docs/super-sirius/execution-flow.md
@@ -117,7 +117,7 @@ After meta-pipeline construction, `initialize_internal()` applies Sirius-specifi
 **File:** `src/sirius_engine.cpp` — `execute()`
 
 1. Creates a `query` object from `new_scheduled` pipelines with a pipeline hashmap
-2. Calls `pipeline_executor.start_query(query)` which:
+2. Calls `task_scheduler.start_query(query)` which:
    - Creates a `completion_handler` with promise/future
    - Distributes the handler to all sub-executors
    - Schedules initial scan tasks from the priority queue
@@ -204,7 +204,7 @@ sequenceDiagram
     participant Ext as sirius_extension
     participant Iface as sirius_interface
     participant Engine as sirius_engine
-    participant PE as pipeline_executor
+    participant PE as task_scheduler
     participant SE as scan_executor
     participant GPE as gpu_pipeline_executor
     participant TC as task_creator

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -91,7 +91,7 @@ Only applies to INNER and LEFT joins with pure equality conditions (excludes IS 
 1. At query startup, at most 2 scans are scheduled initially
 2. In `task_creator::manager_loop`, scan exhaustion (continuous creation) only runs when `_num_scans_in_plan == 1`. For 2+ scans, the `get_next_task_hint()` topology-driven mechanism controls task creation instead.
 
-**Code path:** `src/creator/task_creator.cpp` — `manager_loop()`, `src/pipeline/pipeline_executor.cpp` — `schedule_next_scan_tasks()`
+**Code path:** `src/creator/task_creator.cpp` — `manager_loop()`, `src/pipeline/task_scheduler.cpp` — `schedule_next_scan_tasks()`
 
 **Config:** `max_build_hash_table_bytes` (default: 500 MB) — now independent from `concat_batch_bytes`, enabling larger build sides in BUILD_PROBE mode without affecting other joins.
 

--- a/docs/super-sirius/pipeline-execution.md
+++ b/docs/super-sirius/pipeline-execution.md
@@ -113,9 +113,9 @@ The **destructor** calls `pipeline->mark_task_completed()` to update pipeline co
 
 ## Pipeline Executor
 
-**File:** `src/include/pipeline/pipeline_executor.hpp`, `src/pipeline/pipeline_executor.cpp`
+**File:** `src/include/pipeline/task_scheduler.hpp`, `src/pipeline/task_scheduler.cpp`
 
-The `pipeline_executor` is the top-level orchestrator that owns GPU and scan sub-executors.
+The `task_scheduler` is the top-level orchestrator that owns GPU and scan sub-executors.
 
 ### Key Methods
 
@@ -203,7 +203,7 @@ The completion check happens **before** scheduling downstream tasks to prevent s
 GPU executors communicate with the pipeline executor via `exec::channel<task_request>`:
 
 ```
-gpu_executor → task_request_publisher.send() → pipeline_executor.management_eventloop()
+gpu_executor → task_request_publisher.send() → task_scheduler.management_eventloop()
              ← task_queue.push()              ← task_creator.schedule()
 ```
 
@@ -246,7 +246,7 @@ If max retries are exceeded, the error propagates and terminates the query.
 
 ## Error Handling and Draining
 
-**File:** `src/pipeline/pipeline_executor.cpp`
+**File:** `src/pipeline/task_scheduler.cpp`
 
 `drain_after_error()` performs a multi-stage clean shutdown:
 
@@ -262,8 +262,8 @@ This ensures that when `drain_after_error()` returns, no tasks are referencing o
 
 | File | Purpose |
 |------|---------|
-| `src/include/pipeline/pipeline_executor.hpp` | Top-level executor |
-| `src/pipeline/pipeline_executor.cpp` | Event loop, query lifecycle |
+| `src/include/pipeline/task_scheduler.hpp` | Top-level executor |
+| `src/pipeline/task_scheduler.cpp` | Event loop, query lifecycle |
 | `src/include/pipeline/gpu_pipeline_executor.hpp` | Per-GPU executor |
 | `src/pipeline/gpu_pipeline_executor.cpp` | Manager loop, OOM handling |
 | `src/include/pipeline/gpu_pipeline_task.hpp` | GPU task class |

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -23,7 +23,7 @@ operator->get_next_task_hint() → READY or WAITING_FOR_INPUT_DATA
     ↓
 Create task (duckdb_scan_task, parquet_scan_task, or gpu_pipeline_task)
     ↓
-Dispatch to executor (scan_executor or pipeline_executor)
+Dispatch to executor (scan_executor or task_scheduler)
 ```
 
 ## Global State Maps
@@ -238,7 +238,7 @@ while running:
            - Loop while (!node.all_ports_empty()):
              - pipeline.mark_task_created()  // BEFORE popping data
              - data = node.get_next_task_input_data()
-             - If data: create gpu_pipeline_task, dispatch to pipeline_executor
+             - If data: create gpu_pipeline_task, dispatch to task_scheduler
              - If no data: pipeline.mark_task_completed()
 ```
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -27,7 +27,7 @@
 #include "op/sirius_physical_iceberg_scan.hpp"
 #include "op/sirius_physical_parquet_scan.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
-#include "pipeline/pipeline_executor.hpp"
+#include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
 #include "sirius_context.hpp"
 
@@ -58,9 +58,9 @@ void task_creator::set_client_context(::duckdb::ClientContext& client_context)
     std::make_unique<duckdb::ExecutionContext>(client_context, *_thread_context, nullptr);
 }
 
-void task_creator::set_pipeline_executor(sirius::pipeline::pipeline_executor& pipeline_executor)
+void task_creator::set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler)
 {
-  _pipeline_executor = &pipeline_executor;
+  _task_scheduler = &task_scheduler;
 }
 
 void task_creator::prepare_for_query(const sirius::planner::query& query)
@@ -86,7 +86,7 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
         operator_id,
         std::make_shared<op::scan::duckdb_scan_task_global_state>(
           pipeline,
-          *_pipeline_executor,
+          *_task_scheduler,
           *_client_context,
           &source_operator->Cast<op::sirius_physical_duckdb_scan>()));
     } else if (source_operator->type == ::sirius::op::SiriusPhysicalOperatorType::CPU_SOURCE) {
@@ -306,7 +306,7 @@ void task_creator::manager_loop()
             scan_task_global_state);
           pipeline->mark_task_created();  // WSM TODO: this needs to be done atomically
                                           // with the task creation
-          _pipeline_executor->schedule(std::move(scan_task));
+          _task_scheduler->schedule(std::move(scan_task));
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::ICEBERG_SCAN) {
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
@@ -345,7 +345,7 @@ void task_creator::manager_loop()
                                                             destination_data_repositories[0],
                                                             std::move(parquet_task_local_state),
                                                             parquet_task_global_state);
-            _pipeline_executor->schedule(std::move(parquet_task));
+            _task_scheduler->schedule(std::move(parquet_task));
 
             // If there is only a single scan in the plan, continue creating scan tasks to create
             // I/O parallelism. Otherwise, let the plan drive the creation of more tasks.
@@ -372,7 +372,7 @@ void task_creator::manager_loop()
                                                                   *_client_context);
           SIRIUS_LOG_DEBUG("Task Creator: scheduling cpu_source_task, dest_repos={}",
                            destination_data_repositories.size());
-          _pipeline_executor->schedule(std::move(task));
+          _task_scheduler->schedule(std::move(task));
         } else {
           // need to exhaust input batches until all ports are empty
           while (!node->all_ports_empty()) {
@@ -411,12 +411,12 @@ void task_creator::manager_loop()
                                                             destination_data_repositories,
                                                             std::move(local_state),
                                                             gpu_pipeline_task_global_state);
-            _pipeline_executor->schedule(std::move(task));
+            _task_scheduler->schedule(std::move(task));
           }
         }
       } catch (const std::exception& e) {
         SIRIUS_LOG_ERROR("Task Creator: Exception during task creation: {}", e.what());
-        _pipeline_executor->terminate_query(std::current_exception());
+        _task_scheduler->terminate_query(std::current_exception());
         stop();
       }
     });

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -230,7 +230,7 @@ void downgrade_executor::processing_loop()
       if (pool_interrupted) break;
     }
 
-    // === TIER 2: pipeline_executor task queue ===
+    // === TIER 2: task_scheduler task queue ===
     if (!req->satisfied.load() && _pipeline_task_queue) {
       convertible_gpu_pipeline_task_provider pipeline_provider(*_pipeline_task_queue);
       while (!req->satisfied.load()) {

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -40,7 +40,7 @@
 #include <variant>
 
 namespace sirius::pipeline {
-class pipeline_executor;
+class task_scheduler;
 class sirius_pipeline_task_global_state;
 }  // namespace sirius::pipeline
 
@@ -102,7 +102,7 @@ class task_creator {
   void set_client_context(::duckdb::ClientContext& client_context);
 
   /// \brief sets pipeline executor reference
-  void set_pipeline_executor(sirius::pipeline::pipeline_executor& pipeline_executor);
+  void set_task_scheduler(sirius::pipeline::task_scheduler& task_scheduler);
 
   /// \brief prepare global states for all pipelines in the query
   void prepare_for_query(const sirius::planner::query& query);
@@ -180,7 +180,7 @@ class task_creator {
   std::unique_ptr<exec::bounded_thread_pool> _bounded_pool;
   std::thread _manager_thread;
   ::duckdb::ClientContext* _client_context;
-  sirius::pipeline::pipeline_executor* _pipeline_executor{nullptr};
+  sirius::pipeline::task_scheduler* _task_scheduler{nullptr};
   sirius::memory::sirius_memory_reservation_manager& _mem_res_mgr;
   std::atomic<uint64_t> _task_id{0};
   size_t _num_scans_in_plan{0};

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -132,7 +132,7 @@ class downgrade_executor {
    * Must be called before start(). Allows deferred wiring when the queue
    * is not available at construction time.
    *
-   * @param pipeline_task_queue Pointer to the pipeline_executor's task queue
+   * @param pipeline_task_queue Pointer to the task_scheduler's task queue
    */
   void set_pipeline_task_queue(
     sirius::exec::inspectable_mpsc<sirius::parallel::itask>* pipeline_task_queue);

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -24,10 +24,10 @@
 #include <duckdb/main/client_context.hpp>
 #include <op/sirius_physical_cpu_source.hpp>
 #include <parallel/task.hpp>
-#include <pipeline/pipeline_executor.hpp>
 #include <pipeline/sirius_pipeline.hpp>
 #include <pipeline/sirius_pipeline_itask.hpp>
 #include <pipeline/sirius_pipeline_task_states.hpp>
+#include <pipeline/task_scheduler.hpp>
 #include <sirius_context.hpp>
 
 namespace sirius::op::scan {

--- a/src/include/op/scan/duckdb_scan_executor.hpp
+++ b/src/include/op/scan/duckdb_scan_executor.hpp
@@ -156,7 +156,7 @@ class duckdb_scan_executor : public sirius::parallel::itask_executor {
 
  private:
   /**
-   * @brief Submit a scan task request to pipeline_executor
+   * @brief Submit a scan task request to task_scheduler
    */
   void submit_scan_request();
 

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -24,10 +24,10 @@
 #include <op/sirius_physical_duckdb_scan.hpp>
 #include <op/sirius_physical_table_scan.hpp>
 #include <parallel/task.hpp>
-#include <pipeline/pipeline_executor.hpp>
 #include <pipeline/sirius_pipeline.hpp>
 #include <pipeline/sirius_pipeline_itask.hpp>
 #include <pipeline/sirius_pipeline_task_states.hpp>
+#include <pipeline/task_scheduler.hpp>
 #include <sirius_config.hpp>
 #include <sirius_context.hpp>
 
@@ -75,7 +75,7 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
    * @param[in] gpu_pts The GPU physical table scan being executed
    */
   duckdb_scan_task_global_state(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
-                                pipeline::pipeline_executor& pipeline_exec,
+                                pipeline::task_scheduler& pipeline_exec,
                                 duckdb::ClientContext& client_ctx,
                                 sirius_physical_duckdb_scan* scan_op);
 
@@ -149,11 +149,10 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
   //===----------Fields----------===//
   duckdb::SiriusContext* _sirius_ctx;  ///< The Sirius context
   std::unique_ptr<duckdb::GlobalTableFunctionState>
-    _global_tf_state;  ///< Global state for the table function
-  pipeline::pipeline_executor&
-    _pipeline_executor;                      ///< The pipeline executor for scheduling scan tasks
-  sirius_physical_duckdb_scan& _op;          ///< The physical table scan being executed
-  std::atomic<bool> _source_drained{false};  ///< Whether the table scan source is fully drained
+    _global_tf_state;                            ///< Global state for the table function
+  pipeline::task_scheduler& _task_scheduler;     ///< The task scheduler for scheduling scan tasks
+  sirius_physical_duckdb_scan& _op;              ///< The physical table scan being executed
+  std::atomic<bool> _source_drained{false};      ///< Whether the table scan source is fully drained
   std::atomic<int64_t> _active_local_states{0};  ///< Number of active local table function states
   uint64_t _max_threads;                         ///< Maximum number of threads for this scan task
 };

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -61,10 +61,10 @@ class gpu_pipeline_executor;
  * task scheduling. It manages a pool of threads dedicated to executing GPU pipeline
  * tasks with specialized GPU resource management.
  */
-class pipeline_executor {
+class task_scheduler {
  public:
   /**
-   * @brief Constructs a new pipeline_executor with task execution configuration
+   * @brief Constructs a new task_scheduler with task execution configuration
    *
    * @param gpu_executor_config Configuration for the GPU pipeline executor thread pool
    * @param scan_executor_config Configuration for the scan executor thread pool
@@ -72,24 +72,23 @@ class pipeline_executor {
    * @param sys_topology Optional system topology info for CPU affinity
    * @param downgrade_executors Optional vector of downgrade executors
    */
-  explicit pipeline_executor(
-    const exec::thread_pool_config& gpu_executor_config,
-    const exec::thread_pool_config& scan_executor_config,
-    sirius::memory::sirius_memory_reservation_manager& mem_mgr,
-    const cucascade::memory::system_topology_info* sys_topology = nullptr,
-    const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* downgrade_executors =
-      nullptr);
+  explicit task_scheduler(const exec::thread_pool_config& gpu_executor_config,
+                          const exec::thread_pool_config& scan_executor_config,
+                          sirius::memory::sirius_memory_reservation_manager& mem_mgr,
+                          const cucascade::memory::system_topology_info* sys_topology = nullptr,
+                          const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>*
+                            downgrade_executors = nullptr);
 
   /**
-   * @brief Destructor for the gpu_pipeline_executor.
+   * @brief Destructor for the task_scheduler.
    */
-  ~pipeline_executor();
+  ~task_scheduler();
 
   // Non-copyable but movable
-  pipeline_executor(const pipeline_executor&)            = delete;
-  pipeline_executor& operator=(const pipeline_executor&) = delete;
-  pipeline_executor(pipeline_executor&&)                 = delete;
-  pipeline_executor& operator=(pipeline_executor&&)      = delete;
+  task_scheduler(const task_scheduler&)            = delete;
+  task_scheduler& operator=(const task_scheduler&) = delete;
+  task_scheduler(task_scheduler&&)                 = delete;
+  task_scheduler& operator=(task_scheduler&&)      = delete;
 
   /**
    * @brief Schedules a task for execution with GPU-specific logic

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -19,8 +19,8 @@
 #include "creator/task_creator.hpp"
 #include "downgrade/downgrade_executor.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
-#include "pipeline/pipeline_executor.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
 #include "sirius_config.hpp"
 
@@ -150,8 +150,8 @@ class SiriusContext : public ClientContextState {
   [[nodiscard]] const cucascade::shared_data_repository_manager& get_data_repository_manager()
     const;
 
-  [[nodiscard]] sirius::pipeline::pipeline_executor& get_pipeline_executor();
-  [[nodiscard]] const sirius::pipeline::pipeline_executor& get_pipeline_executor() const;
+  [[nodiscard]] sirius::pipeline::task_scheduler& get_task_scheduler();
+  [[nodiscard]] const sirius::pipeline::task_scheduler& get_task_scheduler() const;
 
   /// \brief Get the downgrade executor for a specific memory space.
   [[nodiscard]] sirius::parallel::downgrade_executor& get_downgrade_executor(
@@ -237,7 +237,7 @@ class SiriusContext : public ClientContextState {
   std::optional<rmm::host_device_async_resource_ref> prev_pinned_mr_{};
   std::size_t prev_pinned_threshold_{0};
   std::unique_ptr<cucascade::shared_data_repository_manager> data_repository_manager_;
-  std::unique_ptr<sirius::pipeline::pipeline_executor> pipeline_executor_;
+  std::unique_ptr<sirius::pipeline::task_scheduler> task_scheduler_;
   std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>> downgrade_executors_;
   std::unique_ptr<sirius::creator::task_creator> task_creator_;
   duckdb::shared_ptr<sirius::planner::query> query_;

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -43,13 +43,13 @@ namespace sirius::op::scan {
 //===----------------------------------------------------------------------===//
 duckdb_scan_task_global_state::duckdb_scan_task_global_state(
   duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
-  pipeline::pipeline_executor& pipeline_exec,
+  pipeline::task_scheduler& pipeline_exec,
   duckdb::ClientContext& client_ctx,
   sirius_physical_duckdb_scan* scan_op)
   : sirius_pipeline_task_global_state(pipeline),
     _sirius_ctx(client_ctx.registered_state->Get<duckdb::SiriusContext>("sirius_state").get()),
     _max_threads(pipeline_exec.get_scan_executor().get_num_threads()),
-    _pipeline_executor(pipeline_exec),
+    _task_scheduler(pipeline_exec),
     _op(*scan_op)
 {
   // Initialize global table function state
@@ -597,7 +597,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
       std::static_pointer_cast<duckdb_scan_task_global_state>(this->_global_state);
     auto next_task = std::make_unique<duckdb_scan_task>(
       new_task_id, _data_repo, std::move(new_local_state), shared_global_state);
-    g_state._pipeline_executor.schedule(std::move(next_task));
+    g_state._task_scheduler.schedule(std::move(next_task));
   }
 
   // Make data batch and push to repository

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "pipeline/pipeline_executor.hpp"
+#include "pipeline/task_scheduler.hpp"
 
 #include "creator/task_creator.hpp"
 #include "downgrade/downgrade_executor.hpp"
@@ -34,7 +34,7 @@
 namespace sirius {
 namespace pipeline {
 
-pipeline_executor::pipeline_executor(
+task_scheduler::task_scheduler(
   const exec::thread_pool_config& gpu_executor_config,
   const exec::thread_pool_config& scan_executor_config,
   sirius::memory::sirius_memory_reservation_manager& mem_mgr,
@@ -42,7 +42,7 @@ pipeline_executor::pipeline_executor(
   const std::vector<std::unique_ptr<sirius::parallel::downgrade_executor>>* downgrade_executors)
 {
   // Create the scan executor with memory manager for host allocations
-  // Pass a publisher so it can submit task requests without depending on pipeline_executor
+  // Pass a publisher so it can submit task requests without depending on task_scheduler
   _scan_executor = std::make_unique<sirius::op::scan::duckdb_scan_executor>(
     scan_executor_config, &mem_mgr, _task_request_channel.make_publisher());
 
@@ -81,9 +81,9 @@ pipeline_executor::pipeline_executor(
   }
 }
 
-pipeline_executor::~pipeline_executor() { stop(); }
+task_scheduler::~task_scheduler() { stop(); }
 
-void pipeline_executor::schedule(std::unique_ptr<sirius::parallel::itask> task)
+void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
 {
   if (task->is<sirius::op::scan::duckdb_scan_task>()) {
     _scan_executor->schedule(std::move(task));
@@ -96,7 +96,7 @@ void pipeline_executor::schedule(std::unique_ptr<sirius::parallel::itask> task)
   }
 }
 
-void pipeline_executor::start()
+void task_scheduler::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
@@ -104,10 +104,10 @@ void pipeline_executor::start()
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->start();
   }
-  _management_thread = std::thread(&pipeline_executor::management_eventloop, this);
+  _management_thread = std::thread(&task_scheduler::management_eventloop, this);
 }
 
-void pipeline_executor::stop()
+void task_scheduler::stop()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
@@ -120,7 +120,7 @@ void pipeline_executor::stop()
   if (_management_thread.joinable()) { _management_thread.join(); }
 }
 
-void pipeline_executor::set_task_creator(sirius::creator::task_creator& task_creator)
+void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creator)
 {
   _task_creator = &task_creator;
 
@@ -130,24 +130,23 @@ void pipeline_executor::set_task_creator(sirius::creator::task_creator& task_cre
   }
 }
 
-[[nodiscard]] sirius::op::scan::duckdb_scan_executor&
-pipeline_executor::get_scan_executor() noexcept
+[[nodiscard]] sirius::op::scan::duckdb_scan_executor& task_scheduler::get_scan_executor() noexcept
 {
   return *_scan_executor;
 }
 
-[[nodiscard]] const sirius::op::scan::duckdb_scan_executor& pipeline_executor::get_scan_executor()
+[[nodiscard]] const sirius::op::scan::duckdb_scan_executor& task_scheduler::get_scan_executor()
   const noexcept
 {
   return *_scan_executor;
 }
 
-void pipeline_executor::set_scan_caching_config(sirius::op::scan::cache_level level)
+void task_scheduler::set_scan_caching_config(sirius::op::scan::cache_level level)
 {
   _scan_executor->set_scan_caching_enabled(level);
 }
 
-void pipeline_executor::prepare_for_query(duckdb::shared_ptr<planner::query> query)
+void task_scheduler::prepare_for_query(duckdb::shared_ptr<planner::query> query)
 {
   // Drain leftover tasks from previous query
   _scan_executor->drain_leftover_tasks();
@@ -167,7 +166,7 @@ void pipeline_executor::prepare_for_query(duckdb::shared_ptr<planner::query> que
   }
 }
 
-std::future<void> pipeline_executor::start_query()
+std::future<void> task_scheduler::start_query()
 {
   // Create a new completion handler for this query
   _completion_handler      = std::make_unique<completion_handler>();
@@ -190,15 +189,15 @@ std::future<void> pipeline_executor::start_query()
   return future;
 }
 
-void pipeline_executor::terminate_query(std::exception_ptr error)
+void task_scheduler::terminate_query(std::exception_ptr error)
 {
   _completion_handler->report_error(error);
   stop();
 }
 
-void pipeline_executor::drain_after_error()
+void task_scheduler::drain_after_error()
 {
-  SIRIUS_LOG_INFO("pipeline_executor: draining after error");
+  SIRIUS_LOG_INFO("task_scheduler: draining after error");
   // Drain the task creator first so no thread is inside get_next_task_input_data()/
   // pop_data_batch() when QueryEnd() clears repositories (avoids use-after-free).
   if (_task_creator) { _task_creator->stop_thread_pool(); }
@@ -219,10 +218,10 @@ void pipeline_executor::drain_after_error()
     gpu_exec->drain_and_wait();
   }
   if (_task_creator) { _task_creator->start_thread_pool(); }
-  SIRIUS_LOG_INFO("pipeline_executor: DONE draining after error");
+  SIRIUS_LOG_INFO("task_scheduler: DONE draining after error");
 }
 
-void pipeline_executor::management_eventloop()
+void task_scheduler::management_eventloop()
 {
   while (_running.load()) {
     auto request = _task_request_channel.get();

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -126,9 +126,9 @@ void SiriusContext::QueryBegin(ClientContext& context)
     spdlog::info("QueryBegin: {}", query.substr(0, std::min(query.size(), size_t(120))));
     bool query_cache_hit = false;
     if (config_.is_scan_caching_enabled()) {
-      query_cache_hit = pipeline_executor_->get_scan_executor().cache_scan_results_for_query(query);
+      query_cache_hit = task_scheduler_->get_scan_executor().cache_scan_results_for_query(query);
     }
-    pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
+    task_scheduler_->set_scan_caching_config(config_.get_cache_level());
 
     task_creator_->reset(query_cache_hit);
     task_creator_->set_client_context(context);
@@ -219,7 +219,7 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
 
   data_repository_manager_ = std::make_unique<cucascade::shared_data_repository_manager>();
 
-  // Create one downgrade executor per GPU memory space BEFORE pipeline_executor,
+  // Create one downgrade executor per GPU memory space BEFORE task_scheduler,
   // so pointers are available for injection into gpu_pipeline_executors.
   // HOST->DISK downgrade is not yet implemented, so we skip HOST tier for now.
   auto create_executors_for_tier = [&](cucascade::memory::Tier tier) {
@@ -233,29 +233,29 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
         const_cast<cucascade::memory::memory_space*>(space),
         *memory_manager_);
       // NOTE: do not call executor->start() here -- deferred until after
-      // pipeline_executor_ and task_creator_ are constructed.
+      // task_scheduler_ and task_creator_ are constructed.
       downgrade_executors_.push_back(std::move(executor));
     }
   };
   create_executors_for_tier(cucascade::memory::Tier::GPU);
   create_executors_for_tier(cucascade::memory::Tier::HOST);
 
-  pipeline_executor_ = std::make_unique<sirius::pipeline::pipeline_executor>(
-    config_.get_gpu_pipeline_executor_config(),
-    config_.get_duckdb_scan_executor_config(),
-    *memory_manager_,
-    &config_.get_hw_topology(),
-    &downgrade_executors_);
+  task_scheduler_ =
+    std::make_unique<sirius::pipeline::task_scheduler>(config_.get_gpu_pipeline_executor_config(),
+                                                       config_.get_duckdb_scan_executor_config(),
+                                                       *memory_manager_,
+                                                       &config_.get_hw_topology(),
+                                                       &downgrade_executors_);
 
   task_creator_ = std::make_unique<sirius::creator::task_creator>(config_.get_task_creator_config(),
                                                                   *memory_manager_);
-  task_creator_->set_pipeline_executor(*pipeline_executor_);
-  pipeline_executor_->set_task_creator(*task_creator_);
+  task_creator_->set_task_scheduler(*task_scheduler_);
+  task_scheduler_->set_task_creator(*task_creator_);
 
-  // Wire the pipeline task queue into downgrade executors now that pipeline_executor_
+  // Wire the pipeline task queue into downgrade executors now that task_scheduler_
   // has been constructed.
   for (auto& executor : downgrade_executors_) {
-    executor->set_pipeline_task_queue(pipeline_executor_->get_pipeline_task_queue());
+    executor->set_pipeline_task_queue(task_scheduler_->get_pipeline_task_queue());
   }
 
   // Start everything -- downgrade executors deferred until now
@@ -263,10 +263,10 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     executor->start();
   }
   task_creator_->start_thread_pool();
-  pipeline_executor_->start();
+  task_scheduler_->start();
 
   // Configure scan caching based on config
-  pipeline_executor_->set_scan_caching_config(config_.get_cache_level());
+  task_scheduler_->set_scan_caching_config(config_.get_cache_level());
 
   is_initialized_ = true;
 }
@@ -275,8 +275,8 @@ void SiriusContext::terminate()
 {
   throw_if_not_initialized();
 
-  pipeline_executor_->stop();
-  pipeline_executor_.reset();
+  task_scheduler_->stop();
+  task_scheduler_.reset();
   task_creator_->stop_thread_pool();
   task_creator_.reset();
   for (auto& executor : downgrade_executors_) {
@@ -333,16 +333,16 @@ const cucascade::shared_data_repository_manager& SiriusContext::get_data_reposit
   return *data_repository_manager_;
 }
 
-sirius::pipeline::pipeline_executor& SiriusContext::get_pipeline_executor()
+sirius::pipeline::task_scheduler& SiriusContext::get_task_scheduler()
 {
   throw_if_not_initialized();
-  return *pipeline_executor_;
+  return *task_scheduler_;
 }
 
-const sirius::pipeline::pipeline_executor& SiriusContext::get_pipeline_executor() const
+const sirius::pipeline::task_scheduler& SiriusContext::get_task_scheduler() const
 {
   throw_if_not_initialized();
-  return *pipeline_executor_;
+  return *task_scheduler_;
 }
 
 sirius::parallel::downgrade_executor& SiriusContext::get_downgrade_executor(
@@ -389,7 +389,7 @@ void SiriusContext::create_query(
 {
   throw_if_not_initialized();
   query_ = duckdb::make_shared_ptr<sirius::planner::query>(std::move(pipelines));
-  pipeline_executor_->prepare_for_query(query_);
+  task_scheduler_->prepare_for_query(query_);
   task_creator_->prepare_for_query(*query_);
 }
 

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -206,7 +206,7 @@ void sirius_engine::execute()
 
   // Create the query with the pipelines
   sirius_ctx->create_query(std::move(new_scheduled));
-  auto future = sirius_ctx->get_pipeline_executor().start_query();
+  auto future = sirius_ctx->get_task_scheduler().start_query();
   try {
     future.get();
   } catch (const std::exception& e) {
@@ -215,11 +215,11 @@ void sirius_engine::execute()
     // clear_all_repositories() immediately after execute() throws; without
     // this drain, tasks still running in the thread pool hold raw pointers to
     // those repositories and cause a use-after-free / heap corruption.
-    sirius_ctx->get_pipeline_executor().drain_after_error();
+    sirius_ctx->get_task_scheduler().drain_after_error();
     throw;
   } catch (...) {
     SIRIUS_LOG_ERROR("Unknown error executing query");
-    sirius_ctx->get_pipeline_executor().drain_after_error();
+    sirius_ctx->get_task_scheduler().drain_after_error();
     throw;
   }
 }

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -18,8 +18,8 @@
 #include "creator/task_creator.hpp"
 #include "exec/config.hpp"
 #include "op/sirius_physical_operator.hpp"
-#include "pipeline/pipeline_executor.hpp"
 #include "pipeline/sirius_pipeline.hpp"
+#include "pipeline/task_scheduler.hpp"
 #include "sirius_interface.hpp"
 
 #include <cucascade/data/data_repository.hpp>
@@ -153,14 +153,14 @@ class testable_task_creator : public task_creator {
  public:
   testable_task_creator(int num_threads,
                         duckdb::ClientContext& client_context,
-                        pipeline_executor& pipeline_executor,
+                        task_scheduler& task_sched,
                         sirius::memory::sirius_memory_reservation_manager& mem_res_mgr)
     : task_creator(
         exec::thread_pool_config{.num_threads = num_threads, .thread_name_prefix = "task_creator"},
         mem_res_mgr)
   {
     this->set_client_context(client_context);
-    this->set_pipeline_executor(pipeline_executor);
+    this->set_task_scheduler(task_sched);
   }
 
   void schedule(op::sirius_physical_operator* request) override
@@ -259,7 +259,7 @@ class test_fixture {
   sirius_interface sirius_iface;
   std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> memory_manager;
   sirius_engine engine;
-  pipeline_executor pipeline_exec;
+  task_scheduler pipeline_exec;
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> empty_pipelines;
 };
 

--- a/test/cpp/pipeline/README.md
+++ b/test/cpp/pipeline/README.md
@@ -4,9 +4,9 @@ This directory contains unit tests for the pipeline executor and GPU pipeline ex
 
 ## Test Coverage
 
-### `test_pipeline_executor.cpp`
+### `test_task_scheduler.cpp`
 
-This test file validates the functionality of the pipeline execution framework without executing actual GPU operations. The tests focus on:
+This test file validates the functionality of the task scheduling framework without executing actual GPU operations. The tests focus on:
 
 #### Thread Pool Functionality
 - **Start/Stop Lifecycle**: Verifies that executors can be started and stopped gracefully without hanging or crashing
@@ -20,8 +20,8 @@ This test file validates the functionality of the pipeline execution framework w
 - **Rapid Submission**: Tests queue behavior under heavy load with many tasks submitted quickly
 - **Synchronization**: Validates proper coordination between task queue and request queue
 
-#### Pipeline Executor & GPU Pipeline Executor Interaction
-- **Task Dispatching**: Tests that the pipeline_executor correctly dispatches tasks to GPU executors
+#### Task Scheduler & GPU Pipeline Executor Interaction
+- **Task Dispatching**: Tests that the task_scheduler correctly dispatches tasks to GPU executors
 - **Multi-GPU Support**: Verifies tasks can be routed to different GPU executors based on device_id
 - **Task-Request Pairing**: Ensures tasks and their corresponding requests are properly synchronized
 - **Task Execution**: Validates that scheduled tasks are actually executed by the GPU executors
@@ -42,8 +42,8 @@ These tests are integrated into the main test suite and will run as part of the 
 # Build and run all tests
 make test
 
-# Or run just the pipeline executor tests using catch2 tags
-./build/release/test/unittest "[pipeline_executor]"
+# Or run just the task scheduler tests using catch2 tags
+./build/release/test/unittest "[task_scheduler]"
 ./build/release/test/unittest "[gpu_pipeline_executor]"
 ```
 

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -17,7 +17,7 @@
 #include "catch.hpp"
 #include "exec/config.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
-#include "pipeline/pipeline_executor.hpp"
+#include "pipeline/task_scheduler.hpp"
 #include "scan/test_utils.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
@@ -93,23 +93,23 @@ class mock_gpu_pipeline_task : public gpu_pipeline_task {
   }
 };
 
-TEST_CASE("Pipeline executor can start and stop gracefully", "[pipeline_executor]")
+TEST_CASE("Task scheduler can start and stop gracefully", "[task_scheduler]")
 {
   auto manager = initialize_memory_manager(1);
   sirius::exec::thread_pool_config gpu_config{2};
   sirius::exec::thread_pool_config scan_config{2};
-  pipeline_executor executor(gpu_config, scan_config, *manager);
+  task_scheduler executor(gpu_config, scan_config, *manager);
 
   REQUIRE_NOTHROW(executor.start());
   REQUIRE_NOTHROW(executor.stop());
 }
 
-TEST_CASE("Pipeline executor executes tasks through pipeline_queue", "[pipeline_executor]")
+TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_scheduler]")
 {
   auto manager = initialize_memory_manager(1);
   sirius::exec::thread_pool_config gpu_config{2};
   sirius::exec::thread_pool_config scan_config{2};
-  pipeline_executor executor(gpu_config, scan_config, *manager);
+  task_scheduler executor(gpu_config, scan_config, *manager);
 
   auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
 
@@ -143,7 +143,7 @@ TEST_CASE("Task queue handles empty queue gracefully", "[pipeline_queue]")
   auto manager = initialize_memory_manager(1);
   sirius::exec::thread_pool_config gpu_config{2};
   sirius::exec::thread_pool_config scan_config{2};
-  pipeline_executor executor(gpu_config, scan_config, *manager);
+  task_scheduler executor(gpu_config, scan_config, *manager);
 
   auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
 

--- a/test/cpp/scan/test_scan_executor.cpp
+++ b/test/cpp/scan/test_scan_executor.cpp
@@ -23,7 +23,7 @@
 #include <helper/type_conversions.hpp>
 #include <op/scan/duckdb_scan_executor.hpp>
 #include <op/scan/duckdb_scan_task.hpp>
-#include <pipeline/pipeline_executor.hpp>
+#include <pipeline/task_scheduler.hpp>
 
 // cucascade
 #include <cucascade/data/data_repository.hpp>
@@ -143,13 +143,13 @@ static void run_scan_test(std::string const& table_name,
   auto physical_scan = make_physical_table_scan(client_ctx, table_name);
   REQUIRE(physical_scan);
 
-  // Get pipeline executor from sirius context (owns the scan executor)
-  auto& pipeline_executor = sirius_ctx->get_pipeline_executor();
-  auto& scan_executor     = pipeline_executor.get_scan_executor();
+  // Get task scheduler from sirius context (owns the scan executor)
+  auto& task_sched    = sirius_ctx->get_task_scheduler();
+  auto& scan_executor = task_sched.get_scan_executor();
 
   // Create global state
   auto global_state = std::make_shared<op::scan::duckdb_scan_task_global_state>(
-    nullptr, pipeline_executor, client_ctx, physical_scan.get());
+    nullptr, task_sched, client_ctx, physical_scan.get());
 
   // Create data repository manager (empty, unused for this test)
   cucascade::shared_data_repository data_repo;
@@ -163,20 +163,20 @@ static void run_scan_test(std::string const& table_name,
   // The shared env's SiriusContext already started it, and stopping it would
   // permanently break the interruptible_mpmc queue (no reset on restart).
   bool const manage_executor = !sirius::test::g_shared_env;
-  if (manage_executor) { pipeline_executor.start(); }
+  if (manage_executor) { task_sched.start(); }
 
   for (int i = 0; i < scan_executor.get_num_threads(); ++i) {
     auto local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
       *global_state, *execution_context, batch_size);
     auto task = std::make_unique<op::scan::duckdb_scan_task>(
       static_cast<uint64_t>(i + 1), &data_repo, std::move(local_state), global_state);
-    pipeline_executor.schedule(std::move(task));
+    task_sched.schedule(std::move(task));
   }
   while (!global_state->is_source_drained()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
-  if (manage_executor) { pipeline_executor.stop(); }
+  if (manage_executor) { task_sched.stop(); }
 
   // Validate repository data batches.
   // The stream must be declared before batches so it outlives GPU data allocated on it.


### PR DESCRIPTION
## Summary

- Rename the top-level task orchestrator class from `pipeline_executor` to `task_scheduler` in `sirius::pipeline` namespace
- Better aligns with existing vocabulary (`task_creator`, `task_request`) and more accurately describes the component's scheduling role
- `gpu_pipeline_executor` and its config are **unchanged** — it is a separate per-GPU executor class

## Changes

- **3 file renames** (`git mv`): `pipeline_executor.hpp` → `task_scheduler.hpp`, `.cpp`, and test file
- **13 source/header files**: class name, includes, forward declarations, member variables, method names, log messages
- **3 test files**: types, Catch2 tags, variable names
- **1 CMakeLists.txt**: source file paths
- **8 documentation files**: terminology updates across architecture, execution flow, and pipeline docs

## Scope boundary

Only `pipeline_executor` is renamed. The following are **not** changed:
- `gpu_pipeline_executor` (separate per-GPU executor class)
- `_gpu_pipeline_executor_config` / `get_gpu_pipeline_executor_config()` (belongs to `gpu_pipeline_executor`)
- YAML config keys (`executor.pipeline`, `thread_name_prefix: "sirius_pipeline_executor"`)

## Test plan

- [x] Build compiles cleanly (971/971 targets)
- [x] `[task_scheduler]` unit tests pass (2 test cases, 3 assertions)
- [x] `[gpu_pipeline_executor]` and `[pipeline_queue]` tests pass (no regressions)
- [x] `grep -rn pipeline_executor src/ test/ docs/` returns only `gpu_pipeline_executor` and YAML config refs