### PR TITLE
CI: Change CI builds from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/  @mbrobbel @mike-wendt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{ matrix.environment == 'vcpkg'
-        && fromJSON('["self-hosted", "ubuntu-22.04", "cuda-13", "cpu-xl-spot"]')
+        && fromJSON('["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl-spot"]')
         || format('ubuntu-24.04{0}', case(matrix.arch == 'arm64', '-arm', '')) }}
     timeout-minutes: ${{ case(matrix.environment == 'vcpkg', 240, 60) }}
     continue-on-error: ${{ matrix.cudf-channel == 'nightly' }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -42,7 +42,7 @@ jobs:
       cuda_archs: '75-real;80-real;86-real;90a-real;100f-real;120a-real;120'
       cuda_version: '13'
       artifact_postfix: '-cuda13'
-      runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "cuda-13", "arm-xl"]}'
+      runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "cuda-13", "arm-xl"]}'
 
   cuda-12:
     uses: sirius-db/extension-ci-tools/.github/workflows/_extension_distribution.yml@sirius
@@ -64,4 +64,4 @@ jobs:
       cuda_archs: '75-real;80-real;86-real;90a-real'
       cuda_version: '12'
       artifact_postfix: '-cuda12'
-      runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "cuda-13", "arm-xl"]}'
+      runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "cuda-13", "arm-xl"]}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, ubuntu-22.04, cuda-13, cpu-xl-spot]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, cpu-xl-spot]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,7 +59,7 @@ jobs:
           retention-days: 1
 
   test:
-    runs-on: [self-hosted, ubuntu-22.04, cuda-13, gpu-t4]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-t4]
     needs: build
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
GHA workflows running on GH runners are already using Ubuntu 24.04, this brings the self-hosted runners to the same OS version for more consistent tests and builds as they were using Ubuntu 22.04