### PR TITLE
added unit tests which test for empty results

### DIFF
--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -3119,6 +3119,124 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
 }
 
 //===----------------------------------------------------------------------===//
+// Empty result queries
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - empty simple query",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l_linestatus, l_orderkey, l_comment, l_receiptdate from lineitem where l_linestatus = "
+    "'J' and l_orderkey = 1;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - empty simple query parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l_linestatus, l_orderkey, l_comment, l_receiptdate from lineitem where l_linestatus = "
+    "'J' and l_orderkey = 1;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - empty aggregation with group by query",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l_linestatus, count(*), min(l_orderkey) as mino, sum(l_orderkey), count(l_orderkey), "
+    "count(l_receiptdate), min(l_receiptdate), count(l_comment), min(l_comment) from lineitem "
+    "where l_linestatus = 'J' group by l_linestatus;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - empty aggregation with group by query parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l_linestatus, count(*), min(l_orderkey) as mino, sum(l_orderkey), count(l_orderkey), "
+    "count(l_receiptdate), min(l_receiptdate), count(l_comment), min(l_comment) from lineitem "
+    "where l_linestatus = 'J' group by l_linestatus;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - empty aggregation without group by query",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select count(*), min(l_orderkey), sum(l_orderkey) as sumo, count(l_orderkey), "
+    "count(l_receiptdate), min(l_receiptdate), count(l_comment), min(l_comment) from lineitem "
+    "where l_linestatus = 'J';");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - empty aggregation without group by query parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select count(*), min(l_orderkey), sum(l_orderkey) as sumo, count(l_orderkey), "
+    "count(l_receiptdate), min(l_receiptdate), count(l_comment), min(l_comment) from lineitem "
+    "where l_linestatus = 'J';");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with empty one side",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey as lokey, l.l_linestatus, o.o_custkey from lineitem l inner join orders o "
+    "on l.l_orderkey = o.o_orderkey where l_linestatus = 'J';");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - join with empty one side parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey as lokey, l.l_linestatus, o.o_custkey from lineitem l inner join orders o "
+    "on l.l_orderkey = o.o_orderkey where l_linestatus = 'J';");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with empty two sides",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linestatus, o.o_custkey as ockey from lineitem l inner join orders o "
+    "on l.l_orderkey = o.o_orderkey where l_linestatus = 'J' and o.o_comment = 'Special';");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - join with empty two sides parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linestatus, o.o_custkey as ockey from lineitem l inner join orders o "
+    "on l.l_orderkey = o.o_orderkey where l_linestatus = 'J' and o.o_comment = 'Special';");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with empty output and order by",
+                 "[integration][gpu_execution][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linestatus, o.o_custkey from lineitem l inner join orders o on "
+    "l.l_orderkey = o.o_orderkey where l.l_orderkey > 10000 and o.o_orderkey < 10000 order by "
+    "l.l_orderkey, o.o_custkey;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - join with empty output and order by parquet",
+                 "[integration][gpu_execution][parquet][empty_result]")
+{
+  compare_gpu_vs_cpu(
+    "select l.l_orderkey, l.l_linestatus, o.o_custkey from lineitem l inner join orders o on "
+    "l.l_orderkey = o.o_orderkey where l.l_orderkey > 10000 and o.o_orderkey < 10000 order by "
+    "l.l_orderkey, o.o_custkey;");
+}
+
+//===----------------------------------------------------------------------===//
 // TPC-H queries
 //===----------------------------------------------------------------------===//
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,


### PR DESCRIPTION
This PR just makes sure that the engine properly handles empty results. All integration tests work, so no fixes to the engine were necessary

Implements #475 