### PR TITLE
feat: sirius::value AST constant payload (Phase 2 of #666 — closes #695)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ set(TEST_SOURCES
     test/cpp/expression/test_ast_scaffold.cpp
     test/cpp/expression/test_expression.cpp
     test/cpp/expression/test_join_condition.cpp
+    test/cpp/expression/test_value.cpp
     test/cpp/expression_executor/test_gpu_expression_executor.cpp
     test/cpp/expression_executor/test_gpu_expression_translator.cpp
     test/cpp/helper/test_logical_type.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(EXTENSION_SOURCES
     src/downgrade/downgrade_executor.cpp
     src/expression/expression.cpp
     src/expression/join_condition.cpp
+    src/expression/value.cpp
     src/expression_executor/expression_executor_strategy.cpp
     src/expression_executor/gpu_expression_executor.cpp
     src/expression_executor/gpu_expression_translator.cpp

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "expression/value.hpp"
+
+#include "helper/type_conversions.hpp"
+#include "sirius/exception.hpp"
+
+// duckdb
+#include <duckdb/common/types/date.hpp>
+#include <duckdb/common/types/decimal.hpp>
+#include <duckdb/common/types/hugeint.hpp>
+#include <duckdb/common/types/timestamp.hpp>
+#include <duckdb/common/types/value.hpp>
+
+// standard library
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace sirius {
+
+value from_duckdb(const duckdb::Value& v, const logical_type& type)
+{
+  // D-05: typed NULL fidelity — every IsNull() input becomes null_value,
+  // regardless of the value's logical type. The SQL type of the NULL is
+  // recovered later via the supplied logical_type at the to_duckdb boundary.
+  if (v.IsNull()) { return value{null_value{}}; }
+
+  switch (type.id()) {
+    case type_id::BOOLEAN: return value{v.GetValue<bool>()};
+    case type_id::TINYINT: return value{v.GetValue<int8_t>()};
+    case type_id::SMALLINT: return value{v.GetValue<int16_t>()};
+    case type_id::INTEGER: return value{v.GetValue<int32_t>()};
+    case type_id::BIGINT: return value{v.GetValue<int64_t>()};
+    case type_id::HUGEINT: return value{v.GetValue<int64_t>()};  // D-03 narrowing
+    case type_id::UTINYINT: return value{v.GetValue<uint8_t>()};
+    case type_id::USMALLINT: return value{v.GetValue<uint16_t>()};
+    case type_id::UINTEGER: return value{v.GetValue<uint32_t>()};
+    case type_id::UBIGINT: return value{v.GetValue<uint64_t>()};
+    case type_id::UHUGEINT: return value{v.GetValue<uint64_t>()};  // D-03 narrowing
+    case type_id::FLOAT: return value{v.GetValue<float>()};
+    case type_id::DOUBLE: return value{v.GetValue<double>()};
+    case type_id::DATE: return value{date_value{v.GetValue<duckdb::date_t>().days}};
+    case type_id::TIMESTAMP_SEC:
+      return value{timestamp_sec_value{v.GetValue<duckdb::timestamp_sec_t>().value}};
+    case type_id::TIMESTAMP_MS:
+      return value{timestamp_ms_value{v.GetValue<duckdb::timestamp_ms_t>().value}};
+    case type_id::TIMESTAMP:
+      // gpu_execute_constant.cpp:140 uses duckdb::timestamp_tz_t for microsecond
+      // TIMESTAMP — mirror that accessor exactly so Phase 5's executor migration
+      // is a structural rewrite, not a behavior change.
+      return value{timestamp_us_value{v.GetValue<duckdb::timestamp_tz_t>().value}};
+    case type_id::TIMESTAMP_NS:
+      return value{timestamp_ns_value{v.GetValue<duckdb::timestamp_ns_t>().value}};
+    case type_id::VARCHAR: return value{v.GetValue<std::string>()};
+    case type_id::DECIMAL: {
+      // D-06: precision lives in the supplied logical_type, NOT in the
+      // alternative struct. The alt carries only (rep, scale).
+      auto const precision = type.decimal_precision();
+      auto const scale     = type.decimal_scale();
+      if (precision <= logical_type::decimal_max_precision_int32) {
+        // DuckDB stores precision <= 4 as int16_t and 5..9 as int32_t.
+        // Sirius has only decimal32/64/128 (mirrors gpu_execute_constant.cpp:148-167).
+        // GetValueUnsafe<int32_t>() widens int16-storage cleanly.
+        return value{decimal32{v.GetValueUnsafe<int32_t>(), scale}};
+      }
+      if (precision <= logical_type::decimal_max_precision_int64) {
+        return value{decimal64{v.GetValueUnsafe<int64_t>(), scale}};
+      }
+      // DECIMAL128 unpack — mirror gpu_execute_constant.cpp:162-163 EXACTLY.
+      auto const hi  = v.GetValueUnsafe<duckdb::hugeint_t>();
+      auto const rep = (static_cast<__int128_t>(hi.upper) << 64) | hi.lower;
+      return value{decimal128{rep, scale}};
+    }
+    default:
+      throw not_implemented_exception("sirius::from_duckdb: unsupported type {}", type.to_string());
+  }
+}
+
+duckdb::Value to_duckdb(const value& v, const logical_type& type)
+{
+  // D-05: typed NULL recovery — null_value plus the supplied type yields a
+  // typed-null duckdb::Value via the `Value(LogicalType)` ctor. Reuses the
+  // sirius::to_duckdb(logical_type) overload from helper/type_conversions.hpp.
+  if (std::holds_alternative<null_value>(v)) { return duckdb::Value(to_duckdb(type)); }
+
+  switch (type.id()) {
+    case type_id::BOOLEAN: return duckdb::Value::BOOLEAN(std::get<bool>(v));
+    case type_id::TINYINT: return duckdb::Value::TINYINT(std::get<int8_t>(v));
+    case type_id::SMALLINT: return duckdb::Value::SMALLINT(std::get<int16_t>(v));
+    case type_id::INTEGER: return duckdb::Value::INTEGER(std::get<int32_t>(v));
+    case type_id::BIGINT: return duckdb::Value::BIGINT(std::get<int64_t>(v));
+    case type_id::HUGEINT:
+      return duckdb::Value::HUGEINT(std::get<int64_t>(v));  // D-03: narrowed alt → widen via factory
+    case type_id::UTINYINT: return duckdb::Value::UTINYINT(std::get<uint8_t>(v));
+    case type_id::USMALLINT: return duckdb::Value::USMALLINT(std::get<uint16_t>(v));
+    case type_id::UINTEGER: return duckdb::Value::UINTEGER(std::get<uint32_t>(v));
+    case type_id::UBIGINT: return duckdb::Value::UBIGINT(std::get<uint64_t>(v));
+    case type_id::UHUGEINT: return duckdb::Value::UHUGEINT(std::get<uint64_t>(v));
+    case type_id::FLOAT: return duckdb::Value::FLOAT(std::get<float>(v));
+    case type_id::DOUBLE: return duckdb::Value::DOUBLE(std::get<double>(v));
+    case type_id::DATE:
+      return duckdb::Value::DATE(duckdb::date_t{std::get<date_value>(v).days});
+    case type_id::TIMESTAMP_SEC:
+      return duckdb::Value::TIMESTAMPSEC(
+        duckdb::timestamp_sec_t{std::get<timestamp_sec_value>(v).value});
+    case type_id::TIMESTAMP_MS:
+      return duckdb::Value::TIMESTAMPMS(
+        duckdb::timestamp_ms_t{std::get<timestamp_ms_value>(v).value});
+    case type_id::TIMESTAMP:
+      return duckdb::Value::TIMESTAMP(
+        duckdb::timestamp_t{std::get<timestamp_us_value>(v).value});
+    case type_id::TIMESTAMP_NS:
+      return duckdb::Value::TIMESTAMPNS(
+        duckdb::timestamp_ns_t{std::get<timestamp_ns_value>(v).value});
+    case type_id::VARCHAR: return duckdb::Value(std::get<std::string>(v));
+    case type_id::DECIMAL: {
+      auto const precision = type.decimal_precision();
+      auto const scale     = type.decimal_scale();
+      if (precision <= logical_type::decimal_max_precision_int16) {
+        // DuckDB physical width int16_t — narrow decimal32 down.
+        auto const& d = std::get<decimal32>(v);
+        return duckdb::Value::DECIMAL(static_cast<int16_t>(d.value), precision, scale);
+      }
+      if (precision <= logical_type::decimal_max_precision_int32) {
+        auto const& d = std::get<decimal32>(v);
+        return duckdb::Value::DECIMAL(d.value, precision, scale);
+      }
+      if (precision <= logical_type::decimal_max_precision_int64) {
+        auto const& d = std::get<decimal64>(v);
+        return duckdb::Value::DECIMAL(d.value, precision, scale);
+      }
+      // DECIMAL128 — repack into duckdb::hugeint_t (reverse of from_duckdb).
+      auto const& d = std::get<decimal128>(v);
+      duckdb::hugeint_t hi{static_cast<int64_t>(d.value >> 64), static_cast<uint64_t>(d.value)};
+      return duckdb::Value::DECIMAL(hi, precision, scale);
+    }
+    default:
+      throw not_implemented_exception("sirius::to_duckdb: unsupported type {}", type.to_string());
+  }
+}
+
+}  // namespace sirius

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -105,7 +105,8 @@ duckdb::Value to_duckdb(const value& v, const logical_type& type)
     case type_id::INTEGER: return duckdb::Value::INTEGER(std::get<int32_t>(v));
     case type_id::BIGINT: return duckdb::Value::BIGINT(std::get<int64_t>(v));
     case type_id::HUGEINT:
-      return duckdb::Value::HUGEINT(std::get<int64_t>(v));  // D-03: narrowed alt → widen via factory
+      return duckdb::Value::HUGEINT(
+        std::get<int64_t>(v));  // D-03: narrowed alt → widen via factory
     case type_id::UTINYINT: return duckdb::Value::UTINYINT(std::get<uint8_t>(v));
     case type_id::USMALLINT: return duckdb::Value::USMALLINT(std::get<uint16_t>(v));
     case type_id::UINTEGER: return duckdb::Value::UINTEGER(std::get<uint32_t>(v));
@@ -113,8 +114,7 @@ duckdb::Value to_duckdb(const value& v, const logical_type& type)
     case type_id::UHUGEINT: return duckdb::Value::UHUGEINT(std::get<uint64_t>(v));
     case type_id::FLOAT: return duckdb::Value::FLOAT(std::get<float>(v));
     case type_id::DOUBLE: return duckdb::Value::DOUBLE(std::get<double>(v));
-    case type_id::DATE:
-      return duckdb::Value::DATE(duckdb::date_t{std::get<date_value>(v).days});
+    case type_id::DATE: return duckdb::Value::DATE(duckdb::date_t{std::get<date_value>(v).days});
     case type_id::TIMESTAMP_SEC:
       return duckdb::Value::TIMESTAMPSEC(
         duckdb::timestamp_sec_t{std::get<timestamp_sec_value>(v).value});
@@ -122,8 +122,7 @@ duckdb::Value to_duckdb(const value& v, const logical_type& type)
       return duckdb::Value::TIMESTAMPMS(
         duckdb::timestamp_ms_t{std::get<timestamp_ms_value>(v).value});
     case type_id::TIMESTAMP:
-      return duckdb::Value::TIMESTAMP(
-        duckdb::timestamp_t{std::get<timestamp_us_value>(v).value});
+      return duckdb::Value::TIMESTAMP(duckdb::timestamp_t{std::get<timestamp_us_value>(v).value});
     case type_id::TIMESTAMP_NS:
       return duckdb::Value::TIMESTAMPNS(
         duckdb::timestamp_ns_t{std::get<timestamp_ns_value>(v).value});

--- a/src/include/expression/ast/constant.hpp
+++ b/src/include/expression/ast/constant.hpp
@@ -16,21 +16,23 @@
 
 #pragma once
 
-namespace sirius::ast {
+// sirius
+#include "expression/value.hpp"     // sirius::value
+#include "helper/logical_type.hpp"  // sirius::logical_type
 
-namespace detail {
-/// Placeholder carrier for the constant payload.
-/// Phase 2 replaces this with sirius::value.
-struct value_placeholder {};
-}  // namespace detail
+namespace sirius::ast {
 
 /**
  * @brief Sirius-native mirror of duckdb::BoundConstantExpression.
  *
- * Carries a literal value. The payload is a placeholder until Phase 2.
+ * Carries a typed literal. `payload` is the typed sum-type holding the
+ * SQL value; `return_type` carries DECIMAL precision (D-06) and the SQL
+ * type of typed NULLs (D-05). Mirrors the shape of cast::target_type
+ * and function_call::return_type.
  */
 struct constant {
-  detail::value_placeholder payload{};
+  sirius::value payload;
+  sirius::logical_type return_type;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/value.hpp
+++ b/src/include/expression/value.hpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
+// standard library
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace duckdb {
+class Value;
+}  // namespace duckdb
+
+namespace sirius {
+
+/**
+ * @brief Carrier for a typed SQL NULL literal.
+ *
+ * Empty by design — the SQL type of a NULL is recovered from the
+ * sibling sirius::logical_type that travels with the value (see
+ * sirius::ast::constant::return_type, D-05/D-10).
+ */
+struct null_value {};
+
+/**
+ * @brief Carrier for a SQL DATE literal (32-bit days from epoch).
+ *
+ * Wrapped in a named struct so std::visit dispatches DATE separately
+ * from int32_t (INTEGER). Mirrors duckdb::date_t.days.
+ */
+struct date_value {
+  int32_t days{};
+};
+
+/**
+ * @brief Carrier for a SQL TIMESTAMP literal in seconds resolution.
+ *
+ * 64-bit signed seconds from epoch. Mirrors duckdb::timestamp_sec_t.value.
+ */
+struct timestamp_sec_value {
+  int64_t value{};
+};
+
+/**
+ * @brief Carrier for a SQL TIMESTAMP literal in milliseconds resolution.
+ *
+ * 64-bit signed milliseconds from epoch. Mirrors duckdb::timestamp_ms_t.value.
+ */
+struct timestamp_ms_value {
+  int64_t value{};
+};
+
+/**
+ * @brief Carrier for a SQL TIMESTAMP literal in microseconds resolution
+ *        (the SQL default TIMESTAMP precision).
+ *
+ * 64-bit signed microseconds from epoch. Mirrors duckdb::timestamp_tz_t.value
+ * (the accessor used by gpu_execute_constant.cpp:140 for microsecond TIMESTAMP).
+ */
+struct timestamp_us_value {
+  int64_t value{};
+};
+
+/**
+ * @brief Carrier for a SQL TIMESTAMP literal in nanoseconds resolution.
+ *
+ * 64-bit signed nanoseconds from epoch. Mirrors duckdb::timestamp_ns_t.value.
+ */
+struct timestamp_ns_value {
+  int64_t value{};
+};
+
+/**
+ * @brief Carrier for a fixed-point DECIMAL literal whose unscaled value
+ *        fits in int32_t (precision <= 9).
+ *
+ * Precision lives in the sibling sirius::logical_type (D-06). cuDF expects
+ * a *negative* scale (numeric::scale_type{-scale}); the negation happens at
+ * the cuDF boundary in Phase 5, NOT in this struct.
+ */
+struct decimal32 {
+  int32_t value{};
+  uint8_t scale{};
+};
+
+/**
+ * @brief Carrier for a fixed-point DECIMAL literal whose unscaled value
+ *        fits in int64_t (precision 10..18).
+ */
+struct decimal64 {
+  int64_t value{};
+  uint8_t scale{};
+};
+
+/**
+ * @brief Carrier for a fixed-point DECIMAL literal whose unscaled value
+ *        requires __int128_t (precision 19..38).
+ */
+struct decimal128 {
+  __int128_t value{};
+  uint8_t scale{};
+};
+
+/**
+ * @brief Sum type over every supported SQL literal kind.
+ *
+ * The alternative order is part of the public ABI — std::variant indexes
+ * by position and Phase 5's std::visit dispatch will depend on this
+ * ordering. NULL is alternative 0 so value{} default-constructs to NULL.
+ *
+ * HUGEINT and UHUGEINT do not have distinct alternatives; they reuse
+ * int64_t and uint64_t respectively (D-03 narrowing — matches the
+ * executor's current cuDF mapping).
+ */
+using value = std::variant<null_value,
+                           bool,
+                           int8_t,
+                           int16_t,
+                           int32_t,
+                           int64_t,  // BIGINT and HUGEINT (D-03)
+                           uint8_t,
+                           uint16_t,
+                           uint32_t,
+                           uint64_t,  // UBIGINT and UHUGEINT (D-03)
+                           float,
+                           double,
+                           date_value,
+                           timestamp_sec_value,
+                           timestamp_ms_value,
+                           timestamp_us_value,
+                           timestamp_ns_value,
+                           decimal32,
+                           decimal64,
+                           decimal128,
+                           std::string>;
+
+/**
+ * @brief Convert a duckdb::Value to a sirius::value.
+ *
+ * The supplied logical_type drives DECIMAL precision recovery (D-06)
+ * and typed-NULL fidelity (D-05). For HUGEINT / UHUGEINT, the value is
+ * narrowed to int64_t / uint64_t (D-03) — same narrowing the executor
+ * performs today via duckdb::GetCudfType.
+ *
+ * @throws sirius::not_implemented_exception if the type is unsupported.
+ */
+value from_duckdb(const duckdb::Value& v, const logical_type& type);
+
+/**
+ * @brief Convert a sirius::value back to a duckdb::Value.
+ *
+ * The supplied logical_type drives DECIMAL precision width selection
+ * (Value::DECIMAL(int16_t,...) vs int32 vs int64 vs hugeint_t) and
+ * recovers the SQL type of typed NULLs (D-05).
+ *
+ * @throws sirius::not_implemented_exception if the type is unsupported.
+ */
+duckdb::Value to_duckdb(const value& v, const logical_type& type);
+
+}  // namespace sirius

--- a/test/cpp/expression/test_value.cpp
+++ b/test/cpp/expression/test_value.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for sirius::value — the typed-payload variant + DuckDB boundary mappers.
+//
+// Round-trips every supported sirius::type_id through from_duckdb / to_duckdb,
+// verifies typed-NULL fidelity (D-05), DECIMAL across all three width classes
+// (D-02 / D-06), HUGEINT narrowing (D-03), and the unsupported-type throw
+// path (D-07).
+
+#include "catch.hpp"
+#include "expression/value.hpp"
+#include "helper/logical_type.hpp"
+#include "sirius/exception.hpp"
+
+#include <duckdb/common/types/value.hpp>
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+using sirius::date_value;
+using sirius::decimal128;
+using sirius::decimal32;
+using sirius::decimal64;
+using sirius::logical_type;
+using sirius::not_implemented_exception;
+using sirius::null_value;
+using sirius::timestamp_ms_value;
+using sirius::timestamp_ns_value;
+using sirius::timestamp_sec_value;
+using sirius::timestamp_us_value;
+using sirius::type_id;
+using sirius::value;
+
+// ============================================================================
+// Compile-time invariants
+// ============================================================================
+
+static_assert(std::is_default_constructible_v<value>,
+              "sirius::value must default-construct (NULL is the natural default).");
+static_assert(std::variant_size_v<value> == 21,
+              "sirius::value has exactly 21 alternatives (D-01 — locked ABI).");
+
+// ============================================================================
+// Round-trip every supported type_id (CONTEXT.md test plan item 1)
+// ============================================================================
+
+TEST_CASE("ast_value - BOOLEAN round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::BOOLEAN);
+  auto const dv = duckdb::Value::BOOLEAN(true);
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<bool>(sv));
+  REQUIRE(std::get<bool>(sv) == true);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - TINYINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::TINYINT);
+  auto const dv = duckdb::Value::TINYINT(static_cast<int8_t>(-7));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<int8_t>(sv));
+  REQUIRE(std::get<int8_t>(sv) == -7);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - SMALLINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::SMALLINT);
+  auto const dv = duckdb::Value::SMALLINT(static_cast<int16_t>(-12345));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<int16_t>(sv));
+  REQUIRE(std::get<int16_t>(sv) == -12345);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - INTEGER round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::INTEGER);
+  auto const dv = duckdb::Value::INTEGER(42);
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<int32_t>(sv));
+  REQUIRE(std::get<int32_t>(sv) == 42);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - BIGINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::BIGINT);
+  auto const dv = duckdb::Value::BIGINT(static_cast<int64_t>(9'000'000'000));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<int64_t>(sv));
+  REQUIRE(std::get<int64_t>(sv) == 9'000'000'000);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - HUGEINT narrows to int64_t (D-03) and round-trips", "[ast_value]")
+{
+  // Use a value that fits cleanly in int64 so the narrowing is lossless.
+  // Out-of-int64-range HUGEINT values are a Phase 5 concern.
+  auto const t  = logical_type::make(type_id::HUGEINT);
+  auto const dv = duckdb::Value::HUGEINT(duckdb::hugeint_t{0, 12345});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<int64_t>(sv));
+  REQUIRE(std::get<int64_t>(sv) == 12345);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - UTINYINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::UTINYINT);
+  auto const dv = duckdb::Value::UTINYINT(static_cast<uint8_t>(255));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<uint8_t>(sv));
+  REQUIRE(std::get<uint8_t>(sv) == 255);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - USMALLINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::USMALLINT);
+  auto const dv = duckdb::Value::USMALLINT(static_cast<uint16_t>(60000));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<uint16_t>(sv));
+  REQUIRE(std::get<uint16_t>(sv) == 60000);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - UINTEGER round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::UINTEGER);
+  auto const dv = duckdb::Value::UINTEGER(static_cast<uint32_t>(4'000'000'000));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<uint32_t>(sv));
+  REQUIRE(std::get<uint32_t>(sv) == 4'000'000'000);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - UBIGINT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::UBIGINT);
+  auto const dv = duckdb::Value::UBIGINT(static_cast<uint64_t>(18'000'000'000ULL));
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<uint64_t>(sv));
+  REQUIRE(std::get<uint64_t>(sv) == 18'000'000'000ULL);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - UHUGEINT narrows to uint64_t (D-03) and round-trips", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::UHUGEINT);
+  auto const dv = duckdb::Value::UHUGEINT(duckdb::uhugeint_t{0, 67890});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<uint64_t>(sv));
+  REQUIRE(std::get<uint64_t>(sv) == 67890);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - FLOAT round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::FLOAT);
+  auto const dv = duckdb::Value::FLOAT(3.14f);
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<float>(sv));
+  REQUIRE(std::get<float>(sv) == 3.14f);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - DOUBLE round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::DOUBLE);
+  auto const dv = duckdb::Value::DOUBLE(1.5);
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<double>(sv));
+  REQUIRE(std::get<double>(sv) == 1.5);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - DATE round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::DATE);
+  auto const dv = duckdb::Value::DATE(duckdb::date_t{19000});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<date_value>(sv));
+  REQUIRE(std::get<date_value>(sv).days == 19000);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - TIMESTAMP_SEC round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::TIMESTAMP_SEC);
+  auto const dv = duckdb::Value::TIMESTAMPSEC(duckdb::timestamp_sec_t{1700000000});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<timestamp_sec_value>(sv));
+  REQUIRE(std::get<timestamp_sec_value>(sv).value == 1700000000);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - TIMESTAMP_MS round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::TIMESTAMP_MS);
+  auto const dv = duckdb::Value::TIMESTAMPMS(duckdb::timestamp_ms_t{1700000000123});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<timestamp_ms_value>(sv));
+  REQUIRE(std::get<timestamp_ms_value>(sv).value == 1700000000123);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - TIMESTAMP (microsecond) round-trips through from_duckdb / to_duckdb",
+          "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::TIMESTAMP);
+  auto const dv = duckdb::Value::TIMESTAMP(duckdb::timestamp_t{1700000000123456});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<timestamp_us_value>(sv));
+  REQUIRE(std::get<timestamp_us_value>(sv).value == 1700000000123456);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - TIMESTAMP_NS round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::TIMESTAMP_NS);
+  auto const dv = duckdb::Value::TIMESTAMPNS(duckdb::timestamp_ns_t{1700000000123456789});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<timestamp_ns_value>(sv));
+  REQUIRE(std::get<timestamp_ns_value>(sv).value == 1700000000123456789);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - VARCHAR round-trips through from_duckdb / to_duckdb", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::VARCHAR);
+  auto const dv = duckdb::Value("hello");
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<std::string>(sv));
+  REQUIRE(std::get<std::string>(sv) == "hello");
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - DECIMAL(4,2) maps to decimal32 (precision <= 4 width class)", "[ast_value]")
+{
+  // precision <= 4 → DuckDB int16 storage; sirius alt is decimal32.
+  auto const t  = logical_type::make_decimal(4, 2);
+  auto const dv = duckdb::Value::DECIMAL(static_cast<int16_t>(1234), uint8_t{4}, uint8_t{2});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<decimal32>(sv));
+  REQUIRE(std::get<decimal32>(sv).value == 1234);
+  REQUIRE(std::get<decimal32>(sv).scale == 2);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - DECIMAL(18,4) maps to decimal64 (precision 10..18 width class)",
+          "[ast_value]")
+{
+  auto const t  = logical_type::make_decimal(18, 4);
+  auto const dv = duckdb::Value::DECIMAL(int64_t{1234567890}, uint8_t{18}, uint8_t{4});
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<decimal64>(sv));
+  REQUIRE(std::get<decimal64>(sv).value == 1234567890);
+  REQUIRE(std::get<decimal64>(sv).scale == 4);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+TEST_CASE("ast_value - DECIMAL(38,10) maps to decimal128 (precision 19..38 width class)",
+          "[ast_value]")
+{
+  auto const t          = logical_type::make_decimal(38, 10);
+  auto const hi_in      = duckdb::hugeint_t{0, 1'000'000'000'000ULL};
+  auto const dv         = duckdb::Value::DECIMAL(hi_in, uint8_t{38}, uint8_t{10});
+  auto const sv         = sirius::from_duckdb(dv, t);
+  auto const expected128 = static_cast<__int128_t>(1'000'000'000'000LL);
+  REQUIRE(std::holds_alternative<decimal128>(sv));
+  REQUIRE(std::get<decimal128>(sv).value == expected128);
+  REQUIRE(std::get<decimal128>(sv).scale == 10);
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back == dv);
+}
+
+// ============================================================================
+// Typed NULL fidelity (D-05; CONTEXT.md test plan item 2)
+// ============================================================================
+
+TEST_CASE("ast_value - typed NULL round-trips for INTEGER", "[ast_value]")
+{
+  auto const t = logical_type::make(type_id::INTEGER);
+  // duckdb::Value(LogicalType) constructs a typed NULL.
+  auto const dv = duckdb::Value(duckdb::LogicalType::INTEGER);
+  REQUIRE(dv.IsNull());
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<null_value>(sv));
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back.IsNull());
+  REQUIRE(back.type() == duckdb::LogicalType::INTEGER);
+}
+
+TEST_CASE("ast_value - typed NULL round-trips for DECIMAL(10,2)", "[ast_value]")
+{
+  auto const t  = logical_type::make_decimal(10, 2);
+  auto const dv = duckdb::Value(duckdb::LogicalType::DECIMAL(10, 2));
+  REQUIRE(dv.IsNull());
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<null_value>(sv));
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back.IsNull());
+  REQUIRE(duckdb::DecimalType::GetWidth(back.type()) == 10);
+  REQUIRE(duckdb::DecimalType::GetScale(back.type()) == 2);
+}
+
+TEST_CASE("ast_value - typed NULL round-trips for VARCHAR", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::VARCHAR);
+  auto const dv = duckdb::Value(duckdb::LogicalType::VARCHAR);
+  REQUIRE(dv.IsNull());
+  auto const sv = sirius::from_duckdb(dv, t);
+  REQUIRE(std::holds_alternative<null_value>(sv));
+  auto const back = sirius::to_duckdb(sv, t);
+  REQUIRE(back.IsNull());
+  REQUIRE(back.type() == duckdb::LogicalType::VARCHAR);
+}
+
+// ============================================================================
+// Unsupported types throw (D-07; CONTEXT.md test plan item 4)
+// ============================================================================
+
+TEST_CASE("ast_value - from_duckdb throws on unsupported logical_type", "[ast_value]")
+{
+  // INTERVAL has no sirius::type_id — type_id::INVALID is used as the carrier
+  // for "unsupported by Sirius". The supplied logical_type drives the throw,
+  // independent of the duckdb::Value's own type.
+  auto const t  = logical_type::make(type_id::INVALID);
+  auto const dv = duckdb::Value::INTERVAL(0, 0, 1);  // 1-microsecond interval — non-NULL
+  REQUIRE_THROWS_AS(sirius::from_duckdb(dv, t), not_implemented_exception);
+}
+
+TEST_CASE("ast_value - to_duckdb throws on unsupported logical_type", "[ast_value]")
+{
+  auto const t  = logical_type::make(type_id::INVALID);
+  auto const sv = value{int32_t{0}};  // any non-null payload — the throw is type-driven
+  REQUIRE_THROWS_AS(sirius::to_duckdb(sv, t), not_implemented_exception);
+}

--- a/test/cpp/expression/test_value.cpp
+++ b/test/cpp/expression/test_value.cpp
@@ -301,10 +301,10 @@ TEST_CASE("ast_value - DECIMAL(18,4) maps to decimal64 (precision 10..18 width c
 TEST_CASE("ast_value - DECIMAL(38,10) maps to decimal128 (precision 19..38 width class)",
           "[ast_value]")
 {
-  auto const t          = logical_type::make_decimal(38, 10);
-  auto const hi_in      = duckdb::hugeint_t{0, 1'000'000'000'000ULL};
-  auto const dv         = duckdb::Value::DECIMAL(hi_in, uint8_t{38}, uint8_t{10});
-  auto const sv         = sirius::from_duckdb(dv, t);
+  auto const t           = logical_type::make_decimal(38, 10);
+  auto const hi_in       = duckdb::hugeint_t{0, 1'000'000'000'000ULL};
+  auto const dv          = duckdb::Value::DECIMAL(hi_in, uint8_t{38}, uint8_t{10});
+  auto const sv          = sirius::from_duckdb(dv, t);
   auto const expected128 = static_cast<__int128_t>(1'000'000'000'000LL);
   REQUIRE(std::holds_alternative<decimal128>(sv));
   REQUIRE(std::get<decimal128>(sv).value == expected128);


### PR DESCRIPTION
Closes [#695](https://github.com/sirius-db/sirius/issues/695). Phase 2 of the 11-phase Sirius expression-framework rework tracked in [#666](https://github.com/sirius-db/sirius/issues/666).

**Stacked on [#707](https://github.com/sirius-db/sirius/pull/707) (Phase 1 — sirius_ast_scaffold).** Until that merges, the Files Changed view will include both PRs' changes; once #707 merges, GitHub auto-rebases this PR to show only Phase 2's diff.

## What this lands

- `src/include/expression/value.hpp` — `sirius::value` 21-alternative variant alias + 11 named alternative structs (null_value, date_value, four timestamp_*_value, decimal32/64/128) + `from_duckdb` / `to_duckdb` decls. DuckDB-include-free; uses `namespace duckdb { class Value; }` forward declaration only.
- `src/expression/value.cpp` — bidirectional mappers in the single new TU added by this phase that includes `<duckdb/common/types/value.hpp>`. Mirrors `gpu_execute_constant.cpp`'s canonical accessor patterns. Typed-NULL fidelity (D-05), HUGEINT/UHUGEINT narrowing to int64_t/uint64_t (D-03), DECIMAL precision-band selection across decimal32/64/128 (D-02/D-06), UB-safe DECIMAL128 unpack/repack.
- `test/cpp/expression/test_value.cpp` — 27 Catch2 cases tagged `[ast_value]`. Compile-time `std::variant_size_v<value> == 21` static_assert pins the locked ABI. Round-trip per supported `type_id` + 3 typed-NULL cases (INTEGER, DECIMAL(10,2), VARCHAR) + 2 unsupported-type throw cases.
- `src/include/expression/ast/constant.hpp` — `detail::value_placeholder` swapped for `sirius::value payload` + `sirius::logical_type return_type`. Phase 1's `[ast_scaffold]` test is byte-unchanged and still passes (regression gate green).
- `CMakeLists.txt` — two single-line additions: `value.cpp` in EXTENSION_SOURCES, `test_value.cpp` in TEST_SOURCES; both `# cmake-format: off`/`on` fence pairs preserved.

## Atomicity

4 commits, each individually revertable:

1. `feat(02-01): add sirius::value variant and DuckDB boundary fn decls`
2. `feat(02-01): add sirius::from_duckdb / to_duckdb mappers and register value.cpp`
3. `test(02-01): add round-trip + typed-NULL + DECIMAL + throw tests for sirius::value`
4. `feat(02-01): swap detail::value_placeholder for sirius::value in ast::constant`

## Test plan

- [x] \`CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc) make\` — clean build, no warnings (clang-tidy WarningsAsErrors honored)
- [x] \`build/release/extension/sirius/test/cpp/sirius_unittest "[ast_value]"\` — 27/27 pass
- [x] \`build/release/extension/sirius/test/cpp/sirius_unittest "[ast_scaffold]"\` — Phase 1 regression gate green
- [x] \`build/release/extension/sirius/test/cpp/sirius_unittest\` — full pre-existing suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)