### PR TITLE
Deduplicate special-cased `get_next_ports_after_sink`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
     test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
     test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
+    test/cpp/pipeline/test_get_next_ports_after_sink.cpp
     test/cpp/pipeline/test_plan_printer.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/test_column_builder.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -25,7 +25,6 @@
 #include "op/sirius_physical_delim_join.hpp"
 #include "op/sirius_physical_duckdb_scan.hpp"
 #include "op/sirius_physical_iceberg_scan.hpp"
-#include "op/sirius_physical_parquet_scan.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
 #include "planner/query.hpp"
@@ -245,39 +244,12 @@ void task_creator::manager_loop()
         // Get what we need to create the task
         auto pipeline = node->get_pipeline();
         std::vector<cucascade::shared_data_repository*> destination_data_repositories;
-        // special handling for delim joins
-        if (pipeline->get_sink()->type ==
-            ::sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-          auto& delim_join    = pipeline->get_sink()->Cast<op::sirius_physical_right_delim_join>();
-          auto partition_join = delim_join.partition_join;
-          auto distinct_op    = delim_join.distinct.get();
-          for (auto& next_port : partition_join->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
-          }
-          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
-          }
-        } else if (pipeline->get_sink()->type ==
-                   ::sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-          auto& delim_join      = pipeline->get_sink()->Cast<op::sirius_physical_left_delim_join>();
-          auto distinct_op      = delim_join.distinct.get();
-          auto column_data_scan = delim_join.column_data_scan;
-          for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
-          }
-          for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
-          }
-        } else {
-          for (auto& next_port : pipeline->get_sink()->get_next_port_after_sink()) {
-            destination_data_repositories.push_back(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo);
-          }
+
+        for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+          destination_data_repositories.push_back(
+            port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
         }
+
         // scheduling scan task
         if (node->type == ::sirius::op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
           // Check to see if you need to create a new global s for this scan operator

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -20,10 +20,8 @@
 #include "exec/bounded_thread_pool.hpp"
 #include "exec/config.hpp"
 #include "exec/interruptible_mpmc.hpp"
-#include "helper/helper.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "op/sirius_physical_operator.hpp"
-#include "parallel/task_executor.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
 #include <blockingconcurrentqueue.h>
@@ -31,13 +29,10 @@
 #include <cucascade/data/data_repository.hpp>
 
 #include <atomic>
-#include <condition_variable>
-#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <variant>
 
 namespace sirius::pipeline {
 class task_scheduler;

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -45,8 +45,7 @@ class cpu_source_task_global_state : public pipeline::sirius_pipeline_task_globa
   std::vector<sirius_physical_operator*> get_output_consumers() const noexcept
   {
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = _op.get_next_ports_after_sink();
-    for (auto& next_port : ports) {
+    for (const auto& next_port : _op.get_next_ports_after_sink()) {
       output_consumers.push_back(next_port.next_operator);
     }
     return output_consumers;

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -45,7 +45,7 @@ class cpu_source_task_global_state : public pipeline::sirius_pipeline_task_globa
   std::vector<sirius_physical_operator*> get_output_consumers() const noexcept
   {
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = _op.get_next_port_after_sink();
+    auto ports = _op.get_next_ports_after_sink();
     for (auto& next_port : ports) {
       output_consumers.push_back(next_port.next_operator);
     }

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -132,7 +132,7 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
   std::vector<sirius_physical_operator*> get_output_consumers() const noexcept
   {
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = _op.get_next_port_after_sink();
+    auto ports = _op.get_next_ports_after_sink();
     for (auto& next_port : ports) {
       output_consumers.push_back(next_port.next_operator);
     }

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -132,8 +132,7 @@ class duckdb_scan_task_global_state : public pipeline::sirius_pipeline_task_glob
   std::vector<sirius_physical_operator*> get_output_consumers() const noexcept
   {
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = _op.get_next_ports_after_sink();
-    for (auto& next_port : ports) {
+    for (const auto& next_port : _op.get_next_ports_after_sink()) {
       output_consumers.push_back(next_port.next_operator);
     }
     return output_consumers;

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -663,8 +663,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
   {
     auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = g_state.get_operator().get_next_ports_after_sink();
-    for (auto& next_port : ports) {
+    for (const auto& next_port : g_state.get_operator().get_next_ports_after_sink()) {
       output_consumers.push_back(next_port.next_operator);
     }
     return output_consumers;

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -663,7 +663,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
   {
     auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
     std::vector<sirius_physical_operator*> output_consumers;
-    auto ports = g_state.get_operator().get_next_port_after_sink();
+    auto ports = g_state.get_operator().get_next_ports_after_sink();
     for (auto& next_port : ports) {
       output_consumers.push_back(next_port.next_operator);
     }

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -16,12 +16,7 @@
 
 #pragma once
 
-#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/common.hpp"
-#include "duckdb/common/enums/operator_result_type.hpp"
-#include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/optimizer/join_order/join_node.hpp"
 #include "helper/logical_type.hpp"
 #include "helper/types.hpp"
 #include "op/sirius_physical_operator_type.hpp"
@@ -377,7 +372,7 @@ class sirius_physical_operator {
   //! Add a next port after sink
   void add_next_port_after_sink(next_port_info port_info);
   //! Get the next ports after sink
-  std::vector<sirius_physical_operator::next_port_info>& get_next_port_after_sink();
+  const std::vector<sirius_physical_operator::next_port_info>& get_next_ports_after_sink() const;
 
   //! Get the next task hint
   virtual std::optional<task_creation_hint> get_next_task_hint();

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -16,18 +16,17 @@
 
 #pragma once
 
-#include "duckdb/common/atomic.hpp"
-#include "duckdb/common/set.hpp"
-#include "duckdb/common/unordered_set.hpp"
-#include "duckdb/function/table_function.hpp"
-#include "duckdb/parallel/task_scheduler.hpp"
-#include "op/sirius_physical_operator.hpp"
-// #include "duckdb/parallel/executor_task.hpp"
 #include "common/optional_ptr.hpp"
 #include "common/reference_map.hpp"
-#include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+#include "op/sirius_physical_delim_join.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_operator_type.hpp"
 
 #include <nvtx3/nvtx3.hpp>
+
+#include <ranges>
+
 namespace sirius {
 
 class sirius_engine;
@@ -126,6 +125,29 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   sirius::optional_ptr<op::sirius_physical_operator> get_source() { return source; }
 
   sirius::optional_ptr<op::sirius_physical_operator> get_source() const noexcept { return source; }
+
+  // Returns an iterable view over next_port_infos, representing the next ports of the sink operator
+  // in the pipeline, handling special-cased composite operators like left and right delim joins.
+  // Returns an empty view if the pipeline sink is not present.
+  [[nodiscard]] auto get_next_ports_after_sink() const noexcept
+  {
+    using span_over_ports = std::span<const op::sirius_physical_operator::next_port_info>;
+    span_over_ports part_1{}, part_2{};
+    if (sink) {
+      if (sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+        auto& right_delim_join = sink->Cast<op::sirius_physical_right_delim_join>();
+        part_1 = span_over_ports{right_delim_join.partition_join->get_next_ports_after_sink()};
+        part_2 = span_over_ports{right_delim_join.distinct->get_next_ports_after_sink()};
+      } else if (sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
+        auto& left_delim_join = sink->Cast<op::sirius_physical_left_delim_join>();
+        part_1 = span_over_ports{left_delim_join.column_data_scan->get_next_ports_after_sink()};
+        part_2 = span_over_ports{left_delim_join.distinct->get_next_ports_after_sink()};
+      } else {
+        part_1 = span_over_ports{sink->get_next_ports_after_sink()};
+      }
+    }
+    return std::views::join(std::array{part_1, part_2});
+  }
 
   //! Set the pipeline ID
   void set_pipeline_id(size_t id) { pipeline_id = id; }

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -25,7 +25,9 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <array>
 #include <ranges>
+#include <span>
 
 namespace sirius {
 

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -17,7 +17,6 @@
 #include "op/sirius_physical_operator.hpp"
 
 #include "log/logging.hpp"
-#include "memory/sirius_memory_reservation_manager.hpp"
 #include "pipeline/batch_lock_utils.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
@@ -216,8 +215,8 @@ void sirius_physical_operator::add_next_port_after_sink(next_port_info port_info
   next_port_after_sink.push_back(port_info);
 }
 
-std::vector<sirius_physical_operator::next_port_info>&
-sirius_physical_operator::get_next_port_after_sink()
+const std::vector<sirius_physical_operator::next_port_info>&
+sirius_physical_operator::get_next_ports_after_sink() const
 {
   return next_port_after_sink;
 }

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -290,7 +290,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
           hash_join.is_build_probe_mode()) {
         // Either sibling may run this block first; configure the build-side CONCAT only.
         auto enable_build_concat_all = [](sirius_physical_operator& part_op) {
-          for (auto& next_port : part_op.get_next_port_after_sink()) {
+          for (auto& next_port : part_op.get_next_ports_after_sink()) {
             if (next_port.next_operator->type != SiriusPhysicalOperatorType::CONCAT) { continue; }
             auto& concat = next_port.next_operator->Cast<sirius_physical_concat>();
             if (concat.is_build_concat()) { concat.set_concat_all(true); }

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -116,10 +116,9 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
     if (should_schedule) {
       duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipeline_inside;
       to_schedule[to_schedule.size() - 1 - meta]->get_pipelines(pipeline_inside, false);
-      for (auto& pipeline_idx : pipeline_inside) {
-        auto& pipeline = pipeline_idx;
-        if (pipeline_idx->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
-          auto& temp = pipeline_idx->source.get()->Cast<op::sirius_physical_hash_join>();
+      for (auto& pipeline : pipeline_inside) {
+        if (pipeline->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
+          auto& temp = pipeline->source.get()->Cast<op::sirius_physical_hash_join>();
           if (temp.join_type == duckdb::JoinType::RIGHT ||
               temp.join_type == duckdb::JoinType::RIGHT_SEMI ||
               temp.join_type == duckdb::JoinType::RIGHT_ANTI) {
@@ -1242,11 +1241,10 @@ void sirius_pipeline_converter::log_pipeline_debug_info() const
                       port_id.data());
 
       // Print the port details if it exists
-      if (auto* port = next_op->get_port(port_id)) {
-        SIRIUS_LOG_INFO("      Port barrier_type={}, repo={}",
-                        static_cast<int>(port->type),
-                        static_cast<void*>(port->repo));
-      }
+      auto* port = next_op->get_port(port_id);
+      SIRIUS_LOG_INFO("      Port barrier_type={}, repo={}",
+                      static_cast<int>(port->type),
+                      static_cast<void*>(port->repo));
     }
 
     SIRIUS_LOG_INFO("");  // Blank line between pipelines

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -17,6 +17,7 @@
 #include "pipeline/sirius_pipeline_converter.hpp"
 
 #include "duckdb/common/multi_file/multi_file_states.hpp"
+#include "duckdb/common/shared_ptr_ipp.hpp"
 #include "log/logging.hpp"
 #include "op/scan/sirius_gpu_parquet_scan_operator.hpp"
 #include "op/scan/sirius_parquet_metadata_scan_operator.hpp"
@@ -25,15 +26,12 @@
 #include "op/sirius_physical_cpu_source.hpp"
 #include "op/sirius_physical_cte.hpp"
 #include "op/sirius_physical_delim_join.hpp"
-#include "op/sirius_physical_duckdb_scan.hpp"
 #include "op/sirius_physical_grouped_aggregate.hpp"
-#include "op/sirius_physical_grouped_aggregate_merge.hpp"
 #include "op/sirius_physical_hash_join.hpp"
-#include "op/sirius_physical_iceberg_scan.hpp"
 #include "op/sirius_physical_merge_sort.hpp"
+#include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "op/sirius_physical_order.hpp"
-#include "op/sirius_physical_parquet_scan.hpp"
 #include "op/sirius_physical_partition.hpp"
 #include "op/sirius_physical_result_collector.hpp"
 #include "op/sirius_physical_sort_partition.hpp"
@@ -41,8 +39,6 @@
 #include "op/sirius_physical_table_scan.hpp"
 #include "op/sirius_physical_top_n.hpp"
 #include "op/sirius_physical_top_n_merge.hpp"
-#include "op/sirius_physical_ungrouped_aggregate.hpp"
-#include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
 #include "sirius_config.hpp"
 #include "sirius_context.hpp"
 #include "sirius_engine.hpp"
@@ -98,23 +94,20 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
     bool should_schedule = true;
 
     // already scheduled
-    if (find(sirius_scheduled.begin(), sirius_scheduled.end(), base_pipeline) !=
-        sirius_scheduled.end()) {
+    if (std::ranges::find(sirius_scheduled, base_pipeline) != sirius_scheduled.end()) {
       should_schedule = false;
     } else {
       // check if all children are scheduled
       for (auto& child : children) {
-        if (find(sirius_scheduled.begin(), sirius_scheduled.end(), child->get_base_pipeline()) ==
+        if (std::ranges::find(sirius_scheduled, child->get_base_pipeline()) ==
             sirius_scheduled.end()) {
           should_schedule = false;
           break;
         }
       }
       // check if all dependencies are scheduled
-      for (int dep = 0; dep < base_pipeline->dependencies.size(); dep++) {
-        if (find(sirius_scheduled.begin(),
-                 sirius_scheduled.end(),
-                 base_pipeline->dependencies[dep]) == sirius_scheduled.end()) {
+      for (const auto& dependency : base_pipeline->dependencies) {
+        if (std::ranges::find(sirius_scheduled, dependency) == sirius_scheduled.end()) {
           should_schedule = false;
           break;
         }
@@ -123,12 +116,10 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
     if (should_schedule) {
       duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> pipeline_inside;
       to_schedule[to_schedule.size() - 1 - meta]->get_pipelines(pipeline_inside, false);
-      for (int pipeline_idx = 0; pipeline_idx < pipeline_inside.size(); pipeline_idx++) {
-        auto& pipeline = pipeline_inside[pipeline_idx];
-        if (pipeline_inside[pipeline_idx]->source->type ==
-            op::SiriusPhysicalOperatorType::HASH_JOIN) {
-          auto& temp =
-            pipeline_inside[pipeline_idx]->source.get()->Cast<op::sirius_physical_hash_join>();
+      for (auto& pipeline_idx : pipeline_inside) {
+        auto& pipeline = pipeline_idx;
+        if (pipeline_idx->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
+          auto& temp = pipeline_idx->source.get()->Cast<op::sirius_physical_hash_join>();
           if (temp.join_type == duckdb::JoinType::RIGHT ||
               temp.join_type == duckdb::JoinType::RIGHT_SEMI ||
               temp.join_type == duckdb::JoinType::RIGHT_ANTI) {
@@ -146,16 +137,16 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
 
   // perform deep copy on scheduled pipelines
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> copied_scheduled;
-  for (size_t i = 0; i < sirius_scheduled.size(); i++) {
+  for (const auto& pipeline : sirius_scheduled) {
     auto copied_pipeline = duckdb::make_shared_ptr<sirius_pipeline>(engine_);
     // copy source
-    copied_pipeline->source = sirius_scheduled[i]->source;
+    copied_pipeline->source = pipeline->source;
     // copy operators
-    for (size_t j = 0; j < sirius_scheduled[i]->operators.size(); j++) {
-      copied_pipeline->operators.push_back(sirius_scheduled[i]->operators[j]);
+    for (size_t j = 0; j < pipeline->operators.size(); j++) {
+      copied_pipeline->operators.push_back(pipeline->operators[j]);
     }
     // copy sink
-    copied_pipeline->sink = sirius_scheduled[i]->sink;
+    copied_pipeline->sink = pipeline->sink;
     copied_scheduled.push_back(copied_pipeline);
   }
 
@@ -367,7 +358,7 @@ void sirius_pipeline_converter::split_intermediate_joins(
       pipeline_breakers_.push_back(std::move(partition_op));
     }
 
-    op::sirius_physical_partition* partition_ptr =
+    auto* partition_ptr =
       static_cast<op::sirius_physical_partition*>(pipeline_breakers_.back().get());
 
     if (join_pos > 0) {
@@ -414,8 +405,7 @@ void sirius_pipeline_converter::split_intermediate_joins(
     concat_pipeline->sink   = concat_op.get();
 
     pipeline_breakers_.push_back(std::move(concat_op));
-    op::sirius_physical_concat* concat_ptr =
-      static_cast<op::sirius_physical_concat*>(pipeline_breakers_.back().get());
+    auto* concat_ptr = static_cast<op::sirius_physical_concat*>(pipeline_breakers_.back().get());
 
     scheduled_.push_back(concat_pipeline);
 
@@ -473,8 +463,7 @@ void sirius_pipeline_converter::split_join_sink(
       op_params_.hash_partition_bytes);
   }
 
-  op::sirius_physical_partition* partition_ptr =
-    static_cast<op::sirius_physical_partition*>(partition_op.get());
+  auto* partition_ptr = static_cast<op::sirius_physical_partition*>(partition_op.get());
 
   if (current_pipeline->operators.size() > 0) {
     // Last op before HASH_JOIN becomes the sink
@@ -527,7 +516,7 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
                                                op_params_.hash_partition_bytes);
     pipeline_breakers_.push_back(std::move(partition_op));
 
-    op::sirius_physical_partition* partition_ptr =
+    auto* partition_ptr =
       static_cast<op::sirius_physical_partition*>(pipeline_breakers_.back().get());
 
     // Keep GROUP_BY as the sink (don't move it to operators)
@@ -744,7 +733,7 @@ void sirius_pipeline_converter::split_delim_join_sink(
                                              distinct_op.get(),
                                              false,
                                              op_params_.hash_partition_bytes);
-  op::sirius_physical_partition* partition_distinct_ptr =
+  auto* partition_distinct_ptr =
     static_cast<op::sirius_physical_partition*>(partition_distinct.get());
 
   // The pipeline that contains the delim join as sink
@@ -872,26 +861,26 @@ void sirius_pipeline_converter::wire_data_repositories()
   }
 
   // add data repositories and ports
-  for (size_t i = 0; i < scheduled_.size(); i++) {
-    if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_GROUP_BY ||
-        scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT ||
-        scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_TOP_N ||
-        scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_AGGREGATE) {
-      auto sink_op             = scheduled_[i]->get_sink().get();
+  for (auto& pipeline : scheduled_) {
+    if (pipeline->sink->type == op::SiriusPhysicalOperatorType::MERGE_GROUP_BY ||
+        pipeline->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT ||
+        pipeline->sink->type == op::SiriusPhysicalOperatorType::MERGE_TOP_N ||
+        pipeline->sink->type == op::SiriusPhysicalOperatorType::MERGE_AGGREGATE) {
+      auto sink_op             = pipeline->get_sink().get();
       std::string_view port_id = "default";
       for (auto const& dependent_pipeline : source_to_pipelines[sink_op]) {
-        engine_.insert_repository(port_id, scheduled_[i], dependent_pipeline);
+        engine_.insert_repository(port_id, pipeline, dependent_pipeline);
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::CTE) {
-      auto& cte_op             = scheduled_[i]->get_sink()->Cast<op::sirius_physical_cte>();
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::CTE) {
+      auto& cte_op             = pipeline->get_sink()->Cast<op::sirius_physical_cte>();
       std::string_view port_id = "default";
       for (auto cte_scan : cte_op.cte_scans) {
         for (auto const& dependent_pipeline : source_to_pipelines[&cte_scan.get()]) {
-          engine_.insert_repository(port_id, scheduled_[i], dependent_pipeline);
+          engine_.insert_repository(port_id, pipeline, dependent_pipeline);
         }
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-      auto delim_join     = scheduled_[i]->get_sink();
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
+      auto delim_join     = pipeline->get_sink();
       auto& right_delim   = delim_join->Cast<op::sirius_physical_right_delim_join>();
       auto partition_join = right_delim.partition_join;
       auto* distinct_op   = right_delim.distinct.get();
@@ -899,31 +888,31 @@ void sirius_pipeline_converter::wire_data_repositories()
       // Wire partition_join -> CONCAT (partition_join pushes via its own
       // sink/next_port_after_sink)
       for (auto const& dependent_pipeline : source_to_pipelines[partition_join]) {
-        engine_.insert_repository("default", partition_join, scheduled_[i], dependent_pipeline);
+        engine_.insert_repository("default", partition_join, pipeline, dependent_pipeline);
       }
 
       // Wire distinct_op -> partition_distinct (distinct output pushed via distinct's
       // next_port_after_sink)
       for (auto const& dependent_pipeline : source_to_pipelines[distinct_op]) {
-        engine_.insert_repository("default", distinct_op, scheduled_[i], dependent_pipeline);
+        engine_.insert_repository("default", distinct_op, pipeline, dependent_pipeline);
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-      auto delim_join       = scheduled_[i]->get_sink();
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
+      auto delim_join       = pipeline->get_sink();
       auto& left_delim      = delim_join->Cast<op::sirius_physical_left_delim_join>();
       auto* distinct_op     = left_delim.distinct.get();
       auto column_data_scan = left_delim.column_data_scan;
 
       // Wire column_data_scan -> downstream (column_data_scan pushes via its own sink)
       for (auto const& dependent_pipeline : source_to_pipelines[column_data_scan]) {
-        engine_.insert_repository("default", column_data_scan, scheduled_[i], dependent_pipeline);
+        engine_.insert_repository("default", column_data_scan, pipeline, dependent_pipeline);
       }
 
       // Wire distinct_op -> partition_distinct
       for (auto const& dependent_pipeline : source_to_pipelines[distinct_op]) {
-        engine_.insert_repository("default", distinct_op, scheduled_[i], dependent_pipeline);
+        engine_.insert_repository("default", distinct_op, pipeline, dependent_pipeline);
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::CONCAT) {
-      auto& concat             = scheduled_[i]->get_sink()->Cast<op::sirius_physical_concat>();
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::CONCAT) {
+      auto& concat             = pipeline->get_sink()->Cast<op::sirius_physical_concat>();
       std::string_view port_id = concat.is_build_concat() ? "build" : "default";
 
       if (concat.is_build_concat()) {
@@ -932,15 +921,15 @@ void sirius_pipeline_converter::wire_data_repositories()
         // Find the pipeline containing this HASH_JOIN as the first operator.
         op::sirius_physical_operator* hash_join_op = concat.get_parent_op();
         bool found                                 = false;
-        for (size_t j = 0; j < scheduled_.size(); j++) {
+        for (const auto& pipeline_inner_handle : scheduled_) {
           // The join is guaranteed to be the first operator in the pipeline
-          if (scheduled_[j]->operators.size() > 0 &&
-              &scheduled_[j]->operators[0].get() == hash_join_op) {
-            engine_.insert_repository(port_id, scheduled_[i], scheduled_[j]);
+          if (pipeline_inner_handle->operators.size() > 0 &&
+              &pipeline_inner_handle->operators[0].get() == hash_join_op) {
+            engine_.insert_repository(port_id, pipeline, pipeline_inner_handle);
             found = true;
             break;
-          } else if (scheduled_[j]->sink == hash_join_op) {
-            engine_.insert_repository(port_id, scheduled_[i], scheduled_[j]);
+          } else if (pipeline_inner_handle->sink == hash_join_op) {
+            engine_.insert_repository(port_id, pipeline, pipeline_inner_handle);
             found = true;
             break;
           }
@@ -951,17 +940,16 @@ void sirius_pipeline_converter::wire_data_repositories()
         }
       } else {
         // Probe concats have dependent pipelines in source_to_pipelines
-        for (auto const& dependent_pipeline :
-             source_to_pipelines[scheduled_[i]->get_sink().get()]) {
-          engine_.insert_repository(port_id, scheduled_[i], dependent_pipeline);
+        for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
+          engine_.insert_repository(port_id, pipeline, dependent_pipeline);
         }
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::PARTITION ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::TOP_N ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_PARTITION) {
-      for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::PARTITION ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::TOP_N ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::MERGE_SORT ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::SORT_PARTITION) {
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
         // if the source is CONCAT, then use partial barrier type
         if ((dependent_pipeline->get_sink()->type == op::SiriusPhysicalOperatorType::CONCAT &&
              dependent_pipeline->get_operators().size() == 0) ||
@@ -969,18 +957,18 @@ void sirius_pipeline_converter::wire_data_repositories()
              dependent_pipeline->get_operators()[0].get().type ==
                op::SiriusPhysicalOperatorType::CONCAT)) {
           engine_.insert_repository(
-            "default", scheduled_[i], dependent_pipeline, op::MemoryBarrierType::PARTIAL);
+            "default", pipeline, dependent_pipeline, op::MemoryBarrierType::PARTIAL);
           // Full barrier operators — wait for upstream to finish before processing
         } else {
           engine_.insert_repository(
-            "default", scheduled_[i], dependent_pipeline, op::MemoryBarrierType::FULL);
+            "default", pipeline, dependent_pipeline, op::MemoryBarrierType::FULL);
         }
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE) {
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE) {
       // Pipeline barrier — sort operators process batches as they arrive
       // (sort_sample overrides get_next_task_hint to wait for N batches)
-      for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
         auto next_op             = dependent_pipeline->get_operators().size() == 0
                                      ? dependent_pipeline->get_sink().get()
                                      : &dependent_pipeline->get_operators()[0].get();
@@ -992,14 +980,14 @@ void sirius_pipeline_converter::wire_data_repositories()
                           std::make_unique<op::sirius_physical_operator::port>(
                             op::MemoryBarrierType::PIPELINE,
                             data_repo_manager.get_repository(op_id, port_id).get(),
-                            scheduled_[i],
+                            pipeline,
                             dependent_pipeline));
-        scheduled_[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
+        pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::ICEBERG_SCAN ||
-               scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::CPU_SOURCE) {
-      for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::ICEBERG_SCAN ||
+               pipeline->sink->type == op::SiriusPhysicalOperatorType::CPU_SOURCE) {
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
         auto next_op             = dependent_pipeline->get_operators().size() == 0
                                      ? dependent_pipeline->get_sink().get()
                                      : &dependent_pipeline->get_operators()[0].get();
@@ -1011,36 +999,35 @@ void sirius_pipeline_converter::wire_data_repositories()
                           std::make_unique<op::sirius_physical_operator::port>(
                             op::MemoryBarrierType::PIPELINE,
                             data_repo_manager.get_repository(op_id, port_id).get(),
-                            scheduled_[i],
+                            pipeline,
                             dependent_pipeline));
-        scheduled_[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
+        pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
       }
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
       // No action needed for RESULT_COLLECTOR sinks
-    } else if (scheduled_[i]->sink->type == op::SiriusPhysicalOperatorType::PARQUET_METADATA_SCAN) {
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::PARQUET_METADATA_SCAN) {
       // Scheduling and completion-detection port. The metadata handoff itself happens
       // through accumulate_metadata(); no data batches flow through this port (repo is
       // null). setup_pipeline_parents() walks metadata_scan's next_port_after_sink list
       // and reads this port's dest_pipeline to register current_pipeline as a parent of
       // metadata_pipeline. gpu_scan_op's get_next_task_hint() also reads this port's
       // src_pipeline->is_pipeline_finished() to detect when all metadata has arrived.
-      for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
         auto* next_op            = dependent_pipeline->get_operators().size() == 0
                                      ? dependent_pipeline->get_sink().get()
                                      : &dependent_pipeline->get_operators()[0].get();
         std::string_view port_id = "handoff";
-        next_op->add_port(
-          port_id,
-          std::make_unique<op::sirius_physical_operator::port>(
-            op::MemoryBarrierType::PARTIAL, nullptr, scheduled_[i], dependent_pipeline));
-        scheduled_[i]->get_sink()->add_next_port_after_sink({next_op, port_id});
+        next_op->add_port(port_id,
+                          std::make_unique<op::sirius_physical_operator::port>(
+                            op::MemoryBarrierType::PARTIAL, nullptr, pipeline, dependent_pipeline));
+        pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
       }
     } else {
       // Intermediate operators acting as pipeline sinks (e.g., filter, projection, join
       // placed as sink before a PARTITION pipeline). Use the base class sink() which
       // pushes data to next_port_after_sink via the data repo.
-      for (auto const& dependent_pipeline : source_to_pipelines[scheduled_[i]->get_sink().get()]) {
-        engine_.insert_repository("default", scheduled_[i], dependent_pipeline);
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
+        engine_.insert_repository("default", pipeline, dependent_pipeline);
       }
     }
   }
@@ -1048,52 +1035,14 @@ void sirius_pipeline_converter::wire_data_repositories()
 
 void sirius_pipeline_converter::setup_pipeline_parents()
 {
-  for (size_t i = 0; i < scheduled_.size(); i++) {
-    scheduled_[i]->parents.clear();
-    scheduled_[i]->dependencies.clear();
+  for (const auto& pipeline : scheduled_) {
+    pipeline->parents.clear();
+    pipeline->dependencies.clear();
 
-    // --- Set pipeline parents ---
-    if (scheduled_[i]->sink.get()) {
-      if (scheduled_[i]->sink.get()->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-        auto& delim_join = scheduled_[i]->sink.get()->Cast<op::sirius_physical_right_delim_join>();
-        auto partition_join = delim_join.partition_join;
-        auto* distinct_op   = delim_join.distinct.get();
-        for (auto& next_port : partition_join->get_next_port_after_sink()) {
-          if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
-            scheduled_[i]->parents.push_back(duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
-          }
-        }
-        for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-          if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
-            scheduled_[i]->parents.push_back(duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
-          }
-        }
-      } else if (scheduled_[i]->sink.get()->type ==
-                 op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-        auto& delim_join  = scheduled_[i]->sink.get()->Cast<op::sirius_physical_left_delim_join>();
-        auto* distinct_op = delim_join.distinct.get();
-        auto column_data_scan = delim_join.column_data_scan;
-        for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-          if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
-            scheduled_[i]->parents.push_back(duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
-          }
-        }
-        for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-          if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
-            scheduled_[i]->parents.push_back(duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
-          }
-        }
-      } else {
-        for (auto& next_port : scheduled_[i]->sink.get()->get_next_port_after_sink()) {
-          if (next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline) {
-            scheduled_[i]->parents.push_back(duckdb::weak_ptr<sirius::pipeline::sirius_pipeline>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->dest_pipeline));
-          }
-        }
+    for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+      if (duckdb::shared_ptr<sirius_pipeline> destination =
+            port_info.next_operator->get_port(port_info.next_operator_port_name)->dest_pipeline) {
+        pipeline->parents.push_back(duckdb::weak_ptr<sirius_pipeline>(destination));
       }
     }
   }
@@ -1104,27 +1053,25 @@ void sirius_pipeline_converter::finalize_pipeline_structure()
   // Finalize pipeline structure: push sink into operators, set source
   // AFTER THIS POINT: operators[] contains ALL operators (source through sink).
   // source = &operators[0], sink = operators.back().
-  for (size_t i = 0; i < scheduled_.size(); i++) {
-    scheduled_[i]->operators.push_back(*scheduled_[i]->sink);
-    scheduled_[i]->source = &scheduled_[i]->operators[0].get();
+  for (const auto& pipeline : scheduled_) {
+    pipeline->operators.push_back(*pipeline->sink);
+    pipeline->source = &pipeline->operators[0].get();
     // for each parent pipeline, add the current pipeline to the dependencies
-    for (auto& parent : scheduled_[i]->parents) {
-      if (auto locked_parent = parent.lock()) {
-        locked_parent->dependencies.push_back(scheduled_[i]);
-      }
+    for (auto& parent : pipeline->parents) {
+      if (auto locked_parent = parent.lock()) { locked_parent->dependencies.push_back(pipeline); }
     }
   }
 }
 
 void sirius_pipeline_converter::link_join_partition_siblings()
 {
-  for (size_t i = 0; i < scheduled_.size(); i++) {
+  for (const auto& pipeline : scheduled_) {
     // for each hash join as a source, get the dependencies (concat) and get the dependencies of
     // concat (partition)
-    if (scheduled_[i]->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
-      auto build_concat_pipeline    = scheduled_[i]->dependencies[0];
+    if (pipeline->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN) {
+      auto build_concat_pipeline    = pipeline->dependencies[0];
       auto build_partition_pipeline = build_concat_pipeline->dependencies[0];
-      auto probe_concat_pipeline    = scheduled_[i]->dependencies[1];
+      auto probe_concat_pipeline    = pipeline->dependencies[1];
       auto probe_partition_pipeline = probe_concat_pipeline->dependencies[0];
       // change probe partition barrier to partial
       probe_partition_pipeline->get_source()->get_port("default")->type =
@@ -1285,8 +1232,8 @@ void sirius_pipeline_converter::log_pipeline_debug_info() const
     }
 
     // Print ports and next operators after sink
-    SIRIUS_LOG_INFO("  Sink next operators and ports:");
-    for (auto& next_port : pipeline->sink->get_next_port_after_sink()) {
+    SIRIUS_LOG_INFO("  Sink's next operators and ports:");
+    for (auto& next_port : pipeline->get_next_ports_after_sink()) {
       auto next_op = next_port.next_operator;
       auto port_id = next_port.next_operator_port_name;
       SIRIUS_LOG_INFO("    Next Op: {} (id={}), Port: '{}'",
@@ -1295,70 +1242,10 @@ void sirius_pipeline_converter::log_pipeline_debug_info() const
                       port_id.data());
 
       // Print the port details if it exists
-      auto* port = next_op->get_port(port_id);
-      if (port) {
+      if (auto* port = next_op->get_port(port_id)) {
         SIRIUS_LOG_INFO("      Port barrier_type={}, repo={}",
                         static_cast<int>(port->type),
                         static_cast<void*>(port->repo));
-      }
-    }
-
-    // Special handling for delim joins
-    if (pipeline->sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN ||
-        pipeline->sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-      auto delim_join = pipeline->get_sink();
-
-      if (pipeline->sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-        auto partition_join =
-          delim_join->Cast<op::sirius_physical_right_delim_join>().partition_join;
-        SIRIUS_LOG_INFO("  Partition Join next operators:");
-        for (auto& next_port : partition_join->get_next_port_after_sink()) {
-          SIRIUS_LOG_INFO(
-            "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-            next_port.next_operator->get_name(),
-            next_port.next_operator->get_operator_id(),
-            next_port.next_operator_port_name.data(),
-            static_cast<void*>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
-        }
-
-        auto distinct_op = delim_join->Cast<op::sirius_physical_right_delim_join>().distinct.get();
-        SIRIUS_LOG_INFO("  Distinct next operators:");
-        for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-          SIRIUS_LOG_INFO(
-            "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-            next_port.next_operator->get_name(),
-            next_port.next_operator->get_operator_id(),
-            next_port.next_operator_port_name.data(),
-            static_cast<void*>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
-        }
-      }
-
-      if (pipeline->sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-        auto column_data_scan =
-          delim_join->Cast<op::sirius_physical_left_delim_join>().column_data_scan;
-        SIRIUS_LOG_INFO("  Column Data Scan next operators:");
-        for (auto& next_port : column_data_scan->get_next_port_after_sink()) {
-          SIRIUS_LOG_INFO(
-            "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-            next_port.next_operator->get_name(),
-            next_port.next_operator->get_operator_id(),
-            next_port.next_operator_port_name.data(),
-            static_cast<void*>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
-        }
-        auto distinct_op = delim_join->Cast<op::sirius_physical_left_delim_join>().distinct.get();
-        SIRIUS_LOG_INFO("  Partition Distinct next operators:");
-        for (auto& next_port : distinct_op->get_next_port_after_sink()) {
-          SIRIUS_LOG_INFO(
-            "    Next Op: {} (id={}), Port: '{}' Repo:'{}'",
-            next_port.next_operator->get_name(),
-            next_port.next_operator->get_operator_id(),
-            next_port.next_operator_port_name.data(),
-            static_cast<void*>(
-              next_port.next_operator->get_port(next_port.next_operator_port_name)->repo));
-        }
       }
     }
 

--- a/src/pipeline/sirius_plan_printer.cpp
+++ b/src/pipeline/sirius_plan_printer.cpp
@@ -108,7 +108,7 @@ void place_node(render_tree& tree,
   if (parent) {
     auto parent_sink = parent->get_sink();
     if (parent_sink) {
-      for (auto& np : parent_sink->get_next_port_after_sink()) {
+      for (auto& np : parent_sink->get_next_ports_after_sink()) {
         if (!np.next_operator) { continue; }
         auto* port = np.next_operator->get_port(np.next_operator_port_name);
         if (port && port->src_pipeline &&
@@ -375,7 +375,7 @@ std::string sirius_plan_printer::render_pipelines() const
 
     // Show output connections from sink
     if (sink) {
-      auto& next_ports = sink->get_next_port_after_sink();
+      auto& next_ports = sink->get_next_ports_after_sink();
       for (auto& np : next_ports) {
         if (!np.next_operator) { continue; }
         ss << "  Output: -> " << np.next_operator->get_name();

--- a/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
+++ b/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <expression/expression.hpp>
+#include <helper/logical_type.hpp>
+#include <op/sirius_physical_column_data_scan.hpp>
+#include <op/sirius_physical_delim_join.hpp>
+#include <op/sirius_physical_dummy_scan.hpp>
+#include <op/sirius_physical_grouped_aggregate.hpp>
+#include <op/sirius_physical_operator.hpp>
+#include <op/sirius_physical_operator_type.hpp>
+#include <op/sirius_physical_partition.hpp>
+#include <pipeline/sirius_pipeline.hpp>
+#include <sirius_engine.hpp>
+#include <sirius_interface.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using sirius::sirius_engine;
+using sirius::sirius_interface;
+using sirius::op::sirius_physical_column_data_scan;
+using sirius::op::sirius_physical_dummy_scan;
+using sirius::op::sirius_physical_grouped_aggregate;
+using sirius::op::sirius_physical_left_delim_join;
+using sirius::op::sirius_physical_operator;
+using sirius::op::sirius_physical_partition;
+using sirius::op::sirius_physical_right_delim_join;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+
+namespace {
+
+class pipeline_test_env {
+ public:
+  pipeline_test_env()
+    : db(std::make_unique<duckdb::DuckDB>(nullptr)),
+      con(std::make_unique<duckdb::Connection>(*db)),
+      iface(std::make_unique<sirius_interface>(*con->context)),
+      engine(std::make_unique<sirius_engine>(*con->context, *iface)),
+      pipeline(duckdb::make_shared_ptr<sirius_pipeline>(*engine))
+  {
+  }
+
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+  std::unique_ptr<sirius_interface> iface;
+  std::unique_ptr<sirius_engine> engine;
+  duckdb::shared_ptr<sirius_pipeline> pipeline;
+};
+
+duckdb::unique_ptr<sirius_physical_operator> make_dummy_two_child_join()
+{
+  duckdb::vector<sirius::logical_type> empty_types;
+  auto join = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::INVALID, empty_types, 0);
+  join->children.push_back(duckdb::make_uniq<sirius_physical_dummy_scan>(empty_types, 0));
+  join->children.push_back(duckdb::make_uniq<sirius_physical_dummy_scan>(empty_types, 0));
+  return join;
+}
+
+}  // namespace
+
+TEST_CASE("yields nothing when no sink is set", "[pipeline][get_next_ports_after_sink]")
+{
+  pipeline_test_env env;
+  REQUIRE(not env.pipeline->get_sink());
+
+  for (const auto& port : env.pipeline->get_next_ports_after_sink()) {
+    FAIL("port found");
+  }
+}
+
+TEST_CASE("returns sink ports for standard (non-delim) sink",
+          "[pipeline][get_next_ports_after_sink]")
+{
+  pipeline_test_env env;
+
+  sirius_physical_operator sink_op;
+  sirius_physical_operator consumer_a;
+  sirius_physical_operator consumer_b;
+  sink_op.add_next_port_after_sink({&consumer_a, "port_a"});
+  sink_op.add_next_port_after_sink({&consumer_b, "port_b"});
+
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*env.pipeline, &sink_op, 0);
+
+  std::vector<sirius_physical_operator::next_port_info> ports;
+  for (const auto& port : env.pipeline->get_next_ports_after_sink()) {
+    ports.push_back(port);
+  }
+  REQUIRE(ports.size() == 2);
+  CHECK(ports[0].next_operator == &consumer_a);
+  CHECK(ports[0].next_operator_port_name == "port_a");
+  CHECK(ports[1].next_operator == &consumer_b);
+  CHECK(ports[1].next_operator_port_name == "port_b");
+}
+
+TEST_CASE("yields nothing for standard sink with no ports", "[pipeline][get_next_ports_after_sink]")
+{
+  pipeline_test_env env;
+
+  sirius_physical_operator sink_op;
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*env.pipeline, &sink_op, 0);
+
+  for (const auto& port : env.pipeline->get_next_ports_after_sink()) {
+    FAIL("port found");
+  }
+}
+
+TEST_CASE("RIGHT_DELIM_JOIN: concatenates partition_join then distinct ports",
+          "[pipeline][get_next_ports_after_sink]")
+{
+  pipeline_test_env env;
+  duckdb::vector<sirius::logical_type> empty_types;
+
+  auto right_delim = duckdb::make_uniq<sirius_physical_right_delim_join>(
+    empty_types,
+    make_dummy_two_child_join(),
+    duckdb::vector<duckdb::const_reference<sirius_physical_operator>>{},
+    0,
+    duckdb::optional_idx());
+
+  // sirius_physical_partition needs a parent_op whose `type` field is one of the supported
+  // values. NESTED_LOOP_JOIN takes a no-op branch and avoids a downcast, so a standard
+  // sirius_physical_operator with that type is enough.
+  auto fake_parent = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, empty_types, 0);
+  auto partition_join =
+    duckdb::make_uniq<sirius_physical_partition>(empty_types, 0, fake_parent.get());
+
+  auto distinct =
+    duckdb::make_uniq<sirius_physical_grouped_aggregate>(*env.con->context,
+                                                         empty_types,
+                                                         duckdb::vector<sirius::expression>{},
+                                                         duckdb::vector<sirius::expression>{},
+                                                         0);
+
+  sirius_physical_operator partition_consumer_x;
+  sirius_physical_operator partition_consumer_y;
+  sirius_physical_operator distinct_consumer;
+  partition_join->add_next_port_after_sink({&partition_consumer_x, "port_x"});
+  partition_join->add_next_port_after_sink({&partition_consumer_y, "port_y"});
+  distinct->add_next_port_after_sink({&distinct_consumer, "distinct_port"});
+
+  right_delim->partition_join = partition_join.get();
+  right_delim->distinct       = std::move(distinct);
+
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*env.pipeline, right_delim.get(), 0);
+
+  std::vector<sirius_physical_operator::next_port_info> ports;
+  for (const auto& port : env.pipeline->get_next_ports_after_sink()) {
+    ports.push_back(port);
+  }
+  REQUIRE(ports.size() == 3);
+  CHECK(ports[0].next_operator == &partition_consumer_x);
+  CHECK(ports[0].next_operator_port_name == "port_x");
+  CHECK(ports[1].next_operator == &partition_consumer_y);
+  CHECK(ports[1].next_operator_port_name == "port_y");
+  CHECK(ports[2].next_operator == &distinct_consumer);
+  CHECK(ports[2].next_operator_port_name == "distinct_port");
+}
+
+TEST_CASE("LEFT_DELIM_JOIN: concatenates column_data_scan then distinct ports",
+          "[pipeline][get_next_ports_after_sink]")
+{
+  pipeline_test_env env;
+  duckdb::vector<sirius::logical_type> empty_types;
+
+  auto left_delim = duckdb::make_uniq<sirius_physical_left_delim_join>(
+    empty_types,
+    make_dummy_two_child_join(),
+    duckdb::vector<duckdb::const_reference<sirius_physical_operator>>{},
+    0,
+    duckdb::optional_idx());
+
+  auto column_data_scan = duckdb::make_uniq<sirius_physical_column_data_scan>(
+    empty_types, SiriusPhysicalOperatorType::COLUMN_DATA_SCAN, 0, static_cast<std::size_t>(0));
+
+  auto distinct =
+    duckdb::make_uniq<sirius_physical_grouped_aggregate>(*env.con->context,
+                                                         empty_types,
+                                                         duckdb::vector<sirius::expression>{},
+                                                         duckdb::vector<sirius::expression>{},
+                                                         0);
+
+  sirius_physical_operator scan_consumer;
+  sirius_physical_operator distinct_consumer_p;
+  sirius_physical_operator distinct_consumer_q;
+  column_data_scan->add_next_port_after_sink({&scan_consumer, "scan_port"});
+  distinct->add_next_port_after_sink({&distinct_consumer_p, "distinct_p"});
+  distinct->add_next_port_after_sink({&distinct_consumer_q, "distinct_q"});
+
+  left_delim->column_data_scan = column_data_scan.get();
+  left_delim->distinct         = std::move(distinct);
+
+  sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_sink(*env.pipeline, left_delim.get(), 0);
+
+  std::vector<sirius_physical_operator::next_port_info> ports;
+  for (const auto& port : env.pipeline->get_next_ports_after_sink()) {
+    ports.push_back(port);
+  }
+  REQUIRE(ports.size() == 3);
+  CHECK(ports[0].next_operator == &scan_consumer);
+  CHECK(ports[0].next_operator_port_name == "scan_port");
+  CHECK(ports[1].next_operator == &distinct_consumer_p);
+  CHECK(ports[1].next_operator_port_name == "distinct_p");
+  CHECK(ports[2].next_operator == &distinct_consumer_q);
+  CHECK(ports[2].next_operator_port_name == "distinct_q");
+}
+

--- a/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
+++ b/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
@@ -228,4 +228,3 @@ TEST_CASE("LEFT_DELIM_JOIN: concatenates column_data_scan then distinct ports",
   CHECK(ports[2].next_operator == &distinct_consumer_q);
   CHECK(ports[2].next_operator_port_name == "distinct_q");
 }
-


### PR DESCRIPTION
Adds `get_next_ports_after_sink` to `sirius_pipeline` to handle special-cased left and right delim joins, in an attempt to deduplicate call sites, improve local reasoning and move towards [reducing cognitive load](https://github.com/zakirullin/cognitive-load).

Also does so simple renames and switches to range-based for loops in the files that the above changes already touch.  