### PR TITLE
Enable IO framework in sirius scan manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(EXTENSION_SOURCES
     src/expression_executor/specializations/gpu_execute_reference.cpp
     src/io/admission_control.cpp
     src/io/datasource_factory.cpp
+    src/io/io_context.cpp
     src/io/prefetching_cache.cpp
     src/io/s3/sigv4.cpp
     src/io/s3/sirius_sigv4_credential_provider.cpp
@@ -260,6 +261,7 @@ set(EXTENSION_SOURCES
     src/scan_manager/parquet_split_provider.cpp
     src/scan_manager/sirius_scan_manager.cpp
     src/scan_manager/split_connector.cpp
+    src/scan_manager/split_provider.cpp
     src/sirius_config.cpp
     src/sirius_context.cpp
     src/sirius_engine.cpp
@@ -481,3 +483,38 @@ if(SIRIUS_LEGACY_COMPILE_DEFINITIONS)
   target_compile_definitions(sirius_unittest
                              PRIVATE ${SIRIUS_LEGACY_COMPILE_DEFINITIONS})
 endif()
+
+# -----------------------------------------------------------------------------
+# test/io/parquet_benchmark — standalone benchmark binary for sirius_datasource
+# -----------------------------------------------------------------------------
+add_executable(parquet_benchmark test/io/parquet_benchmark.cpp)
+
+if(VCPKG_BUILD)
+  set_target_properties(parquet_benchmark PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
+  target_include_directories(parquet_benchmark BEFORE PRIVATE ${_VCPKG_INC})
+endif()
+
+target_include_directories(
+  parquet_benchmark
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>)
+
+target_link_libraries(
+  parquet_benchmark
+  sirius_extension
+  duckdb_static
+  cudf::cudf
+  rmm::rmm
+  spdlog::spdlog
+  cuCascade::cucascade
+  PkgConfig::LIBURING
+  PkgConfig::NUMA)
+link_extension_libraries(parquet_benchmark "")
+
+target_link_options(parquet_benchmark PRIVATE
+                    "LINKER:--allow-multiple-definition")
+
+set_target_properties(
+  parquet_benchmark
+  PROPERTIES CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test/io")

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -16,6 +16,7 @@
 
 #include "creator/task_creator.hpp"
 
+#include "cucascade/memory/common.hpp"
 #include "log/logging.hpp"
 #include "op/scan/cpu_source_task.hpp"
 #include "op/scan/duckdb_scan_executor.hpp"
@@ -33,6 +34,7 @@
 #include <duckdb/execution/execution_context.hpp>
 #include <duckdb/parallel/thread_context.hpp>
 
+#include <limits>
 #include <optional>
 
 namespace sirius::creator {
@@ -344,14 +346,17 @@ void task_creator::manager_loop()
 
         } else {
           // Create all possible tasks until all ports are empty
-          while (!node->all_ports_empty()) {
+          auto is_gpu_parquet_scan = node->type == op::SiriusPhysicalOperatorType::GPU_PARQUET_SCAN;
+          std::size_t count = is_gpu_parquet_scan ? 1 : std::numeric_limits<std::size_t>::max();
+          // need to exhaust input batches until all ports are empty
+          while (!node->all_ports_empty() && count-- > 0) {
             auto task_lock  = pipeline->get_task_creation_lock();
             auto input_data = node->get_next_task_input_data();
             auto* pipelineable_input =
               dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
             if (!input_data ||
                 (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-              // do data to create task for
+              // no data to create task for
               break;
             }
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -346,10 +346,12 @@ void task_creator::manager_loop()
 
         } else {
           // Create all possible tasks until all ports are empty
-          auto is_gpu_parquet_scan = node->type == op::SiriusPhysicalOperatorType::GPU_PARQUET_SCAN;
-          std::size_t count = is_gpu_parquet_scan ? 1 : std::numeric_limits<std::size_t>::max();
-          // need to exhaust input batches until all ports are empty
-          while (!node->all_ports_empty() && count-- > 0) {
+          // TODO(amin) : do this based on the operator hint
+          // auto is_gpu_parquet_scan = node->type ==
+          // op::SiriusPhysicalOperatorType::GPU_PARQUET_SCAN; std::size_t count =
+          // is_gpu_parquet_scan ? 1 : std::numeric_limits<std::size_t>::max(); need to exhaust
+          // input batches until all ports are empty
+          while (!node->all_ports_empty()) {
             auto task_lock  = pipeline->get_task_creation_lock();
             auto input_data = node->get_next_task_input_data();
             auto* pipelineable_input =

--- a/src/include/exec/scoped_dispatcher.hpp
+++ b/src/include/exec/scoped_dispatcher.hpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <absl/functional/any_invocable.h>
+#include <exec/thread_pool.hpp>
+
+#include <concepts>
+#include <condition_variable>
+#include <mutex>
+#include <type_traits>
+#include <utility>
+
+namespace sirius::exec {
+
+class scoped_dispatcher {
+ public:
+  scoped_dispatcher(static_thread_pool& pool, std::size_t max_concurrent_task = 0)
+    : pool_(pool),
+      max_inflight_(max_concurrent_task == 0 ? pool.num_threads()
+                                             : std::min(max_concurrent_task, pool.num_threads()))
+  {
+  }
+
+  ~scoped_dispatcher()
+  {
+    // User contract: drain (via wait_for_all, optionally preceded by
+    // request_stop) before destruction. Loud assert beats silent UAF.
+    std::lock_guard lk(mu_);
+    assert(inflight_ == 0 && pending_.empty() &&
+           "scoped_dispatcher destroyed with outstanding work; "
+           "call request_stop()/wait_for_all() first");
+  }
+
+  scoped_dispatcher(const scoped_dispatcher&)            = delete;
+  scoped_dispatcher& operator=(const scoped_dispatcher&) = delete;
+
+  // @brief Non-blocking. Always returns immediately. Overflow goes to the
+  // dispatcher-local pending queue (unbounded by contract).
+  // After request_stop(), enqueue is a silent no-op.
+  void enqueue(std::invocable auto&& f)
+  {
+    auto task = wrap(std::forward<decltype(f)>(f));
+
+    std::unique_lock lk(mu_);
+    if (stop_.stop_requested()) return;
+
+    if (inflight_ < max_inflight_) {
+      ++inflight_;
+      lk.unlock();
+      pool_.schedule(std::move(task));
+    } else {
+      pending_.push_back(std::move(task));
+    }
+  }
+
+  // @brief Blocking. Waits for an inflight slot, then submits directly to the pool.
+  // Bypasses the pending queue — this is the producer-side back-pressure path.
+  // Returns false iff request_stop() was observed while waiting (or already set).
+  bool schedule(std::invocable auto&& f)
+  {
+    auto task = wrap(std::forward<decltype(f)>(f));
+
+    std::unique_lock lk(mu_);
+    bool ok = cv_slot_.wait(lk, stop_.get_token(), [this] { return inflight_ < max_inflight_; });
+    if (!ok) return false;  // stop requested
+
+    ++inflight_;
+    lk.unlock();
+    pool_.schedule(std::move(task));
+    return true;
+  }
+
+  void request_stop()
+  {
+    std::lock_guard lk(mu_);
+    stop_.request_stop();  // wakes cv_slot_ waiters via stop_callback
+    pending_.clear();      // drop queued-but-not-started work
+    if (inflight_ == 0) { cv_done_.notify_all(); }
+  }
+
+  void wait_for_all()
+  {
+    std::unique_lock lk(mu_);
+    cv_done_.wait(lk, [this] { return inflight_ == 0 && pending_.empty(); });
+  }
+
+ private:
+  using task_t = absl::AnyInvocable<void()>;
+
+  template <typename F>
+  task_t wrap(F&& f)
+  {
+    return [this, f = std::forward<F>(f)]() mutable {
+      if (!stop_.stop_requested()) {
+        try {
+          invoke_with_optional_stop_token(f, stop_.get_token());
+        } catch (...) { /* swallow */
+        }
+      }
+      on_task_done();
+    };
+  }
+
+  template <typename F>
+  static void invoke_with_optional_stop_token(F& f, std::stop_token st)
+  {
+    if constexpr (std::is_invocable_v<F&, std::stop_token>) {
+      f(std::move(st));
+    } else {
+      f();
+    }
+  }
+
+  void on_task_done()
+  {
+    task_t next;
+    bool have_next = false;
+    {
+      std::lock_guard lk(mu_);
+      if (!stop_.stop_requested() && !pending_.empty()) {
+        // Hand the slot to a queued task; inflight_ unchanged → no slot opened.
+        next = std::move(pending_.front());
+        pending_.pop_front();
+        have_next = true;
+      } else {
+        --inflight_;
+        cv_slot_.notify_one();  // a real slot opened — wake one schedule()
+        if (inflight_ == 0 && pending_.empty()) { cv_done_.notify_all(); }
+      }
+    }
+    if (have_next) pool_.schedule(std::move(next));
+  }
+
+  static_thread_pool& pool_;
+  std::size_t max_inflight_;
+
+  std::mutex mu_;
+  std::condition_variable cv_done_;      // drained signal; not stop-aware
+  std::condition_variable_any cv_slot_;  // slot-open signal; stop-aware via wait(token, pred)
+  std::deque<task_t> pending_;
+  std::size_t inflight_ = 0;
+  std::stop_source stop_;
+};
+
+}  // namespace sirius::exec

--- a/src/include/exec/scoped_dispatcher.hpp
+++ b/src/include/exec/scoped_dispatcher.hpp
@@ -22,6 +22,7 @@
 #include <concepts>
 #include <condition_variable>
 #include <mutex>
+#include <source_location>
 #include <type_traits>
 #include <utility>
 
@@ -102,6 +103,20 @@ class scoped_dispatcher {
  private:
   using task_t = absl::AnyInvocable<void()>;
 
+  static void log_exception_ptr(const std::exception_ptr& eptr,
+                                std::source_location loc = std::source_location::current())
+  {
+    try {
+      if (eptr) std::rethrow_exception(eptr);
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_ERROR(
+        "Exception in scoped_dispatcher task at {}:{}: {}", loc.file_name(), loc.line(), e.what());
+    } catch (...) {
+      SIRIUS_LOG_ERROR(
+        "Unknown exception in scoped_dispatcher task at {}:{}", loc.file_name(), loc.line());
+    }
+  }
+
   template <typename F>
   task_t wrap(F&& f)
   {
@@ -110,6 +125,7 @@ class scoped_dispatcher {
         try {
           invoke_with_optional_stop_token(f, stop_.get_token());
         } catch (...) { /* swallow */
+          log_exception_ptr(std::current_exception());
         }
       }
       on_task_done();

--- a/src/include/exec/thread_pool.hpp
+++ b/src/include/exec/thread_pool.hpp
@@ -20,22 +20,25 @@
 
 #include <absl/functional/any_invocable.h>
 
+#include <concepts>
 #include <condition_variable>
+#include <exception>
 #include <latch>
 #include <mutex>
 #include <queue>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace sirius::exec {
 
-class thread_pool {
+class static_thread_pool {
  public:
-  explicit thread_pool(int num_threads,
-                       const std::string& name                             = "thread_pool",
-                       std::vector<int> cpu_ids                            = {},
-                       absl::AnyInvocable<void() noexcept> per_thread_init = nullptr)
+  explicit static_thread_pool(int num_threads,
+                              const std::string& name                             = "thread_pool",
+                              std::vector<int> cpu_ids                            = {},
+                              absl::AnyInvocable<void() noexcept> per_thread_init = nullptr)
   {
     threads_.reserve(num_threads);
 
@@ -69,10 +72,10 @@ class thread_pool {
     if (init_latch) { init_latch->wait(); }
   }
 
-  thread_pool(const thread_pool&)            = delete;
-  thread_pool& operator=(const thread_pool&) = delete;
+  static_thread_pool(const static_thread_pool&)            = delete;
+  static_thread_pool& operator=(const static_thread_pool&) = delete;
 
-  ~thread_pool()
+  ~static_thread_pool()
   {
     stop();
     for (auto& t : threads_) {
@@ -80,23 +83,27 @@ class thread_pool {
     }
   }
 
-  void schedule(absl::AnyInvocable<void()> fn)
+  void schedule(std::invocable auto&& fn)
   {
-    assert(fn != nullptr);
     std::lock_guard l(mu_);
-    queue_.emplace([this, fn = std::move(fn)]() mutable noexcept {
+    queue_.emplace([callable = std::forward<decltype(fn)>(fn)]() mutable noexcept {
       try {
-        fn();
+        callable();
       } catch (const std::exception& e) {
-        SIRIUS_LOG_ERROR("Exception in thread pool task: {}, {}", e.what(), "closing thread pool");
-        stop();
+        SIRIUS_LOG_ERROR("Exception thrown from thread_pool on_error handler {}", e.what());
       } catch (...) {
-        SIRIUS_LOG_ERROR("{}", "Exception in thread pool task, closing thread pool");
-        stop();
+        SIRIUS_LOG_ERROR("Unknown exception thrown from thread_pool");
       }
     });
     cv_.notify_one();
   }
+
+  /// \brief Alias for schedule(). Lets static_thread_pool satisfy the same
+  ///        scheduler shape as scoped_dispatcher (which exposes enqueue()),
+  ///        so generic dispatchers can target either.
+  void enqueue(std::invocable auto&& fn) { schedule(std::forward<decltype(fn)>(fn)); }
+
+  [[nodiscard]] std::size_t num_threads() const noexcept { return threads_.size(); }
 
   void stop() noexcept
   {

--- a/src/include/io/datasource_factory.hpp
+++ b/src/include/io/datasource_factory.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "io/io_context.hpp"
 #include "io/types.hpp"
 
 #include <memory>

--- a/src/include/io/io_context.hpp
+++ b/src/include/io/io_context.hpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "io/types.hpp"
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sirius::io {
+
+class buffer_pool;
+class prefetching_cache;
+
+// ---------------------------------------------------------------------------
+// sirius_ioctx
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Abstract shared context passed to every datasource.
+ *
+ * Holds resources that are shared across all datasources (cache, reactor
+ * threads, ...). Extend this class to provide a concrete I/O backend.
+ */
+class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
+ public:
+  sirius_ioctx();
+  virtual ~sirius_ioctx();
+
+  virtual void shutdown() = 0;
+
+  /// Backend-specific factory: open native handles for @p path and
+  /// return a populated io_object.  Throws on unsupported / unreachable
+  /// paths (callers that want a check-without-open should use
+  /// @c supports()).
+  virtual std::shared_ptr<sirius_io_object> create_io_object(std::string path) = 0;
+
+  virtual std::unique_ptr<cudf::io::datasource> make_datasource(
+    std::shared_ptr<sirius_io_object> io_object) = 0;
+
+  /// Convenience: @c create_io_object + @c make_datasource in one shot.
+  std::unique_ptr<cudf::io::datasource> open_datasource(std::string path)
+  {
+    return make_datasource(create_io_object(std::move(path)));
+  }
+
+  /// Whether this backend can serve reads for @p path.  Backends should
+  /// validate scheme/protocol support and any backend-specific
+  /// preconditions (e.g. file existence for local-disk backends).
+  [[nodiscard]] virtual bool supports(std::string_view path) const = 0;
+
+  /// Construct the owned prefetching_cache.  Must be called before any
+  /// read that should consult the cache; until then device_read falls
+  /// through directly to device_read_io.
+  void initialize_cache(buffer_pool& pool, size_t inflight_budget_chunks = 2048);
+
+  [[nodiscard]] prefetching_cache* cache() noexcept { return _cache.get(); }
+
+  // -- Read API ---------------------------------------------------------------
+
+  size_t host_read(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst);
+
+  std::future<size_t> host_read_async(sirius_io_object& obj,
+                                      size_t offset,
+                                      size_t size,
+                                      uint8_t* dst);
+
+  size_t device_read(
+    sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream);
+
+  std::future<size_t> device_read_async(
+    sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream);
+
+  ///
+
+  virtual size_t host_read_io(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst) = 0;
+
+  virtual void host_read_async_io(sirius_io_object& obj,
+                                  size_t offset,
+                                  size_t size,
+                                  uint8_t* dst,
+                                  io_completion_handler handler) = 0;
+
+  virtual size_t device_read_io(sirius_io_object& obj,
+                                size_t offset,
+                                size_t size,
+                                uint8_t* dst,
+                                rmm::cuda_stream_view stream) = 0;
+
+  virtual void device_read_async_io(sirius_io_object& obj,
+                                    size_t offset,
+                                    size_t size,
+                                    uint8_t* dst,
+                                    rmm::cuda_stream_view stream,
+                                    io_completion_handler handler) = 0;
+
+  virtual void host_read_ranges_async_io(sirius_io_object& obj,
+                                         std::vector<cudf::io::text::byte_range_info> const& ranges,
+                                         std::span<cudf::host_span<std::byte>> dst,
+                                         io_completion_handler handler) = 0;
+
+  // -- Physical range alignment ------------------------------------------------
+
+  virtual cudf::io::text::byte_range_info compute_physical_range(
+    cudf::io::text::byte_range_info logical, size_t file_size) const = 0;
+
+ protected:
+  std::unique_ptr<prefetching_cache> _cache;
+};
+
+}  // namespace sirius::io

--- a/src/include/io/prefetching_cache.hpp
+++ b/src/include/io/prefetching_cache.hpp
@@ -24,13 +24,14 @@
 #include <cuda_runtime.h>
 
 #include <concurrentqueue.h>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
 #include <array>
 #include <atomic>
 #include <future>
 #include <list>
-#include <map>
 #include <memory>
+#include <mutex>
 #include <semaphore>
 #include <shared_mutex>
 #include <span>
@@ -41,38 +42,38 @@
 
 namespace sirius::io {
 
+class sirius_ioctx;
+
 // ---------------------------------------------------------------------------
-// buffer_pool — growable multi-slab pool of 1MB pinned chunks
+// buffer_pool — growable pool of pinned chunks
 // ---------------------------------------------------------------------------
 //
-// Manages one or more CUDA-pinned slabs.  Each slab is a contiguous
-// allocation of CHUNKS_PER_SLAB * 1MB.  New slabs are allocated lazily when
-// the pool is exhausted, up to max_slabs.
+// Backed by a @c cucascade::memory::fixed_size_host_memory_resource.  Each
+// grow step requests CHUNKS_PER_SLAB blocks from the upstream resource and
+// appends the raw pointers to an internal free list.  Blocks are never
+// returned to the upstream resource until the pool is destroyed; allocate()
+// pops from the free list and deallocate() pushes back.
 //
-// allocate() returns a raw pointer to a 1MB region.
-// deallocate() finds the owning slab via a sorted map of slab base addresses
-// and returns the chunk to that slab's free list.
+// The chunk size is taken from @c mr.get_block_size() — all cache layout
+// arithmetic that needs the chunk size reads it from @c chunk_bytes().
 
 class buffer_pool {
  public:
-  static constexpr size_t CHUNK_BYTES       = 1UL << 20;  // 1MB
-  static constexpr uint32_t CHUNKS_PER_SLAB = 500;        // 500 chunks per slab
-  static constexpr size_t SLAB_BYTES        = static_cast<size_t>(CHUNKS_PER_SLAB) * CHUNK_BYTES;
+  static constexpr uint32_t CHUNKS_PER_SLAB = 500;  // 500 chunks per slab
 
-  explicit buffer_pool(uint32_t max_slabs);
+  buffer_pool(cucascade::memory::fixed_size_host_memory_resource& mr, uint32_t max_slabs);
   ~buffer_pool();
 
   buffer_pool(buffer_pool const&)            = delete;
   buffer_pool& operator=(buffer_pool const&) = delete;
 
-  /// Allocate a single 1MB chunk.  Returns nullptr when all slabs are
-  /// exhausted and no new slab can be allocated.
+  /// Allocate a single chunk.  Returns nullptr when the pool is exhausted
+  /// and the upstream resource cannot supply a fresh slab.
   std::byte* allocate();
 
   /// Bulk-allocate up to @p n chunks, appending pointers to @p out.
-  /// Returns the number actually allocated (may be < n if pool is exhausted
-  /// and cannot grow).  Uses try_dequeue_bulk internally to minimise
-  /// per-chunk overhead.
+  /// Returns the number actually allocated (may be < n if the pool is
+  /// exhausted and cannot grow).
   size_t allocate_bulk(size_t n, std::vector<std::byte*>& out);
 
   void deallocate_bulk(std::vector<std::byte*>& out);
@@ -80,29 +81,40 @@ class buffer_pool {
   /// Return a chunk to the pool.
   void deallocate(std::byte* p);
 
-  size_t capacity() const noexcept
+  [[nodiscard]] size_t chunk_bytes() const noexcept { return _chunk_bytes; }
+  [[nodiscard]] size_t slab_bytes() const noexcept
   {
-    return static_cast<size_t>(_total_chunks.load(std::memory_order_relaxed)) * CHUNK_BYTES;
+    return static_cast<size_t>(CHUNKS_PER_SLAB) * _chunk_bytes;
   }
-  uint32_t free_count() const noexcept { return _total_free.load(std::memory_order_relaxed); }
-  uint32_t total_chunks() const noexcept { return _total_chunks.load(std::memory_order_relaxed); }
+  [[nodiscard]] size_t capacity() const noexcept
+  {
+    return static_cast<size_t>(_total_chunks.load(std::memory_order_relaxed)) * _chunk_bytes;
+  }
+  [[nodiscard]] uint32_t free_count() const noexcept
+  {
+    return _total_free.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] uint32_t total_chunks() const noexcept
+  {
+    return _total_chunks.load(std::memory_order_relaxed);
+  }
 
  private:
-  struct slab {
-    std::byte* base{nullptr};
-    duckdb_moodycamel::ConcurrentQueue<std::byte*> free_chunks;
-    std::atomic<uint32_t> free_count{0};
-  };
+  /// Pull one slab worth of blocks from the upstream resource and append
+  /// them to @c _free_list.  Caller must hold @c _mtx.
+  bool grow_locked();
 
-  bool grow();
-  slab* find_slab(std::byte* p);
-
+  cucascade::memory::fixed_size_host_memory_resource& _mr;
+  size_t _chunk_bytes;
   uint32_t _max_slabs;
 
-  // Protected by _grow_mtx (exclusive for grow, shared for find_slab).
-  mutable std::shared_mutex _grow_mtx;
-  std::vector<std::unique_ptr<slab>> _slabs;
-  std::map<std::byte*, slab*> _slab_map;
+  // Protects _allocations and _free_list.
+  std::mutex _mtx;
+  // Held to keep upstream blocks alive for the lifetime of the pool —
+  // the multiple_blocks_allocation destructor is what returns blocks to
+  // the resource, so we never drop these until the pool is destroyed.
+  std::vector<cucascade::memory::fixed_multiple_blocks_allocation> _allocations;
+  std::vector<std::byte*> _free_list;
 
   std::atomic<uint32_t> _total_free{0};
   std::atomic<uint32_t> _total_chunks{0};
@@ -280,7 +292,13 @@ struct alignas(64) cache_entry {
   cudf::io::text::byte_range_info logical_range;
   cudf::io::text::byte_range_info physical_range;
 
-  /// Pointers to 1MB chunks from buffer_pool backing this range.
+  /// Size of each chunk in @c chunks (== buffer_pool::chunk_bytes() at the
+  /// time of entry creation).  Stored on the entry so pinned_view doesn't
+  /// need a pool reference to do chunk-index arithmetic.
+  size_t chunk_bytes{0};
+
+  /// Pointers to pinned chunks (each of size @c chunk_bytes) from buffer_pool
+  /// backing this range.
   std::vector<std::byte*> chunks;
 
   /// Packed state + pin_count.  All state transitions go through this.
@@ -306,26 +324,16 @@ struct alignas(64) cache_entry {
   /// consumption_ts < request_ts.
   std::atomic<uint64_t> consumption_ts{0};
 
-  /// Recorded on the last reader's stream when @c pinned_view goes out of
-  /// scope.  The evictor queries this before releasing chunks so a still
-  /// in-flight cudaMemcpyAsync can't read from pinned memory that we've
-  /// just handed back to the pool.
-  cudaEvent_t read_event{nullptr};
-
   /// Set to true while this entry sits in the evictor's LRU list, cleared
   /// when the evictor pops it out (eviction or otherwise).  Only mutated
   /// by the evictor thread, so no synchronisation is required.
   bool in_lru{false};
 
-  cache_entry(cudf::io::text::byte_range_info logical, cudf::io::text::byte_range_info physical)
-    : logical_range(logical), physical_range(physical)
+  cache_entry(cudf::io::text::byte_range_info logical,
+              cudf::io::text::byte_range_info physical,
+              size_t chunk_bytes)
+    : logical_range(logical), physical_range(physical), chunk_bytes(chunk_bytes)
   {
-    cudaEventCreateWithFlags(&read_event, cudaEventDisableTiming);
-  }
-
-  ~cache_entry()
-  {
-    if (read_event) cudaEventDestroy(read_event);
   }
 
   cache_entry(cache_entry const&)            = delete;
@@ -381,10 +389,12 @@ struct eviction_request {
 class pinned_view {
  public:
   pinned_view() = default;
-  /// @p stream is the caller's CUDA stream; on the last release, we record
-  /// an event on it so the evictor can be certain any in-flight
-  /// cudaMemcpyAsync reading from this entry's chunks has completed before
-  /// the chunks are recycled.
+  /// @p stream is the caller's CUDA stream.  When non-null, the read pin
+  /// is released via a host callback enqueued on this stream, so the entry
+  /// stays in_use (and therefore non-evictable) until any cudaMemcpyAsync
+  /// the caller submitted earlier has finished consuming the chunks.  When
+  /// null, the read is released synchronously on destruction (host-only
+  /// reads have no async work to wait on).
   pinned_view(std::shared_ptr<cache_entry> entry,
               duckdb_moodycamel::ConcurrentQueue<eviction_candidate>& candidate_queue,
               cudaStream_t stream);
@@ -466,9 +476,9 @@ class prefetching_cache {
   /// Non-blocking read of a single range.
   /// Returns an empty pinned_view if the range is not cached or the cached
   /// entry does not fully cover [offset, offset+size).  Updates hit / miss
-  /// counters (see summary()).  @p stream is used by the returned
-  /// pinned_view to record an event on release so the evictor can tell
-  /// when any in-flight async memcpys have finished.
+  /// counters (see summary()).  @p stream, when non-null, defers the
+  /// returned pinned_view's read release until the stream reaches the
+  /// release point — see @c pinned_view's ctor for the full contract.
   [[nodiscard]] pinned_view read(const sirius_io_object& obj,
                                  size_t offset,
                                  size_t size,

--- a/src/include/io/prefetching_cache.hpp
+++ b/src/include/io/prefetching_cache.hpp
@@ -200,12 +200,48 @@ class entry_state {
     _packed.notify_all();
   }
 
+  /// loading → cached using CAS.  Returns false if shutdown or another
+  /// completion path already moved the entry out of loading.
+  bool try_mark_cached() noexcept
+  {
+    auto expected = pack(loading, 0);
+    bool ok = _packed.compare_exchange_strong(expected, pack(cached, 0), std::memory_order_acq_rel);
+    if (ok) { _packed.notify_all(); }
+    return ok;
+  }
+
   /// loading → empty.  IO failed, chunks already freed by caller.
   /// Wakes any readers parked in @c wait_while_loading().
   void mark_load_failed() noexcept
   {
     _packed.store(pack(empty, 0), std::memory_order_release);
     _packed.notify_all();
+  }
+
+  /// loading → empty using CAS.  Returns false if the entry was already
+  /// resolved or aborted.
+  bool try_mark_load_failed() noexcept
+  {
+    auto expected = pack(loading, 0);
+    bool ok = _packed.compare_exchange_strong(expected, pack(empty, 0), std::memory_order_acq_rel);
+    if (ok) { _packed.notify_all(); }
+    return ok;
+  }
+
+  /// (queued | loading) → empty. Used during cache shutdown to wake readers
+  /// that are parked on a background load that may never complete.
+  bool try_abort_pending() noexcept
+  {
+    uint32_t cur = _packed.load(std::memory_order_acquire);
+    while (true) {
+      auto st = unpack_state(cur);
+      if (st != queued && st != loading) return false;
+      if (_packed.compare_exchange_weak(
+            cur, pack(empty, 0), std::memory_order_acq_rel, std::memory_order_acquire)) {
+        _packed.notify_all();
+        return true;
+      }
+    }
   }
 
   /// Block while state == loading.  Returns when the state transitions
@@ -542,6 +578,7 @@ class prefetching_cache {
   void worker_loop(std::stop_token stop);
   void evictor_loop(std::stop_token stop);
   void enqueue_work(work_item item);
+  void abort_pending_entries() noexcept;
 
   /// Release all chunks held by an entry back to the pool.
   void release_chunks(cache_entry& entry);

--- a/src/include/io/prefetching_cache.hpp
+++ b/src/include/io/prefetching_cache.hpp
@@ -469,6 +469,11 @@ class prefetching_cache {
   /// @c shared_from_this() so the underlying file handles stay open
   /// until all pending prefetch work for this file has completed.
   /// @p obj must already be owned by a @c std::shared_ptr.
+  ///
+  /// @p metadata is optional: a non-null pointer overwrites any previously
+  /// stored metadata for this file's cache key, while a null pointer leaves
+  /// the existing entry untouched.  This lets repeat callers re-trigger
+  /// prefetch without having to re-supply (or re-parse) the metadata.
   void insert(sirius_io_object& obj,
               std::shared_ptr<sirius_io_object_metadata> metadata,
               const std::vector<cudf::io::text::byte_range_info>& ranges);
@@ -490,6 +495,15 @@ class prefetching_cache {
     const sirius_io_object& obj,
     const std::vector<cudf::io::text::byte_range_info>& ranges,
     cudaStream_t stream);
+
+  /// Look up the metadata that a previous insert() stored for @p obj.
+  /// Returns nullptr if no entry exists for the object's cache key or no
+  /// metadata was supplied on insert.  Callers that want to skip re-parsing
+  /// a parquet footer (or other backend-specific metadata) check this
+  /// before doing the parse and then call insert() with a freshly-built
+  /// metadata object on a miss.
+  [[nodiscard]] std::shared_ptr<sirius_io_object_metadata> get_metadata(
+    const sirius_io_object& obj) const;
 
   /// Increment _cache_age by 1.  The evictor uses
   /// (n_total_read_request - _cache_age) to score entries into buckets.

--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include "io/types.hpp"
+#include "io/io_context.hpp"
+
+#include <cudf/io/datasource.hpp>
 
 namespace sirius::io {
 
@@ -30,7 +32,7 @@ namespace sirius::io {
  * Thin delegate: every read method forwards to @c sirius_ioctx, passing the
  * owned @c sirius_io_object by reference.
  */
-class sirius_datasource : public io_datasource {
+class sirius_datasource : public cudf::io::datasource {
  public:
   static constexpr size_t NUM_BUFFERS = NUM_CHUNKS;
   static constexpr size_t BUFFER_SIZE = CHUNK_SIZE;
@@ -38,7 +40,7 @@ class sirius_datasource : public io_datasource {
   explicit sirius_datasource(std::shared_ptr<sirius_ioctx> io_ctx,
                              std::shared_ptr<sirius_io_object> io_object);
 
-  ~sirius_datasource() override = default;
+  ~sirius_datasource() override;
 
   sirius_datasource(sirius_datasource const&)            = delete;
   sirius_datasource& operator=(sirius_datasource const&) = delete;
@@ -76,15 +78,6 @@ class sirius_datasource : public io_datasource {
                                         size_t size,
                                         uint8_t* dst,
                                         rmm::cuda_stream_view stream) override;
-
-  // ---- sirius_datasource overrides ------------------------------------------
-
-  void host_read_ranges_async(std::vector<cudf::io::text::byte_range_info> const& ranges,
-                              std::span<cudf::host_span<std::byte>> dst,
-                              io_completion_handler handler) override;
-
-  size_t host_read_ranges(std::vector<cudf::io::text::byte_range_info> const& ranges,
-                          std::span<cudf::host_span<std::byte>> dst) override;
 
  private:
   std::shared_ptr<sirius_ioctx> _io_ctx;

--- a/src/include/io/templated_ioctx.hpp
+++ b/src/include/io/templated_ioctx.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "io/io_context.hpp"
+#include "io/prefetching_cache.hpp"
 #include "io/sirius_datasource.hpp"
 
 #include <rmm/device_buffer.hpp>
@@ -120,10 +121,20 @@ class templated_ioctx : public sirius_ioctx {
       _reactors.emplace_back(factory());
   }
 
+  ~templated_ioctx() override
+  {
+    // sirius_ioctx owns the cache in the base class, which would normally be
+    // destroyed after this derived class's reactor pool. Stop the cache first
+    // so its worker cannot enqueue into reactors while they are shutting down.
+    _cache.reset();
+    shutdown();
+  }
+
   void shutdown() override
   {
-    for (auto& r : _reactors)
+    for (auto& r : _reactors) {
       r->shutdown();
+    }
   }
 
   std::unique_ptr<cudf::io::datasource> make_datasource(

--- a/src/include/io/templated_ioctx.hpp
+++ b/src/include/io/templated_ioctx.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include "io/io_context.hpp"
 #include "io/sirius_datasource.hpp"
-#include "io/types.hpp"
 
 #include <rmm/device_buffer.hpp>
 
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -60,7 +61,9 @@ concept io_reactor_c = requires(R r,
                                 size_t size,
                                 uint8_t* dst,
                                 cudf::io::text::byte_range_info logical,
-                                size_t file_size) {
+                                size_t file_size,
+                                std::string_view path,
+                                std::string path_str) {
   typename R::native_handle_type;
   typename R::io_object_type;
   typename R::device_read_req_type;
@@ -74,6 +77,11 @@ concept io_reactor_c = requires(R r,
   { r.host_enqueue_bulk(hbatch) };
   { r.shutdown() };
   { R::align_to_physical(logical, file_size) } -> std::same_as<cudf::io::text::byte_range_info>;
+  { R::supports(path) } -> std::same_as<bool>;
+  {
+    R::create_io_object(std::move(path_str))
+  } -> std::same_as<std::unique_ptr<typename R::io_object_type>>;
+  { R::size(handle) } -> std::same_as<size_t>;
 };
 
 // ---------------------------------------------------------------------------
@@ -124,6 +132,16 @@ class templated_ioctx : public sirius_ioctx {
     return std::make_unique<sirius_datasource>(shared_from_this(), std::move(io_object));
   }
 
+  std::shared_ptr<sirius_io_object> create_io_object(std::string path) override
+  {
+    return std::shared_ptr<sirius_io_object>(Reactor::create_io_object(std::move(path)));
+  }
+
+  [[nodiscard]] bool supports(std::string_view path) const override
+  {
+    return Reactor::supports(path);
+  }
+
   Reactor& next_reactor()
   {
     size_t idx = _next.fetch_add(1, std::memory_order_relaxed) % _reactors.size();
@@ -132,7 +150,7 @@ class templated_ioctx : public sirius_ioctx {
 
   // -- Host reads (generic: delegate to io_object_type + std::async) --------
 
-  size_t host_read(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst) override
+  size_t host_read_io(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst) override
   {
     auto& tobj = as_typed(obj);
     size       = std::min(size, tobj.size() > offset ? tobj.size() - offset : size_t{0});
@@ -140,33 +158,19 @@ class templated_ioctx : public sirius_ioctx {
     return next_reactor().host_read(tobj.host_handle(), offset, size, dst);
   }
 
-  std::unique_ptr<cudf::io::datasource::buffer> host_read(sirius_io_object& obj,
-                                                          size_t offset,
-                                                          size_t size) override
-  {
-    size = std::min(size, obj.size() > offset ? obj.size() - offset : size_t{0});
-    std::vector<uint8_t> buf(size);
-    size_t n = host_read(obj, offset, size, buf.data());
-    buf.resize(n);
-    return cudf::io::datasource::buffer::create(std::move(buf));
-  }
-
-  void host_read_async(sirius_io_object& obj,
-                       size_t offset,
-                       size_t size,
-                       uint8_t* dst,
-                       io_completion_handler handler) override
+  void host_read_async_io(sirius_io_object& obj,
+                          size_t offset,
+                          size_t size,
+                          uint8_t* dst,
+                          io_completion_handler handler) override
   {
     auto& tobj = as_typed(obj);
     size       = std::min(size, tobj.size() > offset ? tobj.size() - offset : size_t{0});
-    if (size == 0) {
-      handler(0, nullptr);
-      return;
-    }
-    auto ctx         = std::make_shared<request_context>();
-    ctx->handler     = std::move(handler);
-    ctx->total_bytes = size;
-    ctx->pending.store(1, std::memory_order_relaxed);
+
+    // size==0 case is folded into create(): it fires the handler with
+    // (0, nullptr) and returns nullptr.
+    auto ctx = request_context::create(size == 0 ? 0 : 1, size, std::move(handler));
+    if (!ctx) return;
 
     host_read_req_type req;
     req.handle = tobj.host_handle();
@@ -179,21 +183,6 @@ class templated_ioctx : public sirius_ioctx {
 
   // -- Device reads (generic chunking; reactor-backed) ----------------------
 
-  std::unique_ptr<cudf::io::datasource::buffer> device_read_io(
-    sirius_io_object& obj, size_t offset, size_t size, rmm::cuda_stream_view stream) override
-  {
-    rmm::device_buffer dbuf(size, stream);
-    sync_via_promise([&](io_completion_handler h) {
-      enqueue_device_read(as_typed(obj),
-                          offset,
-                          size,
-                          static_cast<uint8_t*>(dbuf.data()),
-                          stream.value(),
-                          std::move(h));
-    });
-    return cudf::io::datasource::buffer::create(std::move(dbuf));
-  }
-
   size_t device_read_io(sirius_io_object& obj,
                         size_t offset,
                         size_t size,
@@ -205,7 +194,7 @@ class templated_ioctx : public sirius_ioctx {
     });
   }
 
-  void device_read_io_async(sirius_io_object& obj,
+  void device_read_async_io(sirius_io_object& obj,
                             size_t offset,
                             size_t size,
                             uint8_t* dst,
@@ -217,10 +206,10 @@ class templated_ioctx : public sirius_ioctx {
 
   // -- Batch host reads (generic: dispatch to reactor host_read_async) ------
 
-  void host_read_ranges_async(sirius_io_object& obj,
-                              std::vector<cudf::io::text::byte_range_info> const& ranges,
-                              std::span<cudf::host_span<std::byte>> dst,
-                              io_completion_handler handler) override
+  void host_read_ranges_async_io(sirius_io_object& obj,
+                                 std::vector<cudf::io::text::byte_range_info> const& ranges,
+                                 std::span<cudf::host_span<std::byte>> dst,
+                                 io_completion_handler handler) override
   {
     auto& tobj     = as_typed(obj);
     auto file_size = tobj.size();
@@ -249,15 +238,11 @@ class templated_ioctx : public sirius_ioctx {
       reqs.push_back(std::move(req));
       total += sz;
     }
-    if (reqs.empty()) {
-      handler(0, nullptr);
-      return;
-    }
-
-    auto ctx         = std::make_shared<request_context>();
-    ctx->handler     = std::move(handler);
-    ctx->total_bytes = total;
-    ctx->pending.store(reqs.size(), std::memory_order_relaxed);
+    // reqs.empty() case is folded into create(): it fires the handler with
+    // (0, nullptr) and returns nullptr.  Early-return retained as a fast
+    // path that skips the per-reactor split loop below.
+    auto ctx = request_context::create(reqs.size(), total, std::move(handler));
+    if (!ctx) return;
     for (auto& r : reqs)
       r.ctx = ctx;
 
@@ -278,21 +263,6 @@ class templated_ioctx : public sirius_ioctx {
         std::span<host_read_req_type>(reqs.data() + off, group_size));
       off += group_size;
     }
-  }
-
-  size_t host_read_ranges(sirius_io_object& obj,
-                          std::vector<cudf::io::text::byte_range_info> const& ranges,
-                          std::span<cudf::host_span<std::byte>> dst) override
-  {
-    std::promise<size_t> p;
-    auto fut = p.get_future();
-    host_read_ranges_async(obj, ranges, dst, [&p](size_t bytes, std::exception_ptr ep) {
-      if (ep)
-        p.set_exception(ep);
-      else
-        p.set_value(bytes);
-    });
-    return fut.get();
   }
 
   cudf::io::text::byte_range_info compute_physical_range(cudf::io::text::byte_range_info logical,
@@ -323,7 +293,9 @@ class templated_ioctx : public sirius_ioctx {
   {
     auto file_size = obj.size();
     if (size == 0 || offset >= file_size) {
-      handler(0, nullptr);
+      // Nothing to read — fire the handler now via a no-chunk create.
+      // The returned nullptr is intentionally discarded.
+      [[maybe_unused]] auto _ = request_context::create(0, 0, std::move(handler));
       return;
     }
     size = std::min(size, file_size - offset);
@@ -336,10 +308,8 @@ class templated_ioctx : public sirius_ioctx {
 
     size_t n_chunks = (a_end - a_start + CHUNK_SIZE - 1) / CHUNK_SIZE;
 
-    auto ctx         = std::make_shared<request_context>();
-    ctx->handler     = std::move(handler);
-    ctx->total_bytes = size;
-    ctx->pending.store(n_chunks, std::memory_order_relaxed);
+    auto ctx = request_context::create(n_chunks, size, std::move(handler));
+    if (!ctx) return;
 
     // Capture the caller's CUDA device so the reactor thread can switch
     // to it before the H2D copy.  In multi-GPU usage a single reactor

--- a/src/include/io/types.hpp
+++ b/src/include/io/types.hpp
@@ -19,27 +19,18 @@
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda_runtime.h>
 
 #include <atomic>
 #include <cstddef>
 #include <exception>
 #include <functional>
-#include <future>
 #include <memory>
-#include <mutex>
-#include <span>
+#include <stdexcept>
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace sirius::io {
-
-// Forward declarations (cache is owned by sirius_ioctx; defined in
-// prefetching_cache.hpp).
-class prefetching_cache;
-class buffer_pool;
 
 // ---------------------------------------------------------------------------
 // Completion handler
@@ -55,7 +46,7 @@ using io_completion_handler = std::function<void(size_t bytes_transferred, std::
 // ---------------------------------------------------------------------------
 
 static constexpr size_t CHUNK_SIZE    = 1UL << 20;  ///< Bounce-buffer chunk size (1 MiB).
-static constexpr size_t NUM_CHUNKS    = 32;         ///< Number of bounce slots per reactor.
+static constexpr size_t NUM_CHUNKS    = 128;        ///< Number of bounce slots per reactor.
 static constexpr size_t IO_BLOCK_SIZE = 4096;       ///< O_DIRECT alignment requirement (bytes).
 
 // ---------------------------------------------------------------------------
@@ -63,9 +54,9 @@ static constexpr size_t IO_BLOCK_SIZE = 4096;       ///< O_DIRECT alignment requ
 // ---------------------------------------------------------------------------
 
 /**
- * @brief Abstract per-file handle that provides file identity to a datasource.
- *
- * Decouples file location / cache-key logic from I/O mechanics.
+ * @brief Abstract per-file handle.  A passive bag of native handles
+ * produced by a backend reactor (e.g. file descriptors, CURL easy
+ * handles, S3 client state).  Performs no I/O of its own.
  *
  * Inherits from @c std::enable_shared_from_this so the prefetching cache can
  * take a reference to an io_object and safely extend its lifetime via
@@ -76,8 +67,17 @@ class sirius_io_object : public std::enable_shared_from_this<sirius_io_object> {
  public:
   virtual ~sirius_io_object() = default;
 
+  /// Stable identifier used as the prefetching-cache key.  Often equal to
+  /// @c object_path() but may differ for backends that need to distinguish
+  /// otherwise-equal paths (versioned S3 keys, normalized URLs, …).
   [[nodiscard]] virtual const std::string& raw_file_cache_id() const noexcept = 0;
-  [[nodiscard]] virtual size_t size() const noexcept                          = 0;
+
+  /// The path / URL / key the caller used to construct this object.
+  [[nodiscard]] virtual const std::string& object_path() const noexcept = 0;
+
+  /// Total size of the underlying object, populated by the reactor at
+  /// construction time and stored on the io_object thereafter.
+  [[nodiscard]] virtual size_t size() const noexcept = 0;
 };
 
 class sirius_io_object_metadata {
@@ -93,35 +93,118 @@ class sirius_io_object_metadata {
  * @brief Shared completion state for one logical read call (host or device).
  *
  * A single read may be split into multiple sub-requests. All sub-requests
- * decrement @c pending; the last one resolves the promise.
+ * decrement @c pending; the last one resolves the handler.
+ *
+ * Construction is gated by @c create() so callers can't forget to set
+ * @c pending or @c handler (a missed setup would silently deadlock the
+ * caller).  The destructor is a safety net: if @c handler hasn't been
+ * fired by the time the last @c shared_ptr drops (e.g., a sub-request
+ * was silently dropped somewhere in the dispatch chain), it fires with
+ * an explicit error so the caller sees a failure instead of hanging.
  */
 struct request_context {
-  io_completion_handler handler;
-  std::atomic<size_t> pending{0};
-  size_t total_bytes{0};
-  std::atomic<bool> failed{false};
-  std::mutex exc_mtx;
-  std::exception_ptr exc;
+ private:
+  // Private tag so only create() can construct.  Public ctor signature so
+  // std::make_shared still works (preserves the single-allocation control
+  // block + object layout).
+  struct create_passkey {};
+
+ public:
+  explicit request_context(create_passkey) noexcept {}
+
+  request_context(request_context const&)            = delete;
+  request_context& operator=(request_context const&) = delete;
+
+  /// Construct a request_context expecting @p n_chunks chunk_done /
+  /// chunk_failed calls.
+  ///
+  /// - If @p n_chunks == 0: invokes @p handler with (0, nullptr) immediately
+  ///   and returns nullptr.  Caller checks `if (!ctx) return;`.
+  /// - If @p handler is null and @p n_chunks > 0: throws
+  ///   @c std::invalid_argument.  A pending count with no handler would
+  ///   silently deadlock the caller.
+  /// - Otherwise: returns a fully-populated shared_ptr.
+  [[nodiscard]] static std::shared_ptr<request_context> create(size_t n_chunks,
+                                                               size_t total_bytes,
+                                                               io_completion_handler handler)
+  {
+    if (n_chunks == 0) {
+      if (handler) {
+        try {
+          handler(0, nullptr);
+        } catch (...) {
+          // Caller's handler threw on the zero-work path; nothing useful
+          // to do here.
+        }
+      }
+      return nullptr;
+    }
+    if (!handler) {
+      throw std::invalid_argument("request_context::create: handler is null but n_chunks > 0");
+    }
+    auto ctx         = std::make_shared<request_context>(create_passkey{});
+    ctx->handler     = std::move(handler);
+    ctx->total_bytes = total_bytes;
+    ctx->pending.store(n_chunks, std::memory_order_relaxed);
+    return ctx;
+  }
+
+  ~request_context() noexcept
+  {
+    // Safety net: if the handler hasn't been fired by the normal path
+    // (e.g., a sub-request was silently dropped between enqueue and
+    // completion), fire it now with an explicit error so the caller
+    // doesn't hang forever waiting on a handler that will never come.
+    bool expected = false;
+    if (handler_fired.compare_exchange_strong(expected, true, std::memory_order_acq_rel) &&
+        handler) {
+      try {
+        handler(0,
+                std::make_exception_ptr(
+                  std::runtime_error("request_context destructed before all chunks completed — "
+                                     "handler resolved by safety net")));
+      } catch (...) {
+        // A throwing handler at destruction time can't propagate anywhere
+        // useful — swallow to keep the destructor noexcept.
+      }
+    }
+  }
 
   void chunk_done()
   {
-    if (pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      std::lock_guard lk{exc_mtx};
-      if (failed.load(std::memory_order_relaxed))
-        handler(0, exc);
-      else
-        handler(total_bytes, nullptr);
+    if (pending.fetch_sub(1, std::memory_order_acq_rel) != 1) return;
+
+    // Last chunk — fire the handler exactly once.  The CAS guard makes
+    // this idempotent against the destructor safety net and against any
+    // future imbalance where chunk_done could be called extra times.
+    bool expected = false;
+    if (!handler_fired.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) return;
+
+    if (failed.load(std::memory_order_relaxed)) {
+      handler(0, exc);
+    } else {
+      handler(total_bytes, nullptr);
     }
   }
 
   void chunk_failed(std::exception_ptr e)
   {
-    if (!failed.exchange(true, std::memory_order_relaxed)) {
-      std::lock_guard lk{exc_mtx};
+    bool expected = false;
+    if (failed.compare_exchange_strong(expected, true, std::memory_order_relaxed)) {
       exc = std::move(e);
     }
     chunk_done();
   }
+
+  io_completion_handler handler;
+  std::atomic<size_t> pending{0};
+  size_t total_bytes{0};
+  std::atomic<bool> failed{false};
+  std::exception_ptr exc;
+  /// Set (via CAS) by whichever path resolves the handler — normal
+  /// completion in chunk_done() or the destructor safety net.
+  /// Guarantees the handler fires at most once.
+  std::atomic<bool> handler_fired{false};
 };
 
 // ---------------------------------------------------------------------------
@@ -161,117 +244,6 @@ struct host_read_req {
   size_t size{0};
   uint8_t* dst{nullptr};
   std::shared_ptr<request_context> ctx;
-};
-
-// ---------------------------------------------------------------------------
-// sirius_ioctx
-// ---------------------------------------------------------------------------
-
-/**
- * @brief Abstract shared context passed to every datasource.
- *
- * Holds resources that are shared across all datasources (ring pools,
- * reactor threads, ...). Extend this class to provide a concrete I/O backend.
- */
-class sirius_ioctx : public std::enable_shared_from_this<sirius_ioctx> {
- public:
-  sirius_ioctx();
-  virtual ~sirius_ioctx();
-
-  virtual void shutdown() = 0;
-
-  virtual std::unique_ptr<cudf::io::datasource> make_datasource(
-    std::shared_ptr<sirius_io_object> io_object) = 0;
-
-  /// Construct the owned prefetching_cache.  Must be called before any
-  /// read that should consult the cache; until then device_read falls
-  /// through directly to device_read_io.
-  void initialize_cache(buffer_pool& pool, size_t inflight_budget_chunks = 2048);
-
-  [[nodiscard]] prefetching_cache* cache() noexcept { return _cache.get(); }
-
-  // -- Read API ---------------------------------------------------------------
-
-  virtual size_t host_read(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst) = 0;
-
-  virtual std::unique_ptr<cudf::io::datasource::buffer> host_read(sirius_io_object& obj,
-                                                                  size_t offset,
-                                                                  size_t size) = 0;
-
-  virtual void host_read_async(sirius_io_object& obj,
-                               size_t offset,
-                               size_t size,
-                               uint8_t* dst,
-                               io_completion_handler handler) = 0;
-
-  // device_read / device_read_async: concrete in the base; consult the
-  // cache first, fall through to device_read_io{,_async} on miss.
-  std::unique_ptr<cudf::io::datasource::buffer> device_read(sirius_io_object& obj,
-                                                            size_t offset,
-                                                            size_t size,
-                                                            rmm::cuda_stream_view stream);
-
-  size_t device_read(
-    sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream);
-
-  void device_read_async(sirius_io_object& obj,
-                         size_t offset,
-                         size_t size,
-                         uint8_t* dst,
-                         rmm::cuda_stream_view stream,
-                         io_completion_handler handler);
-
-  // Backend-specific IO path (no cache lookup).  Implementations read
-  // directly from the underlying device (e.g. O_DIRECT + cuFile).
-  virtual std::unique_ptr<cudf::io::datasource::buffer> device_read_io(
-    sirius_io_object& obj, size_t offset, size_t size, rmm::cuda_stream_view stream) = 0;
-
-  virtual size_t device_read_io(sirius_io_object& obj,
-                                size_t offset,
-                                size_t size,
-                                uint8_t* dst,
-                                rmm::cuda_stream_view stream) = 0;
-
-  virtual void device_read_io_async(sirius_io_object& obj,
-                                    size_t offset,
-                                    size_t size,
-                                    uint8_t* dst,
-                                    rmm::cuda_stream_view stream,
-                                    io_completion_handler handler) = 0;
-
-  virtual void host_read_ranges_async(sirius_io_object& obj,
-                                      std::vector<cudf::io::text::byte_range_info> const& ranges,
-                                      std::span<cudf::host_span<std::byte>> dst,
-                                      io_completion_handler handler) = 0;
-
-  virtual size_t host_read_ranges(sirius_io_object& obj,
-                                  std::vector<cudf::io::text::byte_range_info> const& ranges,
-                                  std::span<cudf::host_span<std::byte>> dst) = 0;
-
-  // -- Physical range alignment ------------------------------------------------
-
-  virtual cudf::io::text::byte_range_info compute_physical_range(
-    cudf::io::text::byte_range_info logical, size_t file_size) const = 0;
-
- protected:
-  std::unique_ptr<prefetching_cache> _cache;
-};
-
-// ---------------------------------------------------------------------------
-// io_datasource
-// ---------------------------------------------------------------------------
-
-/**
- * @brief Extended datasource with batch range-read support.
- */
-class io_datasource : public cudf::io::datasource {
- public:
-  virtual void host_read_ranges_async(std::vector<cudf::io::text::byte_range_info> const& ranges,
-                                      std::span<cudf::host_span<std::byte>> dst,
-                                      io_completion_handler handler) = 0;
-
-  virtual size_t host_read_ranges(std::vector<cudf::io::text::byte_range_info> const& ranges,
-                                  std::span<cudf::host_span<std::byte>> dst) = 0;
 };
 
 }  // namespace sirius::io

--- a/src/include/io/uring/uring_ioctx.hpp
+++ b/src/include/io/uring/uring_ioctx.hpp
@@ -19,73 +19,24 @@
 #include "io/templated_ioctx.hpp"
 #include "io/uring/uring_reactor.hpp"
 
-#include <condition_variable>
-#include <memory>
-#include <mutex>
-
 namespace sirius::io {
-
-// ---------------------------------------------------------------------------
-// ring_pool
-// ---------------------------------------------------------------------------
-
-/**
- * @brief Pool of @c io_uring instances for host (buffered) reads.
- */
-class ring_pool {
- public:
-  struct guard {
-    guard(ring_pool* p, size_t i) noexcept : _pool(p), _idx(i) {}
-
-    io_uring& ring() const { return _pool->_rings[_idx]; }
-
-    ~guard()
-    {
-      if (_pool) _pool->release(_idx);
-    }
-
-    guard(guard const&)            = delete;
-    guard& operator=(guard const&) = delete;
-    guard(guard&& o) noexcept : _pool(std::exchange(o._pool, nullptr)), _idx(o._idx) {}
-
-   private:
-    ring_pool* _pool{nullptr};
-    size_t _idx{0};
-  };
-
-  ring_pool()                            = default;
-  ring_pool(ring_pool const&)            = delete;
-  ring_pool& operator=(ring_pool const&) = delete;
-
-  void init(size_t n_rings, unsigned ring_entries);
-  ~ring_pool();
-  guard acquire();
-
- private:
-  void release(size_t idx);
-
-  std::unique_ptr<io_uring[]> _rings;
-  std::unique_ptr<bool[]> _in_use;
-  size_t _n{0};
-  std::mutex _mtx;
-  std::condition_variable _cv;
-};
 
 // ---------------------------------------------------------------------------
 // uring_ioctx
 // ---------------------------------------------------------------------------
 
 /**
- * @brief io_uring-backed ioctx.  Thin specialisation of
- *        @c templated_ioctx<uring_reactor> adding a side-channel
- *        @c ring_pool for callers that need direct access to a host ring.
+ * @brief io_uring-backed ioctx. Thin specialisation of
+ *        @c templated_ioctx<uring_reactor>.
  */
 class uring_ioctx : public templated_ioctx<uring_reactor> {
  public:
-  explicit uring_ioctx(unsigned host_ring_depth = 16,
-                       unsigned ring_entries    = 64,
-                       size_t n_reactors        = 4,
-                       size_t bounce_slot_size  = 1UL * 1024 * 1024);
+  /// Each @c uring_reactor in the pool allocates its bounce slots from
+  /// @p mr; @p mr must outlive this ioctx.  The bounce-slot size is taken
+  /// from @c mr.get_block_size().
+  uring_ioctx(size_t n_reactors,
+              unsigned ring_entries,
+              cucascade::memory::fixed_size_host_memory_resource& mr);
 };
 
 }  // namespace sirius::io

--- a/src/include/io/uring/uring_reactor.hpp
+++ b/src/include/io/uring/uring_reactor.hpp
@@ -21,6 +21,7 @@
 #include <cuda_runtime.h>
 
 #include <concurrentqueue.h>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <liburing.h>
 
 #include <array>
@@ -28,6 +29,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <string_view>
 #include <thread>
 
 namespace {
@@ -86,31 +88,24 @@ struct ring_deleter {
 };
 using unique_ring = std::unique_ptr<io_uring, ring_deleter>;
 
-/**
- * @brief Custom deleter for CUDA pinned (host) memory allocated with
- *        @c cudaHostAlloc.
- */
-struct pinned_deleter {
-  void operator()(void* p) const noexcept { cudaFreeHost(p); }
-};
-using unique_pinned_buf = std::unique_ptr<void, pinned_deleter>;
-
-/**
- * @brief Converts a byte count to mebibytes.
- */
-inline double to_mb(size_t bytes) noexcept
-{
-  return static_cast<double>(bytes) / (1024.0 * 1024.0);
-}
-
 // ---- bounce_slot -----------------------------------------------------------
 
 /**
  * @brief One pinned-memory staging buffer with a completion flag.
+ *
+ * The buffer is a non-owning pointer into a block owned by the reactor's
+ * @c fixed_size_host_memory_resource allocation — the resource frees the
+ * memory when the reactor is destroyed.
  */
 struct bounce_slot {
-  unique_pinned_buf buf;
+  void* buf{nullptr};
   std::atomic<bool> cuda_done{false};
+  // Status captured by cuda_copy_cb at callback time.  Written before the
+  // release-store on cuda_done, read after the acquire-load — so the
+  // happens-before chain piggybacks on cuda_done.  Lets poll_cuda use the
+  // stream's state when our copy finished, ignoring later unrelated work
+  // the consumer may have queued onto the same stream.
+  cudaError_t cuda_status{cudaSuccess};
 };
 
 // ---------------------------------------------------------------------------
@@ -120,15 +115,23 @@ struct bounce_slot {
 /**
  * @brief Concrete @c sirius_io_object backed by a filesystem path.
  *
- * Opens a buffered @c O_RDONLY fd (for @c pread / host_read) and an
- * @c O_DIRECT fd (for reactor-driven device reads).  The two file
- * descriptors are the native handles consumed by @c uring_reactor.
+ * Passive bag of native handles.  The buffered @c O_RDONLY fd
+ * (for @c pread / host_read) and the @c O_DIRECT fd (for reactor-driven
+ * device reads) are produced by @c uring_reactor::create_io_object — this
+ * class does no I/O of its own.
  */
 class uring_io_object : public sirius_io_object {
  public:
-  explicit uring_io_object(std::string path);
+  uring_io_object(std::string path, file_descriptor fd, file_descriptor fd_direct, size_t file_size)
+    : _path(std::move(path)),
+      _fd(std::move(fd)),
+      _fd_direct(std::move(fd_direct)),
+      _file_size(file_size)
+  {
+  }
 
   [[nodiscard]] const std::string& raw_file_cache_id() const noexcept override { return _path; }
+  [[nodiscard]] const std::string& object_path() const noexcept override { return _path; }
   [[nodiscard]] size_t size() const noexcept override { return _file_size; }
 
   [[nodiscard]] int fd() const noexcept { return _fd.get(); }
@@ -163,7 +166,11 @@ class uring_reactor {
   using device_read_req_type = device_read_req<native_handle_type>;
   using host_read_req_type   = host_read_req<native_handle_type>;
 
-  explicit uring_reactor(unsigned ring_entries = 64, size_t bounce_slot_size = CHUNK_SIZE);
+  /// Bounce slots are allocated from @p mr; their size is taken from
+  /// @c mr.get_block_size().  The reactor keeps the @c multiple_blocks_allocation
+  /// alive for its lifetime — blocks return to the resource on destruction.
+  explicit uring_reactor(cucascade::memory::fixed_size_host_memory_resource& mr,
+                         unsigned ring_entries = 64);
 
   ~uring_reactor();
 
@@ -196,6 +203,18 @@ class uring_reactor {
   static cudf::io::text::byte_range_info align_to_physical(cudf::io::text::byte_range_info logical,
                                                            size_t file_size);
 
+  /// Whether @p path can be served by this reactor.  Local-disk only:
+  /// returns true iff the path refers to an existing, accessible file.
+  [[nodiscard]] static bool supports(std::string_view path);
+
+  /// Open the buffered + O_DIRECT fds for @p path and return them
+  /// packaged in a @c uring_io_object.  Throws on unsupported paths or
+  /// open() failure.
+  static std::unique_ptr<uring_io_object> create_io_object(std::string path);
+
+  /// fstat the open fd to get the file's current size.
+  static size_t size(int fd);
+
  private:
   void worker_loop();
 
@@ -203,8 +222,17 @@ class uring_reactor {
     uring_reactor* self;
     int slot;
   };
-  static void cuda_copy_cb(void* p) noexcept;
+  // cudaStreamAddCallback signature (deprecated but used deliberately).
+  // Unlike cudaLaunchHostFunc, the callback fires even when the stream is
+  // already in an error state — so we never strand a slot in COPYING
+  // waiting for a callback that wouldn't otherwise come.
+  static void cuda_copy_cb(cudaStream_t stream, cudaError_t status, void* p) noexcept;
 
+  // Keeps the bounce-slot blocks alive for the reactor's lifetime.  The
+  // multiple_blocks_allocation destructor returns the blocks to the upstream
+  // resource when the reactor is destroyed.
+  cucascade::memory::fixed_multiple_blocks_allocation _bounce_storage;
+  std::size_t _bounce_slot_size;
   std::array<bounce_slot, NUM_CHUNKS> _bounce;
   std::array<cb_arg, NUM_CHUNKS> _cb_args;
   unsigned _ring_entries;
@@ -213,7 +241,6 @@ class uring_reactor {
   std::thread _worker;
   duckdb_moodycamel::ConcurrentQueue<device_read_req_type> _queue;
   duckdb_moodycamel::ConcurrentQueue<host_read_req_type> _host_queue;
-  std::atomic<uint64_t> _cuda_seq{0};
 };
 
 }  // namespace sirius::io

--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -19,6 +19,8 @@
 // sirius
 #include <data/sirius_converter_registry.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
+#include <io/io_context.hpp>
+#include <io/types.hpp>
 #include <op/scan/scan_plan.hpp>
 #include <op/sirius_physical_operator.hpp>
 
@@ -57,12 +59,16 @@ struct row_group_slice {
                   std::string file_path,
                   std::vector<cudf::size_type> row_group_indices,
                   std::size_t reserved_uncompressed_bytes,
-                  std::size_t reserved_compressed_bytes)
+                  std::size_t reserved_compressed_bytes,
+                  std::shared_ptr<sirius::io::sirius_ioctx> io_ctx        = nullptr,
+                  std::shared_ptr<sirius::io::sirius_io_object> io_object = nullptr)
     : file_metadata(file_metadata),
       file_path(file_path),
       row_group_indices(std::move(row_group_indices)),
       reserved_uncompressed_bytes(reserved_uncompressed_bytes),
-      reserved_compressed_bytes(reserved_compressed_bytes)
+      reserved_compressed_bytes(reserved_compressed_bytes),
+      io_ctx(std::move(io_ctx)),
+      io_object(std::move(io_object))
   {
   }
   std::shared_ptr<cudf::io::parquet::FileMetaData const> file_metadata;
@@ -70,6 +76,13 @@ struct row_group_slice {
   std::vector<cudf::size_type> row_group_indices;
   std::size_t reserved_uncompressed_bytes;
   std::size_t reserved_compressed_bytes;
+  /// Sirius IO context that minted @c io_object.  When non-null, the scan
+  /// operator builds a @c sirius_datasource via @c io_ctx->make_datasource;
+  /// when null, it falls back to @c cudf::io::datasource::create.
+  std::shared_ptr<sirius::io::sirius_ioctx> io_ctx;
+  /// Sirius io_object created by the split provider for this file.  Shared
+  /// across every slice from the same parquet file.
+  std::shared_ptr<sirius::io::sirius_io_object> io_object;
 };
 
 //===----------------------------------------------------------------------===//

--- a/src/include/scan_manager/cached_split_provider.hpp
+++ b/src/include/scan_manager/cached_split_provider.hpp
@@ -25,26 +25,35 @@
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/planner/expression.hpp>
 
+#include <atomic>
 #include <cstddef>
+#include <functional>
 #include <memory>
+#include <variant>
 #include <vector>
 
 namespace sirius::scan_manager {
-
 /**
  * @brief Split provider backed by pre-pinned columns from a pinned_entry.
  *
- * The scan_manager builds the per-column chunk vectors in scan_plan D-order
- * (one entry per @c data_columns slot, looked up by name in the pinned entry).
- * start() then assembles one @ref op::scan::scan_cached_operator_data per
- * chunk: each carries a zero-copy view-backed data_batch over the pinned
- * columns plus the filter expression and a shared scan_plan, and is pushed
- * into the connector.
+ * The scan_manager builds either the per-column GPU chunk vectors (in scan_plan
+ * D-order) or the per-batch host_data_representation chunks (with a D-order
+ * column-index map). Internally both are normalised into a per-batch variant so
+ * @ref produce_split() can dispatch with @c std::visit and emit one
+ * @ref op::scan::scan_cached_operator_data per chunk. Each emitted batch carries
+ * either a zero-copy view-backed gpu_table_representation or a sliced
+ * host_data_representation (downstream conversion happens in
+ * @c scan_cached_operator_data::prepare_for_processing), plus the filter
+ * expression and a shared scan_plan; emissions are pushed into the connector by
+ * @ref split_provider::run.
  *
  * @par Inputs
- *   - @p columns_per_request[d] is the chunk vector for D-position @p d. All
- *     inner vectors must have the same size — that size is the number of
- *     emitted batches.
+ *   - GPU constructor: @p columns_per_request[d] is the chunk vector for
+ *     D-position @p d. All inner vectors must have the same size — that size is
+ *     the number of emitted batches.
+ *   - HOST constructor: @p host_chunks holds one host_data_representation per
+ *     emitted batch (each covering all pinned columns), and @p column_indices
+ *     selects the columns required by the scan in scan_plan D-order.
  *   - @p memory_space is captured into each emitted data_batch so memory
  *     accounting matches where the cached columns reside.
  *   - @p filter_expression and @p plan are forwarded unchanged on every
@@ -55,8 +64,21 @@ namespace sirius::scan_manager {
  */
 class cached_split_provider : public split_provider {
  public:
-  /// GPU-tier constructor: the pinned columns are GPU-resident cudf columns. start()
-  /// emits one zero-copy gpu_table_representation per batch.
+  /// One emitted batch's worth of GPU-resident columns, already arranged in
+  /// scan_plan D-order. produce_split() turns this into a zero-copy
+  /// gpu_table_representation.
+  using gpu_chunk = std::vector<std::shared_ptr<cudf::column>>;
+  /// One emitted batch's worth of host-resident data; produce_split() slices it
+  /// down to the requested column indices before wrapping it as a data_batch.
+  using host_chunk = std::shared_ptr<cucascade::host_data_representation>;
+  /// Per-batch storage — exactly one of the two alternatives is populated per
+  /// emitted chunk. The same provider only ever holds chunks of one tier (set
+  /// at construction by which ctor was called).
+  using chunk_variant = std::variant<gpu_chunk, host_chunk>;
+
+  /// GPU-tier constructor: the pinned columns are GPU-resident cudf columns.
+  /// Each callable returned by @ref next_split_provider() emits one zero-copy
+  /// gpu_table_representation per batch.
   cached_split_provider(std::vector<std::vector<std::shared_ptr<cudf::column>>> columns_per_request,
                         cucascade::memory::memory_space& memory_space,
                         std::shared_ptr<duckdb::Expression> filter_expression,
@@ -64,9 +86,10 @@ class cached_split_provider : public split_provider {
 
   /// HOST-tier constructor: each chunk in @p host_chunks is a host_data_representation
   /// holding all pinned columns. @p column_indices selects the columns required by the
-  /// scan in scan_plan D-order. start() slices each chunk by these indices and emits
-  /// one host_data_representation-backed batch per chunk; conversion to GPU happens
-  /// downstream in scan_cached_operator_data::prepare_for_processing.
+  /// scan in scan_plan D-order. Each callable returned by @ref next_split_provider()
+  /// slices the claimed chunk by these indices and emits one host_data_representation-
+  /// backed batch; conversion to GPU happens downstream in
+  /// scan_cached_operator_data::prepare_for_processing.
   cached_split_provider(
     std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
     std::vector<std::size_t> column_indices,
@@ -74,17 +97,30 @@ class cached_split_provider : public split_provider {
     std::shared_ptr<duckdb::Expression> filter_expression,
     std::shared_ptr<op::scan::scan_plan const> plan);
 
-  std::future<void> start(exec::thread_pool& pool, split_connector& connector) override;
+  [[nodiscard]] bool has_more_splits() const override;
+
+  /// \brief Atomically claim the next chunk index and return a callable that
+  ///        wraps the cached batch in a single-element vector. After every
+  ///        chunk has been claimed, returns a null callable.
+  std::function<std::vector<std::unique_ptr<op::operator_data>>()> next_split_provider() override;
 
  private:
-  // Populated when constructed via the GPU constructor; empty in HOST mode.
-  std::vector<std::vector<std::shared_ptr<cudf::column>>> _columns_per_request;
-  // Populated when constructed via the HOST constructor; empty in GPU mode.
-  std::vector<std::shared_ptr<cucascade::host_data_representation>> _host_chunks;
+  /// \brief Produce the split for an already-claimed chunk index. Called by
+  ///        the callable returned from @ref next_split_provider(); dispatches
+  ///        on @ref chunk_variant to build either a GPU- or host-resident
+  ///        data_batch.
+  std::vector<std::unique_ptr<op::operator_data>> produce_split(std::size_t batch_idx);
+
+  /// One entry per emitted batch; tier is fixed at construction and consistent
+  /// across the vector (every entry holds the same variant alternative).
+  std::vector<chunk_variant> _batches;
+  /// Only meaningful for HOST mode: which columns of each host_data_representation
+  /// to slice out before emitting. Empty in GPU mode.
   std::vector<std::size_t> _column_indices;
   cucascade::memory::memory_space* _memory_space;
   std::shared_ptr<duckdb::Expression> _filter_expression;
   std::shared_ptr<op::scan::scan_plan const> _plan;
+  std::atomic<std::size_t> _next_batch_idx{0};
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/parquet_metadata.hpp
+++ b/src/include/scan_manager/parquet_metadata.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "io/types.hpp"
+
+#include <cudf/io/parquet_schema.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+namespace sirius::scan_manager {
+
+/// Parquet-flavored @c sirius_io_object_metadata stored in the prefetching
+/// cache alongside an io_object.  Holds the parsed @c FileMetaData so future
+/// scans of the same file can skip the footer fetch + parse and construct a
+/// @c hybrid_scan_reader directly from the cached struct.  @c footer_byte_len
+/// is the body size returned by @c fetch_footer_to_host (excludes the 8-byte
+/// trailer) — kept here so callers reassembling the footer byte range for
+/// prefetch don't have to round-trip through the datasource.
+class parquet_metadata final : public sirius::io::sirius_io_object_metadata {
+ public:
+  parquet_metadata(std::shared_ptr<cudf::io::parquet::FileMetaData const> file_metadata,
+                   std::size_t footer_byte_len)
+    : _file_metadata(std::move(file_metadata)), _footer_byte_len(footer_byte_len)
+  {
+  }
+
+  [[nodiscard]] std::shared_ptr<cudf::io::parquet::FileMetaData const> const& file_metadata()
+    const noexcept
+  {
+    return _file_metadata;
+  }
+
+  [[nodiscard]] std::size_t footer_byte_len() const noexcept { return _footer_byte_len; }
+
+ private:
+  std::shared_ptr<cudf::io::parquet::FileMetaData const> _file_metadata;
+  std::size_t _footer_byte_len{0};
+};
+
+}  // namespace sirius::scan_manager

--- a/src/include/scan_manager/parquet_split_provider.hpp
+++ b/src/include/scan_manager/parquet_split_provider.hpp
@@ -26,9 +26,10 @@
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/vector.hpp>
 
+#include <atomic>
 #include <cstddef>
+#include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -37,15 +38,23 @@ class Expression;
 class TableFilterSet;
 }  // namespace duckdb
 
+namespace sirius::io {
+class sirius_ioctx;
+}  // namespace sirius::io
+
 namespace sirius::scan_manager {
 
 /**
  * @brief Split provider that parses parquet metadata and emits one
  *        @c parquet_scan_data per row-group partition.
  *
- * This provider performs up-front filter / projection / hive partition setup, and start() drives
- * the metadata-scan iteration on the provided thread pool, pushing parquet_scan_data into the
- * connector.
+ * The constructor performs up-front filter / projection / hive partition setup
+ * and pre-decomposes the file list into immutable per-task @c file_batch
+ * entries. @ref next_split_provider() atomically claims the next batch index
+ * and returns a callable that runs the metadata scan when invoked — splitting
+ * the claim from the work lets the driver enqueue all batches and have the
+ * worker pool process them in parallel. When the index has overshot the batch
+ * list, the returned callable yields an empty vector.
  */
 class parquet_split_provider : public split_provider {
  public:
@@ -81,7 +90,12 @@ class parquet_split_provider : public split_provider {
     duckdb::unique_ptr<duckdb::TableFilterSet> table_filter_set            = nullptr,
     duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices = {},
     std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE,
-    std::size_t max_file_processed     = DEFAULT_MAX_FILE_PROCESSED);
+    std::size_t max_file_processed     = DEFAULT_MAX_FILE_PROCESSED,
+    /// Optional sirius IO context.  When non-null, footer fetches go through
+    /// @c sirius_datasource, and both the io_object and the ioctx itself are
+    /// attached to each emitted @c row_group_slice so the scan operator can
+    /// reuse the same path for data reads.
+    std::shared_ptr<sirius::io::sirius_ioctx> io_ctx = nullptr);
 
   ~parquet_split_provider() override;
 
@@ -90,20 +104,21 @@ class parquet_split_provider : public split_provider {
   parquet_split_provider(parquet_split_provider&&)                 = delete;
   parquet_split_provider& operator=(parquet_split_provider&&)      = delete;
 
-  std::future<void> start(exec::thread_pool& pool, split_connector& connector) override;
+  [[nodiscard]] bool has_more_splits() const override;
+
+  /// \brief Atomically claim the next batch index and return a callable that
+  ///        runs the metadata scan for it. Once every batch has been claimed,
+  ///        the returned callable yields an empty vector.
+  std::function<std::vector<std::unique_ptr<op::operator_data>>()> next_split_provider() override;
 
  private:
   struct file_batch {
     std::vector<std::string> file_paths;
   };
 
-  /// \brief Pop the next file batch (up to @c _max_file_processed files).
-  ///        Returns nullopt when all files have been dispatched.
-  std::optional<file_batch> next_task_input();
-
-  /// \brief Run the metadata-scan logic for one batch and push parquet_scan_data
-  ///        per partition into @p connector.
-  void run_batch(file_batch const& batch, split_connector& connector);
+  /// \brief Run the metadata-scan logic for one batch, appending one
+  ///        @c parquet_scan_data per emitted partition to @p out.
+  void run_batch(file_batch const& batch, std::vector<std::unique_ptr<op::operator_data>>& out);
 
   std::vector<std::string> _file_paths;
   /// Canonical scan plan — data columns (D order), partition columns, output layout,
@@ -117,7 +132,18 @@ class parquet_split_provider : public split_provider {
   std::size_t _approximate_batch_size;
   std::size_t _max_file_processed;
   std::size_t _total_files;
-  std::size_t _next_file_idx{0};
+  /// Optional ioctx for routing reads through @c sirius_datasource.
+  /// Held as a shared_ptr so it stays alive as long as any emitted slice
+  /// references it.
+  std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
+
+  /// Pre-decomposed file batches built once in the constructor; immutable
+  /// thereafter. Each callable returned by next_split_provider() processes
+  /// one entry.
+  std::vector<file_batch> _batches;
+  /// Atomically incremented to claim the next batch index. Lets multiple
+  /// workers process distinct batches in parallel with no mutex.
+  std::atomic<std::size_t> _next_batch_idx{0};
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "exec/config.hpp"
+#include "exec/scoped_dispatcher.hpp"
 #include "exec/thread_pool.hpp"
 #include "scan_manager/split_provider.hpp"
 
@@ -26,11 +27,20 @@
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
+namespace cucascade::memory {
+class fixed_size_host_memory_resource;
+}  // namespace cucascade::memory
+
 #include <memory>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
+
+namespace sirius::io {
+class sirius_ioctx;
+class buffer_pool;
+}  // namespace sirius::io
 
 namespace sirius::op::scan {
 class sirius_gpu_parquet_scan_operator;
@@ -41,6 +51,36 @@ class query;
 }  // namespace sirius::planner
 
 namespace sirius::scan_manager {
+
+/**
+ * @brief Configuration for the scan_manager.
+ *
+ * @c use_sirius_datasource controls whether the manager builds a
+ * @c sirius_ioctx and routes parquet reads through @c sirius_datasource.
+ * Set to @c false to fall back to @c cudf::io::datasource::create() at
+ * every read site (e.g. when the sirius IO path is misbehaving).
+ */
+struct scan_manager_config {
+  exec::thread_pool_config thread_pool{.num_threads = 8, .thread_name_prefix = "scan_manager"};
+  bool use_sirius_datasource{true};
+  /// Number of @c uring_reactor instances in the ioctx pool.  Ignored when
+  /// @c use_sirius_datasource is false.
+  std::size_t uring_n_reactors{4};
+  /// io_uring submission/completion queue depth per reactor.  Ignored when
+  /// @c use_sirius_datasource is false.
+  unsigned uring_ring_entries{64};
+  /// Enable the prefetching cache.  Requires @c use_sirius_datasource=true;
+  /// when true, the scan_manager allocates a pinned-host buffer_pool and
+  /// initializes the ioctx's cache.  Off by default.
+  bool enable_prefetch_cache{false};
+  /// Total pinned-host bytes reserved for the prefetch cache.  Rounded
+  /// up to the nearest 500 MiB slab.  Ignored when
+  /// @c enable_prefetch_cache is false.
+  std::size_t prefetch_buffer_pool_bytes{20ULL << 30};
+  /// Maximum chunks the cache may have in flight at once (admission
+  /// control).  Ignored when @c enable_prefetch_cache is false.
+  std::size_t prefetch_inflight_budget_chunks{2048};
+};
 
 /**
  * @brief A single pinned-table entry, keyed by table name in the scan_manager.
@@ -86,9 +126,13 @@ class sirius_scan_manager {
   /**
    * @brief Construct a new source manager.
    *
-   * @param config Configuration for the thread pool (thread count, name prefix, CPU affinity).
+   * @param config Scan-manager configuration (thread pool + sirius_datasource toggle).
+   * @param host_mr Host memory resource backing the prefetch buffer_pool.  Required
+   *        when @c config.enable_prefetch_cache is true; ignored otherwise.
    */
-  explicit sirius_scan_manager(exec::thread_pool_config config);
+  explicit sirius_scan_manager(
+    scan_manager_config config,
+    cucascade::memory::fixed_size_host_memory_resource* host_mr = nullptr);
 
   ~sirius_scan_manager();
 
@@ -172,6 +216,11 @@ class sirius_scan_manager {
   /// \brief Remove the pinned entry for @p name. No-op if absent.
   void remove_pinned_entry(const std::string& name);
 
+  /// \brief Process-wide ioctx used to mint @c sirius_datasource instances.
+  ///        Returns nullptr when the manager was configured with
+  ///        @c use_sirius_datasource=false.
+  [[nodiscard]] sirius::io::sirius_ioctx* io_ctx() const noexcept { return _io_ctx.get(); }
+
  private:
   /// \brief Build a split_provider for @p op by reading its parquet scan_info.
   ///        Returns a cached_split_provider when a pinned entry matches, otherwise
@@ -181,15 +230,21 @@ class sirius_scan_manager {
     op::scan::sirius_gpu_parquet_scan_operator* op);
 
   /// \brief Run providers sequentially: start each, wait on its future, advance.
-  void run_driver_loop();
+  void start_metadata_processing();
 
-  exec::thread_pool_config _config;
-  std::unique_ptr<exec::thread_pool> _thread_pool;
+  scan_manager_config _config;
+  /// Pinned-host buffer pool backing the ioctx's prefetching cache.
+  /// Constructed only when @c _config.enable_prefetch_cache is set.
+  /// MUST be declared before @c _io_ctx so the ioctx (and its cache,
+  /// which references the pool) is destroyed first.
+  std::unique_ptr<sirius::io::buffer_pool> _buffer_pool;
+  exec::static_thread_pool _thread_pool;
+  std::unique_ptr<exec::scoped_dispatcher> _dispatcher;
+  std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
   std::unordered_map<op::scan::sirius_gpu_parquet_scan_operator*, std::unique_ptr<split_provider>>
     _providers_by_op;
   std::vector<op::scan::sirius_gpu_parquet_scan_operator*> _scan_op_order;
   std::unordered_map<std::string, pinned_entry> _pinned_entries;
-  std::thread _driver_thread;
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -62,7 +62,7 @@ namespace sirius::scan_manager {
  */
 struct scan_manager_config {
   exec::thread_pool_config thread_pool{.num_threads = 8, .thread_name_prefix = "scan_manager"};
-  bool use_sirius_datasource{true};
+  bool use_sirius_datasource{false};
   /// Number of @c uring_reactor instances in the ioctx pool.  Ignored when
   /// @c use_sirius_datasource is false.
   std::size_t uring_n_reactors{4};

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -16,16 +16,14 @@
 
 #pragma once
 
+#include "op/sirius_physical_operator.hpp"
+
 #include <condition_variable>
 #include <deque>
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <optional>
-
-namespace sirius::op {
-class operator_data;
-}  // namespace sirius::op
 
 namespace sirius::scan_manager {
 

--- a/src/include/scan_manager/split_connector.hpp
+++ b/src/include/scan_manager/split_connector.hpp
@@ -18,6 +18,7 @@
 
 #include <condition_variable>
 #include <deque>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -27,6 +28,8 @@ class operator_data;
 }  // namespace sirius::op
 
 namespace sirius::scan_manager {
+
+class split_provider;
 
 /**
  * @brief Bridge between a scan-side producer (the scan manager) and a scan source operator.
@@ -38,6 +41,13 @@ namespace sirius::scan_manager {
  *
  *   - returns std::nullopt           → connector is closed and drained, no more will arrive.
  *   - returns a non-null unique_ptr  → next split.
+ *   - throws                         → producer surfaced an error via close(exception_ptr)
+ *                                       and the queue is drained.
+ *
+ * Pushes are gated: only @ref split_provider may enqueue splits (via the
+ * @c friend relationship and @ref split_provider::push_to_connector helper).
+ * close() and the consumer-side methods remain public so the scan manager
+ * (driver loop) and the scan operator can drive the lifecycle.
  */
 class split_connector {
  public:
@@ -49,16 +59,21 @@ class split_connector {
   split_connector(split_connector&&)                 = delete;
   split_connector& operator=(split_connector&&)      = delete;
 
-  /// \brief Enqueue a ready split. Producer side. Wakes a waiting consumer.
-  void push_split(std::unique_ptr<op::operator_data> split);
-
   /// \brief Mark the connector as closed: no more splits will be pushed. Idempotent.
   ///        Wakes all waiting consumers.
-  void close();
+  ///
+  /// \param exception Optional exception captured by the producer. The first
+  ///                  non-null exception passed across all close() calls is
+  ///                  stored and rethrown by get_next_split() once the queue
+  ///                  has been drained. Subsequent close() calls do not
+  ///                  overwrite an already-stored exception.
+  void close(std::exception_ptr const& exception = nullptr);
 
   /// \brief Pull the next split, blocking until one is available or the connector
   ///        is closed and drained.
-  /// \return std::nullopt when closed and drained; the next split otherwise.
+  /// \return std::nullopt when closed and drained without error; the next split
+  ///         otherwise.
+  /// \throws The exception passed to close() (if any) once the queue is drained.
   std::optional<std::unique_ptr<op::operator_data>> get_next_split();
 
   /// \brief True iff close() has been called and the queue is drained.
@@ -67,10 +82,18 @@ class split_connector {
   [[nodiscard]] bool has_more_splits() const;
 
  private:
+  friend class split_provider;
+
+  /// \brief Enqueue a ready split. Producer side. Wakes a waiting consumer.
+  ///        Reachable only via @ref split_provider::push_to_connector so all
+  ///        producers route through the provider's friendship channel.
+  void push_split(std::unique_ptr<op::operator_data> split);
+
   mutable std::mutex _mutex;
   std::condition_variable _cv;
   std::deque<std::unique_ptr<op::operator_data>> _splits;
   bool _closed{false};
+  std::exception_ptr _exception;
 };
 
 }  // namespace sirius::scan_manager

--- a/src/include/scan_manager/split_provider.hpp
+++ b/src/include/scan_manager/split_provider.hpp
@@ -16,50 +16,161 @@
 
 #pragma once
 
-#include <future>
+#include "scan_manager/split_connector.hpp"
 
-namespace sirius::exec {
-class thread_pool;
-}  // namespace sirius::exec
+#include <atomic>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace sirius::op {
+class operator_data;
+}  // namespace sirius::op
 
 namespace sirius::scan_manager {
-
-class split_connector;
 
 /**
  * @brief Abstract producer of splits for a scan operator.
  *
- * A concrete provider, when started, dispatches tasks onto a worker pool that
- * compute split metadata and push it (as @c operator_data instances) into the
- * supplied @ref split_connector.
+ * Concrete providers expose two thread-safe primitives:
+ *   - @ref has_more_splits — snapshot check for remaining work.
+ *   - @ref next_split_provider — atomically claim the next batch and return a
+ *     callable that processes it. The claim happens up-front so that the
+ *     potentially expensive per-batch work in the returned callable can run
+ *     in parallel on a worker pool.
  *
- * Lifecycle contract: the connector must be closed on every termination path so
- * that consumers blocked in @c get_next_split() can wake. @c split_connector::close()
- * is idempotent, and the contract is shared between provider and driver:
- *   - On the success path and on failures observed by background tasks, the provider
- *     closes the connector before completing its returned future.
- *   - If @c start() throws synchronously (e.g. precondition failure before any task
- *     is scheduled), the driver closes the connector in its exception handler.
- * Implementations may rely on the driver's safety-net close, but should still close
- * eagerly when they own the failure to avoid stranding consumers.
+ * Splitting the claim from the work is the whole point: it lets @ref run()
+ * enqueue one task per batch on the driver thread without serialising
+ * metadata processing behind a chain of "claim-then-run" tasks. The connector
+ * is closed in the shared @c worker_state's destructor, which fires when the
+ * last enqueued task releases its @c shared_ptr; any captured exception
+ * (first-writer-wins via atomic CAS) is forwarded so consumers see the
+ * failure through @ref split_connector::get_next_split.
  */
 class split_provider {
  public:
   virtual ~split_provider() = default;
 
   /**
-   * @brief Begin producing splits.
+   * @brief Drive the provider to completion, dispatching one task per claimed
+   *        batch onto @p scheduler and pushing each task's splits into
+   *        @p connector.
    *
-   * May dispatch work onto @p pool and return immediately; production may
-   * continue asynchronously. See the class-level lifecycle contract for who
-   * closes @p connector on each termination path.
+   * The calling thread iterates @ref has_more_splits / @ref next_split_provider
+   * and hands the resulting callable to @p scheduler.enqueue. Enqueue is
+   * expected to be non-blocking, so this loop returns quickly. The connector
+   * is closed (with any worker-captured exception) when the last enqueued
+   * task drops its reference to the shared coordination state.
    *
-   * @return a future that completes once the provider has finished pushing
-   *         splits and closed the connector (success path) or surfaced a
-   *         background-task exception. Allows a sequential driver to wait on
-   *         one provider before starting the next.
+   * @tparam Scheduler Anything with a @c enqueue(callable) method that runs
+   *                   the callable asynchronously. @c static_thread_pool and
+   *                   @c scoped_dispatcher both satisfy this shape.
    */
-  virtual std::future<void> start(exec::thread_pool& pool, split_connector& connector) = 0;
+  template <typename Scheduler>
+  void run(Scheduler& scheduler, split_connector& connector);
+
+  /**
+   * @brief Snapshot check for remaining work. Thread-safe.
+   *
+   * Implementations typically compare an atomic batch index against a fixed
+   * total. The result is only a snapshot: a concurrent
+   * @ref next_split_provider() call may consume the remaining batch before
+   * the caller acts on a @c true return.
+   */
+  [[nodiscard]] virtual bool has_more_splits() const = 0;
+
+  /**
+   * @brief Atomically claim the next batch and return a callable that
+   *        produces its splits. Thread-safe.
+   *
+   * The atomic claim happens here; the returned callable owns the (cheap)
+   * batch handle so multiple callables can run concurrently on a worker pool.
+   * Returns a null @c std::function when no batch is available — callers
+   * that already checked @ref has_more_splits() will normally not hit this
+   * path, but the null fallback keeps the contract simple under concurrent
+   * observers.
+   *
+   * The callable captures the provider; the provider must outlive every
+   * callable it hands out.
+   */
+  virtual std::function<std::vector<std::unique_ptr<op::operator_data>>()>
+  next_split_provider() = 0;
+
+ protected:
+  /**
+   * @brief Push a split into a connector.
+   *
+   * The only entry point for enqueueing splits: @ref split_connector::push_split
+   * is private and reaches in only via the @c friend relationship between
+   * @ref split_connector and this class. Because the helper is a protected
+   * static, only @ref split_provider and its subclasses can call it, so
+   * unrelated code cannot bypass the provider abstraction.
+   *
+   * Defined out-of-line because the unique_ptr's deleter needs the complete
+   * @c op::operator_data type, which we keep forward-declared in this header.
+   */
+  static void push_to_connector(split_connector& connector,
+                                std::unique_ptr<op::operator_data> split);
+
+ private:
+  /// RAII coordination shared across the enqueued tasks. Destructor closes
+  /// the connector with the captured exception (if any) once the last task
+  /// drops its ref. Workers race to record the first error via CAS, so no
+  /// mutex is needed and the destructor reads `error_ptr` after all writers
+  /// have gone.
+  struct worker_state {
+    split_connector& connector;
+    std::atomic<bool> error_set{false};
+    std::exception_ptr error_ptr;
+
+    static std::shared_ptr<worker_state> create(split_connector& connector)
+    {
+      return std::shared_ptr<worker_state>(new worker_state(connector));
+    }
+
+    void set_error(std::exception_ptr eptr)
+    {
+      bool expected = false;
+      if (error_set.compare_exchange_strong(expected, true)) { error_ptr = std::move(eptr); }
+    }
+
+    ~worker_state()
+    {
+      // close()-side exceptions are swallowed because destructors must not
+      // propagate; close() is best-effort wakeup.
+      try {
+        connector.close(error_ptr);
+      } catch (...) {
+      }
+    }
+
+   private:
+    explicit worker_state(split_connector& c) : connector(c) {}
+  };
 };
+
+template <typename Scheduler>
+void split_provider::run(Scheduler& scheduler, split_connector& connector)
+{
+  auto state = worker_state::create(connector);
+  while (has_more_splits()) {
+    auto work = next_split_provider();
+    // Concurrent observer could have drained the last batch between the
+    // has_more_splits() check and our claim; skip the empty handoff.
+    if (!work) { continue; }
+    scheduler.enqueue([state, work = std::move(work)]() mutable {
+      try {
+        auto splits = work();
+        for (auto& split : splits) {
+          push_to_connector(state->connector, std::move(split));
+        }
+      } catch (...) {
+        state->set_error(std::current_exception());
+      }
+    });
+  }
+}
 
 }  // namespace sirius::scan_manager

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -19,6 +19,7 @@
 #include "config.hpp"
 #include "exec/config.hpp"
 #include "op/scan/config.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
 
 #include <cucascade/memory/config.hpp>
 #include <cucascade/memory/topology_discovery.hpp>
@@ -78,7 +79,7 @@ struct sirius_config {
 
   [[nodiscard]] const exec::thread_pool_config& get_task_creator_config() const noexcept;
 
-  [[nodiscard]] const exec::thread_pool_config& get_scan_manager_config() const noexcept;
+  [[nodiscard]] const scan_manager::scan_manager_config& get_scan_manager_config() const noexcept;
 
   [[nodiscard]] const exec::thread_pool_config& get_gpu_pipeline_executor_config() const noexcept;
 
@@ -114,8 +115,7 @@ struct sirius_config {
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
   exec::thread_pool_config _task_creator_config{.num_threads        = 2,
                                                 .thread_name_prefix = "task_creator"};
-  exec::thread_pool_config _scan_manager_config{.num_threads        = 2,
-                                                .thread_name_prefix = "scan_manager"};
+  scan_manager::scan_manager_config _scan_manager_config{};
   exec::thread_pool_config _gpu_pipeline_executor_config{.num_threads        = 4,
                                                          .thread_name_prefix = "gpu_pipeline"};
   exec::downgrade_executor_config _downgrade_executor_config;

--- a/src/io/io_context.cpp
+++ b/src/io/io_context.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/io_context.hpp"
+
+#include "driver_types.h"
+#include "io/prefetching_cache.hpp"
+
+#include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cucascade/cuda/event.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sirius::io {
+
+sirius_ioctx::sirius_ioctx()  = default;
+sirius_ioctx::~sirius_ioctx() = default;
+
+void sirius_ioctx::initialize_cache(buffer_pool& pool, size_t inflight_budget_chunks)
+{
+  _cache = std::make_unique<prefetching_cache>(pool, this, inflight_budget_chunks);
+}
+
+namespace {
+
+std::future<size_t> copy_pinned_slices_to_device(
+  std::vector<cudf::io::datasource::non_owning_buffer> const& slices,
+  uint8_t* dst,
+  rmm::cuda_stream_view stream)
+{
+  // Skip empty slices without touching CUDA.
+  size_t n_nonempty =
+    std::count_if(slices.begin(), slices.end(), [](auto const& s) { return s.size() > 0; });
+
+  if (n_nonempty == 0) return std::async(std::launch::deferred, []() { return size_t{0}; });
+
+  cucascade::cuda::cuda_event copy_done_event;
+
+  // Fast path: one slice (common after pinned_view::slice coalescing when
+  // chunks are contiguous in slab memory). Plain cudaMemcpyAsync avoids the
+  // batch-API per-call overhead.
+  if (n_nonempty == 1) {
+    size_t copied = 0;
+    for (auto const& s : slices) {
+      if (s.size() == 0) continue;
+      auto err =
+        cudaMemcpyAsync(dst + copied, s.data(), s.size(), cudaMemcpyHostToDevice, stream.value());
+      if (err != cudaSuccess) {
+        throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyAsync failed: ") +
+                                 cudaGetErrorString(err));
+      }
+      copied += s.size();
+    }
+    copy_done_event.record(stream);
+    return std::async(std::launch::deferred, [e = std::move(copy_done_event), copied]() mutable {
+      e.synchronize();
+      return copied;
+    });
+  }
+
+  // Build the batch descriptors. Copies within a batch are unordered with
+  // respect to each other but the whole batch is stream-ordered; all copies
+  // have disjoint destination ranges.
+  std::vector<void*> dsts;
+  std::vector<void const*> srcs;
+  std::vector<size_t> sizes;
+  dsts.reserve(n_nonempty);
+  srcs.reserve(n_nonempty);
+  sizes.reserve(n_nonempty);
+
+  size_t copied = 0;
+  for (auto const& s : slices) {
+    auto n = s.size();
+    if (n == 0) continue;
+    dsts.push_back(dst + copied);
+    srcs.push_back(s.data());
+    sizes.push_back(n);
+    copied += n;
+  }
+
+#if CUDART_VERSION < 12080
+  // No batch API: fall back to sequential cudaMemcpyAsync on the caller's stream.
+  size_t total_copied = 0;
+  for (size_t i = 0; i < dsts.size(); ++i) {
+    auto err = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyHostToDevice, stream.value());
+    if (err != cudaSuccess) {
+      throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyAsync failed at idx ") +
+                               std::to_string(i) + ": " + cudaGetErrorString(err));
+    }
+    total_copied += sizes[i];
+  }
+  copy_done_event.record(stream);
+  return std::async(std::launch::deferred,
+                    [e = std::move(copy_done_event), total_copied]() mutable {
+                      e.synchronize();
+                      return total_copied;
+                    });
+#else
+  // Batch API available. It does not support legacy/null streams, so in that
+  // case redirect to cudaStreamPerThread. The caller's legacy stream is *not*
+  // ordered against the work in that case — the function's contract is that
+  // the copy is observed-complete only after future.get()/wait() syncs the
+  // event recorded on stream_to_use.
+  bool const stream_is_legacy = (stream.value() == nullptr) || (stream.value() == cudaStreamLegacy);
+  cudaStream_t stream_to_use  = stream_is_legacy ? cudaStreamPerThread : stream.value();
+
+  cudaMemcpyAttributes attrs{};
+  attrs.srcAccessOrder  = cudaMemcpySrcAccessOrderStream;
+  attrs.srcLocHint.type = cudaMemLocationTypeHost;
+  attrs.dstLocHint.type = cudaMemLocationTypeDevice;
+  attrs.flags           = 0;
+
+  size_t attrs_idx = 0;  // attrs applies to all copies -> single entry at index 0
+  size_t fail_idx  = 0;  // out-param: driver writes failing copy index on error
+
+#if CUDART_VERSION < 13000
+  auto err = cudaMemcpyBatchAsync(dsts.data(),
+                                  srcs.data(),
+                                  sizes.data(),
+                                  n_nonempty,
+                                  &attrs,
+                                  &attrs_idx,
+                                  1,
+                                  &fail_idx,
+                                  stream_to_use);
+#else
+  auto err = cudaMemcpyBatchAsync(
+    dsts.data(), srcs.data(), sizes.data(), n_nonempty, &attrs, &attrs_idx, 1, stream_to_use);
+#endif
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyBatchAsync failed at idx ") +
+                             std::to_string(fail_idx) + ": " + cudaGetErrorString(err));
+  }
+  copy_done_event.record(stream_to_use);
+  return std::async(std::launch::deferred, [e = std::move(copy_done_event), copied]() mutable {
+    e.synchronize();
+    return copied;
+  });
+#endif
+}
+}  // namespace
+
+size_t sirius_ioctx::host_read(sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst)
+{
+  if (_cache) {
+    if (auto view = _cache->read(obj, offset, size, nullptr); view) {
+      auto slices   = view.slice(offset, size);
+      size_t copied = 0;
+      for (auto const& s : slices) {
+        std::memcpy(dst + copied, s.data(), s.size());
+        copied += s.size();
+      }
+      return copied;
+    }
+  }
+  return host_read_io(obj, offset, size, dst);
+}
+
+std::future<size_t> sirius_ioctx::host_read_async(sirius_io_object& obj,
+                                                  size_t offset,
+                                                  size_t size,
+                                                  uint8_t* dst)
+{
+  if (_cache) {
+    if (auto view = _cache->read(obj, offset, size, nullptr); view) {
+      auto slices = view.slice(offset, size);
+      try {
+        size_t copied = 0;
+        for (auto const& s : slices) {
+          std::memcpy(dst + copied, s.data(), s.size());
+          copied += s.size();
+        }
+        return std::async(std::launch::deferred, [copied]() { return copied; });
+      } catch (...) {
+        return std::async(std::launch::deferred, [e = std::current_exception()]() -> size_t {
+          std::rethrow_exception(e);
+        });
+      }
+    }
+  }
+  auto promise = std::make_shared<std::promise<size_t>>();
+  host_read_async_io(
+    obj, offset, size, dst, [promise](size_t bytes_transferred, std::exception_ptr ep) {
+      if (ep) {
+        promise->set_exception(std::move(ep));
+      } else {
+        promise->set_value(bytes_transferred);
+      }
+    });
+  return promise->get_future();
+}
+
+size_t sirius_ioctx::device_read(
+  sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream)
+{
+  if (_cache) {
+    if (auto view = _cache->read(obj, offset, size, stream.value()); view) {
+      auto slices = view.slice(offset, size);
+      auto copied = copy_pinned_slices_to_device(slices, dst, stream);
+      return copied.get();
+    }
+  }
+  return device_read_io(obj, offset, size, dst, stream);
+}
+
+std::future<size_t> sirius_ioctx::device_read_async(
+  sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream)
+{
+  if (_cache) {
+    if (auto view = _cache->read(obj, offset, size, stream.value()); view) {
+      auto slices = view.slice(offset, size);
+      try {
+        return copy_pinned_slices_to_device(slices, dst, stream);
+      } catch (...) {
+        return std::async(std::launch::deferred, [e = std::current_exception()]() -> size_t {
+          std::rethrow_exception(e);
+        });
+      }
+    }
+  }
+  auto promise = std::make_shared<std::promise<size_t>>();
+  device_read_async_io(
+    obj, offset, size, dst, stream, [promise](size_t bytes_transferred, std::exception_ptr ep) {
+      if (ep) {
+        promise->set_exception(std::move(ep));
+      } else {
+        promise->set_value(bytes_transferred);
+      }
+    });
+  return promise->get_future();
+}
+
+}  // namespace sirius::io

--- a/src/io/prefetching_cache.cpp
+++ b/src/io/prefetching_cache.cpp
@@ -314,8 +314,22 @@ prefetching_cache::~prefetching_cache()
   _worker_thread.request_stop();
   _evictor_thread.request_stop();
   _work_seq.fetch_add(1, std::memory_order_release);
-  _work_seq.notify_one();
+  _work_seq.notify_all();
   _request_sem.release();
+
+  // Wake readers waiting on entries that were loading when shutdown began.
+  // Outstanding backend requests may still resolve via their request_context
+  // safety net, but waiters should not depend on that happening.
+  abort_pending_entries();
+
+  // Join explicitly so all cache-owned queues and counters outlive the worker
+  // and evictor loops. std::jthread would join during member destruction, but
+  // doing it here lets us abort any entries that raced into loading just before
+  // the worker observed stop.
+  if (_worker_thread.joinable()) { _worker_thread.join(); }
+  if (_evictor_thread.joinable()) { _evictor_thread.join(); }
+
+  abort_pending_entries();
 }
 
 void prefetching_cache::enqueue_work(work_item item)
@@ -330,6 +344,22 @@ void prefetching_cache::release_chunks(cache_entry& entry)
   for (auto* p : entry.chunks)
     _pool.deallocate(p);
   entry.chunks.clear();
+}
+
+void prefetching_cache::abort_pending_entries() noexcept
+{
+  try {
+    std::shared_lock map_lk(_map_mtx);
+    for (auto const& [_, file_ptr] : _file_cache) {
+      if (!file_ptr) { continue; }
+      std::shared_lock file_lk(file_ptr->mtx);
+      for (auto const& entry : file_ptr->entries) {
+        if (entry) { entry->state.try_abort_pending(); }
+      }
+    }
+  } catch (...) {
+    // Destructors must not throw; best effort wake-up only.
+  }
 }
 
 // ===========================================================================
@@ -877,6 +907,15 @@ void prefetching_cache::evictor_loop(std::stop_token stop)
         std::make_exception_ptr(std::runtime_error("eviction aborted — cache shutting down")));
     }
   }
+
+  // A worker may be blocked in fut.get() after enqueueing a request while the
+  // stop token is already set. Drain anything the loop did not pick up and
+  // resolve it with an exception so the worker can exit.
+  eviction_request req;
+  while (_request_queue.try_dequeue(req)) {
+    req.promise.set_exception(
+      std::make_exception_ptr(std::runtime_error("eviction aborted — cache shutting down")));
+  }
 }
 
 // ===========================================================================
@@ -1024,11 +1063,12 @@ void prefetching_cache::worker_loop(std::stop_token stop)
 
     {
       auto& obj_ref = *item.io_obj;
+      auto* pool    = &_pool;
       _io_ctx->host_read_ranges_async_io(
         obj_ref,
         io_ranges,
         io_dsts,
-        [this,
+        [pool,
          batch  = std::move(batch),
          slot   = std::move(slot_holder),
          io_obj = std::move(item.io_obj),
@@ -1040,12 +1080,14 @@ void prefetching_cache::worker_loop(std::stop_token stop)
               spdlog::error("prefetching_cache: IO failed for {}: {}", key, ex.what());
             }
             for (auto const& e : batch) {
-              release_chunks(*e);
-              e->state.mark_load_failed();
+              for (auto* p : e->chunks)
+                pool->deallocate(p);
+              e->chunks.clear();
+              e->state.try_mark_load_failed();
             }
           } else {
             for (auto const& e : batch)
-              e->state.mark_cached();
+              e->state.try_mark_cached();
           }
           // `slot` and `io_obj` destruct here — budget is returned to
           // admission_control, and the file handle is released only

--- a/src/io/prefetching_cache.cpp
+++ b/src/io/prefetching_cache.cpp
@@ -16,12 +16,15 @@
 
 #include "io/prefetching_cache.hpp"
 
+#include "io/io_context.hpp"
+
 #include <cuda_runtime.h>
 
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <stdexcept>
 
 namespace sirius::io {
@@ -30,148 +33,122 @@ namespace sirius::io {
 // buffer_pool
 // ===========================================================================
 
-buffer_pool::buffer_pool(uint32_t max_slabs) : _max_slabs(max_slabs) {}
-
-buffer_pool::~buffer_pool()
+buffer_pool::buffer_pool(cucascade::memory::fixed_size_host_memory_resource& mr, uint32_t max_slabs)
+  : _mr(mr), _chunk_bytes(mr.get_block_size()), _max_slabs(max_slabs)
 {
-  for (auto& s : _slabs)
-    cudaFreeHost(s->base);
+  std::unique_lock lk(_mtx);
+  for (uint32_t i = 0; i < std::min<uint32_t>(10, _max_slabs); ++i) {
+    if (!grow_locked()) break;
+  }
 }
 
-bool buffer_pool::grow()
-{
-  std::unique_lock lk(_grow_mtx);
-  if (_slabs.size() >= _max_slabs) return false;
+buffer_pool::~buffer_pool() = default;
 
-  void* raw = nullptr;
-  // Portable so multi-GPU ioctx users can H2D-copy from these slabs on any
-  // device's stream.
-  auto err = cudaHostAlloc(&raw, SLAB_BYTES, cudaHostAllocPortable);
-  if (err != cudaSuccess) {
-    spdlog::warn("buffer_pool: cudaHostAlloc({:.0f}MB) failed: {}",
-                 static_cast<double>(SLAB_BYTES) / (1024.0 * 1024.0),
-                 cudaGetErrorString(err));
+bool buffer_pool::grow_locked()
+{
+  if (_allocations.size() >= _max_slabs) return false;
+
+  auto const bytes = slab_bytes();
+  cucascade::memory::fixed_multiple_blocks_allocation alloc;
+  try {
+    alloc = _mr.allocate_multiple_blocks(bytes);
+  } catch (std::exception const& e) {
+    spdlog::warn("buffer_pool: allocate_multiple_blocks({:.0f}MB) failed: {}",
+                 static_cast<double>(bytes) / (1024.0 * 1024.0),
+                 e.what());
     return false;
   }
+  if (!alloc) return false;
 
-  auto s  = std::make_unique<slab>();
-  s->base = static_cast<std::byte*>(raw);
-  s->free_count.store(CHUNKS_PER_SLAB, std::memory_order_relaxed);
-  for (uint32_t i = 0; i < CHUNKS_PER_SLAB; ++i)
-    s->free_chunks.enqueue(s->base + static_cast<size_t>(i) * CHUNK_BYTES);
+  auto blocks = alloc->get_blocks();
+  _free_list.reserve(_free_list.size() + blocks.size());
+  for (auto* p : blocks)
+    _free_list.push_back(p);
+  auto const n = static_cast<uint32_t>(blocks.size());
+  _allocations.push_back(std::move(alloc));
+  _total_chunks.fetch_add(n, std::memory_order_relaxed);
+  _total_free.fetch_add(n, std::memory_order_relaxed);
 
-  _slab_map[s->base] = s.get();
-  _slabs.push_back(std::move(s));
-  _total_chunks.fetch_add(CHUNKS_PER_SLAB, std::memory_order_relaxed);
-  _total_free.fetch_add(CHUNKS_PER_SLAB, std::memory_order_relaxed);
-
-  spdlog::debug("buffer_pool: allocated slab {} ({:.0f}MB)",
-                _slabs.size(),
-                static_cast<double>(SLAB_BYTES) / (1024.0 * 1024.0));
+  spdlog::debug("buffer_pool: allocated slab {} ({} chunks, {:.0f}MB)",
+                _allocations.size(),
+                n,
+                static_cast<double>(bytes) / (1024.0 * 1024.0));
   return true;
-}
-
-buffer_pool::slab* buffer_pool::find_slab(std::byte* p)
-{
-  std::shared_lock lk(_grow_mtx);
-  auto it = _slab_map.upper_bound(p);
-  if (it == _slab_map.begin()) return nullptr;
-  --it;
-  if (p >= it->first && p < it->first + SLAB_BYTES) return it->second;
-  return nullptr;
 }
 
 std::byte* buffer_pool::allocate()
 {
-  // Try existing slabs, most recent first (likely to have free chunks).
-  {
-    std::shared_lock lk(_grow_mtx);
-    for (auto it = _slabs.rbegin(); it != _slabs.rend(); ++it) {
-      std::byte* p;
-      if ((*it)->free_chunks.try_dequeue(p)) {
-        (*it)->free_count.fetch_sub(1, std::memory_order_relaxed);
-        _total_free.fetch_sub(1, std::memory_order_relaxed);
-        return p;
-      }
-    }
-  }
-
-  // All slabs exhausted — try to grow.
-  if (!grow()) return nullptr;
-
-  std::shared_lock lk(_grow_mtx);
-  std::byte* p;
-  if (_slabs.back()->free_chunks.try_dequeue(p)) {
-    _slabs.back()->free_count.fetch_sub(1, std::memory_order_relaxed);
-    _total_free.fetch_sub(1, std::memory_order_relaxed);
-    return p;
-  }
-  return nullptr;
+  std::unique_lock lk(_mtx);
+  if (_free_list.empty() && !grow_locked()) return nullptr;
+  std::byte* p = _free_list.back();
+  _free_list.pop_back();
+  _total_free.fetch_sub(1, std::memory_order_relaxed);
+  return p;
 }
 
 size_t buffer_pool::allocate_bulk(size_t n, std::vector<std::byte*>& out)
 {
   if (n == 0) return 0;
 
-  // Scratch buffer for try_dequeue_bulk (stack-allocated for small n,
-  // heap for large).
-  constexpr size_t STACK_MAX = 64;
-  std::byte* stack_buf[STACK_MAX];
-  std::unique_ptr<std::byte*[]> heap_buf;
-  std::byte** buf = stack_buf;
-  if (n > STACK_MAX) {
-    heap_buf = std::make_unique<std::byte*[]>(n);
-    buf      = heap_buf.get();
-  }
-
-  size_t remaining = n;
-  size_t total_got = 0;
-
-  auto drain_slabs = [&]() {
-    std::shared_lock lk(_grow_mtx);
-    for (auto it = _slabs.rbegin(); it != _slabs.rend() && remaining > 0; ++it) {
-      auto got = (*it)->free_chunks.try_dequeue_bulk(buf + total_got, remaining);
-      if (got > 0) {
-        (*it)->free_count.fetch_sub(static_cast<uint32_t>(got), std::memory_order_relaxed);
-        _total_free.fetch_sub(static_cast<uint32_t>(got), std::memory_order_relaxed);
-        total_got += got;
-        remaining -= got;
-      }
+  std::unique_lock lk(_mtx);
+  size_t got = 0;
+  while (got < n) {
+    auto take = std::min(n - got, _free_list.size());
+    if (take > 0) {
+      out.insert(out.end(), _free_list.end() - static_cast<ptrdiff_t>(take), _free_list.end());
+      _free_list.resize(_free_list.size() - take);
+      got += take;
     }
-  };
-
-  drain_slabs();
-
-  // If we still need more, grow and drain the new slab.
-  while (remaining > 0) {
-    if (!grow()) break;
-    drain_slabs();
+    if (got == n) break;
+    if (!grow_locked()) break;
   }
-
-  out.insert(out.end(), buf, buf + total_got);
-  return total_got;
+  _total_free.fetch_sub(static_cast<uint32_t>(got), std::memory_order_relaxed);
+  return got;
 }
 
 void buffer_pool::deallocate_bulk(std::vector<std::byte*>& out)
 {
-  for (auto* p : out) {
-    deallocate(p);
-  }
+  if (out.empty()) return;
+  std::unique_lock lk(_mtx);
+  _free_list.insert(_free_list.end(), out.begin(), out.end());
+  _total_free.fetch_add(static_cast<uint32_t>(out.size()), std::memory_order_relaxed);
+  lk.unlock();
   out.clear();
 }
 
 void buffer_pool::deallocate(std::byte* p)
 {
-  auto* s = find_slab(p);
-  assert(s && "buffer_pool::deallocate: pointer does not belong to any slab");
-  s->free_chunks.enqueue(p);
-  s->free_count.fetch_add(1, std::memory_order_relaxed);
+  std::unique_lock lk(_mtx);
+  _free_list.push_back(p);
   _total_free.fetch_add(1, std::memory_order_relaxed);
 }
 
 // ===========================================================================
 // pinned_view
 // ===========================================================================
+
+namespace {
+
+// Carries a strong ref to the entry until the host callback fires, so the
+// entry can't be destroyed mid-flight even if the cache map drops it.
+struct release_callback_args {
+  std::shared_ptr<cache_entry> entry;
+};
+
+// cudaStreamAddCallback signature (deprecated but used deliberately).
+// Unlike cudaLaunchHostFunc, this callback fires even when the stream is
+// already in an error state — so a poisoned stream cannot leak the entry's
+// pin and its pool chunks forever.  Status is intentionally ignored: the
+// read pin must be released regardless of whether the H2D copy succeeded.
+void CUDART_CB release_read_host_callback(cudaStream_t /*stream*/,
+                                          cudaError_t /*status*/,
+                                          void* p) noexcept
+{
+  std::unique_ptr<release_callback_args> args(static_cast<release_callback_args*>(p));
+  args->entry->state.release_read();
+}
+
+}  // namespace
 
 pinned_view::pinned_view(std::shared_ptr<cache_entry> entry,
                          duckdb_moodycamel::ConcurrentQueue<eviction_candidate>& candidate_queue,
@@ -206,22 +183,33 @@ pinned_view& pinned_view::operator=(pinned_view&& o) noexcept
 void pinned_view::unpin()
 {
   if (!_entry) return;
-  // release_read returns true only when this was the *last* active reader
-  // (state transitioned in_use → cached).  That's exactly the edge that makes
-  // the entry newly evictable, so post a candidate hint then and only then.
-  if (_entry->state.release_read()) {
-    // Record an event on the reader's stream BEFORE handing the entry to
-    // the evictor.  The evictor checks cudaEventQuery(read_event) before
-    // releasing chunks, so any cudaMemcpyAsync the reader submitted earlier
-    // against this entry's pinned chunks is guaranteed complete before we
-    // recycle those chunks.
-    if (_stream && _entry->read_event) cudaEventRecord(_entry->read_event, _stream);
-    // Silent post: no semaphore release.  The evictor drains candidates on
-    // its next poll tick (EVICTOR_POLL_INTERVAL) or whenever a chunk request
-    // wakes it — whichever comes first.
-    _candidate_queue->enqueue({std::weak_ptr<cache_entry>(_entry)});
+
+  // Always enqueue an eviction candidate — the evictor's state.get_state()
+  // gate skips entries still in_use, so a candidate whose deferred
+  // release_read is still pending on a stream callback simply isn't evicted
+  // until the callback runs.  Silent post: no semaphore release.  The
+  // evictor drains candidates on its next poll tick (EVICTOR_POLL_INTERVAL)
+  // or whenever a chunk request wakes it — whichever comes first.
+  _candidate_queue->enqueue({std::weak_ptr<cache_entry>(_entry)});
+
+  if (_stream == nullptr) {
+    // Synchronous path (host reads): no async ops outstanding, release now.
+    _entry->state.release_read();
+    _entry.reset();
+  } else {
+    // Async path (device reads): defer release_read via a host callback so
+    // it fires only after the caller's stream reaches this point.  Any
+    // cudaMemcpyAsync submitted earlier against this entry's pinned chunks
+    // therefore completes before pin_count drops to zero — at which point
+    // the entry transitions in_use → cached and becomes evictable.
+    auto args   = std::make_unique<release_callback_args>();
+    args->entry = std::move(_entry);
+    // cudaStreamAddCallback (not cudaLaunchHostFunc): fires on error too,
+    // so the release_read() is guaranteed even if the user's stream is
+    // poisoned by an unrelated failure.  Otherwise a single stream error
+    // would permanently leak this entry's pin and its pinned chunks.
+    cudaStreamAddCallback(_stream, &release_read_host_callback, args.release(), 0);
   }
-  _entry.reset();
 }
 
 size_t pinned_view::num_chunks() const noexcept { return _entry ? _entry->chunks.size() : 0; }
@@ -230,8 +218,9 @@ std::span<const std::byte> pinned_view::operator[](size_t i) const noexcept
 {
   if (!_entry || i >= _entry->chunks.size()) return {};
   auto phys_size   = static_cast<size_t>(_entry->physical_range.size());
-  auto chunk_start = i * buffer_pool::CHUNK_BYTES;
-  auto chunk_sz    = std::min(buffer_pool::CHUNK_BYTES, phys_size - chunk_start);
+  auto chunk_bytes = _entry->chunk_bytes;
+  auto chunk_start = i * chunk_bytes;
+  auto chunk_sz    = std::min(chunk_bytes, phys_size - chunk_start);
   return {_entry->chunks[i], chunk_sz};
 }
 
@@ -270,14 +259,15 @@ std::vector<cudf::io::datasource::non_owning_buffer> pinned_view::slice(size_t o
   size_t remaining  = size;
 
   // Walk the chunks that span [phys_start, phys_start + size).
-  size_t chunk_idx    = phys_start / buffer_pool::CHUNK_BYTES;
-  size_t off_in_chunk = phys_start % buffer_pool::CHUNK_BYTES;
+  auto const chunk_bytes = _entry->chunk_bytes;
+  size_t chunk_idx       = phys_start / chunk_bytes;
+  size_t off_in_chunk    = phys_start % chunk_bytes;
 
   while (remaining > 0 && chunk_idx < _entry->chunks.size()) {
-    auto chunk_avail = std::min(buffer_pool::CHUNK_BYTES - off_in_chunk,
-                                phys_size - chunk_idx * buffer_pool::CHUNK_BYTES - off_in_chunk);
-    auto n           = std::min(remaining, chunk_avail);
-    auto* p          = reinterpret_cast<uint8_t const*>(_entry->chunks[chunk_idx]) + off_in_chunk;
+    auto chunk_avail =
+      std::min(chunk_bytes - off_in_chunk, phys_size - chunk_idx * chunk_bytes - off_in_chunk);
+    auto n  = std::min(remaining, chunk_avail);
+    auto* p = reinterpret_cast<uint8_t const*>(_entry->chunks[chunk_idx]) + off_in_chunk;
 
     // Coalesce with the previous slice if this chunk is contiguous with the
     // tail of the previous slice in the pinned host address space.  Adjacent
@@ -450,7 +440,7 @@ void prefetching_cache::insert(sirius_io_object& obj,
       ++ex_it;
     } else {
       auto physical = _io_ctx->compute_physical_range(logical, file_size);
-      auto e        = std::make_shared<cache_entry>(logical, physical);
+      auto e        = std::make_shared<cache_entry>(logical, physical, _pool.chunk_bytes());
       e->n_total_request.fetch_add(1, std::memory_order_relaxed);
       e->n_request.store(1, std::memory_order_relaxed);
       e->request_ts.store(tick, std::memory_order_release);
@@ -517,7 +507,14 @@ pinned_view prefetching_cache::read(const sirius_io_object& obj,
     }
     if (st == entry_state::loading) {
       waited_on_loading = true;
+      // Release file_lk across the wait: the entry is pinned by our local
+      // shared_ptr, and file.mtx no longer protects anything we touch while
+      // parked.  Holding it shared would stall every concurrent insert() on
+      // this file (and, under writer-preference shared_mutex, every reader
+      // queued behind that insert).
+      file_lk.unlock();
       entry->state.wait_while_loading();
+      file_lk.lock();
       continue;
     }
     _partial_miss_count.fetch_add(1, std::memory_order_relaxed);
@@ -580,7 +577,12 @@ std::vector<pinned_view> prefetching_cache::read_ranges(
       }
       if (st == entry_state::loading) {
         waited_on_loading = true;
+        // Release file_lk across the wait: see read() for the rationale.
+        // The entry is pinned by our local shared_ptr; the next find_entry()
+        // call (for the next range in the batch) will re-take file_lk.
+        file_lk.unlock();
         entry->state.wait_while_loading();
+        file_lk.lock();
         continue;
       }
       _partial_miss_count.fetch_add(1, std::memory_order_relaxed);
@@ -606,8 +608,7 @@ void prefetching_cache::refresh_cache()
     }
   }
 
-  // Log the stats snapshot at each aging event.
-  (void)summary();
+  spdlog::info("cache being refreshed: closing — {}", summary());
 }
 
 std::string prefetching_cache::summary() const
@@ -732,16 +733,16 @@ void prefetching_cache::evictor_loop(std::stop_token stop)
   std::stop_callback stop_cb(stop, [this] { _request_sem.release(); });
 
   // Free one cached entry's chunks back to the pool.  Returns the number
-  // of chunks freed, or 0 if the entry isn't eligible right now (racing
-  // reader, in-flight cudaMemcpyAsync, etc.).  Caller removes the entry
-  // from the LRU on non-zero return.
+  // of chunks freed, or 0 if the entry isn't eligible right now.  Caller
+  // removes the entry from the LRU on non-zero return.
+  //
+  // The state-machine gate (state == cached, pin_count == 0) is the only
+  // in-use check needed: pinned_view::unpin defers release_read via a host
+  // callback on the reader's stream, so an entry stays in_use until any
+  // cudaMemcpyAsync the reader submitted has completed.
   auto try_evict_raw = [this](cache_entry* entry, int64_t age) -> size_t {
     if (entry->state.get_state() != entry_state::cached) return 0;
     if (!entry->is_consumed_or_stale(static_cast<uint64_t>(age))) return 0;
-    if (entry->read_event) {
-      auto q = cudaEventQuery(entry->read_event);
-      if (q != cudaSuccess) return 0;
-    }
     if (!entry->state.try_start_evicting()) return 0;
     size_t n = entry->chunks.size();
     _pool.deallocate_bulk(entry->chunks);
@@ -889,13 +890,14 @@ void prefetching_cache::worker_loop(std::stop_token stop)
     // filtered again in Phase 4 by try_start_loading.
     std::vector<size_t> per_entry_chunks(item.entries.size(), 0);
     size_t upper_bound_chunks = 0;
+    auto const chunk_bytes    = _pool.chunk_bytes();
     for (size_t i = 0; i < item.entries.size(); ++i) {
       auto const& e = item.entries[i];
       if (e->n_request.load(std::memory_order_acquire) <= 0) continue;
       auto st = e->state.get_state();
       if (st != entry_state::empty && st != entry_state::queued) continue;
       auto phys_size      = static_cast<size_t>(e->physical_range.size());
-      auto n              = (phys_size + buffer_pool::CHUNK_BYTES - 1) / buffer_pool::CHUNK_BYTES;
+      auto n              = (phys_size + chunk_bytes - 1) / chunk_bytes;
       per_entry_chunks[i] = n;
       upper_bound_chunks += n;
     }
@@ -988,11 +990,12 @@ void prefetching_cache::worker_loop(std::stop_token stop)
     std::vector<cudf::io::text::byte_range_info> io_ranges;
     std::vector<cudf::host_span<std::byte>> io_dsts;
     for (auto const& e : batch) {
-      auto phys_off  = static_cast<size_t>(e->physical_range.offset());
-      auto phys_size = static_cast<size_t>(e->physical_range.size());
+      auto phys_off          = static_cast<size_t>(e->physical_range.offset());
+      auto phys_size         = static_cast<size_t>(e->physical_range.size());
+      auto const chunk_bytes = e->chunk_bytes;
       for (size_t i = 0; i < e->chunks.size(); ++i) {
-        auto off = phys_off + i * buffer_pool::CHUNK_BYTES;
-        auto sz  = std::min(buffer_pool::CHUNK_BYTES, phys_size - i * buffer_pool::CHUNK_BYTES);
+        auto off = phys_off + i * chunk_bytes;
+        auto sz  = std::min(chunk_bytes, phys_size - i * chunk_bytes);
         io_ranges.emplace_back(static_cast<int64_t>(off), static_cast<int64_t>(sz));
         io_dsts.emplace_back(e->chunks[i], sz);
       }
@@ -1004,7 +1007,7 @@ void prefetching_cache::worker_loop(std::stop_token stop)
 
     {
       auto& obj_ref = *item.io_obj;
-      _io_ctx->host_read_ranges_async(
+      _io_ctx->host_read_ranges_async_io(
         obj_ref,
         io_ranges,
         io_dsts,
@@ -1015,7 +1018,7 @@ void prefetching_cache::worker_loop(std::stop_token stop)
          key    = std::move(item.file_key)](size_t /*bytes*/, std::exception_ptr ep) {
           if (ep) {
             try {
-              std::rethrow_exception(ep);
+              std::rethrow_exception(std::move(ep));
             } catch (std::exception const& ex) {
               spdlog::error("prefetching_cache: IO failed for {}: {}", key, ex.what());
             }

--- a/src/io/prefetching_cache.cpp
+++ b/src/io/prefetching_cache.cpp
@@ -403,7 +403,10 @@ void prefetching_cache::insert(sirius_io_object& obj,
 
   file.io_obj    = obj_sp;
   file.file_size = file_size;
-  file.metadata  = std::move(metadata);
+  // A nullptr @p metadata means "no new metadata to store" — preserve whatever
+  // a previous insert() left in place so callers can skip re-supplying it on
+  // every prefetch insert.
+  if (metadata) { file.metadata = std::move(metadata); }
 
   // Every range in the insert becomes a prefetch request, regardless of the
   // entry's current state.  The worker decides at dispatch time whether the
@@ -592,6 +595,20 @@ std::vector<pinned_view> prefetching_cache::read_ranges(
     result.push_back(std::move(view));
   }
   return result;
+}
+
+std::shared_ptr<sirius_io_object_metadata> prefetching_cache::get_metadata(
+  const sirius_io_object& obj) const
+{
+  auto const& key = obj.raw_file_cache_id();
+
+  std::shared_lock map_lk(_map_mtx);
+  auto it = _file_cache.find(key);
+  if (it == _file_cache.end()) { return nullptr; }
+  auto& file = *it->second;
+
+  std::shared_lock file_lk(file.mtx);
+  return file.metadata;
 }
 
 void prefetching_cache::refresh_cache()

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -17,186 +17,28 @@
 #include "io/sirius_datasource.hpp"
 
 #include "io/prefetching_cache.hpp"
-#include "io/types.hpp"
 
 #include <rmm/device_buffer.hpp>
-
-#include <cuda_runtime.h>
 
 #include <fcntl.h>
 #include <spdlog/spdlog.h>
 #include <sys/stat.h>
 
 #include <algorithm>
-#include <ranges>
-#include <stdexcept>
+#include <future>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace sirius::io {
-
-// ---------------------------------------------------------------------------
-// sirius_ioctx
-// ---------------------------------------------------------------------------
-
-sirius_ioctx::sirius_ioctx()  = default;
-sirius_ioctx::~sirius_ioctx() = default;
-
-void sirius_ioctx::initialize_cache(buffer_pool& pool, size_t inflight_budget_chunks)
-{
-  _cache = std::make_unique<prefetching_cache>(pool, this, inflight_budget_chunks);
-}
-
-namespace {
-
-// Copy each pinned-host slice to the device buffer on @p stream.
-// Returns the total bytes issued (== sum of slice sizes).
-size_t copy_pinned_slices_to_device(
-  std::vector<cudf::io::datasource::non_owning_buffer> const& slices,
-  uint8_t* dst,
-  rmm::cuda_stream_view stream)
-{
-  // Skip empty slices without touching CUDA.
-  size_t n_nonempty = 0;
-  for (auto const& s : slices)
-    if (s.size() > 0) ++n_nonempty;
-
-  if (n_nonempty == 0) return 0;
-
-  // Fast path: one slice (common after pinned_view::slice coalescing when
-  // chunks are contiguous in slab memory).  Plain cudaMemcpyAsync avoids the
-  // batch-API per-call overhead.
-  if (n_nonempty == 1) {
-    size_t copied = 0;
-    for (auto const& s : slices) {
-      if (s.size() == 0) continue;
-      auto err =
-        cudaMemcpyAsync(dst + copied, s.data(), s.size(), cudaMemcpyHostToDevice, stream.value());
-      if (err != cudaSuccess)
-        throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyAsync failed: ") +
-                                 cudaGetErrorString(err));
-      copied += s.size();
-    }
-    return copied;
-  }
-
-  // Batch path: hand all non-contiguous slices to the driver in one call.
-  // Copies within a batch are unordered with respect to each other but the
-  // whole batch is stream-ordered — fine here, all copies have disjoint
-  // destination ranges.
-  std::vector<void*> dsts;
-  std::vector<void const*> srcs;
-  std::vector<size_t> sizes;
-  dsts.reserve(n_nonempty);
-  srcs.reserve(n_nonempty);
-  sizes.reserve(n_nonempty);
-
-  size_t copied = 0;
-  for (auto const& s : slices) {
-    auto n = s.size();
-    if (n == 0) continue;
-    dsts.push_back(dst + copied);
-    srcs.push_back(s.data());
-    sizes.push_back(n);
-    copied += n;
-  }
-
-#if CUDA_VERSION >= 12080
-  // cudaMemcpyBatchAsync available since CUDA 12.8 — issue all copies in one driver call.
-  cudaMemcpyAttributes attrs{};
-  attrs.srcAccessOrder  = cudaMemcpySrcAccessOrderStream;
-  attrs.srcLocHint.type = cudaMemLocationTypeHost;
-  attrs.dstLocHint.type = cudaMemLocationTypeDevice;
-  attrs.flags           = 0;
-  size_t attrs_idx      = 0;
-  size_t fail_idx       = 0;
-
-#if CUDART_VERSION < 13000
-  auto err = cudaMemcpyBatchAsync(dsts.data(),
-                                  srcs.data(),
-                                  sizes.data(),
-                                  n_nonempty,
-                                  &attrs,
-                                  &attrs_idx,
-                                  1,
-                                  nullptr,
-                                  stream.value());
-#else
-  auto err = cudaMemcpyBatchAsync(
-    dsts.data(), srcs.data(), sizes.data(), n_nonempty, &attrs, &attrs_idx, 1, stream.value());
-#endif
-  if (err != cudaSuccess)
-    throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyBatchAsync failed at idx ") +
-                             std::to_string(fail_idx) + ": " + cudaGetErrorString(err));
-#else
-  // Fallback for CUDA < 12.8: sequential stream-ordered copies.
-  for (size_t i = 0; i < n_nonempty; ++i) {
-    auto err = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyHostToDevice, stream.value());
-    if (err != cudaSuccess)
-      throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyAsync failed at idx ") +
-                               std::to_string(i) + ": " + cudaGetErrorString(err));
-  }
-#endif
-  return copied;
-}
-
-}  // namespace
-
-size_t sirius_ioctx::device_read(
-  sirius_io_object& obj, size_t offset, size_t size, uint8_t* dst, rmm::cuda_stream_view stream)
-{
-  if (_cache) {
-    if (auto view = _cache->read(obj, offset, size, stream.value()); view) {
-      auto slices = view.slice(offset, size);
-      return copy_pinned_slices_to_device(slices, dst, stream);
-    }
-  }
-  return device_read_io(obj, offset, size, dst, stream);
-}
-
-std::unique_ptr<cudf::io::datasource::buffer> sirius_ioctx::device_read(
-  sirius_io_object& obj, size_t offset, size_t size, rmm::cuda_stream_view stream)
-{
-  if (_cache) {
-    if (auto view = _cache->read(obj, offset, size, stream.value()); view) {
-      auto slices = view.slice(offset, size);
-      rmm::device_buffer dbuf(size, stream);
-      copy_pinned_slices_to_device(slices, static_cast<uint8_t*>(dbuf.data()), stream);
-      return cudf::io::datasource::buffer::create(std::move(dbuf));
-    }
-  }
-  return device_read_io(obj, offset, size, stream);
-}
-
-void sirius_ioctx::device_read_async(sirius_io_object& obj,
-                                     size_t offset,
-                                     size_t size,
-                                     uint8_t* dst,
-                                     rmm::cuda_stream_view stream,
-                                     io_completion_handler handler)
-{
-  if (_cache) {
-    if (auto view = _cache->read(obj, offset, size, stream.value()); view) {
-      auto slices = view.slice(offset, size);
-      try {
-        auto copied = copy_pinned_slices_to_device(slices, dst, stream);
-        handler(copied, nullptr);
-      } catch (...) {
-        handler(0, std::current_exception());
-      }
-      return;
-    }
-  }
-  device_read_io_async(obj, offset, size, dst, stream, std::move(handler));
-}
-
-// ---------------------------------------------------------------------------
-// sirius_datasource
-// ---------------------------------------------------------------------------
 
 sirius_datasource::sirius_datasource(std::shared_ptr<sirius_ioctx> io_ctx,
                                      std::shared_ptr<sirius_io_object> io_object)
   : _io_ctx(std::move(io_ctx)), _io_object(std::move(io_object))
 {
 }
+
+sirius_datasource::~sirius_datasource() {}
 
 size_t sirius_datasource::size() const { return _io_object->size(); }
 
@@ -212,45 +54,39 @@ size_t sirius_datasource::host_read(size_t offset, size_t size, uint8_t* dst)
 std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::host_read(size_t offset,
                                                                            size_t size)
 {
-  return _io_ctx->host_read(*_io_object, offset, size);
+  std::vector<uint8_t> buf(size);
+  _io_ctx->host_read(*_io_object, offset, size, buf.data());
+  return cudf::io::datasource::buffer::create(std::move(buf));
 }
 
 std::future<size_t> sirius_datasource::host_read_async(size_t offset, size_t size, uint8_t* dst)
 {
-  auto p = std::make_shared<std::promise<size_t>>();
-  auto f = p->get_future();
-  _io_ctx->host_read_async(*_io_object, offset, size, dst, [p](size_t n, std::exception_ptr ep) {
-    if (ep)
-      p->set_exception(ep);
-    else
-      p->set_value(n);
-  });
-  return f;
+  return _io_ctx->host_read_async(*_io_object, offset, size, dst);
 }
 
 std::future<std::unique_ptr<cudf::io::datasource::buffer>> sirius_datasource::host_read_async(
   size_t offset, size_t size)
 {
-  size     = std::min(size, _io_object->size() > offset ? _io_object->size() - offset : size_t{0});
-  auto buf = std::make_shared<std::vector<uint8_t>>(size);
-  auto p   = std::make_shared<std::promise<std::unique_ptr<datasource::buffer>>>();
-  auto f   = p->get_future();
-  _io_ctx->host_read_async(
-    *_io_object, offset, size, buf->data(), [p, buf](size_t n, std::exception_ptr ep) {
-      if (ep) {
-        p->set_exception(ep);
-        return;
-      }
-      buf->resize(n);
-      p->set_value(datasource::buffer::create(std::move(*buf)));
-    });
-  return f;
+  auto file_size = _io_object->size();
+  size           = std::min(size, file_size > offset ? file_size - offset : size_t{0});
+  auto buf       = std::make_shared<std::vector<uint8_t>>(size);
+  auto inner_fut = std::make_shared<std::future<size_t>>(
+    _io_ctx->host_read_async(*_io_object, offset, size, buf->data()));
+  return std::async(std::launch::deferred, [buf, inner_fut]() mutable {
+    auto n = inner_fut->get();
+    buf->resize(n);
+    return datasource::buffer::create(std::move(*buf));
+  });
 }
 
 std::unique_ptr<cudf::io::datasource::buffer> sirius_datasource::device_read(
   size_t offset, size_t size, rmm::cuda_stream_view stream)
 {
-  return _io_ctx->device_read(*_io_object, offset, size, stream);
+  rmm::device_buffer buf(size, stream);
+  size_t n =
+    _io_ctx->device_read(*_io_object, offset, size, static_cast<uint8_t*>(buf.data()), stream);
+  buf.resize(n, stream);
+  return cudf::io::datasource::buffer::create(std::move(buf));
 }
 
 size_t sirius_datasource::device_read(size_t offset,
@@ -266,31 +102,7 @@ std::future<size_t> sirius_datasource::device_read_async(size_t offset,
                                                          uint8_t* dst,
                                                          rmm::cuda_stream_view stream)
 {
-  auto p = std::make_shared<std::promise<size_t>>();
-  auto f = p->get_future();
-  _io_ctx->device_read_async(
-    *_io_object, offset, size, dst, stream, [p](size_t n, std::exception_ptr ep) {
-      if (ep)
-        p->set_exception(ep);
-      else
-        p->set_value(n);
-    });
-  return f;
-}
-
-void sirius_datasource::host_read_ranges_async(
-  std::vector<cudf::io::text::byte_range_info> const& ranges,
-  std::span<cudf::host_span<std::byte>> dst,
-  io_completion_handler handler)
-{
-  _io_ctx->host_read_ranges_async(*_io_object, ranges, dst, std::move(handler));
-}
-
-size_t sirius_datasource::host_read_ranges(
-  std::vector<cudf::io::text::byte_range_info> const& ranges,
-  std::span<cudf::host_span<std::byte>> dst)
-{
-  return _io_ctx->host_read_ranges(*_io_object, ranges, dst);
+  return _io_ctx->device_read_async(*_io_object, offset, size, dst, stream);
 }
 
 }  // namespace sirius::io

--- a/src/io/uring/uring_reactor.cpp
+++ b/src/io/uring/uring_reactor.cpp
@@ -16,52 +16,68 @@
 
 #include "io/uring/uring_reactor.hpp"
 
+#include "driver_types.h"
+#include "io/types.hpp"
+
 #include <fcntl.h>
 #include <spdlog/spdlog.h>
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cstring>
 #include <deque>
+#include <filesystem>
 #include <ranges>
 #include <stdexcept>
 
 namespace sirius::io {
 
 // ---------------------------------------------------------------------------
-// uring_io_object
-// ---------------------------------------------------------------------------
-
-uring_io_object::uring_io_object(std::string path) : _path(std::move(path))
-{
-  _fd = file_descriptor(::open(_path.c_str(), O_RDONLY));
-  if (!_fd)
-    throw std::runtime_error("uring_io_object: open failed: " + _path + ": " + strerror(errno));
-
-  struct stat st{};
-  if (::fstat(_fd.get(), &st) < 0)
-    throw std::runtime_error("uring_io_object: fstat failed: " + std::string(strerror(errno)));
-  _file_size = static_cast<size_t>(st.st_size);
-
-  _fd_direct = file_descriptor(::open(_path.c_str(), O_RDONLY | O_DIRECT));
-  if (!_fd_direct)
-    throw std::runtime_error("uring_io_object: O_DIRECT open failed: " + _path + ": " +
-                             strerror(errno));
-}
-
-// ---------------------------------------------------------------------------
 // uring_reactor
 // ---------------------------------------------------------------------------
 
-uring_reactor::uring_reactor(unsigned ring_entries, size_t bounce_slot_size)
-  : _ring_entries(ring_entries)
+std::unique_ptr<uring_io_object> uring_reactor::create_io_object(std::string path)
 {
+  if (!supports(path))
+    throw std::runtime_error("uring_reactor::create_io_object: unsupported path: " + path);
+
+  file_descriptor fd{::open(path.c_str(), O_RDONLY)};
+  if (!fd)
+    throw std::runtime_error("uring_reactor::create_io_object: open failed: " + path + ": " +
+                             strerror(errno));
+
+  file_descriptor fd_direct{::open(path.c_str(), O_RDONLY | O_DIRECT)};
+  if (!fd_direct)
+    throw std::runtime_error("uring_reactor::create_io_object: O_DIRECT open failed: " + path +
+                             ": " + strerror(errno));
+
+  auto file_size = size(fd.get());
+  return std::make_unique<uring_io_object>(
+    std::move(path), std::move(fd), std::move(fd_direct), file_size);
+}
+
+size_t uring_reactor::size(int fd)
+{
+  struct stat st{};
+  if (::fstat(fd, &st) != 0)
+    throw std::runtime_error("uring_reactor::size: fstat failed: " + std::string(strerror(errno)));
+  return static_cast<size_t>(st.st_size);
+}
+
+uring_reactor::uring_reactor(cucascade::memory::fixed_size_host_memory_resource& mr,
+                             unsigned ring_entries)
+  : _bounce_slot_size(mr.get_block_size()), _ring_entries(ring_entries)
+{
+  _bounce_storage = mr.allocate_multiple_blocks(NUM_CHUNKS * _bounce_slot_size);
+  auto blocks     = _bounce_storage->get_blocks();
+  if (blocks.size() < NUM_CHUNKS) {
+    throw std::runtime_error(
+      "uring_reactor: fixed_size_host_memory_resource returned fewer blocks (" +
+      std::to_string(blocks.size()) + ") than required (" + std::to_string(NUM_CHUNKS) + ")");
+  }
   for (int i = 0; i < static_cast<int>(NUM_CHUNKS); ++i) {
-    void* raw = nullptr;
-    // Portable flag so these buffers are reachable from CUDA contexts
-    // other than the one current at ioctx construction (multi-GPU usage).
-    CUDA_CHECK(cudaHostAlloc(&raw, bounce_slot_size, cudaHostAllocPortable));
-    _bounce[i].buf.reset(raw);
-    _cb_args[i] = {this, i};
+    _bounce[i].buf = blocks[i];
+    _cb_args[i]    = {this, i};
   }
 
   _worker = std::thread([this] { worker_loop(); });
@@ -84,12 +100,19 @@ void uring_reactor::shutdown()
   }
 }
 
-void uring_reactor::cuda_copy_cb(void* p) noexcept
+void uring_reactor::cuda_copy_cb(cudaStream_t /*stream*/, cudaError_t status, void* p) noexcept
 {
   auto* arg = static_cast<cb_arg*>(p);
+  // Write status BEFORE the release-store on cuda_done so a reader that
+  // observes cuda_done == true via acquire also observes this status.
+  arg->self->_bounce[arg->slot].cuda_status = status;
   arg->self->_bounce[arg->slot].cuda_done.store(true, std::memory_order_release);
-  arg->self->_cuda_seq.fetch_add(1, std::memory_order_release);
-  arg->self->_cuda_seq.notify_one();
+  // Bump the unified wake atomic — the same one queue enqueues and
+  // interrupt() bump.  The reactor's single park point on _wake_seq wakes
+  // on any event, so a stalled CUDA callback no longer blocks the reactor
+  // from observing new host reads or shutdown.
+  arg->self->_wake_seq.fetch_add(1, std::memory_order_release);
+  arg->self->_wake_seq.notify_one();
 }
 
 cudf::io::text::byte_range_info uring_reactor::align_to_physical(
@@ -103,10 +126,35 @@ cudf::io::text::byte_range_info uring_reactor::align_to_physical(
   return {static_cast<int64_t>(a_start), static_cast<int64_t>(a_end - a_start)};
 }
 
+bool uring_reactor::supports(std::string_view path)
+{
+  std::error_code ec;
+  std::filesystem::path p{path};
+  return std::filesystem::is_regular_file(p, ec) && !ec;
+}
+
 void uring_reactor::enqueue_bulk(std::span<device_read_req_type> batch)
 {
   if (batch.empty()) return;
-  _queue.enqueue_bulk(std::make_move_iterator(batch.begin()), batch.size());
+
+  // Capture ctxs before bulk-enqueue: on failure (OOM in moodycamel) items
+  // may already be moved-from, so batch[i].ctx could be null.  The captured
+  // shared_ptrs let us drain ctx->pending via chunk_failed so the
+  // completion handler still fires instead of stranding readers in
+  // wait_while_loading().
+  std::vector<std::shared_ptr<request_context>> ctxs;
+  ctxs.reserve(batch.size());
+  for (auto& r : batch)
+    ctxs.push_back(r.ctx);
+
+  if (!_queue.enqueue_bulk(std::make_move_iterator(batch.begin()), batch.size())) {
+    auto e = std::make_exception_ptr(
+      std::runtime_error("uring_reactor::enqueue_bulk: queue enqueue failed"));
+    for (auto& ctx : ctxs)
+      ctx->chunk_failed(e);
+    return;
+  }
+
   _wake_seq.fetch_add(1, std::memory_order_release);
   _wake_seq.notify_one();
 }
@@ -114,15 +162,33 @@ void uring_reactor::enqueue_bulk(std::span<device_read_req_type> batch)
 size_t uring_reactor::host_read(int fd, size_t offset, size_t size, uint8_t* dst)
 {
   if (size == 0) return 0;
-  ssize_t n = ::pread(fd, dst, size, static_cast<off_t>(offset));
-  if (n < 0)
-    throw std::runtime_error("uring_reactor::host_read pread: " + std::string(strerror(errno)));
-  return static_cast<size_t>(n);
+  // Loop until either the full requested size is read, EOF (n == 0), or a
+  // real error. pread on a regular file should only return short on EOF, but
+  // we retry defensively against EINTR and any unexpected short-read paths
+  // so callers don't have to.
+  size_t total = 0;
+  while (total < size) {
+    ssize_t n = ::pread(fd, dst + total, size - total, static_cast<off_t>(offset + total));
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      throw std::runtime_error("uring_reactor::host_read pread: " + std::string(strerror(errno)));
+    }
+    if (n == 0) break;  // EOF
+    total += static_cast<size_t>(n);
+  }
+  return total;
 }
 
 void uring_reactor::host_read_async(host_read_req_type req)
 {
-  _host_queue.enqueue(std::move(req));
+  // Hold the ctx separately so we can drain pending via chunk_failed if the
+  // enqueue itself fails (otherwise req.ctx may be moved-from and lost).
+  auto ctx = req.ctx;
+  if (!_host_queue.enqueue(std::move(req))) {
+    ctx->chunk_failed(std::make_exception_ptr(
+      std::runtime_error("uring_reactor::host_read_async: queue enqueue failed")));
+    return;
+  }
   _wake_seq.fetch_add(1, std::memory_order_release);
   _wake_seq.notify_one();
 }
@@ -130,7 +196,23 @@ void uring_reactor::host_read_async(host_read_req_type req)
 void uring_reactor::host_enqueue_bulk(std::span<host_read_req_type> batch)
 {
   if (batch.empty()) return;
-  _host_queue.enqueue_bulk(std::make_move_iterator(batch.begin()), batch.size());
+
+  // See enqueue_bulk() above for the rationale: snapshot ctxs first so a
+  // partial-move failure on the moodycamel queue still drains ctx->pending
+  // and fires the completion handler instead of deadlocking readers.
+  std::vector<std::shared_ptr<request_context>> ctxs;
+  ctxs.reserve(batch.size());
+  for (auto& r : batch)
+    ctxs.push_back(r.ctx);
+
+  if (!_host_queue.enqueue_bulk(std::make_move_iterator(batch.begin()), batch.size())) {
+    auto e = std::make_exception_ptr(
+      std::runtime_error("uring_reactor::host_enqueue_bulk: queue enqueue failed"));
+    for (auto& ctx : ctxs)
+      ctx->chunk_failed(e);
+    return;
+  }
+
   _wake_seq.fetch_add(1, std::memory_order_release);
   _wake_seq.notify_one();
 }
@@ -139,15 +221,20 @@ void uring_reactor::worker_loop()
 {
   unique_ring ring = [this]() -> unique_ring {
 #if defined(IORING_SETUP_SINGLE_ISSUER) && defined(IORING_SETUP_DEFER_TASKRUN)
-    auto r = std::make_unique<io_uring>();
-    int rc = io_uring_queue_init(
-      _ring_entries, r.get(), IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN);
+    auto r                   = std::make_unique<io_uring>();
+    struct io_uring_params p = {0};
+    // Disable kernel locks (assuming 1 thread per ring)
+    p.flags |= IORING_SETUP_SINGLE_ISSUER;
+
+    // Keep completions on the current CPU, avoid cache thrashing
+    p.flags |= IORING_SETUP_COOP_TASKRUN | IORING_SETUP_DEFER_TASKRUN;
+    int rc = io_uring_queue_init_params(_ring_entries, r.get(), &p);
     if (rc == 0) {
-      spdlog::debug("uring_reactor: ring using SINGLE_ISSUER|DEFER_TASKRUN");
+      spdlog::debug("uring_device_reactor: ring using SINGLE_ISSUER|DEFER_TASKRUN");
       return unique_ring{r.release()};
     }
     spdlog::debug(
-      "uring_reactor: SINGLE_ISSUER|DEFER_TASKRUN unsupported "
+      "uring_device_reactor: SINGLE_ISSUER|DEFER_TASKRUN unsupported "
       "({}), falling back to plain flags",
       strerror(-rc));
 #endif
@@ -159,12 +246,30 @@ void uring_reactor::worker_loop()
     return unique_ring{r2.release()};
   }();
 
+  std::array<iovec, NUM_CHUNKS> iovecs{};
+  for (size_t i = 0; i < NUM_CHUNKS; ++i)
+    iovecs[i] = {_bounce[i].buf, _bounce_slot_size};
+  if (int rc = io_uring_register_buffers(ring.get(), iovecs.data(), NUM_CHUNKS); rc < 0)
+    throw std::runtime_error("uring_device_reactor: io_uring_register_buffers: " +
+                             std::string(strerror(-rc)));
+
   static constexpr uint64_t HOST_TAG = 1ULL << 63;
 
   enum class slot_state : uint8_t { FREE, READING, COPYING };
   struct slot_info {
     slot_state state{slot_state::FREE};
     device_read_req_type req{};
+    // Cumulative bytes read for the current request across short-read retries.
+    // Reset to 0 on slot acquisition; on each completion we add `cqe->res` and
+    // either re-submit the remainder or proceed to the H2D path.
+    size_t bytes_read{0};
+  };
+  // Heap-allocated wrapper for in-flight host reads. Mirrors the device
+  // slot's bytes_read tracking so we can retry short reads at the same
+  // user_data identity across multiple SQE submissions.
+  struct host_in_flight {
+    host_read_req_type req;
+    size_t bytes_read{0};
   };
   std::array<slot_info, NUM_CHUNKS> slots{};
   std::deque<device_read_req_type> pending;
@@ -183,7 +288,17 @@ void uring_reactor::worker_loop()
     for (auto i : std::views::iota(size_t{0}, NUM_CHUNKS)) {
       if (slots[i].state == slot_state::COPYING &&
           _bounce[i].cuda_done.load(std::memory_order_acquire)) {
-        slots[i].req.ctx->chunk_done();
+        // cuda_copy_cb stored the stream's status at callback time, before
+        // the release-store on cuda_done.  Read it directly — this is the
+        // state of the stream when our copy finished, not the current state
+        // (which may also include later work the consumer queued).
+        cudaError_t err = _bounce[i].cuda_status;
+        if (err != cudaSuccess) {
+          slots[i].req.ctx->chunk_failed(std::make_exception_ptr(std::runtime_error(
+            std::string("uring_reactor: H2D copy failed: ") + cudaGetErrorString(err))));
+        } else {
+          slots[i].req.ctx->chunk_done();
+        }
         slots[i] = slot_info{};
       }
     }
@@ -205,32 +320,33 @@ void uring_reactor::worker_loop()
       io_uring_sqe* sqe = io_uring_get_sqe(ring.get());
       if (!sqe) break;
       auto& req = pending.front();
-      spdlog::trace("reactor submit slot={} fd={} file_off={} io_size={:.2f}MB",
-                    si,
-                    req.handle,
-                    req.file_off,
-                    to_mb(req.io_size));
-      io_uring_prep_read(
-        sqe, req.handle, _bounce[si].buf.get(), (unsigned)req.io_size, (__u64)req.file_off);
+      // Bounce slots are pre-registered via io_uring_register_buffers, so
+      // submit through the fixed-buffer fast path — skips per-IO buffer
+      // pin/unmap overhead in the kernel.
+      io_uring_prep_read_fixed(sqe,
+                               req.handle,
+                               _bounce[si].buf,
+                               (unsigned)req.io_size,
+                               (unsigned long long)req.file_off,
+                               si);
       io_uring_sqe_set_data64(sqe, (uint64_t)si);
-      slots[si].state = slot_state::READING;
-      slots[si].req   = std::move(req);
+      slots[si].state      = slot_state::READING;
+      slots[si].bytes_read = 0;  // fresh request → reset retry accumulator
+      slots[si].req        = std::move(req);
       pending.pop_front();
       ++inflight;
       ++added;
     }
-    // Host reads: heap-allocate the req and tag the pointer in user_data.
+    // Host reads: heap-allocate a host_in_flight wrapper so we can carry
+    // cumulative bytes across short-read retries via the same user_data tag.
     while (!pending_host.empty()) {
       io_uring_sqe* sqe = io_uring_get_sqe(ring.get());
       if (!sqe) break;
-      auto* req = new host_read_req_type(std::move(pending_host.front()));
+      auto* hf = new host_in_flight{std::move(pending_host.front()), 0};
       pending_host.pop_front();
-      spdlog::trace("reactor host submit fd={} offset={} size={:.2f}MB",
-                    req->handle,
-                    req->offset,
-                    to_mb(req->size));
-      io_uring_prep_read(sqe, req->handle, req->dst, (unsigned)req->size, (__u64)req->offset);
-      io_uring_sqe_set_data64(sqe, reinterpret_cast<uint64_t>(req) | HOST_TAG);
+      io_uring_prep_read(
+        sqe, hf->req.handle, hf->req.dst, (unsigned)hf->req.size, (__u64)hf->req.offset);
+      io_uring_sqe_set_data64(sqe, reinterpret_cast<uint64_t>(hf) | HOST_TAG);
       ++inflight;
       ++added;
     }
@@ -238,7 +354,8 @@ void uring_reactor::worker_loop()
   };
   auto reap_cqes = [&]() {
     io_uring_cqe* cqes[NUM_CHUNKS];
-    unsigned n = io_uring_peek_batch_cqe(ring.get(), cqes, NUM_CHUNKS);
+    unsigned n         = io_uring_peek_batch_cqe(ring.get(), cqes, NUM_CHUNKS);
+    bool need_resubmit = false;  // any retry SQE prepared in this pass?
     for (auto* cqe : std::span{cqes, n}) {
       uint64_t data = io_uring_cqe_get_data64(cqe);
       int res       = cqe->res;
@@ -247,18 +364,48 @@ void uring_reactor::worker_loop()
 
       if (data & HOST_TAG) {
         // Host read completion.
-        auto* req = reinterpret_cast<host_read_req_type*>(data & ~HOST_TAG);
+        auto* hf = reinterpret_cast<host_in_flight*>(data & ~HOST_TAG);
         if (res < 0) {
-          req->ctx->chunk_failed(std::make_exception_ptr(
+          hf->req.ctx->chunk_failed(std::make_exception_ptr(
             std::runtime_error("reactor host read: " + std::string(strerror(-res)))));
-        } else {
-          spdlog::trace("reactor host done fd={} offset={} rd={:.2f}MB",
-                        req->handle,
-                        req->offset,
-                        to_mb((size_t)res));
-          req->ctx->chunk_done();
+          delete hf;
+          continue;
         }
-        delete req;
+        size_t rd = static_cast<size_t>(res);
+        hf->bytes_read += rd;
+        bool const fully_read = hf->bytes_read >= hf->req.size;
+        bool const eof        = (rd == 0);
+        if (!fully_read && !eof) {
+          // Short read mid-file: queue a follow-up SQE for the unread tail.
+          // We reuse the same host_in_flight identity so subsequent CQEs
+          // continue to accumulate bytes_read against this request.
+          io_uring_sqe* sqe = io_uring_get_sqe(ring.get());
+          if (sqe) {
+            io_uring_prep_read(sqe,
+                               hf->req.handle,
+                               hf->req.dst + hf->bytes_read,
+                               (unsigned)(hf->req.size - hf->bytes_read),
+                               (__u64)(hf->req.offset + hf->bytes_read));
+            io_uring_sqe_set_data64(sqe, reinterpret_cast<uint64_t>(hf) | HOST_TAG);
+            ++inflight;
+            need_resubmit = true;
+            spdlog::warn(
+              "uring_reactor: host short read, retrying tail. fd={} offset={} size={} "
+              "bytes_read={} this_rd={}",
+              hf->req.handle,
+              hf->req.offset,
+              hf->req.size,
+              hf->bytes_read,
+              rd);
+            continue;
+          }
+          // SQE exhaustion is unexpected (we have _ring_entries SQEs and
+          // never more than NUM_CHUNKS in flight); fall through and complete
+          // with whatever we have rather than spin.
+          spdlog::warn("uring_reactor: SQE exhausted on host short-read retry");
+        }
+        hf->req.ctx->chunk_done();
+        delete hf;
       } else {
         // Device read completion.
         int si      = static_cast<int>(data);
@@ -268,65 +415,159 @@ void uring_reactor::worker_loop()
           req.ctx->chunk_failed(std::make_exception_ptr(
             std::runtime_error("reactor read: " + std::string(strerror(-res)))));
           sinfo = slot_info{};
-        } else {
-          size_t rd     = (size_t)res;
-          size_t actual = rd > req.data_off ? std::min(req.data_size, rd - req.data_off) : 0;
-          if (actual > 0 && !req.ctx->failed.load(std::memory_order_relaxed)) {
-            _bounce[si].cuda_done.store(false, std::memory_order_relaxed);
-            if (req.device_id >= 0) cudaSetDevice(req.device_id);
-            cudaMemcpyAsync(req.dst,
-                            (uint8_t*)_bounce[si].buf.get() + req.data_off,
-                            actual,
-                            cudaMemcpyHostToDevice,
-                            req.stream);
-            cudaLaunchHostFunc(req.stream, cuda_copy_cb, &_cb_args[si]);
-            sinfo.state = slot_state::COPYING;
-          } else {
-            req.ctx->chunk_done();
-            sinfo = slot_info{};
+          continue;
+        }
+        size_t rd = static_cast<size_t>(res);
+        sinfo.bytes_read += rd;
+        bool const fully_read = sinfo.bytes_read >= req.io_size;
+        bool const eof        = (rd == 0);
+        if (!fully_read && !eof) {
+          // Short read mid-file: queue a follow-up SQE for the unread tail
+          // into the same bounce slot at the next-byte offset. The slot
+          // stays in READING; once we get the full io_size (or EOF), we
+          // proceed to the H2D path below using sinfo.bytes_read.
+          io_uring_sqe* sqe = io_uring_get_sqe(ring.get());
+          if (sqe) {
+            io_uring_prep_read_fixed(sqe,
+                                     req.handle,
+                                     (uint8_t*)_bounce[si].buf + sinfo.bytes_read,
+                                     (unsigned)(req.io_size - sinfo.bytes_read),
+                                     (__u64)(req.file_off + sinfo.bytes_read),
+                                     si);
+            io_uring_sqe_set_data64(sqe, (uint64_t)si);
+            ++inflight;
+            need_resubmit = true;
+            spdlog::warn(
+              "uring_reactor: device short read, retrying tail. slot={} file_off={} "
+              "io_size={} bytes_read={} this_rd={}",
+              si,
+              req.file_off,
+              req.io_size,
+              sinfo.bytes_read,
+              rd);
+            continue;
           }
+          spdlog::warn("uring_reactor: SQE exhausted on device short-read retry");
+        }
+        // Fully read or true EOF: compute user-visible bytes from the
+        // accumulated bytes_read, not just this CQE's `rd`.
+        size_t actual = sinfo.bytes_read > req.data_off
+                          ? std::min(req.data_size, sinfo.bytes_read - req.data_off)
+                          : 0;
+        if (actual > 0 && !req.ctx->failed.load(std::memory_order_relaxed)) {
+          _bounce[si].cuda_done.store(false, std::memory_order_relaxed);
+          _bounce[si].cuda_status = cudaSuccess;
+          if (req.device_id >= 0) cudaSetDevice(req.device_id);
+          cudaError_t cpy_err = cudaMemcpyAsync(req.dst,
+                                                (uint8_t*)_bounce[si].buf + req.data_off,
+                                                actual,
+                                                cudaMemcpyHostToDevice,
+                                                req.stream);
+          if (cpy_err != cudaSuccess) {
+            // Synchronous failure (e.g., invalid pointer / context).  Drain
+            // the sticky error so unrelated runtime calls don't observe it,
+            // fail the slot, and skip the callback registration — there's
+            // no stream work to attach a callback to.
+            cudaGetLastError();
+            req.ctx->chunk_failed(std::make_exception_ptr(
+              std::runtime_error(std::string("uring_reactor: cudaMemcpyAsync failed: ") +
+                                 cudaGetErrorString(cpy_err))));
+            sinfo = slot_info{};
+            continue;
+          }
+          // cudaStreamAddCallback (deprecated but used deliberately): unlike
+          // cudaLaunchHostFunc, the callback fires even if the stream is in
+          // an error state — guaranteeing we never strand the slot in
+          // COPYING waiting for a callback that won't come.
+          cudaStreamAddCallback(req.stream, cuda_copy_cb, &_cb_args[si], 0);
+          sinfo.state = slot_state::COPYING;
+        } else {
+          // After retry-to-completion this only fires when the file truly
+          // ends inside the alignment prefix (actual == 0) or when another
+          // chunk of the same request already failed. The handler still
+          // resolves with total_bytes, so anything in `req.dst` past what
+          // we could read is left untouched — log so it surfaces.
+          spdlog::warn(
+            "uring_reactor: chunk completed with no H2D after retry. "
+            "slot={} file_off={} io_size={} data_off={} data_size={} bytes_read={} actual={} "
+            "ctx_failed={}",
+            si,
+            req.file_off,
+            req.io_size,
+            req.data_off,
+            req.data_size,
+            sinfo.bytes_read,
+            actual,
+            req.ctx->failed.load(std::memory_order_relaxed));
+          req.ctx->chunk_done();
+          sinfo = slot_info{};
         }
       }
     }
+    if (need_resubmit) io_uring_submit(ring.get());
+  };
+
+  // Single park atomic: _wake_seq is bumped by every event source —
+  // queue enqueues, interrupt(), and cuda_copy_cb.  CQE delivery is the
+  // only exception: those are signalled by the kernel directly, so we
+  // wait on io_uring_wait_cqe_timeout when (and only when) there is
+  // in-flight IO that can produce one.
+  auto any_copying = [&]() {
+    return std::ranges::any_of(slots, [](auto& s) { return s.state == slot_state::COPYING; });
   };
 
   while (true) {
-    // Always drain the moodycamel queues into local dequeues BEFORE checking
-    // has_active() — the dequeues are the only state has_active() looks at.
-    // Without this, a producer that enqueued + bumped wake_seq before our
-    // seq.load() will leave work sitting invisible in the moodycamel queue,
-    // and we'll park on seq=current_value and never wake.
     drain_queue();
+    poll_cuda();  // retire COPYING slots whose callback has fired
 
-    if (!has_active()) {
-      if (_stop.load(std::memory_order_acquire)) break;
+    if (_stop.load(std::memory_order_acquire)) break;
+
+    bool work_to_submit = !pending.empty() || !pending_host.empty();
+
+    if (!work_to_submit && inflight == 0 && !any_copying()) {
+      // Fully idle.  Park on _wake_seq with the standard race-guard:
+      // load the seq, re-drain, and only park if still idle.
       uint64_t seq = _wake_seq.load(std::memory_order_acquire);
-      // Re-drain AFTER the seq load.  Any producer whose enqueue is now
-      // observable either (a) landed before our load and is pulled in here,
-      // making has_active() true, or (b) landed after our load, in which
-      // case their fetch_add(1) made wake_seq != seq so the wait below
-      // returns immediately.  Either way, no lost wake-up.
       drain_queue();
-      if (!has_active()) { _wake_seq.wait(seq, std::memory_order_relaxed); }
-      if (_stop.load(std::memory_order_acquire)) break;
-      // Pull whatever work woke us up before the main body runs.
-      drain_queue();
+      poll_cuda();
+      if (pending.empty() && pending_host.empty() && inflight == 0 && !any_copying() &&
+          !_stop.load(std::memory_order_acquire)) {
+        _wake_seq.wait(seq, std::memory_order_relaxed);
+      }
+      continue;
     }
 
     submit_pending();
 
     if (inflight > 0) {
       io_uring_cqe* tmp = nullptr;
-      io_uring_wait_cqe(ring.get(), &tmp);
+      // Bounded wait so the top-of-loop _stop check is reachable even
+      // when no CQE arrives.  SINGLE_ISSUER means we can't post a NOP
+      // SQE from interrupt() to unblock a plain wait_cqe; the timeout
+      // bounds shutdown latency to SHUTDOWN_POLL_MS instead.
+      static constexpr long SHUTDOWN_POLL_MS = 100;
+      __kernel_timespec ts{};
+      ts.tv_sec  = SHUTDOWN_POLL_MS / 1000;
+      ts.tv_nsec = (SHUTDOWN_POLL_MS % 1000) * 1'000'000L;
+      int rc     = io_uring_wait_cqe_timeout(ring.get(), &tmp, &ts);
+      if (rc < 0 && rc != -EINTR && rc != -ETIME) {
+        spdlog::error("uring_reactor: io_uring_wait_cqe_timeout failed: {}", strerror(-rc));
+        break;
+      }
       reap_cqes();
+      continue;  // loop top: drain_queue + poll_cuda handle any state change
     }
 
-    uint64_t cuda_seq = _cuda_seq.load(std::memory_order_acquire);
-    poll_cuda();
-
-    if (inflight == 0 && pending.empty() && has_active()) {
-      _cuda_seq.wait(cuda_seq, std::memory_order_acquire);
-    }
+    // Here: nothing to submit, no in-flight IO, but has_active is true
+    // because of COPYING slots.  Park on _wake_seq until cuda_copy_cb
+    // (or new queue work / interrupt) bumps it.
+    uint64_t seq = _wake_seq.load(std::memory_order_acquire);
+    poll_cuda();  // race-guard: a callback may have fired since the top
+    drain_queue();
+    if (!pending.empty() || !pending_host.empty() || !any_copying() ||
+        _stop.load(std::memory_order_acquire))
+      continue;
+    _wake_seq.wait(seq, std::memory_order_relaxed);
   }
 }
 

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -92,10 +92,7 @@ std::optional<task_creation_hint> sirius_gpu_parquet_scan_operator::get_next_tas
   return task_creation_hint{TaskCreationHint::READY, this};
 }
 
-bool sirius_gpu_parquet_scan_operator::all_ports_empty()
-{
-  return _split_connector->is_closed() && !_split_connector->has_more_splits();
-}
+bool sirius_gpu_parquet_scan_operator::all_ports_empty() { return _split_connector->is_closed(); }
 
 std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::get_next_task_input_data()
 {
@@ -123,7 +120,14 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
   rg_per_src.reserve(scan_data.rg_slices.size());
 
   for (auto const& slice : scan_data.rg_slices) {
-    sources.push_back(cudf::io::datasource::create(slice.file_path));
+    if (slice.io_ctx && slice.io_object) {
+      // sirius path: reuse the io_object minted by the split provider so the
+      // prefetching cache (if enabled) can serve these reads from pinned memory.
+      sources.push_back(slice.io_ctx->make_datasource(slice.io_object));
+    } else {
+      // Fallback when scan_manager was configured with use_sirius_datasource=false.
+      sources.push_back(cudf::io::datasource::create(slice.file_path));
+    }
     metadatas.push_back(*slice.file_metadata);  // copy unavoidable: cudf takes by value
     rg_per_src.push_back(slice.row_group_indices);
   }

--- a/src/scan_manager/cached_split_provider.cpp
+++ b/src/scan_manager/cached_split_provider.cpp
@@ -18,8 +18,6 @@
 
 #include "data/data_batch_utils.hpp"
 #include "op/scan/parquet_scan_operator_data.hpp"
-#include "op/sirius_physical_operator.hpp"
-#include "scan_manager/split_connector.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
@@ -29,8 +27,10 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 
+#include <span>
 #include <stdexcept>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace sirius::scan_manager {
@@ -40,11 +40,32 @@ cached_split_provider::cached_split_provider(
   cucascade::memory::memory_space& memory_space,
   std::shared_ptr<duckdb::Expression> filter_expression,
   std::shared_ptr<op::scan::scan_plan const> plan)
-  : _columns_per_request(std::move(columns_per_request)),
-    _memory_space(&memory_space),
+  : _memory_space(&memory_space),
     _filter_expression(std::move(filter_expression)),
     _plan(std::move(plan))
 {
+  // Transpose [column_idx][chunk_idx] -> [chunk_idx][column_idx]. The
+  // per-chunk-column layout matches how produce_split() consumes it (one
+  // table_view's worth of columns per chunk), and lets us hold every chunk in a
+  // uniform variant alongside the host-mode shape.
+  std::size_t const num_batches =
+    columns_per_request.empty() ? 0 : columns_per_request.front().size();
+  for (auto const& col_chunks : columns_per_request) {
+    if (col_chunks.size() != num_batches) {
+      throw std::runtime_error(
+        "[cached_split_provider] mismatched chunk count across requested columns");
+    }
+  }
+
+  _batches.reserve(num_batches);
+  for (std::size_t b = 0; b < num_batches; ++b) {
+    gpu_chunk chunk_cols;
+    chunk_cols.reserve(columns_per_request.size());
+    for (auto& col_chunks : columns_per_request) {
+      chunk_cols.push_back(std::move(col_chunks[b]));
+    }
+    _batches.emplace_back(std::move(chunk_cols));
+  }
 }
 
 cached_split_provider::cached_split_provider(
@@ -53,82 +74,76 @@ cached_split_provider::cached_split_provider(
   cucascade::memory::memory_space& memory_space,
   std::shared_ptr<duckdb::Expression> filter_expression,
   std::shared_ptr<op::scan::scan_plan const> plan)
-  : _host_chunks(std::move(host_chunks)),
-    _column_indices(std::move(column_indices)),
+  : _column_indices(std::move(column_indices)),
     _memory_space(&memory_space),
     _filter_expression(std::move(filter_expression)),
     _plan(std::move(plan))
 {
+  _batches.reserve(host_chunks.size());
+  for (auto& chunk : host_chunks) {
+    if (!chunk) {
+      throw std::runtime_error(
+        "[cached_split_provider] null host_data_representation in pinned chunks");
+    }
+    _batches.emplace_back(std::move(chunk));
+  }
 }
 
-std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
-                                               split_connector& connector)
+bool cached_split_provider::has_more_splits() const
 {
-  std::promise<void> promise;
-  auto future = promise.get_future();
+  return _next_batch_idx.load(std::memory_order_relaxed) < _batches.size();
+}
 
-  if (!_host_chunks.empty()) {
-    // HOST tier: slice each pinned chunk down to the requested columns and emit a
-    // data_batch wrapping the resulting host_data_representation. The batch is
-    // converted to GPU later by scan_cached_operator_data::prepare_for_processing,
-    // so downstream execute() still sees a gpu_table_representation.
-    for (auto const& chunk : _host_chunks) {
-      if (!chunk) {
-        throw std::runtime_error(
-          "[cached_split_provider] null host_data_representation in pinned chunks");
+std::function<std::vector<std::unique_ptr<op::operator_data>>()>
+cached_split_provider::next_split_provider()
+{
+  // Atomic claim happens here so the produce_split() work captured below can
+  // run in parallel on a worker pool — distinct callables operate on distinct
+  // chunk indices.
+  auto const batch_idx = _next_batch_idx.fetch_add(1, std::memory_order_relaxed);
+  if (batch_idx >= _batches.size()) { return nullptr; }
+  return [this, batch_idx]() { return produce_split(batch_idx); };
+}
+
+std::vector<std::unique_ptr<op::operator_data>> cached_split_provider::produce_split(
+  std::size_t batch_idx)
+{
+  auto batch = std::visit(
+    [this](auto& chunk) -> std::shared_ptr<cucascade::data_batch> {
+      using T = std::decay_t<decltype(chunk)>;
+      if constexpr (std::is_same_v<T, gpu_chunk>) {
+        std::vector<cudf::column_view> col_views;
+        col_views.reserve(chunk.size());
+        std::size_t alloc_size = 0;
+        for (auto const& col_ptr : chunk) {
+          col_views.emplace_back(col_ptr->view());
+          alloc_size += col_ptr->alloc_size();
+        }
+        // The shared_ptr<column> entries in `chunk` keep the underlying
+        // device buffers alive; we move them into the gpu_table_representation
+        // as its owner so the table_view's pointers stay valid for the
+        // lifetime of the emitted data_batch. Each chunk index is claimed
+        // exactly once, so moving from the variant alternative is safe.
+        cudf::table_view view(col_views);
+        auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
+          view, std::move(chunk), alloc_size, *_memory_space);
+        return std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(),
+                                                       std::move(gpu_repr));
+      } else if constexpr (std::is_same_v<T, host_chunk>) {
+        // HOST tier: each chunk holds the full pinned table; slice down to the
+        // columns the scan actually wants. Conversion back to GPU happens later
+        // in scan_cached_operator_data::prepare_for_processing.
+        auto sliced = chunk->slice(std::span<const std::size_t>(_column_indices));
+        return std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(),
+                                                       std::move(sliced));
       }
-      auto sliced = chunk->slice(_column_indices);
-      auto batch =
-        std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(sliced));
-      connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
-        std::move(batch), _filter_expression, _plan));
-    }
+    },
+    _batches[batch_idx]);
 
-    connector.close();
-    promise.set_value();
-    return future;
-  }
-
-  std::size_t const num_batches =
-    _columns_per_request.empty() ? 0 : _columns_per_request.front().size();
-
-  // Sanity-check: every column must contribute the same number of chunks.
-  for (auto const& col_chunks : _columns_per_request) {
-    if (col_chunks.size() != num_batches) {
-      throw std::runtime_error(
-        "[cached_split_provider] mismatched chunk count across requested columns");
-    }
-  }
-
-  for (std::size_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
-    std::vector<cudf::column_view> col_views;
-    col_views.reserve(_columns_per_request.size());
-    // Owner keeps the shared_ptr<column> chunks alive for the lifetime of the
-    // emitted data_batch, so the table_view's pointers stay valid even though
-    // the gpu_table_representation does not own the underlying memory.
-    std::vector<std::shared_ptr<cudf::column>> owner;
-    owner.reserve(_columns_per_request.size());
-    std::size_t alloc_size = 0;
-    for (auto const& col_chunks : _columns_per_request) {
-      auto const& col_ptr = col_chunks[batch_idx];
-      col_views.emplace_back(col_ptr->view());
-      alloc_size += col_ptr->alloc_size();
-      owner.push_back(col_ptr);
-    }
-
-    cudf::table_view view(col_views);
-    auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
-      view, std::move(owner), alloc_size, *_memory_space);
-    auto batch =
-      std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
-
-    connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
-      std::move(batch), _filter_expression, _plan));
-  }
-
-  connector.close();
-  promise.set_value();
-  return future;
+  std::vector<std::unique_ptr<op::operator_data>> out;
+  out.push_back(std::make_unique<op::scan::scan_cached_operator_data>(
+    std::move(batch), _filter_expression, _plan));
+  return out;
 }
 
 }  // namespace sirius::scan_manager

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -16,13 +16,13 @@
 
 #include "scan_manager/parquet_split_provider.hpp"
 
-#include "exec/thread_pool.hpp"
 #include "expression_executor/gpu_expression_translator_internal.hpp"
+#include "io/io_context.hpp"
+#include "io/prefetching_cache.hpp"
 #include "log/logging.hpp"
 #include "op/scan/parquet_scan_operator_data.hpp"
 #include "op/scan/parquet_schema_mapping.hpp"
 #include "op/scan/scan_utils.hpp"
-#include "scan_manager/split_connector.hpp"
 
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet.hpp>
@@ -34,13 +34,11 @@
 #include <duckdb/common/hive_partitioning.hpp>
 
 #include <algorithm>
-#include <atomic>
-#include <exception>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace sirius::scan_manager {
 
@@ -68,11 +66,13 @@ parquet_split_provider::parquet_split_provider(
   duckdb::unique_ptr<duckdb::TableFilterSet> table_filter_set,
   duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices,
   std::size_t approximate_batch_size,
-  std::size_t max_file_processed)
+  std::size_t max_file_processed,
+  std::shared_ptr<sirius::io::sirius_ioctx> io_ctx)
   : _file_paths(file_paths),
     _approximate_batch_size(approximate_batch_size),
     _max_file_processed(max_file_processed),
-    _total_files(file_paths.size())
+    _total_files(file_paths.size()),
+    _io_ctx(std::move(io_ctx))
 {
   // Any non-trivial scan shape — reader-side projection, filter pushdown, or hive-partition
   // injection — needs column names for reader set_column_names / AST name resolution /
@@ -102,87 +102,45 @@ parquet_split_provider::parquet_split_provider(
                                               _plan->partition_primary_indices);
     if (duckdb_expression) { _duckdb_filter_expression = std::move(duckdb_expression); }
   }
+
+  // Pre-decompose the file list into per-task batches once; next_split_provider() iterates this
+  // list one batch at a time and hands each claimed batch to a worker for parallel processing.
+  for (std::size_t start = 0; start < _total_files; start += _max_file_processed) {
+    auto const end = std::min(start + _max_file_processed, _total_files);
+    file_batch batch;
+    batch.file_paths.assign(_file_paths.begin() + static_cast<std::ptrdiff_t>(start),
+                            _file_paths.begin() + static_cast<std::ptrdiff_t>(end));
+    _batches.push_back(std::move(batch));
+  }
 }
 
 parquet_split_provider::~parquet_split_provider() = default;
 
-std::optional<parquet_split_provider::file_batch> parquet_split_provider::next_task_input()
+bool parquet_split_provider::has_more_splits() const
 {
-  if (_next_file_idx >= _total_files) { return std::nullopt; }
-  auto const start = _next_file_idx;
-  auto const end   = std::min(start + _max_file_processed, _total_files);
-  _next_file_idx   = end;
-
-  file_batch batch;
-  batch.file_paths.assign(_file_paths.begin() + static_cast<std::ptrdiff_t>(start),
-                          _file_paths.begin() + static_cast<std::ptrdiff_t>(end));
-  return batch;
+  return _next_batch_idx.load(std::memory_order_relaxed) < _batches.size();
 }
 
-std::future<void> parquet_split_provider::start(exec::thread_pool& pool, split_connector& connector)
+std::function<std::vector<std::unique_ptr<op::operator_data>>()>
+parquet_split_provider::next_split_provider()
 {
-  // Drain all batches up-front so we can size the remaining-task counter
-  // precisely; the connector closes when the last batch lands.
-  std::vector<file_batch> batches;
-  while (auto next = next_task_input()) {
-    batches.push_back(std::move(*next));
-  }
-
-  auto promise = std::make_shared<std::promise<void>>();
-  auto future  = promise->get_future();
-
-  if (batches.empty()) {
-    connector.close();
-    promise->set_value();
-    return future;
-  }
-
-  auto remaining   = std::make_shared<std::atomic<std::size_t>>(batches.size());
-  auto first_error = std::make_shared<std::atomic<bool>>(false);
-  auto error_ptr   = std::make_shared<std::exception_ptr>();
-  auto error_mutex = std::make_shared<std::mutex>();
-
-  for (auto& batch : batches) {
-    pool.schedule([this,
-                   batch = std::move(batch),
-                   &connector,
-                   remaining,
-                   promise,
-                   first_error,
-                   error_ptr,
-                   error_mutex]() {
-      try {
-        run_batch(batch, connector);
-      } catch (const std::exception& e) {
-        SIRIUS_LOG_ERROR("[parquet_split_provider] metadata scan task failed: {}", e.what());
-        bool expected = false;
-        if (first_error->compare_exchange_strong(expected, true)) {
-          std::lock_guard<std::mutex> lock(*error_mutex);
-          *error_ptr = std::current_exception();
-        }
-      } catch (...) {
-        SIRIUS_LOG_ERROR("[parquet_split_provider] metadata scan task failed (unknown)");
-        bool expected = false;
-        if (first_error->compare_exchange_strong(expected, true)) {
-          std::lock_guard<std::mutex> lock(*error_mutex);
-          *error_ptr = std::current_exception();
-        }
-      }
-      if (remaining->fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        connector.close();
-        if (first_error->load(std::memory_order_acquire)) {
-          std::lock_guard<std::mutex> lock(*error_mutex);
-          promise->set_exception(*error_ptr);
-        } else {
-          promise->set_value();
-        }
-      }
-    });
-  }
-  return future;
+  // Atomic claim happens here so the (expensive) run_batch work captured
+  // below can run in parallel on a worker pool — distinct callables operate
+  // on distinct batch indices. fetch_add can briefly observe an index past
+  // the end (when more workers run than batches); returning null in that
+  // case signals "no work claimed" without forcing the caller to invoke a
+  // dummy callable.
+  auto const batch_idx = _next_batch_idx.fetch_add(1, std::memory_order_relaxed);
+  if (batch_idx >= _batches.size()) { return nullptr; }
+  return [this, batch_idx]() {
+    std::vector<std::unique_ptr<op::operator_data>> out;
+    run_batch(_batches[batch_idx], out);
+    return out;
+  };
 }
 
-void parquet_split_provider::run_batch(file_batch const& batch, split_connector& connector)
+void parquet_split_provider::run_batch(file_batch const& batch,
+                                       std::vector<std::unique_ptr<op::operator_data>>& out)
 {
   auto stream = cudf::get_default_stream();
 
@@ -220,12 +178,12 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
 
   // Loop over files to read footers, parse metadata, and compute row-group partitions.
   rg_accumulator accum;
-  // flush() pushes the bundled slices but does NOT reset partition_values. The file loop owns
-  // partition_values and re-seeds it on every file iteration; clearing it here would orphan the
-  // post-flush tail of a mid-file overflow.
+  // flush() appends the bundled slices to `out` but does NOT reset partition_values. The file
+  // loop owns partition_values and re-seeds it on every file iteration; clearing it here would
+  // orphan the post-flush tail of a mid-file overflow.
   auto flush = [&]() {
     if (accum.slices.empty()) { return; }
-    connector.push_split(std::make_unique<op::scan::parquet_scan_data>(
+    out.push_back(std::make_unique<op::scan::parquet_scan_data>(
       std::move(accum.slices),
       reader_options,
       _duckdb_filter_expression,
@@ -255,7 +213,18 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
     }
 
     //===----------Read metadata footers----------===//
-    auto datasource    = cudf::io::datasource::create(file_path);
+    // When the manager exposes a sirius_ioctx, mint an io_object up-front and
+    // route the footer fetch through sirius_datasource so the same io_object
+    // can be threaded onto every emitted row_group_slice.  Falls through to
+    // cudf's path when the manager was configured with use_sirius_datasource=false.
+    std::shared_ptr<sirius::io::sirius_io_object> file_io_object;
+    std::unique_ptr<cudf::io::datasource> datasource;
+    if (_io_ctx != nullptr) {
+      file_io_object = _io_ctx->create_io_object(file_path);
+      datasource     = _io_ctx->make_datasource(file_io_object);
+    } else {
+      datasource = cudf::io::datasource::create(file_path);
+    }
     auto footer_buffer = cudf::io::parquet::fetch_footer_to_host(*datasource);
 
     //===----------Parse metadata----------===//
@@ -313,14 +282,79 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
       // clang-format on
     }
 
+    //===----------Prefetch cache prewarm----------===//
+    // When the ioctx has a cache, hand it the exact byte ranges scan_task
+    // will request: PAR1 header + (merged) column-chunk ranges for every
+    // surviving row group + footer/trailer.  insert() must use the same
+    // merged ranges scan_task computes — the cache only serves reads that
+    // are fully covered by an inserted range.
+    if (file_io_object && _io_ctx != nullptr && _io_ctx->cache() != nullptr &&
+        !row_group_indices.empty()) {
+      using range_t = cudf::io::text::byte_range_info;
+
+      auto chunk_ranges = reader.all_column_chunks_byte_ranges(row_group_indices, *reader_options);
+
+      // Inline merge: parquet_scan_task::detail::merge_byte_ranges is TU-local;
+      // duplicating the ~10-line walk avoids cross-component coupling.
+      std::sort(chunk_ranges.begin(), chunk_ranges.end(), [](auto const& a, auto const& b) {
+        return a.offset() < b.offset();
+      });
+      std::vector<range_t> merged;
+      merged.reserve(chunk_ranges.size());
+      if (!chunk_ranges.empty()) {
+        auto cur_start = chunk_ranges[0].offset();
+        auto cur_end   = cur_start + chunk_ranges[0].size();
+        for (auto const& r : chunk_ranges) {
+          auto const rs = r.offset();
+          auto const re = rs + r.size();
+          if (rs <= cur_end) {
+            cur_end = std::max(cur_end, re);
+          } else {
+            merged.emplace_back(cur_start, cur_end - cur_start);
+            cur_start = rs;
+            cur_end   = re;
+          }
+        }
+        merged.emplace_back(cur_start, cur_end - cur_start);
+      }
+
+      // footer_offset / footer_size mirror parquet_scan_task's computation:
+      // the trailer is 8 bytes (4 footer_len + 4 magic) and footer_buffer
+      // returns the footer body alone.
+      constexpr std::size_t FOOTER_TAIL_SIZE = 8;
+      auto const file_size                   = file_io_object->size();
+      auto const footer_len                  = footer_buffer->size();
+      auto const footer_off  = static_cast<int64_t>(file_size - FOOTER_TAIL_SIZE - footer_len);
+      auto const footer_size = static_cast<int64_t>(FOOTER_TAIL_SIZE + footer_len);
+
+      std::vector<range_t> ranges;
+      ranges.reserve(merged.size() + 2);
+      ranges.emplace_back(0, 4);  // PAR1 header
+      ranges.insert(ranges.end(), merged.begin(), merged.end());
+      ranges.emplace_back(footer_off, footer_size);
+      // Cache requires sorted-by-offset.  Header is at 0, footer is at file end,
+      // and merged column chunks live in between — a defensive sort handles any
+      // pathological layout where a column chunk starts before the header.
+      std::sort(ranges.begin(), ranges.end(), [](auto const& a, auto const& b) {
+        return a.offset() < b.offset();
+      });
+
+      _io_ctx->cache()->insert(*file_io_object, /*metadata=*/nullptr, ranges);
+    }
+
     std::vector<cudf::size_type> cur_rgs;
     std::size_t cur_uncompressed_bytes = 0;
     std::size_t cur_compressed_bytes   = 0;
 
     auto seal_current_file = [&]() {
       if (cur_rgs.empty()) { return; }
-      accum.slices.emplace_back(
-        file_metadata, file_path, std::move(cur_rgs), cur_uncompressed_bytes, cur_compressed_bytes);
+      accum.slices.emplace_back(file_metadata,
+                                file_path,
+                                std::move(cur_rgs),
+                                cur_uncompressed_bytes,
+                                cur_compressed_bytes,
+                                _io_ctx,
+                                file_io_object);
       // Promote the just-sealed slice's uncompressed bytes into the cross-file accumulator.
       accum.total_uncompressed_bytes += cur_uncompressed_bytes;
       cur_rgs.clear();

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -23,6 +23,7 @@
 #include "op/scan/parquet_scan_operator_data.hpp"
 #include "op/scan/parquet_schema_mapping.hpp"
 #include "op/scan/scan_utils.hpp"
+#include "scan_manager/parquet_metadata.hpp"
 
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet.hpp>
@@ -225,14 +226,37 @@ void parquet_split_provider::run_batch(file_batch const& batch,
     } else {
       datasource = cudf::io::datasource::create(file_path);
     }
-    auto footer_buffer = cudf::io::parquet::fetch_footer_to_host(*datasource);
 
-    //===----------Parse metadata----------===//
-    op::scan::hybrid_scan_reader reader(
-      cudf::host_span<uint8_t const>(footer_buffer->data(), footer_buffer->size()),
-      *reader_options);
-    auto file_metadata =
-      std::make_shared<cudf::io::parquet::FileMetaData const>(reader.parquet_metadata());
+    //===----------Parse metadata (with prefetch-cache reuse)----------===//
+    // If the prefetching cache already has a parquet_metadata entry for this
+    // file (from a previous scan of the same path in this session), reuse the
+    // parsed FileMetaData and skip the footer fetch.  Otherwise fetch + parse
+    // and stash the result on the cache below.
+    std::shared_ptr<cudf::io::parquet::FileMetaData const> file_metadata;
+    std::shared_ptr<parquet_metadata> cached_parquet_metadata;
+    std::size_t footer_byte_len = 0;
+    std::unique_ptr<op::scan::hybrid_scan_reader> reader_ptr;
+
+    if (file_io_object && _io_ctx != nullptr && _io_ctx->cache() != nullptr) {
+      if (auto cached = _io_ctx->cache()->get_metadata(*file_io_object)) {
+        cached_parquet_metadata = std::dynamic_pointer_cast<parquet_metadata>(std::move(cached));
+      }
+    }
+
+    if (cached_parquet_metadata) {
+      file_metadata   = cached_parquet_metadata->file_metadata();
+      footer_byte_len = cached_parquet_metadata->footer_byte_len();
+      reader_ptr = std::make_unique<op::scan::hybrid_scan_reader>(*file_metadata, *reader_options);
+    } else {
+      auto footer_buffer = cudf::io::parquet::fetch_footer_to_host(*datasource);
+      footer_byte_len    = footer_buffer->size();
+      reader_ptr         = std::make_unique<op::scan::hybrid_scan_reader>(
+        cudf::host_span<uint8_t const>(footer_buffer->data(), footer_buffer->size()),
+        *reader_options);
+      file_metadata =
+        std::make_shared<cudf::io::parquet::FileMetaData const>(reader_ptr->parquet_metadata());
+    }
+    auto& reader         = *reader_ptr;
     auto const& metadata = *file_metadata;
 
     //===----------Resolve selected DuckDB columns to parquet column chunk indices----------===//
@@ -319,13 +343,13 @@ void parquet_split_provider::run_batch(file_batch const& batch,
       }
 
       // footer_offset / footer_size mirror parquet_scan_task's computation:
-      // the trailer is 8 bytes (4 footer_len + 4 magic) and footer_buffer
-      // returns the footer body alone.
+      // the trailer is 8 bytes (4 footer_len + 4 magic) and the footer body
+      // length (excluding the trailer) is recorded on parquet_metadata so we
+      // don't need the original footer buffer to recompute the range.
       constexpr std::size_t FOOTER_TAIL_SIZE = 8;
       auto const file_size                   = file_io_object->size();
-      auto const footer_len                  = footer_buffer->size();
-      auto const footer_off  = static_cast<int64_t>(file_size - FOOTER_TAIL_SIZE - footer_len);
-      auto const footer_size = static_cast<int64_t>(FOOTER_TAIL_SIZE + footer_len);
+      auto const footer_off  = static_cast<int64_t>(file_size - FOOTER_TAIL_SIZE - footer_byte_len);
+      auto const footer_size = static_cast<int64_t>(FOOTER_TAIL_SIZE + footer_byte_len);
 
       std::vector<range_t> ranges;
       ranges.reserve(merged.size() + 2);
@@ -339,7 +363,16 @@ void parquet_split_provider::run_batch(file_batch const& batch,
         return a.offset() < b.offset();
       });
 
-      _io_ctx->cache()->insert(*file_io_object, /*metadata=*/nullptr, ranges);
+      // When the cache already had parquet_metadata for this file we reused it
+      // and don't need to re-store it; otherwise we just parsed the footer and
+      // hand the freshly-built parquet_metadata to the cache so the next scan
+      // of this file can skip the footer fetch.
+      std::shared_ptr<sirius::io::sirius_io_object_metadata> metadata_to_store =
+        cached_parquet_metadata
+          ? nullptr
+          : std::static_pointer_cast<sirius::io::sirius_io_object_metadata>(
+              std::make_shared<parquet_metadata>(file_metadata, footer_byte_len));
+      _io_ctx->cache()->insert(*file_io_object, std::move(metadata_to_store), ranges);
     }
 
     std::vector<cudf::size_type> cur_rgs;

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -16,6 +16,9 @@
 
 #include "scan_manager/sirius_scan_manager.hpp"
 
+#include "exec/thread_pool.hpp"
+#include "io/prefetching_cache.hpp"
+#include "io/uring/uring_ioctx.hpp"
 #include "log/logging.hpp"
 #include "op/scan/parquet_scan_info.hpp"
 #include "op/scan/scan_plan.hpp"
@@ -29,22 +32,75 @@
 #include "scan_manager/split_connector.hpp"
 #include "scan_manager/split_provider.hpp"
 
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+
 #include <algorithm>
 #include <exception>
+#include <stdexcept>
 #include <utility>
 
 namespace sirius::scan_manager {
 
-sirius_scan_manager::sirius_scan_manager(exec::thread_pool_config config)
-  : _config(std::move(config))
+sirius_scan_manager::sirius_scan_manager(
+  scan_manager_config config, cucascade::memory::fixed_size_host_memory_resource* host_mr)
+  : _config(std::move(config)),
+    _thread_pool(_config.thread_pool.num_threads,
+                 _config.thread_pool.thread_name_prefix,
+                 _config.thread_pool.cpu_affinity_list),
+    _dispatcher(
+      std::make_unique<exec::scoped_dispatcher>(_thread_pool, _config.thread_pool.num_threads))
 {
+  if (_config.use_sirius_datasource) {
+    if (host_mr == nullptr) {
+      throw std::runtime_error(
+        "[sirius_scan_manager] use_sirius_datasource is true but no host "
+        "fixed_size_host_memory_resource was provided");
+    }
+    _io_ctx = std::make_shared<sirius::io::uring_ioctx>(
+      _config.uring_n_reactors, _config.uring_ring_entries, *host_mr);
+    SIRIUS_LOG_DEBUG(
+      "[sirius_scan_manager] sirius_datasource enabled (uring_ioctx n_reactors={} ring_entries={})",
+      _config.uring_n_reactors,
+      _config.uring_ring_entries);
+
+    if (_config.enable_prefetch_cache) {
+      // Slab size = CHUNKS_PER_SLAB blocks at the resource's block size.
+      // Round the byte budget up so the user gets at least what they asked for.
+      auto const slab_bytes = host_mr->get_block_size() *
+                              static_cast<std::size_t>(sirius::io::buffer_pool::CHUNKS_PER_SLAB);
+      auto const max_slabs =
+        static_cast<uint32_t>((_config.prefetch_buffer_pool_bytes + slab_bytes - 1) / slab_bytes);
+      _buffer_pool = std::make_unique<sirius::io::buffer_pool>(*host_mr, max_slabs);
+      _io_ctx->initialize_cache(*_buffer_pool, _config.prefetch_inflight_budget_chunks);
+      SIRIUS_LOG_DEBUG(
+        "[sirius_scan_manager] prefetch cache enabled (slabs={} budget_bytes={} "
+        "inflight_chunks={})",
+        max_slabs,
+        max_slabs * slab_bytes,
+        _config.prefetch_inflight_budget_chunks);
+    }
+  } else {
+    SIRIUS_LOG_DEBUG(
+      "[sirius_scan_manager] sirius_datasource disabled — falling back to "
+      "cudf::io::datasource::create");
+  }
 }
 
-sirius_scan_manager::~sirius_scan_manager() { stop(); }
+sirius_scan_manager::~sirius_scan_manager()
+{
+  if (_io_ctx && _io_ctx->cache() != nullptr) {
+    SIRIUS_LOG_INFO("[sirius_scan_manager] cache summary: {}", _io_ctx->cache()->summary());
+  }
+  stop();
+}
 
 void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query)
 {
   reset();
+
+  // Advance the cache age so the evictor can score this query's inserts
+  // against entries left over from prior queries.
+  if (_io_ctx && _io_ctx->cache()) { _io_ctx->cache()->refresh_cache(); }
 
   SIRIUS_LOG_DEBUG("[sirius_scan_manager::prepare_for_query] pipelines={}",
                    query.get_pipelines().size());
@@ -74,11 +130,7 @@ void sirius_scan_manager::prepare_for_query(const sirius::planner::query& query)
 
   if (_scan_op_order.empty()) { return; }
 
-  if (!_thread_pool) {
-    throw std::runtime_error("[sirius_scan_manager::prepare_for_query] thread pool not started");
-  }
-
-  _driver_thread = std::thread(&sirius_scan_manager::run_driver_loop, this);
+  start_metadata_processing();
 }
 
 std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
@@ -211,18 +263,21 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   } catch (...) {
     SIRIUS_LOG_TRACE("not all the columns are pinned for this query");
   }
-  return std::make_unique<parquet_split_provider>(info->returned_types,
-                                                  info->file_paths,
-                                                  info->column_ids,
-                                                  info->projection_ids,
-                                                  info->names,
-                                                  op->get_types().size(),
-                                                  std::move(info->table_filters),
-                                                  info->partition_indices,
-                                                  info->approximate_batch_size);
+  return std::make_unique<parquet_split_provider>(
+    info->returned_types,
+    info->file_paths,
+    info->column_ids,
+    info->projection_ids,
+    info->names,
+    op->get_types().size(),
+    std::move(info->table_filters),
+    info->partition_indices,
+    info->approximate_batch_size,
+    parquet_split_provider::DEFAULT_MAX_FILE_PROCESSED,
+    _io_ctx);
 }
 
-void sirius_scan_manager::run_driver_loop()
+void sirius_scan_manager::start_metadata_processing()
 {
   for (auto* op : _scan_op_order) {
     auto it = _providers_by_op.find(op);
@@ -231,36 +286,36 @@ void sirius_scan_manager::run_driver_loop()
     if (connector == nullptr) { continue; }
 
     try {
-      auto future = it->second->start(*_thread_pool, *connector);
-      future.get();
+      // run() is fire-and-forget: it enqueues workers and returns immediately.
+      // Worker exceptions ride on connector.close(exception_ptr) and surface
+      // when the consumer drains via get_next_split().
+      it->second->run(*_dispatcher, *connector);
     } catch (const std::exception& e) {
-      SIRIUS_LOG_ERROR("[sirius_scan_manager] driver: provider failed: {}", e.what());
-      // Make sure the consumer is unblocked even on failure.
-      connector->close();
+      SIRIUS_LOG_ERROR("[sirius_scan_manager] driver: provider failed to start: {}", e.what());
+      // Synchronous failure inside run() (e.g. scheduler.enqueue throwing)
+      // bypasses the worker error path, so forward it through the connector
+      // here. close() is idempotent and keeps the first stored exception.
+      connector->close(std::current_exception());
     }
   }
 }
 
 void sirius_scan_manager::reset()
 {
-  if (_driver_thread.joinable()) { _driver_thread.join(); }
+  _dispatcher->request_stop();
+  _dispatcher->wait_for_all();
   _scan_op_order.clear();
   _providers_by_op.clear();
+  _dispatcher =
+    std::make_unique<exec::scoped_dispatcher>(_thread_pool, _config.thread_pool.num_threads);
 }
 
-void sirius_scan_manager::start()
-{
-  if (_thread_pool) { return; }
-  _thread_pool = std::make_unique<exec::thread_pool>(
-    _config.num_threads, _config.thread_name_prefix, _config.cpu_affinity_list);
-}
+void sirius_scan_manager::start() {}
 
 void sirius_scan_manager::stop()
 {
-  if (_driver_thread.joinable()) { _driver_thread.join(); }
-  if (!_thread_pool) { return; }
-  _thread_pool->stop();
-  _thread_pool.reset();
+  reset();
+  _thread_pool.stop();
 }
 
 void sirius_scan_manager::insert_pinned_entry(const std::string& name,

--- a/src/scan_manager/split_connector.cpp
+++ b/src/scan_manager/split_connector.cpp
@@ -37,11 +37,15 @@ void split_connector::push_split(std::unique_ptr<op::operator_data> split)
   _cv.notify_one();
 }
 
-void split_connector::close()
+void split_connector::close(std::exception_ptr const& exception)
 {
   {
     std::lock_guard<std::mutex> lock(_mutex);
     _closed = true;
+    // First non-null exception wins. Subsequent close() calls (idempotent)
+    // do not overwrite an already-recorded error so the consumer always
+    // sees the original cause of the producer's failure.
+    if (exception && !_exception) { _exception = exception; }
   }
   _cv.notify_all();
 }
@@ -50,6 +54,8 @@ std::optional<std::unique_ptr<op::operator_data>> split_connector::get_next_spli
 {
   std::unique_lock<std::mutex> lock(_mutex);
   _cv.wait(lock, [this] { return !_splits.empty() || _closed; });
+  // if there is an exception, propagate it to the consumer instead of returning more splits
+  if (_exception) { std::rethrow_exception(_exception); }
   if (!_splits.empty()) {
     auto split = std::move(_splits.front());
     _splits.pop_front();

--- a/src/scan_manager/split_provider.cpp
+++ b/src/scan_manager/split_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026, Sirius Contributors.
+ * Copyright 2025, Sirius Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-#include "io/uring/uring_ioctx.hpp"
+#include "scan_manager/split_provider.hpp"
 
-#include <memory>
+#include "op/sirius_physical_operator.hpp"
+#include "scan_manager/split_connector.hpp"
 
-namespace sirius::io {
+#include <utility>
 
-uring_ioctx::uring_ioctx(size_t n_reactors,
-                         unsigned ring_entries,
-                         cucascade::memory::fixed_size_host_memory_resource& mr)
-  : templated_ioctx<uring_reactor>(
-      n_reactors, [&mr, ring_entries] { return std::make_unique<uring_reactor>(mr, ring_entries); })
+namespace sirius::scan_manager {
+
+void split_provider::push_to_connector(split_connector& connector,
+                                       std::unique_ptr<op::operator_data> split)
 {
+  connector.push_split(std::move(split));
 }
 
-}  // namespace sirius::io
+}  // namespace sirius::scan_manager

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -80,6 +80,23 @@ static void from_yaml(const YAML::Node& node, exec::thread_pool_config& opt)
   r.reject_unknown();
 }
 
+static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config& opt)
+{
+  yaml::reader r(node, "scan_manager");
+  r.optional("num_threads", opt.thread_pool.num_threads, yaml::greater_than<int>{0});
+  r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
+  r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
+  r.optional("use_sirius_datasource", opt.use_sirius_datasource);
+  r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
+  r.optional("uring_ring_entries", opt.uring_ring_entries, yaml::greater_than<unsigned>{0});
+  r.optional("enable_prefetch_cache", opt.enable_prefetch_cache);
+  r.optional("prefetch_buffer_pool_bytes", yaml::bytes(opt.prefetch_buffer_pool_bytes));
+  r.optional("prefetch_inflight_budget_chunks",
+             opt.prefetch_inflight_budget_chunks,
+             yaml::greater_than<std::size_t>{0});
+  r.reject_unknown();
+}
+
 static void from_yaml(const YAML::Node& node, operator_params& opt)
 {
   yaml::reader r(node, "operator_params");
@@ -403,7 +420,7 @@ const exec::thread_pool_config& sirius_config::get_task_creator_config() const n
   return _task_creator_config;
 }
 
-const exec::thread_pool_config& sirius_config::get_scan_manager_config() const noexcept
+const scan_manager::scan_manager_config& sirius_config::get_scan_manager_config() const noexcept
 {
   return _scan_manager_config;
 }

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -43,7 +43,6 @@
 #include <cstddef>
 #include <cstdlib>  // for std::getenv
 #include <filesystem>
-#include <iostream>
 #include <memory>
 #include <optional>
 #include <string>
@@ -246,14 +245,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   // Configure cuDF to use our pinned slab allocator for small internal host buffers
   // (e.g. column_device_view metadata arrays in cudf::concatenate).  This eliminates
   // the pageable H2D transfers that cuDF issues by default.
+  cucascade::memory::fixed_size_host_memory_resource* host_fsmr = nullptr;
   {
     auto host_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
     if (!host_spaces.empty()) {
-      auto* fsmr = host_spaces[0]
-                     ->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
-      if (fsmr != nullptr) {
+      host_fsmr = host_spaces[0]
+                    ->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
+      if (host_fsmr != nullptr) {
         small_pinned_allocator_ =
-          std::make_unique<cucascade::memory::small_pinned_host_memory_resource>(*fsmr);
+          std::make_unique<cucascade::memory::small_pinned_host_memory_resource>(*host_fsmr);
         small_pinned_allocator_view_.emplace(
           sirius::memory::make_host_device_resource_view_checked(small_pinned_allocator_.get()));
         prev_pinned_threshold_ = cudf::get_allocate_host_as_pinned_threshold();
@@ -264,6 +264,11 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
         spdlog::info("SiriusContext: cuDF pinned memory resource configured (max slab {} B)",
                      cucascade::memory::small_pinned_host_memory_resource::MAX_SLAB_SIZE);
       }
+    } else {
+      throw std::runtime_error(
+        "SiriusContext: no HOST memory space configured; pinned memory for small cuDF buffers is "
+        "disabled. This may cause performance degradation due to increased pageable H2D transfers. "
+        "To fix this, add a HOST memory space to the Sirius config.");
     }
   }
 
@@ -302,8 +307,8 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   task_creator_->set_task_scheduler(*task_scheduler_);
   task_scheduler_->set_task_creator(*task_creator_);
 
-  scan_manager_ =
-    std::make_unique<sirius::scan_manager::sirius_scan_manager>(config_.get_scan_manager_config());
+  scan_manager_ = std::make_unique<sirius::scan_manager::sirius_scan_manager>(
+    config_.get_scan_manager_config(), host_fsmr);
 
   // Wire the pipeline task queue into downgrade executors now that task_scheduler_
   // has been constructed.

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -336,10 +336,7 @@ void SiriusContext::terminate()
 
   task_scheduler_->stop();
   task_scheduler_.reset();
-  if (scan_manager_) {
-    scan_manager_->stop();
-    scan_manager_->reset();
-  }
+  if (scan_manager_) { scan_manager_->stop(); }
   task_creator_->stop_thread_pool();
   task_creator_.reset();
   for (auto& executor : downgrade_executors_) {
@@ -353,6 +350,15 @@ void SiriusContext::terminate()
   // sync, the subsequent cudaFreeHost inside the memory manager destructor
   // can deadlock against a new cudaHostAlloc from the next SiriusContext.
   cudaDeviceSynchronize();
+
+  // The scan manager owns the sirius_ioctx, prefetch buffer_pool, pinned-table
+  // entries, and cached parquet columns. All of those are backed by memory
+  // resources owned by memory_manager_, so the manager must be destroyed before
+  // memory_manager_->shutdown()/reset().
+  scan_manager_.reset();
+
+  // Drop any remaining repositories while the memory manager is still alive.
+  data_repository_manager_.reset();
 
   // Restore the previous cuDF pinned memory resource and threshold before destroying the
   // slab allocator — cuDF holds a non-owning reference and would dangle after reset().

--- a/test/cpp/io/test_datasource_factory.cpp
+++ b/test/cpp/io/test_datasource_factory.cpp
@@ -45,33 +45,26 @@ class mock_ioctx : public sirius_ioctx {
  public:
   void shutdown() override {}
 
+  std::shared_ptr<sirius_io_object> create_io_object(std::string) override
+  {
+    throw std::logic_error("unused");
+  }
+
   std::unique_ptr<cudf::io::datasource> make_datasource(std::shared_ptr<sirius_io_object>) override
   {
     ++make_datasource_calls;
     throw std::logic_error("mock_ioctx::make_datasource should not run in PR1");
   }
 
-  size_t host_read(sirius_io_object&, size_t, size_t, uint8_t*) override
+  [[nodiscard]] bool supports(std::string_view) const override { return true; }
+
+  size_t host_read_io(sirius_io_object&, size_t, size_t, uint8_t*) override
   {
     throw std::logic_error("unused");
   }
 
-  std::unique_ptr<cudf::io::datasource::buffer> host_read(sirius_io_object&,
-                                                          size_t,
-                                                          size_t) override
-  {
-    throw std::logic_error("unused");
-  }
-
-  void host_read_async(sirius_io_object&, size_t, size_t, uint8_t*, io_completion_handler) override
-  {
-    throw std::logic_error("unused");
-  }
-
-  std::unique_ptr<cudf::io::datasource::buffer> device_read_io(sirius_io_object&,
-                                                               size_t,
-                                                               size_t,
-                                                               rmm::cuda_stream_view) override
+  void host_read_async_io(
+    sirius_io_object&, size_t, size_t, uint8_t*, io_completion_handler) override
   {
     throw std::logic_error("unused");
   }
@@ -81,7 +74,7 @@ class mock_ioctx : public sirius_ioctx {
     throw std::logic_error("unused");
   }
 
-  void device_read_io_async(sirius_io_object&,
+  void device_read_async_io(sirius_io_object&,
                             size_t,
                             size_t,
                             uint8_t*,
@@ -91,17 +84,10 @@ class mock_ioctx : public sirius_ioctx {
     throw std::logic_error("unused");
   }
 
-  void host_read_ranges_async(sirius_io_object&,
-                              std::vector<cudf::io::text::byte_range_info> const&,
-                              std::span<cudf::host_span<std::byte>>,
-                              io_completion_handler) override
-  {
-    throw std::logic_error("unused");
-  }
-
-  size_t host_read_ranges(sirius_io_object&,
-                          std::vector<cudf::io::text::byte_range_info> const&,
-                          std::span<cudf::host_span<std::byte>>) override
+  void host_read_ranges_async_io(sirius_io_object&,
+                                 std::vector<cudf::io::text::byte_range_info> const&,
+                                 std::span<cudf::host_span<std::byte>>,
+                                 io_completion_handler) override
   {
     throw std::logic_error("unused");
   }

--- a/test/cpp/scan/test_parquet_split_provider.cpp
+++ b/test/cpp/scan/test_parquet_split_provider.cpp
@@ -35,7 +35,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <filesystem>
-#include <future>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -107,9 +106,11 @@ duckdb::vector<sirius::logical_type> default_returned_types()
 std::vector<std::unique_ptr<parquet_scan_data>> drive_provider(parquet_split_provider& provider,
                                                                int n_threads = 2)
 {
-  exec::thread_pool pool(n_threads, "psp_test_pool");
+  exec::static_thread_pool pool(n_threads, "psp_test_pool");
   split_connector connector;
-  auto fut = provider.start(pool, connector);
+  // run() is fire-and-forget; metadata-scan errors flow through connector.close()
+  // and surface here when get_next_split() rethrows.
+  provider.run(pool, connector);
 
   std::vector<std::unique_ptr<parquet_scan_data>> drained;
   while (true) {
@@ -121,7 +122,6 @@ std::vector<std::unique_ptr<parquet_scan_data>> drive_provider(parquet_split_pro
     REQUIRE(parquet != nullptr);
     drained.emplace_back(std::unique_ptr<parquet_scan_data>(parquet));
   }
-  fut.get();  // surface any error from a metadata-scan task
   return drained;
 }
 

--- a/test/cpp/scan/test_split_connector.cpp
+++ b/test/cpp/scan/test_split_connector.cpp
@@ -20,6 +20,7 @@
 // sirius
 #include <op/sirius_physical_operator.hpp>
 #include <scan_manager/split_connector.hpp>
+#include <scan_manager/split_provider.hpp>
 
 // standard library
 #include <future>
@@ -42,15 +43,27 @@ struct tagged_split : public op::operator_data {
   int tag;
 };
 
+// Test-only provider that re-exposes the protected push_to_connector helper.
+// split_connector::push_split is private and reachable only via this gate, so
+// tests that exercise the connector queue directly go through the provider.
+struct test_pusher : public split_provider {
+  using split_provider::push_to_connector;
+  [[nodiscard]] bool has_more_splits() const override { return false; }
+  std::function<std::vector<std::unique_ptr<op::operator_data>>()> next_split_provider() override
+  {
+    return nullptr;
+  }
+};
+
 }  // namespace
 
 TEST_CASE("split_connector - push then get returns FIFO", "[scan_manager][split_connector]")
 {
   split_connector connector;
 
-  connector.push_split(std::make_unique<tagged_split>(1));
-  connector.push_split(std::make_unique<tagged_split>(2));
-  connector.push_split(std::make_unique<tagged_split>(3));
+  test_pusher::push_to_connector(connector, std::make_unique<tagged_split>(1));
+  test_pusher::push_to_connector(connector, std::make_unique<tagged_split>(2));
+  test_pusher::push_to_connector(connector, std::make_unique<tagged_split>(3));
 
   REQUIRE(connector.has_more_splits());
   REQUIRE_FALSE(connector.is_closed());
@@ -86,8 +99,8 @@ TEST_CASE("split_connector - close after pushes drains then returns nullopt",
           "[scan_manager][split_connector]")
 {
   split_connector connector;
-  connector.push_split(std::make_unique<tagged_split>(7));
-  connector.push_split(std::make_unique<tagged_split>(8));
+  test_pusher::push_to_connector(connector, std::make_unique<tagged_split>(7));
+  test_pusher::push_to_connector(connector, std::make_unique<tagged_split>(8));
   connector.close();
 
   // Closed but not drained — is_closed() should report false until items are pulled.
@@ -138,7 +151,8 @@ TEST_CASE("split_connector - multi-producer / multi-consumer preserves all items
   for (int p = 0; p < k_producers; ++p) {
     producers.emplace_back([&, p] {
       for (int i = 0; i < k_pushes_per_producer; ++i) {
-        connector.push_split(std::make_unique<tagged_split>(p * k_pushes_per_producer + i));
+        test_pusher::push_to_connector(
+          connector, std::make_unique<tagged_split>(p * k_pushes_per_producer + i));
       }
     });
   }

--- a/test/io/parquet_benchmark.cpp
+++ b/test/io/parquet_benchmark.cpp
@@ -1,0 +1,326 @@
+#include "io/prefetching_cache.hpp"
+#include "io/sirius_datasource.hpp"
+#include "io/types.hpp"
+#include "io/uring/uring_ioctx.hpp"
+
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_metadata.hpp>
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/numa_region_pinned_host_allocator.hpp>
+#include <fcntl.h>
+#include <glob.h>
+#include <spdlog/common.h>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+// 4 columns used by the classic TPC-H lineitem aggregations (Q1, Q6, …).
+static const std::vector<std::string> COLUMNS = {
+  "l_orderkey",
+  "l_extendedprice",
+  "l_discount",
+  "l_shipdate",
+};
+
+enum class DataSource { cudf, uring };
+
+static DataSource parse_source(std::string_view s)
+{
+  if (s == "cudf") return DataSource::cudf;
+  if (s == "uring") return DataSource::uring;
+  throw std::invalid_argument(std::string("unknown datasource: ") + std::string(s) +
+                              "  (expected: cudf | uring)");
+}
+
+static bool drop_caches()
+{
+  ::sync();
+  int fd = ::open("/proc/sys/vm/drop_caches", O_WRONLY);
+  if (fd < 0) return false;
+  bool ok = ::write(fd, "3", 1) == 1;
+  ::close(fd);
+  return ok;
+}
+
+// Expand @p spec to a sorted list of file paths.  If it contains '*', POSIX
+// glob expansion is used; otherwise the spec is returned as a single path.
+static std::vector<std::string> expand_paths(std::string const& spec)
+{
+  if (spec.find('*') == std::string::npos) return {spec};
+
+  std::vector<std::string> paths;
+  glob_t g{};
+  int rc = ::glob(spec.c_str(), GLOB_TILDE, nullptr, &g);
+  if (rc == 0) {
+    paths.reserve(g.gl_pathc);
+    for (size_t i = 0; i < g.gl_pathc; ++i)
+      paths.emplace_back(g.gl_pathv[i]);
+  }
+  ::globfree(&g);
+  std::sort(paths.begin(), paths.end());
+  return paths;
+}
+
+static void usage(char const* prog)
+{
+  std::cerr << "usage: " << prog << " <path|glob> <cudf|uring> <num_rows> [n_reactors]\n"
+            << "  path|glob  – parquet file path, or shell glob (e.g. "
+               "'dir/*.parquet')\n"
+            << "  cudf       – cudf default (mmap/pread)\n"
+            << "  uring      – O_DIRECT io_uring + DMA to GPU\n"
+            << "  num_rows   – rows to read (0 = all)\n"
+            << "  n_reactors – uring reactor threads (default 2; uring only)\n";
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 4 && argc != 5) {
+    usage(argv[0]);
+    return 1;
+  }
+
+  std::string path_spec = argv[1];
+
+  DataSource source;
+  try {
+    source = parse_source(argv[2]);
+  } catch (std::invalid_argument const& e) {
+    std::cerr << e.what() << "\n";
+    usage(argv[0]);
+    return 1;
+  }
+
+  long long num_rows_arg = std::stoll(argv[3]);
+  if (num_rows_arg < 0) {
+    std::cerr << "num_rows must be >= 0\n";
+    return 1;
+  }
+  size_t num_rows = static_cast<size_t>(num_rows_arg);  // 0 means all
+
+  size_t n_reactors = 2;
+  if (argc == 5) {
+    long long n_reactors_arg = std::stoll(argv[4]);
+    if (n_reactors_arg <= 0) {
+      std::cerr << "n_reactors must be > 0\n";
+      return 1;
+    }
+    n_reactors = static_cast<size_t>(n_reactors_arg);
+  }
+
+  auto paths = expand_paths(path_spec);
+  if (paths.empty()) {
+    std::cerr << "no files matched: " << path_spec << "\n";
+    return 1;
+  }
+
+  spdlog::set_level(spdlog::level::info);  // show per-read trace
+
+  std::cout << "Source : " << argv[2] << "\n"
+            << "Files  : " << paths.size() << "\n";
+  for (auto const& p : paths)
+    std::cout << "  " << p << "\n";
+  std::cout << "Rows   : " << (num_rows == 0 ? "all" : std::to_string(num_rows)) << "\n"
+            << "Columns: ";
+  for (auto const& c : COLUMNS)
+    std::cout << c << "  ";
+  std::cout << "\n\n";
+
+  bool can_drop = drop_caches();
+  if (!can_drop) std::cout << "WARNING: cannot drop caches (run as root for cold results)\n\n";
+
+  cudaFree(nullptr);
+
+  rmm::mr::cuda_async_memory_resource async_mr;
+  rmm::mr::set_current_device_resource(&async_mr);
+
+  auto time_ms = [](auto fn) -> double {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    fn();
+    return std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now() - t0)
+      .count();
+  };
+
+  // Approximate device-memory footprint of a materialized table: data buffer
+  // for fixed-width columns + null-mask buffer where present.  Variable-width
+  // columns (strings/lists) are not in our schema so we skip their children.
+  auto table_bytes = [](cudf::table_view const& tv) -> size_t {
+    size_t bytes = 0;
+    for (cudf::size_type i = 0; i < tv.num_columns(); ++i) {
+      auto const& col = tv.column(i);
+      if (cudf::is_fixed_width(col.type()))
+        bytes += static_cast<size_t>(col.size()) * cudf::size_of(col.type());
+      if (col.nullable()) bytes += cudf::bitmask_allocation_size_bytes(col.size());
+    }
+    return bytes;
+  };
+
+  auto log_table = [&](cudf::io::table_with_metadata const& t) {
+    auto bytes = table_bytes(t.tbl->view());
+    std::cout << "Schema : " << t.tbl->num_columns() << " columns, " << t.tbl->num_rows()
+              << " rows, " << std::fixed << std::setprecision(2)
+              << static_cast<double>(bytes) / (1024.0 * 1024.0) << " MiB materialized\n\n";
+  };
+  (void)log_table;
+
+  auto scan_opts = cudf::io::parquet_reader_options::builder().column_names(COLUMNS).build();
+
+  // Per-file: probe the footer with cudf's default datasource (so timed paths
+  // don't pay metadata cost), then run hybrid_scan to collect the byte ranges
+  // we'd touch for the selected columns.  The num_rows budget is consumed
+  // in file order — we stop adding row groups once we've covered it.
+  std::vector<cudf::io::parquet::FileMetaData> metadatas;
+  metadatas.reserve(paths.size());
+  size_t total_range_bytes = 0;
+  size_t total_row_groups  = 0;
+  size_t total_ranges      = 0;
+  int64_t accumulated_rows = 0;
+
+  for (auto const& path : paths) {
+    std::vector<uint8_t> footer_buf;
+    {
+      auto probe_sources = cudf::io::make_datasources(cudf::io::source_info{{path}});
+      auto& probe_ds     = *probe_sources.front();
+      auto file_size     = probe_ds.size();
+      cudf::io::parquet::file_ender_s ender{};
+      probe_ds.host_read(
+        file_size - sizeof(ender), sizeof(ender), reinterpret_cast<uint8_t*>(&ender));
+      footer_buf.resize(ender.footer_len);
+      probe_ds.host_read(
+        file_size - sizeof(ender) - ender.footer_len, ender.footer_len, footer_buf.data());
+    }
+
+    cudf::io::parquet::experimental::hybrid_scan_reader scanner{
+      cudf::host_span<uint8_t const>{footer_buf.data(), footer_buf.size()}, scan_opts};
+    auto file_metadata = scanner.parquet_metadata();
+
+    std::vector<cudf::size_type> selected_row_groups;
+    if (num_rows == 0) {
+      selected_row_groups = scanner.all_row_groups(scan_opts);
+    } else if (accumulated_rows < static_cast<int64_t>(num_rows)) {
+      for (cudf::size_type i = 0;
+           i < static_cast<cudf::size_type>(file_metadata.row_groups.size()) &&
+           accumulated_rows < static_cast<int64_t>(num_rows);
+           ++i) {
+        selected_row_groups.push_back(i);
+        accumulated_rows += file_metadata.row_groups[i].num_rows;
+      }
+    }
+
+    auto byte_ranges = scanner.all_column_chunks_byte_ranges(selected_row_groups, scan_opts);
+    std::sort(byte_ranges.begin(), byte_ranges.end(), [](auto const& a, auto const& b) {
+      return a.offset() < b.offset();
+    });
+    std::vector<cudf::io::text::byte_range_info> coalesced;
+    coalesced.reserve(byte_ranges.size());
+    for (auto const& br : byte_ranges) {
+      if (br.size() <= 0) continue;
+      if (!coalesced.empty()) {
+        auto& back       = coalesced.back();
+        int64_t back_end = back.offset() + back.size();
+        if (br.offset() <= back_end) {
+          int64_t br_end = br.offset() + br.size();
+          if (br_end > back_end)
+            back = cudf::io::text::byte_range_info{back.offset(), br_end - back.offset()};
+          continue;
+        }
+      }
+      coalesced.push_back(br);
+    }
+
+    for (auto const& br : coalesced)
+      total_range_bytes += static_cast<size_t>(br.size());
+    total_row_groups += selected_row_groups.size();
+    total_ranges += coalesced.size();
+
+    metadatas.push_back(std::move(file_metadata));
+  }
+
+  std::cout << "Hybrid scan: " << total_row_groups << " row group(s), " << total_ranges
+            << " byte range(s), " << std::fixed << std::setprecision(2)
+            << static_cast<double>(total_range_bytes) / (1024.0 * 1024.0) << " MiB total\n\n";
+
+  // Build read options (no source — provided separately as a datasource
+  // vector).
+  auto read_opts_builder = cudf::io::parquet_reader_options::builder().column_names(COLUMNS);
+  if (num_rows > 0) read_opts_builder.num_rows(num_rows);
+  auto read_opts = read_opts_builder.build();
+
+  // cudaMemcpyBatchAsync rejects the legacy / per-thread default streams with
+  // cudaMemLocation hints — pass an explicit stream so all H2D copies inside
+  // the datasource and cudf share the same one.
+  rmm::cuda_stream stream;
+
+  // Timed run.
+  double ms = 0;
+  if (source == DataSource::cudf) {
+    std::vector<std::string> path_list = paths;
+    auto sources = cudf::io::make_datasources(cudf::io::source_info{path_list});
+    ms           = time_ms([&] {
+      auto tbl =
+        cudf::io::read_parquet(std::move(sources), std::move(metadatas), read_opts, stream.view());
+    });
+  } else {
+    // Size the buffer pool to fit the working set, plus headroom.
+    constexpr uint32_t POOL_MAX_SLABS       = 20;
+    constexpr size_t INFLIGHT_BUDGET_CHUNKS = 2048;
+    constexpr size_t POOL_CAPACITY          = static_cast<size_t>(POOL_MAX_SLABS) *
+                                     static_cast<size_t>(sirius::io::buffer_pool::CHUNKS_PER_SLAB) *
+                                     sirius::io::CHUNK_SIZE;
+
+    cucascade::memory::numa_region_pinned_host_memory_resource upstream(0, /*make_portable=*/true);
+    cucascade::memory::fixed_size_host_memory_resource host_mr(
+      0,                                                              // device_id
+      upstream,                                                       // upstream allocator
+      POOL_CAPACITY,                                                  // mem_limit
+      POOL_CAPACITY,                                                  // capacity
+      sirius::io::CHUNK_SIZE,                                         // block_size = 1 MiB
+      static_cast<size_t>(sirius::io::buffer_pool::CHUNKS_PER_SLAB),  // pool_size
+      1);                                                             // initial_pools
+
+    sirius::io::buffer_pool pool(host_mr, POOL_MAX_SLABS);
+
+    auto io_ctx =
+      std::make_shared<sirius::io::uring_ioctx>(n_reactors, 2 * sirius::io::NUM_CHUNKS, host_mr);
+    // io_ctx->initialize_cache(pool, INFLIGHT_BUDGET_CHUNKS);
+
+    std::vector<std::unique_ptr<cudf::io::datasource>> sources;
+    sources.reserve(paths.size());
+    for (auto const& path : paths) {
+      auto io_obj = io_ctx->create_io_object(path);
+      sources.push_back(std::make_unique<sirius::io::sirius_datasource>(io_ctx, io_obj));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    ms = time_ms([&] {
+      auto tbl =
+        cudf::io::read_parquet(std::move(sources), std::move(metadatas), read_opts, stream.view());
+    });
+
+    // std::cout << "cache summary : " << io_ctx->cache()->summary() <<
+    // std::endl;
+  }
+
+  std::cout << std::fixed << std::setprecision(1) << ms << " ms\n";
+  return 0;
+}

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -37,6 +37,9 @@ from tpch_pin_columns import (
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
 def log(msg):
     """Timestamped, flushed progress log so hangs are visible in real time."""
     ts = datetime.now().strftime("%H:%M:%S.%f")[:-3]


### PR DESCRIPTION
This PR addresses comments on previous ScanManager PR, and Io Framework PR
as well as enabling the prefetching and IoContext in Sirius

---

- It introduces scope_dispatcher for static_thread_pool. better interface for managing tasks in thread-pool, will soon replace bounded_thread_pools.
- It introduces minor change to Io reactors. enables cache path for host reads as well.

----
DO NOT MERGE YET:
1. I am still investigating intermittent failure on TPCH when running with PR
2. I am still investigating why we get more OOMs with this PR compared to dev.
3. the overal cold perfromance with prefetching seems to be 30-50% better than our current cold numbers, but cold numbers without prefetching doesn't translate to signifcant wins on the e2e runs. I am investigating why 2-4X better parqeust performance compared to default cudf path in microbenchmarks doesn't translate to overal win without prefetching. 

