### PR TITLE
Fixed bug with bytes to materialize and other improvements

### DIFF
--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -62,7 +62,7 @@ class cpu_source_task_local_state : public pipeline::sirius_pipeline_task_local_
 
   // The consumption basis feeds pipeline_memory_history, which cpu_source_task
   // does not use — its reservation size is estimated directly from the
-  // collection row count in get_estimated_reservation_size(), not from
+  // collection row count in get_estimated_reservation_size_info(), not from
   // historical data. Return 0 to satisfy the interface.
   [[nodiscard]] std::size_t get_task_consumption_basis() const override { return 0; }
 };
@@ -87,7 +87,8 @@ class cpu_source_task : public pipeline::sirius_pipeline_itask {
 
   void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
 
-  [[nodiscard]] std::size_t get_estimated_reservation_size() const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
+    const override;
 
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -492,7 +492,8 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
    */
   void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
 
-  [[nodiscard]] std::size_t get_estimated_reservation_size() const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
+    const override;
 
   /// @brief Get the output consumer operators for this task.
   std::vector<op::sirius_physical_operator*> get_output_consumers() override

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -565,7 +565,7 @@ class parquet_scan_task_local_state : public pipeline::sirius_pipeline_task_loca
 
   [[nodiscard]] std::size_t get_task_consumption_basis() const override
   {
-    return get_reserved_compressed_bytes();
+    return get_reserved_uncompressed_bytes();
   }
 
   /**
@@ -651,12 +651,15 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
   void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) override;
 
   /**
-   * @brief Get the estimated reservation size for this task, which is the number of compressed
-   * bytes reserved by this task's local state.
+   * @brief Compute the full reservation size breakdown for this task.
    *
-   * @return The estimated reservation size in bytes.
+   * Uses pipeline_memory_history to refine the estimate when history is available.
+   * bytes_to_materialize_input is always 0 for scan tasks.
+   *
+   * @return reservation_size_info with all fields populated.
    */
-  [[nodiscard]] std::size_t get_estimated_reservation_size() const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
+    const override;
 
   /**
    * @brief Get the output consumers operators for this task.

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -66,7 +66,6 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
                                          size_t start_operator_index = 0)
     : _input_data(std::move(input_data)), _start_operator_index(start_operator_index)
   {
-    _bytes_to_materialize_input = get_estimated_bytes_to_materialize_input();
   }
 
   std::unique_ptr<op::operator_data> _input_data;  ///< Input data batches for the pipeline
@@ -77,27 +76,12 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
   /// Task ID of the original (non-retried) task; only meaningful when retry_count > 0.
   std::optional<uint64_t> original_task_id = std::nullopt;
 
-  // We want to cache the estimation basis, because its going to be calculated from the inputs, but
-  // if the inputs change due to preparing for processing then we will loose this information and we
-  // can't then provide it to the operator history
-  mutable std::optional<std::size_t> _estimation_basis = std::nullopt;
-
-  // The peak bytes observed to materialize the input data. We need to track this so we can subtract
-  // it from the peak bytes observed to compute the operators' peak bytes.
-  size_t _bytes_to_materialize_input = 0;
-
-  /**
-   * @brief Get a const pointer to the reservation (non-owning).
-   *
-   * @return const cucascade::memory::reservation* Pointer to the reservation, or nullptr
-   */
-  const cucascade::memory::reservation* get_reservation() const { return _reservation.get(); }
-
   [[nodiscard]] std::size_t get_task_consumption_basis() const override
   {
-    if (_estimation_basis) { return *_estimation_basis; }
-    _estimation_basis = _input_data ? _input_data->get_estimated_size_in_bytes() : 0;
-    return *_estimation_basis;
+    if (_reservation_size_info) { return _reservation_size_info->input_basis; }
+    // Fallback for code paths that call this before get_estimated_reservation_size_info()
+    // (e.g. tests that bypass the normal executor flow).
+    return _input_data ? _input_data->get_estimated_size_in_bytes() : 0;
   }
 
   [[nodiscard]] std::size_t get_estimated_bytes_to_materialize_input() const
@@ -190,7 +174,8 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
    */
   std::size_t get_input_size() const;
 
-  std::size_t get_estimated_reservation_size() const override;
+  [[nodiscard]] pipeline::reservation_size_info get_estimated_reservation_size_info()
+    const override;
 
   /// @brief Get the output consumer operators for this task.
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;

--- a/src/include/pipeline/pipeline_memory_history.hpp
+++ b/src/include/pipeline/pipeline_memory_history.hpp
@@ -86,13 +86,15 @@ class pipeline_memory_history {
 
     std::lock_guard<std::mutex> lock(_mutex);
 
-    // Look for an existing failure record with the same estimated_bytes
+    // Look for existing records with the same estimated_bytes
+    bool found = false;
     for (auto& rec : _records) {
-      if (rec.estimated_bytes == estimated_bytes && !rec.output_bytes.has_value()) {
+      if (rec.estimated_bytes == estimated_bytes) {
         rec.peak_memory_bytes = std::max(rec.peak_memory_bytes, peak_memory_bytes);
-        return;
+        found                 = true;
       }
     }
+    if (found) { return; }
 
     // No existing failure record found; insert a new one into the ring buffer
     task_memory_record rec{estimated_bytes, peak_memory_bytes, std::nullopt};

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -73,13 +73,26 @@ class sirius_pipeline_itask : public parallel::itask {
   virtual void publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream) = 0;
 
   /**
-   * @brief Get the estimated reservation memory size needed for this task.
+   * @brief Compute the full breakdown of the pre-execution memory reservation estimate.
    *
-   * This method returns the estimated reservation size for this task.
+   * Derived classes implement this to fill all fields of reservation_size_info.
+   * The caller (executor) uses reservation_size_info::reservation_size to acquire a
+   * reservation, then passes the struct to set_reservation() so execute() can read
+   * the components without re-computing them.
    *
-   * @return std::size_t The estimated reservation size
+   * @return reservation_size_info with input_basis, bytes_to_materialize_input,
+   *         peak_memory_estimate, reservation_size, and had_history populated.
    */
-  [[nodiscard]] virtual std::size_t get_estimated_reservation_size() const = 0;
+  [[nodiscard]] virtual pipeline::reservation_size_info get_estimated_reservation_size_info()
+    const = 0;
+
+  /**
+   * @brief Convenience wrapper — returns only the reservation size in bytes.
+   */
+  [[nodiscard]] std::size_t get_estimated_reservation_size() const
+  {
+    return get_estimated_reservation_size_info().reservation_size;
+  }
 
   /// @brief Get the output consumer operators for this task.
   virtual std::vector<op::sirius_physical_operator*> get_output_consumers() = 0;

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -86,14 +86,6 @@ class sirius_pipeline_itask : public parallel::itask {
   [[nodiscard]] virtual pipeline::reservation_size_info get_estimated_reservation_size_info()
     const = 0;
 
-  /**
-   * @brief Convenience wrapper — returns only the reservation size in bytes.
-   */
-  [[nodiscard]] std::size_t get_estimated_reservation_size() const
-  {
-    return get_estimated_reservation_size_info().reservation_size;
-  }
-
   /// @brief Get the output consumer operators for this task.
   virtual std::vector<op::sirius_physical_operator*> get_output_consumers() = 0;
 

--- a/src/include/pipeline/sirius_pipeline_task_states.hpp
+++ b/src/include/pipeline/sirius_pipeline_task_states.hpp
@@ -28,6 +28,20 @@ namespace sirius {
 namespace pipeline {
 
 /**
+ * @brief Breakdown of a task's pre-execution memory reservation estimate.
+ *
+ * Computed by get_estimated_reservation_size_info() and cached on the local state via
+ * set_reservation() so that execute() can access all components without re-computing.
+ */
+struct reservation_size_info {
+  std::size_t input_basis                = 0;  ///< Estimation basis (e.g. input data size)
+  std::size_t bytes_to_materialize_input = 0;  ///< Cost to bring non-GPU input to GPU; 0 for scans
+  std::size_t peak_memory_estimate = 0;  ///< Predicted operator peak; 2*input_basis if no history
+  std::size_t reservation_size     = 0;  ///< peak_memory_estimate + bytes_to_materialize_input
+  bool had_history                 = false;  ///< True if estimate came from pipeline_memory_history
+};
+
+/**
  * @brief Global state shared across all GPU pipeline tasks in an execution context.
  *
  * This class maintains resources and state that are shared among multiple tasks
@@ -122,7 +136,30 @@ class sirius_pipeline_task_local_state : public parallel::itask_local_state {
     }
   }
 
+  /**
+   * @brief Set a memory reservation and cache the pre-computed size breakdown.
+   *
+   * Combines set_reservation() with storing the reservation_size_info produced by
+   * get_estimated_reservation_size_info(), so execute() can read all estimation
+   * components from _reservation_size_info without re-computing them.
+   *
+   * @param res  The memory reservation to set (ownership transferred to the task)
+   * @param info The pre-computed reservation size breakdown
+   */
+  void set_reservation(std::unique_ptr<cucascade::memory::reservation> res,
+                       reservation_size_info info)
+  {
+    set_reservation(std::move(res));
+    _reservation_size_info = info;
+  }
+
   [[nodiscard]] std::size_t get_reservation_bytes() const { return _reservation_bytes; }
+
+  [[nodiscard]] const std::optional<reservation_size_info>& get_reservation_size_info()
+    const noexcept
+  {
+    return _reservation_size_info;
+  }
 
   /**
    * @brief Non-owning accessor for the held reservation.
@@ -154,6 +191,7 @@ class sirius_pipeline_task_local_state : public parallel::itask_local_state {
   std::unique_ptr<cucascade::memory::reservation>
     _reservation;  ///< Memory reservation for GPU resources
   std::size_t _reservation_bytes = 0;
+  std::optional<reservation_size_info> _reservation_size_info;  ///< Cached estimation breakdown
 };
 
 }  // namespace pipeline

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -268,18 +268,21 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(table));
 }
 
-std::size_t cpu_source_task::get_estimated_reservation_size() const
+pipeline::reservation_size_info cpu_source_task::get_estimated_reservation_size_info() const
 {
   constexpr std::size_t kMinBytes = 64ULL * 1024;
   auto& g_state                   = _global_state->cast<cpu_source_task_global_state>();
   auto& source                    = g_state.get_source_op();
+  std::size_t reservation_size    = kMinBytes;
   if (source.collection) {
     auto count = source.collection->Count();
     if (count > 0) {
-      return std::max(kMinBytes, static_cast<std::size_t>(count) * std::size_t{256});
+      reservation_size = std::max(kMinBytes, static_cast<std::size_t>(count) * std::size_t{256});
     }
   }
-  return kMinBytes;
+  pipeline::reservation_size_info info;
+  info.reservation_size = reservation_size;
+  return info;
 }
 
 std::unique_ptr<op::operator_data> cpu_source_task::compute_task(rmm::cuda_stream_view stream)

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -263,9 +263,10 @@ void duckdb_scan_executor::manager_loop()
         parquet_task->set_materialized_columns(
           wrap_batch_data, cache_decoded_table, _gpu_memory_space);
       }
-      auto bytes_needed = scan_task->get_estimated_reservation_size();
-      auto reservation  = _mem_mgr->request_reservation(
-        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST}, bytes_needed);
+      auto reservation_info = scan_task->get_estimated_reservation_size_info();
+      auto reservation      = _mem_mgr->request_reservation(
+        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST},
+        reservation_info.reservation_size);
       if (!reservation) {
         SIRIUS_LOG_ERROR("DuckDB Scan Executor: Failed to acquire host memory reservation");
         _completion_handler->report_error(
@@ -274,17 +275,29 @@ void duckdb_scan_executor::manager_loop()
       }
       if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
             scan_task->local_state())) {
-        local_state->set_reservation(std::move(reservation));
+        local_state->set_reservation(std::move(reservation), reservation_info);
       } else {
         _completion_handler->report_error(
           "DuckDB Scan Executor: Failed to cast local state for task");
         SIRIUS_LOG_ERROR("DuckDB Scan Executor: Failed to cast local state for task");
         break;
       }
+    } else if (scan_task && scan_task->is<duckdb_scan_task>()) {
+      auto reservation_info = scan_task->get_estimated_reservation_size_info();
+      if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
+            scan_task->local_state())) {
+        local_state->set_reservation(nullptr, reservation_info);
+      } else {
+        _completion_handler->report_error(
+          "DuckDB Scan Executor: Failed to cast local state for duckdb_scan_task");
+        SIRIUS_LOG_ERROR("DuckDB Scan Executor: Failed to cast local state for duckdb_scan_task");
+        break;
+      }
     } else if (scan_task && scan_task->is<cpu_source_task>()) {
-      auto bytes_needed = scan_task->get_estimated_reservation_size();
-      auto reservation  = _mem_mgr->request_reservation(
-        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST}, bytes_needed);
+      auto reservation_info = scan_task->get_estimated_reservation_size_info();
+      auto reservation      = _mem_mgr->request_reservation(
+        cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST},
+        reservation_info.reservation_size);
       if (!reservation) {
         SIRIUS_LOG_ERROR(
           "DuckDB Scan Executor: Failed to acquire host memory reservation for CPU source");
@@ -294,7 +307,7 @@ void duckdb_scan_executor::manager_loop()
       }
       if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
             scan_task->local_state())) {
-        local_state->set_reservation(std::move(reservation));
+        local_state->set_reservation(std::move(reservation), reservation_info);
       } else {
         _completion_handler->report_error(
           "DuckDB Scan Executor: Failed to cast local state for cpu_source_task");

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -530,7 +530,8 @@ void duckdb_scan_task::process_chunk(duckdb_scan_task_local_state& l_state)
 
 void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
 {
-  auto estimated_bytes = get_estimated_reservation_size();
+  // _reservation_size_info is set by duckdb_scan_executor::manager_loop before dispatch.
+  auto& ls = this->_local_state->cast<duckdb_scan_task_local_state>();
 
   // Record memory metrics for future reservation estimates.
   // Scan tasks don't have peak memory tracking, so use output size as proxy.
@@ -544,10 +545,8 @@ void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
       }
     }
     auto& g_state = _global_state->cast<duckdb_scan_task_global_state>();
-    // Use the raw task consumption basis from local state when recording history
-    auto consumption_basis =
-      this->_local_state->cast<duckdb_scan_task_local_state>().get_task_consumption_basis();
-    g_state.get_memory_history().record({consumption_basis, output_bytes, output_bytes});
+    g_state.get_memory_history().record(
+      {ls.get_reservation_size_info()->input_basis, output_bytes, output_bytes});
 
     publish_output(*output_data, stream);
   }
@@ -621,14 +620,19 @@ void duckdb_scan_task::publish_output(op::operator_data& output_data, rmm::cuda_
   }
 }
 
-std::size_t duckdb_scan_task::get_estimated_reservation_size() const
+pipeline::reservation_size_info duckdb_scan_task::get_estimated_reservation_size_info() const
 {
-  auto current_estimate =
+  std::size_t input_basis =
     this->_local_state->cast<duckdb_scan_task_local_state>().get_task_consumption_basis();
   auto& g_state = this->_global_state->cast<duckdb_scan_task_global_state>();
-  auto refined  = g_state.get_memory_history().estimate_peak_memory(current_estimate);
-  if (refined) { return *refined; }
-  return current_estimate;
+  auto peak_opt = g_state.get_memory_history().estimate_peak_memory(input_basis);
+
+  pipeline::reservation_size_info info;
+  info.input_basis          = input_basis;
+  info.had_history          = peak_opt.has_value();
+  info.peak_memory_estimate = peak_opt.value_or(input_basis);
+  info.reservation_size     = info.peak_memory_estimate;
+  return info;
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -944,14 +944,19 @@ void parquet_scan_task::publish_output(op::operator_data& output_data,
   }
 }
 
-size_t parquet_scan_task::get_estimated_reservation_size() const
+pipeline::reservation_size_info parquet_scan_task::get_estimated_reservation_size_info() const
 {
-  auto current_estimate =
+  std::size_t input_basis =
     this->_local_state->cast<parquet_scan_task_local_state>().get_task_consumption_basis();
   auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
-  auto refined  = g_state.get_memory_history().estimate_peak_memory(current_estimate);
-  if (refined) { return *refined; }
-  return current_estimate;
+  auto peak_opt = g_state.get_memory_history().estimate_peak_memory(input_basis);
+
+  pipeline::reservation_size_info info;
+  info.input_basis          = input_basis;
+  info.had_history          = peak_opt.has_value();
+  info.peak_memory_estimate = peak_opt.value_or(input_basis);
+  info.reservation_size     = info.peak_memory_estimate;
+  return info;
 }
 
 void parquet_scan_task::read_range_into_allocation(

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -89,7 +89,8 @@ void gpu_pipeline_executor::manager_loop()
       }
       break;
     }
-    auto bytes_needs = gpu_task->get_estimated_reservation_size();
+    auto reservation_info = gpu_task->get_estimated_reservation_size_info();
+    auto bytes_needs      = reservation_info.reservation_size;
     SIRIUS_LOG_TRACE(
       "GPU Pipeline Executor: Acquiring memory reservation for pipeline {} of {} bytes for task "
       "{}. Memory "
@@ -193,7 +194,7 @@ void gpu_pipeline_executor::manager_loop()
     }
     if (auto* local_state = dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(
           gpu_task->local_state())) {
-      local_state->set_reservation(std::move(reservation));
+      local_state->set_reservation(std::move(reservation), reservation_info);
     } else {
       SIRIUS_LOG_ERROR("GPU Pipeline Executor: Failed to cast local state for task {}",
                        gpu_task->get_task_id());

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -243,7 +243,8 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
       auto peak_bytes = _allocator ? _allocator->get_peak_allocated_bytes(stream) : 0;
       // Subtract the peak allocated bytes to the input data to get the peak allocated bytes for the
       // operators, clamping to zero to avoid unsigned underflow.
-      auto const bytes_to_materialize_input = local_state._bytes_to_materialize_input;
+      auto const bytes_to_materialize_input =
+        local_state.get_reservation_size_info()->bytes_to_materialize_input;
       if (peak_bytes > bytes_to_materialize_input) {
         peak_bytes -= bytes_to_materialize_input;
       } else {
@@ -276,14 +277,16 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
         static_cast<double>(global_usage) / (1024.0 * 1024.0),
         peak_bytes,
         static_cast<double>(peak_bytes) / (1024.0 * 1024.0),
-        local_state._bytes_to_materialize_input,
-        static_cast<double>(local_state._bytes_to_materialize_input) / (1024.0 * 1024.0),
+        local_state.get_reservation_size_info()->bytes_to_materialize_input,
+        static_cast<double>(local_state.get_reservation_size_info()->bytes_to_materialize_input) /
+          (1024.0 * 1024.0),
         reservation_bytes,
         static_cast<double>(reservation_bytes) / (1024.0 * 1024.0),
         _task_id);
 
-      auto input_basis =
-        _local_state->cast<gpu_pipeline_task_local_state>().get_task_consumption_basis();
+      auto input_basis = _local_state->cast<gpu_pipeline_task_local_state>()
+                           .get_reservation_size_info()
+                           ->input_basis;
       auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
       global.get_memory_history().record_on_failure(input_basis, peak_bytes);
 
@@ -363,7 +366,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     local_state._input_data->prepare_for_processing(requested_memory_space, stream);
   } catch (const rmm::out_of_memory& oom) {
     auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
-    auto input_basis = local_state.get_task_consumption_basis();
+    auto input_basis = local_state.get_reservation_size_info()->input_basis;
     auto& global     = _global_state->cast<gpu_pipeline_task_global_state>();
     global.get_memory_history().record_on_failure(input_basis, peak_bytes);
 
@@ -395,8 +398,8 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   // 2. Set reservation_aware_memory_resource_ref as the default cudf allocator
   // 3. Execute cudf operators on the pipeline
-  _allocator                                     = allocator;
-  auto input_basis                               = local_state.get_task_consumption_basis();
+  _allocator       = allocator;
+  auto input_basis = local_state.get_reservation_size_info()->input_basis;
   std::unique_ptr<op::operator_data> output_data = compute_task(stream);
 
   // Record memory metrics for future reservation estimates
@@ -404,8 +407,8 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
     auto peak_bytes = _allocator ? _allocator->get_peak_allocated_bytes(stream) : 0;
     // Subtract the peak allocated bytes to the input data to get the peak allocated bytes for the
     // operators. Clamp at zero to avoid size_t underflow when estimates exceed the observed peak.
-    if (peak_bytes > local_state._bytes_to_materialize_input) {
-      peak_bytes -= local_state._bytes_to_materialize_input;
+    if (peak_bytes > local_state.get_reservation_size_info()->bytes_to_materialize_input) {
+      peak_bytes -= local_state.get_reservation_size_info()->bytes_to_materialize_input;
     } else {
       peak_bytes = 0;
     }
@@ -427,7 +430,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       output_bytes,
       reservation_bytes,
       peak_bytes,
-      local_state._bytes_to_materialize_input);
+      local_state.get_reservation_size_info()->bytes_to_materialize_input);
   }
 
   if (output_data) { publish_output(*output_data, stream); }
@@ -450,18 +453,21 @@ std::size_t gpu_pipeline_task::get_input_size() const
   return input_size;
 }
 
-std::size_t gpu_pipeline_task::get_estimated_reservation_size() const
+pipeline::reservation_size_info gpu_pipeline_task::get_estimated_reservation_size_info() const
 {
-  auto input_size =
-    _local_state->cast<gpu_pipeline_task_local_state>().get_task_consumption_basis();
+  auto& ls                         = _local_state->cast<gpu_pipeline_task_local_state>();
+  auto& gs                         = _global_state->cast<gpu_pipeline_task_global_state>();
+  std::size_t input_basis          = ls.get_task_consumption_basis();
+  std::size_t bytes_to_materialize = ls.get_estimated_bytes_to_materialize_input();
+  auto peak_opt                    = gs.get_memory_history().estimate_peak_memory(input_basis);
 
-  auto bytes_to_materialize_input =
-    _local_state->cast<gpu_pipeline_task_local_state>()._bytes_to_materialize_input;
-  auto& global  = _global_state->cast<gpu_pipeline_task_global_state>();
-  auto estimate = global.get_memory_history().estimate_peak_memory(input_size);
-  if (estimate) { return *estimate + bytes_to_materialize_input; }
-  // Fallback: no history yet (first batch in pipeline)
-  return input_size * 2 + bytes_to_materialize_input;
+  pipeline::reservation_size_info info;
+  info.input_basis                = input_basis;
+  info.bytes_to_materialize_input = bytes_to_materialize;
+  info.had_history                = peak_opt.has_value();
+  info.peak_memory_estimate       = peak_opt.value_or(input_basis * 2);
+  info.reservation_size           = info.peak_memory_estimate + bytes_to_materialize;
+  return info;
 }
 
 std::vector<op::sirius_physical_operator*> gpu_pipeline_task::get_output_consumers()

--- a/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_executor.cpp
@@ -127,7 +127,12 @@ class sirius_pipeline_task : public sirius::pipeline::gpu_pipeline_task {
     global.executed_count.fetch_add(1, std::memory_order_relaxed);
   }
 
-  std::size_t get_estimated_reservation_size() const override { return kReservationBytes; }
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info() const override
+  {
+    sirius::pipeline::reservation_size_info info;
+    info.reservation_size = kReservationBytes;
+    return info;
+  }
 
   std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
 };

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -247,21 +247,24 @@ std::unique_ptr<sirius::pipeline::gpu_pipeline_task> create_pipeline_task(
   batches.push_back(std::move(batch));
   auto op_data = std::make_unique<sirius::op::pipelineable_operator_data>(std::move(batches));
 
-  auto local_state =
-    std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data));
+  auto task = std::make_unique<sirius::pipeline::gpu_pipeline_task>(
+    task_id,
+    std::vector<cucascade::shared_data_repository*>{},
+    std::make_unique<sirius::pipeline::gpu_pipeline_task_local_state>(std::move(op_data)),
+    std::move(global_state));
 
   if (reservation_size > 0) {
+    auto info        = task->get_estimated_reservation_size_info();
     auto reservation = f.manager->request_reservation(
       cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::GPU}, reservation_size);
     REQUIRE(reservation != nullptr);
-    local_state->set_reservation(std::move(reservation));
+    auto* ls =
+      dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(task->local_state());
+    REQUIRE(ls != nullptr);
+    ls->set_reservation(std::move(reservation), info);
   }
 
-  return std::make_unique<sirius::pipeline::gpu_pipeline_task>(
-    task_id,
-    std::vector<cucascade::shared_data_repository*>{},
-    std::move(local_state),
-    std::move(global_state));
+  return task;
 }
 }  // namespace
 
@@ -449,7 +452,8 @@ TEST_CASE("gpu_pipeline_task execute successfully records to pipeline memory his
 
   auto task2 = create_pipeline_task(f, global_state, input_batch2, 0, /*task_id=*/2);
 
-  auto estimation2 = task2->get_estimated_reservation_size();
+  auto info2       = task2->get_estimated_reservation_size_info();
+  auto estimation2 = info2.reservation_size;
   REQUIRE(estimation2 ==
           ((float)kInputDataSize2 / (float)kInputDataSize1) * (kExecuteConsumptionSize1));
   auto task_reservation2 = f.manager->request_reservation(
@@ -458,7 +462,7 @@ TEST_CASE("gpu_pipeline_task execute successfully records to pipeline memory his
   auto* local_state2_ptr =
     dynamic_cast<sirius::pipeline::sirius_pipeline_task_local_state*>(task2->local_state());
   REQUIRE(local_state2_ptr != nullptr);
-  local_state2_ptr->set_reservation(std::move(task_reservation2));
+  local_state2_ptr->set_reservation(std::move(task_reservation2), info2);
 
   task2->execute(stream);
 

--- a/test/cpp/pipeline/test_oom_reschedule.cpp
+++ b/test/cpp/pipeline/test_oom_reschedule.cpp
@@ -134,7 +134,12 @@ class oom_test_task_base : public sirius::pipeline::gpu_pipeline_task {
 
   void publish_output(sirius::op::operator_data&, rmm::cuda_stream_view) override {}
 
-  std::size_t get_estimated_reservation_size() const override { return kReservationSize; }
+  sirius::pipeline::reservation_size_info get_estimated_reservation_size_info() const override
+  {
+    sirius::pipeline::reservation_size_info info;
+    info.reservation_size = kReservationSize;
+    return info;
+  }
 
   std::vector<sirius::op::sirius_physical_operator*> get_output_consumers() override { return {}; }
 


### PR DESCRIPTION
This PR fixes a bug where the bytes to materialize (how much memory you need, if any, to move data onto the GPU prior to processing). This value was instantiated when the task was constructed, which means that if the task was downgraded, this value could be incorrect.

This PR also changes the function `size_t get_estimated_reservation_size()` into `pipeline::reservation_size_info get_estimated_reservation_size_info()` which captures more information and improves how this data flows through the executor. 

Finally this PR also fixes duckdb_scan_task so that the reservation is done in the duckdb_scan_executor and not in the compute function itself. 

