### PR TITLE
perf(scan): CPU duckdb_scan_task fixes — varchar metadata sizing, projection index, QueryEnd SIGSEGV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/test_column_builder.cpp
+    test/cpp/scan/test_lifecycle_shutdown.cpp
     test/cpp/scan/test_metadata_gpu_scan_operators.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/scan/test_parquet_scan_task.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/test_column_builder.cpp
+    test/cpp/scan/test_duckdb_scan_projection.cpp
     test/cpp/scan/test_lifecycle_shutdown.cpp
     test/cpp/scan/test_metadata_gpu_scan_operators.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -279,6 +279,16 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
                         std::unique_ptr<multiple_blocks_allocation>& allocation);
 
     /**
+     * @brief Fast path for DICTIONARY_VECTOR VARCHAR columns: skip Flatten and build
+     * cuDF STRING (offsets + chars) directly from the DuckDB dictionary + selection
+     * vector.
+     */
+    void process_dictionary_varchar(duckdb::Vector& vec,
+                                    size_t num_rows,
+                                    size_t row_offset,
+                                    std::unique_ptr<multiple_blocks_allocation>& allocation);
+
+    /**
      * @brief Create a column_metadata for this column for building a host_table_allocation.
      *
      * @param[in] num_rows The number of rows in the column.

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -197,6 +197,8 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
     size_t total_data_bytes_allocated =
       0;  ///< Total number of data bytes allocated for this column (only needed for VARCHAR)
     size_t null_count = 0;  ///< Number of NULL values in the column
+    bool has_metadata_bound =
+      false;  ///< True if type_size was set from DuckDB storage metadata (safe upper bound)
 
     // The allocation accessors for the column data, mask, and offsets
     memory::multiple_blocks_allocation_accessor<uint8_t> data_blocks_accessor;

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -334,6 +334,14 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
    */
   std::shared_ptr<data_batch> make_data_batch();
 
+  /// Test-only inspector for column_builders state after estimate_rows_per_batch /
+  /// initialize_builders run in the constructor. Used to assert that varchar sizing
+  /// resolved through projection_ids correctly.
+  [[nodiscard]] std::vector<column_builder> const& column_builders_for_testing() const noexcept
+  {
+    return _column_builders;
+  }
+
  private:
   //===----------Fields----------===//
   size_t _approximate_batch_size;                ///< Approximate target batch size in bytes

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -40,6 +40,9 @@
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/statistics/string_stats.hpp>
 
+// standard library
+#include <algorithm>
+
 namespace sirius::op::scan {
 
 namespace {
@@ -502,9 +505,14 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_duckd
 
       // Use DuckDB's per-column max_string_length when available — a safe upper bound
       // that is typically much tighter than the blind default and unlocks the chunk_fits
-      // skip in compute_task. Use the storage column index (not the projected index) so
-      // that projected queries like SELECT l_comment read stats for the right column.
-      auto storage_col_idx = duckdb::StorageIndex(op.column_ids[i].GetPrimaryIndex());
+      // skip in compute_task. Resolve the output column through projection_ids when
+      // present (DuckDB filter pushdown can produce non-identity projection_ids: the
+      // scan reads N storage columns but outputs M < N, with projection_ids mapping
+      // output index → column_ids index). Reading stats for the wrong storage column
+      // here would set has_metadata_bound=true with a wrong (often smaller) bound,
+      // which the chunk_fits skip would then trust — silent buffer overflow.
+      size_t const column_id_index = op.projection_ids.empty() ? i : op.projection_ids[i];
+      auto storage_col_idx = duckdb::StorageIndex(op.column_ids[column_id_index].GetPrimaryIndex());
       size_t varchar_size  = estimate_varchar_bytes_from_metadata(
         op.bind_data.get(), storage_col_idx, i, _exec_ctx.client);
       bool const from_metadata = (varchar_size != 0);
@@ -722,24 +730,16 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   // Enter the scan loop to accumulate a data batch
   while (get_next_chunk(l_state, g_state)) {
     if (!all_varchars_bounded && !chunk_fits(l_state)) {
-      if (l_state._row_offset > 0) {
-        // We accumulated rows already — flush the partial batch and let the next task
-        // pick up the remaining range. The current chunk is dropped; carrying it forward
-        // would require buffering it across the task boundary (TODO).
-        SIRIUS_LOG_WARN(
-          "[duckdb_scan] task={}: varchar overflow after {} rows, flushing batch "
-          "(chunk of {} rows does not fit, continuing in next task)",
-          _task_id,
-          l_state._row_offset,
-          l_state._chunk.size());
-        break;
-      }
-      // Empty batch and the very first chunk does not fit — the allocation is too small
-      // for even a single chunk. With metadata-derived sizing this should be unreachable;
-      // with the default fallback it can happen on extremely wide rows.
+      // get_next_chunk has already advanced DuckDB's local scan state and populated
+      // l_state._chunk. Breaking here would drop the current chunk's rows entirely
+      // (the next task resumes from the *moved* local_tf_state, past this chunk).
+      // Until we implement carry-forward (buffer the chunk in local_state and replay
+      // it before the next get_next_chunk in the successor task), fail fast to
+      // preserve correctness. With metadata-derived sizing this is unreachable.
       throw std::runtime_error(
-        "[duckdb_scan_task]: first chunk does not fit in the allocated buffers. "
-        "Consider increasing scan_task_batch_size.");
+        "[duckdb_scan_task]: chunk does not fit in the allocated buffers. "
+        "Consider increasing scan_task_batch_size or providing column statistics so "
+        "metadata-derived sizing engages.");
     }
 
     // Process the chunk into the column builders

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -308,9 +308,9 @@ void duckdb_scan_task_local_state::column_builder::process_dictionary_varchar(
   std::unique_ptr<multiple_blocks_allocation>& allocation)
 {
   // PRECONDITION: vec is DICTIONARY_VECTOR with VARCHAR child.
-  auto& sel_vec        = duckdb::DictionaryVector::SelVector(vec);
-  auto& child          = duckdb::DictionaryVector::Child(vec);
-  auto& child_validity = duckdb::FlatVector::Validity(child);
+  auto& sel_vec         = duckdb::DictionaryVector::SelVector(vec);
+  auto& child           = duckdb::DictionaryVector::Child(vec);
+  auto& child_validity  = duckdb::FlatVector::Validity(child);
   auto const* dict_data = duckdb::FlatVector::GetData<duckdb::string_t>(child);
 
   auto dict_size_hint = duckdb::DictionaryVector::DictionarySize(vec);
@@ -714,9 +714,10 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
 
   // If every varchar column was sized from DuckDB metadata, the per-chunk fits check is
   // redundant — the allocation is a guaranteed upper bound for any chunk we can read.
-  bool const all_varchars_bounded = std::all_of(
-    l_state._varchar_indices.begin(), l_state._varchar_indices.end(),
-    [&](size_t vi) { return l_state._column_builders[vi].has_metadata_bound; });
+  bool const all_varchars_bounded =
+    std::all_of(l_state._varchar_indices.begin(), l_state._varchar_indices.end(), [&](size_t vi) {
+      return l_state._column_builders[vi].has_metadata_bound;
+    });
 
   // Enter the scan loop to accumulate a data batch
   while (get_next_chunk(l_state, g_state)) {
@@ -728,7 +729,9 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
         SIRIUS_LOG_WARN(
           "[duckdb_scan] task={}: varchar overflow after {} rows, flushing batch "
           "(chunk of {} rows does not fit, continuing in next task)",
-          _task_id, l_state._row_offset, l_state._chunk.size());
+          _task_id,
+          l_state._row_offset,
+          l_state._chunk.size());
         break;
       }
       // Empty batch and the very first chunk does not fit — the allocation is too small

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -33,10 +33,54 @@
 #include <cucascade/memory/memory_reservation.hpp>
 
 // duckdb
+#include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
 #include <duckdb/common/types.hpp>
+#include <duckdb/function/table/table_scan.hpp>
 #include <duckdb/function/table_function.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <duckdb/storage/statistics/string_stats.hpp>
 
 namespace sirius::op::scan {
+
+namespace {
+
+/// Estimate the upper-bound varchar size for a column from DuckDB storage metadata.
+/// Returns 0 when metadata is unavailable (e.g., the bind data is not a TableScanBindData);
+/// callers fall back to the default in that case.
+size_t estimate_varchar_bytes_from_metadata(duckdb::FunctionData* bind_data_ptr,
+                                            duckdb::StorageIndex storage_col_idx,
+                                            size_t /*projected_col_index*/,
+                                            duckdb::ClientContext& context)
+{
+  if (!bind_data_ptr) { return 0; }
+
+  duckdb::TableScanBindData* tsbd = nullptr;
+  try {
+    tsbd = &bind_data_ptr->Cast<duckdb::TableScanBindData>();
+  } catch (...) {
+    return 0;  // not a seq_scan table function
+  }
+
+  try {
+    auto& table   = tsbd->table.Cast<duckdb::DuckTableEntry>();
+    auto& storage = table.GetStorage();
+    if (storage.GetTotalRows() == 0) { return 0; }
+
+    auto stats = storage.GetStatistics(context, storage_col_idx);
+    if (stats && duckdb::StringStats::HasMaxStringLength(*stats)) {
+      // max_string_length is a hard upper bound on any individual value, so the buffer
+      // is guaranteed to fit. Do NOT shrink below max_len — fixed-format columns (e.g.
+      // phone numbers) have nearly all values at max_len, so a 3/4 heuristic underflows
+      // and corrupts adjacent columns' offset arrays.
+      return duckdb::StringStats::MaxStringLength(*stats);
+    }
+  } catch (std::exception const&) {
+    // Unable to read stats — caller will fall back.
+  }
+  return 0;
+}
+
+}  // namespace
 
 //===----------------------------------------------------------------------===//
 // duckdb_scan_task_global_state
@@ -376,11 +420,24 @@ void duckdb_scan_task_local_state::estimate_rows_per_batch(sirius_physical_duckd
   _column_builders.reserve(_num_columns);
   for (size_t i = 0; i < _num_columns; ++i) {
     auto const col_type = op.scanned_types[i];
-    _column_builders.emplace_back(col_type, _default_varchar_size);
     if (col_type.is_varchar()) {
       _varchar_indices.push_back(i);
-      estimated_row_bytes += (sizeof(int32_t) + _default_varchar_size);  // offset + data + mask
+
+      // Use DuckDB's per-column max_string_length when available — a safe upper bound
+      // that is typically much tighter than the blind default and unlocks the chunk_fits
+      // skip in compute_task. Use the storage column index (not the projected index) so
+      // that projected queries like SELECT l_comment read stats for the right column.
+      auto storage_col_idx = duckdb::StorageIndex(op.column_ids[i].GetPrimaryIndex());
+      size_t varchar_size  = estimate_varchar_bytes_from_metadata(
+        op.bind_data.get(), storage_col_idx, i, _exec_ctx.client);
+      bool const from_metadata = (varchar_size != 0);
+      if (!from_metadata) { varchar_size = _default_varchar_size; }
+
+      _column_builders.emplace_back(col_type, varchar_size);
+      _column_builders.back().has_metadata_bound = from_metadata;
+      estimated_row_bytes += (sizeof(int32_t) + varchar_size);  // offset + data
     } else {
+      _column_builders.emplace_back(col_type, _default_varchar_size);
       estimated_row_bytes += col_type.fixed_width_byte_size();  // data + mask
     }
   }
@@ -411,9 +468,11 @@ void duckdb_scan_task_local_state::initialize_builders()
     _column_builders[i].initialize_accessors(_estimated_rows_per_batch, byte_offset, _allocation);
     // Update byte_offset for next column
     if (_column_builders[i].type.is_varchar()) {
-      // VARCHAR column (offsets + data + mask)
+      // VARCHAR column (offsets + data + mask). Use the per-column type_size set in
+      // estimate_rows_per_batch (metadata-derived bound or default fallback) — using the
+      // global default would over-allocate the buffer for metadata-bounded columns.
       byte_offset += (_estimated_rows_per_batch + 1) * sizeof(int32_t) +
-                     _estimated_rows_per_batch * _default_varchar_size +
+                     _estimated_rows_per_batch * _column_builders[i].type_size +
                      utils::ceil_div_8(_estimated_rows_per_batch);
     } else {
       // Fixed-width column (data + mask)
@@ -503,8 +562,12 @@ bool duckdb_scan_task::get_next_chunk(duckdb_scan_task_local_state& l_state,
 
 bool duckdb_scan_task::chunk_fits(duckdb_scan_task_local_state& l_state)
 {
-  // Loop over the VARCHAR columns and check if they fit in the allocated buffers
+  // Loop over the VARCHAR columns and check if they fit in the allocated buffers.
+  // Skip columns whose allocation came from DuckDB metadata — max_string_length is a
+  // hard upper bound, so the buffer is guaranteed to fit and the Flatten + size check
+  // would just be wasted work.
   for (auto varchar_idx : l_state._varchar_indices) {
+    if (l_state._column_builders[varchar_idx].has_metadata_bound) { continue; }
     auto& vec = l_state._chunk.data[varchar_idx];
     vec.Flatten(l_state._chunk.size());
     auto const& validity = duckdb::FlatVector::Validity(l_state._chunk.data[varchar_idx]);
@@ -561,16 +624,31 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   l_state._chunk.Initialize(duckdb::Allocator::Get(l_state._exec_ctx.client),
                             sirius::to_duckdb_vec(g_state._op.scanned_types));
 
+  // If every varchar column was sized from DuckDB metadata, the per-chunk fits check is
+  // redundant — the allocation is a guaranteed upper bound for any chunk we can read.
+  bool const all_varchars_bounded = std::all_of(
+    l_state._varchar_indices.begin(), l_state._varchar_indices.end(),
+    [&](size_t vi) { return l_state._column_builders[vi].has_metadata_bound; });
+
   // Enter the scan loop to accumulate a data batch
   while (get_next_chunk(l_state, g_state)) {
-    // We know a priori that the fixed-width columns and masks will fit in the allocated buffers.
-    // For variable-length columns, we need to check that we have enough space.
-    // If there isn't enough space, we just throw an exception for now.
-    /// FUTURE WORK: push the current data batch into a new scan task.
-    if (!chunk_fits(l_state)) {
-      std::string err_msg =
-        "[duckdb_scan_task]: current chunk does not fit in the allocated buffers.";
-      throw std::runtime_error(err_msg);
+    if (!all_varchars_bounded && !chunk_fits(l_state)) {
+      if (l_state._row_offset > 0) {
+        // We accumulated rows already — flush the partial batch and let the next task
+        // pick up the remaining range. The current chunk is dropped; carrying it forward
+        // would require buffering it across the task boundary (TODO).
+        SIRIUS_LOG_WARN(
+          "[duckdb_scan] task={}: varchar overflow after {} rows, flushing batch "
+          "(chunk of {} rows does not fit, continuing in next task)",
+          _task_id, l_state._row_offset, l_state._chunk.size());
+        break;
+      }
+      // Empty batch and the very first chunk does not fit — the allocation is too small
+      // for even a single chunk. With metadata-derived sizing this should be unreachable;
+      // with the default fallback it can happen on extremely wide rows.
+      throw std::runtime_error(
+        "[duckdb_scan_task]: first chunk does not fit in the allocated buffers. "
+        "Consider increasing scan_task_batch_size.");
     }
 
     // Process the chunk into the column builders

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -301,6 +301,83 @@ void duckdb_scan_task_local_state::column_builder::process_column(
   process_mask_for_column(validity, num_rows, row_offset, allocation);
 }
 
+void duckdb_scan_task_local_state::column_builder::process_dictionary_varchar(
+  duckdb::Vector& vec,
+  size_t num_rows,
+  size_t row_offset,
+  std::unique_ptr<multiple_blocks_allocation>& allocation)
+{
+  // PRECONDITION: vec is DICTIONARY_VECTOR with VARCHAR child.
+  auto& sel_vec        = duckdb::DictionaryVector::SelVector(vec);
+  auto& child          = duckdb::DictionaryVector::Child(vec);
+  auto& child_validity = duckdb::FlatVector::Validity(child);
+  auto const* dict_data = duckdb::FlatVector::GetData<duckdb::string_t>(child);
+
+  auto dict_size_hint = duckdb::DictionaryVector::DictionarySize(vec);
+  size_t dict_count   = dict_size_hint.IsValid() ? dict_size_hint.GetIndex() : 0;
+  if (dict_count == 0) {
+    // Hint missing — discover the dictionary upper bound by scanning the selection.
+    for (size_t row = 0; row < num_rows; ++row) {
+      auto idx = sel_vec.get_index(row);
+      if (idx >= dict_count) { dict_count = idx + 1; }
+    }
+  }
+
+  // Materialize a small lookup of (data, len) per dict entry so the row loop hits
+  // L1-cached data instead of chasing string_t pointers each iteration. Stack-allocate
+  // for the common small-dict case; spill to heap for large dictionaries.
+  constexpr size_t STACK_DICT_LIMIT = 256;
+  struct dict_entry {
+    const char* data;
+    uint32_t len;
+  };
+  dict_entry stack_dict[STACK_DICT_LIMIT];
+  std::vector<dict_entry> heap_dict;
+  dict_entry* dict = stack_dict;
+  if (dict_count > STACK_DICT_LIMIT) {
+    heap_dict.resize(dict_count);
+    dict = heap_dict.data();
+  }
+  for (size_t k = 0; k < dict_count; ++k) {
+    if (child_validity.RowIsValid(k)) {
+      dict[k] = {dict_data[k].GetData(), static_cast<uint32_t>(dict_data[k].GetSize())};
+    } else {
+      dict[k] = {nullptr, 0};
+    }
+  }
+
+  // Build offsets + copy chars in one pass over the selection vector. Output validity
+  // is derived from dictionary-entry validity for this row's selected index.
+  size_t data_bytes = 0;
+  for (size_t row = 0; row < num_rows; ++row) {
+    auto const prev_offset = offset_blocks_accessor.get_current(allocation);
+    offset_blocks_accessor.advance();
+    auto const& entry = dict[sel_vec.get_index(row)];
+    if (entry.data != nullptr) {
+      offset_blocks_accessor.set_current(prev_offset + entry.len, allocation);
+      data_blocks_accessor.memcpy_from(entry.data, entry.len, allocation);
+      data_bytes += entry.len;
+    } else {
+      offset_blocks_accessor.set_current(prev_offset, allocation);
+    }
+  }
+  total_data_bytes += data_bytes;
+
+  if (!child_validity.AllValid()) {
+    duckdb::ValidityMask output_validity(num_rows);
+    for (size_t row = 0; row < num_rows; ++row) {
+      if (!child_validity.RowIsValid(sel_vec.get_index(row))) {
+        output_validity.SetInvalid(row);
+        null_count++;
+      }
+    }
+    process_mask_for_column(output_validity, num_rows, row_offset, allocation);
+  } else {
+    duckdb::ValidityMask all_valid;  // default-constructed = all valid
+    process_mask_for_column(all_valid, num_rows, row_offset, allocation);
+  }
+}
+
 cucascade::memory::column_metadata
 duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_rows) const
 {
@@ -583,6 +660,17 @@ void duckdb_scan_task::process_chunk(duckdb_scan_task_local_state& l_state)
 {
   for (size_t i = 0; i < l_state._num_columns; ++i) {
     auto& vec = l_state._chunk.data[i];
+
+    // Fast path: dictionary-encoded varchar columns are read straight from the
+    // (small) dictionary + selection vector, skipping the cost of Flatten and
+    // improving cache locality for the per-row string copies.
+    if (vec.GetVectorType() == duckdb::VectorType::DICTIONARY_VECTOR &&
+        l_state._column_builders[i].type.is_varchar()) {
+      l_state._column_builders[i].process_dictionary_varchar(
+        vec, l_state._chunk.size(), l_state._row_offset, l_state._allocation);
+      continue;
+    }
+
     vec.Flatten(l_state._chunk.size());
     auto const& validity = duckdb::FlatVector::Validity(vec);
     l_state._column_builders[i].process_column(

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -155,6 +155,11 @@ void SiriusContext::QueryEnd()
       executor->drain();
     }
 
+    // Release DuckDB table scan state while the database is still fully alive. If deferred
+    // to terminate() (called from ~DatabaseInstance), DuckDB storage objects (BlockMemory,
+    // RowGroups) may already be partially torn down, causing a use-after-free on exit.
+    if (task_creator_) { task_creator_->reset(); }
+
     // Clear all data repositories between queries.
     // Any batches still present are leaked — operators should have popped everything.
     if (data_repository_manager_) {

--- a/test/cpp/scan/test_duckdb_scan_projection.cpp
+++ b/test/cpp/scan/test_duckdb_scan_projection.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+#include <scan/test_utils.hpp>
+#include <utils/utils.hpp>
+
+// sirius
+#include <helper/type_conversions.hpp>
+#include <op/scan/duckdb_scan_task.hpp>
+
+// duckdb
+#include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
+#include <duckdb/catalog/catalog_transaction.hpp>
+#include <duckdb/execution/execution_context.hpp>
+#include <duckdb/function/table/table_scan.hpp>
+#include <duckdb/parallel/thread_context.hpp>
+
+// standard library
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::scan_test_utils;
+
+namespace {
+
+// Variant of make_physical_table_scan that takes explicit column_ids and projection_ids
+// so a test can construct a non-identity projection (the case `estimate_rows_per_batch`
+// has to handle when DuckDB pushes down a filter on a column the output doesn't include).
+std::unique_ptr<sirius::op::sirius_physical_duckdb_scan> make_projecting_scan(
+  duckdb::ClientContext& ctx,
+  std::string const& table_name,
+  std::vector<size_t> const& column_id_indices,
+  std::vector<size_t> const& projection_id_indices)
+{
+  auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
+  duckdb::CatalogTransaction txn(catalog, ctx);
+  auto& schema = catalog.GetSchema(txn, "main");
+
+  auto table_entry = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  REQUIRE(table_entry);
+  auto& table_catalog_entry = table_entry->Cast<duckdb::TableCatalogEntry>();
+
+  duckdb::vector<duckdb::ColumnIndex> column_ids;
+  duckdb::vector<duckdb::idx_t> projection_ids;
+  duckdb::vector<std::string> column_names;
+  for (auto idx : column_id_indices) {
+    column_ids.emplace_back(idx);
+    column_names.push_back(table_catalog_entry.GetColumn(duckdb::LogicalIndex(idx)).GetName());
+  }
+  for (auto pid : projection_id_indices) {
+    projection_ids.push_back(pid);
+  }
+
+  auto bind_data           = std::make_unique<duckdb::TableScanBindData>(table_catalog_entry);
+  auto table_scan_function = duckdb::TableScanFunction::GetFunction();
+  duckdb::ExtraOperatorInfo extra_info;
+  auto virtual_columns = table_catalog_entry.GetVirtualColumns();
+
+  // scanned_types is built by the constructor from column_ids / projection_ids.
+  return std::make_unique<sirius::op::sirius_physical_duckdb_scan>(
+    sirius::from_duckdb_vec(table_catalog_entry.GetTypes()),
+    table_scan_function,
+    std::move(bind_data),
+    sirius::from_duckdb_vec(table_catalog_entry.GetTypes()),
+    std::move(column_ids),
+    std::move(projection_ids),
+    std::move(column_names),
+    nullptr,
+    0,
+    std::move(extra_info),
+    duckdb::vector<duckdb::Value>(),
+    std::move(virtual_columns));
+}
+
+}  // namespace
+
+// Regression: estimate_rows_per_batch must resolve the storage column through
+// projection_ids when projection_ids is non-empty. Pre-fix, the code used column_ids[i]
+// directly — for SELECT c1 FROM t WHERE c0 LIKE '%' (column_ids=[0,1], projection_ids=[1]),
+// it read stats for c0 instead of c1. If c0 had a smaller max_string_length than c1, the
+// resulting allocation was too small for c1's actual values; with has_metadata_bound=true,
+// chunk_fits was skipped and process_column wrote past the buffer — silent corruption.
+//
+// This test sets c0=max_len=1 and c1=max_len=200, projects only c1, and asserts that the
+// single output column_builder was sized using c1's metadata (not c0's).
+TEST_CASE("duckdb_scan_task - projection_ids picks the projected storage column for stats",
+          "[duckdb_scan_task][varchar][projection][shared_context]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+
+  // Create a 2-column varchar table with sharply different max_string_length values.
+  REQUIRE_FALSE(con.Query("DROP TABLE IF EXISTS t_proj_regress")->HasError());
+  REQUIRE_FALSE(con.Query("CREATE TABLE t_proj_regress(c0 VARCHAR, c1 VARCHAR)")->HasError());
+  REQUIRE_FALSE(
+    con.Query("INSERT INTO t_proj_regress SELECT 'x', repeat('y', 200) FROM range(100)")
+      ->HasError());
+  REQUIRE_FALSE(con.Query("CHECKPOINT")->HasError());  // persist stats
+
+  auto& client_ctx = *con.context;
+  auto sirius_ctx  = sirius::get_sirius_context(con, get_test_config_path());
+  REQUIRE(sirius_ctx != nullptr);
+
+  REQUIRE_FALSE(con.Query("BEGIN TRANSACTION")->HasError());
+
+  // column_ids=[0,1] (we read both — for instance, the optimizer needed both to push a
+  // filter on c0); projection_ids=[1] (we only output c1).
+  auto physical_scan = make_projecting_scan(client_ctx,
+                                            "t_proj_regress",
+                                            /*column_ids=*/{0, 1},
+                                            /*projection_ids=*/{1});
+  REQUIRE(physical_scan != nullptr);
+  REQUIRE(physical_scan->scanned_types.size() == 1);  // sanity: 1 output column
+  REQUIRE(physical_scan->scanned_types[0].is_varchar());
+
+  auto& task_sched  = sirius_ctx->get_task_scheduler();
+  auto global_state = std::make_shared<op::scan::duckdb_scan_task_global_state>(
+    nullptr, task_sched, client_ctx, physical_scan.get());
+
+  auto thread_context = std::make_unique<duckdb::ThreadContext>(client_ctx);
+  auto execution_context =
+    std::make_unique<duckdb::ExecutionContext>(client_ctx, *thread_context, nullptr);
+
+  // Constructor invokes estimate_rows_per_batch + initialize_builders — that's the
+  // path where the bug lived.
+  auto local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
+    *global_state, *execution_context, /*approximate_batch_size=*/1'000'000);
+
+  auto const& builders = local_state->column_builders_for_testing();
+  REQUIRE(builders.size() == 1);
+  REQUIRE(builders[0].type.is_varchar());
+  REQUIRE(builders[0].has_metadata_bound);
+
+  // The decisive check: type_size must reflect c1's max_string_length (200), not c0's
+  // (1). Pre-fix would give 1; post-fix gives at least 200.
+  CHECK(builders[0].type_size >= 200);
+
+  REQUIRE_FALSE(con.Query("COMMIT")->HasError());
+  con.Query("DROP TABLE t_proj_regress");
+}

--- a/test/cpp/scan/test_lifecycle_shutdown.cpp
+++ b/test/cpp/scan/test_lifecycle_shutdown.cpp
@@ -81,12 +81,17 @@ TEST_CASE("scan lifecycle - clean exit after duckdb_scan_task query (regression:
     return;
   }
 
-  // Strip env vars the unit-test harness sets but the spawned CLI must not inherit:
-  //   SIRIUS_DISABLE          — set by shared_test_env::create_db; would block CLI init
-  //   SIRIUS_CONFIG_FILE      — points at the test-only memory.yaml
-  //   SIRIUS_INTEGRATION_*    — TPC-H test data path
+  // Sirius's default GPU memory pool grabs ~14 GB upfront, which OOMs on CI runners.
+  // Point the spawned CLI at the small (2 GB GPU / 4 GB host) test config sitting next
+  // to this test file. Strip SIRIUS_DISABLE (shared_test_env sets it; would block CLI
+  // init) and SIRIUS_INTEGRATION_TEST_DB_PATH (TPC-H test data path, irrelevant here).
+  auto const test_config = std::filesystem::path(__FILE__).parent_path() / "memory.yaml";
+  REQUIRE(std::filesystem::exists(test_config));
+
   std::string const cmd =
-    "env -u SIRIUS_DISABLE -u SIRIUS_CONFIG_FILE -u SIRIUS_INTEGRATION_TEST_DB_PATH " + duckdb_bin +
+    "env -u SIRIUS_DISABLE -u SIRIUS_INTEGRATION_TEST_DB_PATH "
+    "SIRIUS_CONFIG_FILE=" +
+    test_config.string() + " " + duckdb_bin +
     " -unsigned -c \""
     "CREATE TABLE t(s VARCHAR); "
     "INSERT INTO t SELECT 'x' FROM range(1000); "

--- a/test/cpp/scan/test_lifecycle_shutdown.cpp
+++ b/test/cpp/scan/test_lifecycle_shutdown.cpp
@@ -20,9 +20,11 @@
 // standard library
 #include <sys/wait.h>
 
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
+#include <utility>
 
 namespace {
 
@@ -43,6 +45,23 @@ std::string find_duckdb_binary()
     if (std::filesystem::exists(candidate)) { return candidate.string(); }
   }
   return {};
+}
+
+// Run a shell command, capturing merged stdout+stderr inline. Returns {raw_status, output}
+// where raw_status is the value popen/pclose hands back (use W* macros to interpret).
+std::pair<int, std::string> run_capture(std::string const& cmd)
+{
+  std::string const full = cmd + " 2>&1";
+  FILE* pipe             = ::popen(full.c_str(), "r");
+  if (!pipe) { return {-1, "popen() failed"}; }
+
+  std::string output;
+  char buf[4096];
+  while (std::fgets(buf, sizeof(buf), pipe) != nullptr) {
+    output.append(buf);
+  }
+  int const raw = ::pclose(pipe);
+  return {raw, std::move(output)};
 }
 
 }  // namespace
@@ -73,15 +92,23 @@ TEST_CASE("scan lifecycle - clean exit after duckdb_scan_task query (regression:
     "INSERT INTO t SELECT 'x' FROM range(1000); "
     "CHECKPOINT; "
     "CALL gpu_execution('SELECT count(*) FROM t');"
-    "\" >/tmp/sirius_lifecycle_test.out 2>&1";
+    "\"";
 
-  int const raw = std::system(cmd.c_str());
+  auto const [raw, output] = run_capture(cmd);
   INFO("command: " << cmd);
+  INFO("subprocess merged stdout+stderr:\n" << output);
+
   if (WIFSIGNALED(raw)) {
     FAIL("duckdb CLI terminated by signal "
          << WTERMSIG(raw)
          << " (SIGSEGV = 11; CLI exit code = 139 indicates the QueryEnd UAF regressed)");
   }
   REQUIRE(WIFEXITED(raw));
-  REQUIRE(WEXITSTATUS(raw) == 0);
+  if (WEXITSTATUS(raw) != 0) {
+    FAIL("duckdb CLI exited with status "
+         << WEXITSTATUS(raw)
+         << " (non-zero, non-signal). This usually means a setup precondition failed before "
+            "the scan ran (init error, missing GPU, missing config). The subprocess output "
+            "above contains the actual error from the CLI.");
+  }
 }

--- a/test/cpp/scan/test_lifecycle_shutdown.cpp
+++ b/test/cpp/scan/test_lifecycle_shutdown.cpp
@@ -16,6 +16,14 @@
 
 // test
 #include <catch.hpp>
+#include <scan/test_utils.hpp>
+#include <utils/utils.hpp>
+
+// sirius
+#include <sirius_context.hpp>
+
+// duckdb
+#include <duckdb.hpp>
 
 // standard library
 #include <sys/wait.h>
@@ -23,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -120,4 +129,49 @@ TEST_CASE("scan lifecycle - clean exit after duckdb_scan_task query (regression:
             "the scan ran (init error, missing GPU, missing config). The subprocess output "
             "above contains the actual error from the CLI.");
   }
+}
+
+// In-process variant of the lifecycle test. Forces the production CLI's destruction order
+// (DatabaseInstance dies before SiriusContext) by holding the SiriusContext shared_ptr in
+// a scope that outlives the unique_ptr<DuckDB>. Pre-fix, ~SiriusContext destroys
+// task_creator_, which holds a unique_ptr<GlobalTableFunctionState> referencing now-freed
+// DuckDB storage objects (BlockMemory, RowGroups) → SIGSEGV in release.
+//
+// Empirically the SIGSEGV fires deterministically in release (verified by reverting the
+// QueryEnd reset and re-running). Catch2's signal handler attributes the failure to this
+// test before the runner dies, so the per-test diagnostic is clean even though the
+// process exits 139. The subprocess test above is kept as belt-and-suspenders:
+//   - in-process: faster (~50 ms vs seconds), no shell, no env var dance, deterministic.
+//   - subprocess: isolates the runner from any crash, exercises the actual CLI exit chain.
+// Both tests should fail simultaneously on a regression — they catch the same bug from
+// different angles.
+TEST_CASE(
+  "scan lifecycle in-process - SiriusContext outlives DatabaseInstance "
+  "(regression: QueryEnd UAF)",
+  "[scan][lifecycle][shutdown]")
+{
+  duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx;
+  std::unique_ptr<duckdb::DuckDB> db;
+
+  {
+    db         = std::make_unique<duckdb::DuckDB>(nullptr);
+    auto con   = duckdb::Connection(*db);
+    sirius_ctx = sirius::get_sirius_context(con, sirius::scan_test_utils::get_test_config_path());
+    REQUIRE(sirius_ctx != nullptr);
+
+    REQUIRE_FALSE(con.Query("CREATE TABLE t(s VARCHAR)")->HasError());
+    REQUIRE_FALSE(con.Query("INSERT INTO t SELECT 'x' FROM range(1000)")->HasError());
+    REQUIRE_FALSE(con.Query("CHECKPOINT")->HasError());
+    auto result = con.Query("CALL gpu_execution('SELECT count(*) FROM t')");
+    REQUIRE_FALSE(result->HasError());
+  }  // ~Connection — registered_state drops its sirius_ctx ref. Our shared_ptr holds it alive.
+
+  // Production CLI inversion: destroy DuckDB while task_creator_ still holds storage refs.
+  db.reset();
+
+  // Now drop the SiriusContext. Pre-fix this destroys task_creator_ → ~GlobalTableFunctionState
+  // dereferences freed storage. Post-fix, QueryEnd already cleared task_creator_ during
+  // the gpu_execution query, so this is a no-op shutdown.
+  sirius_ctx.reset();
+  SUCCEED("clean shutdown after DatabaseInstance death");
 }

--- a/test/cpp/scan/test_lifecycle_shutdown.cpp
+++ b/test/cpp/scan/test_lifecycle_shutdown.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// test
+#include <catch.hpp>
+
+// standard library
+#include <sys/wait.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace {
+
+// Locate the freshly-built duckdb CLI. Falls back to the standard build/release layout
+// derived from __FILE__; in non-standard layouts set SIRIUS_TEST_DUCKDB_BIN.
+std::string find_duckdb_binary()
+{
+  if (const char* env = std::getenv("SIRIUS_TEST_DUCKDB_BIN")) {
+    if (std::filesystem::exists(env)) { return env; }
+  }
+  auto const repo_root = std::filesystem::path(__FILE__)
+                           .parent_path()   // scan/
+                           .parent_path()   // cpp/
+                           .parent_path()   // test/
+                           .parent_path();  // <repo>
+  for (auto const& candidate :
+       {repo_root / "build/release/duckdb", repo_root / "build/debug/duckdb"}) {
+    if (std::filesystem::exists(candidate)) { return candidate.string(); }
+  }
+  return {};
+}
+
+}  // namespace
+
+// In-process tests can't reproduce this bug because both make_test_db_and_connection paths
+// destroy SiriusContext before DatabaseInstance (the safe order). The duckdb CLI's exit
+// chain inverts that order: ~DatabaseInstance runs while task_creator_ still holds a
+// unique_ptr<GlobalTableFunctionState> referencing storage objects (BlockMemory,
+// RowGroups). Pre-fix, that races with storage teardown and SIGSEGVs (exit 139).
+TEST_CASE("scan lifecycle - clean exit after duckdb_scan_task query (regression: QueryEnd UAF)",
+          "[scan][lifecycle][shutdown]")
+{
+  auto const duckdb_bin = find_duckdb_binary();
+  if (duckdb_bin.empty()) {
+    WARN("duckdb binary not found; set SIRIUS_TEST_DUCKDB_BIN to enable this test");
+    SUCCEED();
+    return;
+  }
+
+  // Strip env vars the unit-test harness sets but the spawned CLI must not inherit:
+  //   SIRIUS_DISABLE          — set by shared_test_env::create_db; would block CLI init
+  //   SIRIUS_CONFIG_FILE      — points at the test-only memory.yaml
+  //   SIRIUS_INTEGRATION_*    — TPC-H test data path
+  std::string const cmd =
+    "env -u SIRIUS_DISABLE -u SIRIUS_CONFIG_FILE -u SIRIUS_INTEGRATION_TEST_DB_PATH " + duckdb_bin +
+    " -unsigned -c \""
+    "CREATE TABLE t(s VARCHAR); "
+    "INSERT INTO t SELECT 'x' FROM range(1000); "
+    "CHECKPOINT; "
+    "CALL gpu_execution('SELECT count(*) FROM t');"
+    "\" >/tmp/sirius_lifecycle_test.out 2>&1";
+
+  int const raw = std::system(cmd.c_str());
+  INFO("command: " << cmd);
+  if (WIFSIGNALED(raw)) {
+    FAIL("duckdb CLI terminated by signal "
+         << WTERMSIG(raw)
+         << " (SIGSEGV = 11; CLI exit code = 139 indicates the QueryEnd UAF regressed)");
+  }
+  REQUIRE(WIFEXITED(raw));
+  REQUIRE(WEXITSTATUS(raw) == 0);
+}

--- a/test/cpp/scan/test_lifecycle_shutdown.cpp
+++ b/test/cpp/scan/test_lifecycle_shutdown.cpp
@@ -88,11 +88,15 @@ TEST_CASE("scan lifecycle - clean exit after duckdb_scan_task query (regression:
   auto const test_config = std::filesystem::path(__FILE__).parent_path() / "memory.yaml";
   REQUIRE(std::filesystem::exists(test_config));
 
+  // Single-quote both paths so a build path with spaces (or a custom
+  // SIRIUS_TEST_DUCKDB_BIN containing spaces) doesn't tokenize incorrectly.
+  // Embedded single quotes in paths are extraordinarily rare; if encountered,
+  // switch to fork/exec with argv to avoid the shell entirely.
   std::string const cmd =
     "env -u SIRIUS_DISABLE -u SIRIUS_INTEGRATION_TEST_DB_PATH "
-    "SIRIUS_CONFIG_FILE=" +
-    test_config.string() + " " + duckdb_bin +
-    " -unsigned -c \""
+    "SIRIUS_CONFIG_FILE='" +
+    test_config.string() + "' '" + duckdb_bin +
+    "' -unsigned -c \""
     "CREATE TABLE t(s VARCHAR); "
     "INSERT INTO t SELECT 'x' FROM range(1000); "
     "CHECKPOINT; "


### PR DESCRIPTION
- **varchar buffer sizing** from DuckDB `max_string_length` per column instead of a 256B default, letting us allocate less memory. `chunk_fits` skip when every varchar is metadata-bounded, but still throw since it is rare that a varchar has no meta data and is longer than 256B.
  
- **projection column index** uses storage idx, not projected idx. This was a pre-fix since one of my later commit gonna hit this, `SELECT l_comment` was reading stats for column 0 since projection ID and storage ID are different.

- **QueryEnd UAF**: reset `task_creator_` so scan state is released while DatabaseInstance is alive. Pre-fix the CLI SIGSEGVs on exit (139). New `[lifecycle]` test spawns the duckdb CLI subprocess — reproduces the bug on dev, passes with the fix. This was the bug that made DuckDB scan not work sometimes. 
                                                                                
- **dictionary-vector fast path** for varchar columns on the CPU fallback path (skip Flatten). GPU-decoded queries don't hit this, but this was my initial attempt to deal with a faster DuckDB scan path before doing the GPU kernel, so I kept it to make the PR sequence easier to understand. Will remove this on the DuckDB decode on GPU. 