### PR TITLE
s3datasource credential providers - (2/3) of S3 to parquet scan path 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,9 @@ set(TEST_SOURCES
     test/cpp/expression_executor/test_gpu_expression_executor.cpp
     test/cpp/expression_executor/test_gpu_expression_translator.cpp
     test/cpp/helper/test_logical_type.cpp
+    test/cpp/io/s3/test_sigv4.cpp
+    test/cpp/io/s3/test_sirius_sigv4_credential_provider.cpp
+    test/cpp/io/s3/test_static_credentials.cpp
     test/cpp/io/test_datasource_factory.cpp
     test/cpp/io/test_uri_parser.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ find_package(spdlog REQUIRED CONFIG)
 find_package(yaml-cpp REQUIRED CONFIG)
 find_package(absl REQUIRED CONFIG)
 find_package(PkgConfig REQUIRED)
+find_package(OpenSSL REQUIRED)
 pkg_check_modules(NUMA REQUIRED IMPORTED_TARGET numa)
 pkg_check_modules(LIBURING REQUIRED IMPORTED_TARGET liburing)
 
@@ -164,6 +165,8 @@ set(EXTENSION_SOURCES
     src/io/admission_control.cpp
     src/io/datasource_factory.cpp
     src/io/prefetching_cache.cpp
+    src/io/s3/sigv4.cpp
+    src/io/s3/sirius_sigv4_credential_provider.cpp
     src/io/sirius_datasource.cpp
     src/io/uri_parser.cpp
     src/io/uring/uring_ioctx.cpp
@@ -330,9 +333,10 @@ endforeach()
 
 # Additional libraries only needed by the static extension
 target_link_libraries(sirius_extension PkgConfig::NUMA PkgConfig::LIBURING
-                      yaml-cpp::yaml-cpp absl::any_invocable)
+                      OpenSSL::Crypto yaml-cpp::yaml-cpp absl::any_invocable)
 
-target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING)
+target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
+                      OpenSSL::Crypto)
 
 # Required by DuckDB's export set (duckdb_static -> sirius_extension ->
 # cucascade_static / telemetry_bridge)

--- a/src/include/io/io_errors.hpp
+++ b/src/include/io/io_errors.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+namespace sirius::io {
+
+/**
+ * @brief Raised by @c credential_provider implementations when credential
+ *        acquisition or signing fails.
+ *
+ * Surfaces from:
+ *   - missing or malformed static credentials (caught at provider construction
+ *     or first call),
+ *   - misconfigured endpoint / region,
+ *   - underlying signing-library failure (HMAC / SHA256),
+ *   - upstream credential broker errors (in future refresh-aware impls).
+ *
+ * Backends translate this into the broader IO error path of the caller.
+ * Future IO-layer error types share this header.
+ */
+class credential_error : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+}  // namespace sirius::io

--- a/src/include/io/s3/credential_provider.hpp
+++ b/src/include/io/s3/credential_provider.hpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace sirius::io::s3 {
+
+/// Method-specific presigned URL request. AWS presigned URLs are bound to
+/// the HTTP method specified at signing time (presigned-GET != presigned-HEAD)
+/// — passing the wrong method to the underlying HTTP client results in a
+/// SignatureDoesNotMatch error from S3. Sirius needs only read-only S3
+/// operations; PUT / DELETE etc. are intentionally absent.
+enum class presign_method : std::uint8_t { GET, HEAD };
+
+/**
+ * @brief Object reference passed to @c credential_provider::get_presigned_url.
+ *
+ * @c bucket carries the object-store bucket name (no scheme, no trailing
+ * slashes). @c key carries the object key, RFC3986-decoded — the provider
+ * re-encodes for canonical URI construction.
+ */
+struct s3_object_ref {
+  std::string bucket;
+  std::string key;
+};
+
+/**
+ * @brief Pluggable source of presigned object URLs (credential / signer seam).
+ *
+ * Lets downstream projects plug in their own credential / signer
+ * implementation (AWS SDK presigner, internal auth broker, IMDS-backed STS
+ * chain, SSO, ...) without forcing Sirius to depend on @c aws-sdk-cpp.
+ * Sirius ships @c sirius_sigv4_credential_provider as the default impl using
+ * the existing hand-rolled SigV4 over @c static_credentials.
+ *
+ * The public surface is intentionally presign-only — there is no
+ * @c get_credentials() method. Implementations that lack raw key material
+ * (signed-URL services, broker-issued URLs) compose cleanly.
+ *
+ * @par Lifetime
+ *   Implementations should be safe to share across threads via @c shared_ptr.
+ *   Backends call @c get_presigned_url() once per request, inline at the
+ *   call site that issues the underlying HTTP request. Never call at
+ *   scan-task creation time — presigned URLs carry an expiration and may
+ *   become invalid before the deferred task runs.
+ *
+ * @par Errors
+ *   Implementations throw @c sirius::io::credential_error on credential /
+ *   signing failure. Backends translate into the broader IO error path.
+ */
+class credential_provider {
+ public:
+  virtual ~credential_provider() = default;
+
+  credential_provider()                                      = default;
+  credential_provider(credential_provider const&)            = delete;
+  credential_provider& operator=(credential_provider const&) = delete;
+
+  /**
+   * @brief Generate a presigned URL for the given object + HTTP method.
+   *
+   * The returned URL is fully qualified (@c "scheme://host/canonical_uri?...").
+   * Caller appends a @c Range header on the actual HTTP request when needed
+   * — the presigned URL signs only the @c host header so range / accept /
+   * etc. headers may be added unsigned without invalidating the signature.
+   *
+   * @throw sirius::io::credential_error on credential / signing failure.
+   */
+  [[nodiscard]] virtual std::string get_presigned_url(s3_object_ref const& obj,
+                                                      presign_method method) = 0;
+};
+
+}  // namespace sirius::io::s3

--- a/src/include/io/s3/mock_credential_provider.hpp
+++ b/src/include/io/s3/mock_credential_provider.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "io/io_errors.hpp"
+#include "io/s3/credential_provider.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace sirius::io::s3 {
+
+/**
+ * @brief Test-only @c credential_provider that returns a canned URL or throws.
+ *
+ * Header-only so the S3 reactor PR (PR3) and downstream test suites can
+ * include it without a separate library target. Produces deterministic
+ * output for unit tests of code that consumes @c credential_provider through
+ * the abstract base class — typical pattern is:
+ *
+ * @code
+ *   auto provider = std::make_shared<mock_credential_provider>("https://canned/url");
+ *   reactor->set_credentials(provider);
+ *   reactor->read(obj);
+ *   CHECK(provider->call_count() == 1);
+ *   CHECK(provider->last_bucket() == "mybucket");
+ * @endcode
+ *
+ * Default behavior: every call to @c get_presigned_url returns the URL
+ * passed to the constructor verbatim (independent of @p obj / @p method) so
+ * tests can verify "the reactor passed our URL to libcurl unchanged". To
+ * exercise error paths, call @c set_throw to make subsequent calls throw
+ * @c sirius::io::credential_error.
+ *
+ * Thread safety: counters are atomic; @c last_bucket / @c last_key are
+ * guarded by an internal mutex. Safe to share across threads when tests
+ * exercise concurrent reactor paths.
+ */
+class mock_credential_provider final : public credential_provider {
+ public:
+  explicit mock_credential_provider(std::string url) : _url(std::move(url)) {}
+
+  std::string get_presigned_url(s3_object_ref const& obj, presign_method method) override
+  {
+    ++_call_count;
+    if (method == presign_method::GET) ++_get_count;
+    if (method == presign_method::HEAD) ++_head_count;
+    {
+      std::scoped_lock lk{_last_mtx};
+      _last_bucket = obj.bucket;
+      _last_key    = obj.key;
+    }
+    if (_should_throw.load()) {
+      std::string msg;
+      {
+        std::scoped_lock lk{_last_mtx};
+        msg =
+          _throw_msg.empty() ? std::string{"mock_credential_provider: forced failure"} : _throw_msg;
+      }
+      throw credential_error(msg);
+    }
+    return _url;
+  }
+
+  /// Subsequent calls throw @c credential_error with @p msg (or default).
+  void set_throw(std::string msg = {})
+  {
+    {
+      std::scoped_lock lk{_last_mtx};
+      _throw_msg = std::move(msg);
+    }
+    _should_throw.store(true);
+  }
+
+  /// Stop throwing.
+  void clear_throw()
+  {
+    _should_throw.store(false);
+    {
+      std::scoped_lock lk{_last_mtx};
+      _throw_msg.clear();
+    }
+  }
+
+  [[nodiscard]] int call_count() const noexcept { return _call_count.load(); }
+  [[nodiscard]] int get_count() const noexcept { return _get_count.load(); }
+  [[nodiscard]] int head_count() const noexcept { return _head_count.load(); }
+
+  [[nodiscard]] std::string last_bucket() const
+  {
+    std::scoped_lock lk{_last_mtx};
+    return _last_bucket;
+  }
+  [[nodiscard]] std::string last_key() const
+  {
+    std::scoped_lock lk{_last_mtx};
+    return _last_key;
+  }
+
+ private:
+  std::string _url;
+  std::atomic<int> _call_count{0};
+  std::atomic<int> _get_count{0};
+  std::atomic<int> _head_count{0};
+  std::atomic<bool> _should_throw{false};
+  mutable std::mutex _last_mtx;
+  std::string _last_bucket;
+  std::string _last_key;
+  std::string _throw_msg;
+};
+
+}  // namespace sirius::io::s3

--- a/src/include/io/s3/sigv4.hpp
+++ b/src/include/io/s3/sigv4.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace sirius::io::s3 {
+
+/// Static credentials + region/service for SigV4 signing.
+///
+/// @c session_token is non-empty for temporary credentials (STS / IMDS / SSO);
+/// when non-empty, @c sign_request injects it as the @c x-amz-security-token
+/// header and @c presign_url injects it as the @c X-Amz-Security-Token query
+/// parameter. The token participates in the signature in both cases.
+struct sigv4_signer_config {
+  std::string access_key;
+  std::string secret_key;
+  std::string region;
+  std::string service = "s3";
+  std::string session_token;
+};
+
+/// Headers to attach to an HTTP request, in the order caller should emit them.
+/// Caller adds every entry verbatim (Authorization, x-amz-date, etc.).
+struct sigv4_signed_request {
+  std::vector<std::pair<std::string, std::string>> headers;
+};
+
+/**
+ * @brief Sign an HTTP request using AWS Signature Version 4.
+ *
+ * Computes the canonical request / string-to-sign / signing key chain per
+ * https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html and returns
+ * the full set of headers the caller must attach.
+ *
+ * @param method             HTTP method (`"GET"`, `"HEAD"`).
+ * @param host               Host header value (e.g. `"s3.us-west-2.amazonaws.com"`
+ *                           or `"minio.local:9000"`).
+ * @param canonical_uri      URI path, already RFC3986-encoded (e.g. `"/bucket/key"`).
+ * @param canonical_query    Canonical query string, already encoded & sorted; empty if none.
+ * @param payload_sha256_hex Hex SHA256 of the request body. For GET/HEAD with
+ *                           no body, pass @c sha256_hex("").
+ * @param extra_headers      Additional headers to sign (e.g. `{"range", "bytes=0-99"}`).
+ *                           Keys lowercase; do NOT include `host`, `x-amz-date`,
+ *                           or `x-amz-content-sha256` here — they are added
+ *                           automatically.
+ * @param creds              Access key, secret key, region, service.
+ * @param timestamp_utc      Seconds since epoch; sign produces `x-amz-date`
+ *                           and the scope's date from this. Passed explicitly
+ *                           so tests are deterministic.
+ *
+ * @throw std::invalid_argument on empty credentials.
+ */
+sigv4_signed_request sign_request(
+  std::string_view method,
+  std::string_view host,
+  std::string_view canonical_uri,
+  std::string_view canonical_query,
+  std::string_view payload_sha256_hex,
+  std::vector<std::pair<std::string, std::string>> const& extra_headers,
+  sigv4_signer_config const& creds,
+  std::time_t timestamp_utc);
+
+/**
+ * @brief Build a SigV4 presigned URL.
+ *
+ * Authentication parameters go in the query string (X-Amz-Algorithm,
+ * X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-SignedHeaders, optional
+ * X-Amz-Security-Token, X-Amz-Signature). Returns the fully-qualified URL.
+ *
+ * Unlike @c sign_request, this path uses @c "UNSIGNED-PAYLOAD" as the canonical
+ * payload hash (the body of the actual request is not part of the presigned
+ * URL's signature; only @c host is signed) so callers may freely add @c Range
+ * or other unsigned headers to the resulting GET / HEAD without breaking the
+ * signature.
+ *
+ * @param method        HTTP method (@c "GET" / @c "HEAD" — the only methods
+ *                      Sirius uses for read-only S3).
+ * @param scheme        URL scheme (@c "http" / @c "https"), already lowercase.
+ * @param host          Host[:port], already lowercase.
+ * @param canonical_uri URI path, already RFC3986-encoded
+ *                      (e.g. @c "/bucket/key" or @c "/bucket/path%20space.parquet").
+ * @param creds         Access key, secret key, region, service, optional
+ *                      @c session_token.
+ * @param timestamp_utc Seconds since epoch; @c X-Amz-Date is derived from this.
+ *                      Passed explicitly so tests are deterministic.
+ * @param ttl           Validity window. Becomes the @c X-Amz-Expires query
+ *                      parameter (in seconds).
+ *
+ * @throw std::invalid_argument on empty credentials / region / service /
+ *                              method / scheme / host, or non-positive @p ttl.
+ */
+std::string presign_url(std::string_view method,
+                        std::string_view scheme,
+                        std::string_view host,
+                        std::string_view canonical_uri,
+                        sigv4_signer_config const& creds,
+                        std::time_t timestamp_utc,
+                        std::chrono::seconds ttl);
+
+/// Hex-encoded SHA256 digest of @p data. Thin wrapper around OpenSSL SHA256.
+std::string sha256_hex(std::string_view data);
+
+/// RFC 3986 URI-encode @p s. If @p encode_slash is false, `/` passes through
+/// (used for path segments); if true, `/` becomes `%2F` (used for query components).
+std::string uri_encode(std::string_view s, bool encode_slash);
+
+}  // namespace sirius::io::s3

--- a/src/include/io/s3/sirius_sigv4_credential_provider.hpp
+++ b/src/include/io/s3/sirius_sigv4_credential_provider.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "io/s3/credential_provider.hpp"
+#include "io/s3/static_credentials.hpp"
+
+#include <chrono>
+#include <string>
+
+namespace sirius::io::s3 {
+
+/**
+ * @brief Default @c credential_provider implementation: hand-rolled SigV4
+ *        over static credentials.
+ *
+ * Wraps the @c sirius::io::s3::sigv4 module to produce presigned URLs without
+ * pulling in @c aws-sdk-cpp. Suitable for:
+ *   - production with long-lived access keys (typical SET s3_access_key /
+ *     s3_secret_key flow),
+ *   - production with externally-rotated temporary credentials (caller
+ *     reconstructs the provider on rotation; this impl does not refresh).
+ *
+ * Downstream projects that want refresh-aware credentials (IMDS / STS chain /
+ * SSO) should ship their own @c credential_provider implementation; the
+ * public surface is presign-only so they can do so without exposing raw keys
+ * to Sirius.
+ */
+class sirius_sigv4_credential_provider final : public credential_provider {
+ public:
+  /**
+   * @brief Construct with static credentials, signing scope, endpoint, and
+   *        default TTL.
+   *
+   * @param creds        Access key, secret key, optional session token,
+   *                     optional @c expires_at (informational only — this
+   *                     impl does not refresh).
+   * @param region       Signing region (e.g. @c "us-east-1").
+   * @param endpoint     Fully-qualified service URL:
+   *                     @c "https://s3.us-east-1.amazonaws.com",
+   *                     @c "http://minio.local:9000", etc. Must be
+   *                     scheme://host[:port] with no path / query / fragment.
+   * @param default_ttl  @c X-Amz-Expires for every presigned URL produced.
+   *                     Default 5 minutes — inline-at-request-time presigning
+   *                     means URLs are issued just before the libcurl call,
+   *                     so a short TTL is safe and limits the blast radius
+   *                     of an accidentally-leaked URL.
+   *
+   * @throw sirius::io::credential_error on empty creds, empty region,
+   *                                     non-positive @p default_ttl, or
+   *                                     malformed endpoint.
+   */
+  sirius_sigv4_credential_provider(static_credentials creds,
+                                   std::string region,
+                                   std::string endpoint,
+                                   std::chrono::seconds default_ttl = std::chrono::minutes{5});
+
+  /**
+   * @brief Generate a SigV4 presigned URL for path-style S3 access:
+   *        @c "{scheme}://{host}/{bucket}/{key}?X-Amz-...".
+   *
+   * Thread-safe: the underlying @c sigv4::presign_url is pure (no shared
+   * mutable state) and this provider's members are immutable after
+   * construction.
+   *
+   * @throw sirius::io::credential_error on empty bucket / key, or any failure
+   *                                     surfaced from the SigV4 layer.
+   */
+  std::string get_presigned_url(s3_object_ref const& obj, presign_method method) override;
+
+ private:
+  static_credentials _creds;
+  std::string _region;
+  std::string _scheme;  // "https" / "http"
+  std::string _host;    // host[:port]
+  std::chrono::seconds _ttl;
+};
+
+}  // namespace sirius::io::s3

--- a/src/include/io/s3/static_credentials.hpp
+++ b/src/include/io/s3/static_credentials.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+namespace sirius::io::s3 {
+
+/**
+ * @brief Credentials snapshot consumed by @c sirius_sigv4_credential_provider's
+ *        constructor (and other static-creds-based providers).
+ *
+ * Long-lived creds (typical SET s3_access_key / s3_secret_key flow): leave
+ * @c session_token empty and @c expires_at @c nullopt.
+ *
+ * Temporary creds (STS AssumeRole / IMDS / SSO): populate @c session_token;
+ * set @c expires_at when the source can report it. The static provider treats
+ * @c expires_at as informational; future refresh-aware providers (downstream)
+ * may use it to schedule re-acquisition.
+ *
+ * This is a pure POD by design: integration code constructs it from
+ * @c object_store_config string fields, hands it to the provider's
+ * constructor, and the provider holds an internal copy. There is no public
+ * accessor on @c credential_provider to read these back — the seam is
+ * presigned-URL-only (see @c credential_provider.hpp).
+ */
+struct static_credentials {
+  std::string access_key_id;
+  std::string secret_access_key;
+  std::string session_token;
+  std::optional<std::chrono::system_clock::time_point> expires_at;
+};
+
+}  // namespace sirius::io::s3

--- a/src/io/s3/sigv4.cpp
+++ b/src/io/s3/sigv4.cpp
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/s3/sigv4.hpp"
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <stdexcept>
+
+namespace sirius::io::s3 {
+
+namespace {
+
+constexpr char kHexLower[] = "0123456789abcdef";
+
+std::string hex_encode(unsigned char const* data, std::size_t len)
+{
+  std::string out;
+  out.resize(len * 2);
+  for (std::size_t i = 0; i < len; ++i) {
+    out[2 * i]     = kHexLower[(data[i] >> 4) & 0xF];
+    out[2 * i + 1] = kHexLower[data[i] & 0xF];
+  }
+  return out;
+}
+
+// Raw HMAC-SHA256. Returns 32 bytes.
+std::array<unsigned char, 32> hmac_sha256(std::string_view key, std::string_view msg)
+{
+  std::array<unsigned char, 32> out{};
+  unsigned int len = 0;
+  // HMAC returns nullptr on failure; for HMAC-SHA256 on valid inputs that
+  // should never happen, but guard anyway so we fail loudly rather than
+  // produce a silently-zero signature.
+  if (HMAC(EVP_sha256(),
+           key.data(),
+           static_cast<int>(key.size()),
+           reinterpret_cast<unsigned char const*>(msg.data()),
+           msg.size(),
+           out.data(),
+           &len) == nullptr ||
+      len != out.size()) {
+    throw std::runtime_error("sigv4: HMAC-SHA256 failed");
+  }
+  return out;
+}
+
+// Trim leading/trailing ASCII spaces. SigV4 canonicalization does not
+// collapse interior runs for our header set (host/date/content-sha256/range),
+// so this simple trim is sufficient.
+std::string trim_header_value(std::string_view v)
+{
+  std::size_t b = 0;
+  std::size_t e = v.size();
+  while (b < e && (v[b] == ' ' || v[b] == '\t'))
+    ++b;
+  while (e > b && (v[e - 1] == ' ' || v[e - 1] == '\t'))
+    --e;
+  return std::string(v.substr(b, e - b));
+}
+
+std::string to_lower(std::string_view s)
+{
+  std::string out(s);
+  for (auto& c : out)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return out;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+std::string sha256_hex(std::string_view data)
+{
+  std::array<unsigned char, SHA256_DIGEST_LENGTH> md{};
+  SHA256(reinterpret_cast<unsigned char const*>(data.data()), data.size(), md.data());
+  return hex_encode(md.data(), md.size());
+}
+
+std::string uri_encode(std::string_view s, bool encode_slash)
+{
+  static constexpr char kHexUpper[] = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char c : s) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                      c == '-' || c == '_' || c == '.' || c == '~';
+    if (unreserved || (c == '/' && !encode_slash)) {
+      out.push_back(static_cast<char>(c));
+    } else {
+      out.push_back('%');
+      out.push_back(kHexUpper[(c >> 4) & 0xF]);
+      out.push_back(kHexUpper[c & 0xF]);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// sign_request
+// ---------------------------------------------------------------------------
+
+sigv4_signed_request sign_request(
+  std::string_view method,
+  std::string_view host,
+  std::string_view canonical_uri,
+  std::string_view canonical_query,
+  std::string_view payload_sha256_hex,
+  std::vector<std::pair<std::string, std::string>> const& extra_headers,
+  sigv4_signer_config const& creds,
+  std::time_t timestamp_utc)
+{
+  if (creds.access_key.empty() || creds.secret_key.empty() || creds.region.empty() ||
+      creds.service.empty()) {
+    throw std::invalid_argument("sigv4: empty credentials/region/service");
+  }
+
+  // ---- 1. Format timestamp. ----
+  std::tm tm_utc{};
+  ::gmtime_r(&timestamp_utc, &tm_utc);
+
+  char amz_date[17];   // YYYYMMDDTHHMMSSZ + NUL
+  char date_stamp[9];  // YYYYMMDD + NUL
+  std::strftime(amz_date, sizeof(amz_date), "%Y%m%dT%H%M%SZ", &tm_utc);
+  std::strftime(date_stamp, sizeof(date_stamp), "%Y%m%d", &tm_utc);
+
+  // ---- 2. Assemble the full header set that will be signed. ----
+  // host, x-amz-date, x-amz-content-sha256 are always signed; x-amz-security-token
+  // is auto-injected when creds carry a session token (temporary creds: STS /
+  // IMDS / SSO). Caller-supplied extras are merged in. Keys are lowercased and
+  // sorted.
+  std::vector<std::pair<std::string, std::string>> headers;
+  headers.reserve(3 + (creds.session_token.empty() ? 0 : 1) + extra_headers.size());
+  headers.emplace_back("host", std::string(host));
+  headers.emplace_back("x-amz-content-sha256", std::string(payload_sha256_hex));
+  headers.emplace_back("x-amz-date", amz_date);
+  if (!creds.session_token.empty()) {
+    headers.emplace_back("x-amz-security-token", creds.session_token);
+  }
+  for (auto const& [k, v] : extra_headers) {
+    headers.emplace_back(to_lower(k), trim_header_value(v));
+  }
+  std::sort(
+    headers.begin(), headers.end(), [](auto const& a, auto const& b) { return a.first < b.first; });
+
+  // ---- 3. Canonical headers + signed header list. ----
+  std::string canonical_headers;
+  std::string signed_headers;
+  for (std::size_t i = 0; i < headers.size(); ++i) {
+    canonical_headers += headers[i].first;
+    canonical_headers += ':';
+    canonical_headers += headers[i].second;
+    canonical_headers += '\n';
+    if (i != 0) signed_headers += ';';
+    signed_headers += headers[i].first;
+  }
+
+  // ---- 4. Canonical request. ----
+  std::string canonical_request;
+  canonical_request += method;
+  canonical_request += '\n';
+  canonical_request += canonical_uri;
+  canonical_request += '\n';
+  canonical_request += canonical_query;
+  canonical_request += '\n';
+  canonical_request += canonical_headers;
+  canonical_request += '\n';
+  canonical_request += signed_headers;
+  canonical_request += '\n';
+  canonical_request += payload_sha256_hex;
+
+  // ---- 5. String to sign. ----
+  std::string credential_scope;
+  credential_scope += date_stamp;
+  credential_scope += '/';
+  credential_scope += creds.region;
+  credential_scope += '/';
+  credential_scope += creds.service;
+  credential_scope += "/aws4_request";
+
+  std::string string_to_sign;
+  string_to_sign += "AWS4-HMAC-SHA256\n";
+  string_to_sign += amz_date;
+  string_to_sign += '\n';
+  string_to_sign += credential_scope;
+  string_to_sign += '\n';
+  string_to_sign += sha256_hex(canonical_request);
+
+  // ---- 6. Signing key chain. ----
+  std::string k_secret = "AWS4" + creds.secret_key;
+  auto k_date          = hmac_sha256(k_secret, date_stamp);
+  auto k_region        = hmac_sha256(
+    std::string_view(reinterpret_cast<char const*>(k_date.data()), k_date.size()), creds.region);
+  auto k_service =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_region.data()), k_region.size()),
+                creds.service);
+  auto k_signing =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_service.data()), k_service.size()),
+                "aws4_request");
+  auto sig =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_signing.data()), k_signing.size()),
+                string_to_sign);
+
+  std::string signature_hex = hex_encode(sig.data(), sig.size());
+
+  // ---- 7. Authorization header. ----
+  std::string authorization;
+  authorization += "AWS4-HMAC-SHA256 Credential=";
+  authorization += creds.access_key;
+  authorization += '/';
+  authorization += credential_scope;
+  authorization += ", SignedHeaders=";
+  authorization += signed_headers;
+  authorization += ", Signature=";
+  authorization += signature_hex;
+
+  // ---- 8. Assemble response headers. Order mirrors what a caller would
+  //         typically emit: Authorization last so it's easy to spot in logs.
+  sigv4_signed_request out;
+  out.headers.reserve(3 + (creds.session_token.empty() ? 0 : 1) + extra_headers.size());
+  out.headers.emplace_back("Host", std::string(host));
+  out.headers.emplace_back("x-amz-date", amz_date);
+  out.headers.emplace_back("x-amz-content-sha256", std::string(payload_sha256_hex));
+  if (!creds.session_token.empty()) {
+    out.headers.emplace_back("x-amz-security-token", creds.session_token);
+  }
+  for (auto const& [k, v] : extra_headers) {
+    out.headers.emplace_back(k, v);
+  }
+  out.headers.emplace_back("Authorization", std::move(authorization));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// presign_url
+// ---------------------------------------------------------------------------
+
+std::string presign_url(std::string_view method,
+                        std::string_view scheme,
+                        std::string_view host,
+                        std::string_view canonical_uri,
+                        sigv4_signer_config const& creds,
+                        std::time_t timestamp_utc,
+                        std::chrono::seconds ttl)
+{
+  if (creds.access_key.empty() || creds.secret_key.empty() || creds.region.empty() ||
+      creds.service.empty()) {
+    throw std::invalid_argument("sigv4: empty credentials/region/service");
+  }
+  if (method.empty() || scheme.empty() || host.empty()) {
+    throw std::invalid_argument("sigv4: empty method/scheme/host");
+  }
+  if (ttl.count() <= 0) { throw std::invalid_argument("sigv4: ttl must be positive"); }
+
+  // ---- 1. Format timestamp. ----
+  std::tm tm_utc{};
+  ::gmtime_r(&timestamp_utc, &tm_utc);
+
+  char amz_date[17];   // YYYYMMDDTHHMMSSZ + NUL
+  char date_stamp[9];  // YYYYMMDD + NUL
+  std::strftime(amz_date, sizeof(amz_date), "%Y%m%dT%H%M%SZ", &tm_utc);
+  std::strftime(date_stamp, sizeof(date_stamp), "%Y%m%d", &tm_utc);
+
+  // ---- 2. Credential scope and credential query-param value. ----
+  std::string credential_scope;
+  credential_scope += date_stamp;
+  credential_scope += '/';
+  credential_scope += creds.region;
+  credential_scope += '/';
+  credential_scope += creds.service;
+  credential_scope += "/aws4_request";
+
+  std::string credential_qparam = creds.access_key;
+  credential_qparam += '/';
+  credential_qparam += credential_scope;
+
+  // ---- 3. Canonical query string.
+  //         All X-Amz-* parameters that participate in the signature, sorted
+  //         by key (alphabetical), each value RFC3986-encoded with
+  //         encode_slash=true (per AWS query-encoding rules). The
+  //         X-Amz-Signature itself is appended *after* signing — it is not
+  //         part of the canonical request. ----
+  std::vector<std::pair<std::string, std::string>> qparams;
+  qparams.reserve(6);
+  qparams.emplace_back("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+  qparams.emplace_back("X-Amz-Credential", credential_qparam);
+  qparams.emplace_back("X-Amz-Date", amz_date);
+  qparams.emplace_back("X-Amz-Expires", std::to_string(ttl.count()));
+  if (!creds.session_token.empty()) {
+    qparams.emplace_back("X-Amz-Security-Token", creds.session_token);
+  }
+  qparams.emplace_back("X-Amz-SignedHeaders", "host");
+
+  std::sort(
+    qparams.begin(), qparams.end(), [](auto const& a, auto const& b) { return a.first < b.first; });
+
+  std::string canonical_query;
+  for (std::size_t i = 0; i < qparams.size(); ++i) {
+    if (i != 0) canonical_query += '&';
+    canonical_query += uri_encode(qparams[i].first, /*encode_slash=*/true);
+    canonical_query += '=';
+    canonical_query += uri_encode(qparams[i].second, /*encode_slash=*/true);
+  }
+
+  // ---- 4. Canonical headers (host only) and signed headers list. ----
+  std::string canonical_headers = "host:";
+  canonical_headers += host;
+  canonical_headers += '\n';
+  std::string const signed_headers = "host";
+
+  // ---- 5. Canonical request. Payload hash field is the literal string
+  //         "UNSIGNED-PAYLOAD" — this is the key difference from the
+  //         header-based sign_request path. ----
+  std::string canonical_request;
+  canonical_request += method;
+  canonical_request += '\n';
+  canonical_request += canonical_uri;
+  canonical_request += '\n';
+  canonical_request += canonical_query;
+  canonical_request += '\n';
+  canonical_request += canonical_headers;
+  canonical_request += '\n';
+  canonical_request += signed_headers;
+  canonical_request += '\n';
+  canonical_request += "UNSIGNED-PAYLOAD";
+
+  // ---- 6. String to sign. ----
+  std::string string_to_sign;
+  string_to_sign += "AWS4-HMAC-SHA256\n";
+  string_to_sign += amz_date;
+  string_to_sign += '\n';
+  string_to_sign += credential_scope;
+  string_to_sign += '\n';
+  string_to_sign += sha256_hex(canonical_request);
+
+  // ---- 7. Signing key chain (identical to sign_request). ----
+  std::string k_secret = "AWS4" + creds.secret_key;
+  auto k_date          = hmac_sha256(k_secret, date_stamp);
+  auto k_region        = hmac_sha256(
+    std::string_view(reinterpret_cast<char const*>(k_date.data()), k_date.size()), creds.region);
+  auto k_service =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_region.data()), k_region.size()),
+                creds.service);
+  auto k_signing =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_service.data()), k_service.size()),
+                "aws4_request");
+  auto sig =
+    hmac_sha256(std::string_view(reinterpret_cast<char const*>(k_signing.data()), k_signing.size()),
+                string_to_sign);
+
+  std::string signature_hex = hex_encode(sig.data(), sig.size());
+
+  // ---- 8. Assemble the final URL:
+  //         scheme://host<canonical_uri>?<canonical_query>&X-Amz-Signature=<sig>. ----
+  std::string out;
+  out.reserve(scheme.size() + 3 + host.size() + canonical_uri.size() + 1 + canonical_query.size() +
+              /* &X-Amz-Signature= */ 18 + signature_hex.size());
+  out.append(scheme.data(), scheme.size());
+  out += "://";
+  out.append(host.data(), host.size());
+  out.append(canonical_uri.data(), canonical_uri.size());
+  out += '?';
+  out += canonical_query;
+  out += "&X-Amz-Signature=";
+  out += signature_hex;
+  return out;
+}
+
+}  // namespace sirius::io::s3

--- a/src/io/s3/sirius_sigv4_credential_provider.cpp
+++ b/src/io/s3/sirius_sigv4_credential_provider.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/s3/sirius_sigv4_credential_provider.hpp"
+
+#include "io/io_errors.hpp"
+#include "io/s3/sigv4.hpp"
+
+#include <cctype>
+#include <ctime>
+#include <stdexcept>
+#include <utility>
+
+namespace sirius::io::s3 {
+
+namespace {
+
+/// Lowercase ASCII. RFC 3986 says scheme is case-insensitive and DNS host is
+/// case-insensitive; the SigV4 canonical form requires the lowercased version.
+std::string to_lower(std::string_view s)
+{
+  std::string out(s);
+  for (auto& c : out)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return out;
+}
+
+/// Split @p endpoint into (scheme, host_with_optional_port). Trailing path /
+/// query / fragment is rejected — the endpoint identifies the S3 service, not
+/// a specific bucket or object.
+std::pair<std::string, std::string> parse_endpoint(std::string_view endpoint)
+{
+  if (endpoint.empty()) {
+    throw credential_error("sirius_sigv4_credential_provider: empty endpoint");
+  }
+  auto sep = endpoint.find("://");
+  if (sep == std::string_view::npos) {
+    throw credential_error(
+      "sirius_sigv4_credential_provider: endpoint missing scheme (expected http:// or https://)");
+  }
+  std::string scheme = to_lower(endpoint.substr(0, sep));
+  if (scheme != "http" && scheme != "https") {
+    throw credential_error(
+      "sirius_sigv4_credential_provider: endpoint scheme must be http or https (got '" + scheme +
+      "')");
+  }
+  std::string remainder{endpoint.substr(sep + 3)};
+  // Anything past host[:port] (path, query, fragment) is rejected — endpoint
+  // is service-level, not URL.
+  auto bad = remainder.find_first_of("/?#");
+  if (bad != std::string::npos) {
+    throw credential_error(
+      "sirius_sigv4_credential_provider: endpoint must be scheme://host[:port] only (got "
+      "trailing '" +
+      remainder.substr(bad) + "')");
+  }
+  if (remainder.empty()) {
+    throw credential_error("sirius_sigv4_credential_provider: endpoint missing host");
+  }
+  return {std::move(scheme), to_lower(remainder)};
+}
+
+}  // namespace
+
+sirius_sigv4_credential_provider::sirius_sigv4_credential_provider(static_credentials creds,
+                                                                   std::string region,
+                                                                   std::string endpoint,
+                                                                   std::chrono::seconds default_ttl)
+  : _creds(std::move(creds)), _region(std::move(region)), _ttl(default_ttl)
+{
+  if (_creds.access_key_id.empty() || _creds.secret_access_key.empty()) {
+    throw credential_error(
+      "sirius_sigv4_credential_provider: access_key_id and secret_access_key must be non-empty");
+  }
+  if (_region.empty()) {
+    throw credential_error("sirius_sigv4_credential_provider: region must be non-empty");
+  }
+  if (_ttl.count() <= 0) {
+    throw credential_error("sirius_sigv4_credential_provider: default_ttl must be positive");
+  }
+
+  auto [scheme, host] = parse_endpoint(endpoint);
+  _scheme             = std::move(scheme);
+  _host               = std::move(host);
+}
+
+std::string sirius_sigv4_credential_provider::get_presigned_url(s3_object_ref const& obj,
+                                                                presign_method method)
+{
+  if (obj.bucket.empty()) {
+    throw credential_error("sirius_sigv4_credential_provider: empty bucket");
+  }
+  if (obj.key.empty()) { throw credential_error("sirius_sigv4_credential_provider: empty key"); }
+
+  // Path-style URL: /<bucket>/<key>. Bucket is encoded with encode_slash=true
+  // (no slash valid in bucket names anyway); key is encoded with
+  // encode_slash=false so '/' separators in nested keys pass through.
+  std::string canonical_uri = "/";
+  canonical_uri += uri_encode(obj.bucket, /*encode_slash=*/true);
+  canonical_uri += '/';
+  canonical_uri += uri_encode(obj.key, /*encode_slash=*/false);
+
+  // Translate static_credentials → sigv4_signer_config. Region/service are
+  // signing-scope, separate from the credentials snapshot; session_token
+  // (when present) participates in the signed query.
+  sigv4_signer_config signer{};
+  signer.access_key    = _creds.access_key_id;
+  signer.secret_key    = _creds.secret_access_key;
+  signer.region        = _region;
+  signer.service       = "s3";
+  signer.session_token = _creds.session_token;
+
+  std::string_view method_str;
+  switch (method) {
+    case presign_method::GET: method_str = "GET"; break;
+    case presign_method::HEAD: method_str = "HEAD"; break;
+  }
+
+  try {
+    return presign_url(method_str, _scheme, _host, canonical_uri, signer, std::time(nullptr), _ttl);
+  } catch (credential_error const&) {
+    throw;
+  } catch (std::exception const& e) {
+    throw credential_error(std::string("sirius_sigv4_credential_provider: ") + e.what());
+  }
+}
+
+}  // namespace sirius::io::s3

--- a/test/cpp/io/s3/test_sigv4.cpp
+++ b/test/cpp/io/s3/test_sigv4.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "io/s3/sigv4.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+using sirius::io::s3::presign_url;
+using sirius::io::s3::sha256_hex;
+using sirius::io::s3::sign_request;
+using sirius::io::s3::sigv4_signer_config;
+using sirius::io::s3::uri_encode;
+
+namespace {
+
+sigv4_signer_config aws_example_creds()
+{
+  sigv4_signer_config creds;
+  creds.access_key = "AKIAIOSFODNN7EXAMPLE";
+  creds.secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+  creds.region     = "us-east-1";
+  creds.service    = "s3";
+  return creds;
+}
+
+std::string authorization_header(sirius::io::s3::sigv4_signed_request const& req)
+{
+  for (auto const& [key, value] : req.headers) {
+    if (key == "Authorization") { return value; }
+  }
+  return {};
+}
+
+std::string header_value(sirius::io::s3::sigv4_signed_request const& req, std::string_view wanted)
+{
+  for (auto const& [key, value] : req.headers) {
+    if (key == wanted) { return value; }
+  }
+  return {};
+}
+
+std::string query_string(std::string_view url)
+{
+  auto pos = url.find('?');
+  REQUIRE(pos != std::string_view::npos);
+  return std::string{url.substr(pos + 1)};
+}
+
+std::string query_value(std::string_view url, std::string_view key)
+{
+  auto query  = query_string(url);
+  auto needle = std::string{key} + "=";
+  auto begin  = query.find(needle);
+  if (begin == std::string::npos) { return {}; }
+  begin += needle.size();
+  auto end = query.find('&', begin);
+  if (end == std::string::npos) { end = query.size(); }
+  return query.substr(begin, end - begin);
+}
+
+bool contains(std::string_view haystack, std::string_view needle)
+{
+  return haystack.find(needle) != std::string_view::npos;
+}
+
+bool is_lower_hex_64(std::string_view value)
+{
+  return value.size() == 64 && std::all_of(value.begin(), value.end(), [](unsigned char c) {
+           return std::isdigit(c) || (c >= 'a' && c <= 'f');
+         });
+}
+
+}  // namespace
+
+TEST_CASE("sha256_hex returns standard digests", "[s3][sigv4]")
+{
+  CHECK(sha256_hex("") == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  CHECK(sha256_hex("abc") == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST_CASE("uri_encode follows RFC3986 rules needed by SigV4", "[s3][sigv4]")
+{
+  CHECK(uri_encode("Abc-_.~", false) == "Abc-_.~");
+  CHECK(uri_encode("a/b/c", false) == "a/b/c");
+  CHECK(uri_encode("a/b/c", true) == "a%2Fb%2Fc");
+  CHECK(uri_encode("a b", true) == "a%20b");
+  CHECK(uri_encode("~!@#$", true) == "~%21%40%23%24");
+}
+
+TEST_CASE("sign_request rejects incomplete signer config", "[s3][sigv4]")
+{
+  auto creds = aws_example_creds();
+
+  auto bad = creds;
+  bad.access_key.clear();
+  CHECK_THROWS_AS(sign_request("GET",
+                               "examplebucket.s3.amazonaws.com",
+                               "/test.txt",
+                               "",
+                               sha256_hex(""),
+                               {},
+                               bad,
+                               1369353600),
+                  std::invalid_argument);
+
+  bad = creds;
+  bad.secret_key.clear();
+  CHECK_THROWS_AS(sign_request("GET",
+                               "examplebucket.s3.amazonaws.com",
+                               "/test.txt",
+                               "",
+                               sha256_hex(""),
+                               {},
+                               bad,
+                               1369353600),
+                  std::invalid_argument);
+
+  bad = creds;
+  bad.region.clear();
+  CHECK_THROWS_AS(sign_request("GET",
+                               "examplebucket.s3.amazonaws.com",
+                               "/test.txt",
+                               "",
+                               sha256_hex(""),
+                               {},
+                               bad,
+                               1369353600),
+                  std::invalid_argument);
+
+  bad = creds;
+  bad.service.clear();
+  CHECK_THROWS_AS(sign_request("GET",
+                               "examplebucket.s3.amazonaws.com",
+                               "/test.txt",
+                               "",
+                               sha256_hex(""),
+                               {},
+                               bad,
+                               1369353600),
+                  std::invalid_argument);
+}
+
+TEST_CASE("sign_request signs empty GET payload with sha256 empty digest", "[s3][sigv4]")
+{
+  auto out = sign_request("GET",
+                          "examplebucket.s3.amazonaws.com",
+                          "/test.txt",
+                          "",
+                          sha256_hex(""),
+                          {},
+                          aws_example_creds(),
+                          1369353600);
+
+  CHECK(header_value(out, "x-amz-content-sha256") ==
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  CHECK(contains(authorization_header(out), "SignedHeaders=host;x-amz-content-sha256;x-amz-date"));
+}
+
+TEST_CASE("sign_request injects temporary credential session token header", "[s3][sigv4]")
+{
+  auto creds          = aws_example_creds();
+  creds.session_token = "temporary/session+token=";
+
+  auto out = sign_request("GET",
+                          "examplebucket.s3.amazonaws.com",
+                          "/test.txt",
+                          "",
+                          sha256_hex(""),
+                          {},
+                          creds,
+                          1369353600);
+
+  CHECK(header_value(out, "x-amz-security-token") == "temporary/session+token=");
+  CHECK(contains(authorization_header(out),
+                 "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token"));
+}
+
+TEST_CASE("presign_url matches AWS S3 published query-auth vector", "[s3][sigv4]")
+{
+  auto url = presign_url("GET",
+                         "https",
+                         "examplebucket.s3.amazonaws.com",
+                         "/test.txt",
+                         aws_example_creds(),
+                         1369353600,
+                         std::chrono::seconds{86400});
+
+  CHECK(url ==
+        "https://examplebucket.s3.amazonaws.com/test.txt?"
+        "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+        "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&"
+        "X-Amz-Date=20130524T000000Z&"
+        "X-Amz-Expires=86400&"
+        "X-Amz-SignedHeaders=host&"
+        "X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
+}
+
+TEST_CASE("presign_url binds the signature to the HTTP method", "[s3][sigv4]")
+{
+  auto get_url  = presign_url("GET",
+                             "https",
+                             "examplebucket.s3.amazonaws.com",
+                             "/test.txt",
+                             aws_example_creds(),
+                             1369353600,
+                             std::chrono::seconds{300});
+  auto head_url = presign_url("HEAD",
+                              "https",
+                              "examplebucket.s3.amazonaws.com",
+                              "/test.txt",
+                              aws_example_creds(),
+                              1369353600,
+                              std::chrono::seconds{300});
+
+  CHECK(query_value(get_url, "X-Amz-Signature") != query_value(head_url, "X-Amz-Signature"));
+}
+
+TEST_CASE("presign_url injects session token only when present", "[s3][sigv4]")
+{
+  auto without_token = presign_url("GET",
+                                   "https",
+                                   "examplebucket.s3.amazonaws.com",
+                                   "/test.txt",
+                                   aws_example_creds(),
+                                   1369353600,
+                                   std::chrono::seconds{300});
+  CHECK_FALSE(contains(without_token, "X-Amz-Security-Token="));
+
+  auto creds          = aws_example_creds();
+  creds.session_token = "temporary/session+token=";
+  auto with_token     = presign_url("GET",
+                                "https",
+                                "examplebucket.s3.amazonaws.com",
+                                "/test.txt",
+                                creds,
+                                1369353600,
+                                std::chrono::seconds{300});
+
+  CHECK(contains(with_token, "X-Amz-Security-Token=temporary%2Fsession%2Btoken%3D"));
+  CHECK(query_value(with_token, "X-Amz-Signature") !=
+        query_value(without_token, "X-Amz-Signature"));
+}
+
+TEST_CASE("presign_url keeps canonical query ordering deterministic", "[s3][sigv4]")
+{
+  auto creds          = aws_example_creds();
+  creds.session_token = "token";
+  auto url            = presign_url("GET",
+                         "https",
+                         "examplebucket.s3.amazonaws.com",
+                         "/test.txt",
+                         creds,
+                         1369353600,
+                         std::chrono::seconds{300});
+  auto query          = query_string(url);
+
+  auto algorithm      = query.find("X-Amz-Algorithm=");
+  auto credential     = query.find("X-Amz-Credential=");
+  auto date           = query.find("X-Amz-Date=");
+  auto expires        = query.find("X-Amz-Expires=");
+  auto token          = query.find("X-Amz-Security-Token=");
+  auto signed_headers = query.find("X-Amz-SignedHeaders=");
+  auto signature      = query.find("X-Amz-Signature=");
+
+  REQUIRE(algorithm != std::string::npos);
+  REQUIRE(credential != std::string::npos);
+  REQUIRE(date != std::string::npos);
+  REQUIRE(expires != std::string::npos);
+  REQUIRE(token != std::string::npos);
+  REQUIRE(signed_headers != std::string::npos);
+  REQUIRE(signature != std::string::npos);
+
+  CHECK(algorithm < credential);
+  CHECK(credential < date);
+  CHECK(date < expires);
+  CHECK(expires < token);
+  CHECK(token < signed_headers);
+  CHECK(signed_headers < signature);
+}
+
+TEST_CASE("presign_url signs only the host header", "[s3][sigv4]")
+{
+  auto url = presign_url("GET",
+                         "https",
+                         "examplebucket.s3.amazonaws.com",
+                         "/test.txt",
+                         aws_example_creds(),
+                         1369353600,
+                         std::chrono::seconds{300});
+
+  CHECK(query_value(url, "X-Amz-SignedHeaders") == "host");
+}
+
+TEST_CASE("presign_url propagates ttl into X-Amz-Expires", "[s3][sigv4]")
+{
+  auto url_300   = presign_url("GET",
+                             "https",
+                             "examplebucket.s3.amazonaws.com",
+                             "/test.txt",
+                             aws_example_creds(),
+                             1369353600,
+                             std::chrono::seconds{300});
+  auto url_86400 = presign_url("GET",
+                               "https",
+                               "examplebucket.s3.amazonaws.com",
+                               "/test.txt",
+                               aws_example_creds(),
+                               1369353600,
+                               std::chrono::seconds{86400});
+
+  CHECK(query_value(url_300, "X-Amz-Expires") == "300");
+  CHECK(query_value(url_86400, "X-Amz-Expires") == "86400");
+}
+
+TEST_CASE("presign_url rejects invalid required inputs", "[s3][sigv4]")
+{
+  auto creds = aws_example_creds();
+
+  CHECK_THROWS_AS(presign_url("",
+                              "https",
+                              "examplebucket.s3.amazonaws.com",
+                              "/test.txt",
+                              creds,
+                              1369353600,
+                              std::chrono::seconds{300}),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(presign_url("GET",
+                              "",
+                              "examplebucket.s3.amazonaws.com",
+                              "/test.txt",
+                              creds,
+                              1369353600,
+                              std::chrono::seconds{300}),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(
+    presign_url("GET", "https", "", "/test.txt", creds, 1369353600, std::chrono::seconds{300}),
+    std::invalid_argument);
+  CHECK_THROWS_AS(presign_url("GET",
+                              "https",
+                              "examplebucket.s3.amazonaws.com",
+                              "/test.txt",
+                              creds,
+                              1369353600,
+                              std::chrono::seconds{0}),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(presign_url("GET",
+                              "https",
+                              "examplebucket.s3.amazonaws.com",
+                              "/test.txt",
+                              creds,
+                              1369353600,
+                              std::chrono::seconds{-1}),
+                  std::invalid_argument);
+}
+
+TEST_CASE("presign_url leaves already-encoded canonical URI untouched", "[s3][sigv4]")
+{
+  auto url = presign_url("GET",
+                         "https",
+                         "examplebucket.s3.amazonaws.com",
+                         "/path/with%20space.parquet",
+                         aws_example_creds(),
+                         1369353600,
+                         std::chrono::seconds{300});
+
+  CHECK(contains(url, "https://examplebucket.s3.amazonaws.com/path/with%20space.parquet?"));
+  CHECK_FALSE(contains(url, "%2520"));
+}
+
+TEST_CASE("presign_url preserves the caller-selected scheme", "[s3][sigv4]")
+{
+  auto url = presign_url("GET",
+                         "http",
+                         "minio.local:9000",
+                         "/bucket/test.txt",
+                         aws_example_creds(),
+                         1369353600,
+                         std::chrono::seconds{300});
+
+  CHECK(url.find("http://minio.local:9000/bucket/test.txt?") == 0);
+  CHECK(is_lower_hex_64(query_value(url, "X-Amz-Signature")));
+}

--- a/test/cpp/io/s3/test_sirius_sigv4_credential_provider.cpp
+++ b/test/cpp/io/s3/test_sirius_sigv4_credential_provider.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "io/io_errors.hpp"
+#include "io/s3/mock_credential_provider.hpp"
+#include "io/s3/sirius_sigv4_credential_provider.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+using sirius::io::credential_error;
+using sirius::io::s3::mock_credential_provider;
+using sirius::io::s3::presign_method;
+using sirius::io::s3::s3_object_ref;
+using sirius::io::s3::sirius_sigv4_credential_provider;
+using sirius::io::s3::static_credentials;
+
+namespace {
+
+static_credentials example_static_credentials()
+{
+  static_credentials creds;
+  creds.access_key_id     = "AKIAIOSFODNN7EXAMPLE";
+  creds.secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+  return creds;
+}
+
+std::string query_string(std::string_view url)
+{
+  auto pos = url.find('?');
+  REQUIRE(pos != std::string_view::npos);
+  return std::string{url.substr(pos + 1)};
+}
+
+std::string query_value(std::string_view url, std::string_view key)
+{
+  auto query  = query_string(url);
+  auto needle = std::string{key} + "=";
+  auto begin  = query.find(needle);
+  if (begin == std::string::npos) { return {}; }
+  begin += needle.size();
+  auto end = query.find('&', begin);
+  if (end == std::string::npos) { end = query.size(); }
+  return query.substr(begin, end - begin);
+}
+
+bool contains(std::string_view haystack, std::string_view needle)
+{
+  return haystack.find(needle) != std::string_view::npos;
+}
+
+bool starts_with(std::string_view s, std::string_view prefix)
+{
+  return s.size() >= prefix.size() && s.substr(0, prefix.size()) == prefix;
+}
+
+bool is_lower_hex_64(std::string_view value)
+{
+  return value.size() == 64 && std::all_of(value.begin(), value.end(), [](unsigned char c) {
+           return std::isdigit(c) || (c >= 'a' && c <= 'f');
+         });
+}
+
+}  // namespace
+
+TEST_CASE("sirius_sigv4_credential_provider normalizes HTTPS endpoint", "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-west-2", "HTTPS://S3.US-WEST-2.AMAZONAWS.COM");
+
+  auto url = provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::GET);
+
+  CHECK(starts_with(url, "https://s3.us-west-2.amazonaws.com/examplebucket/test.txt?"));
+  CHECK(query_value(url, "X-Amz-Credential").find("%2Fus-west-2%2Fs3%2Faws4_request") !=
+        std::string::npos);
+  CHECK(query_value(url, "X-Amz-SignedHeaders") == "host");
+}
+
+TEST_CASE("sirius_sigv4_credential_provider preserves HTTP endpoint ports",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-east-1", "http://minio.local:9000");
+
+  auto url = provider.get_presigned_url({"bucket", "object.parquet"}, presign_method::GET);
+
+  CHECK(starts_with(url, "http://minio.local:9000/bucket/object.parquet?"));
+  CHECK(is_lower_hex_64(query_value(url, "X-Amz-Signature")));
+}
+
+TEST_CASE("sirius_sigv4_credential_provider rejects malformed construction inputs",
+          "[s3][credential_provider]")
+{
+  auto creds = example_static_credentials();
+
+  CHECK_THROWS_AS(sirius_sigv4_credential_provider(creds, "us-east-1", ""), credential_error);
+  CHECK_THROWS_AS(
+    sirius_sigv4_credential_provider(creds, "us-east-1", "s3.us-east-1.amazonaws.com"),
+    credential_error);
+  CHECK_THROWS_AS(sirius_sigv4_credential_provider(creds, "us-east-1", "ftp://example.com"),
+                  credential_error);
+  CHECK_THROWS_AS(
+    sirius_sigv4_credential_provider(creds, "us-east-1", "https://example.com/prefix"),
+    credential_error);
+  CHECK_THROWS_AS(sirius_sigv4_credential_provider(creds, "us-east-1", "https://example.com?x=1"),
+                  credential_error);
+  CHECK_THROWS_AS(
+    sirius_sigv4_credential_provider(creds, "us-east-1", "https://example.com#fragment"),
+    credential_error);
+
+  auto no_access_key = creds;
+  no_access_key.access_key_id.clear();
+  CHECK_THROWS_AS(
+    sirius_sigv4_credential_provider(no_access_key, "us-east-1", "https://example.com"),
+    credential_error);
+
+  auto no_secret_key = creds;
+  no_secret_key.secret_access_key.clear();
+  CHECK_THROWS_AS(
+    sirius_sigv4_credential_provider(no_secret_key, "us-east-1", "https://example.com"),
+    credential_error);
+
+  CHECK_THROWS_AS(sirius_sigv4_credential_provider(creds, "", "https://example.com"),
+                  credential_error);
+  CHECK_THROWS_AS(sirius_sigv4_credential_provider(
+                    creds, "us-east-1", "https://example.com", std::chrono::seconds{0}),
+                  credential_error);
+}
+
+TEST_CASE("sirius_sigv4_credential_provider generates distinct GET and HEAD URLs",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  auto get_url  = provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::GET);
+  auto head_url = provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::HEAD);
+
+  CHECK(query_value(get_url, "X-Amz-SignedHeaders") == "host");
+  CHECK(query_value(head_url, "X-Amz-SignedHeaders") == "host");
+  CHECK(query_value(get_url, "X-Amz-Signature") != query_value(head_url, "X-Amz-Signature"));
+}
+
+TEST_CASE("sirius_sigv4_credential_provider encodes bucket and key path components",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  auto spaced =
+    provider.get_presigned_url({"bucket", "path with space.parquet"}, presign_method::GET);
+  CHECK(
+    starts_with(spaced, "https://s3.us-east-1.amazonaws.com/bucket/path%20with%20space.parquet?"));
+
+  auto nested = provider.get_presigned_url({"bucket", "a/b/c.parquet"}, presign_method::GET);
+  CHECK(starts_with(nested, "https://s3.us-east-1.amazonaws.com/bucket/a/b/c.parquet?"));
+  CHECK_FALSE(contains(nested, "a%2Fb%2Fc.parquet"));
+
+  auto unicode_key =
+    provider.get_presigned_url({"bucket", "\xE4\xB8\xAD\xE6\x96\x87.parquet"}, presign_method::GET);
+  CHECK(starts_with(unicode_key,
+                    "https://s3.us-east-1.amazonaws.com/bucket/%E4%B8%AD%E6%96%87.parquet?"));
+}
+
+TEST_CASE("sirius_sigv4_credential_provider propagates session tokens", "[s3][credential_provider]")
+{
+  auto creds          = example_static_credentials();
+  creds.session_token = "temporary/session+token=";
+  sirius_sigv4_credential_provider provider(
+    creds, "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  auto url = provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::GET);
+
+  CHECK(contains(url, "X-Amz-Security-Token=temporary%2Fsession%2Btoken%3D"));
+}
+
+TEST_CASE("sirius_sigv4_credential_provider uses default and explicit ttl",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider default_provider(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+  sirius_sigv4_credential_provider explicit_provider(example_static_credentials(),
+                                                     "us-east-1",
+                                                     "https://s3.us-east-1.amazonaws.com",
+                                                     std::chrono::minutes{30});
+
+  auto default_url =
+    default_provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::GET);
+  auto explicit_url =
+    explicit_provider.get_presigned_url({"examplebucket", "test.txt"}, presign_method::GET);
+
+  CHECK(query_value(default_url, "X-Amz-Expires") == "300");
+  CHECK(query_value(explicit_url, "X-Amz-Expires") == "1800");
+}
+
+TEST_CASE("sirius_sigv4_credential_provider rejects empty object references",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  CHECK_THROWS_AS(provider.get_presigned_url({"", "test.txt"}, presign_method::GET),
+                  credential_error);
+  CHECK_THROWS_AS(provider.get_presigned_url({"bucket", ""}, presign_method::GET),
+                  credential_error);
+}
+
+TEST_CASE("sirius_sigv4_credential_provider is safe under concurrent presigning",
+          "[s3][credential_provider]")
+{
+  sirius_sigv4_credential_provider provider(
+    example_static_credentials(), "us-east-1", "https://s3.us-east-1.amazonaws.com");
+
+  constexpr int n_threads = 8;
+  constexpr int n_iters   = 25;
+  std::atomic<int> malformed{0};
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+
+  for (int t = 0; t < n_threads; ++t) {
+    threads.emplace_back([&provider, &malformed, t] {
+      for (int i = 0; i < n_iters; ++i) {
+        auto url = provider.get_presigned_url({"bucket", "key-" + std::to_string(t) + ".parquet"},
+                                              presign_method::GET);
+        if (!starts_with(url, "https://s3.us-east-1.amazonaws.com/bucket/key-") ||
+            query_value(url, "X-Amz-SignedHeaders") != "host" ||
+            !is_lower_hex_64(query_value(url, "X-Amz-Signature"))) {
+          ++malformed;
+        }
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  CHECK(malformed.load() == 0);
+}
+
+TEST_CASE("mock_credential_provider returns canned URLs and records calls",
+          "[s3][credential_provider]")
+{
+  mock_credential_provider provider("https://signed.example/object");
+
+  CHECK(provider.get_presigned_url({"bucket", "key"}, presign_method::GET) ==
+        "https://signed.example/object");
+  CHECK(provider.get_presigned_url({"bucket", "head-key"}, presign_method::HEAD) ==
+        "https://signed.example/object");
+
+  CHECK(provider.call_count() == 2);
+  CHECK(provider.get_count() == 1);
+  CHECK(provider.head_count() == 1);
+  CHECK(provider.last_bucket() == "bucket");
+  CHECK(provider.last_key() == "head-key");
+}
+
+TEST_CASE("mock_credential_provider can force credential errors", "[s3][credential_provider]")
+{
+  mock_credential_provider provider("https://signed.example/object");
+  provider.set_throw("boom");
+
+  CHECK_THROWS_AS(provider.get_presigned_url({"bucket", "key"}, presign_method::GET),
+                  credential_error);
+
+  provider.clear_throw();
+  CHECK(provider.get_presigned_url({"bucket", "key"}, presign_method::GET) ==
+        "https://signed.example/object");
+}

--- a/test/cpp/io/s3/test_sirius_sigv4_credential_provider.cpp
+++ b/test/cpp/io/s3/test_sirius_sigv4_credential_provider.cpp
@@ -176,6 +176,9 @@ TEST_CASE("sirius_sigv4_credential_provider encodes bucket and key path componen
   CHECK(starts_with(nested, "https://s3.us-east-1.amazonaws.com/bucket/a/b/c.parquet?"));
   CHECK_FALSE(contains(nested, "a%2Fb%2Fc.parquet"));
 
+  auto leading = provider.get_presigned_url({"bucket", "/foo"}, presign_method::GET);
+  CHECK(starts_with(leading, "https://s3.us-east-1.amazonaws.com/bucket//foo?"));
+
   auto unicode_key =
     provider.get_presigned_url({"bucket", "\xE4\xB8\xAD\xE6\x96\x87.parquet"}, presign_method::GET);
   CHECK(starts_with(unicode_key,

--- a/test/cpp/io/s3/test_static_credentials.cpp
+++ b/test/cpp/io/s3/test_static_credentials.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "io/s3/static_credentials.hpp"
+
+#include <chrono>
+
+using sirius::io::s3::static_credentials;
+
+TEST_CASE("static_credentials default constructs to empty inert values",
+          "[s3][credential_provider][static_credentials]")
+{
+  static_credentials creds;
+
+  CHECK(creds.access_key_id.empty());
+  CHECK(creds.secret_access_key.empty());
+  CHECK(creds.session_token.empty());
+  CHECK_FALSE(creds.expires_at.has_value());
+}
+
+TEST_CASE("static_credentials preserves session token and expiration across copies",
+          "[s3][credential_provider][static_credentials]")
+{
+  static_credentials creds;
+  creds.access_key_id     = "access";
+  creds.secret_access_key = "secret";
+  creds.session_token     = "session";
+  creds.expires_at        = std::chrono::system_clock::time_point{std::chrono::seconds{12345}};
+
+  auto copy = creds;
+
+  CHECK(copy.access_key_id == "access");
+  CHECK(copy.secret_access_key == "secret");
+  CHECK(copy.session_token == "session");
+  REQUIRE(copy.expires_at.has_value());
+  CHECK(*copy.expires_at == *creds.expires_at);
+}


### PR DESCRIPTION
## Context

This is **PR2 of 3** that splits the work in #742.

The split:
- [PR1 (#746)](https://github.com/sirius-db/sirius/pull/746) — backend-neutral foundation (factory + registry + URI parser + inert config). **Independent of this PR; can be reviewed in parallel.**
- **PR2 (this PR)** — `credential_provider` abstraction (S3-scoped, presigned-URL seam) + Sirius's hand-rolled SigV4 as the default impl.
- **PR3** — S3 reactor (`s3_io_object`, signing-blind `s3_ioctx`, MinIO fixtures). Depends on PR1 + PR2.
- **Integration** — registry placement on `SiriusContext`, SET handlers, scan-path dispatch, connector error handling are out of scope here per the comment thread.

This branch is cut from `upstream/dev` directly (no PR1 ancestry); the two PRs share zero code-level dependencies.

## What's in this PR

`namespace sirius::io::s3`:

- **`credential_provider`** ([credential_provider.hpp](src/include/io/s3/credential_provider.hpp)) — abstract interface, single virtual `get_presigned_url(s3_object_ref, presign_method)`. Method-specific (presign_method::GET / HEAD only). Public surface is presign-only — no `get_credentials()` — so impls without raw key material (signed-URL services, broker chains) compose cleanly. Lets downstream projects plug in their own credential / signer implementation without forcing Sirius to depend on `aws-sdk-cpp`.
- **`static_credentials`** ([static_credentials.hpp](src/include/io/s3/static_credentials.hpp)) — POD: access_key_id / secret_access_key / session_token / optional expires_at. Consumed by the default impl's ctor; not part of the abstract interface.
- **`sirius_sigv4_credential_provider`** ([.hpp](src/include/io/s3/sirius_sigv4_credential_provider.hpp) / [.cpp](src/io/s3/sirius_sigv4_credential_provider.cpp)) — default implementation. Parses endpoint (scheme + host[:port]) at construction, validates creds / region / TTL, builds path-style canonical URI per call, delegates to `sigv4::presign_url`. Default TTL 5 min — inline-at-request-time presigning means short TTL is safe and limits leaked-URL blast radius.
- **`mock_credential_provider`** ([mock_credential_provider.hpp](src/include/io/s3/mock_credential_provider.hpp)) — header-only test fixture. Returns canned URL or throws on demand; thread-safe counters; used by the credential_provider tests, will be reused by PR3 reactor tests and downstream test suites.

`namespace sirius::io`:

- **`credential_error`** ([io_errors.hpp](src/include/io/io_errors.hpp)) — exception type for credential acquisition / signing failures. Future IO-layer error types share this header.

`namespace sirius::io::s3` (modifications to existing sigv4):

- **`presign_url(method, scheme, host, canonical_uri, creds, ts, ttl)`** — new public function on [sigv4.hpp](src/include/io/s3/sigv4.hpp). Builds a SigV4 query-string-signed URL with X-Amz-* params (Algorithm, Credential, Date, Expires, SignedHeaders, optional Security-Token, Signature). Uses `UNSIGNED-PAYLOAD`; signs only `host` so callers can freely add `Range` / `Accept` / etc.
- **`sigv4_signer_config`** — new `session_token` field (default empty). Both `sign_request` (header-based) and `presign_url` (query-string-based) auto-inject the security token when non-empty (covers temporary STS / IMDS / SSO credentials).

## Public seam: presigned URL, not raw credentials

Boundary by design. The `credential_provider` interface yields fully-qualified URLs; the reactor (PR3 onwards) issues HTTP requests against those URLs and never sees the underlying access key. Downstream forks can plug in:

- An AWS-SDK-backed provider (no extra dep on Sirius)
- An internal auth broker that issues signed URLs centrally
- An IMDS / STS chain
- Any future SSO scheme

without touching this PR's source.

## What's deliberately NOT here

- S3 reactor (`s3_io_object`, signing-blind `s3_ioctx`, MinIO fixtures) — **PR3**.
- `sirius_engine` / `SiriusContext` mutations, SET handlers, `sirius_read_parquet`, scan-path dispatch, connector error API — **integration PR** (reviewer-owned).
- AWS-SDK-cpp adapter — downstream's responsibility per the design.
- libcurl — only OpenSSL is added as a build dep here (already required by SigV4).

## Test plan

Targeted suite passing on Linux CI host:

```bash
build/release/extension/sirius/test/cpp/sirius_unittest \
  "[s3][sigv4],[s3][credential_provider]"
Result: 27 test cases / 893 assertions, all passing.

