### PR TITLE
docs: refresh Super Sirius docs for scan manager and recent changes

### DIFF
--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -55,4 +55,4 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 11. **Configuration** — tuning knobs and runtime settings
 12. **Optimizations** — performance improvements and their mechanisms
 
-<!-- last-updated-commit: 662eb28df59609c188bec5ea1adae9388325f660 -->
+<!-- last-updated-commit: d6baaedc0d2bb07b27a00c65135513f3c23f0b37 -->

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -261,7 +261,7 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 |----------|---------|-------------|
 | `print_gpu_table_max_rows` | - | Max rows to print in debug output |
 | `enable_fallback_check` | - | Enable fallback validation |
-| `enable_duckdb_fallback` | false | Fall back to DuckDB CPU on Sirius errors |
+| `enable_duckdb_fallback` | true | Fall back to DuckDB CPU on Sirius errors. Matches the legacy `gpu_processing` path. Set to `false` to surface Sirius errors instead of silently falling back. |
 | `enable_regex_jit_impl` | - | Use JIT regex implementation |
 
 ## Legacy Config Flags
@@ -275,7 +275,7 @@ Static constants from `namespace duckdb::Config` (used by legacy Sirius) and `na
 | `USE_PIN_MEM_FOR_CPU_PROCESSING` | true | `duckdb::Config` |
 | `USE_PIN_MEM_FOR_CACHING` | false | `duckdb::Config` |
 | `USE_CUDF_EXPR` | true | `duckdb::Config` |
-| `ENABLE_DUCKDB_FALLBACK` | false | `duckdb::Config` |
+| `ENABLE_DUCKDB_FALLBACK` | true | `duckdb::Config` |
 | `NUM_GPU_EXECUTOR_THREADS` | 2 | `sirius::Config` |
 | `NUM_PIPELINE_EXECUTOR_THREADS` | 1 | `sirius::Config` |
 | `NUM_GPU` | 1 | `sirius::Config` |

--- a/docs/super-sirius/expression-executor.md
+++ b/docs/super-sirius/expression-executor.md
@@ -8,6 +8,8 @@ This document covers the GPU expression execution subsystem used by FILTER and P
 
 `gpu_expression_executor` evaluates DuckDB expressions on the GPU. It provides two execution modes:
 
+> **API boundary:** Operator headers and the executor's public header take expressions as `sirius::expression` / `sirius::join_condition` — opaque PIMPL wrappers around `duckdb::Expression` / `duckdb::JoinCondition` defined in `src/include/expression/`. Plan builders wrap at the DuckDB boundary (`sirius::wrap`); operator `.cpp` files unwrap internally via `expression/expression_internal.hpp` to access the raw DuckDB type. This keeps `duckdb/planner/expression/...` includes out of the operator surface.
+
 | Method | Purpose | Used By |
 |--------|---------|---------|
 | `execute(batch)` | Projects: evaluates expressions and returns result columns with all rows | PROJECTION |
@@ -59,11 +61,15 @@ SET expression_executor_strategy = 'ast_jit';   -- or 'ast_interpret', 'material
 | Constant | `BoundConstantExpression` | `42`, `'hello'` |
 | Comparison | `BoundComparisonExpression` | `a > b`, `x = 10`, `a IS NOT DISTINCT FROM b` |
 | Conjunction | `BoundConjunctionExpression` | `a AND b`, `x OR y` |
-| Arithmetic/logical | `BoundOperatorExpression` | `a + b`, `NOT x` |
+| Arithmetic/logical | `BoundOperatorExpression` | `a + b`, `NOT x`, `COALESCE(a, b, 0)`, `x IN (1, 2, 3)` |
 | Function call | `BoundFunctionExpression` | `UPPER(name)`, `YEAR(date)` |
 | Type cast | `BoundCastExpression` | `CAST(x AS DOUBLE)` |
 | CASE/WHEN | `BoundCaseExpression` | `CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END` |
 | BETWEEN | `BoundBetweenExpression` | `x BETWEEN 10 AND 20` |
+
+`COALESCE` is materialized via `cudf::replace_nulls` iteratively across children: the first child is materialized (scalars are lifted to a column); each subsequent child replaces the residual nulls in the running result. Children are only evaluated when the running result still has nulls. The result is wrapped via `materialize_as_ast_column` so COALESCE composes inside AST-capable parents. `count_ast_ops` returns 0 — COALESCE always takes the materialize-only path.
+
+`COMPARE_IN` covers the full numeric set (INT8–INT64, UINT8–UINT64, BOOL8, FLOAT, DOUBLE, DECIMAL32/64/128, all TIMESTAMP precisions, DATE) plus VARCHAR. BOOL8 dispatches via `uint8_t` because `std::vector<bool>::data()` is deleted.
 
 Per-expression-type dispatch lives in `src/expression_executor/specializations/` (one file per expression class: `gpu_execute_comparison.cpp`, `gpu_execute_case.cpp`, etc.). Each specialization decides how to emit AST nodes, materialize, or fall back based on the effective execution mode.
 

--- a/docs/super-sirius/memory-management.md
+++ b/docs/super-sirius/memory-management.md
@@ -103,7 +103,7 @@ The downgrade executor uses a request-based model with tiered candidate fetching
 2. The processing thread dequeues requests **sequentially** (to avoid contention between concurrent requests competing for the same batches).
 3. For each request, the processing loop fetches candidates lazily in tiered order:
    - **Tier 1 (data repositories):** Creates a `convertible_data_batch_provider` per repository and fetches idle GPU-resident batches one at a time
-   - **Tier 2 (pipeline_executor queue):** Creates a `convertible_gpu_pipeline_task_provider` to extract tasks with convertible data batches from the pipeline-level task queue
+   - **Tier 2 (task_scheduler queue):** Creates a `convertible_gpu_pipeline_task_provider` to extract tasks with convertible data batches from the pipeline-level task queue
 4. Each candidate is dispatched to the `bounded_thread_pool` and converted via `convertible_data::convert()`. After each conversion, the `predicate` is evaluated. If it returns `true`, no new candidates are dispatched (in-flight conversions finish naturally). The promise resolves with total bytes freed.
 
 **Pipeline integration:** When `gpu_pipeline_executor` gets a partial memory reservation (shortfall), it issues a single `request_downgrade(predicate)` where the predicate attempts `make_reservation_or_null(bytes_needed)`. The downgrade stops as soon as the reservation succeeds -- single request, no over-freeing.

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -56,23 +56,17 @@ Direct Parquet file scan. Reads column-chunk byte ranges and optionally material
 ### `sirius_physical_iceberg_scan` — `ICEBERG_SCAN`
 **File:** `src/include/op/sirius_physical_iceberg_scan.hpp`
 
-Apache Iceberg table scan with GPU-accelerated delete filters. Inherits from `sirius_physical_parquet_scan` since Iceberg uses Parquet as the data layer. Supports Iceberg V1 (append-only) and V2 (positional and equality deletes).
+Apache Iceberg table scan with GPU-accelerated delete filters. Inherits from `sirius_physical_parquet_scan` since Iceberg uses Parquet as the data layer. Supports Iceberg V1 (append-only), V2 (positional and equality deletes, including heterogeneous equality-delete schemas), and V3 (deletion vectors via PUFFIN files). Handles schema evolution, snapshot time-travel, and partition evolution.
 
-- **Delete filter pipeline:** Composes `positional_delete_filter` (sorted row position binary search) and `equality_delete_filter` (GPU `cudf::distinct_hash_join` anti-join mask) to apply deletes entirely on GPU with no D2H copies
-- **Metadata:** Custom `iceberg_metadata_reader` with lightweight Avro parser for manifest-list and manifest files
-- **Key members:** `positional_delete_files`, `equality_delete_files`
+- **Delete filter pipeline:** Composes `positional_delete_filter`, `equality_delete_filter` (per-key-schema groups, sequence-scoped), and a deletion-vector filter for V3 to apply deletes entirely on GPU with no D2H copies
+- **Metadata:** Manifest discovery delegates to DuckDB's `iceberg_metadata()`; the custom `iceberg_avro_reader` is the fallback for V3 deletion-vector PUFFIN files
 
 See [Scan — Iceberg Scan](scan.md#iceberg-scan) for details.
-
-### `sirius_parquet_metadata_scan_operator` — `PARQUET_METADATA_SCAN`
-**File:** `src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp`
-
-First pipeline operator in the two-pipeline Parquet scan architecture. Parses Parquet footers for up to 8 files per task, attempts cuDF AST filter translation, and emits `partitioned_parquet_metadata` containing reader options, file metadata, and row-group partitions. See [Scan — Two-Pipeline Metadata Scan](scan.md#two-pipeline-metadata-scan).
 
 ### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
 **File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
 
-Second pipeline operator in the two-pipeline Parquet scan architecture. Acts as sink of Pipeline 1 (accumulating metadata from `PARQUET_METADATA_SCAN`) and source of Pipeline 2 (serving `parquet_scan_data` tasks that call `cudf::io::read_parquet`). See [Scan — Two-Pipeline Metadata Scan](scan.md#two-pipeline-metadata-scan).
+Source operator for parquet scans. Carries a `parquet_scan_info` populated by the pipeline converter and pulls splits from a `split_connector` populated by `sirius_scan_manager` on its own thread pool. Each `parquet_scan_data` split drives a `cudf::io::read_parquet` call followed by `scan_plan`-driven output assembly (data columns, hive-partition synthesis, output ordering). See [Scan — Scan Manager](scan.md#scan-manager).
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
@@ -305,8 +299,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | DUCKDB_SCAN | Scan | DuckDB table function |
 | PARQUET_SCAN | Scan | Direct Parquet reading |
 | ICEBERG_SCAN | Scan | Parquet reading with Iceberg delete filters |
-| PARQUET_METADATA_SCAN | Scan | Parquet footer parsing + row group partitioning |
-| GPU_PARQUET_SCAN | Scan | Parquet byte reading from metadata |
+| GPU_PARQUET_SCAN | Scan | Source operator served by `sirius_scan_manager` |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `gpu_expression_executor::select()` |

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -210,17 +210,38 @@ If translation fails, filtering falls back to `gpu_expression_executor` on the d
 
 **Config:** `scan_task_batch_size` (default: 512 MB)
 
-### Two-Pipeline Metadata Scan (PR #571)
+### Asynchronous Parquet Metadata via Scan Manager (PRs #571, #620, #731)
 
-**Motivation:** Synchronous metadata parsing in `parquet_scan_task_global_state` constructor blocks all pipeline tasks until all file footers are read.
+**Motivation:** Synchronous metadata parsing on the GPU pipeline thread blocks all pipeline tasks until file footers are read, AST filters are translated, and row-group partitions are computed.
 
-**Mechanism:** Extracts metadata work into a dedicated first pipeline:
-- **Pipeline 1** (`PARQUET_METADATA_SCAN` → `GPU_PARQUET_SCAN`): Parses Parquet footers (up to 8 files per task), translates AST filters, computes row-group partitions
-- **Pipeline 2** (`GPU_PARQUET_SCAN` as source): Serves self-contained `parquet_scan_data` tasks, each calling `cudf::io::read_parquet`
+**Mechanism:** A dedicated `sirius_scan_manager` runs alongside the GPU executors and owns a thread pool that drives one `split_provider` per parquet scan operator. The provider parses footers (up to 8 files per task by default), translates AST filters, prunes row groups, and pushes `parquet_scan_data` splits into a per-operator `split_connector`. The GPU scan operator's `get_next_task_input_data()` blocks on the connector and returns each split as it arrives, so consumer scheduling is decoupled from production order. Providers are started sequentially in plan order so per-query memory pressure stays bounded.
 
 **Code path:**
-- `src/op/scan/sirius_parquet_metadata_scan_operator.cpp` — metadata scan operator
-- `src/op/scan/sirius_gpu_parquet_scan_operator.cpp` — GPU parquet scan operator
+- `src/scan_manager/sirius_scan_manager.cpp` — manager thread pool, provider registry, sequential driver loop
+- `src/scan_manager/parquet_split_provider.cpp` — metadata parsing, AST filter translation, row-group bundling
+- `src/scan_manager/split_connector.cpp` — blocking queue between provider and operator
+
+### Multifile Parquet Splits (PR #738)
+
+**Motivation:** Many small parquet files each yielding a tiny GPU batch causes per-task scheduling and kernel-launch overhead to dominate scan throughput.
+
+**Mechanism:** `parquet_split_provider` coalesces row-group slices from multiple parquet files into a single split when the bundled files share identical hive-partition values (so synthesized partition columns remain scalar). `accum.total_uncompressed_bytes` accumulates across files; a split is emitted once the total exceeds `approximate_batch_size` or partition values change. The downstream `cudf::io::read_parquet` reads from all bundled files in one invocation.
+
+**Code path:** `src/scan_manager/parquet_split_provider.cpp` — `run_batch()` accumulator
+
+**Config:** `scan_task_batch_size` (default: 512 MB) is forwarded as `approximate_batch_size` to the provider.
+
+### Sirius IO + Prefetching Cache (PR #675)
+
+**Motivation:** Repeated parquet reads pay full file-system cost on every query. A pinned-memory cache between the file and cuDF's parquet reader can serve subsequent reads at H2D-copy speed without re-reading from disk.
+
+**Mechanism:** `sirius::io` provides a `cudf::io::datasource` (`sirius_datasource`) backed by io_uring reactors and an optional pinned-memory `prefetching_cache`. The cache hit path issues `cudaMemcpyAsync` from pinned host memory directly to device; the miss path falls through to backend I/O, which uses `O_DIRECT` reads through pinned bounce slots and round-robin dispatch across reactor threads. A packed atomic state machine (4-bit state + 28-bit pin count in one `atomic<uint32_t>`) eliminates TOCTOU between readability checks and pin acquisition. Eviction is driven by a tiered LRU score; admission control caps concurrent in-flight chunks to keep memory bounded.
+
+**Code path:**
+- `src/io/sirius_datasource.cpp` — `cudf::io::datasource` implementation
+- `src/io/prefetching_cache.cpp` — chunk cache, worker, evictor, buffer pool
+- `src/io/uring/uring_reactor.cpp` — io_uring backend reactor
+- `src/io/admission_control.cpp` — RAII budget enforcement
 
 ### Skip File I/O from Cache (PR #455)
 

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -99,7 +99,7 @@ Key methods:
 - `mark_task_completed()` — increments `tasks_completed`, calls `update_pipeline_status()`
 - `update_pipeline_status()` — checks source-dependent completion logic:
   - DUCKDB_SCAN: finished when `exhausted` flag is set
-  - PARQUET_SCAN: finished when `has_more_partitions` is false and `tasks_created == tasks_completed`
+  - GPU_PARQUET_SCAN: finished when the bound `split_connector` is closed and drained and `tasks_created == tasks_completed`
   - Others: finished when upstream done, ports empty, and all tasks completed
 - `is_ready()` — marks pipeline ready and reverses operators to execution order
 - `register_new_batch_index()` / `update_batch_index()` — batch ordering for order-preserving execution
@@ -206,14 +206,18 @@ In the diagrams below, `[A, B, C]` denotes a pipeline where A is `operators[0]` 
 
 ### TABLE_SCAN Splitting
 
-TABLE_SCAN is replaced with DUCKDB_SCAN or PARQUET_SCAN. A separate scan pipeline is created, and the original TABLE_SCAN is kept as the first operator of the main pipeline:
+TABLE_SCAN splits along two paths depending on the table function:
+
+**Parquet (`parquet_scan` / `read_parquet`):** TABLE_SCAN is replaced with `GPU_PARQUET_SCAN` at `operators[0]` of the same pipeline — no separate scan pipeline is created. The DuckDB bind data is captured into a `parquet_scan_info` and parked on the operator. During `prepare_for_query`, `sirius_scan_manager` reads the info, builds a `split_provider` (parquet or cached), and binds a `split_connector` to the operator. The operator pulls splits from the connector inside `get_next_task_input_data()` (see [Scan — Scan Manager](scan.md#scan-manager)).
+
+**DuckDB-managed (`seq_scan`, `iceberg_scan`):** A separate scan pipeline is created, and the original TABLE_SCAN is kept as the first operator of the main pipeline:
 
 ```mermaid
 graph LR
     SP["Scan Pipeline<br/>[DUCKDB_SCAN]"] -->|"PIPELINE, 'scan'"| MP["Main Pipeline<br/>[TABLE_SCAN, filter, ..., sink]"]
 ```
 
-The DUCKDB_SCAN (or PARQUET_SCAN) is the sole operator in the scan pipeline. TABLE_SCAN stays at `operators[0]` of the main pipeline (line 391). The repository uses `PIPELINE` barrier on the `"scan"` port.
+DUCKDB_SCAN (or ICEBERG_SCAN) is the sole operator in the scan pipeline. TABLE_SCAN stays at `operators[0]` of the main pipeline. The repository uses `PIPELINE` barrier on the `"scan"` port.
 
 ### HASH_JOIN Probe Side
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -9,11 +9,11 @@ Super Sirius supports four scan paths:
 | Path | Operator | Use Case | Data Flow |
 |------|----------|----------|-----------|
 | **DuckDB Scan** | `DUCKDB_SCAN` | General DuckDB-managed tables | DuckDB table function → column builders → `host_data_representation` |
-| **Parquet Scan** | `PARQUET_SCAN` | Direct Parquet file reading | Parquet byte ranges → `host_parquet_representation` |
-| **Metadata Scan** | `PARQUET_METADATA_SCAN` → `GPU_PARQUET_SCAN` | Two-pipeline Parquet reading | Metadata parsing pipeline → GPU parquet read pipeline |
-| **Iceberg Scan** | `ICEBERG_SCAN` | Apache Iceberg V1/V2 tables | Parquet scan + GPU-accelerated delete filters |
+| **Parquet Scan** | `PARQUET_SCAN` | Legacy direct Parquet reading | Parquet byte ranges → `host_parquet_representation` |
+| **GPU Parquet Scan** | `GPU_PARQUET_SCAN` | Parquet file reading via the scan manager | `sirius_scan_manager` produces `parquet_scan_data` splits → GPU read |
+| **Iceberg Scan** | `ICEBERG_SCAN` | Apache Iceberg V1/V2/V3 tables | Parquet scan + GPU-accelerated delete filters |
 
-All paths funnel data through the same scan executor and data repository infrastructure.
+The DuckDB and legacy parquet paths funnel through `duckdb_scan_executor` and the data-repository infrastructure. The GPU parquet path is driven by `sirius_scan_manager` and a dedicated `split_provider` per scan operator (see [Scan Manager](#scan-manager)).
 
 ## Scan Operators
 
@@ -48,15 +48,107 @@ Direct Parquet file scan. Maintains:
 
 Iceberg table scan. Inherits from `sirius_physical_parquet_scan`. Holds delete file lists (`positional_delete_files`, `equality_delete_files`) and routes through the GPU parquet scan pipeline with a post-convert delete filter hook. See [Iceberg Scan](#iceberg-scan) below.
 
-### `sirius_parquet_metadata_scan_operator` — `PARQUET_METADATA_SCAN`
-**File:** `src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp`
-
-First pipeline in the two-pipeline scan architecture. Parses Parquet footers and computes row group partitions. Its `get_next_task_input_data()` atomically advances `_next_file_idx` and returns a `parquet_metadata_input` covering up to 8 files. Its `execute()` reads footers (via `cudf::io::parquet::fetch_footer_to_host()`), attempts AST filter translation using `gpu_expression_translator`, and emits `partitioned_parquet_metadata` containing reader options, file metadata, and row-group partitions.
-
 ### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
 **File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
 
-Second pipeline in the two-pipeline scan architecture. Acts as the sink of Pipeline 1 (accumulating metadata) and the source of Pipeline 2 (serving self-contained `parquet_scan_data` tasks). Each task calls `cudf::io::read_parquet`, applies fallback DuckDB expression filtering if AST translation failed, and prunes pure-filter columns post-filtering.
+Source operator for parquet scans. Carries a `parquet_scan_info` populated by the pipeline converter from the DuckDB bind data (file paths, projected column ids, table filters, hive partition indices, target batch size). The operator owns a bound `split_connector`; `get_next_task_input_data()` blocks inside `split_connector::get_next_split()` until either a `parquet_scan_data` is available or the connector is closed and drained.
+
+`execute(input_data)` runs per task: it calls `cudf::io::read_parquet` over the row-group slices in the split, optionally applies a fallback DuckDB expression filter when AST translation failed, prunes pure-filter columns, and assembles the output table according to the `scan_plan` (data columns, hive-partition synthesis, output ordering).
+
+## Scan Manager
+
+**Files:** `src/include/scan_manager/sirius_scan_manager.hpp`, `src/scan_manager/sirius_scan_manager.cpp`, `src/include/scan_manager/split_provider.hpp`, `src/include/scan_manager/split_connector.hpp`
+
+`sirius_scan_manager` owns a configurable thread pool and is responsible for producing the input splits consumed by every `GPU_PARQUET_SCAN` source operator. It runs alongside the GPU pipeline executors and is independent from the data repository / port machinery used between intermediate operators.
+
+### Components
+
+| Component | File | Role |
+|-----------|------|------|
+| `sirius_scan_manager` | `scan_manager/sirius_scan_manager.{hpp,cpp}` | Owns thread pool, holds providers and pinned-table entries, drives provider execution |
+| `split_provider` | `scan_manager/split_provider.hpp` | Abstract producer of `operator_data` splits |
+| `parquet_split_provider` | `scan_manager/parquet_split_provider.{hpp,cpp}` | Provider that parses parquet metadata and emits `parquet_scan_data` per row-group partition |
+| `cached_split_provider` | `scan_manager/cached_split_provider.{hpp,cpp}` | Provider that emits zero-copy splits over pinned columns (see [Pinned Tables](#pinned-tables)) |
+| `split_connector` | `scan_manager/split_connector.hpp` | Lock-protected blocking queue between the provider and the operator |
+
+### Lifecycle
+
+1. **Plan stage:** during pipeline conversion, `split_parquet_scan_source` packages the DuckDB bind data into a `parquet_scan_info` and constructs a `sirius_gpu_parquet_scan_operator` carrying that info. The operator is inserted at `operators[0]` of the pipeline; no separate metadata pipeline is created.
+2. **Per-query preparation:** `sirius_scan_manager::prepare_for_query(query)` walks the plan, picks each parquet scan source, and calls `create_provider_for(op)`. The factory returns either a `cached_split_provider` (when a pinned entry matches the operator's file paths) or a `parquet_split_provider`. A fresh `split_connector` is bound to the operator and the provider is stored in the manager's map.
+3. **Execution:** a driver thread runs providers **sequentially** in registration order. Each provider's `start(pool, connector)` schedules work onto the manager's thread pool and returns a future; the driver waits on it before starting the next provider. Inside the operator, `get_next_task_input_data()` blocks on `split_connector::get_next_split()` and returns each split as it arrives, so consumer-side scheduling is decoupled from production order.
+4. **Teardown:** the provider closes the connector on every termination path (success, exception); on synchronous failure the manager closes it as a safety net. Once closed and drained, the operator's `all_ports_empty()` returns true and `get_next_task_hint()` returns `nullopt`.
+
+### `parquet_split_provider`
+
+`start()` iterates over the file list in `_max_file_processed`-sized batches (default 8). Each batch:
+
+1. Fetches parquet footers via `cudf::io::parquet::fetch_footer_to_host()`.
+2. Translates the cached DuckDB filter expression into a cuDF AST on a task-local CUDA stream (filter translation is deferred from construction so each task gets its own stream).
+3. Prunes row groups by min/max statistics (`filter_row_groups_with_stats`).
+4. Bundles row-group slices into partitions of approximately `approximate_batch_size` uncompressed bytes. Multiple files with identical hive-partition values may be coalesced into a single partition (see [Multifile Bundling](#multifile-bundling)).
+5. Pushes one `parquet_scan_data` per partition into the connector. Each split carries the row-group slices, the reader options, the AST filter (if translated), and a `shared_ptr<const scan_plan>`.
+
+### `scan_plan`
+
+**File:** `src/include/op/scan/scan_plan.hpp`, `src/op/scan/scan_plan.cpp`
+
+`scan_plan` is the canonical description of what a scan reads, how it assembles output, and how filters map between index spaces. It is constructed once per provider and shared (immutably) with every emitted split.
+
+```cpp
+struct scan_plan {
+  std::vector<data_column>           data_columns;       // columns read from parquet, in batch order (D)
+  std::vector<partition_column>      partition_columns;  // hive-injected columns (name, type, primary index)
+  std::vector<output_entry>          output_layout;      // one entry per output column, in DuckDB order
+  std::vector<std::optional<size_t>> batch_position_by_column_id;  // C → D map
+  std::unordered_set<size_t>         partition_primary_indices;    // for filter-skip
+};
+```
+
+Three index spaces appear in the parquet path:
+
+- **P (primary index)** — DuckDB schema position
+- **C (column-ids position)** — index into the scan's `column_ids` list
+- **D (batch position)** — column position in the cuDF reader output (post-hive-removal)
+
+`output_layout` is walked once in `execute()` to produce the final table: `DATA(k)` entries `std::move` from the read batch at position k, `PARTITION(k)` entries synthesize a scalar-backed column from the hive partition value. Pure-filter data columns (read but not output) fall out of scope and free.
+
+For `SELECT *` with no partitions and no pure-filter columns, `build_inject_fn()` returns `nullptr` and the operator forwards the reader output unchanged — no permute, no copy. `SELECT count(*)` short-circuits the same way (output_layout empty) so the count aggregation sees a 0-column table without a synthesized 0-column reshape.
+
+### Multifile Bundling
+
+When many small parquet files each yield a small batch, scheduling and kernel-launch overhead dominates. `parquet_split_provider` coalesces row-group slices from **multiple files** into a single split as long as the bundled files share identical hive-partition values (so the synthesized partition columns remain scalar). `accum.total_uncompressed_bytes` accumulates across files; a split is emitted once it exceeds `approximate_batch_size` or partition values change. The downstream `cudf::io::read_parquet` call reads from all bundled files in one invocation.
+
+### Column Mapping
+
+Parquet column-chunk order is not guaranteed to match DuckDB's logical column order. `parquet_split_provider` builds a name-based DuckDB→parquet mapping via `parquet_schema_mapping::leaf_indices_for_column(schema, column_name)`, which walks the parquet schema's `path_in_schema` (case-insensitive, mirroring DuckDB).
+
+For nested types (`STRUCT`, `LIST`), one DuckDB column maps to multiple parquet leaf chunks; the mapping returns all leaves under the top-level column name. The cuDF parquet reader, given a top-level column name, materializes the nested `cudf::column` natively without post-read reassembly.
+
+## Pinned Tables
+
+**Files:** `src/include/pin_table.hpp`, `src/pin_table.cpp`, `src/include/scan_manager/cached_split_provider.hpp`
+
+The `pin_table` table function lets users pre-load a parquet table's columns into GPU memory (or, in the future, host memory) so subsequent scans of the same path bypass file I/O entirely.
+
+```sql
+CALL pin_table('/path/to/lineitem.parquet',
+               name = 'lineitem',
+               tier = 'gpu',
+               cols = ['l_orderkey', 'l_quantity', 'l_extendedprice', 'l_shipdate']);
+
+-- Subsequent reads of the same path are served from the pinned columns.
+SELECT SUM(l_extendedprice * l_quantity)
+  FROM read_parquet('/path/to/lineitem.parquet')
+  WHERE l_shipdate >= DATE '1994-01-01';
+
+CALL unpin_table('lineitem');
+```
+
+`tier` accepts `gpu` or `host`; only `gpu` is supported today (a `host` argument throws `NotImplementedException` and will be added later).
+
+A `pinned_entry` stores the column projection, resolved file paths, per-column chunk vectors, and the memory space the columns reside in. When `prepare_for_query` runs, the scan manager matches the operator's `parquet_scan_info::file_paths` against pinned entries; on a hit, it constructs a `cached_split_provider` (zero-copy view-backed `data_batch` per chunk) instead of a `parquet_split_provider`. The cached provider forwards the same `scan_plan` and filter expression as the parquet path, so the operator's `execute()` is unchanged. When `needs_output_assembly(*plan)` is false (identity layout), the cached batch is forwarded straight through with no permute or prune.
+
+`insert_pinned_entry` supports re-pinning: if an entry exists with the same row count, only new columns are merged in (duplicates dropped); a different row count drops and replaces the entry.
 
 ## DuckDB Scan Task
 
@@ -257,31 +349,83 @@ Uses deferred lambda with CUDA event synchronization:
 1. Records `cuda_event_guard` after async copies
 2. Returns future that syncs the event on `get()`
 
+## Sirius IO Subsystem
+
+**Files:** `src/include/io/`, `src/io/`
+
+`sirius::io` is a `cudf::io::datasource`-compatible I/O stack designed for high-throughput parquet reading. It is built around io_uring reactors and a pinned-memory prefetching cache, with a pluggable backend seam so additional backends (e.g. cuFile) can be added without changing the cache or the datasource layer.
+
+### Architecture
+
+| Component | File | Role |
+|-----------|------|------|
+| `sirius_datasource` | `io/sirius_datasource.{hpp,cpp}` | `cudf::io::datasource` implementation; `supports_device_read() = true`; delegates every read to the bound `sirius_ioctx` |
+| `sirius_ioctx` | `io/types.hpp` | Abstract shared context owning the optional `prefetching_cache` and the reactor pool. `device_read{,_async}` consults the cache and falls through to backend I/O on miss |
+| `templated_ioctx<Reactor>` | `io/templated_ioctx.hpp` | Generic ioctx implementation: request splitting, aligned 1 MiB chunking, round-robin dispatch across reactors, sync/async adapters |
+| `uring_reactor` / `uring_ioctx` | `io/uring/` | Concrete io_uring backend. One thread per reactor, `O_DIRECT` device reads through pinned bounce slots, buffered host reads on the same ring |
+| `prefetching_cache` | `io/prefetching_cache.{hpp,cpp}` | Pinned-memory chunk cache with lock-free per-entry state machine, background worker, evictor threads, and tiered LRU buckets |
+| `buffer_pool` | `io/prefetching_cache.cpp` | Growable multi-slab pool of 1 MiB pinned chunks |
+| `admission_control` | `io/admission_control.{hpp,cpp}` | RAII slot handed out against a fixed in-flight budget (default 2 GiB worth of chunks) |
+
+### Backend Seam
+
+Two C++20 concepts define the plug-in contract:
+
+- `io_object_c<O, Handle>` — derives from `sirius_io_object`, exposes `host_handle()` / `device_handle()` of type `Handle`.
+- `io_reactor_c<R>` — associated types (`native_handle_type`, `io_object_type`, `device_read_req_type`, `host_read_req_type`) plus operations: `enqueue_bulk`, `host_read`, `host_read_async`, `shutdown`, static `align_to_physical`.
+
+A new backend is: a custom `io_object` + reactor + `templated_ioctx<your_reactor>`. `uring_ioctx = templated_ioctx<uring_reactor>` is the first instantiation.
+
+### Cache Seam
+
+`sirius_ioctx::device_read{,_async}` is non-virtual: it consults `_cache` and falls through to pure-virtual `device_read_io{,_async}`. Backends never see the cache; the cache never sees the backend. `supports_device_read()` stays `true` even when the cache serves the read because the final copy is still `cudaMemcpyAsync` from pinned host memory to device.
+
+### Cache Internals
+
+- **Packed atomic state machine.** `entry_state` encodes a 4-bit state enum and a 28-bit pin count in a single `atomic<uint32_t>`. Every transition is one CAS, closing the TOCTOU gap between "is this entry readable?" and "bump the pin count." Readers park in `wait_while_loading()` via `atomic::wait` and are woken by `notify_all()` on completion.
+- **Request aggregation via `request_context`.** One logical read fans out into N chunk sub-requests; each sub-request decrements `pending`; the last one fires the user's completion handler. Error reporting is single-writer (`failed.exchange`) so partial failures don't race.
+- **Batch dispatch, amortized wakes.** `templated_ioctx::enqueue_device_read` groups chunks per-reactor with a rotating round-robin start and dispatches one `enqueue_bulk` per non-empty group, collapsing N wake-notifies to at most M (reactor count).
+- **Multi-GPU safe.** `device_read_req` carries the caller's `device_id`; reactor threads `cudaSetDevice()` before issuing the H2D copy. Bounce slabs are `cudaHostAllocPortable` so they're reachable from any CUDA context.
+- **Evictor as backpressure service.** When `buffer_pool.allocate_bulk` can't satisfy the worker, the worker posts an `eviction_request` (promise + chunk count) and blocks on the future. The evictor walks LRU buckets coldest-first, returns chunks to the pool, then resolves the promise. Pool exhaustion is never a silent failure.
+- **Tiered LRU with age drift.** Five buckets; `refresh_cache()` is the caller's input to the aging signal. Score is `(NUM_BUCKETS-1) + n_total_request − cache_age`, clamped. Never-consumed entries get a floor of 1 to avoid being first out; raw score `< -5` is evicted on the spot during candidate drain.
+- **Admission control deadlock escape.** A request larger than the total budget is granted the full budget when no other slots are outstanding, so oversized reads make progress instead of waiting forever.
+
+### Constants (in `io/types.hpp`)
+
+| Name | Value | Role |
+|------|-------|------|
+| `CHUNK_SIZE` | 1 MiB | Bounce-buffer / cache chunk size |
+| `NUM_CHUNKS` | 32 | Bounce slots per reactor |
+| `IO_BLOCK_SIZE` | 4096 | `O_DIRECT` alignment |
+| `CHUNKS_PER_SLAB` | 500 | Pinned chunks per `buffer_pool` slab |
+
 ## Row Group Pruning
+
 When filter pushdown is enabled and the `gpu_expression_translator` successfully converts DuckDB `TableFilterSet` filters into a cuDF AST, two optimizations activate:
 
-1. **Row group statistics pruning:** During `parquet_scan_task_global_state::initialize_from_files()`, `filter_row_groups_with_stats()` uses Parquet column min/max statistics to discard row groups that cannot match the filter predicate — before any I/O is scheduled.
+1. **Row group statistics pruning:** `parquet_split_provider::run_batch` calls `filter_row_groups_with_stats()` on each fetched footer; row groups whose Parquet column min/max statistics cannot match the filter are dropped before any read is scheduled. Pure hive-partition filters are dropped during plan construction since hive columns aren't in the parquet file.
 
 2. **Reader-level filter pushdown:** The cuDF AST is set on `parquet_reader_options` via `set_filter()`, so cuDF applies the filter inside `read_parquet`. The `TABLE_SCAN` operator is set to passthrough (`passthrough = true`) since filtering is already done by the reader.
 
-If AST translation fails (e.g., unsupported expression types), the `TABLE_SCAN` operator runs the `gpu_expression_executor` on the decoded batch as before.
+If AST translation fails (e.g., unsupported expression types), `GPU_PARQUET_SCAN`'s `execute()` runs the cached DuckDB filter expression through `gpu_expression_executor` on the decoded batch.
 
-**Filter translation path:** `TableFilterSet` → `convert_table_filters_to_expression()` (skips `OPTIONAL_FILTER` and `IS_NOT_NULL` types) → `gpu_expression_translator` → cuDF AST tree.
+**Filter translation path:** `TableFilterSet` → `convert_table_filters_to_expression()` (skips `OPTIONAL_FILTER`, `IS_NOT_NULL`, and partition-column filters) → `gpu_expression_translator` → cuDF AST tree.
 
 ## Batch Coalescing
-When many small Parquet files each produce a tiny GPU batch, per-task scheduling and kernel launch overhead dominates. Two mechanisms address this:
 
-1. **Accumulation in `get_next_task_input_data()`** (`sirius_physical_table_scan`): Pops batches in a loop until `accumulated_bytes >= scan_task_batch_size` OR `batch_count >= 32`, returning a `pipelineable_operator_data` wrapping the accumulated batches.
+When many small files each produce a tiny GPU batch, per-task scheduling and kernel-launch overhead dominates. Two mechanisms address this depending on the scan path:
 
-2. **GPU concatenation in `execute()`**: When multiple batches are accumulated, calls `cudf::concatenate()` to produce a single fused table before filtering/projecting, reducing kernel launches.
+1. **Multifile bundling in `parquet_split_provider`** (GPU_PARQUET_SCAN): a single split may bundle row-group slices from multiple parquet files when those files share the same hive-partition values, up to `approximate_batch_size` uncompressed bytes. The downstream `cudf::io::read_parquet` call reads the bundled slices in one invocation.
 
-When the parquet scan pipeline applies filter+projection via the cuDF reader (passthrough mode from filter pushdown), `TABLE_SCAN` skips concatenation — only the DuckDB-source code path goes through coalescing.
+2. **Post-read coalescing in `sirius_physical_table_scan`** (DUCKDB_SCAN): `get_next_task_input_data()` pops batches in a loop until `accumulated_bytes >= scan_task_batch_size` OR `batch_count >= 32`, returning a `pipelineable_operator_data` wrapping the accumulated batches. `execute()` then calls `cudf::concatenate()` before filtering/projecting.
+
+When the GPU parquet scan applies filter+projection via the cuDF reader (passthrough mode), `TABLE_SCAN` skips concatenation — only the DuckDB-source code path goes through post-read coalescing.
 
 ## Iceberg Scan
 
 **File:** `src/include/op/sirius_physical_iceberg_scan.hpp`, `src/op/scan/iceberg_scan_task.cpp`
 
-`sirius_physical_iceberg_scan` inherits from `sirius_physical_parquet_scan` and adds support for Iceberg V1 and V2 tables.
+`sirius_physical_iceberg_scan` inherits from `sirius_physical_parquet_scan` and adds support for Iceberg V1, V2, and V3 tables.
 
 ### Supported Iceberg Features
 
@@ -289,44 +433,54 @@ When the parquet scan pipeline applies filter+projection via the cuDF reader (pa
 |---------|---------|---------------|
 | V1 | Append-only (no deletes) | Identical to plain parquet scan |
 | V2 | Positional deletes | `positional_delete_filter`: binary-searches sorted row positions, builds boolean mask, applies `cudf::apply_boolean_mask` |
-| V2 | Equality deletes | `equality_delete_filter`: builds `cudf::distinct_hash_join` with delete key rows, probes with data chunk keys, computes anti-join mask on GPU via `thrust::transform` (custom CUDA kernel in `equality_delete_mask.cu`), applies `cudf::apply_boolean_mask` |
+| V2 | Equality deletes (heterogeneous) | A `vector<EqualityDeleteGroup>` carries one `cudf::distinct_hash_join` per distinct key schema; each group is sequence-scoped so it only applies to data files written before its sequence number |
+| V3 | Deletion vectors | Read from PUFFIN files via `puffin_reader`; the resulting bitmap drives the same boolean-mask filter as positional deletes |
+| V2/V3 | Schema evolution | Per-file projection detects which columns are present in each parquet file; missing columns are injected as typed NULL columns post-read |
+| V2/V3 | Snapshot time-travel | `snapshot_from_id` is forwarded to DuckDB's `iceberg_metadata()` so the manifest matches the requested snapshot |
+| V2/V3 | Partition evolution | Per-file inject function decides whether each column comes from parquet data, from the file path (hive-style), or is NULL — handles tables whose partition scheme changed across snapshots |
 
 ### Architecture
 
-- `iceberg_scan_task_global_state` inherits from `parquet_scan_task_global_state`. Its `build_delete_pipeline()` reads delete files via `iceberg_metadata_reader` (lightweight Avro parser for manifest-list and manifest files) and installs a composed `iceberg_delete_pipeline` as a `post_convert_fn_t` hook.
+- `iceberg_scan_task_global_state` inherits from `parquet_scan_task_global_state`. Its `build_delete_pipeline()` reads delete files (manifest discovery delegates to DuckDB's `iceberg_metadata()`; the custom Avro reader in `iceberg_avro_reader.cpp` is the fallback for V3 deletion-vector PUFFIN files) and installs a composed `iceberg_delete_pipeline` as a `post_convert_fn_t` hook.
 - The `post_convert_fn_t` hook fires after each row-group batch is decompressed to a `cudf::table`, applying all delete filters in-place with zero `cudaMemcpy D2H` in the hot path.
-- Equality-delete key columns not in the user's projection are force-projected, then stripped via zero-copy `release()` + truncate after all filters run.
-- V3 deletion vectors are not yet implemented but the interface supports adding them.
+- Equality-delete key columns not in the user's projection are force-projected at read time, then stripped via zero-copy `release()` + truncate after all filters run, so downstream operators see only the requested columns.
+- Equality deletes apply only to data files whose sequence number is less than the delete group's, mirroring Iceberg's snapshot semantics.
 
 ## Complete Scan Flow
 
 ```mermaid
 graph TD
-    TS[sirius_physical_table_scan] -->|"converted"| DS[DUCKDB_SCAN]
-    TS -->|"or"| PS[PARQUET_SCAN]
+    TS[sirius_physical_table_scan] -->|"convert"| GPS[GPU_PARQUET_SCAN]
+    TS -->|"or"| DS[DUCKDB_SCAN]
     TS -->|"or"| IS[ICEBERG_SCAN]
 
+    SM[sirius_scan_manager] -->|"build provider"| PSP[parquet_split_provider]
+    SM -->|"on pinned-table hit"| CSP[cached_split_provider]
+
+    PSP -->|"push split"| SC["split_connector<br/>(per operator)"]
+    CSP -->|"push split"| SC
+    SC -->|"get_next_split()"| GPS
+
     DS -->|"task_creator.schedule()"| TC[task_creator]
-    PS -->|"task_creator.schedule()"| TC
     IS -->|"task_creator.schedule()"| TC
+    GPS -->|"task_creator.schedule()"| TC
 
     TC -->|"create task"| DST[duckdb_scan_task]
-    TC -->|"create task"| PST[parquet_scan_task]
+    TC -->|"create task"| GPT["gpu_pipeline_task<br/>(reads parquet_scan_data)"]
     TC -->|"create task"| IST["iceberg_scan_task<br/>(parquet + delete filters)"]
 
-    DST -->|"dispatch"| SE[scan_executor]
-    PST -->|"dispatch"| SE
+    DST -->|"dispatch"| SE[duckdb_scan_executor]
     IST -->|"dispatch"| SE
 
     SE -->|"execute on worker"| DST2[DuckDB table function → column builders → host_data_representation]
-    SE -->|"execute on worker"| PST2[Parquet byte reads → host_parquet_representation]
     SE -->|"execute on worker"| IST2["Parquet reads → GPU delete filters → host_parquet_representation"]
+    GPT -->|"execute on GPU executor"| GPS2["cudf::io::read_parquet → scan_plan assembly → gpu_table_representation"]
 
     DST2 -->|"publish"| DR[data_repository]
-    PST2 -->|"publish"| DR
     IST2 -->|"publish"| DR
+    GPS2 -->|"to next operator"| DR
 
-    DR -->|"consumed by"| GPT[gpu_pipeline_task]
+    DR -->|"consumed by"| GPT2[gpu_pipeline_task]
 ```
 
 ## Key Files
@@ -335,19 +489,29 @@ graph TD
 |------|---------|
 | `src/op/scan/duckdb_scan_task.cpp` | DuckDB scan implementation |
 | `src/include/op/scan/duckdb_scan_task.hpp` | DuckDB scan task, column builders |
-| `src/op/scan/parquet_scan_task.cpp` | Parquet scan implementation |
-| `src/include/op/scan/parquet_scan_task.hpp` | Parquet scan task, row group partitioning |
+| `src/op/scan/parquet_scan_task.cpp` | Legacy parquet scan implementation |
+| `src/include/op/scan/parquet_scan_task.hpp` | Legacy parquet scan task, row group partitioning |
 | `src/op/scan/duckdb_scan_executor.cpp` | Scan executor manager loop |
 | `src/include/op/scan/duckdb_scan_executor.hpp` | Scan executor interface |
-| `src/op/scan/prefetched_data_source.cpp` | Cached datasource for cuDF |
-| `src/include/op/scan/prefetched_data_source.hpp` | Datasource interface |
+| `src/op/scan/prefetched_data_source.cpp` | Legacy cached datasource for cuDF |
+| `src/include/op/scan/prefetched_data_source.hpp` | Legacy cached datasource interface |
 | `src/op/scan/cached_ranges.cpp` | Byte range coalescing and lookup |
 | `src/include/op/scan/cached_ranges.hpp` | Cache range structure |
 | `src/include/op/scan/config.hpp` | Scan config, cache_level enum |
-| `src/include/op/scan/sirius_parquet_metadata_scan_operator.hpp` | Metadata scan operator (two-pipeline architecture) |
-| `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp` | GPU parquet scan operator (two-pipeline architecture) |
+| `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp` | GPU parquet scan source operator |
+| `src/include/op/scan/parquet_scan_info.hpp` | Bind data parked on the scan operator for the scan manager |
+| `src/include/op/scan/parquet_scan_operator_data.hpp` | `parquet_scan_data` split type emitted by providers |
+| `src/include/op/scan/scan_plan.hpp` | Index-space mapping (P/C/D), output layout, partition injection |
+| `src/include/op/scan/parquet_schema_mapping.hpp` | Name-based DuckDB→parquet column resolution |
+| `src/include/scan_manager/sirius_scan_manager.hpp` | Scan manager: thread pool, providers, pinned-table registry |
+| `src/include/scan_manager/split_provider.hpp` | Abstract split producer |
+| `src/include/scan_manager/parquet_split_provider.hpp` | Parquet metadata-driven split provider |
+| `src/include/scan_manager/cached_split_provider.hpp` | Pinned-column split provider |
+| `src/include/scan_manager/split_connector.hpp` | Blocking queue between provider and operator |
+| `src/include/pin_table.hpp` / `src/pin_table.cpp` | `pin_table` / `unpin_table` table-function bindings |
 | `src/include/op/sirius_physical_iceberg_scan.hpp` | Iceberg scan operator |
 | `src/include/op/scan/iceberg_scan_task.hpp` | Iceberg scan task with delete filters |
-| `src/include/op/scan/iceberg_metadata_reader.hpp` | Iceberg Avro manifest reader |
-| `src/op/scan/scan_utils.cpp` | Row group pruning, `build_batch_column_map()` |
+| `src/include/op/scan/iceberg_metadata_reader.hpp` | Iceberg manifest reader (DuckDB `iceberg_metadata()` + Avro fallback) |
+| `src/include/op/scan/puffin_reader.hpp` | V3 deletion-vector PUFFIN reader |
+| `src/op/scan/scan_utils.cpp` | Row group pruning, filter expression conversion |
 | `src/include/data/cached_data_representation.hpp` | Cached data wrappers |


### PR DESCRIPTION
## Summary

Refreshes Super Sirius reference documentation to reflect changes merged on `dev` since the last marker.

- **Scan rewrite (`scan.md`, `operators.md`, `physical-plan-generation.md`):** removes the two-pipeline metadata-scan model. Adds a Scan Manager section covering `sirius_scan_manager`, `split_provider`, `split_connector`, `parquet_split_provider`, and `cached_split_provider`. Documents the `scan_plan` index spaces (P/C/D), multifile bundling, name-based and nested column projection, and pinned tables (`pin_table` / `unpin_table`). Adds a Sirius IO subsystem section (io_uring reactors, prefetching cache, admission control, backend seam).
- **Iceberg:** expanded to cover V3 deletion vectors (PUFFIN), heterogeneous equality-delete schemas, sequence-scoped delete application, schema evolution, snapshot time-travel, and partition evolution.
- **Optimizations:** replaced "Two-Pipeline Metadata Scan" entry with "Asynchronous Parquet Metadata via Scan Manager"; added Multifile Parquet Splits and Sirius IO + Prefetching Cache entries.
- **Expression executor:** added a note about the `sirius::expression` / `sirius::join_condition` PIMPL boundary; documented COALESCE and the expanded COMPARE_IN dispatch.
- **Configuration:** `enable_duckdb_fallback` default flipped from `false` to `true` to match the runtime default.
- **Memory management:** renamed stale `pipeline_executor queue` reference to `task_scheduler queue`.
- **Marker:** advanced from `662eb28d` (unreachable) to `d6baaedc`.

## Coverage

Triaged 43 PRs since the effective baseline (`6205a9ac`, PR #658). Substantive PRs reflected in this update: #571, #574, #620, #637, #656, #662, #663, #672, #673, #675, #683, #687, #689, #706, #721, #731, #738. CI/build/legacy/internal-bug-fix PRs were intentionally not surfaced in reference docs.

## Test plan

- [x] `pre-commit run --files <doc files>` — all hooks pass (codespell, trailing whitespace, EOL, smartquote)
- [x] Manual review of each updated doc against current source

🤖 Generated with [Claude Code](https://claude.com/claude-code)