### PR TITLE
Fix for race condition between task creation and finalizing pipelines

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -258,7 +258,7 @@ void task_creator::manager_loop()
             _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
               ->get_config()
               .get_operator_params();
-          // Local state construction (memory reservation) happens outside the lock.
+
           auto scan_task_local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
             *scan_task_global_state,
             *_execution_context,
@@ -283,7 +283,9 @@ void task_creator::manager_loop()
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::ICEBERG_SCAN) {
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
-          auto* parquet_scan             = static_cast<op::sirius_physical_parquet_scan*>(node);
+          // ICEBERG_SCAN inherits from PARQUET_SCAN; Cast<> is type-checked by enum so use
+          // static_cast for iceberg nodes.
+          auto* parquet_scan = static_cast<op::sirius_physical_parquet_scan*>(node);
 
           while (true) {
             // Hold the pipeline lock across the partition claim and task construction so
@@ -292,10 +294,7 @@ void task_creator::manager_loop()
             // to update_pipeline_status().
             auto task_lock = pipeline->get_task_creation_lock();
             auto partition = parquet_task_global_state->claim_next_rg_partition();
-            if (!partition.has_value()) {
-              // No partitions remain — no task created, counters unchanged.
-              return;
-            }
+            if (!partition.has_value()) { return; }
             if (!parquet_task_global_state->has_more_partitions()) {
               parquet_scan->has_more_partitions.store(false, std::memory_order_release);
             }

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -285,7 +285,9 @@ void task_creator::manager_loop()
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
           // ICEBERG_SCAN inherits from PARQUET_SCAN; Cast<> is type-checked by enum so use
           // static_cast for iceberg nodes.
-          auto* parquet_scan = static_cast<op::sirius_physical_parquet_scan*>(node);
+          auto* parquet_scan = (node->type == op::SiriusPhysicalOperatorType::ICEBERG_SCAN)
+                                 ? static_cast<op::sirius_physical_parquet_scan*>(node)
+                                 : &node->Cast<op::sirius_physical_parquet_scan>();
 
           while (true) {
             // Hold the pipeline lock across the partition claim and task construction so
@@ -296,7 +298,7 @@ void task_creator::manager_loop()
             auto partition = parquet_task_global_state->claim_next_rg_partition();
             if (!partition.has_value()) { return; }
             if (!parquet_task_global_state->has_more_partitions()) {
-              parquet_scan->has_more_partitions.store(false, std::memory_order_release);
+              parquet_scan->has_more_partitions.store(false);
             }
 
             auto parquet_task_local_state =
@@ -314,8 +316,8 @@ void task_creator::manager_loop()
             task_lock.unlock();
             _task_scheduler->schedule(std::move(parquet_task));
 
-            // For single-scan plans, keep looping to create I/O parallelism.
-            // For multi-scan plans, let the plan re-drive task creation.
+            // If there is only a single scan in the plan, continue creating scan tasks to create
+            // I/O parallelism. Otherwise, let the plan drive the creation of more tasks.
             if (_num_scans_in_plan >= 2) { break; }
           }
 
@@ -341,10 +343,7 @@ void task_creator::manager_loop()
           _task_scheduler->schedule(std::move(task));
 
         } else {
-          // Drain all available port batches, creating one GPU pipeline task per batch.
-          // The pipeline lock is acquired around each port pop + task construction so
-          // that all_ports_empty() / tasks_created checks in update_pipeline_status()
-          // cannot race with task creation.
+          // Create all possible tasks until all ports are empty
           while (!node->all_ports_empty()) {
             auto task_lock  = pipeline->get_task_creation_lock();
             auto input_data = node->get_next_task_input_data();
@@ -352,7 +351,7 @@ void task_creator::manager_loop()
               dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
             if (!input_data ||
                 (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-              // Port was empty by the time we looked — no task created, counters unchanged.
+              // do data to create task for
               break;
             }
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -340,8 +340,7 @@ void task_creator::manager_loop()
           auto task        = std::make_unique<op::scan::cpu_source_task>(get_next_task_id(),
                                                                   destination_data_repositories[0],
                                                                   std::move(local_state),
-                                                                  cpu_source_global,
-                                                                  *_client_context);
+                                                                  cpu_source_global);
           SIRIUS_LOG_DEBUG("Task Creator: scheduling cpu_source_task, dest_repos={}",
                            destination_data_repositories.size());
           _task_scheduler->schedule(std::move(task));

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -250,9 +250,7 @@ void task_creator::manager_loop()
             port_info.next_operator->get_port(port_info.next_operator_port_name)->repo);
         }
 
-        // scheduling scan task
         if (node->type == ::sirius::op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
-          // Check to see if you need to create a new global s for this scan operator
           size_t operator_id          = node->get_operator_id();
           auto scan_task_global_state = _scan_operator_global_state_map.at(operator_id);
 
@@ -260,6 +258,7 @@ void task_creator::manager_loop()
             _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state")
               ->get_config()
               .get_operator_params();
+          // Local state construction (memory reservation) happens outside the lock.
           auto scan_task_local_state = std::make_unique<op::scan::duckdb_scan_task_local_state>(
             *scan_task_global_state,
             *_execution_context,
@@ -269,45 +268,41 @@ void task_creator::manager_loop()
             throw std::runtime_error(
               "No destination data repositories provided for scan task creation.");
           }
-          auto scan_task = std::make_unique<op::scan::duckdb_scan_task>(
-            get_next_task_id(),
-            destination_data_repositories[0],  // WSM amin TODO: is this correct? there probably
-                                               // needs to be multiple possible destination data
-                                               // repositories
-            std::move(scan_task_local_state),
-            scan_task_global_state);
-          pipeline->mark_task_created();  // WSM TODO: this needs to be done atomically
-                                          // with the task creation
+          // Hold the pipeline lock while constructing the task so that
+          // mark_task_created() (called by the constructor) and
+          // update_pipeline_status() are mutually exclusive.
+          auto task_lock = pipeline->get_task_creation_lock();
+          auto scan_task =
+            std::make_unique<op::scan::duckdb_scan_task>(get_next_task_id(),
+                                                         destination_data_repositories[0],
+                                                         std::move(scan_task_local_state),
+                                                         scan_task_global_state);
+          task_lock.unlock();
           _task_scheduler->schedule(std::move(scan_task));
+
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::ICEBERG_SCAN) {
           size_t operator_id             = node->get_operator_id();
           auto parquet_task_global_state = _parquet_scan_operator_global_state_map.at(operator_id);
-          // ICEBERG_SCAN inherits from PARQUET_SCAN; Cast<> is type-checked by enum so use
-          // static_cast for iceberg nodes.
-          auto* parquet_scan = (node->type == op::SiriusPhysicalOperatorType::ICEBERG_SCAN)
-                                 ? static_cast<op::sirius_physical_parquet_scan*>(node)
-                                 : &node->Cast<op::sirius_physical_parquet_scan>();
+          auto* parquet_scan             = static_cast<op::sirius_physical_parquet_scan*>(node);
+
           while (true) {
-            pipeline->mark_task_created();
+            // Hold the pipeline lock across the partition claim and task construction so
+            // that claim_next_rg_partition() (which advances the pipeline's scan state)
+            // and mark_task_created() (called by the constructor) are atomic with respect
+            // to update_pipeline_status().
+            auto task_lock = pipeline->get_task_creation_lock();
             auto partition = parquet_task_global_state->claim_next_rg_partition();
             if (!partition.has_value()) {
-              pipeline->mark_task_completed();
-              if (pipeline->is_pipeline_finished()) {
-                auto output_consumers = pipeline->get_output_consumers();
-                for (auto& output_consumer : output_consumers) {
-                  schedule(output_consumer);
-                }
-              }
+              // No partitions remain — no task created, counters unchanged.
               return;
             }
             if (!parquet_task_global_state->has_more_partitions()) {
-              parquet_scan->has_more_partitions = false;
+              parquet_scan->has_more_partitions.store(false, std::memory_order_release);
             }
 
             auto parquet_task_local_state =
               std::make_unique<op::scan::parquet_scan_task_local_state>(*parquet_task_global_state,
                                                                         *partition);
-
             if (destination_data_repositories.empty()) {
               throw std::runtime_error(
                 "No destination data repositories provided for parquet scan task creation.");
@@ -317,64 +312,53 @@ void task_creator::manager_loop()
                                                             destination_data_repositories[0],
                                                             std::move(parquet_task_local_state),
                                                             parquet_task_global_state);
+            task_lock.unlock();
             _task_scheduler->schedule(std::move(parquet_task));
 
-            // If there is only a single scan in the plan, continue creating scan tasks to create
-            // I/O parallelism. Otherwise, let the plan drive the creation of more tasks.
+            // For single-scan plans, keep looping to create I/O parallelism.
+            // For multi-scan plans, let the plan re-drive task creation.
             if (_num_scans_in_plan >= 2) { break; }
           }
+
         } else if (node->type == ::sirius::op::SiriusPhysicalOperatorType::CPU_SOURCE) {
           SIRIUS_LOG_DEBUG("Task Creator: creating cpu_source_task for operator {}",
                            node->get_name());
           size_t operator_id     = node->get_operator_id();
           auto cpu_source_global = _cpu_source_operator_global_state_map.at(operator_id);
 
-          pipeline->mark_task_created();
-
           if (destination_data_repositories.empty()) {
             throw std::runtime_error(
               "No destination data repositories provided for cpu source task creation.");
           }
-
           auto local_state = std::make_unique<op::scan::cpu_source_task_local_state>();
+          auto task_lock   = pipeline->get_task_creation_lock();
           auto task        = std::make_unique<op::scan::cpu_source_task>(get_next_task_id(),
                                                                   destination_data_repositories[0],
                                                                   std::move(local_state),
                                                                   cpu_source_global);
           SIRIUS_LOG_DEBUG("Task Creator: scheduling cpu_source_task, dest_repos={}",
                            destination_data_repositories.size());
+          task_lock.unlock();
           _task_scheduler->schedule(std::move(task));
-        } else {
-          // need to exhaust input batches until all ports are empty
-          while (!node->all_ports_empty()) {
-            // Mark task created BEFORE popping data from ports to prevent a race
-            // condition where update_pipeline_status() sees empty ports and matching
-            // task counters, prematurely marking the pipeline as finished.
-            pipeline->mark_task_created();
 
+        } else {
+          // Drain all available port batches, creating one GPU pipeline task per batch.
+          // The pipeline lock is acquired around each port pop + task construction so
+          // that all_ports_empty() / tasks_created checks in update_pipeline_status()
+          // cannot race with task creation.
+          while (!node->all_ports_empty()) {
+            auto task_lock  = pipeline->get_task_creation_lock();
             auto input_data = node->get_next_task_input_data();
             auto* pipelineable_input =
               dynamic_cast<op::pipelineable_operator_data*>(input_data.get());
             if (!input_data ||
                 (pipelineable_input && pipelineable_input->get_data_batches().empty())) {
-              // No data was available (e.g., another thread already consumed it).
-              // Balance the counter. mark_task_completed() calls update_pipeline_status()
-              // which is correct: if all ports are truly empty and all real tasks have
-              // completed, the pipeline should finish.
-              pipeline->mark_task_completed();
-              if (pipeline->is_pipeline_finished()) {
-                auto output_consumers = pipeline->get_output_consumers();
-                for (auto& output_consumer : output_consumers) {
-                  this->schedule(output_consumer);
-                }
-              }
+              // Port was empty by the time we looked — no task created, counters unchanged.
               break;
             }
 
-            // Check to see if you need to create a new global state for this operator
             size_t operator_id                  = node->get_operator_id();
             auto gpu_pipeline_task_global_state = _gpu_operator_global_state_map.at(operator_id);
-
             auto local_state =
               std::make_unique<pipeline::gpu_pipeline_task_local_state>(std::move(input_data));
             auto task =
@@ -382,6 +366,7 @@ void task_creator::manager_loop()
                                                             destination_data_repositories,
                                                             std::move(local_state),
                                                             gpu_pipeline_task_global_state);
+            task_lock.unlock();
             _task_scheduler->schedule(std::move(task));
           }
         }

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -21,14 +21,12 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <duckdb/common/types.hpp>
-#include <duckdb/main/client_context.hpp>
 #include <op/sirius_physical_cpu_source.hpp>
 #include <parallel/task.hpp>
 #include <pipeline/sirius_pipeline.hpp>
 #include <pipeline/sirius_pipeline_itask.hpp>
 #include <pipeline/sirius_pipeline_task_states.hpp>
 #include <pipeline/task_scheduler.hpp>
-#include <sirius_context.hpp>
 
 namespace sirius::op::scan {
 
@@ -62,14 +60,10 @@ class cpu_source_task_local_state : public pipeline::sirius_pipeline_task_local_
  public:
   cpu_source_task_local_state() = default;
 
-  // Required override of the base class's pure virtual. The consumption
-  // basis feeds pipeline_memory_history (via estimate_peak_memory /
-  // record_on_failure / record) so the estimator can learn a task's memory
-  // footprint over time. cpu_source_task never exercises that code path: it
-  // does not call get_estimated_reservation_size(), does not record memory
-  // history, and is only scheduled through the CPU_SOURCE branch in
-  // task_creator/duckdb_scan_executor (neither reads this value). Return 0
-  // to satisfy the interface; the field is otherwise unused for this task.
+  // The consumption basis feeds pipeline_memory_history, which cpu_source_task
+  // does not use — its reservation size is estimated directly from the
+  // collection row count in get_estimated_reservation_size(), not from
+  // historical data. Return 0 to satisfy the interface.
   [[nodiscard]] std::size_t get_task_consumption_basis() const override { return 0; }
 };
 
@@ -85,8 +79,7 @@ class cpu_source_task : public pipeline::sirius_pipeline_itask {
   cpu_source_task(uint64_t task_id,
                   cucascade::shared_data_repository* data_repo,
                   std::unique_ptr<cpu_source_task_local_state> local_state,
-                  std::shared_ptr<cpu_source_task_global_state> global_state,
-                  duckdb::ClientContext& client_ctx);
+                  std::shared_ptr<cpu_source_task_global_state> global_state);
 
   ~cpu_source_task() override;
 
@@ -94,13 +87,12 @@ class cpu_source_task : public pipeline::sirius_pipeline_itask {
 
   void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
 
-  [[nodiscard]] std::size_t get_estimated_reservation_size() const override { return 0; }
+  [[nodiscard]] std::size_t get_estimated_reservation_size() const override;
 
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 
  private:
   cucascade::shared_data_repository* _data_repo;
-  duckdb::ClientContext& _client_ctx;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -415,6 +415,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
       _data_repo(data_repo)
   {
     g_state->_total_task_count.fetch_add(1);
+    if (g_state->get_pipeline()) { g_state->get_pipeline()->mark_task_created(); }
   };
 
   //===----------Destructor----------===//

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -619,6 +619,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
       _task_id(task_id),
       _data_repo(data_repo)
   {
+    if (auto pipeline = g_state->get_operator().get_pipeline()) { pipeline->mark_task_created(); }
   }
 
   ~parquet_scan_task() override;

--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -194,7 +194,7 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   // Sink Interface
   bool is_sink() const override { return true; }
 
-  void finalize_operator() override;
+  void on_finalize_operator() override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -315,8 +315,20 @@ class sirius_physical_operator {
   virtual void build_pipelines(pipeline::sirius_pipeline& current,
                                pipeline::sirius_meta_pipeline& meta_pipeline);
 
-  //! Called when the pipeline this operator belongs to finishes. Override to release resources.
-  virtual void finalize_operator() {}
+  //! Called when the pipeline this operator belongs to finishes. Sets finalized=true, then
+  //! dispatches to on_finalize_operator(). Do not override this; override on_finalize_operator().
+  void finalize_operator()
+  {
+    finalized = true;
+    on_finalize_operator();
+  }
+
+  //! True after finalize_operator() has been called on this operator.
+  bool finalized = false;
+
+ protected:
+  //! Override this instead of finalize_operator() to perform cleanup when a pipeline finishes.
+  virtual void on_finalize_operator() {}
 
  public:
   template <class TARGET>

--- a/src/include/op/sirius_physical_sort_partition.hpp
+++ b/src/include/op/sirius_physical_sort_partition.hpp
@@ -66,7 +66,7 @@ class sirius_physical_sort_partition : public sirius_physical_operator {
   //! Get the sample operator
   sirius_physical_sort_sample* get_sample_op() const { return _sample_op; }
 
-  void finalize_operator() override;
+  void on_finalize_operator() override;
 
  private:
   sirius_physical_sort_sample* _sample_op = nullptr;

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -196,19 +196,6 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 
   /**
-   * @brief Mark this task as rescheduled due to OOM.
-   *
-   * When set, the destructor will NOT call mark_task_completed() on the pipeline,
-   * since the rescheduled replacement task will handle that instead.
-   */
-  void mark_as_rescheduled() noexcept { _oom_rescheduled = true; }
-
-  /**
-   * @brief Check if this task was rescheduled due to OOM.
-   */
-  [[nodiscard]] bool is_rescheduled() const noexcept { return _oom_rescheduled; }
-
-  /**
    * @brief Get the data repositories for output publishing.
    *
    * Used by the executor to create a rescheduled task with the same output destinations.
@@ -245,7 +232,6 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
  private:
   uint64_t _task_id;
   std::vector<cucascade::shared_data_repository*> _data_repos;
-  bool _oom_rescheduled                                             = false;
   cucascade::memory::reservation_aware_resource_adaptor* _allocator = nullptr;
   /// Input data_batches held for subscribe/unsubscribe lifecycle (LIFE-01/LIFE-02, D-06)
   std::vector<std::shared_ptr<cucascade::data_batch>> _input_batches;

--- a/src/include/pipeline/sirius_pipeline.hpp
+++ b/src/include/pipeline/sirius_pipeline.hpp
@@ -27,6 +27,7 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <mutex>
 #include <vector>
 
 namespace sirius {
@@ -167,6 +168,13 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   //! Set the task_creator pointer so this pipeline can schedule downstream consumers on finish.
   void set_task_creator(sirius::creator::task_creator* tc);
 
+  //! Returns a scoped lock on the pipeline status mutex.
+  //! Callers must hold this lock across the operation that consumes pipeline state
+  //! (port data pop, partition claim, etc.) and the task constructor that calls
+  //! mark_task_created(), so that update_pipeline_status() cannot observe an
+  //! empty-port / balanced-counter state while a task is mid-creation.
+  [[nodiscard]] std::unique_lock<std::mutex> get_task_creation_lock();
+
   [[nodiscard]] uuid::UUID pipeline_uuid() const { return _pipeline_uuid; }
 
  private:
@@ -208,6 +216,11 @@ class sirius_pipeline : public duckdb::enable_shared_from_this<sirius_pipeline> 
   size_t pipeline_id = 0;
   //! Plan-time context (replaces sirius_engine& for plan-time needs)
   pipeline_build_context build_ctx_;
+
+  //! Serialises update_pipeline_status() checks against task_creator's port-pop +
+  //! mark_task_created() sequences so neither can observe a transiently-balanced
+  //! counter while the other is mid-operation.
+  mutable std::mutex _status_mutex;
 
   //! Whether the pipeline has been finished
   std::atomic<bool> pipeline_finished = false;

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -54,6 +54,9 @@ cpu_source_task::cpu_source_task(uint64_t task_id,
                                  std::shared_ptr<cpu_source_task_global_state> global_state)
   : sirius_pipeline_itask(std::move(local_state), std::move(global_state)), _data_repo(data_repo)
 {
+  if (auto* pipeline = _global_state->cast<cpu_source_task_global_state>().get_pipeline()) {
+    pipeline->mark_task_created();
+  }
 }
 
 cpu_source_task::~cpu_source_task()

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -51,11 +51,8 @@ cpu_source_task_global_state::cpu_source_task_global_state(
 cpu_source_task::cpu_source_task(uint64_t task_id,
                                  cucascade::shared_data_repository* data_repo,
                                  std::unique_ptr<cpu_source_task_local_state> local_state,
-                                 std::shared_ptr<cpu_source_task_global_state> global_state,
-                                 duckdb::ClientContext& client_ctx)
-  : sirius_pipeline_itask(std::move(local_state), std::move(global_state)),
-    _data_repo(data_repo),
-    _client_ctx(client_ctx)
+                                 std::shared_ptr<cpu_source_task_global_state> global_state)
+  : sirius_pipeline_itask(std::move(local_state), std::move(global_state)), _data_repo(data_repo)
 {
 }
 
@@ -268,38 +265,37 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(table));
 }
 
+std::size_t cpu_source_task::get_estimated_reservation_size() const
+{
+  constexpr std::size_t kMinBytes = 64ULL * 1024;
+  auto& g_state                   = _global_state->cast<cpu_source_task_global_state>();
+  auto& source                    = g_state.get_source_op();
+  if (source.collection) {
+    auto count = source.collection->Count();
+    if (count > 0) {
+      return std::max(kMinBytes, static_cast<std::size_t>(count) * std::size_t{256});
+    }
+  }
+  return kMinBytes;
+}
+
 std::unique_ptr<op::operator_data> cpu_source_task::compute_task(rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"cpu_source_task::compute_task"};
 
-  auto& g_state    = _global_state->cast<cpu_source_task_global_state>();
-  auto& source     = g_state.get_source_op();
-  auto* sirius_ctx = _client_ctx.registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
+  auto& g_state = _global_state->cast<cpu_source_task_global_state>();
+  auto& source  = g_state.get_source_op();
 
-  // Request a host memory reservation
-  auto& mem_mgr = sirius_ctx->get_memory_manager();
-  // Use a conservative estimate — ColumnDataCollection is small
-  size_t reserve_size = 64 * 1024;  // 64 KB default
-  if (source.collection) {
-    // Estimate from collection size: count * avg_row_bytes
-    auto count = source.collection->Count();
-    if (count > 0) {
-      reserve_size = std::max(reserve_size, count * 256);  // generous estimate
-    }
-  }
-  auto reservation = mem_mgr.request_reservation(
-    cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST}, reserve_size);
-  if (!reservation) { throw std::runtime_error("[cpu_source_task] Failed to reserve host memory"); }
-  auto& mem_space = const_cast<cucascade::memory::memory_space&>(reservation->get_memory_space());
-
-  // Hand ownership of the reservation to the task's local state. Batches
-  // produced below reference memory backed by this reservation; keeping it
-  // alive on the task (not as a function-local) is what keeps the memory_space
-  // valid until the batches are consumed downstream.
+  // The reservation was acquired by duckdb_scan_executor::manager_loop before
+  // this task was dispatched. Batches produced below reference memory backed
+  // by this reservation, so it must stay alive on the local state until the
+  // batches are consumed downstream.
   auto* local = dynamic_cast<cpu_source_task_local_state*>(local_state());
   if (!local) { throw std::runtime_error("[cpu_source_task] Unexpected local state type"); }
-  local->set_reservation(std::move(reservation));
   auto* reservation_ptr = local->reservation();
+  if (!reservation_ptr) { throw std::runtime_error("[cpu_source_task] No memory reservation set"); }
+  auto& mem_space =
+    const_cast<cucascade::memory::memory_space&>(reservation_ptr->get_memory_space());
 
   std::vector<std::shared_ptr<cucascade::data_batch>> batches;
 

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -281,6 +281,26 @@ void duckdb_scan_executor::manager_loop()
         SIRIUS_LOG_ERROR("DuckDB Scan Executor: Failed to cast local state for task");
         break;
       }
+    } else if (scan_task && scan_task->is<cpu_source_task>()) {
+      auto bytes_needed = scan_task->get_estimated_reservation_size();
+      auto reservation  = _mem_mgr->request_reservation(
+        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST}, bytes_needed);
+      if (!reservation) {
+        SIRIUS_LOG_ERROR(
+          "DuckDB Scan Executor: Failed to acquire host memory reservation for CPU source");
+        _completion_handler->report_error(
+          "DuckDB Scan Executor: Failed to acquire host memory reservation for CPU source");
+        break;
+      }
+      if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
+            scan_task->local_state())) {
+        local_state->set_reservation(std::move(reservation));
+      } else {
+        _completion_handler->report_error(
+          "DuckDB Scan Executor: Failed to cast local state for cpu_source_task");
+        SIRIUS_LOG_ERROR("DuckDB Scan Executor: Failed to cast local state for cpu_source_task");
+        break;
+      }
     }
 
     auto exc_stream = _stream_pool->acquire_stream(

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -1163,7 +1163,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                             stream);
 }
 
-void sirius_physical_hash_join::finalize_operator()
+void sirius_physical_hash_join::on_finalize_operator()
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -164,7 +164,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   return std::make_unique<pipelineable_operator_data>(output_batches);
 }
 
-void sirius_physical_sort_partition::finalize_operator()
+void sirius_physical_sort_partition::on_finalize_operator()
 {
   if (_sample_op) { _sample_op->clear_partition_boundaries(); }
 }

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -269,10 +269,6 @@ void gpu_pipeline_executor::manager_loop()
             orig_task_id,
             oom.get_resume_operator_index());
 
-          // Mark old task as rescheduled so its destructor skips mark_task_completed().
-          // The rescheduled task will handle completion instead.
-          gpu_task->mark_as_rescheduled();
-
           auto intermediate_data = oom.release_intermediate_data();
           if (auto pipelineable_data =
                 dynamic_cast<op::pipelineable_operator_data*>(intermediate_data.get())) {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -184,6 +184,9 @@ gpu_pipeline_task::gpu_pipeline_task(
       }
     }
   }
+  if (auto* pipeline = _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()) {
+    pipeline->mark_task_created();
+  }
 }
 
 gpu_pipeline_task::~gpu_pipeline_task()

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -204,7 +204,6 @@ gpu_pipeline_task::~gpu_pipeline_task()
     }
   }
 
-  if (_oom_rescheduled) { return; }
   if (_global_state == nullptr ||
       _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline() == nullptr) {
     return;

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -365,6 +365,9 @@ void sirius_pipeline::update_pipeline_status()
       if (table_scan.exhausted.load()) {
         if (tasks_created.load() == tasks_completed.load()) {
           pipeline_finished.store(true);
+          for (auto& op : get_operators()) {
+            op.get().finalize_operator();
+          }
           should_notify = true;
         }
         end_nvtx_range_if_finished();
@@ -374,6 +377,9 @@ void sirius_pipeline::update_pipeline_status()
       if (!parquet_scan.has_more_partitions.load()) {
         if (tasks_created.load() == tasks_completed.load()) {
           pipeline_finished.store(true);
+          for (auto& op : get_operators()) {
+            op.get().finalize_operator();
+          }
           should_notify = true;
         }
         end_nvtx_range_if_finished();
@@ -383,6 +389,9 @@ void sirius_pipeline::update_pipeline_status()
       if (cpu_source.exhausted.load()) {
         if (tasks_created.load() == tasks_completed.load()) {
           pipeline_finished.store(true);
+          for (auto& op : get_operators()) {
+            op.get().finalize_operator();
+          }
           should_notify = true;
         }
         end_nvtx_range_if_finished();

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -25,6 +25,7 @@
 #include "op/sirius_physical_delim_join.hpp"
 #include "op/sirius_physical_duckdb_scan.hpp"
 #include "op/sirius_physical_grouped_aggregate.hpp"
+#include "op/sirius_physical_iceberg_scan.hpp"
 #include "op/sirius_physical_parquet_scan.hpp"
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "sirius/exception.hpp"
@@ -339,67 +340,83 @@ void sirius_pipeline::notify_downstream_pipelines()
   }
 }
 
+std::unique_lock<std::mutex> sirius_pipeline::get_task_creation_lock()
+{
+  return std::unique_lock<std::mutex>(_status_mutex);
+}
+
 void sirius_pipeline::update_pipeline_status()
 {
-  auto end_nvtx_range_if_finished = [this]() {
-    if (pipeline_finished.load() && _nvtx_range_started.load()) {
-      nvtxRangeEnd(_nvtx_pipeline_range_id);
-    }
-  };
+  bool should_notify = false;
+  {
+    std::lock_guard<std::mutex> lock(_status_mutex);
 
-  // Skip if already finished — avoids redundant re-evaluation and re-notification.
-  if (pipeline_finished.load()) {
-    notify_downstream_pipelines();
-    return;
-  }
+    auto end_nvtx_range_if_finished = [this]() {
+      if (pipeline_finished.load() && _nvtx_range_started.load()) {
+        nvtxRangeEnd(_nvtx_pipeline_range_id);
+      }
+    };
 
-  if (get_source()->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
-    auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
-    if (table_scan.exhausted.load()) {  // WSM amin TODO: can we use exhausted? how about we use
-                                        // get_next_task_hint() to check if the source is ready?
-      if (tasks_created.load() == tasks_completed.load()) {
-        pipeline_finished.store(true);
-        notify_downstream_pipelines();
-      }
-      end_nvtx_range_if_finished();
-      return;
-    }
-  } else if (get_source()->type == op::SiriusPhysicalOperatorType::CPU_SOURCE) {
-    auto& cpu_source = get_source()->Cast<op::sirius_physical_cpu_source>();
-    if (cpu_source.exhausted.load()) {
-      if (tasks_created.load() == tasks_completed.load()) {
-        pipeline_finished.store(true);
-        notify_downstream_pipelines();
-      }
-      end_nvtx_range_if_finished();
-      return;
-    }
-  } else {
-    op::sirius_physical_operator* first_node =
-      operators.size() > 0 ? &operators[0].get() : (sink ? sink.get() : nullptr);
-    if (first_node == nullptr) { throw internal_exception("First node of pipeline is nullptr"); }
-    // Check if any operator has exhausted its limit — this allows the pipeline to finish
-    // early without waiting for the source pipeline to drain all remaining batches.
-    bool limit_exhausted = false;
-    for (auto& op_ref : operators) {
-      if (op_ref.get().is_limit_exhausted()) {
-        limit_exhausted = true;
-        break;
-      }
-    }
-    if (limit_exhausted ||
-        (first_node->is_source_pipeline_finished() && first_node->all_ports_empty())) {
-      if (tasks_created.load() == tasks_completed.load()) {
-        pipeline_finished.store(true);
-        for (auto& op : get_operators()) {
-          op.get().finalize_operator();
+    // Skip if already finished — avoids redundant re-evaluation and re-notification.
+    if (pipeline_finished.load()) {
+      should_notify = true;
+    } else if (get_source()->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
+      auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
+      if (table_scan.exhausted.load()) {
+        if (tasks_created.load() == tasks_completed.load()) {
+          pipeline_finished.store(true);
+          should_notify = true;
         }
         end_nvtx_range_if_finished();
-        notify_downstream_pipelines();
       }
+    } else if (get_source()->type == op::SiriusPhysicalOperatorType::ICEBERG_SCAN) {
+      auto& parquet_scan = static_cast<op::sirius_physical_parquet_scan&>(*get_source());
+      if (!parquet_scan.has_more_partitions.load()) {
+        if (tasks_created.load() == tasks_completed.load()) {
+          pipeline_finished.store(true);
+          should_notify = true;
+        }
+        end_nvtx_range_if_finished();
+      }
+    } else if (get_source()->type == op::SiriusPhysicalOperatorType::CPU_SOURCE) {
+      auto& cpu_source = get_source()->Cast<op::sirius_physical_cpu_source>();
+      if (cpu_source.exhausted.load()) {
+        if (tasks_created.load() == tasks_completed.load()) {
+          pipeline_finished.store(true);
+          should_notify = true;
+        }
+        end_nvtx_range_if_finished();
+      }
+    } else {
+      op::sirius_physical_operator* first_node =
+        operators.size() > 0 ? &operators[0].get() : (sink ? sink.get() : nullptr);
+      if (first_node == nullptr) { throw internal_exception("First node of pipeline is nullptr"); }
+      // Check if any operator has exhausted its limit — this allows the pipeline to finish
+      // early without waiting for the source pipeline to drain all remaining batches.
+      bool limit_exhausted = false;
+      for (auto& op_ref : operators) {
+        if (op_ref.get().is_limit_exhausted()) {
+          limit_exhausted = true;
+          break;
+        }
+      }
+      if (limit_exhausted ||
+          (first_node->is_source_pipeline_finished() && first_node->all_ports_empty())) {
+        if (tasks_created.load() == tasks_completed.load()) {
+          pipeline_finished.store(true);
+          for (auto& op : get_operators()) {
+            op.get().finalize_operator();
+          }
+          end_nvtx_range_if_finished();
+          should_notify = true;
+        }
+      }
+      if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
     }
-    if (!pipeline_finished.load()) { end_nvtx_range_if_finished(); }
-  }
+  }  // _status_mutex released here — notify_downstream_pipelines must run outside the lock
+     // to avoid holding the child pipeline mutex while acquiring a parent's
+
+  if (should_notify) { notify_downstream_pipelines(); }
 }
 
 void sirius_pipeline::mark_task_created()

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -355,18 +355,20 @@ void sirius_pipeline::update_pipeline_status()
 
   if (get_source()->type == op::SiriusPhysicalOperatorType::DUCKDB_SCAN) {
     auto& table_scan = get_source()->Cast<op::sirius_physical_duckdb_scan>();
-    if (table_scan.exhausted) {  // WSM amin TODO: can we use exhausted? how about we use
-                                 // get_next_task_hint() to check if the source is ready?
-      pipeline_finished.store(true);
+    if (table_scan.exhausted.load()) {  // WSM amin TODO: can we use exhausted? how about we use
+                                        // get_next_task_hint() to check if the source is ready?
+      if (tasks_created.load() == tasks_completed.load()) {
+        pipeline_finished.store(true);
+        notify_downstream_pipelines();
+      }
       end_nvtx_range_if_finished();
-      notify_downstream_pipelines();
       return;
     }
   } else if (get_source()->type == op::SiriusPhysicalOperatorType::CPU_SOURCE) {
     auto& cpu_source = get_source()->Cast<op::sirius_physical_cpu_source>();
     if (cpu_source.exhausted.load()) {
       if (tasks_created.load() == tasks_completed.load()) {
-        pipeline_finished = true;
+        pipeline_finished.store(true);
         notify_downstream_pipelines();
       }
       end_nvtx_range_if_finished();

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -150,6 +150,7 @@ void SiriusContext::QueryEnd()
   try {
     spdlog::info("QueryEnd");
     captured_logical_plan_.reset();
+
     query_.reset();
 
     // Drain all downgrade executors before clearing repositories — ensures no downgrade

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -223,6 +223,10 @@ void sirius_engine::execute()
     future.get();
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
+    // Drain all in-flight GPU tasks before returning.  QueryEnd() will call
+    // clear_all_repositories() immediately after execute() throws; without
+    // this drain, tasks still running in the thread pool hold raw pointers to
+    // those repositories and cause a use-after-free / heap corruption.
     sirius_ctx->get_task_scheduler().drain_after_error();
     throw;
   } catch (...) {

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -223,16 +223,27 @@ void sirius_engine::execute()
     future.get();
   } catch (const std::exception& e) {
     SIRIUS_LOG_ERROR("Error executing query: {}", e.what());
-    // Drain all in-flight GPU tasks before returning.  QueryEnd() will call
-    // clear_all_repositories() immediately after execute() throws; without
-    // this drain, tasks still running in the thread pool hold raw pointers to
-    // those repositories and cause a use-after-free / heap corruption.
     sirius_ctx->get_task_scheduler().drain_after_error();
     throw;
   } catch (...) {
     SIRIUS_LOG_ERROR("Unknown error executing query");
     sirius_ctx->get_task_scheduler().drain_after_error();
     throw;
+  }
+
+  // All tasks completed — operators and pipelines are still alive here.
+  // Warn about any intermediate operators that were never finalized.
+  if (auto query = sirius_ctx->get_query()) {
+    for (const auto& pipeline : query->get_pipelines()) {
+      for (const auto& op_ref : pipeline->get_operators()) {
+        const auto& op = op_ref.get();
+        if (!op.finalized) {
+          SIRIUS_LOG_WARN("[execute] operator '{}' (id={}) was not finalized",
+                          op.get_name(),
+                          op.get_operator_id());
+        }
+      }
+    }
   }
 }
 

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1944,7 +1944,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l join orders o on l.l_orderkey = o.o_orderkey order by "
-    "l.l_orderkey, l.l_linenumber;");
+    "l.l_orderkey, l.l_linenumber limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
@@ -1954,7 +1954,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l join orders o on l.l_orderkey = o.o_orderkey order by "
-    "l.l_orderkey, l.l_linenumber;");
+    "l.l_orderkey, l.l_linenumber limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
@@ -1964,7 +1964,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l left join orders o on l.l_orderkey = o.o_orderkey "
-    "order by l.l_orderkey, l.l_linenumber;");
+    "order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
@@ -1974,7 +1974,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l left join orders o on l.l_orderkey = o.o_orderkey "
-    "order by l.l_orderkey, l.l_linenumber;");
+    "order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
@@ -1984,7 +1984,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l right join orders o on l.l_orderkey = o.o_orderkey "
-    "order by l.l_orderkey, l.l_linenumber;");
+    "order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
@@ -1994,7 +1994,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l right join orders o on l.l_orderkey = o.o_orderkey "
-    "order by l.l_orderkey, l.l_linenumber;");
+    "order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
@@ -2004,7 +2004,7 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l full outer join orders o on l.l_orderkey = "
-    "o.o_orderkey order by l.l_orderkey, l.l_linenumber;");
+    "o.o_orderkey order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 TEST_CASE_METHOD(GPUExecutionParquetFixture,
@@ -2014,7 +2014,7 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu(
     "select l.l_orderkey, l.l_linenumber, l.l_quantity, l.l_partkey, o.o_orderkey, o.o_totalprice, "
     "o.o_custkey, o_comment from lineitem l full outer join orders o on l.l_orderkey = "
-    "o.o_orderkey order by l.l_orderkey, l.l_linenumber;");
+    "o.o_orderkey order by l.l_orderkey, l.l_linenumber  limit 5000;");
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -172,6 +172,7 @@ struct pipeline_task_history_fixture {
 //------------------------------------------------------------------------------
 struct pipeline_context {
   duckdb::shared_ptr<sirius::pipeline::sirius_pipeline> pipeline;
+  std::unique_ptr<stub_operator> stub_source;
   std::unique_ptr<stub_operator> stub_op;
 };
 
@@ -181,9 +182,11 @@ pipeline_context create_pipeline_context()
   const sirius::pipeline::pipeline_build_context build_ctx{true};
   ctx.pipeline = duckdb::make_shared_ptr<sirius::pipeline::sirius_pipeline>(build_ctx);
   ctx.pipeline->set_pipeline_id(42);
-  ctx.stub_op = std::make_unique<stub_operator>();
+  ctx.stub_source = std::make_unique<stub_operator>();
+  ctx.stub_op     = std::make_unique<stub_operator>();
 
   sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.set_pipeline_source(*ctx.pipeline, *ctx.stub_source);
   build_state.add_pipeline_operator(*ctx.pipeline, *ctx.stub_op);
   build_state.set_pipeline_sink(*ctx.pipeline, *ctx.stub_op, 1);
   return ctx;
@@ -323,8 +326,6 @@ TEST_CASE(
 
   auto task =
     create_pipeline_task(f, global_state, std::move(input_batch), kReservationSize, /*task_id=*/1);
-  // This unit test constructs a minimal pipeline shell, so never run the completion path.
-  task->mark_as_rescheduled();
 
   REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
 
@@ -382,7 +383,6 @@ TEST_CASE("gpu_pipeline_task execute OOM in operator execute records to pipeline
 
   auto task =
     create_pipeline_task(f, global_state, std::move(input_batch), kReservationSize, /*task_id=*/1);
-  task->mark_as_rescheduled();
 
   REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
 
@@ -435,9 +435,6 @@ TEST_CASE("gpu_pipeline_task execute successfully records to pipeline memory his
     create_pipeline_task(f, global_state, std::move(input_batch), kReservationSize1, /*task_id=*/1);
 
   task1->execute(stream);
-  // Mark as rescheduled so the destructor does not call mark_task_completed()
-  // (which would dereference the pipeline's null source operator).
-  task1->mark_as_rescheduled();
 
   // Verify: memory history should have one record with the peak_bytes
   REQUIRE(global_state->get_memory_history().size() == 1);
@@ -464,9 +461,6 @@ TEST_CASE("gpu_pipeline_task execute successfully records to pipeline memory his
   local_state2_ptr->set_reservation(std::move(task_reservation2));
 
   task2->execute(stream);
-  // Mark as rescheduled so the destructor does not call mark_task_completed()
-  // (which would dereference the pipeline's null source operator).
-  task2->mark_as_rescheduled();
 
   // Verify: memory history should have two records with the peak_bytes, and verify that
   // estimates now consider the second tasks history
@@ -550,7 +544,6 @@ TEST_CASE("record_on_failure deduplicates OOM records and keeps max peak",
 
     auto task =
       create_pipeline_task(f, global_state, std::move(batch), kReservationSize, /*task_id=*/1);
-    task->mark_as_rescheduled();
     REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
   }
 
@@ -569,7 +562,6 @@ TEST_CASE("record_on_failure deduplicates OOM records and keeps max peak",
 
     auto task =
       create_pipeline_task(f, global_state, std::move(batch), kReservationSize, /*task_id=*/2);
-    task->mark_as_rescheduled();
     REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
   }
 
@@ -588,7 +580,6 @@ TEST_CASE("record_on_failure deduplicates OOM records and keeps max peak",
 
     auto task =
       create_pipeline_task(f, global_state, std::move(batch), kReservationSize, /*task_id=*/3);
-    task->mark_as_rescheduled();
     REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
   }
 
@@ -607,7 +598,6 @@ TEST_CASE("record_on_failure deduplicates OOM records and keeps max peak",
 
     auto task =
       create_pipeline_task(f, global_state, std::move(batch), kReservationSize, /*task_id=*/4);
-    task->mark_as_rescheduled();
     REQUIRE_THROWS_AS(task->execute(stream), sirius::pipeline::oom_reschedule_exception);
   }
 


### PR DESCRIPTION
This PR fixes a race condition which was primarily caused by the fact that we can be checking if a pipeline is completed at the same time as tasks are being created. 

This PR adds a mutex to the sirius_pipeline class. Now task creation (including pulling data from a port to create the task) is done within this lock and updating the pipeline status (to set it to complete)  is also done within the same lock, removing the race condition.

This PR also fixes other minor issues related to pipeline and operator completion, such as ensuring all operators are finalized and checking at the end of a query to ensure that is the case.
It also fixes CPU_SOURCE_TASKS so that memory reservation is done in the duckdb_scan_executor instead of in its compute_task function. 