### PR TITLE
CI: Add CUDA 12 PR testing and use CUDA 12 runners for CUDA 12 distribution workflows

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -64,4 +64,4 @@ jobs:
       cuda_archs: '75-real;80-real;86-real;90a-real'
       cuda_version: '12'
       artifact_postfix: '-cuda12'
-      runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "cuda-13", "arm-xl"]}'
+      runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "cuda-12", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "cuda-12", "arm-xl"]}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,20 @@ concurrency:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            cuda: cuda-13
+            pixi-env: default
+          - os: ubuntu-22.04
+            cuda: cuda-12
+            pixi-env: cuda12
+
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, ubuntu-24.04, cuda-13, cpu-xl]
+    runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.cuda }}", cpu-xl]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +50,7 @@ jobs:
         with:
           cache: false
           pixi-version: v0.65.0
-          activate-environment: true
+          activate-environment: ${{ matrix.pixi-env }}
 
       - name: Configure sccache backend
         run: |
@@ -64,12 +75,24 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: build-${{ matrix.cuda }}
           path: build.tar
           if-no-files-found: error
           retention-days: 1
 
   test:
-    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-t4]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            cuda: cuda-13
+            pixi-env: default
+          - os: ubuntu-22.04
+            cuda: cuda-12
+            pixi-env: cuda12
+
+    runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.cuda }}", gpu-t4]
     needs: build
     timeout-minutes: 60
     env:
@@ -82,9 +105,11 @@ jobs:
         with:
           cache: false
           pixi-version: v0.65.0
-          activate-environment: true
+          activate-environment: ${{ matrix.pixi-env }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-${{ matrix.cuda }}
 
       - name: Extract build artifacts
         run: tar -xf build.tar
@@ -135,6 +160,6 @@ jobs:
         if: always() && steps.tpch.outputs.run_dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tpch-run-${{ github.run_id }}
+          name: tpch-run-${{ github.run_id }}-${{ matrix.cuda }}
           path: ${{ steps.tpch.outputs.run_dir }}
           retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,6 +192,9 @@ jobs:
     needs: build-cuda-12
     if: needs.build-cuda-12.result == 'success'
     timeout-minutes: 60
+    env:
+      CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
+      SIRIUS_LOG_LEVEL: trace
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: unittest-logs-${{ github.run_id }}
+          name: unittest-logs-cuda13-${{ github.run_id }}
           path: build/release/extension/sirius/test/cpp/log/
           if-no-files-found: ignore
           retention-days: 14
@@ -209,7 +209,16 @@ jobs:
         run: tar -xf build.tar
 
       - name: Run C++ unit tests
-        run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+        run: timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+
+      - name: Upload unit test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unittest-logs-cuda12-${{ github.run_id }}
+          path: build/release/extension/sirius/test/cpp/log/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Prepare SQL test datasets
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,3 +248,27 @@ jobs:
           name: tpch-run-${{ github.run_id }}-cuda-12
           path: ${{ steps.tpch.outputs.run_dir }}
           retention-days: 14
+
+  build:
+    runs-on: ubuntu-slim
+    needs: [build-cuda-13, build-cuda-12]
+    if: always()
+    steps:
+      - name: All builds ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some builds failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+  test:
+    runs-on: ubuntu-slim
+    needs: [test-cuda-13, test-cuda-12]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,21 +25,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel existing runs on PRs but run on all `dev` and merge queue commits
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            cuda: cuda-13
-            pixi-env: default
-          - os: ubuntu-22.04
-            cuda: cuda-12
-            pixi-env: cuda12
-
+  build-cuda-13:
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.cuda }}", cpu-xl]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, cpu-xl]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,7 +39,7 @@ jobs:
         with:
           cache: false
           pixi-version: v0.65.0
-          activate-environment: ${{ matrix.pixi-env }}
+          activate-environment: default
 
       - name: Configure sccache backend
         run: |
@@ -75,25 +64,59 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: build-${{ matrix.cuda }}
+          name: build-cuda-13
           path: build.tar
           if-no-files-found: error
           retention-days: 1
 
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            cuda: cuda-13
-            pixi-env: default
-          - os: ubuntu-22.04
-            cuda: cuda-12
-            pixi-env: cuda12
+  build-cuda-12:
+    env:
+      SCCACHE_GHA_ENABLED: true
+    runs-on: [self-hosted, ubuntu-22.04, cuda-12, cpu-xl]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
 
-    runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.cuda }}", gpu-t4]
-    needs: build
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+        with:
+          cache: false
+          pixi-version: v0.65.0
+          activate-environment: cuda12
+
+      - name: Configure sccache backend
+        run: |
+          if [[ -n "${SCCACHE_BUCKET}" ]]; then
+            echo "SCCACHE_BUCKET DEFINED -> Self Hosted Runner, Disable GHA sccache"
+            echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
+          else
+            echo "SCCACHE_BUCKET UNDEFINED -> GitHub Runner, Enable GHA sccache"
+            echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          fi
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Build
+        env:
+          CUDAARCHS: "75" # For Turing, T4 capability
+        run: make -j$(nproc)
+
+      - name: Package build artifacts
+        run: tar -cf build.tar build/release/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-cuda-12
+          path: build.tar
+          if-no-files-found: error
+          retention-days: 1
+
+  test-cuda-13:
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-t4]
+    needs: build-cuda-13
+    if: needs.build-cuda-13.result == 'success'
     timeout-minutes: 60
     env:
       CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
@@ -105,11 +128,11 @@ jobs:
         with:
           cache: false
           pixi-version: v0.65.0
-          activate-environment: ${{ matrix.pixi-env }}
+          activate-environment: default
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: build-${{ matrix.cuda }}
+          name: build-cuda-13
 
       - name: Extract build artifacts
         run: tar -xf build.tar
@@ -160,6 +183,68 @@ jobs:
         if: always() && steps.tpch.outputs.run_dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tpch-run-${{ github.run_id }}-${{ matrix.cuda }}
+          name: tpch-run-${{ github.run_id }}-cuda-13
+          path: ${{ steps.tpch.outputs.run_dir }}
+          retention-days: 14
+
+  test-cuda-12:
+    runs-on: [self-hosted, ubuntu-22.04, cuda-12, gpu-t4]
+    needs: build-cuda-12
+    if: needs.build-cuda-12.result == 'success'
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+        with:
+          cache: false
+          pixi-version: v0.65.0
+          activate-environment: cuda12
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-cuda-12
+
+      - name: Extract build artifacts
+        run: tar -xf build.tar
+
+      - name: Run C++ unit tests
+        run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+
+      - name: Prepare SQL test datasets
+        run: |
+          ./setup_test_datasets.sh
+          chmod -R a+r test_datasets/
+          mkdir -p test_datasets/tpch_parquet_sf1
+          ./build/release/duckdb -f scripts/tpch_to_parquet.sql
+
+      - name: TPC-H performance snapshot
+        id: tpch
+        env:
+          SIRIUS_CONFIG_FILE: ${{ github.workspace }}/test/cpp/integration/integration.yaml
+          PARQUET_DIR: ${{ github.workspace }}/test_datasets/tpch_parquet_sf1
+        run: |
+          ./test/tpch_performance/benchmark_and_validate.sh 1
+          RUN_DIR=$(ls -td runs/*/ | head -1)
+          echo "run_dir=$RUN_DIR" >> "$GITHUB_OUTPUT"
+          {
+            echo "## TPC-H Performance (SF1)"
+            echo '```'
+            cat "$RUN_DIR/comparison.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          ERRORS=$(tail -n +2 "$RUN_DIR/validation.csv" | grep -cE ',error$' || true)
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::TPC-H snapshot: $ERRORS queries errored"
+            if [ "${{ github.event_name }}" = "merge_group" ]; then
+              exit 1
+            fi
+          fi
+
+      - name: Upload TPC-H run artifacts
+        if: always() && steps.tpch.outputs.run_dir != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tpch-run-${{ github.run_id }}-cuda-12
           path: ${{ steps.tpch.outputs.run_dir }}
           retention-days: 14


### PR DESCRIPTION
This week there have been two PRs merged that break `dev` and the Distribution workflows as they are the only workflow to compile and build CUDA 12 versions of Sirius. Both of these PRs used a function introduced to CUDA 12.8 and required version gating to support CUDA 12.x comptatibility

This PR makes two important changes to ensure we catch these issues before they are merged to `dev`

1. New PR testing with a parallel Test workflow that builds and tests CUDA 12
2. Updates the Distribution workflows to use a CUDA 12 Ubuntu 22.04 runner for building CUDA 12 Sirius
  - The pixi environment `cuda12` ensures we have a CUDA 12 environment even when the base image is CUDA 13, this is just to match the testing done in `1` for consistency
  - Also worth noting that CUDA 12 images do exist for Ubunutu 24.04, so we use 22.04 instead; our CUDA 13 build/test uses 24.04