### PR TITLE
scan_manager: polymorphic scan_info + cache-extracted factory (DuckDB format GPU-native Part 8a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ set(EXTENSION_SOURCES
     src/op/scan/iceberg_scan_task.cpp
     src/op/scan/positional_delete_filter.cpp
     src/op/scan/puffin_reader.cpp
+    src/op/scan/parquet_scan_info.cpp
     src/op/scan/parquet_scan_task.cpp
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/prefetched_data_source.cpp

--- a/src/include/op/scan/parquet_scan_info.hpp
+++ b/src/include/op/scan/parquet_scan_info.hpp
@@ -33,7 +33,7 @@ namespace sirius::op::scan {
  */
 struct parquet_scan_info : scan_info {
   std::unique_ptr<scan_manager::split_provider> make_provider(
-    scan_manager::sirius_scan_manager& manager) override;
+    std::shared_ptr<sirius::io::sirius_ioctx> io_ctx) override;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/scan_info.hpp
+++ b/src/include/op/scan/scan_info.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "helper/logical_type.hpp"
+#include "sirius_config.hpp"
+
+#include <duckdb/common/column_index.hpp>
+#include <duckdb/common/multi_file/multi_file_data.hpp>
+#include <duckdb/common/types.hpp>
+#include <duckdb/common/vector.hpp>
+#include <duckdb/planner/table_filter.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace sirius::scan_manager {
+class sirius_scan_manager;
+class split_provider;
+}  // namespace sirius::scan_manager
+
+namespace sirius::op::scan {
+
+/**
+ * @brief Polymorphic base for per-format bind-data parked on a gpu scan operator.
+ *
+ * Carries the scan fields common to every file-format scan (file paths,
+ * projection, filters, partitions, output arity). Subclasses add format-specific
+ * fields (e.g. iceberg snapshot id, manifest paths) and implement @ref make_provider
+ * to construct the format's split_provider.
+ *
+ * The scan_manager reads scan_info during prepare_for_query to either short-circuit
+ * to a cached_split_provider (using only base fields, so format-agnostic) or
+ * dispatch through @ref make_provider to the format-specific provider.
+ *
+ * Populated once by the pipeline converter, then moved into the operator. Consumed
+ * once by the scan_manager via the operator's take_scan_info().
+ */
+struct scan_info {
+  /// Logical types of the scan source's columns, in source schema order.
+  duckdb::vector<sirius::logical_type> returned_types;
+  std::vector<std::string> file_paths;
+  /// Column ids exposed by the table function.
+  duckdb::vector<duckdb::ColumnIndex> column_ids;
+  /// Indices into @ref column_ids that the planner projected (empty = read all columns).
+  duckdb::vector<duckdb::idx_t> projection_ids;
+  /// Column names in source schema order.
+  duckdb::vector<std::string> names;
+  /// Filter set for row-group pruning / pushdown. May be null.
+  duckdb::unique_ptr<duckdb::TableFilterSet> table_filters;
+  duckdb::vector<duckdb::HivePartitioningIndex> partition_indices;
+  /// Target uncompressed bytes per row-group partition.
+  std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE;
+  /// Number of output columns the gpu scan operator returns.
+  /// Set by the pipeline converter from the scan operator's `types.size()`.
+  std::size_t scan_output_arity = 0;
+
+  scan_info()                            = default;
+  virtual ~scan_info()                   = default;
+  scan_info(scan_info const&)            = delete;
+  scan_info& operator=(scan_info const&) = delete;
+  scan_info(scan_info&&)                 = default;
+  scan_info& operator=(scan_info&&)      = default;
+
+  /**
+   * @brief Build the format-specific split_provider this scan_info dispatches to.
+   *
+   * Called once by the scan_manager after the cache short-circuit has been
+   * checked and missed. May consume mutable fields on @c *this (e.g. moving
+   * @ref table_filters into the constructed provider).
+   *
+   * @param manager  The scan_manager driving this query (provides the thread
+   *                 pool and any cross-format context the provider needs).
+   */
+  virtual std::unique_ptr<scan_manager::split_provider> make_provider(
+    scan_manager::sirius_scan_manager& manager) = 0;
+};
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/scan_info.hpp
+++ b/src/include/op/scan/scan_info.hpp
@@ -30,8 +30,11 @@
 #include <string>
 #include <vector>
 
+namespace sirius::io {
+class sirius_ioctx;
+}  // namespace sirius::io
+
 namespace sirius::scan_manager {
-class sirius_scan_manager;
 class split_provider;
 }  // namespace sirius::scan_manager
 
@@ -69,7 +72,7 @@ struct scan_info {
   std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE;
   /// Number of output columns the gpu scan operator returns.
   /// Set by the pipeline converter from the scan operator's `types.size()`.
-  std::size_t scan_output_arity = 0;
+  std::size_t scan_output_arity;
 
   scan_info()                            = default;
   virtual ~scan_info()                   = default;
@@ -85,11 +88,12 @@ struct scan_info {
    * checked and missed. May consume mutable fields on @c *this (e.g. moving
    * @ref table_filters into the constructed provider).
    *
-   * @param manager  The scan_manager driving this query (provides the thread
-   *                 pool and any cross-format context the provider needs).
+   * @param io_ctx  Process-wide ioctx the provider attaches to its emitted
+   *                slices. May be null when the scan_manager is configured
+   *                with @c use_sirius_datasource=false.
    */
   virtual std::unique_ptr<scan_manager::split_provider> make_provider(
-    scan_manager::sirius_scan_manager& manager) = 0;
+    std::shared_ptr<sirius::io::sirius_ioctx> io_ctx) = 0;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -36,7 +36,7 @@ class sirius_scan_manager;
 
 namespace sirius::op::scan {
 
-struct parquet_scan_info;
+struct scan_info;
 
 //===----------------------------------------------------------------------===//
 // Parquet scan operator
@@ -45,13 +45,14 @@ struct parquet_scan_info;
  * @brief Operator that reads parquet byte ranges for a batch of row groups and produces
  *        gpu_table_representation data batches for downstream GPU operators.
  *
- * The operator carries a parquet_scan_info populated by the pipeline converter; the
- * scan_manager reads it during prepare_for_query to construct a parquet_split_provider
- * for this operator. Splits — one parquet_scan_data per row-group partition — are
- * pushed into the operator's bound split_connector by the provider on the scan_manager
- * thread pool. The operator pulls splits via get_next_task_input_data(), which blocks
- * inside split_connector::get_next_split until a split arrives or the connector is
- * closed.
+ * The operator carries a scan_info (populated by the pipeline converter as a concrete
+ * subclass — parquet_scan_info today). The scan_manager reads it during prepare_for_query,
+ * checks for a pinned-cache match against the scan_info's common fields, and otherwise
+ * dispatches through scan_info::make_provider() to build the format's split_provider.
+ * Splits — one parquet_scan_data per row-group partition — are pushed into the operator's
+ * bound split_connector by the provider on the scan_manager thread pool. The operator
+ * pulls splits via get_next_task_input_data(), which blocks inside
+ * split_connector::get_next_split until a split arrives or the connector is closed.
  */
 class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
  public:
@@ -66,7 +67,16 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
    */
   sirius_gpu_parquet_scan_operator(duckdb::vector<sirius::logical_type> types,
                                    duckdb::idx_t estimated_cardinality,
-                                   std::unique_ptr<parquet_scan_info> scan_info);
+                                   std::unique_ptr<scan_info> scan_info);
+
+  /// Test-only delegating constructor. The pipeline converter always builds the
+  /// 3-arg form; unit tests that don't exercise the scan_manager path use this
+  /// to keep their old @c (types, estimated_cardinality) call sites unchanged.
+  sirius_gpu_parquet_scan_operator(duckdb::vector<sirius::logical_type> types,
+                                   duckdb::idx_t estimated_cardinality)
+    : sirius_gpu_parquet_scan_operator(std::move(types), estimated_cardinality, nullptr)
+  {
+  }
 
   ~sirius_gpu_parquet_scan_operator() override;
 
@@ -139,7 +149,7 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
 
   /// \brief Take ownership of the bind-data so the scan_manager's factory can build a
   ///        split provider. Called once per query; subsequent calls return nullptr.
-  std::unique_ptr<parquet_scan_info> take_scan_info();
+  std::unique_ptr<scan_info> take_scan_info();
 
   /// \brief Install the split connector that the scan_manager will feed.
   void set_split_connector(std::unique_ptr<scan_manager::split_connector> connector);
@@ -149,7 +159,7 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
 
   //===----------Fields----------===//
   std::unique_ptr<scan_manager::split_connector> _split_connector;
-  std::unique_ptr<parquet_scan_info> _scan_info;
+  std::unique_ptr<scan_info> _scan_info;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -69,15 +69,6 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
                                    duckdb::idx_t estimated_cardinality,
                                    std::unique_ptr<scan_info> scan_info);
 
-  /// Test-only delegating constructor. The pipeline converter always builds the
-  /// 3-arg form; unit tests that don't exercise the scan_manager path use this
-  /// to keep their old @c (types, estimated_cardinality) call sites unchanged.
-  sirius_gpu_parquet_scan_operator(duckdb::vector<sirius::logical_type> types,
-                                   duckdb::idx_t estimated_cardinality)
-    : sirius_gpu_parquet_scan_operator(std::move(types), estimated_cardinality, nullptr)
-  {
-  }
-
   ~sirius_gpu_parquet_scan_operator() override;
 
   //===----------Source interface----------===//

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -44,6 +44,7 @@ class buffer_pool;
 
 namespace sirius::op::scan {
 class sirius_gpu_parquet_scan_operator;
+struct scan_info;
 }  // namespace sirius::op::scan
 
 namespace sirius::planner {
@@ -92,7 +93,7 @@ struct scan_manager_config {
 struct pinned_entry {
   std::vector<std::string> column_names;
   /// Resolved (globbed) file paths captured at pin time. The scan_manager uses
-  /// this list to match an incoming scan operator's parquet_scan_info::file_paths
+  /// this list to match an incoming scan operator's scan_info::file_paths
   /// against this entry, so it can swap in a cached split provider.
   std::vector<std::string> file_paths;
   /// GPU-tier storage: one chunk vector per pinned column name. Populated by
@@ -221,13 +222,32 @@ class sirius_scan_manager {
   ///        @c use_sirius_datasource=false.
   [[nodiscard]] sirius::io::sirius_ioctx* io_ctx() const noexcept { return _io_ctx.get(); }
 
+  /// \brief Same ioctx as @ref io_ctx(), shared so format-specific scan_info
+  ///        subclasses can attach it to a split_provider's emitted slices.
+  [[nodiscard]] std::shared_ptr<sirius::io::sirius_ioctx> shared_io_ctx() const noexcept
+  {
+    return _io_ctx;
+  }
+
  private:
-  /// \brief Build a split_provider for @p op by reading its parquet scan_info.
-  ///        Returns a cached_split_provider when a pinned entry matches, otherwise
-  ///        a parquet_split_provider; in both cases the provider carries the
-  ///        scan_plan that the operator's execute() consults for output assembly.
+  /// \brief Build a split_provider for @p op by reading its scan_info.
+  ///        Tries the pinned-cache short-circuit (format-agnostic; uses only
+  ///        the common scan_info fields) and otherwise dispatches through
+  ///        scan_info::make_provider() to the format-specific provider.
   std::unique_ptr<split_provider> create_provider_for(
     op::scan::sirius_gpu_parquet_scan_operator* op);
+
+  /// \brief Try to short-circuit @p info to a cached_split_provider when a
+  ///        pinned entry matches the scan's file paths. Returns nullptr on
+  ///        miss so the caller can fall through to per-format dispatch.
+  ///        Format-agnostic: uses only fields on the scan_info base.
+  ///
+  /// @param info   Scan bind-data — file_paths, column_ids, names, types,
+  ///               projection_ids, partition_indices, table_filters,
+  ///               scan_output_arity. Read-only; not consumed.
+  /// @param op_id  Operator id for diagnostic logging.
+  std::unique_ptr<split_provider> try_cached_for(op::scan::scan_info const& info,
+                                                 std::size_t op_id);
 
   /// \brief Run providers sequentially: start each, wait on its future, advance.
   void start_metadata_processing();

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -222,13 +222,6 @@ class sirius_scan_manager {
   ///        @c use_sirius_datasource=false.
   [[nodiscard]] sirius::io::sirius_ioctx* io_ctx() const noexcept { return _io_ctx.get(); }
 
-  /// \brief Same ioctx as @ref io_ctx(), shared so format-specific scan_info
-  ///        subclasses can attach it to a split_provider's emitted slices.
-  [[nodiscard]] std::shared_ptr<sirius::io::sirius_ioctx> shared_io_ctx() const noexcept
-  {
-    return _io_ctx;
-  }
-
  private:
   /// \brief Build a split_provider for @p op by reading its scan_info.
   ///        Tries the pinned-cache short-circuit (format-agnostic; uses only
@@ -237,17 +230,17 @@ class sirius_scan_manager {
   std::unique_ptr<split_provider> create_provider_for(
     op::scan::sirius_gpu_parquet_scan_operator* op);
 
-  /// \brief Try to short-circuit @p info to a cached_split_provider when a
-  ///        pinned entry matches the scan's file paths. Returns nullptr on
-  ///        miss so the caller can fall through to per-format dispatch.
-  ///        Format-agnostic: uses only fields on the scan_info base.
+  /// \brief Build a cached_split_provider when a pinned entry matches the
+  ///        scan's file paths. Returns nullptr on miss so the caller can
+  ///        fall through to per-format dispatch. Format-agnostic: uses only
+  ///        fields on the scan_info base.
   ///
   /// @param info   Scan bind-data — file_paths, column_ids, names, types,
   ///               projection_ids, partition_indices, table_filters,
   ///               scan_output_arity. Read-only; not consumed.
   /// @param op_id  Operator id for diagnostic logging.
-  std::unique_ptr<split_provider> try_cached_for(op::scan::scan_info const& info,
-                                                 std::size_t op_id);
+  std::unique_ptr<split_provider> try_make_cached_provider(op::scan::scan_info const& info,
+                                                           std::size_t op_id);
 
   /// \brief Run providers sequentially: start each, wait on its future, advance.
   void start_metadata_processing();

--- a/src/op/scan/parquet_scan_info.cpp
+++ b/src/op/scan/parquet_scan_info.cpp
@@ -14,26 +14,31 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "op/scan/parquet_scan_info.hpp"
 
-#include "op/scan/scan_info.hpp"
+#include "scan_manager/parquet_split_provider.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
 
 #include <memory>
+#include <utility>
 
 namespace sirius::op::scan {
 
-/**
- * @brief Bind-data for a parquet scan.
- *
- * All scan fields are inherited from @ref scan_info; this subclass exists so
- * @ref make_provider dispatches to @ref scan_manager::parquet_split_provider.
- *
- * Populated once during plan generation and parked on the gpu parquet scan
- * operator. The scan_manager reads it during prepare_for_query.
- */
-struct parquet_scan_info : scan_info {
-  std::unique_ptr<scan_manager::split_provider> make_provider(
-    scan_manager::sirius_scan_manager& manager) override;
-};
+std::unique_ptr<scan_manager::split_provider> parquet_scan_info::make_provider(
+  scan_manager::sirius_scan_manager& manager)
+{
+  return std::make_unique<scan_manager::parquet_split_provider>(
+    returned_types,
+    file_paths,
+    column_ids,
+    projection_ids,
+    names,
+    scan_output_arity,
+    std::move(table_filters),
+    partition_indices,
+    approximate_batch_size,
+    scan_manager::parquet_split_provider::DEFAULT_MAX_FILE_PROCESSED,
+    manager.shared_io_ctx());
+}
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/parquet_scan_info.cpp
+++ b/src/op/scan/parquet_scan_info.cpp
@@ -17,7 +17,6 @@
 #include "op/scan/parquet_scan_info.hpp"
 
 #include "scan_manager/parquet_split_provider.hpp"
-#include "scan_manager/sirius_scan_manager.hpp"
 
 #include <memory>
 #include <utility>
@@ -25,7 +24,7 @@
 namespace sirius::op::scan {
 
 std::unique_ptr<scan_manager::split_provider> parquet_scan_info::make_provider(
-  scan_manager::sirius_scan_manager& manager)
+  std::shared_ptr<sirius::io::sirius_ioctx> io_ctx)
 {
   return std::make_unique<scan_manager::parquet_split_provider>(
     returned_types,
@@ -38,7 +37,7 @@ std::unique_ptr<scan_manager::split_provider> parquet_scan_info::make_provider(
     partition_indices,
     approximate_batch_size,
     scan_manager::parquet_split_provider::DEFAULT_MAX_FILE_PROCESSED,
-    manager.shared_io_ctx());
+    std::move(io_ctx));
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -18,8 +18,8 @@
 #include <data/data_batch_utils.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <log/logging.hpp>
-#include <op/scan/parquet_scan_info.hpp>
 #include <op/scan/parquet_scan_operator_data.hpp>
+#include <op/scan/scan_info.hpp>
 #include <op/scan/scan_plan.hpp>
 #include <op/scan/sirius_gpu_parquet_scan_operator.hpp>
 #include <op/sirius_physical_operator.hpp>
@@ -47,7 +47,7 @@ namespace sirius::op::scan {
 sirius_gpu_parquet_scan_operator::sirius_gpu_parquet_scan_operator(
   duckdb::vector<sirius::logical_type> types,
   duckdb::idx_t estimated_cardinality,
-  std::unique_ptr<parquet_scan_info> scan_info)
+  std::unique_ptr<scan_info> scan_info)
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::GPU_PARQUET_SCAN, std::move(types), estimated_cardinality),
     _split_connector(std::make_unique<scan_manager::split_connector>()),
@@ -61,7 +61,7 @@ sirius_gpu_parquet_scan_operator::~sirius_gpu_parquet_scan_operator() = default;
 //===----------------------------------------------------------------------===//
 // Friend access — wired by sirius_scan_manager during prepare_for_query.
 //===----------------------------------------------------------------------===//
-std::unique_ptr<parquet_scan_info> sirius_gpu_parquet_scan_operator::take_scan_info()
+std::unique_ptr<scan_info> sirius_gpu_parquet_scan_operator::take_scan_info()
 {
   return std::move(_scan_info);
 }

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -244,6 +244,7 @@ void sirius_pipeline_converter::insert_parquet_scan_operator(
   scan_info->names             = scan_op.names;
   scan_info->table_filters     = std::move(scan_op.table_filters);
   scan_info->partition_indices = partition_indices;
+  scan_info->scan_output_arity = scan_op.types.size();
 
   auto gpu_scan_op = duckdb::make_uniq<op::scan::sirius_gpu_parquet_scan_operator>(
     scan_op.types, scan_op.estimated_cardinality, std::move(scan_info));

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -143,12 +143,12 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   // projection_ids, partition_indices, table_filters) — format-agnostic. If
   // it misses, dispatch through scan_info::make_provider() to the format's
   // own split_provider construction.
-  if (auto cached = try_cached_for(*info, op->get_operator_id())) { return cached; }
-  return info->make_provider(*this);
+  if (auto cached = try_make_cached_provider(*info, op->get_operator_id())) { return cached; }
+  return info->make_provider(_io_ctx);
 }
 
-std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::scan_info const& info,
-                                                                    std::size_t op_id)
+std::unique_ptr<split_provider> sirius_scan_manager::try_make_cached_provider(
+  op::scan::scan_info const& info, std::size_t op_id)
 {
   // If a pinned entry's file paths match this scan_info, build the same
   // scan_plan the parquet path would build and serve the scan from cache.
@@ -164,7 +164,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::sc
     for (auto const& [pinned_name, entry] : _pinned_entries) {
       if (!matches_scan_info(entry)) { continue; }
       if (entry.memory_space == nullptr) {
-        throw std::runtime_error("[sirius_scan_manager::try_cached_for] pinned entry '" +
+        throw std::runtime_error("[sirius_scan_manager::try_make_cached_provider] pinned entry '" +
                                  pinned_name + "' has no memory_space");
       }
 
@@ -186,7 +186,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::sc
       // which extracts partition values per file at read time.
       if (plan.has_partitions()) {
         SIRIUS_LOG_DEBUG(
-          "[sirius_scan_manager::try_cached_for] pinned entry '{}' matches op_id={} but "
+          "[sirius_scan_manager::try_make_cached_provider] pinned entry '{}' matches op_id={} but "
           "scan has hive partitions; falling through to per-format split_provider",
           pinned_name,
           op_id);
@@ -229,7 +229,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::sc
         }
 
         SIRIUS_LOG_DEBUG(
-          "[sirius_scan_manager::try_cached_for] using host cached_split_provider for "
+          "[sirius_scan_manager::try_make_cached_provider] using host cached_split_provider for "
           "op_id={} (pinned='{}' data_cols={} chunks={} needs_assembly={})",
           op_id,
           pinned_name,
@@ -251,15 +251,15 @@ std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::sc
       for (auto const& dc : plan.data_columns) {
         auto it = entry.data_batches_by_column.find(dc.name);
         if (it == entry.data_batches_by_column.end()) {
-          throw std::runtime_error("[sirius_scan_manager::try_cached_for] pinned entry '" +
-                                   pinned_name + "' missing column '" + dc.name +
-                                   "' required by scan op");
+          throw std::runtime_error(
+            "[sirius_scan_manager::try_make_cached_provider] pinned entry '" + pinned_name +
+            "' missing column '" + dc.name + "' required by scan op");
         }
         columns_per_request.push_back(it->second);
       }
 
       SIRIUS_LOG_DEBUG(
-        "[sirius_scan_manager::try_cached_for] using cached_split_provider for op_id={} "
+        "[sirius_scan_manager::try_make_cached_provider] using cached_split_provider for op_id={} "
         "(pinned='{}' data_cols={} needs_assembly={})",
         op_id,
         pinned_name,

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -20,7 +20,7 @@
 #include "io/prefetching_cache.hpp"
 #include "io/uring/uring_ioctx.hpp"
 #include "log/logging.hpp"
-#include "op/scan/parquet_scan_info.hpp"
+#include "op/scan/scan_info.hpp"
 #include "op/scan/scan_plan.hpp"
 #include "op/scan/scan_utils.hpp"
 #include "op/scan/sirius_gpu_parquet_scan_operator.hpp"
@@ -28,7 +28,6 @@
 #include "pipeline/sirius_pipeline.hpp"
 #include "planner/query.hpp"
 #include "scan_manager/cached_split_provider.hpp"
-#include "scan_manager/parquet_split_provider.hpp"
 #include "scan_manager/split_connector.hpp"
 #include "scan_manager/split_provider.hpp"
 
@@ -139,12 +138,24 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   auto info = op->take_scan_info();
   if (!info) { return nullptr; }
 
-  // If a pinned entry's file paths match this operator's scan_info, build the same
+  // Pinned-cache short-circuit lives on the manager because it uses only the
+  // common scan_info fields (file_paths, column_ids, names, returned_types,
+  // projection_ids, partition_indices, table_filters) — format-agnostic. If
+  // it misses, dispatch through scan_info::make_provider() to the format's
+  // own split_provider construction.
+  if (auto cached = try_cached_for(*info, op->get_operator_id())) { return cached; }
+  return info->make_provider(*this);
+}
+
+std::unique_ptr<split_provider> sirius_scan_manager::try_cached_for(op::scan::scan_info const& info,
+                                                                    std::size_t op_id)
+{
+  // If a pinned entry's file paths match this scan_info, build the same
   // scan_plan the parquet path would build and serve the scan from cache.
   auto matches_scan_info = [&info](const pinned_entry& entry) {
-    if (entry.file_paths.size() != info->file_paths.size()) { return false; }
+    if (entry.file_paths.size() != info.file_paths.size()) { return false; }
     auto sorted_a = entry.file_paths;
-    auto sorted_b = info->file_paths;
+    auto sorted_b = info.file_paths;
     std::sort(sorted_a.begin(), sorted_a.end());
     std::sort(sorted_b.begin(), sorted_b.end());
     return sorted_a == sorted_b;
@@ -153,7 +164,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
     for (auto const& [pinned_name, entry] : _pinned_entries) {
       if (!matches_scan_info(entry)) { continue; }
       if (entry.memory_space == nullptr) {
-        throw std::runtime_error("[sirius_scan_manager::create_provider_for] pinned entry '" +
+        throw std::runtime_error("[sirius_scan_manager::try_cached_for] pinned entry '" +
                                  pinned_name + "' has no memory_space");
       }
 
@@ -162,23 +173,23 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
       // Held by shared_ptr<const> so each emitted scan_cached_operator_data can
       // carry it to the GPU scan operator's per-task assembly check without copying.
       auto plan_shared = std::make_shared<op::scan::scan_plan const>(
-        op::scan::build_scan_plan(info->column_ids,
-                                  info->projection_ids,
-                                  info->names,
-                                  info->returned_types,
-                                  op->get_types().size(),
-                                  info->partition_indices));
+        op::scan::build_scan_plan(info.column_ids,
+                                  info.projection_ids,
+                                  info.names,
+                                  info.returned_types,
+                                  info.scan_output_arity,
+                                  info.partition_indices));
       auto const& plan = *plan_shared;
 
       // Hive partitions on a cached scan would require per-chunk file_path metadata
-      // that pinned entries don't carry today. Fall through to the parquet path,
+      // that pinned entries don't carry today. Fall through to the per-format path,
       // which extracts partition values per file at read time.
       if (plan.has_partitions()) {
         SIRIUS_LOG_DEBUG(
-          "[sirius_scan_manager::create_provider_for] pinned entry '{}' matches op_id={} but "
-          "scan has hive partitions; falling through to parquet_split_provider",
+          "[sirius_scan_manager::try_cached_for] pinned entry '{}' matches op_id={} but "
+          "scan has hive partitions; falling through to per-format split_provider",
           pinned_name,
-          op->get_operator_id());
+          op_id);
         break;
       }
 
@@ -187,11 +198,11 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
       // the cached batch (which is in D-order by construction above). Built before the
       // tier-specific assembly so both branches share the same filter.
       std::shared_ptr<duckdb::Expression> filter_expression;
-      if (info->table_filters && !info->table_filters->filters.empty()) {
+      if (info.table_filters && !info.table_filters->filters.empty()) {
         auto duckdb_expression =
-          op::convert_table_filters_to_expression(*info->table_filters,
-                                                  info->column_ids,
-                                                  info->returned_types,
+          op::convert_table_filters_to_expression(*info.table_filters,
+                                                  info.column_ids,
+                                                  info.returned_types,
                                                   plan.batch_position_by_column_id,
                                                   plan.partition_primary_indices);
         if (duckdb_expression) {
@@ -218,9 +229,9 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
         }
 
         SIRIUS_LOG_DEBUG(
-          "[sirius_scan_manager::create_provider_for] using host cached_split_provider for "
+          "[sirius_scan_manager::try_cached_for] using host cached_split_provider for "
           "op_id={} (pinned='{}' data_cols={} chunks={} needs_assembly={})",
-          op->get_operator_id(),
+          op_id,
           pinned_name,
           column_indices.size(),
           entry.host_chunks.size(),
@@ -240,7 +251,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
       for (auto const& dc : plan.data_columns) {
         auto it = entry.data_batches_by_column.find(dc.name);
         if (it == entry.data_batches_by_column.end()) {
-          throw std::runtime_error("[sirius_scan_manager::create_provider_for] pinned entry '" +
+          throw std::runtime_error("[sirius_scan_manager::try_cached_for] pinned entry '" +
                                    pinned_name + "' missing column '" + dc.name +
                                    "' required by scan op");
         }
@@ -248,9 +259,9 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
       }
 
       SIRIUS_LOG_DEBUG(
-        "[sirius_scan_manager::create_provider_for] using cached_split_provider for op_id={} "
+        "[sirius_scan_manager::try_cached_for] using cached_split_provider for op_id={} "
         "(pinned='{}' data_cols={} needs_assembly={})",
-        op->get_operator_id(),
+        op_id,
         pinned_name,
         columns_per_request.size(),
         op::scan::needs_output_assembly(plan));
@@ -263,18 +274,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   } catch (...) {
     SIRIUS_LOG_TRACE("not all the columns are pinned for this query");
   }
-  return std::make_unique<parquet_split_provider>(
-    info->returned_types,
-    info->file_paths,
-    info->column_ids,
-    info->projection_ids,
-    info->names,
-    op->get_types().size(),
-    std::move(info->table_filters),
-    info->partition_indices,
-    info->approximate_batch_size,
-    parquet_split_provider::DEFAULT_MAX_FILE_PROCESSED,
-    _io_ctx);
+  return nullptr;
 }
 
 void sirius_scan_manager::start_metadata_processing()

--- a/test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
+++ b/test/cpp/pipeline/test_metadata_gpu_pipeline_task_counting.cpp
@@ -260,8 +260,8 @@ TEST_CASE("pipeline task counting - single file, default max_file_processed (one
   std::vector<std::string> files = {path.string()};
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(schema.types),
-                                                            0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(schema.types), 0, nullptr);
   sirius::op::scan::sirius_parquet_metadata_scan_operator metadata_op(
     &gpu_op,
     sirius::from_duckdb_vec(schema.types),
@@ -328,8 +328,8 @@ TEST_CASE("pipeline task counting - multi-file metadata scan with max_file_proce
   auto schema = synthetic_schema();
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(schema.types),
-                                                            0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(schema.types), 0, nullptr);
   sirius::op::scan::sirius_parquet_metadata_scan_operator metadata_op(
     &gpu_op,
     sirius::from_duckdb_vec(schema.types),

--- a/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
+++ b/test/cpp/scan/test_metadata_gpu_scan_operators.cpp
@@ -181,8 +181,8 @@ std::vector<std::shared_ptr<cucascade::data_batch>> run_two_pipeline_scan(
   duckdb::unique_ptr<duckdb::TableFilterSet> table_filters = nullptr,
   rmm::cuda_stream_view stream                             = cudf::get_default_stream())
 {
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(output_types),
-                                                            0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(output_types), 0, nullptr);
 
   // --- Pipeline 1: metadata scan ---
   sirius::op::scan::sirius_parquet_metadata_scan_operator metadata_op(
@@ -286,8 +286,8 @@ TEST_CASE("metadata_scan_operator - source interface dispatches all files",
   std::vector<std::string> files = {path.string()};
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(schema.types),
-                                                            0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(schema.types), 0, nullptr);
   sirius::op::scan::sirius_parquet_metadata_scan_operator op(&gpu_op,
                                                              sirius::from_duckdb_vec(schema.types),
                                                              sirius::from_duckdb_vec(schema.types),
@@ -326,8 +326,8 @@ TEST_CASE("metadata_scan_operator - execute produces partitioned metadata",
   std::vector<std::string> files = {path.string()};
   duckdb::vector<duckdb::idx_t> no_projection;
 
-  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(schema.types),
-                                                            0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+    sirius::from_duckdb_vec(schema.types), 0, nullptr);
   sirius::op::scan::sirius_parquet_metadata_scan_operator op(&gpu_op,
                                                              sirius::from_duckdb_vec(schema.types),
                                                              sirius::from_duckdb_vec(schema.types),
@@ -397,8 +397,8 @@ TEST_CASE("metadata_scan_operator - projection restricts byte accounting to sele
   // --- Full scan (no projection): all chunks contribute. ---
   std::size_t full_uncompressed_bytes = 0;
   {
-    sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(sirius::from_duckdb_vec(full_types),
-                                                              0);
+    sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
+      sirius::from_duckdb_vec(full_types), 0, nullptr);
     sirius::op::scan::sirius_parquet_metadata_scan_operator op(
       &gpu_op,
       sirius::from_duckdb_vec(full_types),
@@ -427,7 +427,7 @@ TEST_CASE("metadata_scan_operator - projection restricts byte accounting to sele
                                                         duckdb::LogicalType::INTEGER};
     duckdb::vector<duckdb::idx_t> projection_ids{1, 2};
     sirius::op::scan::sirius_gpu_parquet_scan_operator gpu_op(
-      sirius::from_duckdb_vec(projected_types), 0);
+      sirius::from_duckdb_vec(projected_types), 0, nullptr);
     sirius::op::scan::sirius_parquet_metadata_scan_operator op(
       &gpu_op,
       sirius::from_duckdb_vec(projected_types),
@@ -812,7 +812,7 @@ TEST_CASE("gpu_scan_operator - idle without handoff port", "[gpu_scan_operator][
 
   duckdb::vector<duckdb::LogicalType> types;
   types.push_back(duckdb::LogicalType::INTEGER);
-  sirius::op::scan::sirius_gpu_parquet_scan_operator op(sirius::from_duckdb_vec(types), 0);
+  sirius::op::scan::sirius_gpu_parquet_scan_operator op(sirius::from_duckdb_vec(types), 0, nullptr);
 
   REQUIRE(op.is_source());
 


### PR DESCRIPTION
Delivers the design proposed in PR #731 review (a polymorphic scan_info base with virtual make_provider, replacing the parquet-typed factory body) at the moment it stays cheap — the manager still has one consumer (parquet), so this PR is purely structural.

Three coordinated changes:

1. New op::scan::scan_info polymorphic base (src/include/op/scan/scan_info.hpp). Carries the fields common to every file-format scan (file_paths, column_ids, projection_ids, names, returned_types, partition_indices, table_filters, approximate_batch_size, scan_output_arity). Subclasses add format-specific fields and implement make_provider() to construct their split_provider.

2. parquet_scan_info derives from scan_info; its make_provider() builds a parquet_split_provider (logic moved out of sirius_scan_manager into the new src/op/scan/parquet_scan_info.cpp).

3. sirius_scan_manager::create_provider_for splits the cache short-circuit into a separate try_cached_for(scan_info&, op_id) pre-step that uses only the common base fields (so it stays format-agnostic) and dispatches format-specific construction through info->make_provider(*this).

Behavior should be unchanged on the parquet path. Operator stores unique_ptr<scan_info> instead of unique_ptr<parquet_scan_info>; pipeline converter sets the new scan_output_arity field from scan_op.types.size() so the manager can build scan_plan without reaching into the operator.

This unblocks adding the iceberg path as a sibling subclass — iceberg's follow-up PR can add iceberg_scan_info : scan_info + iceberg_split_provider without touching the factory and also preparation for the DuckDb subclass to do the same thing