### PR TITLE
Patch use of cudaMemcpyBatchAsync for CUDA < 12.8

### DIFF
--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -99,6 +99,8 @@ size_t copy_pinned_slices_to_device(
     copied += n;
   }
 
+#if CUDA_VERSION >= 12080
+  // cudaMemcpyBatchAsync available since CUDA 12.8 — issue all copies in one driver call.
   cudaMemcpyAttributes attrs{};
   attrs.srcAccessOrder  = cudaMemcpySrcAccessOrderStream;
   attrs.srcLocHint.type = cudaMemLocationTypeHost;
@@ -112,6 +114,15 @@ size_t copy_pinned_slices_to_device(
   if (err != cudaSuccess)
     throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyBatchAsync failed at idx ") +
                              std::to_string(fail_idx) + ": " + cudaGetErrorString(err));
+#else
+  // Fallback for CUDA < 12.8: sequential stream-ordered copies.
+  for (size_t i = 0; i < n_nonempty; ++i) {
+    auto err = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyHostToDevice, stream.value());
+    if (err != cudaSuccess)
+      throw std::runtime_error(std::string("sirius_ioctx: cudaMemcpyAsync failed at idx ") +
+                               std::to_string(i) + ": " + cudaGetErrorString(err));
+  }
+#endif
   return copied;
 }
 


### PR DESCRIPTION
Fixes our CUDA 12 distribution pipelines that have been broken since the merge of #675 that introduced the usage of `cudaMemcpyBatchAsync`. `cudaMemcpyBatchAsync` was introduced in CUDA 12.8 and this patch ensures that for CUDA 12.X compatibility we fall back to sequential stream-ordered copies on CUDA < 12.8