### PR TITLE
CI: Improve CI GPU Testing reliability and debugging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,8 @@ jobs:
     runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-t4]
     needs: build
     timeout-minutes: 60
+    env:
+      CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,16 @@ jobs:
         run: tar -xf build.tar
 
       - name: Run C++ unit tests
-        run: ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+        run: timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+
+      - name: Upload unit test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unittest-logs-${{ github.run_id }}
+          path: build/release/extension/sirius/test/cpp/log/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Prepare SQL test datasets
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
     timeout-minutes: 60
     env:
       CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
+      SIRIUS_LOG_LEVEL: trace
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Sirius
+
+## Getting started
+
+**Prerequisites:** [pixi](https://prefix.dev/) for environment management.
+
+```bash
+git clone --recurse-submodules <repo>
+cd sirius
+pixi shell                              # activate environment
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+```
+
+If you create a new git worktree, initialize submodules manually:
+```bash
+git submodule update --init --recursive
+```
+
+## Running tests
+
+```bash
+# C++ unit tests
+build/release/extension/sirius/test/cpp/sirius_unittest
+
+# Run a specific tag or test name
+build/release/extension/sirius/test/cpp/sirius_unittest "[cpu_cache]"
+build/release/extension/sirius/test/cpp/sirius_unittest "test_cpu_cache_basic_string_single_col"
+
+# SQL logic tests (end-to-end)
+make test
+```
+
+Test logs are written to `build/release/extension/sirius/test/cpp/log/`.
+
+## Code style
+
+Sirius uses pre-commit hooks for formatting and linting. Install them once after cloning:
+
+```bash
+pre-commit install
+```
+
+To run all checks manually:
+
+```bash
+pre-commit run -a
+```
+
+Tools enforced: `clang-format` (C++/CUDA), `black` (Python), `cmake-format`, `codespell`.
+
+## Submodules
+
+The `duckdb/`, `duckdb-python/`, and `vcpkg/` directories are third-party submodules. Their `CONTRIBUTING.md` files apply to contributing to those upstream projects, not to Sirius. Do not modify submodule contents directly.
+
+## Troubleshooting CI failures
+
+When the C++ unit test job fails or times out, the workflow automatically uploads log artifacts to GitHub Actions. Download them from the **Summary** tab of the failed run.
+
+### Available artifacts
+
+| Artifact | Contents | Retained |
+|---|---|---|
+| `unittest-logs-<run_id>` | Sirius log files from the failing test run | 14 days |
+| `tpch-run-<run_id>` | TPC-H benchmark comparison and validation CSV | 14 days |
+
+### How to download
+
+1. Open the failed GitHub Actions run
+2. Scroll to the **Artifacts** section at the bottom of the Summary tab
+3. Click the artifact name to download a zip
+4. The unit test log is at `sirius_<YYYY-MM-DD>.log` inside the zip
+
+### What to look for in `sirius_<date>.log`
+
+- The last test number logged before output stops — this is the test that hung or crashed
+- Any CUDA error messages preceding the hang
+- Stack traces if the binary aborted


### PR DESCRIPTION
This PR improves CI debugging by uploading the unit test logs from the GPU Test workflow in order for devs to review on failed or timed out unit test runs. The log level is `SIRIUS_LOG_LEVEL=trace` for the unit tests now to help with debugging. Unit tests now also time out after `45 min` so there is time to upload the logs before the runner times out.

In order to assist with debugging, an initial `CONTRIBUTING.md` has been added detailing how to view the unit test as well as the TPC-H logs for debugging.

In addition to this change, the CUDA cache has been updated to use the working directory of the runner, ensuring a clean cache each run. 