### PR TITLE
CI: Remove GHA Runner Spot Usage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{ matrix.environment == 'vcpkg'
-        && fromJSON('["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl-spot"]')
+        && fromJSON('["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl"]')
         || format('ubuntu-24.04{0}', case(matrix.arch == 'arm64', '-arm', '')) }}
     timeout-minutes: ${{ case(matrix.environment == 'vcpkg', 240, 60) }}
     continue-on-error: ${{ matrix.cudf-channel == 'nightly' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, ubuntu-24.04, cuda-13, cpu-xl-spot]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, cpu-xl]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
While we have dropped down to only a few spot-interruptions in a 24 hr period these are still very disruptive to devs. Switching to full on-demand usage for the time being to remove the failures associated with spot-interruptions until we can handle these more gracefully