### PR TITLE
fix(value): widen int16-stored DECIMAL via int16 read in from_duckdb

### DIFF
--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -72,10 +72,15 @@ value from_duckdb(const duckdb::Value& v, const logical_type& type)
       // alternative struct. The alt carries only (rep, scale).
       auto const precision = type.decimal_precision();
       auto const scale     = type.decimal_scale();
+      // Sirius has only decimal32/64/128, so DuckDB's narrower physical
+      // widths are widened on read. GetValueUnsafe<T> reinterprets the
+      // value union — it does NOT cast — so each branch must read at the
+      // actual storage width (mirrors to_duckdb above and
+      // gpu_execute_constant.cpp:148-167).
+      if (precision <= logical_type::decimal_max_precision_int16) {
+        return value{decimal32{static_cast<int32_t>(v.GetValueUnsafe<int16_t>()), scale}};
+      }
       if (precision <= logical_type::decimal_max_precision_int32) {
-        // DuckDB stores precision <= 4 as int16_t and 5..9 as int32_t.
-        // Sirius has only decimal32/64/128 (mirrors gpu_execute_constant.cpp:148-167).
-        // GetValueUnsafe<int32_t>() widens int16-storage cleanly.
         return value{decimal32{v.GetValueUnsafe<int32_t>(), scale}};
       }
       if (precision <= logical_type::decimal_max_precision_int64) {


### PR DESCRIPTION
## Summary
- `sirius::from_duckdb` produced `decimal32` values with garbage upper 16 bits for `DECIMAL(precision <= 4)`. Root cause: `duckdb::Value::GetValueUnsafe<T>` is a reinterpret accessor — it returns the `T`-typed member of `Value::value_` directly, **not** a typed cast. DECIMAL(precision ≤ 4) is physically stored in `value_.smallint` (int16_t), but the code read it via `GetValueUnsafe<int32_t>()`, returning the lower 16 bits correctly (e.g. `0x04d2` for `1234`) and the upper 16 bits uninitialized.
- Fix splits the precision branch in `from_duckdb` on `logical_type::decimal_max_precision_int16`, mirroring the existing `to_duckdb` branch (`src/expression/value.cpp:133`): the int16-storage case now reads `GetValueUnsafe<int16_t>()` and explicitly widens via `static_cast<int32_t>`. The precision-5..9 (int32 storage) and wider branches are unchanged.
- The round-trip `to_duckdb` path narrows via `static_cast<int16_t>(d.value)`, which masked the corruption on the way back. Only `REQUIRE(std::get<decimal32>(sv).value == 1234)` at `test/cpp/expression/test_value.cpp:282` caught it; the surrounding `REQUIRE(back == dv)` did not.

## Test plan
- [ ] CI: `[ast_value]` cases in `test/cpp/expression/test_value.cpp` — DECIMAL(4,2), DECIMAL(18,4), DECIMAL(38,10) all pass
- [ ] CI: existing SQLLogic tests touching small-precision DECIMAL constants still pass
- [ ] Note: local build/test was not run in this worktree (duckdb submodule uninitialised; full CUDA build is expensive). The fix is mechanically narrow — one branch added, false comment removed — so relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)