### PR TITLE
Improve sirius pipeline diagnostics: rename converter symbols and annotate plan printer with barrier info

### DIFF
--- a/src/include/pipeline/sirius_pipeline_converter.hpp
+++ b/src/include/pipeline/sirius_pipeline_converter.hpp
@@ -32,8 +32,9 @@ namespace pipeline {
 struct pipeline_conversion_result {
   //! The execution-ready pipelines in dependency order
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> scheduled_pipelines;
-  //! Ownership container for operators created during splitting (PARTITION, CONCAT, MERGE, etc.)
-  duckdb::vector<duckdb::unique_ptr<op::sirius_physical_operator>> pipeline_breakers;
+  //! Ownership container for operators inserted during splitting (PARTITION, CONCAT, MERGE,
+  //! and source-side operators such as DUCKDB_SCAN, GPU_PARQUET_SCAN, CPU_SOURCE).
+  duckdb::vector<duckdb::unique_ptr<op::sirius_physical_operator>> inserted_operators;
   //! Number of meta-pipelines (used for progress tracking)
   std::size_t meta_pipeline_count;
 };
@@ -61,7 +62,7 @@ class sirius_pipeline_converter {
 
   // Phase 2: Split pipelines by operator type
   void split_pipelines(duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled);
-  void split_parquet_scan_source(duckdb::shared_ptr<sirius_pipeline>& current_pipeline);
+  void insert_parquet_scan_operator(duckdb::shared_ptr<sirius_pipeline>& current_pipeline);
   void split_table_scan_source(duckdb::shared_ptr<sirius_pipeline>& current_pipeline);
   void split_cpu_source(duckdb::shared_ptr<sirius_pipeline>& current_pipeline);
   void split_intermediate_joins(duckdb::shared_ptr<sirius_pipeline>& current_pipeline);
@@ -96,7 +97,7 @@ class sirius_pipeline_converter {
 
   // Internal state built during convert(), moved into result
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>> scheduled_;
-  duckdb::vector<duckdb::unique_ptr<op::sirius_physical_operator>> pipeline_breakers_;
+  duckdb::vector<duckdb::unique_ptr<op::sirius_physical_operator>> inserted_operators_;
   std::size_t meta_pipeline_count_ = 0;
 };
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -58,7 +58,7 @@ sirius_pipeline_converter::sirius_pipeline_converter(sirius_engine& engine,
 pipeline_conversion_result sirius_pipeline_converter::convert(sirius_meta_pipeline& root_pipeline)
 {
   scheduled_.clear();
-  pipeline_breakers_.clear();
+  inserted_operators_.clear();
 
   auto copied_scheduled = schedule_and_copy_pipelines(root_pipeline);
   split_pipelines(copied_scheduled);
@@ -68,7 +68,7 @@ pipeline_conversion_result sirius_pipeline_converter::convert(sirius_meta_pipeli
   link_join_partition_siblings();
   log_pipeline_debug_info();
 
-  return {std::move(scheduled_), std::move(pipeline_breakers_), meta_pipeline_count_};
+  return {std::move(scheduled_), std::move(inserted_operators_), meta_pipeline_count_};
 }
 
 duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>
@@ -153,7 +153,7 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
 }
 
 //===----------------------------------------------------------------------===//
-// split_parquet_scan_source()
+// insert_parquet_scan_operator()
 //
 // Rewrites a DuckDB parquet table scan into a Sirius gpu_scan_op as the
 // pipeline source. The companion metadata scan operator is constructed here
@@ -162,7 +162,7 @@ sirius_pipeline_converter::schedule_and_copy_pipelines(sirius_meta_pipeline& roo
 // so the scan_manager can take ownership and drive its execute() on its own
 // thread pool during prepare_for_query.
 //===----------------------------------------------------------------------===//
-void sirius_pipeline_converter::split_parquet_scan_source(
+void sirius_pipeline_converter::insert_parquet_scan_operator(
   duckdb::shared_ptr<sirius_pipeline>& current_pipeline)
 {
   auto& scan_op = current_pipeline->get_source()->Cast<op::sirius_physical_table_scan>();
@@ -171,7 +171,7 @@ void sirius_pipeline_converter::split_parquet_scan_source(
   auto const& bind_data = scan_op.bind_data->Cast<duckdb::MultiFileBindData>();
   if (!bind_data.file_list || bind_data.file_list->IsEmpty()) {
     throw std::runtime_error(
-      "[sirius_pipeline_converter::split_parquet_scan_source] No input files to scan");
+      "[sirius_pipeline_converter::insert_parquet_scan_operator] No input files to scan");
   }
   std::vector<std::string> file_paths;
   for (auto const& file : bind_data.file_list->GetAllFiles()) {
@@ -196,7 +196,7 @@ void sirius_pipeline_converter::split_parquet_scan_source(
   // finalize_pipeline_structure() will set current_pipeline->source = &operators[0] = gpu_scan_op.
   current_pipeline->operators.insert(current_pipeline->operators.begin(), *gpu_scan_ptr);
 
-  pipeline_breakers_.push_back(std::move(gpu_scan_op));
+  inserted_operators_.push_back(std::move(gpu_scan_op));
 }
 
 void sirius_pipeline_converter::split_table_scan_source(
@@ -208,7 +208,7 @@ void sirius_pipeline_converter::split_table_scan_source(
 
   // If parquet scan, route to metadata scan + gpu scan operator pipeline
   if (scan_op.function.name == "parquet_scan" || scan_op.function.name == "read_parquet") {
-    split_parquet_scan_source(current_pipeline);
+    insert_parquet_scan_operator(current_pipeline);
     return;
   }
 
@@ -227,7 +227,7 @@ void sirius_pipeline_converter::split_table_scan_source(
     current_pipeline->operators.insert(current_pipeline->operators.begin(), scan_op);
 
     scheduled_.push_back(new_pipeline);
-    pipeline_breakers_.push_back(std::move(new_scan_op));
+    inserted_operators_.push_back(std::move(new_scan_op));
   } else {
     throw std::runtime_error("Unsupported scan function: " + scan_op.function.name);
   }
@@ -274,7 +274,7 @@ void sirius_pipeline_converter::split_cpu_source(
   current_pipeline->operators.insert(current_pipeline->operators.begin(), *source_op);
 
   scheduled_.push_back(new_pipeline);
-  pipeline_breakers_.push_back(std::move(cpu_source_op));
+  inserted_operators_.push_back(std::move(cpu_source_op));
 }
 
 void sirius_pipeline_converter::split_intermediate_joins(
@@ -313,7 +313,7 @@ void sirius_pipeline_converter::split_intermediate_joins(
         concat_op.get(),
         false,
         op_params_.hash_partition_bytes);
-      pipeline_breakers_.push_back(std::move(partition_op));
+      inserted_operators_.push_back(std::move(partition_op));
     } else {
       concat_op = make_uniq<op::sirius_physical_concat>(
         current_pipeline->operators[join_pos - 1].get().types,
@@ -327,11 +327,11 @@ void sirius_pipeline_converter::split_intermediate_joins(
         concat_op.get(),
         false,
         op_params_.hash_partition_bytes);
-      pipeline_breakers_.push_back(std::move(partition_op));
+      inserted_operators_.push_back(std::move(partition_op));
     }
 
     auto* partition_ptr =
-      static_cast<op::sirius_physical_partition*>(pipeline_breakers_.back().get());
+      static_cast<op::sirius_physical_partition*>(inserted_operators_.back().get());
 
     if (join_pos > 0) {
       auto new_pipeline = duckdb::make_shared_ptr<sirius_pipeline>(engine_);
@@ -376,8 +376,8 @@ void sirius_pipeline_converter::split_intermediate_joins(
     concat_pipeline->source = partition_ptr;
     concat_pipeline->sink   = concat_op.get();
 
-    pipeline_breakers_.push_back(std::move(concat_op));
-    auto* concat_ptr = static_cast<op::sirius_physical_concat*>(pipeline_breakers_.back().get());
+    inserted_operators_.push_back(std::move(concat_op));
+    auto* concat_ptr = static_cast<op::sirius_physical_concat*>(inserted_operators_.back().get());
 
     scheduled_.push_back(concat_pipeline);
 
@@ -468,8 +468,8 @@ void sirius_pipeline_converter::split_join_sink(
     scheduled_.push_back(concat_pipeline);
   }
 
-  pipeline_breakers_.push_back(std::move(partition_op));
-  pipeline_breakers_.push_back(std::move(concat_op));
+  inserted_operators_.push_back(std::move(partition_op));
+  inserted_operators_.push_back(std::move(concat_op));
 }
 
 void sirius_pipeline_converter::split_group_aggregate_sink(
@@ -486,10 +486,10 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
                                                current_pipeline->get_sink().get(),
                                                false,
                                                op_params_.hash_partition_bytes);
-    pipeline_breakers_.push_back(std::move(partition_op));
+    inserted_operators_.push_back(std::move(partition_op));
 
     auto* partition_ptr =
-      static_cast<op::sirius_physical_partition*>(pipeline_breakers_.back().get());
+      static_cast<op::sirius_physical_partition*>(inserted_operators_.back().get());
 
     // Keep GROUP_BY as the sink (don't move it to operators)
     scheduled_.push_back(current_pipeline);
@@ -513,7 +513,7 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
       }
     }
     scheduled_.push_back(merge_pipeline);
-    pipeline_breakers_.push_back(std::move(merge_op));
+    inserted_operators_.push_back(std::move(merge_op));
   } else {
     // UNGROUPED_AGGREGATE — no PARTITION needed
     scheduled_.push_back(current_pipeline);
@@ -530,7 +530,7 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
       }
     }
     scheduled_.push_back(new_pipeline);
-    pipeline_breakers_.push_back(std::move(merge_op));
+    inserted_operators_.push_back(std::move(merge_op));
   }
 }
 
@@ -625,9 +625,9 @@ void sirius_pipeline_converter::split_order_by_sink(
   }
 
   // Store ownership
-  pipeline_breakers_.push_back(std::move(sample_op));
-  pipeline_breakers_.push_back(std::move(partition_op));
-  pipeline_breakers_.push_back(std::move(merge_op));
+  inserted_operators_.push_back(std::move(sample_op));
+  inserted_operators_.push_back(std::move(partition_op));
+  inserted_operators_.push_back(std::move(merge_op));
 }
 
 void sirius_pipeline_converter::split_top_n_sink(
@@ -660,7 +660,7 @@ void sirius_pipeline_converter::split_top_n_sink(
   }
 
   // Store ownership
-  pipeline_breakers_.push_back(std::move(merge_op));
+  inserted_operators_.push_back(std::move(merge_op));
 }
 
 void sirius_pipeline_converter::split_delim_join_sink(
@@ -744,8 +744,8 @@ void sirius_pipeline_converter::split_delim_join_sink(
     concat_pipeline->source = partition_join.get();
     concat_pipeline->sink   = concat_op.get();
 
-    pipeline_breakers_.push_back(std::move(partition_join));
-    pipeline_breakers_.push_back(std::move(concat_op));
+    inserted_operators_.push_back(std::move(partition_join));
+    inserted_operators_.push_back(std::move(concat_op));
     scheduled_.push_back(concat_pipeline);
   }
 
@@ -768,8 +768,8 @@ void sirius_pipeline_converter::split_delim_join_sink(
     }
   }
 
-  pipeline_breakers_.push_back(std::move(partition_distinct));
-  pipeline_breakers_.push_back(std::move(merge_distinct_op));
+  inserted_operators_.push_back(std::move(partition_distinct));
+  inserted_operators_.push_back(std::move(merge_distinct_op));
   scheduled_.push_back(merge_pipeline);
 }
 
@@ -965,27 +965,6 @@ void sirius_pipeline_converter::wire_data_repositories()
                                      : &dependent_pipeline->get_operators()[0].get();
         size_t op_id             = next_op->operator_id;
         std::string_view port_id = "scan";
-        data_repo_manager.add_new_repository(
-          op_id, port_id, std::make_unique<::cucascade::shared_data_repository>());
-        next_op->add_port(port_id,
-                          std::make_unique<op::sirius_physical_operator::port>(
-                            op::MemoryBarrierType::PIPELINE,
-                            data_repo_manager.get_repository(op_id, port_id).get(),
-                            pipeline,
-                            dependent_pipeline));
-        pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
-      }
-    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::GPU_PARQUET_SCAN) {
-      // GPU_PARQUET_SCAN streams batches downstream as they arrive (PIPELINE
-      // barrier), but unlike DUCKDB_SCAN/ICEBERG_SCAN there is no intermediate
-      // TABLE_SCAN proxy in the dependent pipeline — the immediate consumer
-      // (e.g. PARTITION) reads from the "default" port directly.
-      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
-        auto next_op             = dependent_pipeline->get_operators().size() == 0
-                                     ? dependent_pipeline->get_sink().get()
-                                     : &dependent_pipeline->get_operators()[0].get();
-        size_t op_id             = next_op->operator_id;
-        std::string_view port_id = "default";
         data_repo_manager.add_new_repository(
           op_id, port_id, std::make_unique<::cucascade::shared_data_repository>());
         next_op->add_port(port_id,

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -975,6 +975,27 @@ void sirius_pipeline_converter::wire_data_repositories()
                             dependent_pipeline));
         pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
       }
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::GPU_PARQUET_SCAN) {
+      // GPU_PARQUET_SCAN streams batches downstream as they arrive (PIPELINE
+      // barrier), but unlike DUCKDB_SCAN/ICEBERG_SCAN there is no intermediate
+      // TABLE_SCAN proxy in the dependent pipeline — the immediate consumer
+      // (e.g. PARTITION) reads from the "default" port directly.
+      for (auto const& dependent_pipeline : source_to_pipelines[pipeline->get_sink().get()]) {
+        auto next_op             = dependent_pipeline->get_operators().size() == 0
+                                     ? dependent_pipeline->get_sink().get()
+                                     : &dependent_pipeline->get_operators()[0].get();
+        size_t op_id             = next_op->operator_id;
+        std::string_view port_id = "default";
+        data_repo_manager.add_new_repository(
+          op_id, port_id, std::make_unique<::cucascade::shared_data_repository>());
+        next_op->add_port(port_id,
+                          std::make_unique<op::sirius_physical_operator::port>(
+                            op::MemoryBarrierType::PIPELINE,
+                            data_repo_manager.get_repository(op_id, port_id).get(),
+                            pipeline,
+                            dependent_pipeline));
+        pipeline->get_sink()->add_next_port_after_sink({next_op, port_id});
+      }
     } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
       // No action needed for RESULT_COLLECTOR sinks
     } else {

--- a/src/pipeline/sirius_plan_printer.cpp
+++ b/src/pipeline/sirius_plan_printer.cpp
@@ -103,20 +103,23 @@ void place_node(render_tree& tree,
   render_node node;
   node.pipeline_id = pipeline.get_pipeline_id();
 
-  // Determine connection label: scan parent's sink next_port_after_sink to find
-  // the port connecting to this child pipeline
+  // Determine connection label: scan THIS pipeline's sink next_port_after_sink
+  // to find the port that delivers data to the parent (consumer) pipeline.
+  // The parent's input operator is operators[0] if any, otherwise its sink.
   if (parent) {
-    auto parent_sink = parent->get_sink();
-    if (parent_sink) {
-      for (auto& np : parent_sink->get_next_ports_after_sink()) {
-        if (!np.next_operator) { continue; }
+    auto child_sink       = pipeline.get_sink();
+    auto parent_ops       = parent->get_operators();
+    auto* parent_input_op = !parent_ops.empty()
+                              ? &parent_ops[0].get()
+                              : (parent->get_sink() ? parent->get_sink().get() : nullptr);
+    if (child_sink && parent_input_op) {
+      for (auto& np : child_sink->get_next_ports_after_sink()) {
+        if (np.next_operator != parent_input_op) { continue; }
         auto* port = np.next_operator->get_port(np.next_operator_port_name);
-        if (port && port->src_pipeline &&
-            port->src_pipeline->get_pipeline_id() == pipeline.get_pipeline_id()) {
-          node.connection_label = std::string(np.next_operator_port_name) + " [" +
-                                  sirius_plan_printer::barrier_type_to_string(port->type) + "]";
-          break;
-        }
+        if (!port) { continue; }
+        node.connection_label = std::string(np.next_operator_port_name) + " [" +
+                                sirius_plan_printer::barrier_type_to_string(port->type) + "]";
+        break;
       }
     }
   }
@@ -154,6 +157,27 @@ void place_node(render_tree& tree,
     node.content_lines.push_back(sirius_plan_printer::format_operator_with_id(*source));
     for (auto& detail : sirius_plan_printer::get_operator_detail_lines(*source)) {
       node.content_lines.push_back(detail);
+    }
+  }
+
+  // Append input-port memory-barrier annotations at the bottom of the box
+  // (data flows in from the source side). For pipelines whose dependent
+  // entry point is the sink (no operators[]), ports live on sink instead.
+  // const_cast: get_port_ids/get_port are not marked const, but the read is
+  // logically const (just inspecting registered ports).
+  auto ops_for_input = pipeline.get_operators();
+  auto* input_op_const =
+    !ops_for_input.empty() ? &ops_for_input[0].get() : (sink ? sink.get() : nullptr);
+  auto* input_op = const_cast<op::sirius_physical_operator*>(input_op_const);
+  if (input_op) {
+    for (auto port_id : input_op->get_port_ids()) {
+      auto* port = input_op->get_port(port_id);
+      if (!port) { continue; }
+      std::string src_label = port->src_pipeline
+                                ? "(#" + std::to_string(port->src_pipeline->get_pipeline_id()) + ")"
+                                : "";
+      node.content_lines.push_back("Input" + src_label + ": " +
+                                   sirius_plan_printer::barrier_type_to_string(port->type));
     }
   }
 
@@ -362,6 +386,24 @@ std::string sirius_plan_printer::render_pipelines() const
     }
     if (sink && sink != source) { ss << " -> " << format_operator_with_id(*sink); }
     ss << "\n";
+
+    // Show input ports on this pipeline's first executable operator (mirrors Output section).
+    // For pipelines whose dependent end is the sink (no explicit operators), ports live on sink.
+    auto* input_op = !ops.empty() ? &ops[0].get() : (sink ? sink.get() : nullptr);
+    if (input_op) {
+      for (auto port_id : input_op->get_port_ids()) {
+        auto* port = input_op->get_port(port_id);
+        if (!port) { continue; }
+        ss << "  Input: ";
+        if (port->src_pipeline) {
+          ss << "<- Pipeline #" << port->src_pipeline->get_pipeline_id();
+        } else {
+          ss << "<- (no source pipeline)";
+        }
+        ss << " [on: " << input_op->get_name() << " (id=" << input_op->get_operator_id() << ")"
+           << ", port: " << port_id << ", barrier: " << barrier_type_to_string(port->type) << "]\n";
+      }
+    }
 
     // Show dependencies
     if (!pipeline->dependencies.empty()) {

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -370,7 +370,7 @@ void sirius_engine::initialize_internal(op::sirius_physical_operator& plan)
   auto result = converter.convert(*root_pipeline);
 
   new_scheduled         = std::move(result.scheduled_pipelines);
-  new_pipeline_breakers = std::move(result.pipeline_breakers);
+  new_pipeline_breakers = std::move(result.inserted_operators);
   total_pipelines       = result.meta_pipeline_count;
 
   // NOTE: dead code preserved for operator ID numbering stability


### PR DESCRIPTION
Two related, no-behavior-change improvements to pipeline diagnostics in `sirius_pipeline_converter` and `sirius_plan_printer`.

## 1. Rename misleading converter symbols

- `pipeline_breakers_` (member) and `pipeline_breakers` (field on `pipeline_conversion_result`) → `inserted_operators_` / `inserted_operators`. The container holds ownership of all operators inserted during pipeline splitting — including source-side operators (`gpu_scan_op`, `DUCKDB_SCAN`, `CPU_SOURCE`) that are **not** pipeline breakers, so the prior name was misleading.
- `split_parquet_scan_source` → `insert_parquet_scan_operator`. Unlike `split_table_scan_source` / `split_cpu_source` (which create new dedicated pipelines), this function does not split the pipeline — it just inserts `gpu_scan_op` into the existing pipeline's `operators[]`.
- The comment on `pipeline_conversion_result::inserted_operators` is updated to enumerate the source-side operator types it now also covers.

## 2. Annotate plan printer with input memory-barrier info

Each pipeline box in `sirius_plan_printer::render_dag()` now embeds one `Input(#X): BARRIER` line per input port — where `#X` is the producing pipeline's id and `BARRIER` is the human-readable `MemoryBarrierType` (`FULL` / `PARTIAL` / `PIPELINE`). Multi-input pipelines (e.g. `HASH_JOIN`) emit one line per port so probe and build inputs are distinguishable. Source-only pipelines (e.g. `GPU_PARQUET_SCAN`) emit nothing.

The compact `render_pipelines()` view gains a symmetric `Input: <- Pipeline #X [...]` section to mirror the existing `Output:` lines.

Sample DAG output (TPC-H Q21, SF1):
```
┌──────────────────────────┐
│ Pipeline #44             │
│ HASH_GROUP_BY (id=58)    │
│ PROJECTION (id=57)       │
│ HASH_JOIN (id=53)        │
│   type: RIGHT_ANTI       │
│ Input(#43): FULL         │
│ Input(#33): FULL         │
└────────────┬─────────────┘
```

The catch-all `else` branch in `wire_data_repositories` continues to handle `GPU_PARQUET_SCAN` sinks with port `"default"` and `FULL` barrier as before — no semantic change to wiring.

## Test plan

- [x] `pixi run pre-commit run --files src/pipeline/sirius_pipeline_converter.cpp src/pipeline/sirius_plan_printer.cpp` — clean (clang-format auto-applied)
- [x] `pixi run make` — full release build green
- [x] `sirius_unittest "[plan_printer]"` — 14/14 pass
- [x] `sirius_unittest "[integration][gpu_execution]"` — 370/370 pass, 69.7M assertions
- [x] Full `sirius_unittest` — 1006/1006 pass, 79.4M assertions
- [x] Manual: TPC-H SF1 Q21 — `Input(#X): BARRIER` annotations visible in `Query Plan DAG` log section, all box widths align (no overflow into adjacent columns)