### PR TITLE
scan: Extract per-file parquet metadata scanner helper in preparation for Iceberg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ set(EXTENSION_SOURCES
     src/op/scan/parquet_scan_task.cpp
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/prefetched_data_source.cpp
+    src/op/scan/parquet_metadata_scanner.cpp
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_utils.cpp
     src/op/scan/sirius_gpu_parquet_scan_operator.cpp

--- a/src/include/op/scan/parquet_metadata_scanner.hpp
+++ b/src/include/op/scan/parquet_metadata_scanner.hpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <op/scan/scan_plan.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace sirius::op::scan {
+
+/// Per-file metadata scan output. Provides everything the caller needs to
+/// produce row_group_slice instances and accumulate per-row-group bytes for
+/// budget-based bundling.
+struct file_metadata_scan_result {
+  /// Parsed parquet metadata. Held by shared_ptr so it can be passed verbatim
+  /// into one or more row_group_slice instances that reference this file.
+  std::shared_ptr<cudf::io::parquet::FileMetaData const> file_metadata;
+  /// Datasource for this parquet file. The caller can hold this for the
+  /// lifetime of any task that reads from the file, or drop it if the
+  /// downstream scan_data does not need it.
+  std::shared_ptr<cudf::io::datasource> datasource;
+  /// Row group indices selected after metadata-stats-based filter pruning,
+  /// in file order. Empty if every row group was pruned (or the file had
+  /// none to begin with).
+  std::vector<cudf::size_type> selected_row_group_indices;
+  /// Parquet column-chunk indices selected by @ref scan_plan projection
+  /// (resolved by name against this file's schema). Empty when the scan is
+  /// non-projected — the caller treats every chunk in the row group as
+  /// selected.
+  std::vector<std::size_t> selected_chunk_indices;
+  /// Subset of @ref selected_chunk_indices marked as pure-filter (read for
+  /// filter evaluation, not part of the output). The caller should exclude
+  /// these from the uncompressed-byte accounting that drives budget-based
+  /// bundling.
+  std::unordered_set<std::size_t> pure_filter_chunk_indices;
+};
+
+/**
+ * @brief Scan one parquet file's footer + metadata and resolve projection /
+ *        row-group filtering. Does not partition the row groups into slices —
+ *        the caller bundles them under whatever budget policy fits its scan
+ *        type.
+ *
+ * @param file_path             Parquet file to scan.
+ * @param plan                  Canonical scan plan; controls projection and
+ *                              pure-filter accounting.
+ * @param reader_options        Reader options carrying any AST filter
+ *                              already installed via set_filter().
+ * @param has_filter_pushdown   True iff @p reader_options has an active AST
+ *                              filter — gates row-group stats pruning.
+ * @param stream                Stream used by row-group stats pruning.
+ *
+ * @throws std::runtime_error if a projected column from @p plan is not
+ *                            found in the file.
+ */
+file_metadata_scan_result scan_parquet_file_metadata(
+  std::string const& file_path,
+  scan_plan const& plan,
+  cudf::io::parquet_reader_options const& reader_options,
+  bool has_filter_pushdown,
+  rmm::cuda_stream_view stream);
+
+/// Per-row-group byte accounting for budget-based partition bundling.
+struct row_group_bytes {
+  /// Sum of total_uncompressed_size over selected (non-pure-filter) chunks.
+  std::size_t uncompressed_bytes;
+  /// Sum of total_compressed_size over all selected chunks (pure-filter
+  /// chunks count toward compressed-byte reservation but not toward the
+  /// uncompressed-byte budget).
+  std::size_t compressed_bytes;
+};
+
+/**
+ * @brief Compute the byte contribution of a single row group, honouring
+ *        @p plan projection and pure-filter exclusion.
+ *
+ * For non-projected scans (@c plan.is_projected() == false) every column
+ * chunk contributes; @p selected_chunk_indices and @p pure_filter_chunk_indices
+ * are ignored.
+ *
+ * For projected scans only the chunks named in @p selected_chunk_indices
+ * contribute; chunks in @p pure_filter_chunk_indices are excluded from the
+ * uncompressed total.
+ */
+row_group_bytes compute_row_group_bytes(
+  cudf::io::parquet::RowGroup const& row_group,
+  scan_plan const& plan,
+  std::vector<std::size_t> const& selected_chunk_indices,
+  std::unordered_set<std::size_t> const& pure_filter_chunk_indices);
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/parquet_metadata_scanner.hpp
+++ b/src/include/op/scan/parquet_metadata_scanner.hpp
@@ -66,23 +66,41 @@ struct file_metadata_scan_result {
  *        the caller bundles them under whatever budget policy fits its scan
  *        type.
  *
+ * Filter-pushdown gating is derived from @p reader_options: row-group stats
+ * pruning runs iff @c reader_options.get_filter().has_value(). The caller is
+ * expected to install (or omit) the AST filter via @c set_filter before
+ * calling this helper.
+ *
  * @param file_path             Parquet file to scan.
- * @param plan                  Canonical scan plan; controls projection and
+ * @param plan                  Canonical scan plan; drives projection /
  *                              pure-filter accounting.
  * @param reader_options        Reader options carrying any AST filter
- *                              already installed via set_filter().
- * @param has_filter_pushdown   True iff @p reader_options has an active AST
- *                              filter — gates row-group stats pruning.
+ *                              already installed via @c set_filter.
+ * @param data_column_names     Projected data-column names in @c scan_plan
+ *                              D-order. Pass once per call site rather than
+ *                              rebuilding per file (the caller typically
+ *                              hoists @c plan.data_column_names() out of its
+ *                              file loop).
+ * @param pure_filter_positions Pure-filter D-positions from @c
+ *                              plan.pure_filter_batch_positions(). Hoisted
+ *                              for the same reason.
  * @param stream                Stream used by row-group stats pruning.
  *
  * @throws std::runtime_error if a projected column from @p plan is not
  *                            found in the file.
+ *
+ * @note A second per-file metadata scan still lives in
+ *       @c parquet_scan_task_global_state::initialize_from_files (legacy
+ *       task-based path); consolidating that caller is gated on legacy
+ *       parquet_scan_task removal and is intentionally out of scope for the
+ *       initial extraction.
  */
 file_metadata_scan_result scan_parquet_file_metadata(
   std::string const& file_path,
   scan_plan const& plan,
   cudf::io::parquet_reader_options const& reader_options,
-  bool has_filter_pushdown,
+  std::vector<std::string> const& data_column_names,
+  std::unordered_set<std::size_t> const& pure_filter_positions,
   rmm::cuda_stream_view stream);
 
 /// Per-row-group byte accounting for budget-based partition bundling.

--- a/src/op/scan/parquet_metadata_scanner.cpp
+++ b/src/op/scan/parquet_metadata_scanner.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "op/scan/parquet_metadata_scanner.hpp"
+
+#include "log/logging.hpp"
+#include "op/scan/parquet_scan_operator_data.hpp"  // hybrid_scan_reader
+#include "op/scan/parquet_schema_mapping.hpp"      // detail::leaf_indices_for_column
+
+#include <cudf/io/parquet_io_utils.hpp>
+
+#include <stdexcept>
+#include <utility>
+
+namespace sirius::op::scan {
+
+file_metadata_scan_result scan_parquet_file_metadata(
+  std::string const& file_path,
+  scan_plan const& plan,
+  cudf::io::parquet_reader_options const& reader_options,
+  bool has_filter_pushdown,
+  rmm::cuda_stream_view stream)
+{
+  file_metadata_scan_result result;
+
+  //===----------Read metadata footer----------===//
+  auto datasource    = cudf::io::datasource::create(file_path);
+  auto footer_buffer = cudf::io::parquet::fetch_footer_to_host(*datasource);
+
+  //===----------Parse metadata----------===//
+  hybrid_scan_reader reader(
+    cudf::host_span<uint8_t const>(footer_buffer->data(), footer_buffer->size()), reader_options);
+  result.file_metadata =
+    std::make_shared<cudf::io::parquet::FileMetaData const>(reader.parquet_metadata());
+
+  //===----------Resolve selected DuckDB columns to parquet column chunk indices----------===//
+  // row_group.columns is indexed in parquet schema-leaf order (preorder), which can differ from
+  // DuckDB's logical column order. Resolve by name per file (chunk order is consistent across row
+  // groups in a single file, but can vary across files).
+  if (plan.is_projected()) {
+    auto const data_column_names     = plan.data_column_names();
+    auto const pure_filter_positions = plan.pure_filter_batch_positions();
+    result.selected_chunk_indices.reserve(data_column_names.size());
+    for (std::size_t k = 0; k < data_column_names.size(); ++k) {
+      auto leaves = detail::leaf_indices_for_column(*result.file_metadata, data_column_names[k]);
+      if (leaves.empty()) {
+        throw std::runtime_error("[scan_parquet_file_metadata] Projected column '" +
+                                 data_column_names[k] +
+                                 "' not found in parquet file: " + file_path);
+      }
+      bool const is_pure_filter = pure_filter_positions.count(k);
+      for (auto const leaf : leaves) {
+        result.selected_chunk_indices.push_back(leaf);
+        if (is_pure_filter) { result.pure_filter_chunk_indices.insert(leaf); }
+      }
+    }
+  }
+
+  //===----------Row Group Pruning----------===//
+  result.selected_row_group_indices = reader.all_row_groups(reader_options);
+  if (has_filter_pushdown) {
+    auto const before = result.selected_row_group_indices.size();
+    // clang-format off
+    SIRIUS_LOG_DEBUG("[scan_parquet_file_metadata] Row group pruning: file: {}\n" \
+                     "                                                    before: {}",
+                     file_path,
+                     before);
+    // clang-format on
+    result.selected_row_group_indices = reader.filter_row_groups_with_stats(
+      result.selected_row_group_indices, reader_options, stream);
+    auto const after = result.selected_row_group_indices.size();
+    // clang-format off
+    SIRIUS_LOG_DEBUG("[scan_parquet_file_metadata]                       after: {} (pruned {})",
+                     after,
+                     before - after);
+    // clang-format on
+  }
+
+  result.datasource = std::shared_ptr<cudf::io::datasource>(std::move(datasource));
+  return result;
+}
+
+row_group_bytes compute_row_group_bytes(
+  cudf::io::parquet::RowGroup const& row_group,
+  scan_plan const& plan,
+  std::vector<std::size_t> const& selected_chunk_indices,
+  std::unordered_set<std::size_t> const& pure_filter_chunk_indices)
+{
+  row_group_bytes bytes{0, 0};
+
+  auto accumulate = [&](cudf::io::parquet::ColumnChunk const& chunk, bool is_pure_filter) {
+    auto const& md = chunk.meta_data;
+    // Pure filter columns are not part of the scan result, so we omit them from the
+    // uncompressed byte count used for sizing partitions.
+    if (md.total_uncompressed_size > 0 && !is_pure_filter) {
+      bytes.uncompressed_bytes += static_cast<std::size_t>(md.total_uncompressed_size);
+    }
+    if (md.total_compressed_size > 0) {
+      bytes.compressed_bytes += static_cast<std::size_t>(md.total_compressed_size);
+    }
+  };
+
+  if (plan.is_projected()) {
+    for (auto const chunk_idx : selected_chunk_indices) {
+      accumulate(row_group.columns[chunk_idx], pure_filter_chunk_indices.contains(chunk_idx));
+    }
+  } else {
+    // Non-projected: all chunks contribute, no pure-filter pruning.
+    for (auto const& chunk : row_group.columns) {
+      accumulate(chunk, false);
+    }
+  }
+
+  return bytes;
+}
+
+}  // namespace sirius::op::scan

--- a/src/op/scan/parquet_metadata_scanner.cpp
+++ b/src/op/scan/parquet_metadata_scanner.cpp
@@ -31,7 +31,8 @@ file_metadata_scan_result scan_parquet_file_metadata(
   std::string const& file_path,
   scan_plan const& plan,
   cudf::io::parquet_reader_options const& reader_options,
-  bool has_filter_pushdown,
+  std::vector<std::string> const& data_column_names,
+  std::unordered_set<std::size_t> const& pure_filter_positions,
   rmm::cuda_stream_view stream)
 {
   file_metadata_scan_result result;
@@ -51,8 +52,6 @@ file_metadata_scan_result scan_parquet_file_metadata(
   // DuckDB's logical column order. Resolve by name per file (chunk order is consistent across row
   // groups in a single file, but can vary across files).
   if (plan.is_projected()) {
-    auto const data_column_names     = plan.data_column_names();
-    auto const pure_filter_positions = plan.pure_filter_batch_positions();
     result.selected_chunk_indices.reserve(data_column_names.size());
     for (std::size_t k = 0; k < data_column_names.size(); ++k) {
       auto leaves = detail::leaf_indices_for_column(*result.file_metadata, data_column_names[k]);
@@ -70,8 +69,10 @@ file_metadata_scan_result scan_parquet_file_metadata(
   }
 
   //===----------Row Group Pruning----------===//
+  // Single source of truth for "is filter-pushdown active": the AST filter installed on
+  // reader_options. Avoids the caller passing a redundant boolean that could drift out of sync.
   result.selected_row_group_indices = reader.all_row_groups(reader_options);
-  if (has_filter_pushdown) {
+  if (reader_options.get_filter().has_value()) {
     auto const before = result.selected_row_group_indices.size();
     // clang-format off
     SIRIUS_LOG_DEBUG("[scan_parquet_file_metadata] Row group pruning: file: {}\n" \

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -19,15 +19,12 @@
 #include "exec/thread_pool.hpp"
 #include "expression_executor/gpu_expression_translator_internal.hpp"
 #include "log/logging.hpp"
+#include "op/scan/parquet_metadata_scanner.hpp"
 #include "op/scan/parquet_scan_operator_data.hpp"
-#include "op/scan/parquet_schema_mapping.hpp"
 #include "op/scan/scan_utils.hpp"
 #include "scan_manager/split_connector.hpp"
 
-#include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet.hpp>
-#include <cudf/io/parquet_io_utils.hpp>
-#include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -39,7 +36,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <stdexcept>
 #include <utility>
 
 namespace sirius::scan_manager {
@@ -254,73 +250,22 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
       accum.partition_values = std::move(file_partition_values);
     }
 
-    //===----------Read metadata footers----------===//
-    auto datasource    = cudf::io::datasource::create(file_path);
-    auto footer_buffer = cudf::io::parquet::fetch_footer_to_host(*datasource);
-
-    //===----------Parse metadata----------===//
-    op::scan::hybrid_scan_reader reader(
-      cudf::host_span<uint8_t const>(footer_buffer->data(), footer_buffer->size()),
-      *reader_options);
-    auto file_metadata =
-      std::make_shared<cudf::io::parquet::FileMetaData const>(reader.parquet_metadata());
-    auto const& metadata = *file_metadata;
-
-    //===----------Resolve selected DuckDB columns to parquet column chunk indices----------===//
-    // row_group.columns is indexed in parquet schema-leaf order (preorder), which can differ from
-    // DuckDB's logical column order. Resolve by name per file (chunk order is consistent across row
-    // groups in a single file, but can vary across files).
-    std::vector<std::size_t> selected_chunk_indices;
-    std::unordered_set<std::size_t> pure_filter_chunk_indices;
-    if (_plan->is_projected()) {
-      auto const pure_filter_positions = _plan->pure_filter_batch_positions();
-      selected_chunk_indices.reserve(data_column_names.size());
-      for (std::size_t k = 0; k < data_column_names.size(); ++k) {
-        auto leaves = op::scan::detail::leaf_indices_for_column(metadata, data_column_names[k]);
-        if (leaves.empty()) {
-          throw std::runtime_error("[parquet_split_provider] Projected column '" +
-                                   data_column_names[k] +
-                                   "' not found in parquet file: " + file_path);
-        }
-        bool const is_pure_filter = pure_filter_positions.count(k);
-        for (auto const leaf : leaves) {
-          selected_chunk_indices.push_back(leaf);
-          if (is_pure_filter) { pure_filter_chunk_indices.insert(leaf); }
-        }
-      }
-    }
+    //===----------Per-file metadata scan + row-group pruning + projection resolution----------===//
+    auto file_md = op::scan::scan_parquet_file_metadata(
+      file_path, *_plan, *reader_options, ast_expression.has_value(), stream);
 
     //===----------Row Group Partitioning----------===//
-    auto row_group_indices = reader.all_row_groups(*reader_options);
-    // Row group pruning with filter pushdown using metadata statistics.
-    if (ast_expression) {
-      auto const row_groups_before_pruning = row_group_indices.size();
-      // clang-format off
-      SIRIUS_LOG_DEBUG("[parquet_split_provider] Row group pruning: file: {}\n" \
-                       "                                                  before: {}",
-                       file_path,
-                       row_groups_before_pruning);
-      // clang-format on
-      // Prune row groups with filter pushdown using metadata statistics.
-      row_group_indices =
-        reader.filter_row_groups_with_stats(row_group_indices, *reader_options, stream);
-      auto const row_groups_after_pruning = row_group_indices.size();
-      auto const pruned_row_groups        = row_groups_before_pruning - row_groups_after_pruning;
-      // clang-format off
-      SIRIUS_LOG_DEBUG("[parquet_split_provider]                     after: {} (pruned {})",
-                       row_groups_after_pruning,
-                       pruned_row_groups);
-      // clang-format on
-    }
-
     std::vector<cudf::size_type> cur_rgs;
     std::size_t cur_uncompressed_bytes = 0;
     std::size_t cur_compressed_bytes   = 0;
 
     auto seal_current_file = [&]() {
       if (cur_rgs.empty()) { return; }
-      accum.slices.emplace_back(
-        file_metadata, file_path, std::move(cur_rgs), cur_uncompressed_bytes, cur_compressed_bytes);
+      accum.slices.emplace_back(file_md.file_metadata,
+                                file_path,
+                                std::move(cur_rgs),
+                                cur_uncompressed_bytes,
+                                cur_compressed_bytes);
       // Promote the just-sealed slice's uncompressed bytes into the cross-file accumulator.
       accum.total_uncompressed_bytes += cur_uncompressed_bytes;
       cur_rgs.clear();
@@ -328,47 +273,25 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
       cur_compressed_bytes   = 0;
     };
 
-    // Compute the row group's contribution
-    auto rg_contribution = [&](cudf::io::parquet::RowGroup const& row_group) {
-      std::size_t rg_uncompressed = 0;
-      std::size_t rg_compressed   = 0;
-      auto add_chunk = [&](cudf::io::parquet::ColumnChunk const& chunk, bool is_pure_filter) {
-        auto const& column_metadata = chunk.meta_data;
-        // Pure-filter columns are not part of the scan result, so omit them from the
-        // uncompressed byte count used for sizing partitions.
-        if (!is_pure_filter) {
-          rg_uncompressed += static_cast<std::size_t>(column_metadata.total_uncompressed_size);
-        }
-        rg_compressed += static_cast<std::size_t>(column_metadata.total_compressed_size);
-      };
-      if (_plan->is_projected()) {
-        for (auto const chunk_idx : selected_chunk_indices) {
-          add_chunk(row_group.columns[chunk_idx], pure_filter_chunk_indices.contains(chunk_idx));
-        }
-      } else {
-        // Non-projected: all chunks contribute, no pure-filter pruning.
-        for (auto const& chunk : row_group.columns) {
-          add_chunk(chunk, false);
-        }
-      }
-      return std::pair{rg_uncompressed, rg_compressed};
-    };
-
-    for (auto const rg_idx : row_group_indices) {
-      auto const& row_group        = metadata.row_groups[rg_idx];
-      auto const [rg_unc, rg_comp] = rg_contribution(row_group);
+    for (auto const rg_idx : file_md.selected_row_group_indices) {
+      auto const rg_bytes =
+        op::scan::compute_row_group_bytes(file_md.file_metadata->row_groups[rg_idx],
+                                          *_plan,
+                                          file_md.selected_chunk_indices,
+                                          file_md.pure_filter_chunk_indices);
 
       // Ensure that a single oversized rg/file still gets through.
       if (!accum.slices.empty() || !cur_rgs.empty()) {
-        if (accum.total_uncompressed_bytes + cur_uncompressed_bytes + rg_unc >
+        if (accum.total_uncompressed_bytes + cur_uncompressed_bytes +
+              rg_bytes.uncompressed_bytes >
             _approximate_batch_size) {
           seal_current_file();
           flush();
         }
       }
 
-      cur_uncompressed_bytes += rg_unc;
-      cur_compressed_bytes += rg_comp;
+      cur_uncompressed_bytes += rg_bytes.uncompressed_bytes;
+      cur_compressed_bytes += rg_bytes.compressed_bytes;
       cur_rgs.push_back(rg_idx);
     }
     seal_current_file();

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -183,8 +183,11 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
   auto stream = cudf::get_default_stream();
 
   //===----------Build reader options----------===//
-  auto const data_column_names = _plan->data_column_names();
-  auto reader_options          = std::make_shared<cudf::io::parquet_reader_options>(
+  // Hoisted out of the file loop: scan_plan rebuilds these on every call, so passing them into
+  // the per-file helper avoids N copies of the projected name vector / pure-filter set.
+  auto const data_column_names     = _plan->data_column_names();
+  auto const pure_filter_positions = _plan->pure_filter_batch_positions();
+  auto reader_options              = std::make_shared<cudf::io::parquet_reader_options>(
     cudf::io::parquet_reader_options::builder().build());
 
   // Tell the parquet reader which columns to produce. Required whenever the scan
@@ -252,7 +255,7 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
 
     //===----------Per-file metadata scan + row-group pruning + projection resolution----------===//
     auto file_md = op::scan::scan_parquet_file_metadata(
-      file_path, *_plan, *reader_options, ast_expression.has_value(), stream);
+      file_path, *_plan, *reader_options, data_column_names, pure_filter_positions, stream);
 
     //===----------Row Group Partitioning----------===//
     std::vector<cudf::size_type> cur_rgs;
@@ -282,8 +285,7 @@ void parquet_split_provider::run_batch(file_batch const& batch, split_connector&
 
       // Ensure that a single oversized rg/file still gets through.
       if (!accum.slices.empty() || !cur_rgs.empty()) {
-        if (accum.total_uncompressed_bytes + cur_uncompressed_bytes +
-              rg_bytes.uncompressed_bytes >
+        if (accum.total_uncompressed_bytes + cur_uncompressed_bytes + rg_bytes.uncompressed_bytes >
             _approximate_batch_size) {
           seal_current_file();
           flush();


### PR DESCRIPTION
Pulls the per-file footer + metadata + projection-resolution + row-group-pruning logic out of `parquet_split_provider::run_batch` into a reusable helper at `op/scan/parquet_metadata_scanner.{hpp,cpp}`. Pure refactor — preserves `run_batch`'s budget-tracking behaviour verbatim.

## Why

`iceberg_split_provider` (queued for a follow-up PR) will need exactly the same per-file metadata scan: open the parquet datasource, read the footer, resolve DuckDB column names against parquet schema-leaf indices, prune row groups via stats. Today that logic is private to `parquet_split_provider::run_batch`. Either iceberg duplicates ~70 LOC of metadata-scan logic, or it instantiates a parquet provider inside iceberg (provider-inside-provider — awkward).

This PR extracts the logic so iceberg can call it as a free function — composition over inheritance.

## Shape

Two free functions in `sirius::op::scan`:

- `scan_parquet_file_metadata(file_path, plan, reader_options, has_filter_pushdown, stream)` — returns `file_metadata_scan_result { file_metadata, datasource, selected_row_group_indices, selected_chunk_indices, pure_filter_chunk_indices }`. Footer + metadata + column resolution + stats-based row-group pruning.
- `compute_row_group_bytes(row_group, plan, selected_chunk_indices, pure_filter_chunk_indices)` — returns `row_group_bytes { uncompressed_bytes, compressed_bytes }`. Per-row-group byte accounting, honouring projection and pure-filter exclusion.

`parquet_split_provider::run_batch` is unchanged in behaviour — it now calls the two helpers in the same order it used to do the work inline. The `cur_*_bytes` budget-tracking + `seal_current_file` reset logic from #745 is preserved verbatim.

## Follow-ups

This unblocks `iceberg_split_provider` (queued in a separate PR). It does not touch the scan_manager factory or any operator class — those changes are scoped separately.