### PR TITLE
feat(pin_table): support tier='host' for host-tier caching

### DIFF
--- a/src/include/memory/multiple_blocks_allocation_accessor.hpp
+++ b/src/include/memory/multiple_blocks_allocation_accessor.hpp
@@ -66,7 +66,12 @@ struct multiple_blocks_allocation_accessor {
    * @param[in] allocation The multiple blocks allocation.
    * @throws std::runtime_error if the block size is not a multiple of the size of T.
    */
-  void initialize(size_t byte_offset, std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  /// Templated on the smart-pointer type so callers can pass either
+  /// std::unique_ptr<...> (the duckdb/parquet scan task path that owns the
+  /// allocation) or std::shared_ptr<...> (the host_table_chunk_reader path,
+  /// where cucascade now hands out shared host_table_allocation buffers).
+  template <typename Ptr>
+  void initialize(size_t byte_offset, Ptr const& allocation)
   {
     assert(allocation != nullptr);
 
@@ -115,7 +120,8 @@ struct multiple_blocks_allocation_accessor {
    * @param[in] value The value to set.
    * @param[in, out] allocation The allocation.
    */
-  void set_current(T value, std::unique_ptr<multiple_blocks_allocation>& allocation)
+  template <typename Ptr>
+  void set_current(T value, Ptr& allocation)
   {
     assert(block_index < num_blocks);
     assert(allocation != nullptr);
@@ -134,9 +140,8 @@ struct multiple_blocks_allocation_accessor {
    * @tparam S The type to which to cast the value.
    * @param[in] allocation The allocation.
    */
-  template <typename S>
-  [[nodiscard]] S get_current_as(
-    std::unique_ptr<multiple_blocks_allocation> const& allocation) const
+  template <typename S, typename Ptr>
+  [[nodiscard]] S get_current_as(Ptr const& allocation) const
   {
     D_ASSERT(block_index < num_blocks);
     D_ASSERT(allocation != nullptr);
@@ -155,7 +160,8 @@ struct multiple_blocks_allocation_accessor {
    *
    * @param[in] allocation The allocation.
    */
-  [[nodiscard]] T get_current(std::unique_ptr<multiple_blocks_allocation> const& allocation) const
+  template <typename Ptr>
+  [[nodiscard]] T get_current(Ptr const& allocation) const
   {
     return get_current_as<underlying_type>(allocation);
   }
@@ -163,8 +169,8 @@ struct multiple_blocks_allocation_accessor {
   /**
    * @brief Get the value at a specific offset position from the initial offset.
    */
-  [[nodiscard]] T get(size_t offset,
-                      const std::unique_ptr<multiple_blocks_allocation>& allocation) const
+  template <typename Ptr>
+  [[nodiscard]] T get(size_t offset, Ptr const& allocation) const
   {
     size_t global_offset        = initial_byte_offset + sizeof(T) * offset;
     size_t temp_block_index     = global_offset / allocation->block_size();
@@ -209,7 +215,8 @@ struct multiple_blocks_allocation_accessor {
    * @param[in] bytes The number of consecutive values to set.
    * @param[in, out] allocation The allocation.
    */
-  void memset(uint8_t val, size_t bytes, std::unique_ptr<multiple_blocks_allocation>& allocation)
+  template <typename Ptr>
+  void memset(uint8_t val, size_t bytes, Ptr& allocation)
   {
     size_t bytes_set = 0;
     while (bytes_set < bytes) {
@@ -235,9 +242,8 @@ struct multiple_blocks_allocation_accessor {
    * @param[in] bytes Number of bytes to copy from the source buffer.
    * @param[in, out] allocation The allocation.
    */
-  void memcpy_from(void const* src,
-                   size_t bytes,
-                   std::unique_ptr<multiple_blocks_allocation>& allocation)
+  template <typename Ptr>
+  void memcpy_from(void const* src, size_t bytes, Ptr& allocation)
   {
     size_t bytes_copied = 0;
     // Loop over blocks into which to copy the src
@@ -266,9 +272,8 @@ struct multiple_blocks_allocation_accessor {
    * @param[in] dest Pointer to the destination buffer.
    * @param[in] bytes Number of bytes to copy to the destination buffer.
    */
-  void memcpy_to(std::unique_ptr<multiple_blocks_allocation> const& allocation,
-                 void* dest,
-                 size_t bytes)
+  template <typename Ptr>
+  void memcpy_to(Ptr const& allocation, void* dest, size_t bytes)
   {
     size_t bytes_copied = 0;
     // Loop over blocks from which to copy the data

--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -83,7 +83,7 @@ class host_table_chunk_reader {
      * @param[in] allocation The multiple blocks allocation containing the column data
      */
     column_reader(cucascade::memory::column_metadata const& col,
-                  std::unique_ptr<multiple_blocks_allocation> const& allocation);
+                  std::shared_ptr<multiple_blocks_allocation> const& allocation);
 
     /**
      * @brief Copy the null mask to the duckdb validity mask for the given row range
@@ -96,7 +96,7 @@ class host_table_chunk_reader {
     void copy_mask_to_validity(duckdb::ValidityMask& validity,
                                size_t row_offset,
                                size_t count,
-                               std::unique_ptr<multiple_blocks_allocation> const& allocation);
+                               std::shared_ptr<multiple_blocks_allocation> const& allocation);
 
     /**
      * @brief Copy fixed-width data into the duckdb vector for the given row range
@@ -109,7 +109,7 @@ class host_table_chunk_reader {
     void copy_fixed_width(duckdb::Vector& vector,
                           size_t row_offset,
                           size_t count,
-                          std::unique_ptr<multiple_blocks_allocation> const& allocation);
+                          std::shared_ptr<multiple_blocks_allocation> const& allocation);
 
     /**
      * @brief Copy string data into the duckdb vector for the given row range
@@ -122,7 +122,7 @@ class host_table_chunk_reader {
     void copy_string(duckdb::Vector& vector,
                      size_t row_offset,
                      size_t count,
-                     std::unique_ptr<multiple_blocks_allocation> const& allocation);
+                     std::shared_ptr<multiple_blocks_allocation> const& allocation);
   };
 
  public:
@@ -163,7 +163,7 @@ class host_table_chunk_reader {
 
  private:
   duckdb::ClientContext& _client_ctx;  ///< The duckdb client context (for allocation)
-  std::unique_ptr<multiple_blocks_allocation> const&
+  std::shared_ptr<multiple_blocks_allocation> const&
     _allocation;  ///< The multiple blocks allocation for the data batch
   duckdb::vector<duckdb::LogicalType> _types;  ///< The duckdb logical types for each column
   size_t _total_rows{0};                       ///< The total number of rows in the data batch

--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 // sirius
+#include <data/sirius_converter_registry.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
 #include <op/scan/scan_plan.hpp>
 #include <op/sirius_physical_operator.hpp>
@@ -30,6 +31,7 @@
 // cucascade
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/common.hpp>
 
 // standard library
 #include <cstddef>
@@ -203,10 +205,37 @@ class scan_cached_operator_data : public op::operator_data {
   {
   }
 
+  /**
+   * @brief Move host-tier cached batches onto the requested GPU memory space.
+   *
+   * pin_table tier='host' wraps the cached chunks as host_data_representation; the
+   * scan operator's execute() expects gpu_table_representation, so we convert here
+   * (when the gpu_pipeline_executor has already reserved the target memory space).
+   * GPU-resident batches need no work — execute() consumes them directly.
+   */
+  void prepare_for_processing(const ::cucascade::memory::memory_space* requested_memory_space,
+                              rmm::cuda_stream_view stream) override
+  {
+    if (!batch || !requested_memory_space) { return; }
+    {
+      auto ro = batch->to_read_only();
+      if (!ro.get_data() || ro.get_current_tier() == ::cucascade::memory::Tier::GPU) { return; }
+    }
+    auto& registry = ::sirius::converter_registry::get();
+    auto mut       = batch->to_mutable();
+    mut.convert_to<cucascade::gpu_table_representation>(registry, requested_memory_space, stream);
+  }
+
   [[nodiscard]] std::size_t get_estimated_size_in_bytes() const override
   {
-    auto ro = batch->to_read_only();
-    return ro.get_data()->cast<cucascade::gpu_table_representation>().get_size_in_bytes();
+    // Use the generic representation accessor so this works for both GPU-resident
+    // batches and host_data_representation batches that prepare_for_processing
+    // will upgrade to GPU. Sizes are close enough between tiers to size the
+    // task's memory reservation.
+    auto ro          = batch->to_read_only();
+    auto const* data = ro.get_data();
+    if (!data) { return 0; }
+    return data->get_size_in_bytes();
   }
 
   /// Cached data batch viewed by the scan. Owning shared_ptr keeps the pinned

--- a/src/include/scan_manager/cached_split_provider.hpp
+++ b/src/include/scan_manager/cached_split_provider.hpp
@@ -21,9 +21,11 @@
 
 #include <cudf/column/column.hpp>
 
+#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/planner/expression.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <vector>
 
@@ -53,15 +55,33 @@ namespace sirius::scan_manager {
  */
 class cached_split_provider : public split_provider {
  public:
+  /// GPU-tier constructor: the pinned columns are GPU-resident cudf columns. start()
+  /// emits one zero-copy gpu_table_representation per batch.
   cached_split_provider(std::vector<std::vector<std::shared_ptr<cudf::column>>> columns_per_request,
                         cucascade::memory::memory_space& memory_space,
                         std::shared_ptr<duckdb::Expression> filter_expression,
                         std::shared_ptr<op::scan::scan_plan const> plan);
 
+  /// HOST-tier constructor: each chunk in @p host_chunks is a host_data_representation
+  /// holding all pinned columns. @p column_indices selects the columns required by the
+  /// scan in scan_plan D-order. start() slices each chunk by these indices and emits
+  /// one host_data_representation-backed batch per chunk; conversion to GPU happens
+  /// downstream in scan_cached_operator_data::prepare_for_processing.
+  cached_split_provider(
+    std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
+    std::vector<std::size_t> column_indices,
+    cucascade::memory::memory_space& memory_space,
+    std::shared_ptr<duckdb::Expression> filter_expression,
+    std::shared_ptr<op::scan::scan_plan const> plan);
+
   std::future<void> start(exec::thread_pool& pool, split_connector& connector) override;
 
  private:
+  // Populated when constructed via the GPU constructor; empty in HOST mode.
   std::vector<std::vector<std::shared_ptr<cudf::column>>> _columns_per_request;
+  // Populated when constructed via the HOST constructor; empty in GPU mode.
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> _host_chunks;
+  std::vector<std::size_t> _column_indices;
   cucascade::memory::memory_space* _memory_space;
   std::shared_ptr<duckdb::Expression> _filter_expression;
   std::shared_ptr<op::scan::scan_plan const> _plan;

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -23,6 +23,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 
+#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 #include <memory>
@@ -54,9 +55,18 @@ struct pinned_entry {
   /// this list to match an incoming scan operator's parquet_scan_info::file_paths
   /// against this entry, so it can swap in a cached split provider.
   std::vector<std::string> file_paths;
+  /// GPU-tier storage: one chunk vector per pinned column name. Populated by
+  /// @ref sirius_scan_manager::insert_pinned_entry. Empty when @ref tier is HOST.
   std::unordered_map<std::string, std::vector<std::shared_ptr<cudf::column>>>
     data_batches_by_column;
-  /// Memory space the pinned columns reside in. Captured at pin time so the
+  /// HOST-tier storage: one host_data_representation per chunk, each holding all
+  /// pinned columns. The cached_split_provider slices these by column index when
+  /// serving a particular scan. Populated by @ref insert_pinned_entry_host.
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
+  /// Tier the pinned data resides in. Drives which storage member above is used
+  /// and which cached_split_provider variant @ref create_provider_for builds.
+  cucascade::memory::Tier tier{cucascade::memory::Tier::GPU};
+  /// Memory space the pinned data resides in. Captured at pin time so the
   /// cached_split_provider can wrap copied tables as data_batch instances.
   cucascade::memory::memory_space* memory_space{nullptr};
   /// Total number of rows across all pinned chunks. Used by insert_pinned_entry
@@ -136,6 +146,28 @@ class sirius_scan_manager {
                            std::vector<std::string> file_paths,
                            std::vector<std::unique_ptr<cudf::table>> data_tables,
                            cucascade::memory::memory_space& memory_space);
+
+  /// \brief Pin the entry for a table on the host tier.
+  ///
+  /// Each entry in @p host_chunks describes one batch's worth of pinned data
+  /// (covering all pinned columns) as a host_data_representation. The
+  /// cached_split_provider built from this entry slices each chunk by column
+  /// index at scan time. Re-insert with a different row count drops the
+  /// existing entry; otherwise the call replaces the entry's chunks.
+  ///
+  /// \param name          Table name key.
+  /// \param column_names  Column names in the order the chunks were captured (i.e.
+  ///                      the i-th column in each host_data_representation
+  ///                      corresponds to @c column_names[i]).
+  /// \param file_paths    Resolved file paths captured at pin time.
+  /// \param host_chunks   One host_data_representation per emitted batch.
+  /// \param memory_space  Host memory space the chunks reside in.
+  void insert_pinned_entry_host(
+    const std::string& name,
+    std::vector<std::string> column_names,
+    std::vector<std::string> file_paths,
+    std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
+    cucascade::memory::memory_space& memory_space);
 
   /// \brief Remove the pinned entry for @p name. No-op if absent.
   void remove_pinned_entry(const std::string& name);

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -35,7 +35,7 @@ namespace sirius::op::result {
 
 host_table_chunk_reader::column_reader::column_reader(
   cucascade::memory::column_metadata const& col,
-  std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  std::shared_ptr<multiple_blocks_allocation> const& allocation)
 {
   if (allocation == nullptr || allocation->block_size() == 0) {
     throw std::runtime_error(
@@ -70,7 +70,7 @@ void host_table_chunk_reader::column_reader::copy_mask_to_validity(
   duckdb::ValidityMask& validity,
   size_t row_offset,
   size_t count,
-  std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  std::shared_ptr<multiple_blocks_allocation> const& allocation)
 {
   assert(row_offset + count <= static_cast<size_t>(size));
   assert(utils::mod_8(row_offset) == 0);  // Must be byte-aligned start
@@ -87,7 +87,7 @@ void host_table_chunk_reader::column_reader::copy_fixed_width(
   duckdb::Vector& vector,
   size_t row_offset,
   size_t count,
-  std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  std::shared_ptr<multiple_blocks_allocation> const& allocation)
 {
   assert(vector.GetType().InternalType() != duckdb::PhysicalType::VARCHAR);
   assert(row_offset + count <= static_cast<size_t>(size));
@@ -115,7 +115,7 @@ namespace detail {
 template <bool HasNulls, typename OffsetType>
 void make_duckdb_strings(
   memory::multiple_blocks_allocation_accessor<OffsetType>& offset_accessor,
-  std::unique_ptr<
+  std::shared_ptr<
     cucascade::memory::fixed_size_host_memory_resource::multiple_blocks_allocation> const&
     allocation,
   duckdb::Vector& vector,
@@ -168,7 +168,7 @@ void host_table_chunk_reader::column_reader::copy_string(
   duckdb::Vector& vector,
   size_t row_offset,
   size_t count,
-  std::unique_ptr<multiple_blocks_allocation> const& allocation)
+  std::shared_ptr<multiple_blocks_allocation> const& allocation)
 {
   assert(vector.GetType().InternalType() == duckdb::PhysicalType::VARCHAR);
   assert(row_offset + count <= static_cast<size_t>(size));

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -102,7 +102,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
     return std::make_shared<cucascade::data_batch>(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
-        std::make_unique<host_table_allocation>(
+        host_table_allocation::create(
           nullptr, std::vector<cucascade::memory::column_metadata>{}, 0),
         &mem_space));
   }
@@ -138,7 +138,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
     return std::make_shared<cucascade::data_batch>(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
-        std::make_unique<host_table_allocation>(
+        host_table_allocation::create(
           nullptr, std::vector<cucascade::memory::column_metadata>{}, 0),
         &mem_space));
   }
@@ -263,7 +263,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   }
 
   auto table_allocation =
-    std::make_unique<host_table_allocation>(std::move(allocation), std::move(columns), offset);
+    host_table_allocation::create(std::move(allocation), std::move(columns), offset);
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), &mem_space);
   return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(table));
 }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -458,7 +458,7 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   // Make the host table allocation
   auto const sz = get_tail_byte_offset();
   auto table_allocation =
-    std::make_unique<host_table_allocation>(std::move(_allocation), std::move(columns), sz);
+    host_table_allocation::create(std::move(_allocation), std::move(columns), sz);
 
   // Make the host table representation
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), _host_space);

--- a/src/scan_manager/cached_split_provider.cpp
+++ b/src/scan_manager/cached_split_provider.cpp
@@ -25,6 +25,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table_view.hpp>
 
+#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 
@@ -46,11 +47,47 @@ cached_split_provider::cached_split_provider(
 {
 }
 
+cached_split_provider::cached_split_provider(
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
+  std::vector<std::size_t> column_indices,
+  cucascade::memory::memory_space& memory_space,
+  std::shared_ptr<duckdb::Expression> filter_expression,
+  std::shared_ptr<op::scan::scan_plan const> plan)
+  : _host_chunks(std::move(host_chunks)),
+    _column_indices(std::move(column_indices)),
+    _memory_space(&memory_space),
+    _filter_expression(std::move(filter_expression)),
+    _plan(std::move(plan))
+{
+}
+
 std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
                                                split_connector& connector)
 {
   std::promise<void> promise;
   auto future = promise.get_future();
+
+  if (!_host_chunks.empty()) {
+    // HOST tier: slice each pinned chunk down to the requested columns and emit a
+    // data_batch wrapping the resulting host_data_representation. The batch is
+    // converted to GPU later by scan_cached_operator_data::prepare_for_processing,
+    // so downstream execute() still sees a gpu_table_representation.
+    for (auto const& chunk : _host_chunks) {
+      if (!chunk) {
+        throw std::runtime_error(
+          "[cached_split_provider] null host_data_representation in pinned chunks");
+      }
+      auto sliced = chunk->slice(_column_indices);
+      auto batch =
+        std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(sliced));
+      connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
+        std::move(batch), _filter_expression, _plan));
+    }
+
+    connector.close();
+    promise.set_value();
+    return future;
+  }
 
   std::size_t const num_batches =
     _columns_per_request.empty() ? 0 : _columns_per_request.front().size();

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -130,6 +130,57 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
         break;
       }
 
+      // Filter expression: BoundReferences are in D-space, via plan.batch_position_by_column_id.
+      // Same recipe parquet_split_provider uses, so the filter evaluates correctly against
+      // the cached batch (which is in D-order by construction above). Built before the
+      // tier-specific assembly so both branches share the same filter.
+      std::shared_ptr<duckdb::Expression> filter_expression;
+      if (info->table_filters && !info->table_filters->filters.empty()) {
+        auto duckdb_expression =
+          op::convert_table_filters_to_expression(*info->table_filters,
+                                                  info->column_ids,
+                                                  info->returned_types,
+                                                  plan.batch_position_by_column_id,
+                                                  plan.partition_primary_indices);
+        if (duckdb_expression) {
+          filter_expression = std::shared_ptr<duckdb::Expression>(std::move(duckdb_expression));
+        }
+      }
+
+      if (entry.tier == cucascade::memory::Tier::HOST) {
+        // Map each D-position to its index inside the captured host chunk. column_names
+        // is in capture order, so we look up the requested data column by name. A missing
+        // column means the user pinned a subset that doesn't cover this scan — fall back
+        // to the parquet path so the query still succeeds.
+        std::vector<std::size_t> column_indices;
+        column_indices.reserve(plan.data_columns.size());
+        for (auto const& dc : plan.data_columns) {
+          auto it = std::find(entry.column_names.begin(), entry.column_names.end(), dc.name);
+          if (it == entry.column_names.end()) {
+            throw std::runtime_error("[sirius_scan_manager::create_provider_for] pinned entry '" +
+                                     pinned_name + "' missing column '" + dc.name +
+                                     "' required by scan op");
+          }
+          column_indices.push_back(
+            static_cast<std::size_t>(std::distance(entry.column_names.begin(), it)));
+        }
+
+        SIRIUS_LOG_DEBUG(
+          "[sirius_scan_manager::create_provider_for] using host cached_split_provider for "
+          "op_id={} (pinned='{}' data_cols={} chunks={} needs_assembly={})",
+          op->get_operator_id(),
+          pinned_name,
+          column_indices.size(),
+          entry.host_chunks.size(),
+          op::scan::needs_output_assembly(plan));
+
+        return std::make_unique<cached_split_provider>(entry.host_chunks,
+                                                       std::move(column_indices),
+                                                       *entry.memory_space,
+                                                       std::move(filter_expression),
+                                                       std::move(plan_shared));
+      }
+
       // Look up the pinned chunks for each D-position by name. data_columns is in
       // D-order, so columns_per_request[d] is the chunk vector for D-position d.
       std::vector<std::vector<std::shared_ptr<cudf::column>>> columns_per_request;
@@ -142,22 +193,6 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
                                    "' required by scan op");
         }
         columns_per_request.push_back(it->second);
-      }
-
-      // Filter expression: BoundReferences are in D-space, via plan.batch_position_by_column_id.
-      // Same recipe parquet_split_provider uses, so the filter evaluates correctly against
-      // the cached batch (which is in D-order by construction above).
-      std::shared_ptr<duckdb::Expression> filter_expression;
-      if (info->table_filters && !info->table_filters->filters.empty()) {
-        auto duckdb_expression =
-          op::convert_table_filters_to_expression(*info->table_filters,
-                                                  info->column_ids,
-                                                  info->returned_types,
-                                                  plan.batch_position_by_column_id,
-                                                  plan.partition_primary_indices);
-        if (duckdb_expression) {
-          filter_expression = std::shared_ptr<duckdb::Expression>(std::move(duckdb_expression));
-        }
       }
 
       SIRIUS_LOG_DEBUG(
@@ -281,6 +316,7 @@ void sirius_scan_manager::insert_pinned_entry(const std::string& name,
   pinned_entry entry;
   entry.column_names = std::move(column_names);
   entry.file_paths   = std::move(file_paths);
+  entry.tier         = cucascade::memory::Tier::GPU;
   entry.memory_space = &memory_space;
   entry.num_rows     = new_num_rows;
 
@@ -296,6 +332,36 @@ void sirius_scan_manager::insert_pinned_entry(const std::string& name,
       entry.data_batches_by_column[entry.column_names[i]].emplace_back(std::move(cols[i]));
     }
   }
+
+  _pinned_entries[name] = std::move(entry);
+}
+
+void sirius_scan_manager::insert_pinned_entry_host(
+  const std::string& name,
+  std::vector<std::string> column_names,
+  std::vector<std::string> file_paths,
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks,
+  cucascade::memory::memory_space& memory_space)
+{
+  // The host-tier path captures one chunk per emitted batch; each chunk holds every
+  // pinned column. Re-insert always replaces — there is no per-column merge analog
+  // to the GPU path because the chunk-vs-column dimensions are flipped.
+  std::size_t new_num_rows = 0;
+  for (auto const& chunk : host_chunks) {
+    if (!chunk) { continue; }
+    auto const& host_table = chunk->get_host_table();
+    if (host_table && !host_table->columns.empty()) {
+      new_num_rows += static_cast<std::size_t>(host_table->columns.front().num_rows);
+    }
+  }
+
+  pinned_entry entry;
+  entry.column_names = std::move(column_names);
+  entry.file_paths   = std::move(file_paths);
+  entry.tier         = cucascade::memory::Tier::HOST;
+  entry.memory_space = &memory_space;
+  entry.num_rows     = new_num_rows;
+  entry.host_chunks  = std::move(host_chunks);
 
   _pinned_entries[name] = std::move(entry);
 }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -796,64 +796,57 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
   std::size_t const chunk_read_limit =
     sirius_ctx->get_config().get_operator_params().scan_task_batch_size;
 
-  // Read each file via cudf::chunked_parquet_reader so each emitted batch stays within
-  // chunk_read_limit bytes. The optional n_rows budget caps the cumulative row count
-  // across files; once exhausted, stop early.
-  std::vector<std::unique_ptr<cudf::table>> tables;
-  std::vector<std::string> read_column_names;  // captured from parquet metadata
-  int64_t remaining_rows = data.args.n_rows.value_or(-1);
-  for (auto const& path : file_paths) {
-    if (data.args.n_rows.has_value() && remaining_rows <= 0) { break; }
+  // Read all files through a single cudf::chunked_parquet_reader. cudf concatenates the
+  // sources internally and emits batches each within chunk_read_limit bytes; the optional
+  // n_rows budget caps the cumulative row count across files.
+  cudf::io::parquet_reader_options opts =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{file_paths}).build();
+  if (!cols.empty()) { opts.set_column_names(cols); }
+  if (data.args.n_rows.has_value()) { opts.set_num_rows(data.args.n_rows.value()); }
 
-    auto opts = cudf::io::parquet_reader_options::builder(
-                  cudf::io::source_info{std::vector<std::string>{path}})
-                  .build();
-    if (!cols.empty()) { opts.set_column_names(cols); }
-    if (data.args.n_rows.has_value()) { opts.set_num_rows(remaining_rows); }
+  std::vector<std::unique_ptr<cudf::table>> tables;                               // tier='gpu'
+  std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;  // tier='host'
+  std::vector<std::string> read_column_names;
 
+  // For tier='host' the full table may not fit in GPU memory, so each batch is downgraded
+  // to a pinned host_data_representation immediately and the GPU buffers are released
+  // before the next read_chunk(). The GPU↔HOST converter uses cudaMemcpyBatchAsync which
+  // requires a real, non-default stream.
+  cucascade::representation_converter_registry* registry_ptr = nullptr;
+  std::optional<rmm::cuda_stream> pin_stream;
+  rmm::cuda_stream_view stream_view{};
+  if (data.args.tier == "host") {
+    registry_ptr = &sirius::converter_registry::get();
+    pin_stream.emplace();
+    stream_view = pin_stream->view();
+  }
+
+  if (!file_paths.empty()) {
     cudf::io::chunked_parquet_reader reader(chunk_read_limit, opts);
-    int64_t file_rows_read = 0;
     while (reader.has_next()) {
-      auto chunk      = reader.read_chunk();
-      auto chunk_rows = static_cast<int64_t>(chunk.tbl->num_rows());
-      if (chunk_rows == 0) { break; }
+      auto chunk = reader.read_chunk();
+      if (chunk.tbl->num_rows() == 0) { break; }
       if (read_column_names.empty()) {
         read_column_names.reserve(chunk.metadata.schema_info.size());
         for (auto const& col_info : chunk.metadata.schema_info) {
           read_column_names.push_back(col_info.name);
         }
       }
-      file_rows_read += chunk_rows;
-      tables.emplace_back(std::move(chunk.tbl));
+      if (data.args.tier == "host") {
+        cucascade::gpu_table_representation gpu_repr(std::move(chunk.tbl), gpu_mem_space);
+        auto host_repr = registry_ptr->convert<cucascade::host_data_representation>(
+          gpu_repr, host_mem_space, stream_view);
+        // Sync before gpu_repr leaves scope so the async D2H copies finish before its
+        // device buffers are freed.
+        stream_view.synchronize();
+        host_chunks.emplace_back(std::move(host_repr));
+      } else {
+        tables.emplace_back(std::move(chunk.tbl));
+      }
     }
-    if (data.args.n_rows.has_value()) { remaining_rows -= file_rows_read; }
   }
 
   if (data.args.tier == "host") {
-    // Downgrade each freshly-read GPU table to a host_data_representation. The GPU
-    // table is wrapped in a transient gpu_table_representation just so the converter
-    // registry can dispatch on its concrete type. After conversion, the GPU side
-    // is released — the pinned bytes live in pinned host memory.
-    auto& registry = sirius::converter_registry::get();
-    // The GPU↔HOST converter uses cudaMemcpyBatchAsync which requires a real,
-    // non-default stream. Use a per-call rmm::cuda_stream so we don't accidentally
-    // serialize against other concurrent work on the default stream.
-    rmm::cuda_stream pin_stream;
-    auto stream_view = pin_stream.view();
-    std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
-    host_chunks.reserve(tables.size());
-    for (auto& table : tables) {
-      if (!table) { continue; }
-      cucascade::gpu_table_representation gpu_repr(std::move(table), gpu_mem_space);
-      auto host_repr = registry.convert<cucascade::host_data_representation>(
-        gpu_repr, host_mem_space, stream_view);
-      host_chunks.emplace_back(std::move(host_repr));
-    }
-    // Conversion enqueues async D2H copies on the stream; sync before the GPU
-    // representations leave scope so we do not free their device buffers while
-    // copies are still in flight.
-    stream_view.synchronize();
-
     sirius_ctx->get_scan_manager().insert_pinned_entry_host(data.args.name,
                                                             std::move(read_column_names),
                                                             std::move(file_paths),

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -26,7 +26,11 @@
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/types.hpp>
 
+#include <rmm/cuda_stream.hpp>
+
+#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
@@ -694,8 +698,9 @@ unique_ptr<FunctionData> SiriusExtension::PinTableBind(ClientContext& context,
     throw BinderException("pin_table requires a 'tier' named parameter");
   }
   result->args.tier = tier_it->second.ToString();
-  if (result->args.tier == "host") {
-    throw NotImplementedException("pin_table tier='host' is not yet supported");
+  if (result->args.tier != "gpu" && result->args.tier != "host") {
+    throw NotImplementedException("pin_table tier='" + result->args.tier +
+                                  "' is not supported (only 'gpu' and 'host')");
   }
 
   auto name_it = input.named_parameters.find("name");
@@ -739,14 +744,25 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
     throw InvalidInputException("pin_table requires the Sirius context to be initialized");
   }
 
-  // The cudf reader places the table on GPU; pick the first GPU memory space so the
-  // scan_manager can later wrap copies of these columns as data_batch instances.
+  // The cudf reader always places tables on GPU. For tier='gpu' we hand the GPU columns
+  // straight to the scan_manager. For tier='host' we additionally convert each table to
+  // a host_data_representation (via the GPU↔HOST converter) so the pinned data lives in
+  // pinned host memory instead of GPU memory.
   auto& memory_manager = sirius_ctx->get_memory_manager();
   auto gpu_spaces      = memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
   if (gpu_spaces.empty()) {
     throw InvalidInputException("pin_table: no GPU memory space available");
   }
-  auto& mem_space = const_cast<cucascade::memory::memory_space&>(*gpu_spaces[0]);
+  auto& gpu_mem_space = const_cast<cucascade::memory::memory_space&>(*gpu_spaces[0]);
+
+  cucascade::memory::memory_space* host_mem_space = nullptr;
+  if (data.args.tier == "host") {
+    auto host_spaces = memory_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+    if (host_spaces.empty()) {
+      throw InvalidInputException("pin_table: no HOST memory space available");
+    }
+    host_mem_space = const_cast<cucascade::memory::memory_space*>(host_spaces[0]);
+  }
 
   // Glob the user-supplied path into concrete files.
   auto& fs   = FileSystem::GetFileSystem(context);
@@ -813,11 +829,43 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
     if (data.args.n_rows.has_value()) { remaining_rows -= file_rows_read; }
   }
 
-  sirius_ctx->get_scan_manager().insert_pinned_entry(data.args.name,
-                                                     std::move(read_column_names),
-                                                     std::move(file_paths),
-                                                     std::move(tables),
-                                                     mem_space);
+  if (data.args.tier == "host") {
+    // Downgrade each freshly-read GPU table to a host_data_representation. The GPU
+    // table is wrapped in a transient gpu_table_representation just so the converter
+    // registry can dispatch on its concrete type. After conversion, the GPU side
+    // is released — the pinned bytes live in pinned host memory.
+    auto& registry = sirius::converter_registry::get();
+    // The GPU↔HOST converter uses cudaMemcpyBatchAsync which requires a real,
+    // non-default stream. Use a per-call rmm::cuda_stream so we don't accidentally
+    // serialize against other concurrent work on the default stream.
+    rmm::cuda_stream pin_stream;
+    auto stream_view = pin_stream.view();
+    std::vector<std::shared_ptr<cucascade::host_data_representation>> host_chunks;
+    host_chunks.reserve(tables.size());
+    for (auto& table : tables) {
+      if (!table) { continue; }
+      cucascade::gpu_table_representation gpu_repr(std::move(table), gpu_mem_space);
+      auto host_repr = registry.convert<cucascade::host_data_representation>(
+        gpu_repr, host_mem_space, stream_view);
+      host_chunks.emplace_back(std::move(host_repr));
+    }
+    // Conversion enqueues async D2H copies on the stream; sync before the GPU
+    // representations leave scope so we do not free their device buffers while
+    // copies are still in flight.
+    stream_view.synchronize();
+
+    sirius_ctx->get_scan_manager().insert_pinned_entry_host(data.args.name,
+                                                            std::move(read_column_names),
+                                                            std::move(file_paths),
+                                                            std::move(host_chunks),
+                                                            *host_mem_space);
+  } else {
+    sirius_ctx->get_scan_manager().insert_pinned_entry(data.args.name,
+                                                       std::move(read_column_names),
+                                                       std::move(file_paths),
+                                                       std::move(tables),
+                                                       gpu_mem_space);
+  }
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value::BOOLEAN(true));

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -4264,3 +4264,24 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   REQUIRE(unpin_result);
   REQUIRE_FALSE(unpin_result->HasError());
 }
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - pin_table host tier scan and aggregate",
+                 "[integration][gpu_execution][parquet][pin_table_host]")
+{
+  auto parquet_dir = fs::path(__FILE__).parent_path() / "data/parquet";
+  auto pin_query   = "CALL pin_table('" + parquet_dir.string() +
+                   "/lineitem.parquet', tier='host', name='lineitem');";
+  auto pin_result = con->Query(pin_query);
+  REQUIRE(pin_result);
+  if (pin_result->HasError()) { UNSCOPED_INFO("pin_table error: " << pin_result->GetError()); }
+  REQUIRE_FALSE(pin_result->HasError());
+
+  compare_gpu_vs_cpu(
+    "select l_returnflag, l_linestatus, count(*), sum(l_quantity) "
+    "from lineitem group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus;");
+
+  auto unpin_result = con->Query("CALL unpin_table('lineitem');");
+  REQUIRE(unpin_result);
+  REQUIRE_FALSE(unpin_result->HasError());
+}

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -471,9 +471,9 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
   columns.push_back(str_builder.make_column_metadata(num_rows));
   columns.push_back(big_builder.make_column_metadata(num_rows));
 
-  auto const sz         = allocation->size_bytes();
-  auto table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
-    std::move(allocation), std::move(columns), sz);
+  auto const sz = allocation->size_bytes();
+  auto table_allocation =
+    cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =
@@ -601,9 +601,9 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
   columns.push_back(int_builder.make_column_metadata(rows_fit));
   columns.push_back(str_builder.make_column_metadata(rows_fit));
 
-  auto const sz         = allocation->size_bytes();
-  auto table_allocation = std::make_unique<cucascade::memory::host_table_allocation>(
-    std::move(allocation), std::move(columns), sz);
+  auto const sz = allocation->size_bytes();
+  auto table_allocation =
+    cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =


### PR DESCRIPTION
Pin parquet tables into pinned host memory and serve scans from there, slicing the host chunks per-query and converting back to GPU only when a scan task starts.

- pin_table: convert each cudf::table to cucascade::host_data_representation via the GPU↔HOST converter; uses an explicit rmm::cuda_stream because cudaMemcpyBatchAsync rejects the default stream.
- scan_manager: pinned_entry now tracks tier and host_chunks; create_provider_for picks the host-mode cached_split_provider when matched.
- cached_split_provider: new host constructor; start() slices each chunk by the requested column indices and emits one host-resident data_batch per chunk.
- scan_cached_operator_data: prepare_for_processing converts host-resident batches to gpu_table_representation using the task's reserved GPU memory space; get_estimated_size_in_bytes uses the generic representation accessor.
- Integration test: pin_table host tier scan and aggregate over lineitem.

Cucascade-submodule fallout (constructor went private, allocation became shared_ptr): switched to host_table_allocation::create() in cpu_source_task, duckdb_scan_task, and the host_table_utils test; converted host_table_chunk_reader to shared_ptr; templatized multiple_blocks_allocation_accessor methods on the smart-pointer type so unique_ptr and shared_ptr callers both work.