### PR TITLE
Fix nightly errors

### DIFF
--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -211,7 +211,7 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
       cudf::strings::slice_strings(cudf::strings_column_view(input.get_column_view()),
                                    cudf::numeric_scalar(start_val, true, _stream, _mr),
                                    cudf::numeric_scalar(stop_val, true, _stream, _mr),
-                                   1,
+                                   cudf::numeric_scalar<cudf::size_type>(1, true, _stream, _mr),
                                    _stream,
                                    _mr);
     return execute_result(std::move(result_column));

--- a/src/include/op/scan/scan_utils.hpp
+++ b/src/include/op/scan/scan_utils.hpp
@@ -23,6 +23,9 @@
 #include <duckdb/common/types.hpp>
 #include <duckdb/planner/table_filter.hpp>
 
+// standard library
+#include <unordered_set>
+
 namespace sirius::op {
 
 /**
@@ -46,12 +49,19 @@ std::vector<duckdb::idx_t> build_batch_column_map(
  * @brief Convert a DuckDB TableFilterSet into a single bound DuckDB expression (conjunction of
  * all filters), suitable for passing to gpu_expression_translator::translate_expression().
  *
- * Returns nullptr if the filter set is empty or contains only unsupported filter types.
+ * Filters whose column's primary index is in @p skip_primary_indices are omitted. Parquet scans
+ * pass the hive-partition primary-index set here: partition columns don't exist in the parquet
+ * file, so pushing a filter that references one crashes libcudf's reader. DuckDB already applies
+ * partition filters at the file-list level when hive_partitioning is enabled, so dropping them
+ * here is safe.
+ *
+ * Returns nullptr if the filter set is empty or contains only unsupported/skipped filter types.
  */
 duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
   const duckdb::vector<sirius::logical_type>& returned_types,
-  const std::vector<duckdb::idx_t>& batch_column_map);
+  const std::vector<duckdb::idx_t>& batch_column_map,
+  const std::unordered_set<std::size_t>& skip_primary_indices = {});
 
 }  // namespace sirius::op

--- a/src/op/scan/hive_partition.cpp
+++ b/src/op/scan/hive_partition.cpp
@@ -95,7 +95,7 @@ partition_inject_fn_t build_partition_inject_fn(
            std::unique_ptr<cudf::table> tbl,
            std::string const& file_path,
            rmm::cuda_stream_view stream) -> std::unique_ptr<cudf::table> {
-    if (!tbl || tbl->num_rows() == 0) return tbl;
+    if (!tbl) return tbl;
 
     auto partitions     = duckdb::HivePartitioning::Parse(file_path);
     auto const num_rows = tbl->num_rows();

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -57,7 +57,8 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::TableFilterSet& filters,
   const duckdb::vector<duckdb::ColumnIndex>& column_ids,
   const duckdb::vector<sirius::logical_type>& returned_types,
-  const std::vector<duckdb::idx_t>& batch_column_map)
+  const std::vector<duckdb::idx_t>& batch_column_map,
+  const std::unordered_set<std::size_t>& skip_primary_indices)
 {
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> filter_expressions;
 
@@ -80,6 +81,12 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
         std::format("TABLE_SCAN filter: primary_idx ({}) >= returned_types.size() ({})",
                     primary_idx,
                     returned_types.size()));
+    }
+    if (skip_primary_indices.count(primary_idx)) {
+      SIRIUS_LOG_DEBUG(
+        "TABLE_SCAN filter: skipping filter on primary_idx={} (hive partition or equivalent)",
+        primary_idx);
+      continue;
     }
     auto col_type = returned_types[primary_idx];
 

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -170,7 +170,10 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
         duckdb_expr.get(), cudf::get_current_device_resource_ref(), stream);
       auto input_batch  = sirius::make_data_batch(std::move(table), mem_space);
       auto output_batch = gpu_expression_executor.select(input_batch);
-      if (!output_batch) { return std::make_unique<operator_data>(); }
+      if (!output_batch) {
+        return std::make_unique<pipelineable_operator_data>(
+          std::vector<std::shared_ptr<cucascade::data_batch>>());
+      }
       table = output_batch->get_data()->cast<cucascade::gpu_table_representation>().release_table();
       SIRIUS_LOG_DEBUG(
         "[sirius_gpu_parquet_scan_operator] Applied duckdb filter expression post parquet scan.");

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -27,6 +27,7 @@
 // cudf
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
 // standard library
 #include <algorithm>
@@ -154,9 +155,7 @@ std::optional<task_creation_hint> sirius_parquet_metadata_scan_operator::get_nex
 }
 
 bool sirius_parquet_metadata_scan_operator::all_ports_empty()
-{
-  return _next_file_idx.load(std::memory_order_relaxed) >= _total_files;
-}
+{ return _next_file_idx.load(std::memory_order_relaxed) >= _total_files; }
 
 std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::get_next_task_input_data()
 {
@@ -197,40 +196,35 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
   // Filter
   std::shared_ptr<translated_expression> ast_filter;
   if (_has_filter) {
-    if (!_column_name_by_ref.empty()) {
-      gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
-      auto name_resolver = [this](duckdb::idx_t ref_index) -> std::string {
-        if (ref_index >= _column_name_by_ref.size()) {
-          throw std::runtime_error(
-            "[sirius_parquet_metadata_scan_operator] Filter expression contains reference to "
-            "column index " +
-            std::to_string(ref_index) +
-            " which is out of bounds for the provided column metadata.");
-        }
-        return _column_name_by_ref[ref_index];
-      };
-      auto optional_filter =
-        translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
-      if (optional_filter) {
-        ast_filter = std::make_shared<translated_expression>(std::move(*optional_filter));
-        result->reader_options->set_filter(ast_filter->back());
-        result->filter_expression = ast_filter;
-        SIRIUS_LOG_DEBUG(
-          "[sirius_parquet_metadata_scan_operator] Successfully translated filter expression for "
-          "pushdown.");
-      } else {
-        result->filter_expression = _duckdb_filter_expression;
-        SIRIUS_LOG_DEBUG(
-          "[sirius_parquet_metadata_scan_operator] Failed to translate filter expression for "
-          "pushdown. Filter will be applied in the GPU scan operator.");
-      }
-    } else {
-      // Column names were not provided; AST translation requires column name references.
-      result->filter_expression = _duckdb_filter_expression;
-      SIRIUS_LOG_DEBUG(
-        "[sirius_parquet_metadata_scan_operator] Column names not available for AST filter "
-        "translation. Filter will be applied in the GPU scan operator.");
-    }
+    /// KEVIN: there is a bug hiding here that I haven't been able to find yet...
+    // if (!_column_name_by_ref.empty()) {
+    //   gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
+    //   auto name_resolver = [this](duckdb::idx_t ref_index) -> std::string {
+    //     return _column_name_by_ref.at(ref_index);
+    //   };
+    //   auto optional_filter =
+    //     translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
+    //   if (optional_filter) {
+    //     ast_filter = std::make_shared<translated_expression>(std::move(*optional_filter));
+    //     result->reader_options->set_filter(ast_filter->back());
+    //     result->filter_expression = ast_filter;
+    //     SIRIUS_LOG_DEBUG(
+    //       "[sirius_parquet_metadata_scan_operator] Successfully translated filter expression for
+    //       " "pushdown.");
+    //   } else {
+    //     result->filter_expression = _duckdb_filter_expression;
+    //     SIRIUS_LOG_DEBUG(
+    //       "[sirius_parquet_metadata_scan_operator] Failed to translate filter expression for "
+    //       "pushdown. Filter will be applied in the GPU scan operator.");
+    //   }
+    // } else {
+    //   // Column names were not provided; AST translation requires column name references.
+    //   result->filter_expression = _duckdb_filter_expression;
+    //   SIRIUS_LOG_DEBUG(
+    //     "[sirius_parquet_metadata_scan_operator] Column names not available for AST filter "
+    //     "translation. Filter will be applied in the GPU scan operator.");
+    // }
+    result->filter_expression          = _duckdb_filter_expression;
     result->post_filter_projection_ids = _post_filter_projection_ids;
   }
 
@@ -385,8 +379,6 @@ void sirius_parquet_metadata_scan_operator::sink(const operator_data& input_data
 }
 
 void sirius_parquet_metadata_scan_operator::finalize_operator()
-{
-  _gpu_scan->finalize_partitions();
-}
+{ _gpu_scan->finalize_partitions(); }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -91,9 +91,12 @@ sirius_parquet_metadata_scan_operator::sirius_parquet_metadata_scan_operator(
   // execute() so that a task-local CUDA stream can be used.
   _has_filter = false;
   if (table_filter_set && !table_filter_set->filters.empty()) {
-    auto batch_column_map  = build_batch_column_map(projection_ids, column_ids.size());
+    auto batch_column_map = build_batch_column_map(projection_ids, column_ids.size());
+    // Drop filters on hive-partition columns — they aren't in the parquet file, so pushing
+    // them into the reader crashes libcudf. DuckDB already prunes partitions at the file-list
+    // level when hive_partitioning is enabled.
     auto duckdb_expression = convert_table_filters_to_expression(
-      *table_filter_set, column_ids, returned_types, batch_column_map);
+      *table_filter_set, column_ids, returned_types, batch_column_map, _hive_partition_index_set);
     if (duckdb_expression) {
       _has_filter               = true;
       _duckdb_filter_expression = std::move(duckdb_expression);

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -27,7 +27,6 @@
 // cudf
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
-#include <cudf/utilities/default_stream.hpp>
 
 // standard library
 #include <algorithm>
@@ -155,7 +154,9 @@ std::optional<task_creation_hint> sirius_parquet_metadata_scan_operator::get_nex
 }
 
 bool sirius_parquet_metadata_scan_operator::all_ports_empty()
-{ return _next_file_idx.load(std::memory_order_relaxed) >= _total_files; }
+{
+  return _next_file_idx.load(std::memory_order_relaxed) >= _total_files;
+}
 
 std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::get_next_task_input_data()
 {
@@ -379,6 +380,8 @@ void sirius_parquet_metadata_scan_operator::sink(const operator_data& input_data
 }
 
 void sirius_parquet_metadata_scan_operator::finalize_operator()
-{ _gpu_scan->finalize_partitions(); }
+{
+  _gpu_scan->finalize_partitions();
+}
 
 }  // namespace sirius::op::scan

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -21,6 +21,10 @@
 #include "op/scan/scan_utils.hpp"
 #include "op/sirius_physical_table_scan.hpp"
 
+#include <duckdb/common/multi_file/multi_file_states.hpp>
+
+#include <unordered_set>
+
 namespace sirius {
 namespace op {
 
@@ -85,9 +89,19 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(
       auto const primary_idx = column_ids[ref_index].GetPrimaryIndex();
       return names[primary_idx];
     };
-    auto batch_column_map  = build_batch_column_map(projection_ids, column_ids.size());
+    auto batch_column_map = build_batch_column_map(projection_ids, column_ids.size());
+    // Drop filters on hive-partition columns — they aren't in the parquet file, so pushing
+    // them into the reader crashes libcudf. DuckDB already prunes partitions at the file-list
+    // level when hive_partitioning is enabled.
+    std::unordered_set<std::size_t> hive_partition_primary_indices;
+    if (bind_data) {
+      auto const& multi_file_bind = bind_data->Cast<duckdb::MultiFileBindData>();
+      for (auto const& hpi : multi_file_bind.reader_bind.hive_partitioning_indexes) {
+        hive_partition_primary_indices.insert(hpi.index);
+      }
+    }
     auto duckdb_expression = convert_table_filters_to_expression(
-      *table_filters, column_ids, returned_types, batch_column_map);
+      *table_filters, column_ids, returned_types, batch_column_map, hive_partition_primary_indices);
     if (duckdb_expression) {
       gpu_expression_translator translator(rmm::cuda_stream_default,
                                            cudf::get_current_device_resource_ref());


### PR DESCRIPTION
The expression executor is using step size = 1 allocated on the default stream, causing issues at large scale factors with Q22. This is fixed.
The invalid address errors at higher scale factors have been traced to the row group pruning logic in the parquet metadata scan, so this has been temporarily disabled until further investigation produces a fix. Disabling filter pushdown also exposed hive partitioning bugs in the new scan path with the expression executor that needed fixing. 