### PR TITLE
Add per-query pin_table benchmark mode to TPC-H runner

### DIFF
--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -70,13 +70,29 @@ export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 ```
 
 Each run creates a directory under `runs/<timestamp>_sf<SF>_2iter/` containing:
-- `run_info.txt` — git branch/revision, tree clean/dirty, build freshness, hostname, memory, CPUs, GPUs, filesystem read benchmark
+- `run_info.txt` — git branch/revision, tree clean/dirty, build freshness, hostname, memory, CPUs, GPUs, filesystem read benchmark, pinning_mode setting
 - `run_info.patch` — full git diff when tree is dirty
 - `sirius_config.yaml` — copy of the Sirius config used
 - `sirius/` and `duckdb/` — per-engine logs, per-query results and timings
 - `validation.csv` — per-query match/error status
 - `comparison.txt` — cold/warm timing table with speedup ratios
 - `timings.csv` — long-format iteration runtimes (engine,query,iteration,runtime_s)
+
+#### `--pinning-mode per-query` (PR #721 pin_table)
+
+When passed `--pinning-mode per-query`, the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the query for `--iterations` runs back-to-back, then `CALL unpin_table(<table>)` for each pinned table. This isolates per-query pinning cost from query execution: the query-iteration timings written to `timings.csv` reflect query-only time on the pinned-cache scan path.
+
+The per-query column-set is sourced from `tpch_pin_columns.py` (must be a superset of every column the query references, otherwise the scan falls through to disk). The pin path is a glob whose `FileSystem::GlobFiles` expansion must equal the file list of the corresponding `CREATE VIEW … read_parquet([…])` — otherwise `sirius_scan_manager::create_provider_for` will not match and the cache is silently bypassed.
+
+```bash
+./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query 100
+```
+
+The DuckDB engine ignores the flag (pinning is Sirius-only) and runs as the unchanged baseline. Pinning time is **not** measured — markers (`__TPCH_PIN_BEGIN__`, `__TPCH_UNPIN_BEGIN__`, …) keep pin/unpin `Run Time` lines outside the iteration-time parser window. In single-session mode, every pinned table is unpinned at the end of its query block before the next query's pin calls run — no carry-over even when consecutive queries reference the same table. In multi-session mode the unpin still runs before each per-query process exits, defensively releasing GPU memory back to the allocator.
+
+To verify a query actually hit the cache, grep `runs/.../sirius/q<N>/sirius.log` for `using cached_split_provider`; the matching-fallback log line is `not all the columns are pinned for this query`.
+
+Tier override: the helper defaults to `tier='gpu'` — the only tier currently implemented in `src/sirius_extension.cpp`. **`tier='host'` is not supported right now and will be added later**: setting `SIRIUS_PIN_TIER=host` today makes the emitted `CALL pin_table` throw `NotImplementedException` at bind time (`src/sirius_extension.cpp:681-683`), and queries fall through to disk reads. Once host-tier support lands, flip via `SIRIUS_PIN_TIER=host`.
 
 ### Unified query runner
 
@@ -217,6 +233,7 @@ Output: `reports/<label>_<YYYYMMDD_HHMMSS>/` containing `report.md`, `summary.js
 | `rewrite_parquet.py` | Rewrite parquet with GPU-optimized row groups (cudf or pyarrow fallback) |
 | `performance_test.py` | Python-based benchmark with result verification |
 | `queries.py` | TPC-H query definitions (base SQL) |
+| `tpch_pin_columns.py` | Per-query column → table mapping for `--pinning-mode per-query`; emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
 | `generate_test_data.py` | Generate test data via dbgen |
 | `generate_test_data_tpchgen-rs.py` | Generate test data via tpchgen-rs Python wrapper + query files |
 | `pixi.toml` | Python environment with cudf, pyarrow, rust for tooling |

--- a/test/tpch_performance/benchmark_and_validate.sh
+++ b/test/tpch_performance/benchmark_and_validate.sh
@@ -302,6 +302,7 @@ DUCKDB_RESULTS_DIR=""
 DUCKDB_FILE=""
 MULTI_SESSION=false
 DROP_OS_CACHE=false
+PINNING_MODE="none"
 FLOAT_TOL="1e-10"
 while [ $# -gt 1 ]; do
     case "$1" in
@@ -311,6 +312,10 @@ while [ $# -gt 1 ]; do
             ;;
         --float-tolerance)
             FLOAT_TOL="$2"
+            shift 2
+            ;;
+        --pinning-mode)
+            PINNING_MODE="$2"
             shift 2
             ;;
         --data-source)
@@ -366,10 +371,19 @@ done
 NUM_ITERATIONS="${NUM_ITERATIONS:-2}"
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-1200}"
 
+case "$PINNING_MODE" in
+    none|per-query) ;;
+    *)
+        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        exit 1
+        ;;
+esac
+
 if [ $# -ne 1 ]; then
     echo "Usage: $0 [--config <config_file>] [--data-source parquet|duckdb] [--parquet-dir <path>] [--duckdb-file <path>]"
     echo "          [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>]"
-    echo "          [--multi-session] [--drop-os-cache] [--float-tolerance <value>] <scale_factor>"
+    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query]"
+    echo "          [--float-tolerance <value>] <scale_factor>"
     echo "       $0 --report [--float-tolerance <value>] <run_dir>"
     echo "  --data-source parquet  (default) → run_tpch_parquet.sh + test_datasets/tpch_parquet_sf<SF> or --parquet-dir"
     echo "  --data-source duckdb             → run_tpch_duckdb.sh + performance_test.duckdb or --duckdb-file"
@@ -500,6 +514,7 @@ echo "=== Collecting run info and filesystem benchmark ==="
     echo "--- Benchmark settings ---"
     echo "multi_session: $MULTI_SESSION"
     echo "drop_os_cache: $DROP_OS_CACHE"
+    echo "pinning_mode: $PINNING_MODE"
     echo ""
 
     echo "--- Benchmark input ---"
@@ -656,6 +671,11 @@ for engine in $ENGINES; do
     fi
     if [ "$DROP_OS_CACHE" = true ]; then
         EXTRA_ARGS+=(--drop-os-cache)
+    fi
+    # Pinning is a Sirius-only feature; the runner ignores it for the duckdb engine,
+    # but we still pass the flag so DuckDB-engine logs reflect the requested mode.
+    if [ "$PINNING_MODE" != "none" ]; then
+        EXTRA_ARGS+=(--pinning-mode "$PINNING_MODE")
     fi
     OUTPUT_DIR="$ENGINE_DIR" "$RUN_SCRIPT" "${EXTRA_ARGS[@]}" "$engine" "$SF" "${QUERIES[@]}" \
         2>&1 | tee "$ENGINE_DIR/run.log"

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -48,7 +48,8 @@ NUM_ITERATIONS=2
 SESSION_TIMEOUT=1200
 DROP_OS_CACHE=false
 MULTI_SESSION=false
-while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:-}" = "--timeout" ] || [ "${1:-}" = "--drop-os-cache" ] || [ "${1:-}" = "--multi-session" ]; do
+PINNING_MODE="none"
+while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:-}" = "--timeout" ] || [ "${1:-}" = "--drop-os-cache" ] || [ "${1:-}" = "--multi-session" ] || [ "${1:-}" = "--pinning-mode" ]; do
     if [ "$1" = "--parquet-dir" ]; then
         PARQUET_DIR="$2"
         shift 2
@@ -64,16 +65,29 @@ while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:
     elif [ "$1" = "--multi-session" ]; then
         MULTI_SESSION=true
         shift
+    elif [ "$1" = "--pinning-mode" ]; then
+        PINNING_MODE="$2"
+        shift 2
     fi
 done
 
+case "$PINNING_MODE" in
+    none|per-query) ;;
+    *)
+        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        exit 1
+        ;;
+esac
+
 if [ $# -lt 3 ]; then
-    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] <engine> <scale_factor> <query_numbers...>"
+    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] <engine> <scale_factor> <query_numbers...>"
     echo "Example: $0 sirius 100 \`seq 1 22\`"
-    echo "  --iterations N    Number of iterations per query (default: 2, 1 cold + N-1 warm)"
-    echo "  --timeout N       Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
-    echo "  --multi-session   Run each query in its own DuckDB process (fresh state per query)"
-    echo "  --drop-os-cache   Drop OS filesystem cache before each query (requires --multi-session and sudo)"
+    echo "  --iterations N      Number of iterations per query (default: 2, 1 cold + N-1 warm)"
+    echo "  --timeout N         Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
+    echo "  --multi-session     Run each query in its own DuckDB process (fresh state per query)"
+    echo "  --drop-os-cache     Drop OS filesystem cache before each query (requires --multi-session and sudo)"
+    echo "  --pinning-mode MODE 'per-query' calls pin_table for each query's columns before its iterations,"
+    echo "                      then unpin_table afterward. Sirius engine only. Default: 'none'."
     exit 1
 fi
 
@@ -212,6 +226,13 @@ if [ "$DROP_OS_CACHE" = true ]; then
     echo "Drop OS cache: enabled"
 fi
 echo "Iterations: $NUM_ITERATIONS (1 cold + $((NUM_ITERATIONS - 1)) warm)"
+if [ "$PINNING_MODE" != "none" ]; then
+    if [ "$ENGINE" = "sirius" ]; then
+        echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu})"
+    else
+        echo "Pinning mode: $PINNING_MODE (ignored — Sirius-only feature)"
+    fi
+fi
 echo "Queries: ${QUERIES[*]}"
 if [ "$SESSION_TIMEOUT" -gt 0 ] 2>/dev/null; then
     echo "Session timeout: ${SESSION_TIMEOUT}s"
@@ -230,6 +251,11 @@ run_single_session() {
     local MARKER_PREFIX="__TPCH_MARKER__"
     local END_MARKER="__TPCH_END__"
 
+    local PIN_ENABLED=false
+    if [ "$PINNING_MODE" = "per-query" ] && [ "$ENGINE" = "sirius" ]; then
+        PIN_ENABLED=true
+    fi
+
     local TEMP_SQL
     TEMP_SQL=$(mktemp /tmp/tpch_all_XXXXXX.sql)
     printf '%s\n' "$VIEW_SQL" > "$TEMP_SQL"
@@ -237,12 +263,24 @@ run_single_session() {
 
     for q in "${VALID_QUERIES[@]}"; do
         local QUERY_FILE="$QUERY_DIR/q${q}.sql"
+        # Pin/unpin live OUTSIDE the __TPCH_MARKER__ section so pin/unpin
+        # Run Time lines never get counted as query iterations.
+        if [ "$PIN_ENABLED" = true ]; then
+            echo ".print __TPCH_PIN_BEGIN__ ${q}" >> "$TEMP_SQL"
+            python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin "$q" "$PARQUET_DIR" >> "$TEMP_SQL"
+            echo ".print __TPCH_PIN_END__ ${q}" >> "$TEMP_SQL"
+        fi
         echo ".print ${MARKER_PREFIX} ${q}" >> "$TEMP_SQL"
         # N iterations back-to-back — nothing between them.
         for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do
             cat "$QUERY_FILE" >> "$TEMP_SQL"
             printf '\n' >> "$TEMP_SQL"
         done
+        if [ "$PIN_ENABLED" = true ]; then
+            echo ".print __TPCH_UNPIN_BEGIN__ ${q}" >> "$TEMP_SQL"
+            python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin "$q" >> "$TEMP_SQL"
+            echo ".print __TPCH_UNPIN_END__ ${q}" >> "$TEMP_SQL"
+        fi
     done
     echo ".print ${END_MARKER}" >> "$TEMP_SQL"
 
@@ -307,14 +345,15 @@ run_single_session() {
         echo ""
         echo "========== Q${q} =========="
 
-        # Extract the section between this query's marker and the next marker.
+        # Extract the section between this query's marker and the next __TPCH_* marker.
+        # Stopping at any __TPCH_ prefix keeps pin/unpin Run Time lines (which sit in
+        # __TPCH_PIN_*/__TPCH_UNPIN_* sections when --pinning-mode per-query is on)
+        # out of the query iteration window.
         local SECTION
-        SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" \
-                      -v prefix="${MARKER_PREFIX}" \
-                      -v end="${END_MARKER}" '
-            $0 == start                                   { cap = 1; next }
-            cap && ($0 == end || index($0, prefix) == 1)  { exit }
-            cap                                           { print }
+        SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" '
+            $0 == start                            { cap = 1; next }
+            cap && index($0, "__TPCH_") == 1       { exit }
+            cap                                    { print }
         ' "$TEMP_OUTPUT")
 
         if [ -z "$SECTION" ]; then
@@ -405,6 +444,13 @@ run_multi_session() {
         fi
 
         # Build per-query SQL: views + scan cache level (sirius) + timer + N iterations.
+        # In --pinning-mode per-query, pin before iterations and unpin after — the unpin
+        # is mandatory even though the process is about to exit, to release host-pinned
+        # memory cleanly back to the allocator before the next process starts.
+        local PIN_ENABLED=false
+        if [ "$PINNING_MODE" = "per-query" ] && [ "$ENGINE" = "sirius" ]; then
+            PIN_ENABLED=true
+        fi
         local TEMP_SQL
         TEMP_SQL=$(mktemp /tmp/tpch_q${q}_XXXXXX.sql)
         {
@@ -413,10 +459,20 @@ run_multi_session() {
                 printf "SET scan_cache_level = '%s';\n" "${QUERY_CACHE_LEVEL[$q]}"
             fi
             printf ".timer on\n"
+            if [ "$PIN_ENABLED" = true ]; then
+                printf ".print __TPCH_PIN_BEGIN__ %s\n" "$q"
+                python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin "$q" "$PARQUET_DIR"
+                printf ".print __TPCH_PIN_END__ %s\n" "$q"
+            fi
             for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do
                 cat "$QUERY_FILE"
                 printf '\n'
             done
+            if [ "$PIN_ENABLED" = true ]; then
+                printf ".print __TPCH_UNPIN_BEGIN__ %s\n" "$q"
+                python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin "$q"
+                printf ".print __TPCH_UNPIN_END__ %s\n" "$q"
+            fi
         } > "$TEMP_SQL"
 
         # Run in a fresh DuckDB process.
@@ -462,15 +518,29 @@ run_multi_session() {
             continue
         fi
 
+        # When pinning is on, the session output contains pin/unpin Run Time lines
+        # bracketing the iterations. Extract just the iteration window so the
+        # downstream awk and grep see only query iterations.
+        local PARSE_INPUT
+        if [ "$PIN_ENABLED" = true ]; then
+            PARSE_INPUT=$(awk '
+                index($0, "__TPCH_PIN_END__")    == 1 { cap = 1; next }
+                index($0, "__TPCH_UNPIN_BEGIN__") == 1 { exit }
+                cap { print }
+            ' <<< "$OUTPUT")
+        else
+            PARSE_INPUT="$OUTPUT"
+        fi
+
         # Save last-iteration result (lines between the 2nd-to-last and last "Run Time" lines).
         awk -v n="$NUM_ITERATIONS" '
             /Run Time \(s\):/ { tc++; next }
             tc == (n - 1)     { print }
-        ' <<< "$OUTPUT" > "$RESULT_FILE"
+        ' <<< "$PARSE_INPUT" > "$RESULT_FILE"
 
         # Extract per-iteration timings.
         local TIMES
-        readarray -t TIMES < <(grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+' <<< "$OUTPUT")
+        readarray -t TIMES < <(grep -oP 'Run Time \(s\): real \K[0-9]+\.[0-9]+' <<< "$PARSE_INPUT")
 
         {
             echo "step,runtime_s"
@@ -510,10 +580,13 @@ fi
 # ---------------------------------------------------------------------------
 # Split the Sirius log into per-query segments.
 #
-# The log contains "QueryBegin: call gpu_execution(...)" lines for each
-# iteration.  We group every NUM_ITERATIONS consecutive QueryBegin entries
-# (one per iteration) into one query segment and copy it to Q_DIR/sirius.log.
-# The combined log is kept in OUTPUT_DIR.
+# Under Super Sirius transparent execution, each query iteration is logged as
+# "QueryBegin: <raw SQL>" — there is no `call gpu_execution(...)` wrapper.
+# Skip the session prologue (CREATE VIEW for view setup) and any pinning-mode
+# CALLs (pin_table / unpin_table) so the remaining QueryBegin lines correspond
+# 1:1 to user query iterations. We group every NUM_ITERATIONS consecutive
+# entries into one query segment and copy it to Q_DIR/sirius.log. The combined
+# log is kept in OUTPUT_DIR.
 # ---------------------------------------------------------------------------
 if [ "$ENGINE" = "sirius" ] && [ "$MULTI_SESSION" = false ] && [ -n "${OUTPUT_DIR:-}" ] && [ ${#VALID_QUERIES[@]} -gt 0 ]; then
     # spdlog daily sink names files sirius_YYYY-MM-DD.log; find the most recent one.
@@ -524,8 +597,16 @@ if [ "$ENGINE" = "sirius" ] && [ "$MULTI_SESSION" = false ] && [ -n "${OUTPUT_DI
     if [ -n "$LOG_FILE" ]; then
         echo ""
         echo "Splitting Sirius log per query (${NUM_ITERATIONS} iterations per query)..."
-        readarray -t QB_LINES < <(grep -n 'QueryBegin: call' "$LOG_FILE" | cut -d: -f1)
+        readarray -t QB_LINES < <(
+            grep -nE 'QueryBegin:' "$LOG_FILE" \
+                | grep -ivE 'QueryBegin: (CREATE VIEW|CALL (pin_table|unpin_table))' \
+                | cut -d: -f1
+        )
         TOTAL_LOG_LINES=$(wc -l < "$LOG_FILE")
+
+        if [ "${#QB_LINES[@]}" -ne $((${#VALID_QUERIES[@]} * NUM_ITERATIONS)) ]; then
+            echo "  WARNING: expected $((${#VALID_QUERIES[@]} * NUM_ITERATIONS)) QueryBegin lines (queries × iterations) but found ${#QB_LINES[@]} — split may be misaligned."
+        fi
 
         for ((i = 0; i < ${#VALID_QUERIES[@]}; i++)); do
             q="${VALID_QUERIES[$i]}"

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Emit `CALL pin_table(...)` / `CALL unpin_table(...)` SQL for a TPC-H query.
+
+Used by run_tpch_parquet.sh when --pinning-mode per-query is set.
+The path argument passed to pin_table is a glob whose FileSystem::GlobFiles
+expansion must match the file list in the corresponding CREATE VIEW
+read_parquet([...]) call — otherwise the scan_manager path-equality check
+in src/scan_manager/sirius_scan_manager.cpp will fall through to disk.
+
+Pin tier: defaults to 'gpu' (the only tier currently implemented).
+tier='host' is not supported right now and will be added later — emitting
+CALL pin_table(..., tier='host', ...) today raises NotImplementedException
+in src/sirius_extension.cpp. Override the default via SIRIUS_PIN_TIER once
+host support lands.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+# Columns each TPC-H query reads from each table it references.
+# Must be a SUPERSET of every column the planner pulls (filter, join,
+# projection, group-by, aggregation). A missing column makes
+# create_provider_for throw and silently fall back to parquet_split_provider
+# (see sirius_scan_manager.cpp:138-178 — exception is caught and logged
+# as "not all the columns are pinned for this query").
+QUERY_COLUMNS: dict[int, dict[str, list[str]]] = {
+    1: {
+        "lineitem": [
+            "l_returnflag",
+            "l_linestatus",
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_shipdate",
+        ],
+    },
+    2: {
+        "part": ["p_partkey", "p_mfgr", "p_size", "p_type"],
+        "supplier": [
+            "s_suppkey",
+            "s_acctbal",
+            "s_name",
+            "s_address",
+            "s_phone",
+            "s_comment",
+            "s_nationkey",
+        ],
+        "partsupp": ["ps_partkey", "ps_suppkey", "ps_supplycost"],
+        "nation": ["n_nationkey", "n_name", "n_regionkey"],
+        "region": ["r_regionkey", "r_name"],
+    },
+    3: {
+        "customer": ["c_mktsegment", "c_custkey"],
+        "orders": ["o_custkey", "o_orderkey", "o_orderdate", "o_shippriority"],
+        "lineitem": ["l_orderkey", "l_extendedprice", "l_discount", "l_shipdate"],
+    },
+    4: {
+        "orders": ["o_orderkey", "o_orderdate", "o_orderpriority"],
+        "lineitem": ["l_orderkey", "l_commitdate", "l_receiptdate"],
+    },
+    5: {
+        "orders": ["o_custkey", "o_orderkey", "o_orderdate"],
+        "lineitem": ["l_orderkey", "l_suppkey", "l_extendedprice", "l_discount"],
+        "supplier": ["s_suppkey", "s_nationkey"],
+        "nation": ["n_nationkey", "n_name", "n_regionkey"],
+        "region": ["r_regionkey", "r_name"],
+        "customer": ["c_custkey", "c_nationkey"],
+    },
+    6: {
+        "lineitem": ["l_extendedprice", "l_discount", "l_shipdate", "l_quantity"],
+    },
+    7: {
+        "supplier": ["s_suppkey", "s_nationkey"],
+        "lineitem": [
+            "l_suppkey",
+            "l_orderkey",
+            "l_shipdate",
+            "l_extendedprice",
+            "l_discount",
+        ],
+        "orders": ["o_orderkey", "o_custkey"],
+        "customer": ["c_custkey", "c_nationkey"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    8: {
+        "lineitem": [
+            "l_partkey",
+            "l_suppkey",
+            "l_orderkey",
+            "l_extendedprice",
+            "l_discount",
+        ],
+        "part": ["p_partkey", "p_type"],
+        "supplier": ["s_suppkey", "s_nationkey"],
+        "orders": ["o_orderkey", "o_custkey", "o_orderdate"],
+        "customer": ["c_custkey", "c_nationkey"],
+        "nation": ["n_nationkey", "n_regionkey", "n_name"],
+        "region": ["r_regionkey", "r_name"],
+    },
+    9: {
+        "part": ["p_partkey", "p_name"],
+        "supplier": ["s_suppkey", "s_nationkey"],
+        "lineitem": [
+            "l_suppkey",
+            "l_partkey",
+            "l_orderkey",
+            "l_extendedprice",
+            "l_discount",
+            "l_quantity",
+        ],
+        "partsupp": ["ps_suppkey", "ps_partkey", "ps_supplycost"],
+        "orders": ["o_orderkey", "o_orderdate"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    10: {
+        "customer": [
+            "c_custkey",
+            "c_name",
+            "c_acctbal",
+            "c_address",
+            "c_phone",
+            "c_comment",
+            "c_nationkey",
+        ],
+        "orders": ["o_custkey", "o_orderkey", "o_orderdate"],
+        "lineitem": ["l_orderkey", "l_extendedprice", "l_discount", "l_returnflag"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    11: {
+        "partsupp": ["ps_partkey", "ps_suppkey", "ps_supplycost", "ps_availqty"],
+        "supplier": ["s_suppkey", "s_nationkey"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    12: {
+        "orders": ["o_orderkey", "o_orderpriority"],
+        "lineitem": [
+            "l_orderkey",
+            "l_shipmode",
+            "l_commitdate",
+            "l_receiptdate",
+            "l_shipdate",
+        ],
+    },
+    13: {
+        "customer": ["c_custkey"],
+        "orders": ["o_custkey", "o_orderkey", "o_comment"],
+    },
+    14: {
+        "lineitem": ["l_partkey", "l_extendedprice", "l_discount", "l_shipdate"],
+        "part": ["p_partkey", "p_type"],
+    },
+    15: {
+        "lineitem": ["l_suppkey", "l_extendedprice", "l_discount", "l_shipdate"],
+        "supplier": ["s_suppkey", "s_name", "s_address", "s_phone"],
+    },
+    16: {
+        "partsupp": ["ps_partkey", "ps_suppkey"],
+        "part": ["p_partkey", "p_brand", "p_type", "p_size"],
+        "supplier": ["s_suppkey", "s_comment"],
+    },
+    17: {
+        "lineitem": ["l_partkey", "l_extendedprice", "l_quantity"],
+        "part": ["p_partkey", "p_brand", "p_container"],
+    },
+    18: {
+        "customer": ["c_name", "c_custkey"],
+        "orders": ["o_orderkey", "o_custkey", "o_orderdate", "o_totalprice"],
+        "lineitem": ["l_orderkey", "l_quantity"],
+    },
+    19: {
+        "lineitem": [
+            "l_partkey",
+            "l_extendedprice",
+            "l_discount",
+            "l_quantity",
+            "l_shipmode",
+            "l_shipinstruct",
+        ],
+        "part": ["p_partkey", "p_brand", "p_container", "p_size"],
+    },
+    20: {
+        "supplier": ["s_suppkey", "s_name", "s_address", "s_nationkey"],
+        "partsupp": ["ps_suppkey", "ps_partkey", "ps_availqty"],
+        "part": ["p_partkey", "p_name"],
+        "lineitem": ["l_partkey", "l_suppkey", "l_quantity", "l_shipdate"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    21: {
+        "supplier": ["s_suppkey", "s_nationkey", "s_name"],
+        "lineitem": ["l_suppkey", "l_orderkey", "l_receiptdate", "l_commitdate"],
+        "orders": ["o_orderkey", "o_orderstatus"],
+        "nation": ["n_nationkey", "n_name"],
+    },
+    22: {
+        "customer": ["c_custkey", "c_phone", "c_acctbal"],
+        "orders": ["o_custkey"],
+    },
+}
+
+
+def detect_pin_glob(parquet_dir: str, table: str) -> str:
+    """Return a glob whose expansion matches the file list of the existing CREATE VIEW.
+
+    run_tpch_parquet.sh accumulates files from three patterns:
+      1. <dir>/<table>.parquet         (single file)
+      2. <dir>/<table>_*.parquet       (numbered partitions)
+      3. <dir>/<table>/*.parquet       (subdirectory)
+    Patterns 1+2 are both captured by `<dir>/<table>*.parquet`.
+    """
+    abs_dir = os.path.abspath(parquet_dir)
+    same_dir_glob = os.path.join(abs_dir, f"{table}*.parquet")
+    sub_dir_glob = os.path.join(abs_dir, table, "*.parquet")
+    same_dir = sorted(glob.glob(same_dir_glob))
+    sub_dir = sorted(glob.glob(sub_dir_glob))
+
+    if same_dir and sub_dir:
+        raise RuntimeError(
+            f"mixed parquet layout for table '{table}' under {abs_dir}: "
+            f"both '{table}*.parquet' and '{table}/*.parquet' exist; "
+            "pin_table needs a single glob"
+        )
+    if same_dir:
+        return same_dir_glob
+    if sub_dir:
+        return sub_dir_glob
+    raise RuntimeError(f"no parquet files for table '{table}' under {abs_dir}")
+
+
+def emit_pin(query_num: int, parquet_dir: str) -> str:
+    # Tier defaults to 'gpu' — the only tier currently implemented in
+    # src/sirius_extension.cpp. tier='host' is NOT supported right now and
+    # will be added later; setting SIRIUS_PIN_TIER=host today will make the
+    # CALL pin_table statement throw NotImplementedException at bind time
+    # (src/sirius_extension.cpp:681-683). Once host-tier support lands,
+    # flip via SIRIUS_PIN_TIER=host.
+    tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
+    cols_by_table = QUERY_COLUMNS[query_num]
+    lines = []
+    for table, cols in cols_by_table.items():
+        path = detect_pin_glob(parquet_dir, table)
+        col_literals = ",".join(f"'{c}'" for c in cols)
+        lines.append(
+            f"CALL pin_table('{path}', tier='{tier}', name='{table}', cols=[{col_literals}]);"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def emit_unpin(query_num: int) -> str:
+    cols_by_table = QUERY_COLUMNS[query_num]
+    return "\n".join(f"CALL unpin_table('{table}');" for table in cols_by_table) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(
+            "Usage: tpch_pin_columns.py pin   <q_num> <parquet_dir>\n"
+            "       tpch_pin_columns.py unpin <q_num>\n"
+            "\n"
+            "Tier: defaults to 'gpu'; SIRIUS_PIN_TIER=host overrides once host-tier\n"
+            "support lands. tier='host' is NOT supported right now — use it today and\n"
+            "the CALL pin_table will throw NotImplementedException.",
+            file=sys.stderr,
+        )
+        return 1
+    cmd, q_str, *rest = argv[1:]
+    try:
+        q = int(q_str)
+    except ValueError:
+        print(f"q_num must be an integer (got {q_str!r})", file=sys.stderr)
+        return 1
+    if q not in QUERY_COLUMNS:
+        print(f"unknown query: q{q} (valid: 1..22)", file=sys.stderr)
+        return 1
+
+    if cmd == "pin":
+        if len(rest) != 1:
+            print("pin requires <parquet_dir>", file=sys.stderr)
+            return 1
+        try:
+            sys.stdout.write(emit_pin(q, rest[0]))
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+    elif cmd == "unpin":
+        if rest:
+            print("unpin takes no further arguments", file=sys.stderr)
+            return 1
+        sys.stdout.write(emit_unpin(q))
+    else:
+        print(f"unknown command: {cmd!r} (valid: pin, unpin)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

- Adds `--pinning-mode {none,per-query}` to `benchmark_and_validate.sh` and `run_tpch_parquet.sh`. In `per-query` mode the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the iterations back-to-back, then `CALL unpin_table(...)` — isolating per-query pinning cost from query execution and exercising the `cached_split_provider` scan path introduced in #721.
- New helper `test/tpch_performance/tpch_pin_columns.py` keeps the per-query column→table mapping (Q1..Q22), detects parquet layout (single file, `_*` partitioned, or subdirectory), and emits a glob whose `FileSystem::GlobFiles` expansion matches the corresponding `CREATE VIEW … read_parquet([…])` so the path-equality check in `sirius_scan_manager.cpp:92-99` lines up.
- Marker pairs (`__TPCH_PIN_BEGIN__`, `__TPCH_UNPIN_BEGIN__`, …) keep pin/unpin `Run Time` lines outside the iteration-time parser window so `timings.csv` reflects query-only time.
- **Per-query Sirius log split now works under Super Sirius transparent execution.** The splitter previously matched `QueryBegin: call gpu_execution(...)` (the legacy wrapper). Transparent execution logs queries as their raw SQL (`QueryBegin: SELECT ...`), so no per-query `q<N>/sirius.log` files were being produced. The splitter now matches any `QueryBegin:` and excludes the session prologue (`CREATE VIEW`) plus pinning-mode CALLs (`pin_table` / `unpin_table`), producing `runs/.../sirius/q<N>/sirius.log` slices for both `--pinning-mode none` and `--pinning-mode per-query`. Multi-session runs already get isolated per-query logs via `SIRIUS_LOG_DIR=$Q_DIR` and don't go through the splitter.
- DuckDB engine ignores the `--pinning-mode` flag and runs as the unchanged baseline.

Tier default is `gpu` (the only tier currently implemented in `sirius_extension.cpp:681-683`). Once host-tier support lands, set `SIRIUS_PIN_TIER=host` to flip the emitted SQL — no other change needed.

## Test plan

- [x] `bash -n` syntax-clean on both scripts; `pre-commit run` clean (black-formatted)
- [x] SF10 run with `--pinning-mode per-query`: all 22 queries match DuckDB (`validation.csv` all `success`), 168 `using cached_split_provider` hits, 0 fall-through misses, 72 pin / 72 unpin calls balanced
- [x] Per-query `sirius/q<N>/sirius.log` slices produced under `runs/.../`
- [x] Backward compatibility: omitting `--pinning-mode` produces a run identical in structure to today's runs
- [ ] Larger-scale run (SF100+) once available — pin amortization is more visible at I/O-bound scales

🤖 Generated with [Claude Code](https://claude.com/claude-code)