### PR TITLE
Fix row-group pruning in parquet metadata scan and memory reservation for parquet gpu scan

### DIFF
--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -168,6 +168,11 @@ class parquet_scan_data : public op::operator_data {
     return std::vector<::cucascade::data_batch_processing_handle>{};
   };
 
+  [[nodiscard]] std::size_t get_estimated_size_in_bytes() const override
+  {
+    return rg_range.reserved_uncompressed_bytes;
+  }
+
   std::string file_path;
   row_group_range rg_range;
   std::shared_ptr<cudf::io::parquet_reader_options> reader_options;

--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -54,15 +54,13 @@ namespace sirius::op::scan {
  *        the metadata into a shared_ptr and appends one partition_entry per
  *        row_group_range to _partition_index under _metadata_mutex. Partitions become
  *        claimable by the scan pipeline the moment they are appended.
- *      - When the upstream pipeline finishes, its finalize_operator() calls
- *        finalize_partitions() on this operator, which sets _finalized to signal that
- *        no further partitions will arrive.
  *
  *   2. Scan (this pipeline, GPU):
  *      - get_next_task_hint() returns READY as soon as _partition_index contains an
- *        unclaimed entry, regardless of _finalized. If no entry is currently claimable
- *        and _finalized is false, it surfaces the upstream metadata scan as
- *        WAITING_FOR_INPUT_DATA so task_creator can schedule it.
+ *        unclaimed entry. If no entry is currently claimable and the upstream metadata
+ *        pipeline has not yet finished (checked via the "handoff" port's
+ *        src_pipeline->is_pipeline_finished()), it surfaces the upstream metadata scan
+ *        as WAITING_FOR_INPUT_DATA so task_creator can schedule it.
  *      - get_next_task_input_data() claims one partition from the index under
  *        _metadata_mutex and returns it as parquet_scan_data. Each partition maps 1:1
  *        to a row_group_range — the metadata scan operator is responsible for sizing
@@ -74,18 +72,16 @@ namespace sirius::op::scan {
  *   The upstream → downstream pipeline edge is expressed via a null-repo "handoff"
  *   port on this operator (MemoryBarrierType::PARTIAL). setup_pipeline_parents() uses
  *   that port to discover the dependency so the metadata pipeline is registered as a
- *   parent of this pipeline. No data flows through the port — the handoff is via
- *   accumulate_metadata() / finalize_partitions().
+ *   parent of this pipeline. No data flows through the port — the data handoff is via
+ *   accumulate_metadata(). Completion detection uses the standard
+ *   port->src_pipeline->is_pipeline_finished() mechanism rather than a bespoke flag,
+ *   keeping the two operators decoupled.
  *
  * Thread-safety:
  *   - accumulate_metadata() is called from upstream worker threads; _metadata_mutex
  *     serializes its appends to _partition_index against concurrent claims by
  *     get_next_task_input_data() and size reads by get_next_task_hint() /
  *     all_ports_empty().
- *   - finalize_partitions() must be called exactly once, after ALL accumulate_metadata()
- *     calls have returned. It sets _finalized with release semantics; get_next_task_hint()
- *     reads it with acquire semantics to decide whether to return nullopt or to defer
- *     to the upstream pipeline.
  *   - get_next_task_input_data() / get_next_task_hint() / all_ports_empty() are safe to
  *     call from multiple worker threads and serve partitions as soon as they are
  *     appended; returning "no work right now" does not imply the scan is finished.
@@ -117,16 +113,6 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
   void accumulate_metadata(const partitioned_parquet_metadata& metadata);
 
   /**
-   * @brief Signal that no more metadata will arrive.
-   *
-   * Must be called exactly once, after all accumulate_metadata() calls have returned.
-   * Invoked from metadata_scan.finalize_operator(). Sets _finalized under
-   * _metadata_mutex so get_next_task_hint() can return std::nullopt once the partition
-   * index is fully drained instead of continuing to defer to the upstream pipeline.
-   */
-  void finalize_partitions();
-
-  /**
    * @brief Install a hive-partition injection function.
    *
    * Called once by the paired metadata scan operator at construction time when the scan
@@ -150,13 +136,14 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
    *         unclaimed entry (regardless of whether accumulation is still in
    *         progress);
    *         WAITING_FOR_INPUT_DATA pointing at the upstream metadata scan when no
-   *         entry is currently claimable and the metadata pipeline has not yet
-   *         been finalized (surfaces the upstream dependency to
-   *         task_creator::get_operator_for_next_task, which otherwise cannot
-   *         discover it — the metadata handoff is a side channel, not a data
-   *         repo);
-   *         nullopt once all partitions have been claimed AND
-   *         finalize_partitions() has been called.
+   *         entry is currently claimable and the upstream metadata pipeline has
+   *         not yet finished (checked via the "handoff" port's
+   *         src_pipeline->is_pipeline_finished(); surfaces the upstream
+   *         dependency to task_creator::get_operator_for_next_task, which
+   *         otherwise cannot discover it — the metadata handoff is a side
+   *         channel, not a data repo);
+   *         nullopt once all partitions have been claimed AND the metadata
+   *         pipeline has finished.
    */
   std::optional<task_creation_hint> get_next_task_hint() override;
 
@@ -207,13 +194,8 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
   //                         metadata's row_group_partitions.
   //   _next_partition_idx— counter of the next unclaimed entry; advanced under
   //                         _metadata_mutex by get_next_task_input_data().
-  //   _finalized         — set once by finalize_partitions() under _metadata_mutex
-  //                         to signal that no more accumulate_metadata() calls will
-  //                         arrive. Read by get_next_task_hint() under _metadata_mutex
-  //                         to decide nullopt vs. WAITING.
   // ===----------------------------------------------------------------------===//
   std::mutex _metadata_mutex;
-  bool _finalized{false};
   partition_inject_fn_t _hive_partition_inject_fn;
 
   struct partition_entry {

--- a/src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp
+++ b/src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp
@@ -56,10 +56,9 @@ namespace sirius::op::scan {
  *     sirius_gpu_parquet_scan_operator via its accumulate_metadata() entry point.
  *     This is a direct handoff — no inter-pipeline port or data repository is
  *     involved; the metadata never flows through the generic pipeline data path.
- *   - finalize_operator() (invoked once after pipeline 1 completes) calls
- *     gpu_scan::finalize_partitions(), which freezes the partition index and
- *     unblocks the downstream scan pipeline (pipeline 2), where gpu_scan serves
- *     as the source.
+ *   - Completion of this pipeline is detected by the downstream gpu_scan operator
+ *     via the standard "handoff" port / is_pipeline_finished() mechanism — no
+ *     explicit finalize callback is needed.
  *
  * @pre The caller must validate before construction that:
  *   - The table function is NOT an in-out function (in_out_function == false).
@@ -184,17 +183,6 @@ class sirius_parquet_metadata_scan_operator : public sirius_physical_operator {
    */
   void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 
-  /**
-   * @brief Finalize the paired gpu_scan's partition index, unblocking the downstream pipeline.
-   *
-   * Invoked by the pipeline framework exactly once, after every sink() call for this pipeline
-   * has returned. Delegates to gpu_scan::finalize_partitions(), which freezes the accumulated
-   * metadata into a flat partition index and publishes it with release semantics. Until this
-   * call completes, gpu_scan's source methods report "not ready" and the downstream scan
-   * pipeline cannot begin dispatching tasks.
-   */
-  void finalize_operator() override;
-
   //===----------Accessors----------===//
   [[nodiscard]] std::size_t get_total_files() const { return _total_files; }
   [[nodiscard]] std::size_t get_max_file_processed() const { return _max_file_processed; }
@@ -239,8 +227,7 @@ class sirius_parquet_metadata_scan_operator : public sirius_physical_operator {
   std::atomic<std::size_t> _next_file_idx{0};
 
   /// Paired GPU parquet scan operator — the source of the downstream pipeline. sink() forwards
-  /// accumulated metadata into it; finalize_operator() freezes its partition index. Set at
-  /// construction; never null.
+  /// accumulated metadata into it via accumulate_metadata(). Set at construction; never null.
   sirius_gpu_parquet_scan_operator* _gpu_scan;
 };
 

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -119,6 +119,16 @@ class operator_data {
   {
     return std::vector<::cucascade::data_batch_processing_handle>{};
   };
+
+  /**
+   * @brief Estimate the uncompressed GPU memory footprint of this data.
+   *
+   * Used by the reservation system to size memory reservations before a task
+   * executes. The default returns 0, which is appropriate for metadata-only
+   * subclasses (e.g. parquet_metadata_input). Subclasses that carry or
+   * represent GPU-resident data should override to return a meaningful estimate.
+   */
+  [[nodiscard]] virtual std::size_t get_estimated_size_in_bytes() const { return 0; }
 };
 
 /**
@@ -173,6 +183,17 @@ class pipelineable_operator_data : public operator_data {
   std::optional<std::vector<::cucascade::data_batch_processing_handle>> prepare_for_processing(
     const ::cucascade::memory::memory_space* requested_memory_space,
     rmm::cuda_stream_view stream) override;
+
+  [[nodiscard]] std::size_t get_estimated_size_in_bytes() const override
+  {
+    std::size_t total = 0;
+    for (auto const& batch : _data_batches) {
+      if (batch && batch->get_data()) {
+        total += batch->get_data()->get_uncompressed_data_size_in_bytes();
+      }
+    }
+    return total;
+  }
 
  private:
   std::vector<std::shared_ptr<::cucascade::data_batch>> _data_batches;

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -96,17 +96,7 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
   [[nodiscard]] std::size_t get_task_consumption_basis() const override
   {
     if (_estimation_basis) { return *_estimation_basis; }
-    std::size_t input_size = 0;
-    auto* pipelineable_input =
-      dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
-    if (pipelineable_input) {
-      for (const auto& batch : pipelineable_input->get_data_batches()) {
-        if (batch && batch->get_data()) {
-          input_size += batch->get_data()->get_uncompressed_data_size_in_bytes();
-        }
-      }
-    }
-    _estimation_basis = input_size;
+    _estimation_basis = _input_data ? _input_data->get_estimated_size_in_bytes() : 0;
     return *_estimation_basis;
   }
 

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -61,37 +61,29 @@ void sirius_gpu_parquet_scan_operator::accumulate_metadata(
   }
 }
 
-void sirius_gpu_parquet_scan_operator::finalize_partitions()
-{
-  std::lock_guard<std::mutex> lock(_metadata_mutex);
-  _finalized = true;
-}
-
 //===----------------------------------------------------------------------===//
 // Scheduling interface
 //===----------------------------------------------------------------------===//
 std::optional<task_creation_hint> sirius_gpu_parquet_scan_operator::get_next_task_hint()
 {
-  {
-    std::lock_guard<std::mutex> lock(_metadata_mutex);
+  std::lock_guard<std::mutex> lock(_metadata_mutex);
 
-    // 1. Work available? Dispatch immediately, even if metadata pipeline
-    //    is still producing.
-    if (_next_partition_idx < _partition_index.size()) {
-      return task_creation_hint{TaskCreationHint::READY, this};
-    }
-
-    // 2. No work and metadata pipeline is done — we are finished.
-    if (_finalized) { return std::nullopt; }
+  // 1. Work available? Dispatch immediately, even if metadata pipeline
+  //    is still producing.
+  if (_next_partition_idx < _partition_index.size()) {
+    return task_creation_hint{TaskCreationHint::READY, this};
   }
 
-  // 3. Metadata pipeline is still running — defer to it.
+  // 2. Metadata pipeline still running? Wait on it.
   auto it = ports.find("handoff");
-  if (it != ports.end() && it->second && it->second->src_pipeline) {
+  if (it != ports.end() && it->second && it->second->src_pipeline &&
+      !it->second->src_pipeline->is_pipeline_finished()) {
     if (auto upstream = it->second->src_pipeline->get_source()) {
       return task_creation_hint{TaskCreationHint::WAITING_FOR_INPUT_DATA, upstream.get()};
     }
   }
+
+  // 3. No work, pipeline done — finished.
   return std::nullopt;
 }
 

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -96,13 +96,14 @@ bool sirius_gpu_parquet_scan_operator::all_ports_empty()
 std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::get_next_task_input_data()
 {
   std::size_t idx;
+  partition_entry entry;
   {
     std::lock_guard<std::mutex> lock(_metadata_mutex);
     if (_next_partition_idx >= _partition_index.size()) { return nullptr; }
-    idx = _next_partition_idx++;
+    idx   = _next_partition_idx++;
+    entry = _partition_index[idx];
   }
 
-  auto const& entry    = _partition_index[idx];
   auto meta            = entry.metadata;
   auto const& rg_range = meta->row_group_partitions[entry.partition_idx];
 

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -382,9 +382,4 @@ void sirius_parquet_metadata_scan_operator::sink(const operator_data& input_data
   _gpu_scan->accumulate_metadata(*metadata);
 }
 
-void sirius_parquet_metadata_scan_operator::finalize_operator()
-{
-  _gpu_scan->finalize_partitions();
-}
-
 }  // namespace sirius::op::scan

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -201,19 +201,15 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
   std::shared_ptr<translated_expression> ast_filter;
   if (_has_filter) {
     if (!_column_name_by_ref.empty()) {
-      // Allocate scalar literals on the task stream but synchronize before returning
-      // to ensure all device allocations are complete and visible to other streams.
-      // Without this, downstream GPU_PARQUET_SCAN tasks that access the scalars on a
-      // different stream may hit cudaErrorIllegalAddress due to CUDA stream-ordering
-      // semantics in the async memory allocator.
       gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
       auto name_resolver = [this](duckdb::idx_t ref_index) -> std::string {
         return _column_name_by_ref.at(ref_index);
       };
       auto optional_filter =
         translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
-      stream.synchronize();
       if (optional_filter) {
+        stream.synchronize();  // Ensure scalars are materialized for downstream operators executing
+                               // in other streams.
         ast_filter = std::make_shared<translated_expression>(std::move(*optional_filter));
         result->reader_options->set_filter(ast_filter->back());
         result->filter_expression = ast_filter;

--- a/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
+++ b/src/op/scan/sirius_parquet_metadata_scan_operator.cpp
@@ -200,35 +200,40 @@ std::unique_ptr<operator_data> sirius_parquet_metadata_scan_operator::execute(
   // Filter
   std::shared_ptr<translated_expression> ast_filter;
   if (_has_filter) {
-    /// KEVIN: there is a bug hiding here that I haven't been able to find yet...
-    // if (!_column_name_by_ref.empty()) {
-    //   gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
-    //   auto name_resolver = [this](duckdb::idx_t ref_index) -> std::string {
-    //     return _column_name_by_ref.at(ref_index);
-    //   };
-    //   auto optional_filter =
-    //     translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
-    //   if (optional_filter) {
-    //     ast_filter = std::make_shared<translated_expression>(std::move(*optional_filter));
-    //     result->reader_options->set_filter(ast_filter->back());
-    //     result->filter_expression = ast_filter;
-    //     SIRIUS_LOG_DEBUG(
-    //       "[sirius_parquet_metadata_scan_operator] Successfully translated filter expression for
-    //       " "pushdown.");
-    //   } else {
-    //     result->filter_expression = _duckdb_filter_expression;
-    //     SIRIUS_LOG_DEBUG(
-    //       "[sirius_parquet_metadata_scan_operator] Failed to translate filter expression for "
-    //       "pushdown. Filter will be applied in the GPU scan operator.");
-    //   }
-    // } else {
-    //   // Column names were not provided; AST translation requires column name references.
-    //   result->filter_expression = _duckdb_filter_expression;
-    //   SIRIUS_LOG_DEBUG(
-    //     "[sirius_parquet_metadata_scan_operator] Column names not available for AST filter "
-    //     "translation. Filter will be applied in the GPU scan operator.");
-    // }
-    result->filter_expression          = _duckdb_filter_expression;
+    if (!_column_name_by_ref.empty()) {
+      // Allocate scalar literals on the task stream but synchronize before returning
+      // to ensure all device allocations are complete and visible to other streams.
+      // Without this, downstream GPU_PARQUET_SCAN tasks that access the scalars on a
+      // different stream may hit cudaErrorIllegalAddress due to CUDA stream-ordering
+      // semantics in the async memory allocator.
+      gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
+      auto name_resolver = [this](duckdb::idx_t ref_index) -> std::string {
+        return _column_name_by_ref.at(ref_index);
+      };
+      auto optional_filter =
+        translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
+      stream.synchronize();
+      if (optional_filter) {
+        ast_filter = std::make_shared<translated_expression>(std::move(*optional_filter));
+        result->reader_options->set_filter(ast_filter->back());
+        result->filter_expression = ast_filter;
+        SIRIUS_LOG_DEBUG(
+          "[sirius_parquet_metadata_scan_operator] Successfully translated filter expression for "
+          "pushdown ({} scalar literals).",
+          ast_filter->owned_literals.size());
+      } else {
+        result->filter_expression = _duckdb_filter_expression;
+        SIRIUS_LOG_DEBUG(
+          "[sirius_parquet_metadata_scan_operator] Failed to translate filter expression for "
+          "pushdown. Filter will be applied in the GPU scan operator.");
+      }
+    } else {
+      // Column names were not provided; AST translation requires column name references.
+      result->filter_expression = _duckdb_filter_expression;
+      SIRIUS_LOG_DEBUG(
+        "[sirius_parquet_metadata_scan_operator] Column names not available for AST filter "
+        "translation. Filter will be applied in the GPU scan operator.");
+    }
     result->post_filter_projection_ids = _post_filter_projection_ids;
   }
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -171,18 +171,18 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
 //     metadata_scan_op is both source and sink. Its execute() parses parquet
 //     footers and produces partitioned_parquet_metadata; its sink() override
 //     forwards each result directly into the paired gpu_scan_op via
-//     accumulate_metadata(). finalize_operator() calls finalize_partitions()
-//     on gpu_scan_op once the pipeline completes.
+//     accumulate_metadata().
 //
 //   current_pipeline (rewritten):
-//     gpu_scan_op replaces the DuckDB table scan as the source. It cannot
-//     dispatch tasks until its partition index has been finalized by the
-//     upstream metadata_pipeline.
+//     gpu_scan_op replaces the DuckDB table scan as the source. It defers to
+//     the upstream metadata_pipeline via the standard "handoff" port /
+//     is_pipeline_finished() mechanism until all metadata has been produced.
 //
-// The handoff is a direct function call — no data repository is wired
-// between the two pipelines. A null-repo "dependency" port on gpu_scan_op
-// exists only so setup_pipeline_parents() can discover the
-// metadata_pipeline -> current_pipeline scheduling dependency.
+// The metadata handoff is a direct function call — no data repository is
+// wired between the two pipelines. A null-repo "handoff" port on gpu_scan_op
+// lets setup_pipeline_parents() discover the metadata_pipeline ->
+// current_pipeline scheduling dependency, and lets gpu_scan_op's
+// get_next_task_hint() detect when the metadata pipeline has finished.
 //===----------------------------------------------------------------------===//
 void sirius_pipeline_converter::split_parquet_scan_source(
   duckdb::shared_ptr<sirius_pipeline>& current_pipeline)
@@ -202,7 +202,7 @@ void sirius_pipeline_converter::split_parquet_scan_source(
   auto const& partition_indices = bind_data.reader_bind.hive_partitioning_indexes;
 
   // Construct the pair. metadata_scan_op holds a raw pointer back to gpu_scan_op for the direct
-  // accumulate_metadata() / finalize_partitions() handoff.
+  // accumulate_metadata() handoff.
   auto gpu_scan_op = duckdb::make_uniq<op::scan::sirius_gpu_parquet_scan_operator>(
     scan_op.types, scan_op.estimated_cardinality);
   auto metadata_scan_op = duckdb::make_uniq<op::scan::sirius_parquet_metadata_scan_operator>(
@@ -1018,11 +1018,12 @@ void sirius_pipeline_converter::wire_data_repositories()
     } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
       // No action needed for RESULT_COLLECTOR sinks
     } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::PARQUET_METADATA_SCAN) {
-      // Scheduling-only dependency port. The metadata handoff itself happens through
-      // accumulate_metadata() / finalize_partitions(); no data batches flow through this port
-      // (repo is null). setup_pipeline_parents() walks metadata_scan's next_port_after_sink list
+      // Scheduling and completion-detection port. The metadata handoff itself happens
+      // through accumulate_metadata(); no data batches flow through this port (repo is
+      // null). setup_pipeline_parents() walks metadata_scan's next_port_after_sink list
       // and reads this port's dest_pipeline to register current_pipeline as a parent of
-      // metadata_pipeline.
+      // metadata_pipeline. gpu_scan_op's get_next_task_hint() also reads this port's
+      // src_pipeline->is_pipeline_finished() to detect when all metadata has arrived.
       for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
         auto* next_op            = dependent_pipeline->get_operators().size() == 0
                                      ? dependent_pipeline->get_sink().get()

--- a/test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
+++ b/test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
@@ -293,11 +293,6 @@ TEST_CASE("pipeline task counting - single file, default max_file_processed (one
   REQUIRE(metadata_pipeline->get_tasks_completed() == 1);
   REQUIRE(metadata_pipeline->is_pipeline_finished());
 
-  // Hand off to pipeline 2. In production this runs off the sink's
-  // finalize_operator(); update_pipeline_status() only walks get_operators(),
-  // so a single-op self-pipeline needs the engine to invoke it.
-  metadata_op.finalize_operator();
-
   // ----------- pipeline 2: gpu parquet scan -----------
   std::size_t gpu_tasks =
     simulate_task_creator_loop(*gpu_pipeline, gpu_op, [&](sirius::op::operator_data& input) {
@@ -379,12 +374,8 @@ TEST_CASE("pipeline task counting - multi-file metadata scan with max_file_proce
   REQUIRE(metadata_pipeline->get_tasks_completed() == NUM_FILES);
   REQUIRE(metadata_pipeline->is_pipeline_finished());
 
-  // Bridge to pipeline 2 (see note in the single-file test).
-  metadata_op.finalize_operator();
-
-  // Before finalize the gpu op must have been "waiting" on the metadata
-  // pipeline via the handoff port; now that metadata is done,
-  // is_source_pipeline_finished() on gpu_op should report true.
+  // The metadata pipeline is finished; the gpu op detects this via the
+  // handoff port's src_pipeline->is_pipeline_finished().
   REQUIRE(gpu_op.is_source_pipeline_finished());
 
   // ----------- pipeline 2: gpu scan over all accumulated partitions -----------

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -166,7 +166,7 @@ schema_info diverse_table_schema()
   return info;
 }
 
-/// Run the full two-pipeline scan: metadata scan → sink → finalize → GPU scan.
+/// Run the full two-pipeline scan: metadata scan → sink → GPU scan.
 /// Returns all output data_batches.
 std::vector<std::shared_ptr<cucascade::data_batch>> run_two_pipeline_scan(
   std::vector<std::string> const& file_paths,
@@ -205,9 +205,6 @@ std::vector<std::shared_ptr<cucascade::data_batch>> run_two_pipeline_scan(
     REQUIRE(output);
     metadata_op.sink(*output, stream);
   }
-
-  // --- Pipeline 1 → Pipeline 2 transition ---
-  metadata_op.finalize_operator();
 
   // --- Pipeline 2: GPU scan ---
   std::vector<std::shared_ptr<cucascade::data_batch>> all_batches;
@@ -806,7 +803,7 @@ TEST_CASE("two-pipeline scan - small batch size creates multiple partitions",
   REQUIRE(total_rows == NUM_ROWS);
 }
 
-TEST_CASE("gpu_scan_operator - sink and finalize lifecycle", "[gpu_scan_operator][shared_context]")
+TEST_CASE("gpu_scan_operator - idle without handoff port", "[gpu_scan_operator][shared_context]")
 {
   auto memory_manager = initialize_memory_manager();
   auto* gpu_space     = get_space(*memory_manager, Tier::GPU);
@@ -824,11 +821,6 @@ TEST_CASE("gpu_scan_operator - sink and finalize lifecycle", "[gpu_scan_operator
   REQUIRE(op.all_ports_empty());
   REQUIRE(op.get_next_task_hint() == std::nullopt);
   REQUIRE(op.get_next_task_input_data() == nullptr);
-
-  // Finalize with no metadata → no partitions, still idle.
-  op.finalize_partitions();
-  REQUIRE(op.all_ports_empty());
-  REQUIRE(op.get_next_task_hint() == std::nullopt);
 }
 
 TEST_CASE("two-pipeline scan - diverse types with filter on INTEGER",


### PR DESCRIPTION
## Fix GPU scan memory bugs; decouple operator completion detection

### Bug fix 1: AST filter scalar lifetime (use-after-free)

Fix `cudaErrorIllegalAddress` crash caused by failure to enforce stream synchronization between pipeline streams (metadata scan -> gpu scan).

**Fix:** Add `stream.synchronize()` after AST filter translation to establish a
full memory barrier. Without this, downstream `GPU_PARQUET_SCAN` tasks access the
scalar device memory on a different CUDA stream without a dependency on the
producing stream. CUDA's async memory allocator uses stream-ordering semantics, so
the allocations may appear invalid from the consuming stream's perspective.

- Re-enabled AST filter translation (previously commented out with "bug hiding here")
- Added `stream.synchronize()` after `translate_expression_with_names()`
- Validated: TPC-H SF50 all 22 queries × 5 iterations pass without `cudaErrorIllegalAddress`

### Bug fix 2: Zero-byte reservations for GPU scan tasks

`GPU_PARQUET_SCAN` tasks were receiving 0-byte memory reservations because
`get_task_consumption_basis()` only recognized `pipelineable_operator_data` inputs
(GPU data batches). Scan tasks carry `parquet_scan_data` (file paths and metadata),
so their input size was always 0 — blinding the reservation system to their actual
GPU memory needs.

**Fix:** Add a virtual `get_estimated_size_in_bytes()` to the `operator_data` base
class so the reservation system can query any input data for its GPU memory
footprint without downcasting.

- `operator_data` base returns 0 (metadata-only subclasses)
- `pipelineable_operator_data` sums its data batches' uncompressed sizes
- `parquet_scan_data` returns `rg_range.reserved_uncompressed_bytes`
- `gpu_pipeline_task_local_state::get_task_consumption_basis()` simplified from
  a manual `dynamic_cast` + loop to a single `_input_data->get_estimated_size_in_bytes()` call

### Refactor: Decouple GPU scan completion detection

Replace the bespoke `_finalized` / `finalize_partitions()` signaling between
the metadata scan and GPU scan operators with the standard port-based
`is_pipeline_finished()` check that every other operator already uses.

**Before:** The metadata scan operator held a raw pointer to the GPU scan and
called `finalize_partitions()` from its `finalize_operator()` override, setting
a `_finalized` bool to tell `get_next_task_hint()` when to stop waiting.

**After:** `get_next_task_hint()` checks the existing "handoff" port's
`src_pipeline->is_pipeline_finished()` under a single lock. No cross-operator
state mutation needed.

- Removed `finalize_partitions()`, `_finalized` from `sirius_gpu_parquet_scan_operator`
- Removed `finalize_operator()` override from `sirius_parquet_metadata_scan_operator`
- Rewrote `get_next_task_hint()` to use port-based completion detection
- Updated pipeline converter comments, operator docstrings, and tests
