### PR TITLE
scan: DuckDB format GPU-native decode kernel (Part 4: Float ALP/ALPRD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,8 +278,9 @@ set(EXTENSION_SOURCES
 # Legacy Sirius — all legacy-specific config lives in src/legacy/CMakeLists.txt.
 # Deleting src/legacy/ cleanly removes legacy build support.
 set(CUDA_SOURCES
-    src/op/scan/equality_delete_mask.cu src/cuda/scan/gpu_decode_rle.cu
-    src/cuda/scan/gpu_decode_bitpacking.cu src/cuda/scan/gpu_native_decode.cu)
+    src/op/scan/equality_delete_mask.cu src/cuda/scan/gpu_decode_alp.cu
+    src/cuda/scan/gpu_decode_bitpacking.cu src/cuda/scan/gpu_decode_rle.cu
+    src/cuda/scan/gpu_native_decode.cu)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/legacy/CMakeLists.txt")
   add_subdirectory(src/legacy)
   list(APPEND EXTENSION_SOURCES ${SIRIUS_LEGACY_SOURCES}
@@ -428,6 +429,7 @@ set(TEST_SOURCES
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_column_builder.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp
+    test/cpp/scan/test_gpu_decode_alp.cpp
     test/cpp/scan/test_gpu_decode_bitpacking.cpp
     test/cpp/scan/test_gpu_decode_rle.cpp
     test/cpp/scan/test_gpu_native_decode.cpp

--- a/src/cuda/scan/gpu_decode_alp.cu
+++ b/src/cuda/scan/gpu_decode_alp.cu
@@ -14,42 +14,47 @@
  * limitations under the License.
  */
 
-// ALP / ALPRD decode kernels. One CTA = one 1024-row vector. On any bounds
-// check failure the kernel zero-fills `desc.vec_row_count` rows using the
-// trusted host descriptor row count, never parsed metadata.
+//===----------------------------------------------------------------------===//
+// clang-format off
+// ALP / ALPRD decode kernels. The work partitioning is 1 CTA per 1024-row vector.
+// On any bounds check failure the kernel zero-fills `desc.vec_row_count` rows.
 //
-// On-disk layouts (verified against
-// duckdb/src/include/duckdb/storage/compression/{alp,alprd}/):
+// On-disk layouts (see: duckdb/src/include/duckdb/storage/compression/{alp,alprd}/):
 //
 //   ALP segment (one segment holds N 1024-row "vectors"):
 //
-//   byte 0   4                                 metadata_end          seg_end
-//   │        │                                 │                     │
-//   ├─uint32─┼─── per-vector data (forward) ───┼── trailer table ────┤
-//   │ end    │                                 │  uint32[N], V at    │
-//   │        │                                 │  metadata_end-(V+1)*4
-//   └─offset of metadata_end
+//   byte 0   4                                                                    metadata_end
+//   │        │                                 │                                  │
+//   ├─uint32─┼─── per-vector data (forward) ───┼── trailer table (backward) ──────┤
+//   │ end    │                                 │  uint32[N], V at                 │
+//   │        │                                 │  metadata_end-(V+1)*4            │
+//     └─offset of metadata_end
 //
 //   ALP per-vector (compressed) — 13-byte header + bitstream + exceptions:
 //
 //   ┌───┬───┬─────┬────────────────┬──┬────────────────┬───────┬─────────┐
 //   │exp│fac│ ec  │ FOR (uint64)   │bw│ packed uint64  │ exc   │ exc pos │
-//   │ u8│ u8│ u16 │                │u8│ mantissas      │ T[ec] │ u16[ec] │
+//   │ u8│ u8│ u16 │                │u8│ codes          │ T[ec] │ u16[ec] │
 //   └───┴───┴─────┴────────────────┴──┴────────────────┴───────┴─────────┘
-//   0   1   2     4               12  13              ↑       ↑
-//                                                     │       │
-//                                bitstream = round_up(rows,32)*bw/8 bytes
+//   0   1   2     4               12  13              [A]     [B]      [C]
 //
-//   exp == 0xFF → uncompressed-sentinel: 1-byte 0xFF then raw T[rows].
-//   bw ≤ sizeof(T)*8. Exception position bound-checked against fill_rows.
+//   [A] = 13 + round_up(rows, 32) * bw / 8   (end of bitstream)
+//   [B] = [A] + ec * sizeof(T)               (end of exception values)
+//   [C] = [B] + ec * sizeof(u16)             (end of vector)
+//
+//   - Decoded value = code * 10^fac * 10^(-exp).
+//   - Exception positions are walked after decoding to install the exception values at the
+//     corresponding vector positions.
+//   - exp == 0xFF → uncompressed-sentinel: 1-byte 0xFF then raw T[rows].
 //
 //   ALPRD segment (small dict header lives between metadata_end and trailer):
 //
-//   byte 0   4   5   6   7                                 metadata_end ↘
-//   │        │   │   │   │                                 │             │
-//   ├─uint32─┼─u8┼─u8┼─u8┼── uint16 dict[dict_size] ───────┼── per-vec ──┤
-//   │ end    │ rb│ lb│ds │ (≤ 8 entries, lb ≤ 3)           │  data       │
-//   └─offset
+//   byte 0   4   5   6   7                                                                       metadata_end
+//   │        │   │   │   │                                 │             │                       │
+//   ├─uint32─┼─u8┼─u8┼─u8┼── uint16 dict[dict_size] ───────┼── per-vec ──┼── trailer (backward) ─┤
+//   │ end    │ rb│ lb│ds │   (≤ 8 entries, lb ≤ 3)         │   data      │  uint32[N], V at      │
+//   │        │   │   │   │                                 │             │  metadata_end-(V+1)*4 │
+//     └─offset of metadata_end
 //
 //   ALPRD per-vector (compressed) — 2-byte header + two bitstreams + exceptions:
 //
@@ -60,9 +65,12 @@
 //   └─────┴───────────────────┴─────────────────────┴───────┴─────────┘
 //   0     2
 //
-//   ec == 0xFFFF → uncompressed-sentinel: 2-byte 0xFFFF then raw EXACT_T[rows].
-//   Reconstructed bits = (uint64_t)dict[left_idx] << rb | right_part, then
-//   bit-cast to T (double / float).
+//   - Decoded value = dict[left_idx] << rb | right_part
+//   - Exception positions are walked after decoding to install the exception values at the
+//     corresponding vector positions.
+//   - ec == 0xFFFF → uncompressed-sentinel: 2-byte 0xFFFF then raw EXACT_T[rows].
+//===----------------------------------------------------------------------===//
+// clang-format on
 
 #include "cuda/scan/gpu_decode_alp.cuh"
 
@@ -70,8 +78,15 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/numeric>
+#include <cuda/std/type_traits>
 #include <cuda_runtime.h>
 
+#include <duckdb/storage/compression/alp/alp_constants.hpp>
+#include <duckdb/storage/compression/alprd/alprd_constants.hpp>
+
+#include <climits>
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
@@ -84,14 +99,12 @@ namespace sirius::cuda::scan {
 namespace {
 
 constexpr uint32_t BLOCK_DIM = 256;
-
-// Max factor index — the encoder couples (factor, exponent), so this bound
-// is shared across f32 and f64. `MAX_EXPONENT` lives on AlpTypedConstants<T>
-// because exponent IS type-specific.
 constexpr uint8_t ALP_MAX_FACTOR =
   static_cast<uint8_t>(std::extent_v<decltype(duckdb::AlpConstants::FACT_ARR)> - 1);
 
-/// One CTA's unit of work for ALP / ALPRD: one vector within one segment.
+/**
+ * @brief Vector-level descriptor for a CTA
+ */
 struct alp_vector_desc {
   uint8_t const* d_segment;    ///< Device pointer to the segment's first byte.
   uint32_t segment_bytes;      ///< Size of the staged segment buffer.
@@ -100,61 +113,115 @@ struct alp_vector_desc {
   uint32_t global_row_offset;  ///< Output offset, in rows, for this vector.
 };
 
-// Mirrors of `AlpConstants::FACT_ARR` and `AlpTypedConstants<T>::FRAC_ARR`.
-__device__ __constant__ int64_t d_alp_fact[19] = {1LL,
-                                                  10LL,
-                                                  100LL,
-                                                  1000LL,
-                                                  10000LL,
-                                                  100000LL,
-                                                  1000000LL,
-                                                  10000000LL,
-                                                  100000000LL,
-                                                  1000000000LL,
-                                                  10000000000LL,
-                                                  100000000000LL,
-                                                  1000000000000LL,
-                                                  10000000000000LL,
-                                                  100000000000000LL,
-                                                  1000000000000000LL,
-                                                  10000000000000000LL,
-                                                  100000000000000000LL,
-                                                  1000000000000000000LL};
+/**
+ * @brief Per-vector parse outcome. Routes the CTA to one of three paths:
+ * zero-fill (invalid), raw bit-cast (uncompressed sentinel), or bitpacked
+ * decode (compressed).
+ */
+enum class alp_parse_status : uint8_t { invalid, uncompressed, compressed };
 
-__device__ __constant__ float d_alp_frac_f32[11] = {1.0F,
-                                                    0.1F,
-                                                    0.01F,
-                                                    0.001F,
-                                                    0.0001F,
-                                                    0.00001F,
-                                                    0.000001F,
-                                                    0.0000001F,
-                                                    0.00000001F,
-                                                    0.000000001F,
-                                                    0.0000000001F};
+/**
+ * @brief Parsed per-vector metadata. Thread 0 populates this from the
+ * segment header + trailer; the rest of the CTA reads it through shmem.
+ */
+struct alp_vector_meta {
+  alp_parse_status status;
+  uint32_t data_off;              ///< Byte offset of this vector's data within the segment.
+  uint8_t exp;                    ///< Decode exponent index.
+  uint8_t fac;                    ///< Decode factor index.
+  uint16_t exc_count;             ///< Number of exception positions.
+  uint64_t for_val;               ///< Frame-of-reference (added to each unpacked code).
+  uint8_t bw;                     ///< Bitpack width.
+  uint8_t const* packed_bytes_p;  ///< Pointer to the byte-stream of packed codes.
+  uint32_t packed_bytes_count;    ///< Size of the bitpacked stream in bytes.
+};
 
-__device__ __constant__ double d_alp_frac_f64[21] = {1.0,
-                                                     0.1,
-                                                     0.01,
-                                                     0.001,
-                                                     0.0001,
-                                                     0.00001,
-                                                     0.000001,
-                                                     0.0000001,
-                                                     0.00000001,
-                                                     0.000000001,
-                                                     0.0000000001,
-                                                     0.00000000001,
-                                                     0.000000000001,
-                                                     0.0000000000001,
-                                                     0.00000000000001,
-                                                     0.000000000000001,
-                                                     0.0000000000000001,
-                                                     0.00000000000000001,
-                                                     0.000000000000000001,
-                                                     0.0000000000000000001,
-                                                     0.00000000000000000001};
+/**
+ * @brief Per-vector ALPRD parse outcome — see `alp_parse_status` for the
+ * three routing paths.
+ */
+enum class alprd_parse_status : uint8_t { invalid, uncompressed, compressed };
 
+/**
+ * @brief Parsed per-vector ALPRD metadata. Thread 0 populates this from the
+ * segment header + trailer; the rest of the CTA reads it through shmem. The
+ * segment dictionary is loaded separately by a cooperative dict-load.
+ */
+struct alprd_vector_meta {
+  alprd_parse_status status;
+  uint32_t data_off;                    ///< Byte offset of this vector's data within the segment.
+  uint16_t exc_count;                   ///< Number of exception positions.
+  uint8_t right_bw;                     ///< Right-bits packed width.
+  uint8_t left_bw;                      ///< Left-bits packed width.
+  uint8_t dict_size;                    ///< Number of entries in the segment dictionary.
+  uint8_t const* left_packed_bytes_p;   ///< Pointer to the byte-stream of left dict-indices.
+  uint32_t left_packed_bytes_count;     ///< Size of the left bitpacked stream in bytes.
+  uint8_t const* right_packed_bytes_p;  ///< Pointer to the byte-stream of right parts.
+  uint32_t right_packed_bytes_count;    ///< Size of the right bitpacked stream in bytes.
+};
+
+/**
+ * @brief Factor and exponent tables for ALP decoding: decoded val = code * fact[fac] * frac[exp].
+ * Placed in constant memory. Mirrors of `AlpConstants::FACT_ARR` and
+ * `AlpTypedConstants<T>::FRAC_ARR`.
+ */
+__device__ __constant__ int64_t d_alp_fact[] = {1LL,
+                                                10LL,
+                                                100LL,
+                                                1000LL,
+                                                10000LL,
+                                                100000LL,
+                                                1000000LL,
+                                                10000000LL,
+                                                100000000LL,
+                                                1000000000LL,
+                                                10000000000LL,
+                                                100000000000LL,
+                                                1000000000000LL,
+                                                10000000000000LL,
+                                                100000000000000LL,
+                                                1000000000000000LL,
+                                                10000000000000000LL,
+                                                100000000000000000LL,
+                                                1000000000000000000LL};
+
+__device__ __constant__ float d_alp_frac_f32[] = {1.0F,
+                                                  0.1F,
+                                                  0.01F,
+                                                  0.001F,
+                                                  0.0001F,
+                                                  0.00001F,
+                                                  0.000001F,
+                                                  0.0000001F,
+                                                  0.00000001F,
+                                                  0.000000001F,
+                                                  0.0000000001F};
+
+__device__ __constant__ double d_alp_frac_f64[] = {1.0,
+                                                   0.1,
+                                                   0.01,
+                                                   0.001,
+                                                   0.0001,
+                                                   0.00001,
+                                                   0.000001,
+                                                   0.0000001,
+                                                   0.00000001,
+                                                   0.000000001,
+                                                   0.0000000001,
+                                                   0.00000000001,
+                                                   0.000000000001,
+                                                   0.0000000000001,
+                                                   0.00000000000001,
+                                                   0.000000000000001,
+                                                   0.0000000000000001,
+                                                   0.00000000000000001,
+                                                   0.000000000000000001,
+                                                   0.0000000000000000001,
+                                                   0.00000000000000000001};
+
+/**
+ * @brief Get the pointer to the fraction array in constant memory for float/double
+ */
 template <typename T>
 __device__ __forceinline__ T const* alp_frac_ptr();
 template <>
@@ -168,107 +235,107 @@ __device__ __forceinline__ double const* alp_frac_ptr<double>()
   return d_alp_frac_f64;
 }
 
-// Per-vector data starts at arbitrary byte offsets — metadata reads cannot
-// assume 2/4/8-byte alignment, so go through `memcpy`.
-__device__ __forceinline__ uint16_t ld16(uint8_t const* p)
+/**
+ * @brief Perform an unaligned load of type @p T from buffer @p p.
+ *
+ * Per-vector data starts at arbitrary byte offsets, so metadata reads cannot make alignment
+ * assumptions.
+ */
+template <typename T>
+__device__ __forceinline__ T ld_unaligned(uint8_t const* p)
 {
-  uint16_t v;
+  T v;
   memcpy(&v, p, sizeof(v));
   return v;
 }
 
-__device__ __forceinline__ uint32_t ld32(uint8_t const* p)
+/**
+ * @brief Calculate the number of bytes for a bitpacked buffer given @p row_count rows and @p width
+ * bits per row.
+ *
+ * Mirror of DuckDB's `BitpackingPrimitives::GetRequiredBytes`.
+ */
+__device__ __host__ __forceinline__ uint32_t bp_required_bytes(uint32_t row_count, uint32_t width)
 {
-  uint32_t v;
-  memcpy(&v, p, sizeof(v));
-  return v;
+  // DuckDB packs values in groups of 32
+  constexpr uint32_t BITPACK_GROUP = 32;
+
+  if (width == 0) return 0;
+  // Round up to the nearest multiple of 32
+  auto const n_rounded = ::cuda::ceil_div(row_count, BITPACK_GROUP) * BITPACK_GROUP;
+  // Count the number of bytes needed (n_rounded is a multiple of 8 by definition)
+  return (n_rounded * width) / 8;
 }
 
-__device__ __forceinline__ uint64_t ld64(uint8_t const* p)
-{
-  uint64_t v;
-  memcpy(&v, p, sizeof(v));
-  return v;
-}
-
-// Mirror of `BitpackingPrimitives::GetRequiredSize`.
-__device__ __host__ __forceinline__ uint32_t bp_required_bytes(uint32_t count, uint32_t width)
-{
-  if (width == 0u) return 0u;
-  uint32_t const rounded = ::cuda::ceil_div(count, 32u) * 32u;
-  return rounded * width / 8u;
-}
-
-// Caller must supply 2 trailing guard words past the live data (the
-// 64-bit straddle case reads up to 3 consecutive 32-bit words).
+/**
+ * @brief Unpack a value of type ResT from @p packed bitstream.
+ * @note The caller must supply 2 trailing guard words past the live data.
+ */
 template <typename ResT>
 __device__ __forceinline__ ResT unpack_from_shmem(uint32_t const* packed,
                                                   uint32_t idx,
                                                   uint32_t width)
 {
-  if (width == 0u) return ResT(0);
+  constexpr uint32_t WORD_BYTES       = sizeof(uint32_t);
+  constexpr uint32_t WORD_BITS        = ::cuda::std::numeric_limits<uint32_t>::digits;
+  constexpr uint32_t DOUBLE_WORD_BITS = ::cuda::std::numeric_limits<uint64_t>::digits;
+  constexpr uint64_t DOUBLE_WORD_MAX  = ::cuda::std::numeric_limits<uint64_t>::max();
 
-  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
-  uint32_t word_idx = static_cast<uint32_t>(bit_pos >> 5);
-  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31u);
+  if (width == 0) return 0;
 
-  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
-  if (bit_off + width > 32u) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
-  uint64_t result = combined >> bit_off;
+  auto const bit_pos  = static_cast<uint64_t>(idx) * width;
+  auto const word_idx = static_cast<uint32_t>(bit_pos / WORD_BITS);
+  auto const bit_off  = static_cast<uint32_t>(bit_pos % WORD_BITS);
 
-  if constexpr (sizeof(ResT) > 4) {
-    if (bit_off > 0 && bit_off + width > 64u) {
-      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64u - bit_off);
+  auto combined = static_cast<uint64_t>(packed[word_idx]);
+  if (bit_off + width > WORD_BITS) {
+    combined |= static_cast<uint64_t>(packed[word_idx + 1]) << WORD_BITS;
+  }
+  auto result = combined >> bit_off;
+
+  if constexpr (sizeof(ResT) > WORD_BYTES) {
+    static_assert(::cuda::std::is_same_v<ResT, uint64_t>);
+    if (bit_off > 0 && bit_off + width > DOUBLE_WORD_BITS) {
+      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (DOUBLE_WORD_BITS - bit_off);
     }
   }
 
-  uint64_t mask = (width >= 64u) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1u);
+  auto const mask = (width >= DOUBLE_WORD_BITS) ? DOUBLE_WORD_MAX : ((uint64_t{1} << width) - 1u);
   return static_cast<ResT>(result & mask);
 }
 
-// `src` is any byte alignment; `byte_count` need not be a multiple of 4.
-// We can't use `cg::memcpy_async` with `cuda::aligned_size_t<N>` here:
-// `src = vp + 13` where `vp = seg_base + data_off` and `data_off` varies
-// per vector at runtime, so neither 4- nor 16-byte alignment is provable.
-// Each thread doing `memcpy(&v, src + off, 4)` lowers to `ld.u32` (with
-// the unaligned-access handler on sm_75) — same primitive cg::memcpy_async
-// would use on an aligned middle, without the prefix/middle/tail split.
+/**
+ * @brief Copy bytes from @p src to @p dst_words in SMEM. memcpy is used because there is no
+ * guarantee on the byte alignment for @p src pointer.
+ */
 __device__ __forceinline__ void stage_bytes_to_shmem(uint32_t* dst_words,
                                                      uint8_t const* src,
                                                      uint32_t byte_count,
                                                      uint32_t pad_words)
 {
-  uint32_t live_words = ::cuda::ceil_div(byte_count, 4u);
+  constexpr uint32_t WORD_BYTES = sizeof(uint32_t);
+
+  auto const live_words = ::cuda::ceil_div(byte_count, WORD_BYTES);
   for (uint32_t w = threadIdx.x; w < live_words; w += blockDim.x) {
-    uint32_t off = w * 4u;
-    uint32_t v   = 0u;
-    if (off + 4u <= byte_count) {
-      memcpy(&v, src + off, 4);
+    auto const byte_offset = w * WORD_BYTES;
+    uint32_t v             = 0;
+    if (byte_offset + WORD_BYTES <= byte_count) {
+      memcpy(&v, src + byte_offset, WORD_BYTES);
     } else {
       // Tail: at most 3 leftover bytes. Zero-pad the high bytes.
-      uint32_t left = byte_count - off;
-      memcpy(&v, src + off, left);
+      auto const left = byte_count - byte_offset;
+      memcpy(&v, src + byte_offset, left);
     }
     dst_words[w] = v;
   }
   for (uint32_t w = live_words + threadIdx.x; w < live_words + pad_words; w += blockDim.x) {
-    dst_words[w] = 0u;
+    dst_words[w] = 0;
   }
 }
 
-// Read a value the kernel previously wrote with `__stwt`. Correct only after
-// a __syncthreads barrier separating the write from this read: `__stwt`
-// invalidates the issuing SM's L1 line, so the post-sync ordinary load
-// refills from L2 with the freshly written value. Any change to the main
-// loop's store hint (e.g., switching to `__stcg` or vectorized stores) must
-// revisit this helper. Used by ALPRD's exception scatter to recover
-// right-bits without a second pre-pass over `out`.
-template <typename T>
-__device__ __forceinline__ T read_back_after_stwt(T const* out, uint32_t pos)
-{
-  return out[pos];
-}
-
+/**
+ * @brief Zero-fill @p out buffer with @p row_count zeros in the case of malfomation.
+ */
 template <typename T>
 __device__ __forceinline__ void zero_fill_vector(T* out, uint32_t row_count)
 {
@@ -277,417 +344,156 @@ __device__ __forceinline__ void zero_fill_vector(T* out, uint32_t row_count)
   }
 }
 
-// Dynamic shmem: uint32 packed_words[] — bitpacked mantissa stream plus
-// 2 guard words for `unpack_from_shmem`.
+//===----------------------------------------------------------------------===//
+// ALP
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Parse the ALP segment trailer + per-vector header.
+ */
 template <typename T>
+__device__ alp_vector_meta parse_alp_metadata(uint8_t const* seg_base,
+                                              uint32_t seg_bytes,
+                                              uint32_t vec_idx,
+                                              uint32_t fill_rows)
+{
+  constexpr uint32_t T_BITS = sizeof(T) * CHAR_BIT;
+
+  alp_vector_meta meta{};
+  meta.status = alp_parse_status::invalid;
+
+  if (seg_bytes < duckdb::AlpConstants::HEADER_SIZE) return meta;
+
+  // Parse the segment trailer
+  auto const metadata_end = ld_unaligned<uint32_t>(seg_base);
+  // We must have: metadata_end - (ved_idx + 1) * METADATA_POINTER_SIZE >= METADATA_POINTER_SIZE, so
+  // that the desired metadata entry fits within the segment.
+  auto const trailer_need = (vec_idx + 2) * duckdb::AlpConstants::METADATA_POINTER_SIZE;
+  if (metadata_end > seg_bytes || metadata_end < trailer_need) return meta;
+  auto const metadata_entry_offset =
+    metadata_end - (vec_idx + 1) * duckdb::AlpConstants::METADATA_POINTER_SIZE;
+  auto const data_off = ld_unaligned<uint32_t>(seg_base + metadata_entry_offset);
+  if (data_off < duckdb::AlpConstants::HEADER_SIZE || data_off >= metadata_end) return meta;
+  meta.data_off = data_off;
+
+  // Parse the per-vector header
+  auto const* vector_p = seg_base + data_off;
+  auto const exp       = vector_p[0];
+  if (exp == ALP_UNCOMPRESSED_SENTINEL) {
+    // 1-B padding before raw values
+    auto const raw_end = data_off + 1 + fill_rows * sizeof(T);
+    if (raw_end > metadata_end) return meta;
+    meta.status = alp_parse_status::uncompressed;
+    return meta;
+  }
+
+  // Ensure header parsing produces valid reads
+  constexpr auto VECTOR_HEADER_SIZE =
+    duckdb::AlpConstants::EXPONENT_SIZE + duckdb::AlpConstants::FACTOR_SIZE +
+    duckdb::AlpConstants::EXCEPTIONS_COUNT_SIZE + duckdb::AlpConstants::FOR_SIZE +
+    duckdb::AlpConstants::BIT_WIDTH_SIZE;
+  if (data_off + VECTOR_HEADER_SIZE > metadata_end) return meta;
+  auto const fac              = vector_p[1];
+  auto const exceptions_count = ld_unaligned<uint16_t>(vector_p + 2);
+  auto const for_value        = ld_unaligned<uint64_t>(vector_p + 4);
+  auto const bw               = vector_p[12];
+  if (bw > T_BITS) return meta;
+  if (exp > duckdb::AlpTypedConstants<T>::MAX_EXPONENT || fac > ALP_MAX_FACTOR) return meta;
+
+  auto const packed_bytes = bp_required_bytes(fill_rows, bw);
+  auto const payload_end  = data_off + VECTOR_HEADER_SIZE + packed_bytes +
+                           exceptions_count * (sizeof(T) + sizeof(uint16_t));
+  if (payload_end > metadata_end) return meta;
+
+  meta.status             = alp_parse_status::compressed;
+  meta.exp                = exp;
+  meta.fac                = fac;
+  meta.exc_count          = exceptions_count;
+  meta.for_val            = for_value;
+  meta.bw                 = bw;
+  meta.packed_bytes_p     = vector_p + VECTOR_HEADER_SIZE;
+  meta.packed_bytes_count = packed_bytes;
+  return meta;
+}
+
+/**
+ * @brief Decoding kernel for ALP encoded values. Work partitioning is 1 CTA per 1024-row vector.
+ */
+template <int SMEM_WORDS, typename T>
 __global__ void kernel_decode_alp(alp_vector_desc const* __restrict__ descs,
                                   T* __restrict__ d_output,
                                   uint32_t num_vecs)
 {
-  static_assert(sizeof(T) == 4 || sizeof(T) == 8,
+  static_assert(::cuda::std::is_same_v<T, float> || ::cuda::std::is_same_v<T, double>,
                 "ALP only supports float / double; the dispatcher rejects other widths");
 
-  uint32_t vid = blockIdx.x;
-  if (vid >= num_vecs) return;
+  __shared__ uint32_t shmem[SMEM_WORDS];
+  __shared__ alp_vector_meta sh_meta;
 
-  auto const desc          = descs[vid];
-  uint8_t const* seg_base  = desc.d_segment;
-  uint32_t const seg_bytes = desc.segment_bytes;
-  uint32_t const fill_rows = desc.vec_row_count;
-  T* out                   = d_output + desc.global_row_offset;
-
-  __shared__ bool sh_invalid;
-  __shared__ bool sh_uncompressed;
-  __shared__ uint32_t sh_data_off;
-  __shared__ uint8_t sh_exp;
-  __shared__ uint8_t sh_fac;
-  __shared__ uint16_t sh_exc_count;
-  __shared__ uint64_t sh_for;
-  __shared__ uint8_t sh_bw;
-  __shared__ uint32_t sh_packed_bytes;
+  auto const vector_id = blockIdx.x;
+  if (vector_id >= num_vecs) return;
+  auto const desc      = descs[vector_id];
+  auto const* seg_base = desc.d_segment;
+  auto const seg_bytes = desc.segment_bytes;
+  auto const fill_rows = desc.vec_row_count;
+  auto* out            = d_output + desc.global_row_offset;
 
   if (threadIdx.x == 0) {
-    sh_invalid      = false;
-    sh_uncompressed = false;
-    sh_data_off     = 0;
-    sh_exp          = 0;
-    sh_fac          = 0;
-    sh_exc_count    = 0;
-    sh_for          = 0;
-    sh_bw           = 0;
-    sh_packed_bytes = 0;
-
-    if (seg_bytes < 4u) {
-      sh_invalid = true;
-    } else {
-      uint32_t metadata_end = ld32(seg_base);
-      uint64_t trailer_need = uint64_t{4u} + (uint64_t{desc.vec_idx} + 1u) * 4u;
-      if (metadata_end > seg_bytes || metadata_end < trailer_need) {
-        sh_invalid = true;
-      } else {
-        // Vector pointer must land in (4, metadata_end).
-        uint32_t entry_off = metadata_end - (desc.vec_idx + 1u) * 4u;
-        uint32_t data_off  = ld32(seg_base + entry_off);
-        if (data_off < 4u || data_off >= metadata_end) {
-          sh_invalid = true;
-        } else {
-          sh_data_off = data_off;
-          uint8_t exp = seg_base[data_off];
-          if (exp == ALP_UNCOMPRESSED_SENTINEL) {
-            uint64_t raw_end = uint64_t{data_off} + 1u + uint64_t{fill_rows} * sizeof(T);
-            if (raw_end > metadata_end) {
-              sh_invalid = true;
-            } else {
-              sh_uncompressed = true;
-            }
-          } else if (uint64_t{data_off} + 13u > metadata_end) {
-            sh_invalid = true;
-          } else {
-            uint8_t const* vp  = seg_base + data_off;
-            uint16_t exc_count = ld16(vp + 2);
-            uint64_t for_value = ld64(vp + 4);
-            uint8_t bw         = vp[12];
-
-            if (bw > sizeof(T) * 8u) {
-              sh_invalid = true;
-            } else {
-              uint32_t packed_bytes = bp_required_bytes(fill_rows, bw);
-              uint64_t payload_end =
-                uint64_t{data_off} + 13u + packed_bytes + uint64_t{exc_count} * (sizeof(T) + 2u);
-              if (payload_end > metadata_end) {
-                sh_invalid = true;
-              } else {
-                // ALP encoder couples (factor, exponent): factor is bounded
-                // by FACT_ARR extent (shared across types), exponent is
-                // bounded by AlpTypedConstants<T>::MAX_EXPONENT (10/f32,
-                // 18/f64). Out-of-range corrupt values would crash the
-                // constant-memory load.
-                uint8_t fac          = vp[1];
-                uint8_t max_exponent = duckdb::AlpTypedConstants<T>::MAX_EXPONENT;
-                if (exp > max_exponent || fac > ALP_MAX_FACTOR) {
-                  sh_invalid = true;
-                } else {
-                  sh_exp          = exp;
-                  sh_fac          = fac;
-                  sh_exc_count    = exc_count;
-                  sh_for          = for_value;
-                  sh_bw           = bw;
-                  sh_packed_bytes = packed_bytes;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    sh_meta = parse_alp_metadata<T>(seg_base, seg_bytes, desc.vec_idx, fill_rows);
   }
   __syncthreads();
 
-  if (sh_invalid) {
+  if (sh_meta.status == alp_parse_status::invalid) {
     zero_fill_vector<T>(out, fill_rows);
     return;
   }
 
-  // Uncompressed sentinel — bit-cast via u32/u64 because raw_p is byte-aligned.
-  if (sh_uncompressed) {
-    uint8_t const* raw_p = seg_base + sh_data_off + 1u;
-    if constexpr (sizeof(T) == 4) {
-      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-        uint32_t bits = ld32(raw_p + i * 4u);
-        T v;
-        memcpy(&v, &bits, sizeof(T));
-        __stwt(out + i, v);
-      }
-    } else {
-      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-        uint64_t bits = ld64(raw_p + i * 8u);
-        T v;
-        memcpy(&v, &bits, sizeof(T));
-        __stwt(out + i, v);
-      }
+  //===----------Uncompressed----------===/
+  if (sh_meta.status == alp_parse_status::uncompressed) {
+    // 1B pad before the array of uncompressed values
+    auto const* raw_p = seg_base + sh_meta.data_off + 1;
+    for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+      __stwt(out + i, ld_unaligned<T>(raw_p + i * sizeof(T)));
     }
     return;
   }
 
-  // 2 guard words satisfy the 3-word read in unpack_from_shmem for 64-bit
-  // straddles past the last live word.
-  uint8_t const* vp           = seg_base + sh_data_off;
-  uint8_t const* packed_bytes = vp + 13u;
-
-  extern __shared__ uint32_t shmem[];
-  stage_bytes_to_shmem(shmem, packed_bytes, sh_packed_bytes, /*pad_words=*/2u);
+  //===----------Compressed----------===//
+  stage_bytes_to_shmem(shmem, sh_meta.packed_bytes_p, sh_meta.packed_bytes_count, /*pad_words=*/2);
   __syncthreads();
 
-  // FOR add is unsigned-wraparound; cast to int64 before applying FACT/FRAC.
-  T const fact_t       = static_cast<T>(d_alp_fact[sh_fac]);
-  T const frac_t       = alp_frac_ptr<T>()[sh_exp];
-  uint64_t const for_v = sh_for;
-  uint32_t const bw    = sh_bw;
-
+  auto const fact_t = static_cast<T>(d_alp_fact[sh_meta.fac]);
+  auto const frac_t = alp_frac_ptr<T>()[sh_meta.exp];
+  auto const for_v  = sh_meta.for_val;
+  auto const bw     = sh_meta.bw;
   for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-    uint64_t u  = unpack_from_shmem<uint64_t>(shmem, i, bw);
-    int64_t enc = static_cast<int64_t>(u + for_v);
-    T plain     = static_cast<T>(enc) * fact_t * frac_t;
-    __stwt(out + i, plain);
+    auto const u = unpack_from_shmem<uint64_t>(shmem, i, bw);
+    // FOR add is unsigned-wraparound; cast to int64 before applying FACT/FRAC.
+    auto const enc   = static_cast<int64_t>(u + for_v);
+    auto const decod = static_cast<T>(enc) * fact_t * frac_t;
+    __stwt(out + i, decod);
   }
 
-  // Bound-check `pos` to refuse a corrupt OOB write — positions are
-  // unique by construction at compress time, but the parsed value isn't
-  // trusted.
-  uint16_t const exc_count = sh_exc_count;
-  if (exc_count > 0u) {
-    // Sync only on the exception path: every thread must finish its main-loop
-    // store before any thread overwrites a row with its exception value.
-    // `sh_exc_count` is broadcast-shared, so all threads take the same branch.
+  //===----------Exceptions----------===//
+  auto const exc_count = sh_meta.exc_count;
+  if (exc_count > 0) {
+    // Sync ensures that every thread finishes its main-loop store before any thread overwrites with
+    // an exception value
     __syncthreads();
-    uint8_t const* exc_base   = packed_bytes + sh_packed_bytes;
-    uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * sizeof(T);
+    auto const* exc_base          = sh_meta.packed_bytes_p + sh_meta.packed_bytes_count;
+    auto const* exc_position_base = exc_base + uint32_t{exc_count} * sizeof(T);
     for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
       uint16_t pos;
-      memcpy(&pos, exc_p_base + e * 2u, sizeof(pos));
-      if (pos < fill_rows) {
-        T v;
-        if constexpr (sizeof(T) == 4) {
-          uint32_t bits = ld32(exc_base + e * 4u);
-          memcpy(&v, &bits, sizeof(T));
-        } else {
-          uint64_t bits = ld64(exc_base + e * 8u);
-          memcpy(&v, &bits, sizeof(T));
-        }
-        __stwt(out + pos, v);
-      }
+      memcpy(&pos,
+             exc_position_base + e * duckdb::AlpConstants::EXCEPTION_POSITION_SIZE,
+             sizeof(uint16_t));
+      if (pos < fill_rows) { __stwt(out + pos, ld_unaligned<T>(exc_base + e * sizeof(T))); }
     }
   }
 }
 
-// Dynamic shmem layout (4-byte words): left_packed[] | guards |
-// right_packed[] | guards. Static shmem holds the segment dictionary
-// (≤ 16 bytes) plus per-vector parsed state. EXACT_T is the unsigned
-// bit-mirror of T.
-template <typename T>
-__global__ void kernel_decode_alprd(alp_vector_desc const* __restrict__ descs,
-                                    T* __restrict__ d_output,
-                                    uint32_t num_vecs)
-{
-  static_assert(sizeof(T) == 4 || sizeof(T) == 8,
-                "ALPRD only supports float / double; the dispatcher rejects other widths");
-  using EXACT_T = typename std::conditional<sizeof(T) == 4, uint32_t, uint64_t>::type;
-
-  uint32_t vid = blockIdx.x;
-  if (vid >= num_vecs) return;
-
-  auto const desc          = descs[vid];
-  uint8_t const* seg_base  = desc.d_segment;
-  uint32_t const seg_bytes = desc.segment_bytes;
-  uint32_t const fill_rows = desc.vec_row_count;
-  T* out                   = d_output + desc.global_row_offset;
-
-  __shared__ bool sh_invalid;
-  __shared__ bool sh_uncompressed;
-  __shared__ uint32_t sh_data_off;
-  __shared__ uint16_t sh_exc_count;
-  __shared__ uint8_t sh_right_bw;
-  __shared__ uint8_t sh_left_bw;
-  __shared__ uint8_t sh_dict_size;
-  __shared__ uint16_t sh_dict[ALPRD_MAX_DICT_SIZE];
-  __shared__ uint32_t sh_left_bytes;
-  __shared__ uint32_t sh_right_bytes;
-
-  if (threadIdx.x == 0) {
-    sh_invalid      = false;
-    sh_uncompressed = false;
-    sh_data_off     = 0;
-    sh_exc_count    = 0;
-    sh_right_bw     = 0;
-    sh_left_bw      = 0;
-    sh_dict_size    = 0;
-    sh_left_bytes   = 0;
-    sh_right_bytes  = 0;
-
-    if (seg_bytes < ALPRD_HEADER_SIZE) {
-      sh_invalid = true;
-    } else {
-      uint32_t metadata_end = ld32(seg_base);
-      uint64_t trailer_need = uint64_t{ALPRD_HEADER_SIZE} + (uint64_t{desc.vec_idx} + 1u) * 4u;
-      if (metadata_end > seg_bytes || metadata_end < trailer_need) {
-        sh_invalid = true;
-      } else {
-        uint8_t right_bw  = seg_base[4];
-        uint8_t left_bw   = seg_base[5];
-        uint8_t dict_size = seg_base[6];
-        // right_bw + left_bw fits in storage; left_bw ≤ 3 ⇒ dict_size ≤ 8.
-        if (right_bw > sizeof(T) * 8u || left_bw > 3u || dict_size > ALPRD_MAX_DICT_SIZE) {
-          sh_invalid = true;
-        } else {
-          uint64_t header_end = uint64_t{ALPRD_HEADER_SIZE} + uint64_t{dict_size} * 2u;
-          if (header_end > metadata_end) {
-            sh_invalid = true;
-          } else {
-            sh_right_bw  = right_bw;
-            sh_left_bw   = left_bw;
-            sh_dict_size = dict_size;
-
-            uint32_t entry_off = metadata_end - (desc.vec_idx + 1u) * 4u;
-            uint32_t data_off  = ld32(seg_base + entry_off);
-            if (data_off < header_end || data_off >= metadata_end ||
-                uint64_t{data_off} + 2u > metadata_end) {
-              sh_invalid = true;
-            } else {
-              sh_data_off        = data_off;
-              uint16_t exc_count = ld16(seg_base + data_off);
-              if (exc_count == ALPRD_UNCOMPRESSED_SENTINEL) {
-                uint64_t raw_end = uint64_t{data_off} + 2u + uint64_t{fill_rows} * sizeof(T);
-                if (raw_end > metadata_end) {
-                  sh_invalid = true;
-                } else {
-                  sh_uncompressed = true;
-                }
-              } else {
-                sh_exc_count         = exc_count;
-                uint32_t left_bytes  = bp_required_bytes(fill_rows, left_bw);
-                uint32_t right_bytes = bp_required_bytes(fill_rows, right_bw);
-                // payload = 2 + left_bytes + right_bytes + exc_count*(2+2)
-                uint64_t payload_end =
-                  uint64_t{data_off} + 2u + left_bytes + right_bytes + uint64_t{exc_count} * 4u;
-                if (payload_end > metadata_end) {
-                  sh_invalid = true;
-                } else {
-                  sh_left_bytes  = left_bytes;
-                  sh_right_bytes = right_bytes;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Cooperatively zero-init the full 8-entry dict before reading entries
-  // [0, sh_dict_size). With left_bw ≤ 3 (validated above), left_idx ∈ [0,8),
-  // so the inner-loop `sh_dict[left_idx]` read is unconditionally safe — a
-  // corrupt left_idx ≥ sh_dict_size lands on a zero slot, no bounds check
-  // needed in the hot path. Thread 0's parse runs concurrently.
-  if (threadIdx.x < ALPRD_MAX_DICT_SIZE) { sh_dict[threadIdx.x] = 0; }
-  __syncthreads();
-  if (!sh_invalid && threadIdx.x < uint32_t{sh_dict_size}) {
-    uint16_t dv;
-    memcpy(&dv, seg_base + ALPRD_HEADER_SIZE + threadIdx.x * 2u, sizeof(dv));
-    sh_dict[threadIdx.x] = dv;
-  }
-  __syncthreads();
-
-  if (sh_invalid) {
-    zero_fill_vector<T>(out, fill_rows);
-    return;
-  }
-
-  if (sh_uncompressed) {
-    uint8_t const* raw_p = seg_base + sh_data_off + 2u;
-    if constexpr (sizeof(T) == 4) {
-      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-        uint32_t bits = ld32(raw_p + i * 4u);
-        T v;
-        memcpy(&v, &bits, sizeof(T));
-        __stwt(out + i, v);
-      }
-    } else {
-      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-        uint64_t bits = ld64(raw_p + i * 8u);
-        T v;
-        memcpy(&v, &bits, sizeof(T));
-        __stwt(out + i, v);
-      }
-    }
-    return;
-  }
-
-  // Stage left and right packed streams into shmem. Each region carries 2
-  // trailing guard words for the 64-bit straddle case.
-  uint8_t const* left_bp  = seg_base + sh_data_off + 2u;
-  uint8_t const* right_bp = left_bp + sh_left_bytes;
-
-  extern __shared__ uint32_t shmem[];
-  uint32_t left_live    = ::cuda::ceil_div(sh_left_bytes, 4u);
-  uint32_t* left_words  = shmem;
-  uint32_t* right_words = shmem + left_live + 2u;
-
-  stage_bytes_to_shmem(left_words, left_bp, sh_left_bytes, /*pad_words=*/2u);
-  stage_bytes_to_shmem(right_words, right_bp, sh_right_bytes, /*pad_words=*/2u);
-  __syncthreads();
-
-  uint8_t const right_bw = sh_right_bw;
-  uint8_t const left_bw  = sh_left_bw;
-  // right_bw == sizeof(T)*8 ⇒ shifting EXACT_T by that width is UB; gate it.
-  bool const full_right = (right_bw >= sizeof(T) * 8u);
-
-  for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
-    EXACT_T right_val = unpack_from_shmem<EXACT_T>(right_words, i, right_bw);
-    EXACT_T bits;
-    if (full_right) {
-      bits = right_val;
-    } else {
-      uint16_t left_idx = unpack_from_shmem<uint16_t>(left_words, i, left_bw);
-      EXACT_T left_val  = static_cast<EXACT_T>(sh_dict[left_idx]);
-      bits              = (left_val << right_bw) | right_val;
-    }
-    T v;
-    memcpy(&v, &bits, sizeof(T));
-    __stwt(out + i, v);
-  }
-
-  // Exception scatter recovers right-bits via `read_back_after_stwt` —
-  // see helper for the L1-invalidate contract.
-  uint16_t const exc_count = sh_exc_count;
-  if (exc_count > 0u) {
-    // Sync only on the exception path: read_back_after_stwt(out, pos) reads
-    // what other threads wrote in the main loop, so the barrier is required
-    // here. `sh_exc_count` is broadcast-shared — uniform branch is safe.
-    __syncthreads();
-    uint8_t const* exc_base   = right_bp + sh_right_bytes;
-    uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * 2u;
-
-    EXACT_T const r_mask = full_right ? ~EXACT_T{0} : ((EXACT_T{1} << right_bw) - EXACT_T{1});
-
-    for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
-      uint16_t pos;
-      memcpy(&pos, exc_p_base + e * 2u, sizeof(pos));
-      if (pos >= fill_rows) continue;
-
-      uint16_t exc_left;
-      memcpy(&exc_left, exc_base + e * 2u, sizeof(exc_left));
-
-      T existing = read_back_after_stwt(out, pos);
-      EXACT_T existing_bits;
-      memcpy(&existing_bits, &existing, sizeof(EXACT_T));
-      EXACT_T right_part = existing_bits & r_mask;
-      EXACT_T bits =
-        full_right ? right_part : ((static_cast<EXACT_T>(exc_left) << right_bw) | right_part);
-      T v;
-      memcpy(&v, &bits, sizeof(T));
-      __stwt(out + pos, v);
-    }
-  }
-}
-
-std::vector<alp_vector_desc> build_vector_descs(gpu_codec_run const& run)
-{
-  std::vector<alp_vector_desc> descs;
-  // Small over-reservation; tight worst case is ceil(row_count / 1024) per segment.
-  descs.reserve(run.segments.size() * 2);
-  for (auto const& seg : run.segments) {
-    if (seg.row_count == 0) continue;
-    uint32_t num_vecs = ::cuda::ceil_div(seg.row_count, ALP_VECTOR_SIZE);
-    for (uint32_t v = 0; v < num_vecs; ++v) {
-      uint32_t vec_rows =
-        (v + 1u < num_vecs) ? ALP_VECTOR_SIZE : seg.row_count - v * ALP_VECTOR_SIZE;
-      descs.push_back(
-        {seg.d_bytes, seg.bytes_size, v, vec_rows, seg.row_offset + v * ALP_VECTOR_SIZE});
-    }
-  }
-  return descs;
-}
-
+/**
+ * @brief HOST-side ALP decoding kernel dispatcher.
+ */
 template <typename T>
 void launch_alp_typed(alp_vector_desc const* h_descs,
                       size_t num_vecs,
@@ -695,6 +501,10 @@ void launch_alp_typed(alp_vector_desc const* h_descs,
                       rmm::cuda_stream_view stream,
                       rmm::device_async_resource_ref mr)
 {
+  constexpr uint32_t MAX_PACKED_BYTES = duckdb::AlpConstants::ALP_VECTOR_SIZE * sizeof(T);
+  // Two guard words past the live data for the 64-bit straddle case.
+  constexpr uint32_t MAX_PACKED_WORDS = ::cuda::ceil_div(MAX_PACKED_BYTES, sizeof(uint32_t)) + 2;
+
   if (num_vecs == 0) return;
 
   rmm::device_uvector<alp_vector_desc> d_descs(num_vecs, stream, mr);
@@ -704,22 +514,225 @@ void launch_alp_typed(alp_vector_desc const* h_descs,
                                cudaMemcpyHostToDevice,
                                stream.value()));
 
-  // Live shmem footprint per CTA: bitpacked stream, max width sizeof(T)*8,
-  // ALP_VECTOR_SIZE values. Two guard words past the live data for the
-  // 64-bit straddle case.
-  constexpr uint32_t max_width        = sizeof(T) * 8u;
-  constexpr uint32_t max_packed_bytes = ::cuda::ceil_div(ALP_VECTOR_SIZE * max_width, 8u);
-  constexpr uint32_t max_packed_words = ::cuda::ceil_div(max_packed_bytes, 4u) + 2u;
-  constexpr size_t shmem_bytes        = max_packed_words * sizeof(uint32_t);
-  static_assert(shmem_bytes <= 48u * 1024u,
-                "kernel_decode_alp dynamic shmem exceeds 48 KiB; either reduce "
-                "ALP_VECTOR_SIZE or call cudaFuncSetAttribute(MaxDynamicSharedMemorySize) "
-                "before launch");
-
-  kernel_decode_alp<T><<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, shmem_bytes, stream.value()>>>(
-    d_descs.data(), d_output, static_cast<uint32_t>(num_vecs));
+  kernel_decode_alp<MAX_PACKED_WORDS, T>
+    <<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, 0, stream.value()>>>(
+      d_descs.data(), d_output, static_cast<uint32_t>(num_vecs));
 }
 
+//===----------------------------------------------------------------------===//
+// ALPRD
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Parse the ALPRD segment header + per-vector header.
+ */
+template <typename T>
+__device__ alprd_vector_meta parse_alprd_metadata(uint8_t const* seg_base,
+                                                  uint32_t seg_bytes,
+                                                  uint32_t vec_idx,
+                                                  uint32_t fill_rows)
+{
+  constexpr uint32_t T_BITS = sizeof(T) * CHAR_BIT;
+
+  alprd_vector_meta meta{};
+  meta.status = alprd_parse_status::invalid;
+
+  if (seg_bytes < duckdb::AlpRDConstants::HEADER_SIZE) return meta;
+
+  // Parse the segment header
+  auto const metadata_end = ld_unaligned<uint32_t>(seg_base);
+  // We must have: metadata_end - (vec_idx + 1) * METADATA_POINTER_SIZE >= HEADER_SIZE, so
+  // that the desired metadata entry fits within the segment.
+  auto const trailer_need = duckdb::AlpRDConstants::HEADER_SIZE +
+                            (vec_idx + 1) * duckdb::AlpRDConstants::METADATA_POINTER_SIZE;
+  if (metadata_end > seg_bytes || metadata_end < trailer_need) return meta;
+
+  // Segment-level widths sit immediately after the metadata_end pointer.
+  auto const right_bw  = seg_base[duckdb::AlpRDConstants::METADATA_POINTER_SIZE];
+  auto const left_bw   = seg_base[duckdb::AlpRDConstants::METADATA_POINTER_SIZE +
+                                duckdb::AlpRDConstants::RIGHT_BIT_WIDTH_SIZE];
+  auto const dict_size = seg_base[duckdb::AlpRDConstants::METADATA_POINTER_SIZE +
+                                  duckdb::AlpRDConstants::RIGHT_BIT_WIDTH_SIZE +
+                                  duckdb::AlpRDConstants::LEFT_BIT_WIDTH_SIZE];
+  if (right_bw > T_BITS || left_bw > duckdb::AlpRDConstants::MAX_DICTIONARY_BIT_WIDTH ||
+      dict_size > duckdb::AlpRDConstants::MAX_DICTIONARY_SIZE) {
+    return meta;
+  }
+
+  auto const dict_end = duckdb::AlpRDConstants::HEADER_SIZE +
+                        dict_size * duckdb::AlpRDConstants::DICTIONARY_ELEMENT_SIZE;
+  if (dict_end > metadata_end) return meta;
+
+  meta.right_bw  = right_bw;
+  meta.left_bw   = left_bw;
+  meta.dict_size = dict_size;
+
+  // Locate this vector's per-vector data via the trailer pointer table.
+  auto const metadata_entry_offset =
+    metadata_end - (vec_idx + 1) * duckdb::AlpRDConstants::METADATA_POINTER_SIZE;
+  auto const data_off = ld_unaligned<uint32_t>(seg_base + metadata_entry_offset);
+  if (data_off < dict_end ||
+      data_off + duckdb::AlpRDConstants::EXCEPTIONS_COUNT_SIZE > metadata_end) {
+    return meta;
+  }
+  meta.data_off = data_off;
+
+  // Per-vector header is the 2-byte exception count.
+  auto const* vector_p        = seg_base + data_off;
+  auto const exceptions_count = ld_unaligned<uint16_t>(vector_p);
+  if (exceptions_count == ALPRD_UNCOMPRESSED_SENTINEL) {
+    // 2-B sentinel before raw values
+    auto const raw_end =
+      data_off + duckdb::AlpRDConstants::EXCEPTIONS_COUNT_SIZE + fill_rows * sizeof(T);
+    if (raw_end > metadata_end) return meta;
+    meta.status = alprd_parse_status::uncompressed;
+    return meta;
+  }
+
+  auto const left_packed_bytes  = bp_required_bytes(fill_rows, left_bw);
+  auto const right_packed_bytes = bp_required_bytes(fill_rows, right_bw);
+  auto const payload_end        = data_off + duckdb::AlpRDConstants::EXCEPTIONS_COUNT_SIZE +
+                           left_packed_bytes + right_packed_bytes +
+                           exceptions_count * (duckdb::AlpRDConstants::EXCEPTION_SIZE +
+                                               duckdb::AlpRDConstants::EXCEPTION_POSITION_SIZE);
+  if (payload_end > metadata_end) return meta;
+
+  meta.status                   = alprd_parse_status::compressed;
+  meta.exc_count                = exceptions_count;
+  meta.left_packed_bytes_p      = vector_p + duckdb::AlpRDConstants::EXCEPTIONS_COUNT_SIZE;
+  meta.left_packed_bytes_count  = left_packed_bytes;
+  meta.right_packed_bytes_p     = meta.left_packed_bytes_p + left_packed_bytes;
+  meta.right_packed_bytes_count = right_packed_bytes;
+  return meta;
+}
+
+/**
+ * @brief Decoding kernel for ALPRD encoded values. Work partitioning is 1 CTA per 1024-row vector.
+ */
+template <int SMEM_WORDS, typename T>
+__global__ void kernel_decode_alprd(alp_vector_desc const* __restrict__ descs,
+                                    T* __restrict__ d_output,
+                                    uint32_t num_vecs)
+{
+  static_assert(::cuda::std::is_same_v<T, float> || ::cuda::std::is_same_v<T, double>,
+                "ALPRD only supports float / double; the dispatcher rejects other widths");
+  using raw_t = ::cuda::std::conditional_t<::cuda::std::is_same_v<T, float>, uint32_t, uint64_t>;
+  constexpr uint32_t T_BITS = sizeof(T) * CHAR_BIT;
+
+  __shared__ uint32_t shmem[SMEM_WORDS];
+  __shared__ alprd_vector_meta sh_meta;
+  __shared__ uint16_t sh_dict[duckdb::AlpRDConstants::MAX_DICTIONARY_SIZE];
+
+  auto const vector_id = blockIdx.x;
+  if (vector_id >= num_vecs) return;
+  auto const desc      = descs[vector_id];
+  auto const* seg_base = desc.d_segment;
+  auto const seg_bytes = desc.segment_bytes;
+  auto const fill_rows = desc.vec_row_count;
+  auto* out            = d_output + desc.global_row_offset;
+
+  if (threadIdx.x == 0) {
+    sh_meta = parse_alprd_metadata<T>(seg_base, seg_bytes, desc.vec_idx, fill_rows);
+  }
+
+  // Cooperatively zero-init the dict so a corrupt left_idx ≥ dict_size lands
+  // on a zero slot — no bounds check needed in the hot path.
+  if (threadIdx.x < duckdb::AlpRDConstants::MAX_DICTIONARY_SIZE) { sh_dict[threadIdx.x] = 0; }
+  __syncthreads();
+  if (sh_meta.status != alprd_parse_status::invalid && threadIdx.x < sh_meta.dict_size) {
+    auto const* dict_p   = seg_base + duckdb::AlpRDConstants::HEADER_SIZE;
+    sh_dict[threadIdx.x] = ld_unaligned<uint16_t>(
+      dict_p + threadIdx.x * duckdb::AlpRDConstants::DICTIONARY_ELEMENT_SIZE);
+  }
+  __syncthreads();
+
+  if (sh_meta.status == alprd_parse_status::invalid) {
+    zero_fill_vector<T>(out, fill_rows);
+    return;
+  }
+
+  //===----------Uncompressed----------===/
+  if (sh_meta.status == alprd_parse_status::uncompressed) {
+    // 2B sentinel before the array of uncompressed values
+    auto const* raw_p = seg_base + sh_meta.data_off + 2;
+    for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+      __stwt(out + i, ld_unaligned<T>(raw_p + i * sizeof(T)));
+    }
+    return;
+  }
+
+  //===----------Compressed----------===//
+  // Stage left and right packed streams into shmem with 2 guard words after each region.
+  auto const left_live = ::cuda::ceil_div(sh_meta.left_packed_bytes_count, sizeof(uint32_t));
+  auto* left_words     = shmem;
+  auto* right_words    = shmem + left_live + 2;
+  stage_bytes_to_shmem(left_words,
+                       sh_meta.left_packed_bytes_p,
+                       sh_meta.left_packed_bytes_count,
+                       /*pad_words=*/2);
+  stage_bytes_to_shmem(right_words,
+                       sh_meta.right_packed_bytes_p,
+                       sh_meta.right_packed_bytes_count,
+                       /*pad_words=*/2);
+  __syncthreads();
+
+  auto const right_bw = sh_meta.right_bw;
+  auto const left_bw  = sh_meta.left_bw;
+  // right_bw == sizeof(T)*8 ⇒ shifting raw_t by that width is UB; gate it.
+  auto const full_right = right_bw >= T_BITS;
+
+  for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+    auto const right_val = unpack_from_shmem<raw_t>(right_words, i, right_bw);
+    raw_t bits;
+    if (full_right) {
+      bits = right_val;
+    } else {
+      auto const left_idx = unpack_from_shmem<uint16_t>(left_words, i, left_bw);
+      auto const left_val = static_cast<raw_t>(sh_dict[left_idx]);
+      bits                = (left_val << right_bw) | right_val;
+    }
+    T v;
+    memcpy(&v, &bits, sizeof(T));
+    __stwt(out + i, v);
+  }
+
+  //===----------Exceptions----------===//
+  // Recover each row's `right` bits from `out` rather than re-unpacking the
+  // right bitstream.
+  auto const exc_count = sh_meta.exc_count;
+  if (exc_count > 0) {
+    // Sync to ensure the writes to out have completed
+    __syncthreads();
+    auto const* exc_base = sh_meta.right_packed_bytes_p + sh_meta.right_packed_bytes_count;
+    auto const* exc_position_base =
+      exc_base + uint32_t{exc_count} * duckdb::AlpRDConstants::EXCEPTION_SIZE;
+    auto const r_mask =
+      full_right ? ::cuda::std::numeric_limits<raw_t>::max() : ((raw_t{1} << right_bw) - raw_t{1});
+
+    for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
+      uint16_t pos;
+      memcpy(&pos,
+             exc_position_base + e * duckdb::AlpRDConstants::EXCEPTION_POSITION_SIZE,
+             sizeof(uint16_t));
+      if (pos >= fill_rows) continue;
+
+      auto const exc_left =
+        ld_unaligned<uint16_t>(exc_base + e * duckdb::AlpRDConstants::EXCEPTION_SIZE);
+      auto const existing = out[pos];  // Has correct right bits
+      raw_t existing_bits;
+      memcpy(&existing_bits, &existing, sizeof(raw_t));
+      auto const right_part = existing_bits & r_mask;
+      auto const bits =
+        full_right ? right_part : ((static_cast<raw_t>(exc_left) << right_bw) | right_part);
+      T v;
+      memcpy(&v, &bits, sizeof(T));
+      __stwt(out + pos, v);
+    }
+  }
+}
+
+/**
+ * @brief HOST-side ALPRD decoding kernel dispatcher.
+ */
 template <typename T>
 void launch_alprd_typed(alp_vector_desc const* h_descs,
                         size_t num_vecs,
@@ -727,6 +740,16 @@ void launch_alprd_typed(alp_vector_desc const* h_descs,
                         rmm::cuda_stream_view stream,
                         rmm::device_async_resource_ref mr)
 {
+  // Live shmem: left stream (left_bw ≤ MAX_DICTIONARY_BIT_WIDTH) + right
+  // stream (right_bw ≤ sizeof(T)*8). Two guard words past each region for
+  // the 64-bit straddle case.
+  constexpr uint32_t MAX_LEFT_BYTES = ::cuda::ceil_div(
+    duckdb::AlpRDConstants::ALP_VECTOR_SIZE * duckdb::AlpRDConstants::MAX_DICTIONARY_BIT_WIDTH, 8);
+  constexpr uint32_t MAX_RIGHT_BYTES = duckdb::AlpRDConstants::ALP_VECTOR_SIZE * sizeof(T);
+  constexpr uint32_t MAX_LEFT_WORDS  = ::cuda::ceil_div(MAX_LEFT_BYTES, sizeof(uint32_t)) + 2;
+  constexpr uint32_t MAX_RIGHT_WORDS = ::cuda::ceil_div(MAX_RIGHT_BYTES, sizeof(uint32_t)) + 2;
+  constexpr uint32_t SHMEM_WORDS     = MAX_LEFT_WORDS + MAX_RIGHT_WORDS;
+
   if (num_vecs == 0) return;
 
   rmm::device_uvector<alp_vector_desc> d_descs(num_vecs, stream, mr);
@@ -736,30 +759,47 @@ void launch_alprd_typed(alp_vector_desc const* h_descs,
                                cudaMemcpyHostToDevice,
                                stream.value()));
 
-  // Live shmem: left stream (left_bw ≤ 3) + right stream (right_bw ≤
-  // sizeof(T)*8). Guard pair after each region.
-  constexpr uint32_t max_left_bytes  = ::cuda::ceil_div(ALP_VECTOR_SIZE * 3u, 8u);
-  constexpr uint32_t max_right_bytes = ::cuda::ceil_div(ALP_VECTOR_SIZE * sizeof(T) * 8u, 8u);
-  constexpr uint32_t max_left_words  = ::cuda::ceil_div(max_left_bytes, 4u) + 2u;
-  constexpr uint32_t max_right_words = ::cuda::ceil_div(max_right_bytes, 4u) + 2u;
-  constexpr size_t shmem_bytes       = (max_left_words + max_right_words) * sizeof(uint32_t);
-  static_assert(shmem_bytes <= 48u * 1024u, "kernel_decode_alprd dynamic shmem exceeds 48 KiB");
-
-  kernel_decode_alprd<T>
-    <<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, shmem_bytes, stream.value()>>>(
+  kernel_decode_alprd<SHMEM_WORDS, T>
+    <<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, 0, stream.value()>>>(
       d_descs.data(), d_output, static_cast<uint32_t>(num_vecs));
 }
 
-void throw_unsupported_type(uint32_t type_size, char const* codec)
+//===----------------------------------------------------------------------===//
+// CTA-level descriptors
+//===----------------------------------------------------------------------===//
+std::vector<alp_vector_desc> build_vector_descs(gpu_codec_run const& run)
 {
-  throw std::runtime_error(std::string("gpu_decode_table: viability invariant violated — ") +
-                           codec + " type_size " + std::to_string(type_size));
+  std::vector<alp_vector_desc> descs;
+  // Calculate the number of required descriptors
+  size_t total_vecs = 0;
+  for (auto const& seg : run.segments) {
+    total_vecs += ::cuda::ceil_div(seg.row_count, ALP_VECTOR_SIZE);
+  }
+  descs.reserve(total_vecs);
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    auto const num_vecs = ::cuda::ceil_div(seg.row_count, ALP_VECTOR_SIZE);
+    for (uint32_t v = 0; v < num_vecs; ++v) {
+      auto const vec_rows =
+        (v < num_vecs - 1) ? ALP_VECTOR_SIZE : seg.row_count - v * ALP_VECTOR_SIZE;
+      descs.push_back(
+        {seg.d_bytes, seg.bytes_size, v, vec_rows, seg.row_offset + v * ALP_VECTOR_SIZE});
+    }
+  }
+  return descs;
 }
 
 }  // anonymous namespace
 
-// `type` parameter is signature-uniformity for the dispatcher table;
-// `type_size` alone selects the ALP / ALPRD kernel.
+//===----------------------------------------------------------------------===//
+// Public Entry Points for ALP(RD) Decoding
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Decode a set of ALP-encoded segments.
+ *
+ * @param run A set of segments with the ALP codec
+ * @param d_output
+ */
 void decode_alp_data(gpu_codec_run const& run,
                      uint8_t* d_output,
                      cudf::data_type /*type*/,
@@ -779,7 +819,9 @@ void decode_alp_data(gpu_codec_run const& run,
       launch_alp_typed<double>(
         descs.data(), descs.size(), reinterpret_cast<double*>(d_output), stream, mr);
       break;
-    default: throw_unsupported_type(type_size, "ALP");
+    default:
+      throw std::runtime_error("[gpu_decode_alp]: type_size " + std::to_string(type_size) +
+                               " is invalid for ALP decoding.");
   }
 }
 
@@ -790,7 +832,7 @@ void decode_alprd_data(gpu_codec_run const& run,
                        rmm::cuda_stream_view stream,
                        rmm::device_async_resource_ref mr)
 {
-  auto descs = build_vector_descs(run);
+  auto const descs = build_vector_descs(run);
   if (descs.empty()) return;
 
   switch (type_size) {
@@ -802,7 +844,9 @@ void decode_alprd_data(gpu_codec_run const& run,
       launch_alprd_typed<double>(
         descs.data(), descs.size(), reinterpret_cast<double*>(d_output), stream, mr);
       break;
-    default: throw_unsupported_type(type_size, "ALPRD");
+    default:
+      throw std::runtime_error("[gpu_decode_alprd]: type_size " + std::to_string(type_size) +
+                               " is invalid for ALPRD decoding.");
   }
 }
 

--- a/src/cuda/scan/gpu_decode_alp.cu
+++ b/src/cuda/scan/gpu_decode_alp.cu
@@ -1,0 +1,803 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ALP / ALPRD decode kernels. One CTA = one 1024-row vector. On any bounds
+// check failure the kernel zero-fills `desc.vec_row_count` rows using the
+// trusted host descriptor row count, never parsed metadata.
+//
+// On-disk layouts (verified against
+// duckdb/src/include/duckdb/storage/compression/{alp,alprd}/):
+//
+//   ALP segment (one segment holds N 1024-row "vectors"):
+//
+//   byte 0   4                                 metadata_end          seg_end
+//   │        │                                 │                     │
+//   ├─uint32─┼─── per-vector data (forward) ───┼── trailer table ────┤
+//   │ end    │                                 │  uint32[N], V at    │
+//   │        │                                 │  metadata_end-(V+1)*4
+//   └─offset of metadata_end
+//
+//   ALP per-vector (compressed) — 13-byte header + bitstream + exceptions:
+//
+//   ┌───┬───┬─────┬────────────────┬──┬────────────────┬───────┬─────────┐
+//   │exp│fac│ ec  │ FOR (uint64)   │bw│ packed uint64  │ exc   │ exc pos │
+//   │ u8│ u8│ u16 │                │u8│ mantissas      │ T[ec] │ u16[ec] │
+//   └───┴───┴─────┴────────────────┴──┴────────────────┴───────┴─────────┘
+//   0   1   2     4               12  13              ↑       ↑
+//                                                     │       │
+//                                bitstream = round_up(rows,32)*bw/8 bytes
+//
+//   exp == 0xFF → uncompressed-sentinel: 1-byte 0xFF then raw T[rows].
+//   bw ≤ sizeof(T)*8. Exception position bound-checked against fill_rows.
+//
+//   ALPRD segment (small dict header lives between metadata_end and trailer):
+//
+//   byte 0   4   5   6   7                                 metadata_end ↘
+//   │        │   │   │   │                                 │             │
+//   ├─uint32─┼─u8┼─u8┼─u8┼── uint16 dict[dict_size] ───────┼── per-vec ──┤
+//   │ end    │ rb│ lb│ds │ (≤ 8 entries, lb ≤ 3)           │  data       │
+//   └─offset
+//
+//   ALPRD per-vector (compressed) — 2-byte header + two bitstreams + exceptions:
+//
+//   ┌─────┬───────────────────┬─────────────────────┬───────┬─────────┐
+//   │ ec  │ left dict-idx     │ right parts         │ exc   │ exc pos │
+//   │ u16 │ (lb-bit packed)   │ (rb-bit packed,     │ left  │ u16[ec] │
+//   │     │                   │  EXACT_T = u32/u64) │ u16[] │         │
+//   └─────┴───────────────────┴─────────────────────┴───────┴─────────┘
+//   0     2
+//
+//   ec == 0xFFFF → uncompressed-sentinel: 2-byte 0xFFFF then raw EXACT_T[rows].
+//   Reconstructed bits = (uint64_t)dict[left_idx] << rb | right_part, then
+//   bit-cast to T (double / float).
+
+#include "cuda/scan/gpu_decode_alp.cuh"
+
+#include <rmm/detail/error.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <cuda/cmath>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace sirius::cuda::scan {
+
+namespace {
+
+constexpr uint32_t BLOCK_DIM = 256;
+
+// Max factor index — the encoder couples (factor, exponent), so this bound
+// is shared across f32 and f64. `MAX_EXPONENT` lives on AlpTypedConstants<T>
+// because exponent IS type-specific.
+constexpr uint8_t ALP_MAX_FACTOR =
+  static_cast<uint8_t>(std::extent_v<decltype(duckdb::AlpConstants::FACT_ARR)> - 1);
+
+/// One CTA's unit of work for ALP / ALPRD: one vector within one segment.
+struct alp_vector_desc {
+  uint8_t const* d_segment;    ///< Device pointer to the segment's first byte.
+  uint32_t segment_bytes;      ///< Size of the staged segment buffer.
+  uint32_t vec_idx;            ///< Vector index within the segment.
+  uint32_t vec_row_count;      ///< Rows in this vector (last may be < 1024).
+  uint32_t global_row_offset;  ///< Output offset, in rows, for this vector.
+};
+
+// Mirrors of `AlpConstants::FACT_ARR` and `AlpTypedConstants<T>::FRAC_ARR`.
+__device__ __constant__ int64_t d_alp_fact[19] = {1LL,
+                                                  10LL,
+                                                  100LL,
+                                                  1000LL,
+                                                  10000LL,
+                                                  100000LL,
+                                                  1000000LL,
+                                                  10000000LL,
+                                                  100000000LL,
+                                                  1000000000LL,
+                                                  10000000000LL,
+                                                  100000000000LL,
+                                                  1000000000000LL,
+                                                  10000000000000LL,
+                                                  100000000000000LL,
+                                                  1000000000000000LL,
+                                                  10000000000000000LL,
+                                                  100000000000000000LL,
+                                                  1000000000000000000LL};
+
+__device__ __constant__ float d_alp_frac_f32[11] = {1.0F,
+                                                    0.1F,
+                                                    0.01F,
+                                                    0.001F,
+                                                    0.0001F,
+                                                    0.00001F,
+                                                    0.000001F,
+                                                    0.0000001F,
+                                                    0.00000001F,
+                                                    0.000000001F,
+                                                    0.0000000001F};
+
+__device__ __constant__ double d_alp_frac_f64[21] = {1.0,
+                                                     0.1,
+                                                     0.01,
+                                                     0.001,
+                                                     0.0001,
+                                                     0.00001,
+                                                     0.000001,
+                                                     0.0000001,
+                                                     0.00000001,
+                                                     0.000000001,
+                                                     0.0000000001,
+                                                     0.00000000001,
+                                                     0.000000000001,
+                                                     0.0000000000001,
+                                                     0.00000000000001,
+                                                     0.000000000000001,
+                                                     0.0000000000000001,
+                                                     0.00000000000000001,
+                                                     0.000000000000000001,
+                                                     0.0000000000000000001,
+                                                     0.00000000000000000001};
+
+template <typename T>
+__device__ __forceinline__ T const* alp_frac_ptr();
+template <>
+__device__ __forceinline__ float const* alp_frac_ptr<float>()
+{
+  return d_alp_frac_f32;
+}
+template <>
+__device__ __forceinline__ double const* alp_frac_ptr<double>()
+{
+  return d_alp_frac_f64;
+}
+
+// Per-vector data starts at arbitrary byte offsets — metadata reads cannot
+// assume 2/4/8-byte alignment, so go through `memcpy`.
+__device__ __forceinline__ uint16_t ld16(uint8_t const* p)
+{
+  uint16_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+__device__ __forceinline__ uint32_t ld32(uint8_t const* p)
+{
+  uint32_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+__device__ __forceinline__ uint64_t ld64(uint8_t const* p)
+{
+  uint64_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+// Mirror of `BitpackingPrimitives::GetRequiredSize`.
+__device__ __host__ __forceinline__ uint32_t bp_required_bytes(uint32_t count, uint32_t width)
+{
+  if (width == 0u) return 0u;
+  uint32_t const rounded = ::cuda::ceil_div(count, 32u) * 32u;
+  return rounded * width / 8u;
+}
+
+// Caller must supply 2 trailing guard words past the live data (the
+// 64-bit straddle case reads up to 3 consecutive 32-bit words).
+template <typename ResT>
+__device__ __forceinline__ ResT unpack_from_shmem(uint32_t const* packed,
+                                                  uint32_t idx,
+                                                  uint32_t width)
+{
+  if (width == 0u) return ResT(0);
+
+  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
+  uint32_t word_idx = static_cast<uint32_t>(bit_pos >> 5);
+  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31u);
+
+  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
+  if (bit_off + width > 32u) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
+  uint64_t result = combined >> bit_off;
+
+  if constexpr (sizeof(ResT) > 4) {
+    if (bit_off > 0 && bit_off + width > 64u) {
+      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64u - bit_off);
+    }
+  }
+
+  uint64_t mask = (width >= 64u) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1u);
+  return static_cast<ResT>(result & mask);
+}
+
+// `src` is any byte alignment; `byte_count` need not be a multiple of 4.
+// We can't use `cg::memcpy_async` with `cuda::aligned_size_t<N>` here:
+// `src = vp + 13` where `vp = seg_base + data_off` and `data_off` varies
+// per vector at runtime, so neither 4- nor 16-byte alignment is provable.
+// Each thread doing `memcpy(&v, src + off, 4)` lowers to `ld.u32` (with
+// the unaligned-access handler on sm_75) — same primitive cg::memcpy_async
+// would use on an aligned middle, without the prefix/middle/tail split.
+__device__ __forceinline__ void stage_bytes_to_shmem(uint32_t* dst_words,
+                                                     uint8_t const* src,
+                                                     uint32_t byte_count,
+                                                     uint32_t pad_words)
+{
+  uint32_t live_words = ::cuda::ceil_div(byte_count, 4u);
+  for (uint32_t w = threadIdx.x; w < live_words; w += blockDim.x) {
+    uint32_t off = w * 4u;
+    uint32_t v   = 0u;
+    if (off + 4u <= byte_count) {
+      memcpy(&v, src + off, 4);
+    } else {
+      // Tail: at most 3 leftover bytes. Zero-pad the high bytes.
+      uint32_t left = byte_count - off;
+      memcpy(&v, src + off, left);
+    }
+    dst_words[w] = v;
+  }
+  for (uint32_t w = live_words + threadIdx.x; w < live_words + pad_words; w += blockDim.x) {
+    dst_words[w] = 0u;
+  }
+}
+
+// Read a value the kernel previously wrote with `__stwt`. Correct only after
+// a __syncthreads barrier separating the write from this read: `__stwt`
+// invalidates the issuing SM's L1 line, so the post-sync ordinary load
+// refills from L2 with the freshly written value. Any change to the main
+// loop's store hint (e.g., switching to `__stcg` or vectorized stores) must
+// revisit this helper. Used by ALPRD's exception scatter to recover
+// right-bits without a second pre-pass over `out`.
+template <typename T>
+__device__ __forceinline__ T read_back_after_stwt(T const* out, uint32_t pos)
+{
+  return out[pos];
+}
+
+template <typename T>
+__device__ __forceinline__ void zero_fill_vector(T* out, uint32_t row_count)
+{
+  for (uint32_t i = threadIdx.x; i < row_count; i += blockDim.x) {
+    __stwt(out + i, T(0));
+  }
+}
+
+// Dynamic shmem: uint32 packed_words[] — bitpacked mantissa stream plus
+// 2 guard words for `unpack_from_shmem`.
+template <typename T>
+__global__ void kernel_decode_alp(alp_vector_desc const* __restrict__ descs,
+                                  T* __restrict__ d_output,
+                                  uint32_t num_vecs)
+{
+  static_assert(sizeof(T) == 4 || sizeof(T) == 8,
+                "ALP only supports float / double; the dispatcher rejects other widths");
+
+  uint32_t vid = blockIdx.x;
+  if (vid >= num_vecs) return;
+
+  auto const desc          = descs[vid];
+  uint8_t const* seg_base  = desc.d_segment;
+  uint32_t const seg_bytes = desc.segment_bytes;
+  uint32_t const fill_rows = desc.vec_row_count;
+  T* out                   = d_output + desc.global_row_offset;
+
+  __shared__ bool sh_invalid;
+  __shared__ bool sh_uncompressed;
+  __shared__ uint32_t sh_data_off;
+  __shared__ uint8_t sh_exp;
+  __shared__ uint8_t sh_fac;
+  __shared__ uint16_t sh_exc_count;
+  __shared__ uint64_t sh_for;
+  __shared__ uint8_t sh_bw;
+  __shared__ uint32_t sh_packed_bytes;
+
+  if (threadIdx.x == 0) {
+    sh_invalid      = false;
+    sh_uncompressed = false;
+    sh_data_off     = 0;
+    sh_exp          = 0;
+    sh_fac          = 0;
+    sh_exc_count    = 0;
+    sh_for          = 0;
+    sh_bw           = 0;
+    sh_packed_bytes = 0;
+
+    if (seg_bytes < 4u) {
+      sh_invalid = true;
+    } else {
+      uint32_t metadata_end = ld32(seg_base);
+      uint64_t trailer_need = uint64_t{4u} + (uint64_t{desc.vec_idx} + 1u) * 4u;
+      if (metadata_end > seg_bytes || metadata_end < trailer_need) {
+        sh_invalid = true;
+      } else {
+        // Vector pointer must land in (4, metadata_end).
+        uint32_t entry_off = metadata_end - (desc.vec_idx + 1u) * 4u;
+        uint32_t data_off  = ld32(seg_base + entry_off);
+        if (data_off < 4u || data_off >= metadata_end) {
+          sh_invalid = true;
+        } else {
+          sh_data_off = data_off;
+          uint8_t exp = seg_base[data_off];
+          if (exp == ALP_UNCOMPRESSED_SENTINEL) {
+            uint64_t raw_end = uint64_t{data_off} + 1u + uint64_t{fill_rows} * sizeof(T);
+            if (raw_end > metadata_end) {
+              sh_invalid = true;
+            } else {
+              sh_uncompressed = true;
+            }
+          } else if (uint64_t{data_off} + 13u > metadata_end) {
+            sh_invalid = true;
+          } else {
+            uint8_t const* vp  = seg_base + data_off;
+            uint16_t exc_count = ld16(vp + 2);
+            uint64_t for_value = ld64(vp + 4);
+            uint8_t bw         = vp[12];
+
+            if (bw > sizeof(T) * 8u) {
+              sh_invalid = true;
+            } else {
+              uint32_t packed_bytes = bp_required_bytes(fill_rows, bw);
+              uint64_t payload_end =
+                uint64_t{data_off} + 13u + packed_bytes + uint64_t{exc_count} * (sizeof(T) + 2u);
+              if (payload_end > metadata_end) {
+                sh_invalid = true;
+              } else {
+                // ALP encoder couples (factor, exponent): factor is bounded
+                // by FACT_ARR extent (shared across types), exponent is
+                // bounded by AlpTypedConstants<T>::MAX_EXPONENT (10/f32,
+                // 18/f64). Out-of-range corrupt values would crash the
+                // constant-memory load.
+                uint8_t fac          = vp[1];
+                uint8_t max_exponent = duckdb::AlpTypedConstants<T>::MAX_EXPONENT;
+                if (exp > max_exponent || fac > ALP_MAX_FACTOR) {
+                  sh_invalid = true;
+                } else {
+                  sh_exp          = exp;
+                  sh_fac          = fac;
+                  sh_exc_count    = exc_count;
+                  sh_for          = for_value;
+                  sh_bw           = bw;
+                  sh_packed_bytes = packed_bytes;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  if (sh_invalid) {
+    zero_fill_vector<T>(out, fill_rows);
+    return;
+  }
+
+  // Uncompressed sentinel — bit-cast via u32/u64 because raw_p is byte-aligned.
+  if (sh_uncompressed) {
+    uint8_t const* raw_p = seg_base + sh_data_off + 1u;
+    if constexpr (sizeof(T) == 4) {
+      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+        uint32_t bits = ld32(raw_p + i * 4u);
+        T v;
+        memcpy(&v, &bits, sizeof(T));
+        __stwt(out + i, v);
+      }
+    } else {
+      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+        uint64_t bits = ld64(raw_p + i * 8u);
+        T v;
+        memcpy(&v, &bits, sizeof(T));
+        __stwt(out + i, v);
+      }
+    }
+    return;
+  }
+
+  // 2 guard words satisfy the 3-word read in unpack_from_shmem for 64-bit
+  // straddles past the last live word.
+  uint8_t const* vp           = seg_base + sh_data_off;
+  uint8_t const* packed_bytes = vp + 13u;
+
+  extern __shared__ uint32_t shmem[];
+  stage_bytes_to_shmem(shmem, packed_bytes, sh_packed_bytes, /*pad_words=*/2u);
+  __syncthreads();
+
+  // FOR add is unsigned-wraparound; cast to int64 before applying FACT/FRAC.
+  T const fact_t       = static_cast<T>(d_alp_fact[sh_fac]);
+  T const frac_t       = alp_frac_ptr<T>()[sh_exp];
+  uint64_t const for_v = sh_for;
+  uint32_t const bw    = sh_bw;
+
+  for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+    uint64_t u  = unpack_from_shmem<uint64_t>(shmem, i, bw);
+    int64_t enc = static_cast<int64_t>(u + for_v);
+    T plain     = static_cast<T>(enc) * fact_t * frac_t;
+    __stwt(out + i, plain);
+  }
+  __syncthreads();
+
+  // Bound-check `pos` to refuse a corrupt OOB write — positions are
+  // unique by construction at compress time, but the parsed value isn't
+  // trusted.
+  uint16_t const exc_count = sh_exc_count;
+  if (exc_count > 0u) {
+    uint8_t const* exc_base   = packed_bytes + sh_packed_bytes;
+    uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * sizeof(T);
+    for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
+      uint16_t pos;
+      memcpy(&pos, exc_p_base + e * 2u, sizeof(pos));
+      if (pos < fill_rows) {
+        T v;
+        if constexpr (sizeof(T) == 4) {
+          uint32_t bits = ld32(exc_base + e * 4u);
+          memcpy(&v, &bits, sizeof(T));
+        } else {
+          uint64_t bits = ld64(exc_base + e * 8u);
+          memcpy(&v, &bits, sizeof(T));
+        }
+        __stwt(out + pos, v);
+      }
+    }
+  }
+}
+
+// Dynamic shmem layout (4-byte words): left_packed[] | guards |
+// right_packed[] | guards. Static shmem holds the segment dictionary
+// (≤ 16 bytes) plus per-vector parsed state. EXACT_T is the unsigned
+// bit-mirror of T.
+template <typename T>
+__global__ void kernel_decode_alprd(alp_vector_desc const* __restrict__ descs,
+                                    T* __restrict__ d_output,
+                                    uint32_t num_vecs)
+{
+  static_assert(sizeof(T) == 4 || sizeof(T) == 8,
+                "ALPRD only supports float / double; the dispatcher rejects other widths");
+  using EXACT_T = typename std::conditional<sizeof(T) == 4, uint32_t, uint64_t>::type;
+
+  uint32_t vid = blockIdx.x;
+  if (vid >= num_vecs) return;
+
+  auto const desc          = descs[vid];
+  uint8_t const* seg_base  = desc.d_segment;
+  uint32_t const seg_bytes = desc.segment_bytes;
+  uint32_t const fill_rows = desc.vec_row_count;
+  T* out                   = d_output + desc.global_row_offset;
+
+  __shared__ bool sh_invalid;
+  __shared__ bool sh_uncompressed;
+  __shared__ uint32_t sh_data_off;
+  __shared__ uint16_t sh_exc_count;
+  __shared__ uint8_t sh_right_bw;
+  __shared__ uint8_t sh_left_bw;
+  __shared__ uint8_t sh_dict_size;
+  __shared__ uint16_t sh_dict[ALPRD_MAX_DICT_SIZE];
+  __shared__ uint32_t sh_left_bytes;
+  __shared__ uint32_t sh_right_bytes;
+
+  if (threadIdx.x == 0) {
+    sh_invalid      = false;
+    sh_uncompressed = false;
+    sh_data_off     = 0;
+    sh_exc_count    = 0;
+    sh_right_bw     = 0;
+    sh_left_bw      = 0;
+    sh_dict_size    = 0;
+    sh_left_bytes   = 0;
+    sh_right_bytes  = 0;
+
+    if (seg_bytes < ALPRD_HEADER_SIZE) {
+      sh_invalid = true;
+    } else {
+      uint32_t metadata_end = ld32(seg_base);
+      uint64_t trailer_need = uint64_t{ALPRD_HEADER_SIZE} + (uint64_t{desc.vec_idx} + 1u) * 4u;
+      if (metadata_end > seg_bytes || metadata_end < trailer_need) {
+        sh_invalid = true;
+      } else {
+        uint8_t right_bw  = seg_base[4];
+        uint8_t left_bw   = seg_base[5];
+        uint8_t dict_size = seg_base[6];
+        // right_bw + left_bw fits in storage; left_bw ≤ 3 ⇒ dict_size ≤ 8.
+        if (right_bw > sizeof(T) * 8u || left_bw > 3u || dict_size > ALPRD_MAX_DICT_SIZE) {
+          sh_invalid = true;
+        } else {
+          uint64_t header_end = uint64_t{ALPRD_HEADER_SIZE} + uint64_t{dict_size} * 2u;
+          if (header_end > metadata_end) {
+            sh_invalid = true;
+          } else {
+            sh_right_bw  = right_bw;
+            sh_left_bw   = left_bw;
+            sh_dict_size = dict_size;
+
+            uint32_t entry_off = metadata_end - (desc.vec_idx + 1u) * 4u;
+            uint32_t data_off  = ld32(seg_base + entry_off);
+            if (data_off < header_end || data_off >= metadata_end ||
+                uint64_t{data_off} + 2u > metadata_end) {
+              sh_invalid = true;
+            } else {
+              sh_data_off        = data_off;
+              uint16_t exc_count = ld16(seg_base + data_off);
+              if (exc_count == ALPRD_UNCOMPRESSED_SENTINEL) {
+                uint64_t raw_end = uint64_t{data_off} + 2u + uint64_t{fill_rows} * sizeof(T);
+                if (raw_end > metadata_end) {
+                  sh_invalid = true;
+                } else {
+                  sh_uncompressed = true;
+                }
+              } else {
+                sh_exc_count         = exc_count;
+                uint32_t left_bytes  = bp_required_bytes(fill_rows, left_bw);
+                uint32_t right_bytes = bp_required_bytes(fill_rows, right_bw);
+                // payload = 2 + left_bytes + right_bytes + exc_count*(2+2)
+                uint64_t payload_end =
+                  uint64_t{data_off} + 2u + left_bytes + right_bytes + uint64_t{exc_count} * 4u;
+                if (payload_end > metadata_end) {
+                  sh_invalid = true;
+                } else {
+                  sh_left_bytes  = left_bytes;
+                  sh_right_bytes = right_bytes;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Cooperatively zero-init the full 8-entry dict before reading entries
+  // [0, sh_dict_size). With left_bw ≤ 3 (validated above), left_idx ∈ [0,8),
+  // so the inner-loop `sh_dict[left_idx]` read is unconditionally safe — a
+  // corrupt left_idx ≥ sh_dict_size lands on a zero slot, no bounds check
+  // needed in the hot path. Thread 0's parse runs concurrently.
+  if (threadIdx.x < ALPRD_MAX_DICT_SIZE) { sh_dict[threadIdx.x] = 0; }
+  __syncthreads();
+  if (!sh_invalid && threadIdx.x < uint32_t{sh_dict_size}) {
+    uint16_t dv;
+    memcpy(&dv, seg_base + ALPRD_HEADER_SIZE + threadIdx.x * 2u, sizeof(dv));
+    sh_dict[threadIdx.x] = dv;
+  }
+  __syncthreads();
+
+  if (sh_invalid) {
+    zero_fill_vector<T>(out, fill_rows);
+    return;
+  }
+
+  if (sh_uncompressed) {
+    uint8_t const* raw_p = seg_base + sh_data_off + 2u;
+    if constexpr (sizeof(T) == 4) {
+      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+        uint32_t bits = ld32(raw_p + i * 4u);
+        T v;
+        memcpy(&v, &bits, sizeof(T));
+        __stwt(out + i, v);
+      }
+    } else {
+      for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+        uint64_t bits = ld64(raw_p + i * 8u);
+        T v;
+        memcpy(&v, &bits, sizeof(T));
+        __stwt(out + i, v);
+      }
+    }
+    return;
+  }
+
+  // Stage left and right packed streams into shmem. Each region carries 2
+  // trailing guard words for the 64-bit straddle case.
+  uint8_t const* left_bp  = seg_base + sh_data_off + 2u;
+  uint8_t const* right_bp = left_bp + sh_left_bytes;
+
+  extern __shared__ uint32_t shmem[];
+  uint32_t left_live    = ::cuda::ceil_div(sh_left_bytes, 4u);
+  uint32_t* left_words  = shmem;
+  uint32_t* right_words = shmem + left_live + 2u;
+
+  stage_bytes_to_shmem(left_words, left_bp, sh_left_bytes, /*pad_words=*/2u);
+  stage_bytes_to_shmem(right_words, right_bp, sh_right_bytes, /*pad_words=*/2u);
+  __syncthreads();
+
+  uint8_t const right_bw = sh_right_bw;
+  uint8_t const left_bw  = sh_left_bw;
+  // right_bw == sizeof(T)*8 ⇒ shifting EXACT_T by that width is UB; gate it.
+  bool const full_right = (right_bw >= sizeof(T) * 8u);
+
+  for (uint32_t i = threadIdx.x; i < fill_rows; i += blockDim.x) {
+    EXACT_T right_val = unpack_from_shmem<EXACT_T>(right_words, i, right_bw);
+    EXACT_T bits;
+    if (full_right) {
+      bits = right_val;
+    } else {
+      uint16_t left_idx = unpack_from_shmem<uint16_t>(left_words, i, left_bw);
+      EXACT_T left_val  = static_cast<EXACT_T>(sh_dict[left_idx]);
+      bits              = (left_val << right_bw) | right_val;
+    }
+    T v;
+    memcpy(&v, &bits, sizeof(T));
+    __stwt(out + i, v);
+  }
+  __syncthreads();
+
+  // Exception scatter recovers right-bits via `read_back_after_stwt` —
+  // see helper for the L1-invalidate contract.
+  uint16_t const exc_count = sh_exc_count;
+  if (exc_count > 0u) {
+    uint8_t const* exc_base   = right_bp + sh_right_bytes;
+    uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * 2u;
+
+    EXACT_T const r_mask = full_right ? ~EXACT_T{0} : ((EXACT_T{1} << right_bw) - EXACT_T{1});
+
+    for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
+      uint16_t pos;
+      memcpy(&pos, exc_p_base + e * 2u, sizeof(pos));
+      if (pos >= fill_rows) continue;
+
+      uint16_t exc_left;
+      memcpy(&exc_left, exc_base + e * 2u, sizeof(exc_left));
+
+      T existing = read_back_after_stwt(out, pos);
+      EXACT_T existing_bits;
+      memcpy(&existing_bits, &existing, sizeof(EXACT_T));
+      EXACT_T right_part = existing_bits & r_mask;
+      EXACT_T bits =
+        full_right ? right_part : ((static_cast<EXACT_T>(exc_left) << right_bw) | right_part);
+      T v;
+      memcpy(&v, &bits, sizeof(T));
+      __stwt(out + pos, v);
+    }
+  }
+}
+
+std::vector<alp_vector_desc> build_vector_descs(gpu_codec_run const& run)
+{
+  std::vector<alp_vector_desc> descs;
+  // Small over-reservation; tight worst case is ceil(row_count / 1024) per segment.
+  descs.reserve(run.segments.size() * 2);
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    uint32_t num_vecs = ::cuda::ceil_div(seg.row_count, ALP_VECTOR_SIZE);
+    for (uint32_t v = 0; v < num_vecs; ++v) {
+      uint32_t vec_rows =
+        (v + 1u < num_vecs) ? ALP_VECTOR_SIZE : seg.row_count - v * ALP_VECTOR_SIZE;
+      descs.push_back(
+        {seg.d_bytes, seg.bytes_size, v, vec_rows, seg.row_offset + v * ALP_VECTOR_SIZE});
+    }
+  }
+  return descs;
+}
+
+template <typename T>
+void launch_alp_typed(alp_vector_desc const* h_descs,
+                      size_t num_vecs,
+                      T* d_output,
+                      rmm::cuda_stream_view stream,
+                      rmm::device_async_resource_ref mr)
+{
+  if (num_vecs == 0) return;
+
+  rmm::device_uvector<alp_vector_desc> d_descs(num_vecs, stream, mr);
+  RMM_CUDA_TRY(cudaMemcpyAsync(d_descs.data(),
+                               h_descs,
+                               num_vecs * sizeof(alp_vector_desc),
+                               cudaMemcpyHostToDevice,
+                               stream.value()));
+
+  // Live shmem footprint per CTA: bitpacked stream, max width sizeof(T)*8,
+  // ALP_VECTOR_SIZE values. Two guard words past the live data for the
+  // 64-bit straddle case.
+  constexpr uint32_t max_width        = sizeof(T) * 8u;
+  constexpr uint32_t max_packed_bytes = ::cuda::ceil_div(ALP_VECTOR_SIZE * max_width, 8u);
+  constexpr uint32_t max_packed_words = ::cuda::ceil_div(max_packed_bytes, 4u) + 2u;
+  constexpr size_t shmem_bytes        = max_packed_words * sizeof(uint32_t);
+  static_assert(shmem_bytes <= 48u * 1024u,
+                "kernel_decode_alp dynamic shmem exceeds 48 KiB; either reduce "
+                "ALP_VECTOR_SIZE or call cudaFuncSetAttribute(MaxDynamicSharedMemorySize) "
+                "before launch");
+
+  kernel_decode_alp<T><<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, shmem_bytes, stream.value()>>>(
+    d_descs.data(), d_output, static_cast<uint32_t>(num_vecs));
+}
+
+template <typename T>
+void launch_alprd_typed(alp_vector_desc const* h_descs,
+                        size_t num_vecs,
+                        T* d_output,
+                        rmm::cuda_stream_view stream,
+                        rmm::device_async_resource_ref mr)
+{
+  if (num_vecs == 0) return;
+
+  rmm::device_uvector<alp_vector_desc> d_descs(num_vecs, stream, mr);
+  RMM_CUDA_TRY(cudaMemcpyAsync(d_descs.data(),
+                               h_descs,
+                               num_vecs * sizeof(alp_vector_desc),
+                               cudaMemcpyHostToDevice,
+                               stream.value()));
+
+  // Live shmem: left stream (left_bw ≤ 3) + right stream (right_bw ≤
+  // sizeof(T)*8). Guard pair after each region.
+  constexpr uint32_t max_left_bytes  = ::cuda::ceil_div(ALP_VECTOR_SIZE * 3u, 8u);
+  constexpr uint32_t max_right_bytes = ::cuda::ceil_div(ALP_VECTOR_SIZE * sizeof(T) * 8u, 8u);
+  constexpr uint32_t max_left_words  = ::cuda::ceil_div(max_left_bytes, 4u) + 2u;
+  constexpr uint32_t max_right_words = ::cuda::ceil_div(max_right_bytes, 4u) + 2u;
+  constexpr size_t shmem_bytes       = (max_left_words + max_right_words) * sizeof(uint32_t);
+  static_assert(shmem_bytes <= 48u * 1024u, "kernel_decode_alprd dynamic shmem exceeds 48 KiB");
+
+  kernel_decode_alprd<T>
+    <<<static_cast<uint32_t>(num_vecs), BLOCK_DIM, shmem_bytes, stream.value()>>>(
+      d_descs.data(), d_output, static_cast<uint32_t>(num_vecs));
+}
+
+void throw_unsupported_type(uint32_t type_size, char const* codec)
+{
+  throw std::runtime_error(std::string("gpu_decode_table: viability invariant violated — ") +
+                           codec + " type_size " + std::to_string(type_size));
+}
+
+}  // anonymous namespace
+
+// `type` parameter is signature-uniformity for the dispatcher table;
+// `type_size` alone selects the ALP / ALPRD kernel.
+void decode_alp_data(gpu_codec_run const& run,
+                     uint8_t* d_output,
+                     cudf::data_type /*type*/,
+                     uint32_t type_size,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr)
+{
+  auto descs = build_vector_descs(run);
+  if (descs.empty()) return;
+
+  switch (type_size) {
+    case 4:
+      launch_alp_typed<float>(
+        descs.data(), descs.size(), reinterpret_cast<float*>(d_output), stream, mr);
+      break;
+    case 8:
+      launch_alp_typed<double>(
+        descs.data(), descs.size(), reinterpret_cast<double*>(d_output), stream, mr);
+      break;
+    default: throw_unsupported_type(type_size, "ALP");
+  }
+}
+
+void decode_alprd_data(gpu_codec_run const& run,
+                       uint8_t* d_output,
+                       cudf::data_type /*type*/,
+                       uint32_t type_size,
+                       rmm::cuda_stream_view stream,
+                       rmm::device_async_resource_ref mr)
+{
+  auto descs = build_vector_descs(run);
+  if (descs.empty()) return;
+
+  switch (type_size) {
+    case 4:
+      launch_alprd_typed<float>(
+        descs.data(), descs.size(), reinterpret_cast<float*>(d_output), stream, mr);
+      break;
+    case 8:
+      launch_alprd_typed<double>(
+        descs.data(), descs.size(), reinterpret_cast<double*>(d_output), stream, mr);
+      break;
+    default: throw_unsupported_type(type_size, "ALPRD");
+  }
+}
+
+}  // namespace sirius::cuda::scan

--- a/src/cuda/scan/gpu_decode_alp.cu
+++ b/src/cuda/scan/gpu_decode_alp.cu
@@ -430,13 +430,16 @@ __global__ void kernel_decode_alp(alp_vector_desc const* __restrict__ descs,
     T plain     = static_cast<T>(enc) * fact_t * frac_t;
     __stwt(out + i, plain);
   }
-  __syncthreads();
 
   // Bound-check `pos` to refuse a corrupt OOB write — positions are
   // unique by construction at compress time, but the parsed value isn't
   // trusted.
   uint16_t const exc_count = sh_exc_count;
   if (exc_count > 0u) {
+    // Sync only on the exception path: every thread must finish its main-loop
+    // store before any thread overwrites a row with its exception value.
+    // `sh_exc_count` is broadcast-shared, so all threads take the same branch.
+    __syncthreads();
     uint8_t const* exc_base   = packed_bytes + sh_packed_bytes;
     uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * sizeof(T);
     for (uint32_t e = threadIdx.x; e < exc_count; e += blockDim.x) {
@@ -632,12 +635,15 @@ __global__ void kernel_decode_alprd(alp_vector_desc const* __restrict__ descs,
     memcpy(&v, &bits, sizeof(T));
     __stwt(out + i, v);
   }
-  __syncthreads();
 
   // Exception scatter recovers right-bits via `read_back_after_stwt` —
   // see helper for the L1-invalidate contract.
   uint16_t const exc_count = sh_exc_count;
   if (exc_count > 0u) {
+    // Sync only on the exception path: read_back_after_stwt(out, pos) reads
+    // what other threads wrote in the main loop, so the barrier is required
+    // here. `sh_exc_count` is broadcast-shared — uniform branch is safe.
+    __syncthreads();
     uint8_t const* exc_base   = right_bp + sh_right_bytes;
     uint8_t const* exc_p_base = exc_base + uint32_t{exc_count} * 2u;
 

--- a/src/cuda/scan/gpu_decode_alp.cu
+++ b/src/cuda/scan/gpu_decode_alp.cu
@@ -795,10 +795,21 @@ std::vector<alp_vector_desc> build_vector_descs(gpu_codec_run const& run)
 // Public Entry Points for ALP(RD) Decoding
 //===----------------------------------------------------------------------===//
 /**
- * @brief Decode a set of ALP-encoded segments.
+ * @brief Decode a set of ALP-encoded segments into a contiguous output buffer.
  *
- * @param run A set of segments with the ALP codec
- * @param d_output
+ * One CTA decodes one 1024-row vector; segments are split across vectors via
+ * `build_vector_descs`. Each segment writes to `d_output` at its own
+ * `row_offset * type_size`. Malformed vectors are zero-filled rather than
+ * faulted.
+ *
+ * @param run        Segments tagged with the ALP codec.
+ * @param d_output   Device-side output buffer, sized for `run.total_rows * type_size` bytes.
+ * @param type       Output element type (unused; `type_size` alone selects the kernel).
+ * @param type_size  Output element width in bytes — must be 4 (float) or 8 (double).
+ * @param stream     CUDA stream for the descriptor upload and kernel launches.
+ * @param mr         Device memory resource for the per-launch descriptor buffer.
+ *
+ * @throws std::runtime_error if `type_size` is not 4 or 8.
  */
 void decode_alp_data(gpu_codec_run const& run,
                      uint8_t* d_output,
@@ -807,7 +818,7 @@ void decode_alp_data(gpu_codec_run const& run,
                      rmm::cuda_stream_view stream,
                      rmm::device_async_resource_ref mr)
 {
-  auto descs = build_vector_descs(run);
+  auto const descs = build_vector_descs(run);
   if (descs.empty()) return;
 
   switch (type_size) {
@@ -825,6 +836,23 @@ void decode_alp_data(gpu_codec_run const& run,
   }
 }
 
+/**
+ * @brief Decode a set of ALPRD-encoded segments into a contiguous output buffer.
+ *
+ * One CTA decodes one 1024-row vector; segments are split across vectors via
+ * `build_vector_descs`. Each segment writes to `d_output` at its own
+ * `row_offset * type_size`. Malformed vectors are zero-filled rather than
+ * faulted.
+ *
+ * @param run        Segments tagged with the ALPRD codec.
+ * @param d_output   Device-side output buffer, sized for `run.total_rows * type_size` bytes.
+ * @param type       Output element type (unused; `type_size` alone selects the kernel).
+ * @param type_size  Output element width in bytes — must be 4 (float) or 8 (double).
+ * @param stream     CUDA stream for the descriptor upload and kernel launches.
+ * @param mr         Device memory resource for the per-launch descriptor buffer.
+ *
+ * @throws std::runtime_error if `type_size` is not 4 or 8.
+ */
 void decode_alprd_data(gpu_codec_run const& run,
                        uint8_t* d_output,
                        cudf::data_type /*type*/,

--- a/src/cuda/scan/gpu_native_decode.cu
+++ b/src/cuda/scan/gpu_native_decode.cu
@@ -31,6 +31,7 @@
 // every synchronous CUDA API call is individually wrapped in `RMM_CUDA_TRY`.
 //===----------------------------------------------------------------------===//
 
+#include "cuda/scan/gpu_decode_alp.cuh"
 #include "cuda/scan/gpu_decode_bitpacking.cuh"
 #include "cuda/scan/gpu_decode_rle.cuh"
 #include "cuda/scan/gpu_native_decode.cuh"
@@ -440,6 +441,12 @@ void dispatch_data_run(gpu_codec_run const& run,
       return;
     case duckdb::CompressionType::COMPRESSION_BITPACKING:
       decode_bitpacking_data(run, d_output, type, type_size, stream, mr);
+      return;
+    case duckdb::CompressionType::COMPRESSION_ALP:
+      decode_alp_data(run, d_output, type, type_size, stream, mr);
+      return;
+    case duckdb::CompressionType::COMPRESSION_ALPRD:
+      decode_alprd_data(run, d_output, type, type_size, stream, mr);
       return;
     default:
       throw std::runtime_error("gpu_decode_table: viability invariant violated — data codec " +

--- a/src/include/cuda/scan/gpu_decode_alp.cuh
+++ b/src/include/cuda/scan/gpu_decode_alp.cuh
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// ALP / ALPRD decode entries for the GPU-native scan path. On any bounds
+// check failure the kernel zero-fills the trusted host descriptor row
+// range — returning without writing would leak prior device contents.
+// On-disk format reference and per-vector layouts: gpu_decode_alp.cu.
+
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/scan/gpu_native_decode.cuh>
+
+#include <duckdb/storage/compression/alp/alp_constants.hpp>
+#include <duckdb/storage/compression/alprd/alprd_constants.hpp>
+
+#include <cstdint>
+
+namespace sirius::cuda::scan {
+
+// Aliases for DuckDB's per-codec format constants — keep this header in
+// sync with the on-disk format by reading the value from DuckDB rather
+// than redefining it.
+inline constexpr uint32_t ALP_VECTOR_SIZE = duckdb::AlpConstants::ALP_VECTOR_SIZE;
+inline constexpr uint8_t ALP_UNCOMPRESSED_SENTINEL =
+  duckdb::AlpConstants::UNCOMPRESSED_MODE_SENTINEL;
+inline constexpr uint16_t ALPRD_UNCOMPRESSED_SENTINEL =
+  duckdb::AlpRDConstants::UNCOMPRESSED_MODE_SENTINEL;
+inline constexpr uint32_t ALPRD_MAX_DICT_SIZE = duckdb::AlpRDConstants::MAX_DICTIONARY_SIZE;
+inline constexpr uint32_t ALPRD_HEADER_SIZE   = duckdb::AlpRDConstants::HEADER_SIZE;
+
+// `type_size` must be 4 (float) or 8 (double); other widths throw.
+// Output is written at `seg.row_offset * type_size` for each segment.
+void decode_alp_data(gpu_codec_run const& run,
+                     uint8_t* d_output,
+                     cudf::data_type type,
+                     uint32_t type_size,
+                     rmm::cuda_stream_view stream,
+                     rmm::device_async_resource_ref mr);
+
+void decode_alprd_data(gpu_codec_run const& run,
+                       uint8_t* d_output,
+                       cudf::data_type type,
+                       uint32_t type_size,
+                       rmm::cuda_stream_view stream,
+                       rmm::device_async_resource_ref mr);
+
+}  // namespace sirius::cuda::scan

--- a/src/include/cuda/scan/gpu_decode_alp.cuh
+++ b/src/include/cuda/scan/gpu_decode_alp.cuh
@@ -18,8 +18,7 @@
 
 // ALP / ALPRD decode entries for the GPU-native scan path. On any bounds
 // check failure the kernel zero-fills the trusted host descriptor row
-// range — returning without writing would leak prior device contents.
-// On-disk format reference and per-vector layouts: gpu_decode_alp.cu.
+// range. On-disk format reference and per-vector layouts: gpu_decode_alp.cu.
 
 #include <cudf/types.hpp>
 

--- a/test/cpp/scan/alp_synth.hpp
+++ b/test/cpp/scan/alp_synth.hpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Synthetic ALP / ALPRD segment builders for unit tests and microbenches.
+// Byte-by-byte format reference: src/cuda/scan/gpu_decode_alp.cu.
+
+#include <cuda/scan/gpu_decode_alp.cuh>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+namespace sirius::test::decode::alp {
+
+inline constexpr uint32_t VEC = 1024;
+
+/// Pack `values.size()` width-bit values LSB-first into a fresh byte buffer
+/// sized to DuckDB's `BitpackingPrimitives::GetRequiredSize` rule (count
+/// padded up to a 32-value group, then `padded * width / 8` bytes).
+template <typename T>
+inline std::vector<uint8_t> pack_lsb(std::vector<T> const& values, uint32_t width)
+{
+  static_assert(std::is_unsigned_v<T>, "pack_lsb expects an unsigned mantissa type");
+  if (width == 0u) { return std::vector<uint8_t>(0u, 0u); }
+  uint32_t count  = static_cast<uint32_t>(values.size());
+  uint32_t r      = count & 31u;
+  uint32_t padded = r ? (count + 32u - r) : count;
+  uint32_t bytes  = padded * width / 8u;
+  std::vector<uint8_t> out(bytes, 0u);
+  for (uint32_t i = 0; i < count; ++i) {
+    uint64_t v    = static_cast<uint64_t>(values[i]);
+    uint64_t mask = (width >= 64u) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1u);
+    v &= mask;
+    uint64_t bit_pos = uint64_t{i} * width;
+    uint32_t byte0   = static_cast<uint32_t>(bit_pos >> 3);
+    uint32_t bit_off = static_cast<uint32_t>(bit_pos & 7u);
+    // Walk byte-by-byte writing each value's bit slice. The buffer is sized
+    // to a 32-group multiple, which always provides tail headroom for the
+    // last value's straddle bytes.
+    int written = 0;
+    while (written < static_cast<int>(width)) {
+      int dst_byte   = static_cast<int>(byte0) + (static_cast<int>(bit_off) + written) / 8;
+      int dst_bit    = (static_cast<int>(bit_off) + written) % 8;
+      int take       = std::min(8 - dst_bit, static_cast<int>(width) - written);
+      uint8_t byte_v = static_cast<uint8_t>((v >> written) & ((uint64_t{1} << take) - 1u));
+      out[dst_byte] |= static_cast<uint8_t>(byte_v << dst_bit);
+      written += take;
+    }
+  }
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// ALP block builder. `vectors` is a list of per-vector inputs; each vector
+// is either compressed (mantissas + exception list) or uncompressed (raw
+// values). `single_for_value` defaults to 0 — callers can override to test
+// non-trivial frame_of_reference paths.
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct alp_compressed_vector {
+  uint8_t exponent;                           // ≤ AlpTypedConstants<T>::MAX_EXPONENT
+  uint8_t factor;                             // ≤ 18
+  uint64_t frame_of_ref;                      // unsigned wrap-around offset
+  uint8_t bit_width;                          // ≤ sizeof(T)*8
+  uint32_t row_count;                         // ≤ ALP_VECTOR_SIZE
+  std::vector<uint64_t> mantissas;            // size == row_count, all fit in bit_width
+  std::vector<T> exceptions;                  // T-typed real values
+  std::vector<uint16_t> exception_positions;  // size == exceptions.size()
+};
+
+template <typename T>
+struct alp_uncompressed_vector {
+  uint32_t row_count;
+  std::vector<T> values;  // size == row_count
+};
+
+template <typename T>
+using alp_vector = std::variant<alp_compressed_vector<T>, alp_uncompressed_vector<T>>;
+
+/// Append `bytes` to `seg` and return the offset of the first appended byte.
+inline uint32_t append(std::vector<uint8_t>& seg, uint8_t const* bytes, size_t n)
+{
+  uint32_t off = static_cast<uint32_t>(seg.size());
+  seg.insert(seg.end(), bytes, bytes + n);
+  return off;
+}
+
+template <typename T>
+inline std::vector<uint8_t> make_alp_block(std::vector<alp_vector<T>> const& vectors)
+{
+  static_assert(std::is_floating_point_v<T>, "ALP supports float / double only");
+  std::vector<uint8_t> seg;
+  seg.resize(4u, 0u);  // reserve metadata_end slot
+
+  std::vector<uint32_t> per_vec_offsets;
+  per_vec_offsets.reserve(vectors.size());
+
+  for (auto const& vec : vectors) {
+    uint32_t this_vec_off = static_cast<uint32_t>(seg.size());
+    per_vec_offsets.push_back(this_vec_off);
+
+    if (std::holds_alternative<alp_compressed_vector<T>>(vec)) {
+      auto const& cv = std::get<alp_compressed_vector<T>>(vec);
+      // 13-byte header.
+      uint8_t hdr[13];
+      hdr[0]             = cv.exponent;
+      hdr[1]             = cv.factor;
+      uint16_t exc_count = static_cast<uint16_t>(cv.exceptions.size());
+      std::memcpy(hdr + 2, &exc_count, 2);
+      std::memcpy(hdr + 4, &cv.frame_of_ref, 8);
+      hdr[12] = cv.bit_width;
+      seg.insert(seg.end(), hdr, hdr + 13);
+      // Bitpacked mantissas.
+      auto packed = pack_lsb<uint64_t>(cv.mantissas, cv.bit_width);
+      seg.insert(seg.end(), packed.begin(), packed.end());
+      // Exceptions (T-typed) followed by uint16 positions.
+      uint8_t const* exc_bytes = reinterpret_cast<uint8_t const*>(cv.exceptions.data());
+      seg.insert(seg.end(), exc_bytes, exc_bytes + cv.exceptions.size() * sizeof(T));
+      uint8_t const* pos_bytes = reinterpret_cast<uint8_t const*>(cv.exception_positions.data());
+      seg.insert(
+        seg.end(), pos_bytes, pos_bytes + cv.exception_positions.size() * sizeof(uint16_t));
+    } else {
+      auto const& uv = std::get<alp_uncompressed_vector<T>>(vec);
+      // Sentinel byte + raw values.
+      uint8_t sentinel = ::sirius::cuda::scan::ALP_UNCOMPRESSED_SENTINEL;
+      seg.push_back(sentinel);
+      uint8_t const* vbytes = reinterpret_cast<uint8_t const*>(uv.values.data());
+      seg.insert(seg.end(), vbytes, vbytes + uv.values.size() * sizeof(T));
+    }
+  }
+
+  // Append the backwards pointer trailer (one uint32 per vector, written
+  // in reverse so entry V lives at metadata_end - (V+1)*4).
+  for (auto it = per_vec_offsets.rbegin(); it != per_vec_offsets.rend(); ++it) {
+    uint32_t off = *it;
+    uint8_t b[4];
+    std::memcpy(b, &off, 4);
+    seg.insert(seg.end(), b, b + 4);
+  }
+
+  uint32_t metadata_end = static_cast<uint32_t>(seg.size());
+  std::memcpy(seg.data(), &metadata_end, 4);
+  return seg;
+}
+
+//===----------------------------------------------------------------------===//
+// ALPRD block builder.
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct alprd_compressed_vector {
+  uint32_t row_count;
+  std::vector<uint16_t> left_indices;           // size == row_count
+  std::vector<uint64_t> right_parts;            // size == row_count
+  std::vector<uint16_t> exception_left_values;  // size == exception_positions.size()
+  std::vector<uint16_t> exception_positions;
+};
+
+template <typename T>
+struct alprd_uncompressed_vector {
+  uint32_t row_count;
+  std::vector<T> values;
+};
+
+template <typename T>
+using alprd_vector = std::variant<alprd_compressed_vector<T>, alprd_uncompressed_vector<T>>;
+
+template <typename T>
+inline std::vector<uint8_t> make_alprd_block(uint8_t right_bw,
+                                             uint8_t left_bw,
+                                             std::vector<uint16_t> const& dict,
+                                             std::vector<alprd_vector<T>> const& vectors)
+{
+  static_assert(std::is_floating_point_v<T>, "ALPRD supports float / double only");
+  if (dict.size() > ::sirius::cuda::scan::ALPRD_MAX_DICT_SIZE) {
+    throw std::runtime_error("make_alprd_block: dict size > MAX_DICTIONARY_SIZE");
+  }
+  std::vector<uint8_t> seg;
+  // 7-byte header + dict (uint16 each).
+  seg.resize(::sirius::cuda::scan::ALPRD_HEADER_SIZE, 0u);
+  seg[4]                    = right_bw;
+  seg[5]                    = left_bw;
+  seg[6]                    = static_cast<uint8_t>(dict.size());
+  uint8_t const* dict_bytes = reinterpret_cast<uint8_t const*>(dict.data());
+  seg.insert(seg.end(), dict_bytes, dict_bytes + dict.size() * sizeof(uint16_t));
+
+  std::vector<uint32_t> per_vec_offsets;
+  per_vec_offsets.reserve(vectors.size());
+
+  for (auto const& vec : vectors) {
+    uint32_t this_vec_off = static_cast<uint32_t>(seg.size());
+    per_vec_offsets.push_back(this_vec_off);
+
+    if (std::holds_alternative<alprd_compressed_vector<T>>(vec)) {
+      auto const& cv     = std::get<alprd_compressed_vector<T>>(vec);
+      uint16_t exc_count = static_cast<uint16_t>(cv.exception_positions.size());
+      uint8_t exc_b[2];
+      std::memcpy(exc_b, &exc_count, 2);
+      seg.insert(seg.end(), exc_b, exc_b + 2);
+      auto left_packed = pack_lsb<uint16_t>(cv.left_indices, left_bw);
+      seg.insert(seg.end(), left_packed.begin(), left_packed.end());
+      auto right_packed = pack_lsb<uint64_t>(cv.right_parts, right_bw);
+      seg.insert(seg.end(), right_packed.begin(), right_packed.end());
+      uint8_t const* exc_l = reinterpret_cast<uint8_t const*>(cv.exception_left_values.data());
+      seg.insert(seg.end(), exc_l, exc_l + cv.exception_left_values.size() * 2u);
+      uint8_t const* exc_p = reinterpret_cast<uint8_t const*>(cv.exception_positions.data());
+      seg.insert(seg.end(), exc_p, exc_p + cv.exception_positions.size() * 2u);
+    } else {
+      auto const& uv    = std::get<alprd_uncompressed_vector<T>>(vec);
+      uint16_t sentinel = ::sirius::cuda::scan::ALPRD_UNCOMPRESSED_SENTINEL;
+      uint8_t b[2];
+      std::memcpy(b, &sentinel, 2);
+      seg.insert(seg.end(), b, b + 2);
+      uint8_t const* vbytes = reinterpret_cast<uint8_t const*>(uv.values.data());
+      seg.insert(seg.end(), vbytes, vbytes + uv.values.size() * sizeof(T));
+    }
+  }
+
+  for (auto it = per_vec_offsets.rbegin(); it != per_vec_offsets.rend(); ++it) {
+    uint32_t off = *it;
+    uint8_t b[4];
+    std::memcpy(b, &off, 4);
+    seg.insert(seg.end(), b, b + 4);
+  }
+
+  uint32_t metadata_end = static_cast<uint32_t>(seg.size());
+  std::memcpy(seg.data(), &metadata_end, 4);
+  return seg;
+}
+
+/// Multi-vector ALP segment with `n_vecs` full vectors at `bit_width`. No
+/// exceptions — phase-1 measures the bulk-decode hot path. Decoded value at
+/// row `v*1024+i` is `(T)(int64_t)(((uint64_t)i ^ (uint64_t)v) & mask)`
+/// since exponent=factor=frame_of_ref=0.
+template <typename T>
+inline std::vector<uint8_t> synth_alp_segment(uint32_t n_vecs, uint8_t bit_width)
+{
+  uint64_t mask = (bit_width >= 64u) ? ~uint64_t{0} : ((uint64_t{1} << bit_width) - 1u);
+  std::vector<alp_vector<T>> vecs;
+  vecs.reserve(n_vecs);
+  for (uint32_t v = 0; v < n_vecs; ++v) {
+    alp_compressed_vector<T> cv;
+    cv.exponent     = 0;
+    cv.factor       = 0;
+    cv.frame_of_ref = 0;
+    cv.bit_width    = bit_width;
+    cv.row_count    = 1024u;
+    cv.mantissas.resize(1024u);
+    for (uint32_t i = 0; i < 1024u; ++i)
+      cv.mantissas[i] = (uint64_t{i} ^ uint64_t{v}) & mask;
+    vecs.emplace_back(std::move(cv));
+  }
+  return make_alp_block<T>(vecs);
+}
+
+/// Multi-vector ALPRD segment with `n_vecs` vectors at `right_bw`/`left_bw`,
+/// using the supplied dictionary. No exceptions. Decoded bits at row
+/// `v*1024+i` are `(uint64_t)dict[(i^v) & l_mask] << right_bw |
+/// ((i * 0x9E3779B97F4A7C15ULL) & r_mask)` reinterpreted as `T`.
+template <typename T>
+inline std::vector<uint8_t> synth_alprd_segment(uint32_t n_vecs,
+                                                uint8_t right_bw,
+                                                uint8_t left_bw,
+                                                std::vector<uint16_t> const& dict)
+{
+  uint64_t r_mask = (right_bw >= 64u) ? ~uint64_t{0} : ((uint64_t{1} << right_bw) - 1u);
+  uint16_t l_mask =
+    (left_bw >= 16u) ? uint16_t{0xFFFFu} : static_cast<uint16_t>((uint16_t{1} << left_bw) - 1u);
+  std::vector<alprd_vector<T>> vecs;
+  vecs.reserve(n_vecs);
+  for (uint32_t v = 0; v < n_vecs; ++v) {
+    alprd_compressed_vector<T> cv;
+    cv.row_count = 1024u;
+    cv.left_indices.resize(1024u);
+    cv.right_parts.resize(1024u);
+    for (uint32_t i = 0; i < 1024u; ++i) {
+      cv.left_indices[i] = static_cast<uint16_t>((i ^ v) & l_mask);
+      cv.right_parts[i]  = (uint64_t{i} * 0x9E3779B97F4A7C15ULL) & r_mask;
+    }
+    vecs.emplace_back(std::move(cv));
+  }
+  return make_alprd_block<T>(right_bw, left_bw, dict, vecs);
+}
+
+}  // namespace sirius::test::decode::alp

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -19,6 +19,7 @@
 // skip it. Numbers paste into test/data/decode_baselines/<arch>.json.
 //===----------------------------------------------------------------------===//
 
+#include "scan/alp_synth.hpp"
 #include "scan/bitpacking_synth.hpp"
 #include "scan/decode_test_utils.hpp"
 #include "scan/rle_synth.hpp"
@@ -35,6 +36,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <variant>
 #include <vector>
 
 using duckdb::CompressionType;
@@ -587,6 +589,179 @@ TEST_CASE("bench BITPACKING int32 DELTA_FOR width=8 128M rows", "[!benchmark][sc
   double sec     = bench_seconds(stream, {col}, mr);
   double bytes_w = double(size_t{N_SEGS} * SEG_ROWS * sizeof(int32_t));
   std::printf("[bench] BITPACKING   int32 DELTA_FOR w=8 128M rows: %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+//===----------------------------------------------------------------------===//
+// ALP / ALPRD benches. Tagged `[!benchmark]`; numbers paste into
+// test/data/decode_baselines/<arch>.json under the alp / alprd keys.
+//
+// `bw_pinned` cases (most useful for self-relative phase-2 perf comparisons)
+// fix bit_width per case so runs are reproducible across machines.
+//===----------------------------------------------------------------------===//
+
+using sirius::test::decode::alp::synth_alp_segment;
+using sirius::test::decode::alp::synth_alprd_segment;
+
+TEST_CASE("bench ALP double bw=11 32K vectors (32M rows)", "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, /*bit_width=*/11);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT64},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALP,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(double));
+  std::printf("[bench] ALP          f64 bw=11 32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+TEST_CASE("bench ALP float bw=20 32K vectors (32M rows)", "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  auto seg_bytes = synth_alp_segment<float>(N_VECS, /*bit_width=*/20);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT32},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALP,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(float));
+  std::printf("[bench] ALP          f32 bw=20 32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+TEST_CASE("bench ALPRD double right_bw=48 left_bw=3 32K vectors (32M rows)",
+          "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  std::vector<uint16_t> dict = {0xAAAA, 0x5555, 0x1234, 0xABCD, 0xDEAD, 0xBEEF, 0xCAFE, 0xF00D};
+  auto seg_bytes = synth_alprd_segment<double>(N_VECS, /*right_bw=*/48, /*left_bw=*/3, dict);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT64},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALPRD,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(double));
+  std::printf("[bench] ALPRD        f64 r48/l3 32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+// Power-of-2 / byte-aligned widths. ALP-encoded TPC-H integer-derived columns
+// (DECIMAL, dates, narrow ints) cluster on bw=8/16/32; the bw=11/20 cases
+// above exercise the worst-case 64-bit-straddle bit-extract path.
+
+TEST_CASE("bench ALP double bw=8 32K vectors (32M rows)", "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, /*bit_width=*/8);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT64},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALP,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(double));
+  std::printf("[bench] ALP          f64 bw=8  32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+TEST_CASE("bench ALP double bw=16 32K vectors (32M rows)", "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, /*bit_width=*/16);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT64},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALP,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(double));
+  std::printf("[bench] ALP          f64 bw=16 32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+TEST_CASE("bench ALP float bw=32 32K vectors (32M rows)", "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  auto seg_bytes = synth_alp_segment<float>(N_VECS, /*bit_width=*/32);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT32},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALP,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(float));
+  std::printf("[bench] ALP          f32 bw=32 32M rows:      %.6fs  write=%.1f GiB/s\n",
+              sec,
+              bytes_w / sec / GIB);
+}
+
+TEST_CASE("bench ALPRD double right_bw=56 left_bw=2 32K vectors (32M rows)",
+          "[!benchmark][scan][decode]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS = 32u * 1024u;
+  constexpr uint32_t ROWS   = N_VECS * 1024u;
+
+  std::vector<uint16_t> dict = {0xAAAA, 0x5555, 0x1234, 0xABCD};
+  auto seg_bytes = synth_alprd_segment<double>(N_VECS, /*right_bw=*/56, /*left_bw=*/2, dict);
+  auto d_seg     = sirius::test::decode::upload(seg_bytes, stream.view());
+  auto col =
+    sirius::test::decode::one_codec_column(cudf::data_type{cudf::type_id::FLOAT64},
+                                           ROWS,
+                                           CompressionType::COMPRESSION_ALPRD,
+                                           {sirius::test::decode::segment(d_seg, 0, ROWS)});
+
+  double sec     = bench_seconds(stream, {col}, mr);
+  double bytes_w = double(size_t{ROWS} * sizeof(double));
+  std::printf("[bench] ALPRD        f64 r56/l2 32M rows:      %.6fs  write=%.1f GiB/s\n",
               sec,
               bytes_w / sec / GIB);
 }

--- a/test/cpp/scan/decode_test_utils.hpp
+++ b/test/cpp/scan/decode_test_utils.hpp
@@ -160,8 +160,9 @@ inline void verify_decoded_column(rmm::cuda_stream_view stream,
   for (uint32_t i = 0; i < col.total_rows; ++i) {
     T const want = expected_row(i);
     if (out[i] != want) {
-      FAIL("row=" << i << " expected=" << static_cast<long long>(want)
-                  << " got=" << static_cast<long long>(out[i]));
+      // Stream T directly so floating-point T renders without a lossy
+      // long-long cast (`static_cast<long long>(3.14)` would print 3).
+      FAIL("row=" << i << " expected=" << want << " got=" << out[i]);
     }
   }
 }

--- a/test/cpp/scan/test_gpu_decode_alp.cpp
+++ b/test/cpp/scan/test_gpu_decode_alp.cpp
@@ -1,0 +1,850 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ALP / ALPRD decode tests: happy-path round-trips against host references,
+// plus canary-buffer defensive tests that pre-fill output with 0xCC and
+// assert the kernel zero-filled the row range on each malformed input.
+
+#include "scan/alp_synth.hpp"
+#include "scan/decode_test_utils.hpp"
+
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+
+#include <cuda/scan/gpu_decode_alp.cuh>
+
+#include <catch.hpp>
+#include <duckdb/common/enums/compression_type.hpp>
+#include <duckdb/storage/compression/alp/alp_constants.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using duckdb::CompressionType;
+using sirius::cuda::scan::decode_alp_data;
+using sirius::cuda::scan::decode_alprd_data;
+using sirius::cuda::scan::gpu_codec_run;
+using sirius::cuda::scan::gpu_column_decode_input;
+using sirius::cuda::scan::gpu_decode_table;
+using sirius::cuda::scan::gpu_segment_desc;
+using sirius::test::decode::download;
+using sirius::test::decode::one_codec_column;
+using sirius::test::decode::segment;
+using sirius::test::decode::upload;
+using sirius::test::decode::verify_decoded_column;
+using sirius::test::decode::alp::alp_compressed_vector;
+using sirius::test::decode::alp::alp_uncompressed_vector;
+using sirius::test::decode::alp::alp_vector;
+using sirius::test::decode::alp::alprd_compressed_vector;
+using sirius::test::decode::alp::alprd_uncompressed_vector;
+using sirius::test::decode::alp::alprd_vector;
+using sirius::test::decode::alp::make_alp_block;
+using sirius::test::decode::alp::make_alprd_block;
+using sirius::test::decode::alp::synth_alp_segment;
+using sirius::test::decode::alp::synth_alprd_segment;
+
+namespace {
+
+auto const F32 = cudf::data_type{cudf::type_id::FLOAT32};
+auto const F64 = cudf::data_type{cudf::type_id::FLOAT64};
+
+template <typename T>
+std::vector<T> decode_one_alp(std::vector<uint8_t> const& bytes,
+                              cudf::data_type type,
+                              uint32_t row_count)
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_column_decode_input col;
+  col.out_type   = type;
+  col.total_rows = row_count;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_ALP,
+                      {gpu_segment_desc{static_cast<uint8_t const*>(d_seg.data()),
+                                        static_cast<uint32_t>(d_seg.size()),
+                                        0,
+                                        row_count}}});
+  auto t = gpu_decode_table({col}, stream.view(), mr);
+  REQUIRE(t->num_rows() == static_cast<cudf::size_type>(row_count));
+  return download<T>(t->get_column(0).view().data<T>(), row_count, stream.value());
+}
+
+template <typename T>
+std::vector<T> decode_one_alprd(std::vector<uint8_t> const& bytes,
+                                cudf::data_type type,
+                                uint32_t row_count)
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_column_decode_input col;
+  col.out_type   = type;
+  col.total_rows = row_count;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_ALPRD,
+                      {gpu_segment_desc{static_cast<uint8_t const*>(d_seg.data()),
+                                        static_cast<uint32_t>(d_seg.size()),
+                                        0,
+                                        row_count}}});
+  auto t = gpu_decode_table({col}, stream.view(), mr);
+  REQUIRE(t->num_rows() == static_cast<cudf::size_type>(row_count));
+  return download<T>(t->get_column(0).view().data<T>(), row_count, stream.value());
+}
+
+/// Reference ALP decode on host: enc → real-T plain via FACT × FRAC.
+/// Uses DuckDB's source-of-truth tables so this stays in sync with the
+/// kernel's `d_alp_fact` / `alp_frac_ptr<T>()` mirrors.
+inline double alp_decode_f64_ref(uint64_t for_value,
+                                 uint64_t mantissa,
+                                 uint8_t factor,
+                                 uint8_t exponent)
+{
+  int64_t enc = static_cast<int64_t>(mantissa + for_value);
+  return static_cast<double>(enc) * static_cast<double>(duckdb::AlpConstants::FACT_ARR[factor]) *
+         duckdb::AlpTypedConstants<double>::FRAC_ARR[exponent];
+}
+
+inline float alp_decode_f32_ref(uint64_t for_value,
+                                uint64_t mantissa,
+                                uint8_t factor,
+                                uint8_t exponent)
+{
+  int64_t enc = static_cast<int64_t>(mantissa + for_value);
+  return static_cast<float>(enc) * static_cast<float>(duckdb::AlpConstants::FACT_ARR[factor]) *
+         duckdb::AlpTypedConstants<float>::FRAC_ARR[exponent];
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// ALP happy-path tests.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_decode_table ALP - single compressed vector, double, factor/exponent ≠ 0",
+          "[scan][decode][alp]")
+{
+  // 100 values: i / 100.0 for i in [0,100). Encoded as integers i with
+  // factor=0, exponent=2, FOR=0, bit_width=7.
+  uint32_t const N = 100;
+  std::vector<uint64_t> mantissas(N);
+  for (uint32_t i = 0; i < N; ++i)
+    mantissas[i] = i;
+
+  alp_compressed_vector<double> cv;
+  cv.exponent     = 2;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 7;
+  cv.row_count    = N;
+  cv.mantissas    = mantissas;
+
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alp_block<double>(vecs);
+  auto out   = decode_one_alp<double>(bytes, F64, N);
+
+  for (uint32_t i = 0; i < N; ++i) {
+    double expected = alp_decode_f64_ref(0, mantissas[i], 0, 2);
+    REQUIRE(out[i] == Approx(expected).epsilon(1e-12));
+  }
+}
+
+TEST_CASE("gpu_decode_table ALP - single compressed vector with exceptions, float",
+          "[scan][decode][alp]")
+{
+  uint32_t const N = 64;
+  std::vector<uint64_t> mantissas(N);
+  for (uint32_t i = 0; i < N; ++i)
+    mantissas[i] = i * 7u;
+
+  alp_compressed_vector<float> cv;
+  cv.exponent     = 1;
+  cv.factor       = 0;
+  cv.frame_of_ref = 100;
+  cv.bit_width    = 10;
+  cv.row_count    = N;
+  cv.mantissas    = mantissas;
+  // Two exceptions — overwrite positions 5 and 17 with values that don't
+  // round-trip the (factor, exponent) encoding.
+  cv.exceptions.push_back(3.1415926F);
+  cv.exception_positions.push_back(5);
+  cv.exceptions.push_back(2.7182818F);
+  cv.exception_positions.push_back(17);
+
+  std::vector<alp_vector<float>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alp_block<float>(vecs);
+  auto out   = decode_one_alp<float>(bytes, F32, N);
+
+  for (uint32_t i = 0; i < N; ++i) {
+    if (i == 5) {
+      // Exception bytes are stored verbatim and bit-cast back, no arithmetic
+      // ⇒ require bit-exact equality, not approximate.
+      REQUIRE(out[i] == 3.1415926F);
+    } else if (i == 17) {
+      REQUIRE(out[i] == 2.7182818F);
+    } else {
+      float expected = alp_decode_f32_ref(100, mantissas[i], 0, 1);
+      REQUIRE(out[i] == Approx(expected).epsilon(1e-6F));
+    }
+  }
+}
+
+TEST_CASE("gpu_decode_table ALP - uncompressed-sentinel vector double", "[scan][decode][alp]")
+{
+  // A vector with the 0xFF exponent sentinel: raw doubles, no encoding.
+  uint32_t const N = 50;
+  std::vector<double> raw(N);
+  for (uint32_t i = 0; i < N; ++i)
+    raw[i] = static_cast<double>(i) * 3.14159 + 0.5;
+
+  alp_uncompressed_vector<double> uv;
+  uv.row_count = N;
+  uv.values    = raw;
+
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(uv));
+  auto bytes = make_alp_block<double>(vecs);
+  auto out   = decode_one_alp<double>(bytes, F64, N);
+
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == raw[i]);
+}
+
+TEST_CASE("gpu_decode_table ALP - multi-vector segment crosses 1024-row boundary",
+          "[scan][decode][alp]")
+{
+  // Two vectors: one full (1024 rows) + one short (300 rows). Verifies the
+  // last-vector tail-row case + multi-vector backwards trailer parsing.
+  uint32_t const N0 = 1024;
+  uint32_t const N1 = 300;
+  std::vector<uint64_t> m0(N0), m1(N1);
+  for (uint32_t i = 0; i < N0; ++i)
+    m0[i] = i;
+  for (uint32_t i = 0; i < N1; ++i)
+    m1[i] = i + 5000u;
+
+  alp_compressed_vector<double> cv0;
+  cv0.exponent     = 0;
+  cv0.factor       = 0;
+  cv0.frame_of_ref = 0;
+  cv0.bit_width    = 11;
+  cv0.row_count    = N0;
+  cv0.mantissas    = m0;
+
+  alp_compressed_vector<double> cv1;
+  cv1.exponent     = 0;
+  cv1.factor       = 0;
+  cv1.frame_of_ref = 0;
+  cv1.bit_width    = 13;
+  cv1.row_count    = N1;
+  cv1.mantissas    = m1;
+
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv0));
+  vecs.emplace_back(std::move(cv1));
+  auto bytes = make_alp_block<double>(vecs);
+  auto out   = decode_one_alp<double>(bytes, F64, N0 + N1);
+
+  for (uint32_t i = 0; i < N0; ++i)
+    REQUIRE(out[i] == static_cast<double>(m0[i]));
+  for (uint32_t i = 0; i < N1; ++i)
+    REQUIRE(out[N0 + i] == static_cast<double>(m1[i]));
+}
+
+//===----------------------------------------------------------------------===//
+// ALPRD happy-path tests.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_decode_table ALPRD - canonical layout, double", "[scan][decode][alprd]")
+{
+  // Double bit pattern split into 16 left bits + 48 right bits.
+  // Two left-part dictionary entries: 0xABCD and 0x1234.
+  uint8_t const right_bw     = 48;
+  uint8_t const left_bw      = 1;  // dict_size = 2 → log2 = 1
+  std::vector<uint16_t> dict = {0xABCD, 0x1234};
+
+  uint32_t const N = 80;
+  std::vector<uint16_t> left_idx(N);
+  std::vector<uint64_t> right_parts(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    left_idx[i]    = (i & 1u);  // alternate dict entries
+    right_parts[i] = (uint64_t{i} * 0x1234567ULL) & ((uint64_t{1} << right_bw) - 1u);
+  }
+
+  alprd_compressed_vector<double> cv;
+  cv.row_count    = N;
+  cv.left_indices = left_idx;
+  cv.right_parts  = right_parts;
+
+  std::vector<alprd_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alprd_block<double>(right_bw, left_bw, dict, vecs);
+  auto out   = decode_one_alprd<double>(bytes, F64, N);
+
+  for (uint32_t i = 0; i < N; ++i) {
+    uint64_t expected_bits =
+      (static_cast<uint64_t>(dict[left_idx[i]]) << right_bw) | right_parts[i];
+    double expected;
+    std::memcpy(&expected, &expected_bits, sizeof(double));
+    REQUIRE(out[i] == expected);
+  }
+}
+
+TEST_CASE("gpu_decode_table ALPRD - exception patches left-part bits, double",
+          "[scan][decode][alprd]")
+{
+  uint8_t const right_bw     = 48;
+  uint8_t const left_bw      = 2;
+  std::vector<uint16_t> dict = {0x1111, 0x2222, 0x3333, 0x4444};
+
+  uint32_t const N = 64;
+  std::vector<uint16_t> left_idx(N, 0);
+  std::vector<uint64_t> right_parts(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    right_parts[i] = i * 0x9ULL;
+  }
+
+  alprd_compressed_vector<double> cv;
+  cv.row_count    = N;
+  cv.left_indices = left_idx;
+  cv.right_parts  = right_parts;
+  cv.exception_left_values.push_back(0xDEAD);  // not in dict
+  cv.exception_positions.push_back(7);
+
+  std::vector<alprd_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alprd_block<double>(right_bw, left_bw, dict, vecs);
+  auto out   = decode_one_alprd<double>(bytes, F64, N);
+
+  for (uint32_t i = 0; i < N; ++i) {
+    uint64_t left_part     = (i == 7) ? 0xDEADULL : static_cast<uint64_t>(dict[0]);
+    uint64_t expected_bits = (left_part << right_bw) | right_parts[i];
+    double expected;
+    std::memcpy(&expected, &expected_bits, sizeof(double));
+    REQUIRE(out[i] == expected);
+  }
+}
+
+TEST_CASE("gpu_decode_table ALPRD - uncompressed-sentinel vector float", "[scan][decode][alprd]")
+{
+  uint32_t const N = 30;
+  std::vector<float> raw(N);
+  for (uint32_t i = 0; i < N; ++i)
+    raw[i] = std::sqrt(static_cast<float>(i + 1));
+
+  alprd_uncompressed_vector<float> uv;
+  uv.row_count = N;
+  uv.values    = raw;
+
+  std::vector<alprd_vector<float>> vecs;
+  vecs.emplace_back(std::move(uv));
+  // right_bw / left_bw / dict in the header are still present even on the
+  // uncompressed-sentinel path — the kernel skips them when it reads the
+  // 0xFFFF marker. Use any valid values.
+  auto bytes = make_alprd_block<float>(/*right_bw=*/24, /*left_bw=*/0, /*dict=*/{0u}, vecs);
+  auto out   = decode_one_alprd<float>(bytes, F32, N);
+
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == raw[i]);
+}
+
+//===----------------------------------------------------------------------===//
+// Defensive zero-fill guards — direct kernel call with 0xCC canary buffer.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+template <typename T>
+std::vector<T> decode_alp_invalid_with_canary(rmm::cuda_stream& stream,
+                                              rmm::mr::cuda_async_memory_resource& mr,
+                                              gpu_codec_run const& run,
+                                              cudf::data_type type,
+                                              uint32_t total_rows)
+{
+  std::vector<uint8_t> canary(size_t{total_rows} * sizeof(T), 0xCC);
+  rmm::device_buffer d_out(canary.data(), canary.size(), stream.view());
+  decode_alp_data(run, static_cast<uint8_t*>(d_out.data()), type, sizeof(T), stream.view(), mr);
+  return download<T>(d_out.data(), total_rows, stream.value());
+}
+
+template <typename T>
+std::vector<T> decode_alprd_invalid_with_canary(rmm::cuda_stream& stream,
+                                                rmm::mr::cuda_async_memory_resource& mr,
+                                                gpu_codec_run const& run,
+                                                cudf::data_type type,
+                                                uint32_t total_rows)
+{
+  std::vector<uint8_t> canary(size_t{total_rows} * sizeof(T), 0xCC);
+  rmm::device_buffer d_out(canary.data(), canary.size(), stream.view());
+  decode_alprd_data(run, static_cast<uint8_t*>(d_out.data()), type, sizeof(T), stream.view(), mr);
+  return download<T>(d_out.data(), total_rows, stream.value());
+}
+
+}  // namespace
+
+TEST_CASE("gpu_decode_table ALP - metadata_end past segment zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // Garbage segment with metadata_end = 1 GiB.
+  std::vector<uint8_t> bytes(64u, 0u);
+  uint32_t bogus = 1u << 30;
+  std::memcpy(bytes.data(), &bogus, sizeof(bogus));
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  uint32_t const total_rows = 32;
+  gpu_codec_run run{CompressionType::COMPRESSION_ALP,
+                    {gpu_segment_desc{static_cast<uint8_t const*>(d_seg.data()),
+                                      static_cast<uint32_t>(d_seg.size()),
+                                      0,
+                                      total_rows}}};
+  auto out = decode_alp_invalid_with_canary<double>(stream, mr, run, F64, total_rows);
+  for (uint32_t i = 0; i < total_rows; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALP - vector pointer below segment header zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // Build a valid-looking trailer where the vector pointer points back at
+  // metadata_end (out of range — pointer must be < metadata_end).
+  std::vector<uint8_t> bytes(32u, 0u);
+  uint32_t metadata_end = static_cast<uint32_t>(bytes.size());
+  std::memcpy(bytes.data(), &metadata_end, sizeof(metadata_end));
+  uint32_t bogus_ptr = metadata_end;  // invalid: pointer ≥ metadata_end
+  std::memcpy(bytes.data() + metadata_end - 4, &bogus_ptr, sizeof(bogus_ptr));
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  uint32_t const total_rows = 16;
+  gpu_codec_run run{CompressionType::COMPRESSION_ALP,
+                    {gpu_segment_desc{static_cast<uint8_t const*>(d_seg.data()),
+                                      static_cast<uint32_t>(d_seg.size()),
+                                      0,
+                                      total_rows}}};
+  auto out = decode_alp_invalid_with_canary<float>(stream, mr, run, F32, total_rows);
+  for (uint32_t i = 0; i < total_rows; ++i)
+    REQUIRE(out[i] == 0.0F);
+}
+
+TEST_CASE("gpu_decode_table ALP - bit_width > sizeof(T)*8 zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // Build a legitimate-looking ALP block but corrupt bit_width to 65 — the
+  // kernel must refuse and zero-fill rather than reading past the buffer.
+  uint32_t const N = 32;
+  std::vector<uint64_t> m(N, 0u);
+  alp_compressed_vector<double> cv;
+  cv.exponent     = 0;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 11;  // valid
+  cv.row_count    = N;
+  cv.mantissas    = m;
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alp_block<double>(vecs);
+
+  // Find the per-vector bit_width byte (offset 12 within the vector header,
+  // and the vector header starts at byte 4 in this single-vector block).
+  bytes[4 + 12] = 65;  // > 64 → invalid for double
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALP,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alp_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALP - exception payload past metadata_end zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // Construct a vector that claims 1000 exceptions in a 32-row block —
+  // payload trivially overshoots metadata_end. Kernel must zero-fill.
+  uint32_t const N = 32;
+  std::vector<uint64_t> m(N, 7u);
+  alp_compressed_vector<double> cv;
+  cv.exponent     = 0;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 4;
+  cv.row_count    = N;
+  cv.mantissas    = m;
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alp_block<double>(vecs);
+
+  // exceptions_count is at offset 4+2 (vector starts at 4, exc_count at +2).
+  uint16_t huge = 1000;
+  std::memcpy(bytes.data() + 4 + 2, &huge, sizeof(huge));
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALP,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alp_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALPRD - dict_size > MAX_DICTIONARY_SIZE zero-fills",
+          "[scan][decode][alprd][defensive]")
+{
+  // Hand-craft a minimum-shape ALPRD segment, then poison dict_size byte to
+  // 16 (> MAX_DICTIONARY_SIZE=8). Kernel must refuse and zero-fill.
+  std::vector<uint16_t> dict = {0x1111, 0x2222};  // legitimate
+  alprd_uncompressed_vector<double> uv;
+  uv.row_count = 8;
+  uv.values    = std::vector<double>(8, 1.5);
+  std::vector<alprd_vector<double>> vecs;
+  vecs.emplace_back(std::move(uv));
+  auto bytes = make_alprd_block<double>(/*right_bw=*/48, /*left_bw=*/1, dict, vecs);
+  bytes[6]   = 16;  // poison dict_size
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  uint32_t const N = 8;
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALPRD,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alprd_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALP - factor > 18 zero-fills", "[scan][decode][alp][defensive]")
+{
+  // Build a valid ALP block then poison the factor byte (offset 1 within
+  // the vector header) to 19 — past `d_alp_fact[19]`.
+  uint32_t const N = 32;
+  std::vector<uint64_t> m(N, 0u);
+  alp_compressed_vector<double> cv;
+  cv.exponent     = 0;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 4;
+  cv.row_count    = N;
+  cv.mantissas    = m;
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes   = make_alp_block<double>(vecs);
+  bytes[4 + 1] = 19;  // poison factor
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALP,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alp_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALP - exponent > MAX_EXPONENT zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // f32 MAX_EXPONENT = 10. Set exponent = 11 — would overshoot d_alp_frac_f32[11].
+  uint32_t const N = 32;
+  std::vector<uint64_t> m(N, 0u);
+  alp_compressed_vector<float> cv;
+  cv.exponent     = 0;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 4;
+  cv.row_count    = N;
+  cv.mantissas    = m;
+  std::vector<alp_vector<float>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes   = make_alp_block<float>(vecs);
+  bytes[4 + 0] = 11;  // poison exponent for float (max is 10)
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALP,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alp_invalid_with_canary<float>(stream, mr, run, F32, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0F);
+}
+
+TEST_CASE("gpu_decode_table ALP - vector pointer way past metadata_end zero-fills",
+          "[scan][decode][alp][defensive]")
+{
+  // Build a valid ALP block then poison the trailer pointer to land far
+  // past metadata_end. Tests the strict `data_off >= metadata_end` bound
+  // (existing `pointer == metadata_end` test only hits the boundary).
+  uint32_t const N = 16;
+  std::vector<uint64_t> m(N, 0u);
+  alp_compressed_vector<double> cv;
+  cv.exponent     = 0;
+  cv.factor       = 0;
+  cv.frame_of_ref = 0;
+  cv.bit_width    = 4;
+  cv.row_count    = N;
+  cv.mantissas    = m;
+  std::vector<alp_vector<double>> vecs;
+  vecs.emplace_back(std::move(cv));
+  auto bytes = make_alp_block<double>(vecs);
+
+  uint32_t metadata_end;
+  std::memcpy(&metadata_end, bytes.data(), sizeof(metadata_end));
+  uint32_t bogus = metadata_end + 1024u;
+  std::memcpy(bytes.data() + metadata_end - 4, &bogus, sizeof(bogus));
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALP,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alp_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+TEST_CASE("gpu_decode_table ALPRD - right_bw > sizeof(T)*8 zero-fills",
+          "[scan][decode][alprd][defensive]")
+{
+  // Poison right_bw to 65 for a double segment — exceeds storage width.
+  std::vector<uint16_t> dict = {0u};
+  alprd_uncompressed_vector<double> uv;
+  uv.row_count = 4;
+  uv.values    = std::vector<double>(4, 2.5);
+  std::vector<alprd_vector<double>> vecs;
+  vecs.emplace_back(std::move(uv));
+  auto bytes = make_alprd_block<double>(/*right_bw=*/64, /*left_bw=*/0, dict, vecs);
+  bytes[4]   = 65;  // poison right_bw
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  uint32_t const N = 4;
+  gpu_codec_run run{
+    CompressionType::COMPRESSION_ALPRD,
+    {gpu_segment_desc{
+      static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, N}}};
+  auto out = decode_alprd_invalid_with_canary<double>(stream, mr, run, F64, N);
+  for (uint32_t i = 0; i < N; ++i)
+    REQUIRE(out[i] == 0.0);
+}
+
+//===----------------------------------------------------------------------===//
+// Bench-scale verify TEST_CASEs — one per microbench shape in
+// bench_decode_codecs.cpp, asserting every output row against a host model.
+// Bench discards its output, so silent-miscompile coverage at scale lives here.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("gpu_decode_table ALP bench-scale - f64 bw=11 verify", "[scan][decode][alp][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS   = 32u * 1024u;
+  constexpr uint32_t ROWS     = N_VECS * 1024u;
+  constexpr uint8_t BIT_WIDTH = 11u;
+  uint64_t const mask         = (uint64_t{1} << BIT_WIDTH) - 1u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, BIT_WIDTH);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F64, ROWS, CompressionType::COMPRESSION_ALP, {segment(d_seg, 0, ROWS)});
+
+  verify_decoded_column<double>(stream.view(), mr, col, [mask](uint32_t row) {
+    uint32_t const v = row >> 10;
+    uint32_t const i = row & 1023u;
+    return static_cast<double>(static_cast<int64_t>((uint64_t{i} ^ uint64_t{v}) & mask));
+  });
+}
+
+TEST_CASE("gpu_decode_table ALP bench-scale - f32 bw=20 verify", "[scan][decode][alp][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS   = 32u * 1024u;
+  constexpr uint32_t ROWS     = N_VECS * 1024u;
+  constexpr uint8_t BIT_WIDTH = 20u;
+  uint64_t const mask         = (uint64_t{1} << BIT_WIDTH) - 1u;
+
+  auto seg_bytes = synth_alp_segment<float>(N_VECS, BIT_WIDTH);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F32, ROWS, CompressionType::COMPRESSION_ALP, {segment(d_seg, 0, ROWS)});
+
+  verify_decoded_column<float>(stream.view(), mr, col, [mask](uint32_t row) {
+    uint32_t const v = row >> 10;
+    uint32_t const i = row & 1023u;
+    return static_cast<float>(static_cast<int64_t>((uint64_t{i} ^ uint64_t{v}) & mask));
+  });
+}
+
+TEST_CASE("gpu_decode_table ALPRD bench-scale - f64 r48/l3 verify", "[scan][decode][alprd][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS  = 32u * 1024u;
+  constexpr uint32_t ROWS    = N_VECS * 1024u;
+  constexpr uint8_t RIGHT_BW = 48u;
+  constexpr uint8_t LEFT_BW  = 3u;
+  std::vector<uint16_t> dict = {0xAAAA, 0x5555, 0x1234, 0xABCD, 0xDEAD, 0xBEEF, 0xCAFE, 0xF00D};
+
+  auto seg_bytes = synth_alprd_segment<double>(N_VECS, RIGHT_BW, LEFT_BW, dict);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F64, ROWS, CompressionType::COMPRESSION_ALPRD, {segment(d_seg, 0, ROWS)});
+
+  uint64_t const r_mask = (uint64_t{1} << RIGHT_BW) - 1u;
+  uint16_t const l_mask = static_cast<uint16_t>((uint16_t{1} << LEFT_BW) - 1u);
+  verify_decoded_column<double>(stream.view(), mr, col, [&dict, r_mask, l_mask](uint32_t row) {
+    uint32_t const v          = row >> 10;
+    uint32_t const i          = row & 1023u;
+    uint32_t const left_idx   = (i ^ v) & l_mask;
+    uint64_t const right_part = (uint64_t{i} * 0x9E3779B97F4A7C15ULL) & r_mask;
+    uint64_t const bits       = (uint64_t{dict[left_idx]} << RIGHT_BW) | right_part;
+    double d;
+    std::memcpy(&d, &bits, sizeof(d));
+    return d;
+  });
+}
+
+// Power-of-2 / byte-aligned widths. The bw=11/20/r48-l3 cases above stress the
+// 64-bit-straddle path; these mirror the byte-aligned shapes that ALP-encoded
+// TPC-H integer-derived columns hit far more often than odd widths.
+
+TEST_CASE("gpu_decode_table ALP bench-scale - f64 bw=8 verify", "[scan][decode][alp][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS   = 32u * 1024u;
+  constexpr uint32_t ROWS     = N_VECS * 1024u;
+  constexpr uint8_t BIT_WIDTH = 8u;
+  uint64_t const mask         = (uint64_t{1} << BIT_WIDTH) - 1u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, BIT_WIDTH);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F64, ROWS, CompressionType::COMPRESSION_ALP, {segment(d_seg, 0, ROWS)});
+
+  verify_decoded_column<double>(stream.view(), mr, col, [mask](uint32_t row) {
+    uint32_t const v = row >> 10;
+    uint32_t const i = row & 1023u;
+    return static_cast<double>(static_cast<int64_t>((uint64_t{i} ^ uint64_t{v}) & mask));
+  });
+}
+
+TEST_CASE("gpu_decode_table ALP bench-scale - f64 bw=16 verify", "[scan][decode][alp][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS   = 32u * 1024u;
+  constexpr uint32_t ROWS     = N_VECS * 1024u;
+  constexpr uint8_t BIT_WIDTH = 16u;
+  uint64_t const mask         = (uint64_t{1} << BIT_WIDTH) - 1u;
+
+  auto seg_bytes = synth_alp_segment<double>(N_VECS, BIT_WIDTH);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F64, ROWS, CompressionType::COMPRESSION_ALP, {segment(d_seg, 0, ROWS)});
+
+  verify_decoded_column<double>(stream.view(), mr, col, [mask](uint32_t row) {
+    uint32_t const v = row >> 10;
+    uint32_t const i = row & 1023u;
+    return static_cast<double>(static_cast<int64_t>((uint64_t{i} ^ uint64_t{v}) & mask));
+  });
+}
+
+TEST_CASE("gpu_decode_table ALP bench-scale - f32 bw=32 verify", "[scan][decode][alp][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS   = 32u * 1024u;
+  constexpr uint32_t ROWS     = N_VECS * 1024u;
+  constexpr uint8_t BIT_WIDTH = 32u;
+
+  auto seg_bytes = synth_alp_segment<float>(N_VECS, BIT_WIDTH);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F32, ROWS, CompressionType::COMPRESSION_ALP, {segment(d_seg, 0, ROWS)});
+
+  // bw=32 covers the full f32 mantissa width; no mask needed.
+  verify_decoded_column<float>(stream.view(), mr, col, [](uint32_t row) {
+    uint32_t const v = row >> 10;
+    uint32_t const i = row & 1023u;
+    return static_cast<float>(static_cast<int64_t>(uint64_t{i} ^ uint64_t{v}));
+  });
+}
+
+TEST_CASE("gpu_decode_table ALPRD bench-scale - f64 r56/l2 verify", "[scan][decode][alprd][verify]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  constexpr uint32_t N_VECS  = 32u * 1024u;
+  constexpr uint32_t ROWS    = N_VECS * 1024u;
+  constexpr uint8_t RIGHT_BW = 56u;
+  constexpr uint8_t LEFT_BW  = 2u;
+  std::vector<uint16_t> dict = {0xAAAA, 0x5555, 0x1234, 0xABCD};
+
+  auto seg_bytes = synth_alprd_segment<double>(N_VECS, RIGHT_BW, LEFT_BW, dict);
+  auto d_seg     = upload(seg_bytes, stream.view());
+  auto col =
+    one_codec_column(F64, ROWS, CompressionType::COMPRESSION_ALPRD, {segment(d_seg, 0, ROWS)});
+
+  uint64_t const r_mask = (uint64_t{1} << RIGHT_BW) - 1u;
+  uint16_t const l_mask = static_cast<uint16_t>((uint16_t{1} << LEFT_BW) - 1u);
+  verify_decoded_column<double>(stream.view(), mr, col, [&dict, r_mask, l_mask](uint32_t row) {
+    uint32_t const v          = row >> 10;
+    uint32_t const i          = row & 1023u;
+    uint32_t const left_idx   = (i ^ v) & l_mask;
+    uint64_t const right_part = (uint64_t{i} * 0x9E3779B97F4A7C15ULL) & r_mask;
+    uint64_t const bits       = (uint64_t{dict[left_idx]} << RIGHT_BW) | right_part;
+    double d;
+    std::memcpy(&d, &bits, sizeof(d));
+    return d;
+  });
+}


### PR DESCRIPTION
# Summary

GPU decode kernels for DuckDB's ALP (Adaptive Lossless floating-Point) and ALPRD (Real Doubles) codecs. ALP encodes float values as bitpacked integer mantissas with a per-vector factor / exponent / frame-of-reference plus an exception list; ALPRD (the fallback for floats ALP can't compress) splits the raw float bit-pattern into a small dictionary-coded high part and a variable-width low part. One CTA decodes one 1024-row vector. Sibling of #737, #764; stacks on #736.

## DuckDB ALP on-disk format

```
ALP segment (one segment holds N 1024-row "vectors"):

byte 0   4                                 metadata_end          seg_end
│        │                                 │                     │
├─uint32─┼─── per-vector data (forward) ───┼── trailer table ────┤
│ end    │                                 │  uint32[N], V at    │
│        │                                 │  metadata_end-(V+1)*4
└─offset of metadata_end
```

```
ALP per-vector (compressed) — 13-byte header + bitstream + exceptions:

┌───┬───┬─────┬────────────────┬──┬────────────────┬───────┬─────────┐
│exp│fac│ ec  │ FOR (uint64)   │bw│ packed uint64  │ exc   │ exc pos │
│ u8│ u8│ u16 │                │u8│ mantissas      │ T[ec] │ u16[ec] │
└───┴───┴─────┴────────────────┴──┴────────────────┴───────┴─────────┘
0   1   2     4               12  13              ↑       ↑
                                                  │       │
                            bitstream = round_up(rows,32)*bw/8 bytes
```

- `exp == 0xFF` → uncompressed-sentinel: 1-byte `0xFF` then raw `T[rows]`.
- `bw ≤ sizeof(T)*8`. Exception positions bound-checked against `fill_rows`.
- Bitstream is padded to 32-row groups (`BitpackingPrimitives::GetRequiredSize`).

## DuckDB ALPRD on-disk format

```
ALPRD segment (small dict header lives between metadata_end and trailer):

byte 0   4   5   6   7                                 metadata_end ↘
│        │   │   │   │                                 │             │
├─uint32─┼─u8┼─u8┼─u8┼── uint16 dict[dict_size] ───────┼── per-vec ──┤
│ end    │ rb│ lb│ds │ (≤ 8 entries, lb ≤ 3)           │  data       │
└─offset
```

```
ALPRD per-vector (compressed) — 2-byte header + two bitstreams + exceptions:

┌─────┬───────────────────┬─────────────────────┬───────┬─────────┐
│ ec  │ left dict-idx     │ right parts         │ exc   │ exc pos │
│ u16 │ (lb-bit packed)   │ (rb-bit packed,     │ left  │ u16[ec] │
│     │                   │  EXACT_T = u32/u64) │ u16[] │         │
└─────┴───────────────────┴─────────────────────┴───────┴─────────┘
0     2
```

- `ec == 0xFFFF` → uncompressed-sentinel: 2-byte `0xFFFF` then raw `EXACT_T[rows]`.
- Reconstructed bits = `(uint64_t)dict[left_idx] << rb | right_part`, bit-cast to `T`.

## The decode in one picture

ALP, vector with `bw=11`, `exp=2`, `fac=0`, `FOR=100`:

```
packed mantissas (11-bit each):  [m₀ m₁ m₂ ... m₁₀₂₃]
                                          │
                                          ▼  unpack(idx, bw=11)
                                       (uint64 mantissa)
                                          │
                                          ▼  + FOR   (unsigned wrap; cast to int64)
                                       enc_int64
                                          │
                                          ▼  × FACT[fac]   × FRAC<T>[exp]
                                       T plain
                                          │
                                          ▼  __stwt
                                     out[row_offset + idx]

then, for each (pos, exc_value) in exception list:
    __stwt out[row_offset + pos] := exc_value     (bound-checked)
```

ALPRD, vector with `rb=48`, `lb=3`, `dict_size=8`:

```
left bitstream (3-bit):  [l₀ l₁ l₂ ...]   right bitstream (48-bit):  [r₀ r₁ r₂ ...]
                            │                                            │
                            ▼  unpack(idx, lb)                            ▼  unpack(idx, rb)
                          left_idx (0..7)                               right_part
                            │                                            │
                            ▼  bound-check < sh_dict_size                │
                          dict[left_idx]   (uint16, zero-extended)       │
                            │                                            │
                            └────────────────┬───────────────────────────┘
                                             ▼  (left_val << rb) | right_part
                                          uint64_t bits
                                             │
                                             ▼  memcpy → double / float
                                          plain T
                                             │
                                             ▼  __stwt  out[row_offset + idx]
```

## Per-vector pipeline — single kernel, one CTA per vector

```
HOST                          STREAM (one CUDA stream)
─────                         ─────────────────────────
build_vector_descs(run)
  expands segments → vectors
descs[N_VECS]   ────H2D────▶ kernel_decode_alp<T>      (or kernel_decode_alprd)
                               │  blockIdx.x = vid
                               │  thread 0:  parse header → shmem broadcast
                               │  __syncthreads
                               │  cooperative gmem→shmem stage of bitstream(s)
                               │  __syncthreads
                               │  every thread:  unpack → arith → __stwt
                               │  __syncthreads (only if exceptions exist)
                               │  exception scatter (bound-checked positions)
                               ▼
                             d_output (the column)
```

`build_vector_descs` runs on the host: walks the segment trailer table, expands `[seg, V]` into a flat list of per-vector launch descriptors. The kernel sees one CTA per vector.

## Decode kernel — header parse, cooperative stage, parallel decode

Each CTA owns one 1024-row vector. `BLOCK_DIM = 256` threads per CTA.

### Single-thread metadata parse

Vector header is 13 bytes (ALP) or 2 bytes (ALPRD-vector) starting at a runtime byte offset. Thread 0 walks the header, validates every field against the trusted `desc.vec_row_count`, publishes results through static-shmem scalars (`sh_invalid`, `sh_data_off`, `sh_exp`, `sh_fac`, `sh_for`, `sh_bw`, `sh_packed_bytes`). All other threads wait at the `__syncthreads` that follows. Cheap on this workload — the header is ~50 reads per CTA and the kernel is occupancy-saturated, so the SM hides the parse behind other CTAs' compute.

### Cooperative gmem→shmem stage

```
gmem packed bitstream:  [···bytes···][···bytes···][···bytes···]
                              │  (not 4-byte aligned in general)
                              ▼  cooperative copy
shmem packed_words[]:   [w₀ w₁ w₂ … w_live]│[guard][guard]
                                            └─ 2 guard words for the
                                               64-bit straddle case
                                               of unpack_from_shmem
```

Each thread reads one `uint32` per iteration via `memcpy(&v, src + off, 4)` (the canonical cross-arch idiom for unaligned uint32 load — nvcc lowers to `ld.u32`). `cg::memcpy_async` with `cuda::aligned_size_t<N>` would be the more portable primitive but isn't usable here: `packed_bytes = vp + 13u` is provably only 1-byte aligned (the per-vector header pushes the bitstream off any wider boundary), so the alignment hint can't be passed and the API falls back to byte-granularity loads on sm_75. Comment in `stage_bytes_to_shmem` explains the choice.

### Parallel decode loop

```cpp
for (i = threadIdx.x; i < fill_rows; i += blockDim.x) {
    u    = unpack_from_shmem<uint64_t>(shmem, i, bw);   // 3-word read + shift + mask
    enc  = (int64_t)(u + sh_for);                       // unsigned wrap, then sign
    plain = (T)enc * d_alp_fact[sh_fac] * alp_frac<T>[sh_exp];
    __stwt(out + i, plain);
}
```

ALPRD's loop is the same shape but unpacks two streams (`right_words` and `left_words`), gathers `sh_dict[left_idx]`, and combines the bits before bit-casting to `T`.

`__stwt` is "store with no L1 cache" — output is write-once, never reread by this kernel. ALPRD's exception scatter does re-read `out[pos]` to recover the right-bits, which is correct because `__stwt` invalidates the issuing SM's L1 line, so the post-`__syncthreads` read refills from L2 with the freshly written value.

## Malformed input → zero-fill

`sh_invalid == true` is the universal sentinel collapsing every malformed class. The kernel zero-fills `desc.vec_row_count` rows using the host-supplied (trusted) row count and returns. Output buffer is uninitialised by the dispatcher, so this is the only thing between a corrupt segment and leaking prior device contents.

| Codec | Detected by | Condition |
|---|---|---|
| ALP / ALPRD | header parse | `seg_bytes < 4` |
| ALP / ALPRD | header parse | `metadata_end > seg_bytes` or `metadata_end < trailer_need` |
| ALP / ALPRD | header parse | `data_off < 4` or `data_off >= metadata_end` |
| ALP | per-vector | `bw > sizeof(T)*8` |
| ALP | per-vector | exception payload past `metadata_end` |
| ALP | per-vector | `factor > 18` or `exponent > MAX_EXPONENT` (10 / f32, 18 / f64) — keeps `d_alp_fact` / `alp_frac<T>` in-bounds |
| ALPRD | header parse | `right_bw > sizeof(T)*8` |
| ALPRD | header parse | `left_bw > 3` |
| ALPRD | header parse | `dict_size > MAX_DICTIONARY_SIZE` (= 8) |
| ALP / ALPRD | uncompressed sentinel | raw values would overrun `metadata_end` |
| ALPRD | dict gather | corrupt `left_idx >= sh_dict_size` → reads `EXACT_T(0)` (sh_dict is zero-init) |

## Test coverage

`test/cpp/scan/test_gpu_decode_alp.cpp`:
- ALP happy-path: single compressed vector (f64, factor/exponent ≠ 0); single compressed vector with exceptions (f32); uncompressed-sentinel; multi-vector segment crossing the 1024-row boundary
- ALPRD happy-path: canonical layout (f64); exception left-part patches; uncompressed-sentinel (f32)
- 8 canary defensive tests (pre-fill output 0xCC, REQUIRE every byte zero post-decode) covering each malformed-input class above
- 7 bench-scale verify cases (one per microbench shape) that reproduce the bench segment layout and assert every output row against a host model — guards against silent miscompiles since the bench discards its decoded output

`test/cpp/scan/bench_decode_codecs.cpp` adds 7 microbenches:
- ALP f64 bw=8 / 11 / 16, ALP f32 bw=20 / 32, ALPRD f64 r48/l3 + r56/l2

`test/data/decode_baselines/sm75.json` populated with median-of-3 throughputs as a regression gate.