### PR TITLE
Fix data batch refactor deadlock

### DIFF
--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -357,6 +357,11 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     throw std::runtime_error("gpu_pipeline_task::execute: input_data is null");
   }
 
+  SIRIUS_LOG_TRACE("Pipeline {}: prepare_for_processing starting for operator {} (id={}) [{}]",
+                   pipeline->get_pipeline_id(),
+                   first_op.get_name(),
+                   first_op.get_operator_id(),
+                   op_chain);
   try {
     local_state._input_data->prepare_for_processing(requested_memory_space, stream);
   } catch (const rmm::out_of_memory& oom) {
@@ -381,11 +386,13 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   auto const prepare_end = std::chrono::high_resolution_clock::now();
   auto const prepare_duration =
     std::chrono::duration_cast<std::chrono::microseconds>(prepare_end - prepare_start);
-  SIRIUS_LOG_TRACE("Pipeline {}: operator {} (id={}) prepare execution time: {:.2f} ms",
-                   pipeline->get_pipeline_id(),
-                   first_op.get_name(),
-                   first_op.get_operator_id(),
-                   prepare_duration.count() / 1000.0);
+  SIRIUS_LOG_TRACE(
+    "Pipeline {}: prepare_for_processing completed for operator {} (id={}) [{}] in {:.2f} ms",
+    pipeline->get_pipeline_id(),
+    first_op.get_name(),
+    first_op.get_operator_id(),
+    op_chain,
+    prepare_duration.count() / 1000.0);
 
   // All input batches are now locked for reading via _read_only_data_batches inside
   // local_state._input_data. The locks are released when the pipelineable_operator_data

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -357,11 +357,6 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     throw std::runtime_error("gpu_pipeline_task::execute: input_data is null");
   }
 
-  SIRIUS_LOG_TRACE("Pipeline {}: prepare_for_processing starting for operator {} (id={}) [{}]",
-                   pipeline->get_pipeline_id(),
-                   first_op.get_name(),
-                   first_op.get_operator_id(),
-                   op_chain);
   try {
     local_state._input_data->prepare_for_processing(requested_memory_space, stream);
   } catch (const rmm::out_of_memory& oom) {
@@ -386,13 +381,11 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   auto const prepare_end = std::chrono::high_resolution_clock::now();
   auto const prepare_duration =
     std::chrono::duration_cast<std::chrono::microseconds>(prepare_end - prepare_start);
-  SIRIUS_LOG_TRACE(
-    "Pipeline {}: prepare_for_processing completed for operator {} (id={}) [{}] in {:.2f} ms",
-    pipeline->get_pipeline_id(),
-    first_op.get_name(),
-    first_op.get_operator_id(),
-    op_chain,
-    prepare_duration.count() / 1000.0);
+  SIRIUS_LOG_TRACE("Pipeline {}: operator {} (id={}) prepare execution time: {:.2f} ms",
+                   pipeline->get_pipeline_id(),
+                   first_op.get_name(),
+                   first_op.get_operator_id(),
+                   prepare_duration.count() / 1000.0);
 
   // All input batches are now locked for reading via _read_only_data_batches inside
   // local_state._input_data. The locks are released when the pipelineable_operator_data

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -313,7 +313,10 @@ void sirius_pipeline::update_pipeline_status()
   };
 
   // Skip if already finished — avoids redundant re-evaluation and re-notification.
-  if (pipeline_finished.load()) { return; }
+  if (pipeline_finished.load()) {
+    notify_downstream_pipelines();
+    return;
+  }
 
   if (get_source()->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
     auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -299,6 +299,13 @@ void sirius_pipeline::notify_downstream_pipelines()
 
 void sirius_pipeline::update_pipeline_status()
 {
+  SIRIUS_LOG_TRACE(
+    "update_pipeline_status: pipeline_id={}, source={}, sink={}, already_finished={}",
+    pipeline_id,
+    source ? source->get_name() : "?",
+    sink ? sink->get_name() : "?",
+    pipeline_finished.load());
+
   auto end_nvtx_range_if_finished = [this]() {
     if (pipeline_finished.load() && _nvtx_range_started.load()) {
       nvtxRangeEnd(_nvtx_pipeline_range_id);
@@ -312,6 +319,9 @@ void sirius_pipeline::update_pipeline_status()
     auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
     if (table_scan.exhausted) {  // WSM amin TODO: can we use exhausted? how about we use
                                  // get_next_task_hint() to check if the source is ready?
+      SIRIUS_LOG_TRACE(
+        "update_pipeline_status: pipeline_id={} set to completed (DUCKDB_SCAN exhausted)",
+        pipeline_id);
       pipeline_finished.store(true);
       end_nvtx_range_if_finished();
       notify_downstream_pipelines();
@@ -321,6 +331,12 @@ void sirius_pipeline::update_pipeline_status()
     auto& cpu_source = get_source()->Cast<op::sirius_physical_cpu_source>();
     if (cpu_source.exhausted.load()) {
       if (tasks_created.load() == tasks_completed.load()) {
+        SIRIUS_LOG_TRACE(
+          "update_pipeline_status: pipeline_id={} set to completed (CPU_SOURCE exhausted, "
+          "tasks_created={}, tasks_completed={})",
+          pipeline_id,
+          tasks_created.load(),
+          tasks_completed.load());
         pipeline_finished = true;
         notify_downstream_pipelines();
       }
@@ -343,6 +359,13 @@ void sirius_pipeline::update_pipeline_status()
     if (limit_exhausted ||
         (first_node->is_source_pipeline_finished() && first_node->all_ports_empty())) {
       if (tasks_created.load() == tasks_completed.load()) {
+        SIRIUS_LOG_TRACE(
+          "update_pipeline_status: pipeline_id={} set to completed (limit_exhausted={}, "
+          "tasks_created={}, tasks_completed={})",
+          pipeline_id,
+          limit_exhausted,
+          tasks_created.load(),
+          tasks_completed.load());
         pipeline_finished.store(true);
         for (auto& op : get_operators()) {
           op.get().finalize_operator();

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -299,13 +299,6 @@ void sirius_pipeline::notify_downstream_pipelines()
 
 void sirius_pipeline::update_pipeline_status()
 {
-  SIRIUS_LOG_TRACE(
-    "update_pipeline_status: pipeline_id={}, source={}, sink={}, already_finished={}",
-    pipeline_id,
-    source ? source->get_name() : "?",
-    sink ? sink->get_name() : "?",
-    pipeline_finished.load());
-
   auto end_nvtx_range_if_finished = [this]() {
     if (pipeline_finished.load() && _nvtx_range_started.load()) {
       nvtxRangeEnd(_nvtx_pipeline_range_id);
@@ -322,9 +315,6 @@ void sirius_pipeline::update_pipeline_status()
     auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
     if (table_scan.exhausted) {  // WSM amin TODO: can we use exhausted? how about we use
                                  // get_next_task_hint() to check if the source is ready?
-      SIRIUS_LOG_TRACE(
-        "update_pipeline_status: pipeline_id={} set to completed (DUCKDB_SCAN exhausted)",
-        pipeline_id);
       pipeline_finished.store(true);
       end_nvtx_range_if_finished();
       notify_downstream_pipelines();
@@ -334,12 +324,6 @@ void sirius_pipeline::update_pipeline_status()
     auto& cpu_source = get_source()->Cast<op::sirius_physical_cpu_source>();
     if (cpu_source.exhausted.load()) {
       if (tasks_created.load() == tasks_completed.load()) {
-        SIRIUS_LOG_TRACE(
-          "update_pipeline_status: pipeline_id={} set to completed (CPU_SOURCE exhausted, "
-          "tasks_created={}, tasks_completed={})",
-          pipeline_id,
-          tasks_created.load(),
-          tasks_completed.load());
         pipeline_finished = true;
         notify_downstream_pipelines();
       }
@@ -362,13 +346,6 @@ void sirius_pipeline::update_pipeline_status()
     if (limit_exhausted ||
         (first_node->is_source_pipeline_finished() && first_node->all_ports_empty())) {
       if (tasks_created.load() == tasks_completed.load()) {
-        SIRIUS_LOG_TRACE(
-          "update_pipeline_status: pipeline_id={} set to completed (limit_exhausted={}, "
-          "tasks_created={}, tasks_completed={})",
-          pipeline_id,
-          limit_exhausted,
-          tasks_created.load(),
-          tasks_completed.load());
         pipeline_finished.store(true);
         for (auto& op : get_operators()) {
           op.get().finalize_operator();


### PR DESCRIPTION
I am adding a new notification of downstream pipelines to trigger when a pipeline is updated to check that its finished even tough its already finished. 
The fact this is happening means we have a race condition which needs to be properly fixed, but this patches it for now