### PR TITLE
scan: DuckDB format GPU-native decode kernel (Part 5: String DICT/FSST/DICT_FSST/)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ set(EXTENSION_SOURCES
 # Deleting src/legacy/ cleanly removes legacy build support.
 set(CUDA_SOURCES
     src/op/scan/equality_delete_mask.cu src/cuda/scan/gpu_decode_bitpacking.cu
-    src/cuda/scan/gpu_native_decode.cu)
+    src/cuda/scan/gpu_decode_strings.cu src/cuda/scan/gpu_native_decode.cu)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/legacy/CMakeLists.txt")
   add_subdirectory(src/legacy)
   list(APPEND EXTENSION_SOURCES ${SIRIUS_LEGACY_SOURCES}
@@ -422,6 +422,7 @@ set(TEST_SOURCES
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_column_builder.cpp
     test/cpp/scan/test_gpu_decode_bitpacking.cpp
+    test/cpp/scan/test_gpu_decode_strings.cpp
     test/cpp/scan/test_gpu_native_decode.cpp
     test/cpp/scan/test_parquet_schema_mapping.cpp
     test/cpp/scan/test_parquet_scan_task.cpp

--- a/src/cuda/scan/gpu_decode_bitpacking.cu
+++ b/src/cuda/scan/gpu_decode_bitpacking.cu
@@ -42,6 +42,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "cuda/scan/gpu_decode_bitpacking.cuh"
+#include "cuda/scan/unpack_value.cuh"
 
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
@@ -80,47 +81,6 @@ struct bp_group_desc {
   uint32_t group_row_count;    ///< Rows in this group (last group may be < 2048).
   uint32_t global_row_offset;  ///< Output offset, in rows, for this group.
 };
-
-//===----------------------------------------------------------------------===//
-// Bit-level value extraction.
-//===----------------------------------------------------------------------===//
-
-/// Read one width-bit value from `packed[]` at logical index `idx`. Values
-/// are stored LSB-first within 32-bit words.
-///
-/// For T wider than 32 bits a value can span three 32-bit words when both
-/// `bit_off > 0` and `bit_off + width > 64` (e.g. width=50, bit_off=20 reads
-/// bits 20..69, which crosses two 32-bit boundaries). Callers must ensure
-/// `packed[]` has one guard word past the live data so that third-word read
-/// is in-bounds; the kernel writes the guard word itself.
-template <typename T>
-__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
-{
-  auto constexpr WORD_BITS  = ::cuda::std::numeric_limits<uint32_t>::digits;
-  auto constexpr WORD_BYTES = sizeof(uint32_t);
-  if (width == 0) return T(0);
-
-  auto const bit_pos  = static_cast<uint64_t>(idx) * width;
-  auto const word_idx = static_cast<uint32_t>(bit_pos / WORD_BITS);
-  auto const bit_off  = static_cast<uint32_t>(bit_pos % WORD_BITS);
-
-  // We need to upcast in case we need bits from the next word.
-  auto result = static_cast<uint64_t>(packed[word_idx]);
-  if (bit_off + width > WORD_BITS) {
-    result |= static_cast<uint64_t>(packed[word_idx + 1]) << WORD_BITS;
-  }
-  result >>= bit_off;
-
-  // For 8B types, we may need bits from the second next word.
-  if constexpr (sizeof(T) > WORD_BYTES) {
-    if (bit_off > 0 && bit_off + width > 2 * WORD_BITS) {
-      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
-    }
-  }
-
-  auto const mask = (width >= 64) ? ~uint64_t{0} : (uint64_t{1} << width) - 1;
-  return static_cast<T>(result & mask);
-}
 
 //===----------------------------------------------------------------------===//
 // Batched decode kernel.

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -410,30 +410,32 @@ __global__ void kernel_compute_lengths_dict(string_chunk_desc const* __restrict_
                                             uint32_t* __restrict__ d_lengths,
                                             uint32_t num_chunks)
 {
-  uint32_t cid = blockIdx.x;
-  if (cid >= num_chunks) return;
-  auto const desc     = descs[cid];
-  uint8_t const* base = desc.d_bytes;
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc          = descs[chunk_id];
+  auto const* segment_base = desc.d_bytes;
 
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ dict_header_t sm_hdr;
-  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  if (threadIdx.x == 0) { sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
 
   // Malformed metadata → zero-fill using the trusted descriptor row count.
   if (!sm_ok) {
     for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-      d_lengths[desc.global_row_start + i] = 0u;
+      d_lengths[desc.global_row_start + i] = 0;
     }
     return;
   }
 
-  uint32_t const* d_sel = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
-  uint32_t const* d_idx = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
+  // Calculate lengths by unpacking the selection buffer to get dict indices, then looking up
+  // lengths from the index buffer.
+  auto const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
+  auto const* d_idx = reinterpret_cast<uint32_t const*>(segment_base + sm_hdr.index_buffer_offset);
   for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-    uint32_t seg_i = desc.seg_row_start + i;
-    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
-    uint32_t len   = (sel == 0) ? 0u : (d_idx[sel] - d_idx[sel - 1]);
+    auto const segment_idx = desc.seg_row_start + i;
+    auto const sel         = unpack_value<uint32_t>(d_sel, segment_idx, sm_hdr.bitpacking_width);
+    auto const len         = (sel == 0) ? 0 : (d_idx[sel] - d_idx[sel - 1]);
     d_lengths[desc.global_row_start + i] = len;
   }
 }
@@ -443,10 +445,10 @@ __global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
                                    uint8_t* __restrict__ d_chars,
                                    uint32_t num_chunks)
 {
-  uint32_t cid = blockIdx.x;
-  if (cid >= num_chunks) return;
-  auto const desc     = descs[cid];
-  uint8_t const* base = desc.d_bytes;
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc  = descs[chunk_id];
+  auto const* base = desc.d_bytes;
 
   __shared__ uint8_t sm_ok;
   __shared__ dict_header_t sm_hdr;
@@ -887,7 +889,7 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
   uint32_t prev_chunk_last_is_esc = 0;
 
   for (uint32_t off = 0; off < comp_len; off += WARP_THREADS) {
-    auto const bytes_in_chunk = ::cuda::std::min(comp_len - off, WARP_THREADS);
+    auto const bytes_in_chunk = ::cuda::std::min(comp_len - off, uint32_t{WARP_THREADS});
     auto const active         = lane < bytes_in_chunk;
     uint8_t const my_byte     = active ? comp_ptr[off + lane] : 0;
     int const is_esc          = (active && my_byte == FSST_ESC) ? 1 : 0;
@@ -913,10 +915,10 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
     }
 
     // Determine the write offsets into the scratch pad for this lane's decoded symbol via an
-    // inclusive scan of the decoded lengths.
+    // inclusive Hillis-Steele scan of the decoded lengths.
     auto scan = my_len;
 #pragma unroll
-    for (uint32_t step = 1; step < WARP_THREADS; step /= 2) {
+    for (uint32_t step = 1; step < WARP_THREADS; step <<= 1) {
       auto const add = __shfl_up_sync(FULL_MASK, scan, step);
       if (lane >= step) { scan += add; }
     }

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -15,6 +15,7 @@
  */
 
 #include "cuda/scan/gpu_decode_strings.cuh"
+#include "cuda/scan/unpack_value.cuh"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
@@ -237,46 +238,6 @@ std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_
   return out;
 }
 
-/// Bit-packed value reader. DuckDB's BitpackingPrimitives uses 32-element
-/// bit-dense groups on 32-bit boundaries; an 8-byte straddling load is still
-/// safe for widths ≤ 32. For T larger than 4 bytes we may need a third word.
-/// TODO: Refactor into common decoder utilities (see issue #781)
-template <typename T>
-__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
-{
-  if (width == 0) return T(0);
-  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
-  uint32_t word_idx = static_cast<uint32_t>(bit_pos / 32);
-  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31);
-  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
-  if (bit_off + width > 32) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
-  uint64_t result = combined >> bit_off;
-  if constexpr (sizeof(T) > 4) {
-    if (bit_off > 0 && bit_off + width > 64) {
-      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
-    }
-  }
-  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
-  return static_cast<T>(result & mask);
-}
-
-/**
- * @brief Extracts @p width bit value at logical index @p idx from a byte-aligned bitpacked stream
- * @p packed.
- */
-template <typename T>
-T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
-{
-  if (width == 0) return T(0);
-  auto const bit_pos  = static_cast<uint64_t>(idx) * width;
-  auto const byte_off = static_cast<uint32_t>(bit_pos / CHAR_BIT);
-  auto const bit_off  = static_cast<uint32_t>(bit_pos % CHAR_BIT);
-  uint64_t combined;
-  std::memcpy(&combined, packed + byte_off, sizeof(uint64_t));
-  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
-  return static_cast<T>((combined >> bit_off) & mask);
-}
-
 /**
  * @brief Parse DICTIONARY header @p hdr from @p base, bounded by the buffer size @p limit.
  * @return true if the header was successfully parsed (i.e. the header fits within the buffer), and
@@ -311,6 +272,10 @@ __device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
 // Each codec's prepare_* returns one of these; gpu_decode_strings_column
 // aggregates them across runs before launching kernels.
 
+struct prepared_uncomp {
+  std::vector<string_chunk_desc> descs;
+};
+
 struct prepared_dict {
   std::vector<string_chunk_desc> descs_short;  ///< max_string_length < DICT_WARP_COOP_MIN_LEN
   std::vector<string_chunk_desc> descs_long;   ///< max_string_length >= DICT_WARP_COOP_MIN_LEN
@@ -334,7 +299,123 @@ struct prepared_dict_fsst {
 };
 
 //===----------------------------------------------------------------------===//
-// 2. DICTIONARY codec
+// 2. UNCOMPRESSED codec
+//
+//   offset 0                                                       seg_end
+//   +-----------+----------+----------------------+---------------------+
+//   | dict_size | dict_end |       offsets        |        chars        |
+//   |    4B     |    4B    |  int32 × end_row     |  grows BACKWARD     |
+//   |  (unused) |          |  backward-cumul      |  from dict_end      |
+//   +-----------+----------+----------------------+---------------------+
+//   0           4          8                      ^                     ^
+//                                                  8 + 4*end_row        dict_end
+//
+// offsets[i] is signed int32; sign bit is DuckDB's inline-vs-pointer flag
+// for in-memory string_t slots and is irrelevant on disk — take abs() for
+// length math. Row i lives in `[dict_end - |offsets[i]|, dict_end - |offsets[i-1]|)`.
+// One CTA per chunk, grid-stride within the chunk.
+//===----------------------------------------------------------------------===//
+
+/**
+ * @brief Compute decoded string lengths for an UNCOMPRESSED varchar segment.
+ *
+ * Lengths come from successive differences of the backward-cumulative offsets
+ * array. If the segment is too short to contain the offsets region the kernel
+ * zero-fills.
+ */
+__global__ void kernel_compute_lengths_uncomp(string_chunk_desc const* __restrict__ descs,
+                                              uint32_t* __restrict__ d_lengths,
+                                              uint32_t num_chunks)
+{
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc      = descs[chunk_id];
+  auto const* base     = desc.d_bytes;
+  auto const limit     = desc.bytes_size;
+  auto const end_row   = desc.seg_row_start + desc.row_count;
+
+  __shared__ bool sm_ok;
+  if (threadIdx.x == 0) { sm_ok = (limit >= 8u + size_t{end_row} * 4u); }
+  __syncthreads();
+  if (!sm_ok) {
+    for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+      d_lengths[desc.global_row_start + i] = 0u;
+    }
+    return;
+  }
+
+  auto const* duck_offsets = reinterpret_cast<int32_t const*>(base + 8);
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    auto const seg_i = desc.seg_row_start + i;
+    auto const cur   = duck_offsets[seg_i];
+    auto const prev  = (seg_i > 0) ? duck_offsets[seg_i - 1] : 0;
+    auto const abs_cur  = static_cast<uint32_t>(cur >= 0 ? cur : -cur);
+    auto const abs_prev = static_cast<uint32_t>(prev >= 0 ? prev : -prev);
+    d_lengths[desc.global_row_start + i] = abs_cur - abs_prev;
+  }
+}
+
+/**
+ * @brief Gather UNCOMPRESSED segment strings to the output chars buffer.
+ *
+ * Chars region grows backward from `dict_end`, so row i starts at
+ * `dict_end - |offsets[i]|`. Work granularity is one thread per row.
+ */
+__global__ void kernel_gather_uncomp(string_chunk_desc const* __restrict__ descs,
+                                     int32_t const* __restrict__ d_offsets,
+                                     uint8_t* __restrict__ d_chars,
+                                     uint32_t num_chunks)
+{
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc    = descs[chunk_id];
+  auto const* base   = desc.d_bytes;
+  auto const limit   = desc.bytes_size;
+  auto const end_row = desc.seg_row_start + desc.row_count;
+
+  __shared__ bool sm_ok;
+  __shared__ uint32_t sm_dict_end;
+  if (threadIdx.x == 0) {
+    sm_ok = (limit >= 8u + size_t{end_row} * 4u);
+    if (sm_ok) { memcpy(&sm_dict_end, base + 4, sizeof(sm_dict_end)); }
+  }
+  __syncthreads();
+  if (!sm_ok) return;
+
+  auto const* duck_offsets = reinterpret_cast<int32_t const*>(base + 8);
+  auto const* dict_end     = base + sm_dict_end;
+
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    auto const seg_i    = desc.seg_row_start + i;
+    auto const cur      = duck_offsets[seg_i];
+    auto const prev     = (seg_i > 0) ? duck_offsets[seg_i - 1] : 0;
+    auto const abs_cur  = static_cast<uint32_t>(cur >= 0 ? cur : -cur);
+    auto const abs_prev = static_cast<uint32_t>(prev >= 0 ? prev : -prev);
+    auto const str_len  = abs_cur - abs_prev;
+
+    auto const out_pos = d_offsets[desc.global_row_start + i];
+    auto const* src    = dict_end - abs_cur;
+    memcpy(d_chars + out_pos, src, str_len);
+  }
+}
+
+/**
+ * @brief Build per-segment descriptors for an UNCOMPRESSED varchar codec run.
+ */
+prepared_uncomp prepare_uncomp(gpu_string_codec_run const& run)
+{
+  prepared_uncomp out;
+  out.descs.reserve(run.segments.size());
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    out.descs.push_back(
+      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
+  }
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// 3. DICTIONARY codec
 //
 //   offset 0                                                      seg_end
 //   +--------+------------------+------------------+---------------------+
@@ -386,7 +467,8 @@ __global__ void kernel_compute_lengths_dict(string_chunk_desc const* __restrict_
   for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
     auto const segment_idx = desc.seg_row_start + i;
     auto const sel         = unpack_value<uint32_t>(d_sel, segment_idx, sm_hdr.bitpacking_width);
-    auto const len         = (sel == 0) ? 0 : (d_idx[sel] - d_idx[sel - 1]);
+    uint32_t len           = 0u;
+    if (sel != 0u && sel < sm_hdr.index_buffer_count) { len = d_idx[sel] - d_idx[sel - 1]; }
     d_lengths[desc.global_row_start + i] = len;
   }
 }
@@ -504,7 +586,7 @@ prepared_dict prepare_dict(gpu_string_codec_run const& run)
 }
 
 //===----------------------------------------------------------------------===//
-// 3. FSST codec
+// 4. FSST codec
 //
 //   offset 0                                                       seg_end
 //   +--------+--------------------+---------------+------------------------+
@@ -798,7 +880,11 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
     for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
       auto const cumsum      = compressed_cumsum_ptr[i];
       auto const prev_cumsum = (i > 0) ? compressed_cumsum_ptr[i - 1] : start;
-      auto const comp_len    = cumsum - prev_cumsum;
+      if (cumsum > sm_hdr.dict_end || prev_cumsum > cumsum) {
+        if (lane == 0) { d_lengths[desc.global_row_start + i] = 0u; }
+        continue;
+      }
+      auto const comp_len = cumsum - prev_cumsum;
       if (comp_len == 0) {
         if (lane == 0) { d_lengths[desc.global_row_start + i] = 0; }
         continue;
@@ -812,7 +898,11 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
     for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
       auto const cumsum      = compressed_cumsum_ptr[i];
       auto const prev_cumsum = (i > 0) ? compressed_cumsum_ptr[i - 1] : start;
-      auto const comp_len    = cumsum - prev_cumsum;
+      if (cumsum > sm_hdr.dict_end || prev_cumsum > cumsum) {
+        d_lengths[desc.global_row_start + i] = 0u;
+        continue;
+      }
+      auto const comp_len = cumsum - prev_cumsum;
       if (comp_len == 0) {
         d_lengths[desc.global_row_start + i] = 0u;
         continue;
@@ -824,7 +914,8 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
         auto const code = comp_ptr[pos++];
         if (code < FSST_ESC) {
           decomp_len += sm_len[code];
-        } else {
+        } else if (pos < comp_len) {
+          // Trailing escape (corrupt input) is dropped — stay in sync with gather.
           ++pos;
           ++decomp_len;
         }
@@ -1110,7 +1201,7 @@ prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
 }
 
 //===----------------------------------------------------------------------===//
-// 4. DICT_FSST codec
+// 5. DICT_FSST codec
 //
 //   +-----+------------+--------+----------------+--------------------+
 //   | hdr | dict bytes | symtab | string_lengths |    dict_indices    |
@@ -1343,7 +1434,8 @@ __global__ void kernel_compute_lengths_dict_fsst(dict_fsst_desc const* __restric
     uint32_t seg_i = desc.seg_row_start + i;
     uint32_t idx =
       fsst_only ? (seg_i + 1u) : unpack_value<uint32_t>(d_idx, seg_i, desc.dict_indices_width);
-    uint32_t len                         = (idx == 0u) ? 0u : (dec_off[idx + 1] - dec_off[idx]);
+    uint32_t len = 0u;
+    if (idx != 0u && idx < desc.dict_count) { len = dec_off[idx + 1] - dec_off[idx]; }
     d_lengths[desc.global_row_start + i] = len;
   }
 }
@@ -1402,7 +1494,7 @@ __global__ void kernel_predecode_dict_fsst(dict_fsst_desc const* __restrict__ de
           default: memcpy(out_ptr + op, &sym, sym_len); break;
         }
         op += sym_len;
-      } else {
+      } else if (pos < comp_len) {
         out_ptr[op++] = comp_ptr[pos++];
       }
     }
@@ -1780,7 +1872,7 @@ prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run,
 }
 
 //===----------------------------------------------------------------------===//
-// 5. Orchestrator
+// 6. Orchestrator
 //
 // `gpu_decode_strings_column` aggregates per-codec `prepared_*` state across
 // all runs in a column, uploads descriptors, dispatches the codec kernels in
@@ -1828,6 +1920,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
                              std::to_string(total_rows) + ") > cudf::size_type max");
   }
 
+  prepared_uncomp prep_uncomp;
   prepared_dict prep_dict;
   prepared_fsst prep_fsst;
   prepared_dict_fsst prep_dict_fsst;
@@ -1889,12 +1982,9 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
         break;
       }
       case duckdb::CompressionType::COMPRESSION_UNCOMPRESSED: {
-        // Legacy `decode_string_column_batched` handles this codec — reaching
-        // here means upstream viability check let one through.
-        throw std::runtime_error(
-          "gpu_decode_strings_column: UNCOMPRESSED varchar codec "
-          "should route to the legacy varchar path; "
-          "upstream viability check missed it");
+        auto p = prepare_uncomp(run);
+        prep_uncomp.descs.insert(prep_uncomp.descs.end(), p.descs.begin(), p.descs.end());
+        break;
       }
       default:
         throw std::runtime_error(
@@ -1920,6 +2010,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   // Per-row kernels take chunked descriptors; predecode + mark_nulls stay
   // per-segment via prep_dict_fsst.descs.
   auto const target_ctas       = get_target_ctas();
+  auto const uncomp_chunks     = expand_chunks(prep_uncomp.descs, target_ctas);
   auto const dict_chunks_short = expand_chunks(prep_dict.descs_short, target_ctas);
   auto const dict_chunks_long  = expand_chunks(prep_dict.descs_long, target_ctas);
   auto const dict_fsst_chunks  = expand_chunks(prep_dict_fsst.descs, target_ctas);
@@ -1931,6 +2022,8 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
     }
     return buf;
   };
+  rmm::device_buffer d_uncomp_chunks_buf =
+    upload(uncomp_chunks.data(), uncomp_chunks.size() * sizeof(string_chunk_desc));
   rmm::device_buffer d_dict_short_buf =
     upload(dict_chunks_short.data(), dict_chunks_short.size() * sizeof(string_chunk_desc));
   rmm::device_buffer d_dict_long_buf =
@@ -1959,6 +2052,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
 
   auto* d_comp_offsets_p     = static_cast<uint32_t*>(d_comp_offsets.data());
+  auto* d_uncomp_chunks_p    = static_cast<string_chunk_desc*>(d_uncomp_chunks_buf.data());
   auto* d_dict_short_p       = static_cast<string_chunk_desc*>(d_dict_short_buf.data());
   auto* d_dict_long_p        = static_cast<string_chunk_desc*>(d_dict_long_buf.data());
   auto* d_fsst_lengths_p     = static_cast<string_chunk_desc*>(d_fsst_lengths_buf.data());
@@ -1972,6 +2066,13 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   auto* d_decoded_off_p      = static_cast<uint32_t*>(d_decoded_offsets_buf.data());
 
   // Pass 1: lengths. Same kernel for short/long DICTIONARY — only gather forks.
+  if (!uncomp_chunks.empty()) {
+    kernel_compute_lengths_uncomp<<<static_cast<uint32_t>(uncomp_chunks.size()),
+                                    BLOCK_DIM,
+                                    0,
+                                    stream.value()>>>(
+      d_uncomp_chunks_p, d_lengths.data(), static_cast<uint32_t>(uncomp_chunks.size()));
+  }
   if (!dict_chunks_short.empty()) {
     kernel_compute_lengths_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),
                                   BLOCK_DIM,
@@ -2087,6 +2188,15 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   auto* d_chars_p = static_cast<uint8_t*>(d_chars.data());
 
   // Pass 2: gather. See DICT_WARP_COOP_MIN_LEN for the partition rationale.
+  if (!uncomp_chunks.empty()) {
+    kernel_gather_uncomp<<<static_cast<uint32_t>(uncomp_chunks.size()),
+                           BLOCK_DIM,
+                           0,
+                           stream.value()>>>(d_uncomp_chunks_p,
+                                             d_offsets.data(),
+                                             d_chars_p,
+                                             static_cast<uint32_t>(uncomp_chunks.size()));
+  }
   if (!dict_chunks_short.empty()) {
     kernel_gather_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),
                          BLOCK_DIM,

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -84,12 +84,11 @@ enum : uint8_t {
 };
 
 //----- FSST decoder types (shared: FSST + DICT_FSST modes 1+2) --------------//
-
 /// 255 codes (0..254); byte 255 is the escape sentinel.
-constexpr uint32_t FSST_SIZE           = 256;
-constexpr uint32_t FSST_NUM_SYMBOLS    = 255;
-constexpr uint8_t FSST_ESC             = 255;
-constexpr size_t FSST_SYMTAB_MAX_BYTES = 8192;  // opaque serialized blob
+constexpr uint32_t FSST_SIZE             = 256;
+constexpr uint32_t FSST_NUM_SYMBOLS      = 255;
+constexpr uint8_t FSST_ESC               = 255;
+constexpr uint32_t FSST_SYMTAB_MAX_BYTES = 8192;  // opaque serialized blob
 
 /// Trimmed `duckdb_fsst_decoder_t`: drops `version` + `zeroTerminated`.
 /// `len` + `symbol` arrays are ABI-compatible with `_full` for the import memcpy.
@@ -111,8 +110,7 @@ static_assert(sizeof(fsst_decoder_compact::symbol) == sizeof(fsst_decoder_full::
 // Declared locally to avoid pulling the libduckdb FSST header into the CUDA TU.
 extern "C" unsigned int duckdb_fsst_import(void* decoder, unsigned char* buf);
 
-//----- Per-kernel descriptors -----------------------------------------------
-
+//----- Per-kernel descriptors -----------------------------------------------//
 /// Descriptor for DICTIONARY chunks and FSST length-pass segments.
 /// FSST length pass can't chunk: the in-CTA prefix sum is per-segment.
 struct alignas(8) string_chunk_desc {
@@ -152,7 +150,6 @@ struct alignas(8) dict_fsst_desc {
 };
 
 //----- Tuning constants -----------------------------------------------------//
-
 constexpr uint32_t BLOCK_DIM = 256;  // see FSST_WARPS_PER_CTA static_assert
 constexpr uint32_t MIN_ROWS_PER_CHUNK =
   64;  ///< Minimum rows per segment chunk; BLOCK_DIM=256 threads -> 8 warps
@@ -173,11 +170,19 @@ constexpr size_t HOST_UPPER_BOUND_LIMIT = size_t{512} * 1024u * 1024u;
 constexpr uint32_t DICT_WARP_COOP_MIN_LEN = 64u;
 
 //----- Helpers --------------------------------------------------------------//
-
-/// DuckDB's AlignValue<idx_t>.
+/**
+ * @brief Align a value to the next 8-byte boundary.
+ *
+ * Mirror of DuckDB's AlignValue<idx_t> for 64-bit idx_t.
+ */
 constexpr uint32_t align_up8(uint32_t n) { return (n + 7u) & ~7u; }
 
-/// Two waves of full occupancy at BLOCK_DIM threads, per current device.
+/**
+ * @brief Get a target number of CTAs for chunking segments, based on the current device's
+ * occupancy.
+ *
+ * Two waves of full occupancy at BLOCK_DIM threads, per current device.
+ */
 uint32_t get_target_ctas()
 {
   int device = 0;
@@ -193,11 +198,12 @@ uint32_t get_target_ctas()
   return cached;
 }
 
-/// Split per-segment descriptors into smaller row sub-ranges so the kernel
-/// grid fills available SMs. Below MIN_ROWS_PER_CHUNK the per-CTA overhead
-/// dominates and we keep the original shape. Used for per-row work
-/// (compute_lengths, gather); per-dict work (predecode, mark_nulls) keeps
-/// one-CTA-per-segment so dictionaries are not decoded per chunk.
+/**
+ * @brief Expand segment descriptors into smaller chunks.
+ *
+ * Used for per-row work (compute_lengths, gather); per-dict work (predecode, mark_nulls) keeps
+ * one-CTA-per-segment so dictionaries are not decoded per chunk.
+ */
 template <typename Desc>
 std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_ctas)
 {
@@ -234,6 +240,7 @@ std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_
 /// Bit-packed value reader. DuckDB's BitpackingPrimitives uses 32-element
 /// bit-dense groups on 32-bit boundaries; an 8-byte straddling load is still
 /// safe for widths ≤ 32. For T larger than 4 bytes we may need a third word.
+/// TODO: Refactor into common decoder utilities (see issue #781)
 template <typename T>
 __device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
 {
@@ -253,22 +260,28 @@ __device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, 
   return static_cast<T>(result & mask);
 }
 
-/// Host-side counterpart to `unpack_value` — byte-addressed, used during
-/// `prepare_dict_fsst` to walk header regions copied to host.
+/**
+ * @brief Extracts @p width bit value at logical index @p idx from a byte-aligned bitpacked stream
+ * @p packed.
+ */
 template <typename T>
-inline T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
+T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
 {
   if (width == 0) return T(0);
-  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
-  uint32_t byte_off = static_cast<uint32_t>(bit_pos >> 3);
-  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 7u);
+  auto const bit_pos  = static_cast<uint64_t>(idx) * width;
+  auto const byte_off = static_cast<uint32_t>(bit_pos / CHAR_BIT);
+  auto const bit_off  = static_cast<uint32_t>(bit_pos % CHAR_BIT);
   uint64_t combined;
   std::memcpy(&combined, packed + byte_off, sizeof(uint64_t));
   uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
   return static_cast<T>((combined >> bit_off) & mask);
 }
 
-/// false on malformed metadata; callers zero-fill.
+/**
+ * @brief Parse DICTIONARY header @p hdr from @p base, bounded by the buffer size @p limit.
+ * @return true if the header was successfully parsed (i.e. the header fits within the buffer), and
+ * if the header metadata is valid; false otherwise.
+ */
 __device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
                                                   uint32_t limit,
                                                   dict_header_t* hdr)
@@ -472,6 +485,10 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
   }
 }
 
+/**
+ * @brief Build per-segment descriptors for a DICTIONARY codec run, bucketing
+ * each segment into the short- or long-string gather path by `max_string_length`.
+ */
 prepared_dict prepare_dict(gpu_string_codec_run const& run)
 {
   prepared_dict out;
@@ -516,66 +533,67 @@ prepared_dict prepare_dict(gpu_string_codec_run const& run)
 // mode 2 (inline-decompress per row).
 //===----------------------------------------------------------------------===//
 
-//----- On-device FSST symbol-table import -----------------------------------
-
-/// Device port of duckdb_fsst_import (libfsst.cpp:429). Same opaque blob
-/// layout (8B version | 1B zeroTerminated | 8B lenHisto | packed symbols by
-/// length group 1..8,1). CUDA targets are always little-endian so the
-/// host-side swap64_if_be is a no-op here. Used by kernel_build_fsst_decoders
-/// to populate per-segment decoders without round-tripping through host.
-constexpr uint32_t FSST_VERSION_LO        = 20190218u;
-constexpr unsigned long long FSST_CORRUPT = 32774747032022883ull;  // "corrupt" in LE
-
+//----- On-device FSST symbol-table import -----------------------------------//
+/**
+ * @brief Import FSST symbol table on device from the opaque on-disk blob format.
+ *
+ * Device port of duckdb_fsst_import (libfsst.cpp:429). Same opaque blob layout (8B version | 1B
+ * zeroTerminated | 8B lenHisto | packed symbols by length group 1..8,1). Used by
+ * kernel_build_fsst_decoders to populate per-segment decoders without round-tripping through host.
+ */
 __device__ __forceinline__ bool device_fsst_import(uint8_t const* buf, fsst_decoder_compact* out)
 {
-  // Zero first so a bad header / corrupted symtab leaves a deterministic
-  // (all-zero-length) decoder.
+  constexpr uint32_t FSST_VERSION_LO = 20190218;
+  constexpr uint64_t FSST_CORRUPT    = 32774747032022883;  // "corrupt" in LE
+
+  // Zero-fill so a bad header / corrupted symtab leaves a deterministic (all-zero-length) decoder.
   for (uint32_t i = 0; i < FSST_NUM_SYMBOLS; ++i) {
     out->len[i]    = 0;
     out->symbol[i] = 0;
   }
 
   uint64_t version;
-  memcpy(&version, buf, 8);
-  if ((version >> 32) != FSST_VERSION_LO) return false;
+  memcpy(&version, buf, sizeof(uint64_t));
+  if ((version >> 32) != FSST_VERSION_LO) { return false; }
 
-  uint32_t pos     = 17;
-  uint8_t zeroTerm = buf[8] & 1u;
-  uint8_t lenHisto[8];
-  for (uint32_t i = 0; i < 8u; ++i)
-    lenHisto[i] = buf[9 + i];
+  uint32_t pos      = 17;
+  uint8_t zero_term = buf[8] & 1u;
+  uint8_t length_histo[8];
+  for (uint32_t i = 0; i < 8u; ++i) {
+    length_histo[i] = buf[9 + i];
+  }
 
   out->len[0]    = 1;
   out->symbol[0] = 0;
-  uint32_t code  = zeroTerm;
-  if (zeroTerm) lenHisto[0]--;
+  uint32_t code  = zero_term;
+  if (zero_term) length_histo[0]--;
 
   for (uint32_t l = 1; l <= 8u; ++l) {
     uint32_t hist_idx = l & 7u;         // 1,2,3,4,5,6,7,0
     uint32_t sym_len  = (l & 7u) + 1u;  // 2,3,4,5,6,7,8,1
-    for (uint32_t i = 0; i < lenHisto[hist_idx]; ++i, ++code) {
+    for (uint32_t i = 0; i < length_histo[hist_idx]; ++i, ++code) {
       out->len[code] = static_cast<uint8_t>(sym_len);
       uint64_t sym   = 0;
-      for (uint32_t j = 0; j < sym_len; ++j)
+      for (uint32_t j = 0; j < sym_len; ++j) {
         sym |= uint64_t(buf[pos + j]) << (8u * j);
+      }
       out->symbol[code] = sym;
       pos += sym_len;
     }
   }
-  while (code < 255u) {
+  while (code < FSST_NUM_SYMBOLS) {
     out->symbol[code] = FSST_CORRUPT;
     out->len[code++]  = 8u;
   }
   return true;
 }
 
-/// One CTA per segment: coalesced LDG of the symtab into shmem first, then
-/// thread 0 parses from shmem into the decoder slot. A naive one-thread-per-
-/// segment grid suffers ~3-5× from scattered LDG across distinct segment
-/// addresses (each thread reads ~300 B of symtab from a different region of
-/// device memory). Coalesced load amortizes that cost across 256 lanes; the
-/// parse itself is inherently serial (each symbol's start depends on the
-/// previous symbol's length) so we leave that to thread 0.
+/**
+ * @brief Build per-segment FSST decoders from the on-disk symbol table blob.
+ *
+ * Coalesced load of the symbol table blob for the segment into shared memory, then single-threaded
+ * parse into the fsst_decoder_compact format in global memory. One CTA per segment.
+ */
 __global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
   string_chunk_desc const* __restrict__ descs,
   uint32_t num_segments,
@@ -584,13 +602,11 @@ __global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
   auto const seg_idx = blockIdx.x;
   auto const desc    = descs[seg_idx];
 
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ fsst_header_t sm_hdr;
   __shared__ uint8_t sm_symtab[FSST_SYMTAB_MAX_BYTES];
 
-  if (threadIdx.x == 0) {
-    sm_ok = parse_fsst_header(desc.d_bytes, desc.bytes_size, &sm_hdr) ? 1u : 0u;
-  }
+  if (threadIdx.x == 0) { sm_ok = parse_fsst_header(desc.d_bytes, desc.bytes_size, &sm_hdr); }
   __syncthreads();
 
   if (!sm_ok) {
@@ -601,19 +617,19 @@ __global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
     return;
   }
 
-  uint32_t const symtab_off = sm_hdr.fsst_symbol_table_offset;
-  uint32_t symtab_size      = desc.bytes_size - symtab_off;
-  if (symtab_size > FSST_SYMTAB_MAX_BYTES) symtab_size = FSST_SYMTAB_MAX_BYTES;
-  uint8_t const* sym_src = desc.d_bytes + symtab_off;
-  for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x)
+  auto const symtab_off = sm_hdr.fsst_symbol_table_offset;
+  auto const symtab_size =
+    ::cuda::std::min(desc.bytes_size - symtab_off, uint32_t{FSST_SYMTAB_MAX_BYTES});
+  auto const* sym_src = desc.d_bytes + symtab_off;
+  for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x) {
     sm_symtab[i] = sym_src[i];
+  }
   __syncthreads();
 
-  if (threadIdx.x == 0) device_fsst_import(sm_symtab, &d_decoders[seg_idx]);
+  if (threadIdx.x == 0) { device_fsst_import(sm_symtab, &d_decoders[seg_idx]); }
 }
 
-//----- Pass 1 (A+B): per-row compressed-byte offsets ------------------------
-
+//----- Pass 1 (A+B): per-row compressed-byte offsets ------------------------//
 /**
  * @brief Compute the per-row offsets into the FSST compressed byte stream for an FSST segment.
  *
@@ -678,8 +694,7 @@ __global__ void kernel_compute_compressed_offsets_fsst(
   }
 }
 
-//----- Pass 1 (C): per-row decompressed lengths -----------------------------
-
+//----- Pass 1 (C): per-row decompressed lengths -----------------------------//
 /**
  * @brief Compute the compressed length of a row in the FSST compressed stream, where @p comp_ptr
  * points to the start of the compressed bytes for that row, and @p sm_len is the symbol length
@@ -819,8 +834,7 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
   }
 }
 
-//----- Pass 2: gather (decode + emit) ---------------------------------------
-
+//----- Pass 2: gather (decode + emit) ---------------------------------------//
 constexpr uint32_t FSST_SCRATCH_U32_PER_WARP   = 256;
 constexpr uint32_t FSST_SCRATCH_BYTES_PER_WARP = FSST_SCRATCH_U32_PER_WARP * sizeof(uint32_t);
 constexpr uint32_t FSST_MAX_CHUNK_EMIT =
@@ -905,7 +919,7 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
     }
 
     // Determine the write offsets into the scratch pad for this lane's decoded symbol via an
-    // inclusive Hillis-Steele scan of the decoded lengths.
+    // inclusive scan of the decoded lengths.
     auto scan = my_len;
 #pragma unroll
     for (uint32_t step = 1; step < WARP_THREADS; step <<= 1) {
@@ -1027,27 +1041,7 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   }
 }
 
-//----- Host helpers + prepare_fsst ------------------------------------------
-
-/// Count FSST-decoded length without emitting output. Used by
-/// `prepare_dict_fsst` to size per-segment decoded-offset arrays for
-/// mode-1 DICT_FSST segments.
-inline size_t fsst_decompressed_length_host(fsst_decoder_compact const& dec,
-                                            uint8_t const* src,
-                                            size_t src_len)
-{
-  size_t pos = 0, dec_len = 0;
-  while (pos < src_len) {
-    uint8_t code = src[pos++];
-    if (code < FSST_ESC) {
-      dec_len += dec.len[code];
-    } else {
-      ++pos;
-      ++dec_len;
-    }
-  }
-  return dec_len;
-}
+//----- Host helpers + prepare_fsst ------------------------------------------//
 
 prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
 {
@@ -1137,6 +1131,200 @@ prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
 // dict_idx == 0 = NULL. DuckDB ships COMPRESSION_EMPTY validity for these,
 // which the overlay path skips — mark_nulls folds them in.
 //===----------------------------------------------------------------------===//
+
+/**
+ * @brief Parse DICT_FSST header @p hdr from @p base, bounded by the buffer size @p limit.
+ * @return true if the header fits within the buffer and metadata is valid; false otherwise.
+ */
+__device__ __forceinline__ bool parse_dict_fsst_header(uint8_t const* base,
+                                                       uint32_t limit,
+                                                       dict_fsst_header_t* hdr)
+{
+  if (limit < sizeof(dict_fsst_header_t)) return false;
+  memcpy(hdr, base, sizeof(dict_fsst_header_t));
+  return hdr->mode <= DICT_FSST_MODE_FSST_ONLY;
+}
+
+/**
+ * @brief Per-segment scratch input for `kernel_build_dict_fsst_data`. Filled
+ * host-side after a single batched header D2H so the kernel has all metadata
+ * it needs without re-reading the header on device. `base_off` is the
+ * cumulative `(dict_count + 1)` over prior valid segments — it indexes into
+ * the global d_byte_offsets / d_decoded_offsets arrays.
+ */
+struct dict_fsst_pre_desc {
+  uint8_t const* d_bytes;
+  uint32_t bytes_size;
+  uint32_t off_dict;
+  uint32_t off_symtab;
+  uint32_t off_slens;
+  uint32_t base_off;
+  uint32_t dict_count;
+  uint8_t mode;
+  uint8_t string_lengths_width;
+  uint8_t valid;  ///< 0 = host-validated as a stub (kernel writes zeros and returns)
+  uint8_t _pad;
+};
+static_assert(sizeof(dict_fsst_pre_desc) % 4 == 0);
+
+/**
+ * @brief One CTA per segment: parse the symbol table on device, unpack
+ * string_lengths into byte_offsets and inclusive-scan it, then for FSST modes
+ * walk each dict entry to fill decoded_offsets. Writes per-segment outputs
+ * (total decoded bytes + inline-null flag) for the host to aggregate.
+ * Same pattern as `kernel_build_fsst_decoders`.
+ */
+__global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_dict_fsst_data(
+  dict_fsst_pre_desc const* __restrict__ pre,
+  uint32_t num_segments,
+  fsst_decoder_compact* __restrict__ d_decoders,
+  uint32_t* __restrict__ d_byte_offsets,
+  uint32_t* __restrict__ d_decoded_offsets,
+  uint32_t* __restrict__ d_per_seg_decoded_total,
+  uint8_t* __restrict__ d_per_seg_inline_null)
+{
+  using BlockScanT = cub::BlockScan<uint32_t, BLOCK_DIM>;
+
+  __shared__ typename BlockScanT::TempStorage scan_temp;
+  __shared__ uint8_t sm_symtab[FSST_SYMTAB_MAX_BYTES];
+  __shared__ uint8_t sm_len[FSST_NUM_SYMBOLS];
+
+  auto const seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const d = pre[seg_idx];
+
+  if (!d.valid) {
+    if (threadIdx.x == 0) {
+      d_per_seg_decoded_total[seg_idx] = 0;
+      d_per_seg_inline_null[seg_idx]   = 0;
+      for (uint32_t i = 0; i < FSST_NUM_SYMBOLS; ++i) {
+        d_decoders[seg_idx].len[i]    = 0;
+        d_decoders[seg_idx].symbol[i] = 0;
+      }
+    }
+    return;
+  }
+
+  auto* my_byte_off   = d_byte_offsets + d.base_off;
+  auto* my_dec_off    = d_decoded_offsets + d.base_off;
+  bool const has_fsst = (d.mode != DICT_FSST_MODE_DICTIONARY) && (d.dict_count > 1);
+
+  // Phase 1: symbol-table import on device (FSST modes only).
+  if (has_fsst) {
+    auto const symtab_size =
+      ::cuda::std::min(d.bytes_size - d.off_symtab, uint32_t{FSST_SYMTAB_MAX_BYTES});
+    for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x) {
+      sm_symtab[i] = d.d_bytes[d.off_symtab + i];
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) { device_fsst_import(sm_symtab, &d_decoders[seg_idx]); }
+    __syncthreads();
+    // Cache sm_len[] for the per-entry walks below.
+    for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
+      sm_len[i] = d_decoders[seg_idx].len[i];
+    }
+  } else {
+    for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
+      d_decoders[seg_idx].len[i]    = 0;
+      d_decoders[seg_idx].symbol[i] = 0;
+    }
+  }
+  __syncthreads();
+
+  // Phase 2: unpack string_lengths into byte_offsets[1..dict_count+1).
+  // byte_offsets[0] = 0; the inclusive scan below yields the exclusive prefix
+  // sum (decoded_offsets[k] = sum of entry_lens[0..k-1]).
+  if (threadIdx.x == 0) my_byte_off[0] = 0;
+  auto const* slens_packed = reinterpret_cast<uint32_t const*>(d.d_bytes + d.off_slens);
+  for (uint32_t k = threadIdx.x; k < d.dict_count; k += blockDim.x) {
+    my_byte_off[k + 1] = unpack_value<uint32_t>(slens_packed, k, d.string_lengths_width);
+  }
+  __syncthreads();
+
+  // In-place inclusive scan over byte_offsets[0..dict_count].
+  {
+    auto const N              = d.dict_count + 1;
+    auto const max_per_thread = ::cuda::ceil_div(N, blockDim.x);
+    auto const start          = threadIdx.x * max_per_thread;
+    auto const end            = ::cuda::std::min(start + max_per_thread, N);
+    uint32_t thread_sum       = 0;
+    for (int i = start; i < end; ++i) {
+      thread_sum += my_byte_off[i];
+      my_byte_off[i] = thread_sum;
+    }
+    uint32_t exclusive_sum = 0;
+    BlockScanT(scan_temp).ExclusiveSum(thread_sum, exclusive_sum);
+    if (exclusive_sum > 0) {
+      for (int i = start; i < end; ++i) {
+        my_byte_off[i] += exclusive_sum;
+      }
+    }
+  }
+  __syncthreads();
+
+  // Phase 3: decoded_offsets.
+  if (!has_fsst) {
+    // Mode 0 (raw DICTIONARY): decoded_offsets = byte_offsets.
+    for (uint32_t k = threadIdx.x; k <= d.dict_count; k += blockDim.x) {
+      my_dec_off[k] = my_byte_off[k];
+    }
+    __syncthreads();
+  } else {
+    // FSST modes: walk each dict entry's compressed bytes, sum decoded lengths.
+    // Entry k = 0 is the reserved NULL slot (decoded length = 0); per host
+    // contract decoded_offsets[base+1] = decoded_offsets[base] regardless of
+    // entry_lens[0].
+    if (threadIdx.x == 0) my_dec_off[0] = 0;
+    if (threadIdx.x == 0 && d.dict_count >= 1) my_dec_off[1] = 0;  // entry 0 is NULL
+    auto const* dict_bytes_base = d.d_bytes + d.off_dict;
+    for (uint32_t k = threadIdx.x + 1; k < d.dict_count; k += blockDim.x) {
+      auto const comp_start = my_byte_off[k];
+      auto const comp_len   = my_byte_off[k + 1] - comp_start;
+      auto const* cp        = dict_bytes_base + comp_start;
+      uint32_t decomp_len   = 0;
+      uint32_t pos          = 0;
+      while (pos < comp_len) {
+        uint8_t code = cp[pos++];
+        if (code < FSST_ESC) {
+          decomp_len += sm_len[code];
+        } else {
+          ++pos;
+          ++decomp_len;
+        }
+      }
+      my_dec_off[k + 1] = decomp_len;
+    }
+    __syncthreads();
+
+    // In-place inclusive scan over decoded_offsets[0..dict_count].
+    auto const N              = d.dict_count + 1u;
+    auto const max_per_thread = ::cuda::ceil_div(N, blockDim.x);
+    auto const start          = threadIdx.x * max_per_thread;
+    auto const end            = ::cuda::std::min(start + max_per_thread, N);
+    uint32_t thread_sum       = 0;
+    for (uint32_t i = start; i < end; ++i) {
+      thread_sum += my_dec_off[i];
+      my_dec_off[i] = thread_sum;
+    }
+    uint32_t exclusive_sum = 0;
+    BlockScanT(scan_temp).ExclusiveSum(thread_sum, exclusive_sum);
+    if (exclusive_sum > 0) {
+      for (uint32_t i = start; i < end; ++i) {
+        my_dec_off[i] += exclusive_sum;
+      }
+    }
+    __syncthreads();
+  }
+
+  // Phase 4: per-segment scalars.
+  if (threadIdx.x == 0) {
+    d_per_seg_decoded_total[seg_idx] = my_dec_off[d.dict_count];
+    // entry_lens[0] = byte_offsets[1] - byte_offsets[0] = byte_offsets[1].
+    bool const any_null =
+      (d.mode != DICT_FSST_MODE_FSST_ONLY) && (d.dict_count > 1) && (my_byte_off[1] == 0);
+    d_per_seg_inline_null[seg_idx] = any_null ? 1 : 0;
+  }
+}
 
 __global__ void kernel_compute_lengths_dict_fsst(dict_fsst_desc const* __restrict__ descs,
                                                  uint32_t* __restrict__ d_lengths,
@@ -1333,7 +1521,7 @@ __global__ void kernel_dict_fsst_mark_nulls(dict_fsst_desc const* __restrict__ d
 }
 
 /// Stub descriptor for malformed segments — kernel zero-fills these rows.
-inline dict_fsst_desc make_stub_dict_fsst_desc(gpu_string_segment_desc const& seg)
+dict_fsst_desc make_stub_dict_fsst_desc(gpu_string_segment_desc const& seg)
 {
   return {seg.d_bytes,
           seg.bytes_size,
@@ -1351,7 +1539,53 @@ inline dict_fsst_desc make_stub_dict_fsst_desc(gpu_string_segment_desc const& se
           {0, 0, 0, 0, 0, 0}};
 }
 
-prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
+/**
+ * @brief Resizable pinned-host scratch pool. cudaMallocHost is expensive
+ * (~ms per call for MB-class allocations) so we keep a single buffer per
+ * usage site and grow it on demand — once warm, subsequent calls pay zero
+ * allocation cost.
+ */
+class pinned_host_pool {
+  void* ptr_  = nullptr;
+  size_t cap_ = 0;
+
+ public:
+  void* get(size_t bytes)
+  {
+    if (bytes > cap_) {
+      if (ptr_) cudaFreeHost(ptr_);
+      ptr_ = nullptr;
+      cap_ = 0;
+      if (bytes > 0) {
+        RMM_CUDA_TRY(cudaMallocHost(&ptr_, bytes));
+        cap_ = bytes;
+      }
+    }
+    return ptr_;
+  }
+  ~pinned_host_pool()
+  {
+    if (ptr_) cudaFreeHost(ptr_);
+  }
+};
+
+/**
+ * @brief Build per-segment DICT_FSST predecode state on device.
+ *
+ * Pipeline:
+ *   1. Batched async D2H of all headers (one stream-sync, pinned host pool).
+ *   2. Validate headers + compute per-segment region offsets and a cumulative
+ *      `base_off` into the flat byte_offsets / decoded_offsets arrays.
+ *   3. Launch `kernel_build_dict_fsst_data` — one CTA per segment does symbol
+ *      table import, string_lengths unpack + scan, FSST per-entry decoded
+ *      length walks, and per-segment scalar outputs.
+ *   4. Batched async D2H of the small result buffers (one stream-sync).
+ *   5. Host-side build of `dict_fsst_desc[]` with the cross-segment
+ *      `predecode_seg_offset` prefix sum.
+ */
+prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr)
 {
   prepared_dict_fsst out;
   out.any_inline_nulls      = false;
@@ -1359,23 +1593,44 @@ prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
   out.descs.reserve(run.segments.size());
   out.decoders.reserve(run.segments.size());
 
-  for (auto const& seg : run.segments) {
-    if (seg.row_count == 0) continue;
-    if (seg.bytes_size < sizeof(dict_fsst_header_t)) {
-      out.descs.push_back(make_stub_dict_fsst_desc(seg));
+  uint32_t const num_segs = static_cast<uint32_t>(run.segments.size());
+  if (num_segs == 0) return out;
+
+  // Phase 1: batched async D2H of all headers into pinned host memory.
+  // Replaces N synchronous cudaMemcpy(header) calls with a single sync. The
+  // pinned pool amortizes cudaMallocHost across calls — first call pays, the
+  // rest are zero-cost.
+  static thread_local pinned_host_pool headers_pool;
+  auto* headers =
+    static_cast<dict_fsst_header_t*>(headers_pool.get(sizeof(dict_fsst_header_t) * num_segs));
+  for (uint32_t i = 0; i < num_segs; ++i) {
+    auto const& seg = run.segments[i];
+    if (seg.row_count == 0 || seg.bytes_size < sizeof(dict_fsst_header_t)) {
+      headers[i].mode = 0xFFu;  // out-of-range marker, host-validated below
       continue;
     }
+    RMM_CUDA_TRY(cudaMemcpyAsync(&headers[i],
+                                 seg.d_bytes,
+                                 sizeof(dict_fsst_header_t),
+                                 cudaMemcpyDeviceToHost,
+                                 stream.value()));
+  }
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
 
-    // Two targeted D2H reads — dict_indices stays on device.
-    dict_fsst_header_t hdr;
-    RMM_CUDA_TRY(cudaMemcpy(&hdr, seg.d_bytes, sizeof(hdr), cudaMemcpyDeviceToHost));
+  // Phase 2: validate, compute per-segment region offsets + cumulative
+  // base_off into the global byte/decoded_offsets arrays.
+  std::vector<dict_fsst_pre_desc> pre(num_segs);
+  uint32_t total_dict_entries = 0;  // sum of (dict_count + 1) for valid segs
+  for (uint32_t i = 0; i < num_segs; ++i) {
+    auto const& seg = run.segments[i];
+    auto& p         = pre[i];
+    p.valid         = 0;
+    p.d_bytes       = seg.d_bytes;
+    p.bytes_size    = seg.bytes_size;
+    if (seg.row_count == 0 || seg.bytes_size < sizeof(dict_fsst_header_t)) continue;
+    auto const& hdr = headers[i];
+    if (hdr.mode > DICT_FSST_MODE_FSST_ONLY) continue;
 
-    if (hdr.mode > DICT_FSST_MODE_FSST_ONLY) {
-      out.descs.push_back(make_stub_dict_fsst_desc(seg));
-      continue;
-    }
-
-    // Region offsets; each region 8-byte aligned (DuckDB AlignValue).
     uint32_t off_dict   = align_up8(static_cast<uint32_t>(sizeof(hdr)));
     uint32_t off_symtab = align_up8(off_dict + hdr.dict_size);
     uint32_t off_slens  = (hdr.mode == DICT_FSST_MODE_DICTIONARY)
@@ -1383,88 +1638,144 @@ prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
                             : align_up8(off_symtab + hdr.symbol_table_size);
     uint32_t slens_bits = hdr.dict_count * hdr.string_lengths_width;
     uint32_t off_didx   = align_up8(off_slens + (slens_bits + 7u) / 8u);
+    if (off_didx > seg.bytes_size && hdr.mode != DICT_FSST_MODE_FSST_ONLY) continue;
 
-    if (off_didx > seg.bytes_size && hdr.mode != DICT_FSST_MODE_FSST_ONLY) {
+    p.off_dict             = off_dict;
+    p.off_symtab           = off_symtab;
+    p.off_slens            = off_slens;
+    p.dict_count           = hdr.dict_count;
+    p.mode                 = hdr.mode;
+    p.string_lengths_width = hdr.string_lengths_width;
+    p.base_off             = total_dict_entries;
+    p.valid                = 1;
+    total_dict_entries += hdr.dict_count + 1u;
+  }
+
+  if (total_dict_entries == 0) {
+    for (auto const& seg : run.segments) {
+      if (seg.row_count > 0) out.descs.push_back(make_stub_dict_fsst_desc(seg));
+    }
+    return out;
+  }
+
+  // Phase 3: launch the on-device prep kernel. Replaces the per-segment host
+  // pipeline (D2H prefix + duckdb_fsst_import + host walks).
+  rmm::device_buffer d_pre_buf(pre.size() * sizeof(dict_fsst_pre_desc), stream, mr);
+  RMM_CUDA_TRY(cudaMemcpyAsync(d_pre_buf.data(),
+                               pre.data(),
+                               pre.size() * sizeof(dict_fsst_pre_desc),
+                               cudaMemcpyHostToDevice,
+                               stream.value()));
+  rmm::device_buffer d_decoders_buf(num_segs * sizeof(fsst_decoder_compact), stream, mr);
+  rmm::device_buffer d_byte_off_buf(total_dict_entries * sizeof(uint32_t), stream, mr);
+  rmm::device_buffer d_dec_off_buf(total_dict_entries * sizeof(uint32_t), stream, mr);
+  rmm::device_buffer d_per_seg_total_buf(num_segs * sizeof(uint32_t), stream, mr);
+  rmm::device_buffer d_per_seg_inline_null_buf(num_segs * sizeof(uint8_t), stream, mr);
+
+  kernel_build_dict_fsst_data<<<num_segs, BLOCK_DIM, 0, stream.value()>>>(
+    static_cast<dict_fsst_pre_desc const*>(d_pre_buf.data()),
+    num_segs,
+    static_cast<fsst_decoder_compact*>(d_decoders_buf.data()),
+    static_cast<uint32_t*>(d_byte_off_buf.data()),
+    static_cast<uint32_t*>(d_dec_off_buf.data()),
+    static_cast<uint32_t*>(d_per_seg_total_buf.data()),
+    static_cast<uint8_t*>(d_per_seg_inline_null_buf.data()));
+
+  // Phase 4: pull results back into host vectors (small — single ~5 MB D2H
+  // for typical TPC-H multi-segment workloads).
+  out.decoders.resize(num_segs);
+  out.byte_offsets.resize(total_dict_entries);
+  out.decoded_offsets.resize(total_dict_entries);
+  std::vector<uint32_t> per_seg_total(num_segs);
+  std::vector<uint8_t> per_seg_inline_null(num_segs);
+
+  static thread_local pinned_host_pool d2h_pool;
+  size_t const d2h_bytes = num_segs * sizeof(fsst_decoder_compact) +
+                           2 * total_dict_entries * sizeof(uint32_t) + num_segs * sizeof(uint32_t) +
+                           num_segs * sizeof(uint8_t);
+  auto* staging      = static_cast<uint8_t*>(d2h_pool.get(d2h_bytes));
+  size_t off         = 0;
+  auto* pin_decoders = reinterpret_cast<fsst_decoder_compact*>(staging + off);
+  off += num_segs * sizeof(fsst_decoder_compact);
+  auto* pin_byte_off = reinterpret_cast<uint32_t*>(staging + off);
+  off += total_dict_entries * sizeof(uint32_t);
+  auto* pin_dec_off = reinterpret_cast<uint32_t*>(staging + off);
+  off += total_dict_entries * sizeof(uint32_t);
+  auto* pin_per_seg_total = reinterpret_cast<uint32_t*>(staging + off);
+  off += num_segs * sizeof(uint32_t);
+  auto* pin_per_seg_inline_null = reinterpret_cast<uint8_t*>(staging + off);
+
+  RMM_CUDA_TRY(cudaMemcpyAsync(pin_decoders,
+                               d_decoders_buf.data(),
+                               num_segs * sizeof(fsst_decoder_compact),
+                               cudaMemcpyDeviceToHost,
+                               stream.value()));
+  RMM_CUDA_TRY(cudaMemcpyAsync(pin_byte_off,
+                               d_byte_off_buf.data(),
+                               total_dict_entries * sizeof(uint32_t),
+                               cudaMemcpyDeviceToHost,
+                               stream.value()));
+  RMM_CUDA_TRY(cudaMemcpyAsync(pin_dec_off,
+                               d_dec_off_buf.data(),
+                               total_dict_entries * sizeof(uint32_t),
+                               cudaMemcpyDeviceToHost,
+                               stream.value()));
+  RMM_CUDA_TRY(cudaMemcpyAsync(pin_per_seg_total,
+                               d_per_seg_total_buf.data(),
+                               num_segs * sizeof(uint32_t),
+                               cudaMemcpyDeviceToHost,
+                               stream.value()));
+  RMM_CUDA_TRY(cudaMemcpyAsync(pin_per_seg_inline_null,
+                               d_per_seg_inline_null_buf.data(),
+                               num_segs * sizeof(uint8_t),
+                               cudaMemcpyDeviceToHost,
+                               stream.value()));
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+
+  std::memcpy(out.decoders.data(), pin_decoders, num_segs * sizeof(fsst_decoder_compact));
+  std::memcpy(out.byte_offsets.data(), pin_byte_off, total_dict_entries * sizeof(uint32_t));
+  std::memcpy(out.decoded_offsets.data(), pin_dec_off, total_dict_entries * sizeof(uint32_t));
+  std::memcpy(per_seg_total.data(), pin_per_seg_total, num_segs * sizeof(uint32_t));
+  std::memcpy(per_seg_inline_null.data(), pin_per_seg_inline_null, num_segs * sizeof(uint8_t));
+
+  // Phase 5: build dict_fsst_desc[] on host. predecode_seg_offset is a
+  // cross-segment cumulative scan over per_seg_total (mode-1 segs only).
+  uint32_t predecode_cursor = 0;
+  for (uint32_t i = 0; i < num_segs; ++i) {
+    auto const& seg = run.segments[i];
+    if (seg.row_count == 0) continue;
+    auto const& p = pre[i];
+    if (!p.valid) {
       out.descs.push_back(make_stub_dict_fsst_desc(seg));
       continue;
     }
-
-    // +7B pad: host_unpack_bitpacked reads 8B at a time at the tail.
-    uint32_t prefix_bytes = std::min(off_didx, seg.bytes_size);
-    std::vector<uint8_t> host_bytes_vec(size_t{prefix_bytes} + 7u, 0u);
-    uint8_t* host_bytes = host_bytes_vec.data();
-    RMM_CUDA_TRY(cudaMemcpy(host_bytes, seg.d_bytes, prefix_bytes, cudaMemcpyDeviceToHost));
-
-    // entry_lens[k] = bitpacked length of dict entry k (compressed in FSST modes).
-    std::vector<uint32_t> entry_lens(hdr.dict_count, 0);
-    uint8_t const* slens_ptr = host_bytes + off_slens;
-    for (uint32_t k = 0; k < hdr.dict_count; ++k) {
-      entry_lens[k] = host_unpack_bitpacked<uint32_t>(slens_ptr, k, hdr.string_lengths_width);
+    auto const& hdr        = headers[i];
+    uint32_t predecode_off = 0;
+    if (p.mode == DICT_FSST_MODE_DICT_FSST) {
+      predecode_off = predecode_cursor;
+      predecode_cursor += per_seg_total[i];
     }
-
-    // byte_offsets[k] = cumulative compressed-byte position of entry k.
-    uint32_t base_off = static_cast<uint32_t>(out.byte_offsets.size());
-    out.byte_offsets.resize(base_off + hdr.dict_count + 1u);
-    out.byte_offsets[base_off] = 0u;
-    for (uint32_t k = 0; k < hdr.dict_count; ++k) {
-      out.byte_offsets[base_off + k + 1] = out.byte_offsets[base_off + k] + entry_lens[k];
-    }
-
-    // decoded_offsets[k]: same as byte_offsets in mode 0, FSST-walked otherwise.
-    fsst_decoder_compact compact{};
-    if (hdr.mode != DICT_FSST_MODE_DICTIONARY) {
-      fsst_decoder_full full{};
-      duckdb_fsst_import(&full, host_bytes + off_symtab);
-      std::memcpy(compact.len, full.len, sizeof(compact.len));
-      std::memcpy(compact.symbol, full.symbol, sizeof(compact.symbol));
-    }
-    out.decoders.push_back(compact);
-
-    out.decoded_offsets.resize(base_off + hdr.dict_count + 1u);
-    out.decoded_offsets[base_off] = 0u;
-    if (hdr.mode == DICT_FSST_MODE_DICTIONARY) {
-      // Raw dict — decoded == compressed.
-      for (uint32_t k = 0; k <= hdr.dict_count; ++k) {
-        out.decoded_offsets[base_off + k] = out.byte_offsets[base_off + k];
-      }
-    } else {
-      uint8_t const* dict_bytes = host_bytes + off_dict;
-      for (uint32_t k = 0; k < hdr.dict_count; ++k) {
-        size_t comp_start = out.byte_offsets[base_off + k];
-        size_t comp_len   = entry_lens[k];
-        size_t dec_len =
-          (k == 0) ? 0 : fsst_decompressed_length_host(compact, dict_bytes + comp_start, comp_len);
-        out.decoded_offsets[base_off + k + 1] =
-          out.decoded_offsets[base_off + k] + static_cast<uint32_t>(dec_len);
-      }
-    }
-
-    // dict_count>1 + entry_lens[0]==0 => inline-NULL encoding used.
-    out.any_inline_nulls = out.any_inline_nulls || (hdr.mode != DICT_FSST_MODE_FSST_ONLY &&
-                                                    hdr.dict_count > 1 && entry_lens[0] == 0u);
-
-    // Mode-1 only reserves predecode-buffer space.
-    uint32_t predecode_off = 0u;
-    if (hdr.mode == DICT_FSST_MODE_DICT_FSST) {
-      predecode_off = out.total_predecode_bytes;
-      out.total_predecode_bytes += out.decoded_offsets[base_off + hdr.dict_count];
-    }
-
-    out.descs.push_back({seg.d_bytes,
-                         seg.bytes_size,
-                         seg.row_count,
-                         seg.row_offset,
-                         seg.seg_row_start,
-                         off_dict,
-                         (hdr.mode == DICT_FSST_MODE_FSST_ONLY) ? 0u : off_didx,
-                         base_off,
-                         static_cast<uint32_t>(out.decoders.size() - 1u),
-                         hdr.dict_count,
-                         predecode_off,
-                         hdr.dictionary_indices_width,
-                         hdr.mode,
-                         {0, 0, 0, 0, 0, 0}});
+    out.descs.push_back(
+      {seg.d_bytes,
+       seg.bytes_size,
+       seg.row_count,
+       seg.row_offset,
+       seg.seg_row_start,
+       p.off_dict,
+       (p.mode == DICT_FSST_MODE_FSST_ONLY)
+         ? 0u
+         : align_up8(p.off_slens + (p.dict_count * p.string_lengths_width + 7u) / 8u),
+       p.base_off,
+       i,  // seg_decoder_idx — 1:1 with seg_idx in the new layout
+       p.dict_count,
+       predecode_off,
+       hdr.dictionary_indices_width,
+       p.mode,
+       {0, 0, 0, 0, 0, 0}});
+    if (per_seg_inline_null[i]) out.any_inline_nulls = true;
   }
+  out.total_predecode_bytes = predecode_cursor;
+
   return out;
 }
 
@@ -1492,14 +1803,15 @@ void overlay_validity_run(gpu_codec_run const& run, uint8_t* d_mask, rmm::cuda_s
       throw std::runtime_error("gpu_decode_strings_column: validity row_offset (" +
                                std::to_string(seg.row_offset) + ") not byte-aligned");
     }
-    size_t bytes = (size_t{seg.row_count} + 7) / 8;
-    if (size_t{seg.bytes_size} < bytes) {
+    auto const bytes  = ::cuda::ceil_div(seg.row_count, 8);
+    auto const offset = seg.row_offset / 8;
+    if (seg.bytes_size < bytes) {
       throw std::runtime_error("gpu_decode_strings_column: validity segment bytes_size (" +
                                std::to_string(seg.bytes_size) + ") < required " +
                                std::to_string(bytes));
     }
     RMM_CUDA_TRY(cudaMemcpyAsync(
-      d_mask + seg.row_offset / 8, seg.d_bytes, bytes, cudaMemcpyDeviceToDevice, stream.value()));
+      d_mask + offset, seg.d_bytes, bytes, cudaMemcpyDeviceToDevice, stream.value()));
   }
 }
 
@@ -1556,10 +1868,10 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
         break;
       }
       case duckdb::CompressionType::COMPRESSION_DICT_FSST: {
-        auto p                  = prepare_dict_fsst(run);
-        uint32_t bo_base        = static_cast<uint32_t>(prep_dict_fsst.byte_offsets.size());
-        uint32_t dec_base       = static_cast<uint32_t>(prep_dict_fsst.decoders.size());
-        uint32_t predecode_base = prep_dict_fsst.total_predecode_bytes;
+        auto p                    = prepare_dict_fsst(run, stream, mr);
+        auto const bo_base        = static_cast<uint32_t>(prep_dict_fsst.byte_offsets.size());
+        auto const dec_base       = static_cast<uint32_t>(prep_dict_fsst.decoders.size());
+        auto const predecode_base = prep_dict_fsst.total_predecode_bytes;
         for (auto& d : p.descs) {
           d.seg_dict_offset_base += bo_base;
           d.seg_decoder_idx += dec_base;
@@ -1734,8 +2046,8 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   }
 
   // Prefix-sum lengths → byte offsets per row.
-  size_t cub_bytes = 0;
-  int const scan_n = static_cast<int>(total_rows) + 1;
+  size_t cub_bytes  = 0;
+  auto const scan_n = static_cast<int>(total_rows) + 1;
   cub::DeviceScan::ExclusiveSum(nullptr,
                                 cub_bytes,
                                 d_lengths.data(),
@@ -1751,7 +2063,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
                                 stream.value());
 
   // cudf strings offsets are int32; reject up front if the upper bound exceeds it.
-  constexpr size_t INT32_MAX_SIZE = static_cast<size_t>(std::numeric_limits<int32_t>::max());
+  constexpr auto INT32_MAX_SIZE = static_cast<size_t>(std::numeric_limits<int32_t>::max());
   if (!needs_exact_total && cum_chars_upper > INT32_MAX_SIZE) {
     throw std::runtime_error("gpu_decode_strings_column: estimated total_chars (" +
                              std::to_string(cum_chars_upper) + ") exceeds int32 max");

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -15,6 +15,16 @@
  */
 
 // String-codec decode kernels and orchestrator. See gpu_decode_strings.cuh.
+//
+// File layout (top to bottom):
+//   1. Shared core      — on-disk headers, decoder types, descriptor structs,
+//                         tuning constants, helpers used across codecs, and
+//                         the `prepared_*` types each codec produces.
+//   2. DICTIONARY codec — kernels + prepare_dict().
+//   3. FSST codec       — kernels + prepare_fsst(). The warp-decode helper
+//                         `warp_decode_fsst` is reused by DICT_FSST mode 2.
+//   4. DICT_FSST codec  — kernels + prepare_dict_fsst().
+//   5. Orchestrator     — `gpu_decode_strings_column` + validity overlay.
 
 #include "cuda/scan/gpu_decode_strings.cuh"
 
@@ -43,15 +53,17 @@ namespace sirius::cuda::scan {
 namespace {
 
 //===----------------------------------------------------------------------===//
-// On-disk header structs.
+// 1. Shared core
 //
-// Layouts mirror duckdb's compression headers. Sizes / field meanings are
-// authoritative from the references in:
+// Types, constants, and helpers used by more than one codec. References to
+// the DuckDB sources that define the on-disk layouts:
 //   duckdb/src/storage/compression/dictionary.cpp     (DICTIONARY)
 //   duckdb/src/storage/compression/fsst.cpp           (FSST)
 //   duckdb/src/storage/compression/dict_fsst/{compression,decompression}.cpp
 //                                                     (DICT_FSST)
 //===----------------------------------------------------------------------===//
+
+//----- On-disk headers ------------------------------------------------------
 
 struct dict_header_t {
   uint32_t dict_size;
@@ -84,6 +96,8 @@ enum : uint8_t {
   DICT_FSST_MODE_FSST_ONLY  = 2,
 };
 
+//----- FSST decoder types (shared: FSST + DICT_FSST modes 1+2) --------------
+
 /// 255 codes (0..254); byte 255 is the escape sentinel.
 constexpr uint32_t FSST_SIZE        = 256;
 constexpr uint32_t FSST_NUM_SYMBOLS = 255;
@@ -111,6 +125,8 @@ static_assert(sizeof(fsst_decoder_compact::symbol) == sizeof(fsst_decoder_full::
 
 // Declared locally to avoid pulling the libduckdb FSST header into the CUDA TU.
 extern "C" unsigned int duckdb_fsst_import(void* decoder, unsigned char* buf);
+
+//----- Per-kernel descriptors -----------------------------------------------
 
 /// Descriptor for DICTIONARY chunks and FSST length-pass segments.
 /// FSST length pass can't chunk: the in-CTA prefix sum is per-segment.
@@ -150,13 +166,17 @@ struct alignas(8) dict_fsst_desc {
   uint8_t _pad[6];
 };
 
+//----- Tuning constants -----------------------------------------------------
+
 constexpr uint32_t BLOCK_DIM = 256;  // see FSST_WARPS_PER_CTA static_assert
 constexpr uint32_t MIN_ROWS_PER_CHUNK =
-  64;  ///< The minimum number of rows for a segment chunk;
-       ///< BLOCK_DIM=256 threads -> 8 warps per chunk -> 8 rows per warp.
+  64;  ///< Minimum rows per segment chunk; BLOCK_DIM=256 threads -> 8 warps
+       ///< per chunk -> 8 rows per warp at this minimum.
 constexpr uint32_t WARP_THREADS           = 32;
 constexpr uint32_t FULL_MASK              = 0xFFFFFFFFu;
 constexpr uint32_t WARP_BULK_STRIDE_BYTES = WARP_THREADS * 4u;
+constexpr uint32_t MAX_BITPACKING_WIDTH   = 32;
+
 /// Above this, take the exact-total sync rather than trust the host upper
 /// bound — a pathological max_string_length could otherwise force a GB-class
 /// over-allocation.
@@ -166,173 +186,11 @@ constexpr size_t HOST_UPPER_BOUND_LIMIT = size_t{512} * 1024u * 1024u;
 /// (launch-bound at short rows) to warp-cooperative (bandwidth-bound at long
 /// rows). Mirrors cuDF's strings-gather split (32B) with headroom.
 constexpr uint32_t DICT_WARP_COOP_MIN_LEN = 64u;
-constexpr uint32_t MAX_BITPACKING_WIDTH   = 32;
+
+//----- Helpers --------------------------------------------------------------
 
 /// DuckDB's AlignValue<idx_t>.
 constexpr uint32_t align_up8(uint32_t n) { return (n + 7u) & ~7u; }
-
-/// false on malformed metadata; callers zero-fill.
-__device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
-                                                  uint32_t limit,
-                                                  dict_header_t* hdr)
-{
-  if (limit < sizeof(dict_header_t)) return false;
-  memcpy(hdr, base, sizeof(*hdr));
-  return hdr->index_buffer_offset + hdr->index_buffer_count * sizeof(uint32_t) <= limit &&
-         hdr->dict_end <= limit && hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
-}
-
-/// Device port of duckdb_fsst_import (libfsst.cpp:429). Same opaque blob
-/// layout (8B version | 1B zeroTerminated | 8B lenHisto | packed symbols by
-/// length group 1..8,1). CUDA targets are always little-endian so the
-/// host-side swap64_if_be is a no-op here. Used by kernel_build_fsst_decoders
-/// to populate per-segment decoders without round-tripping through host.
-constexpr uint32_t FSST_VERSION_LO        = 20190218u;
-constexpr unsigned long long FSST_CORRUPT = 32774747032022883ull;  // "corrupt" in LE
-
-__device__ __forceinline__ bool device_fsst_import(uint8_t const* buf, fsst_decoder_compact* out)
-{
-  // Zero first so a bad header / corrupted symtab leaves a deterministic
-  // (all-zero-length) decoder.
-  for (uint32_t i = 0; i < FSST_NUM_SYMBOLS; ++i) {
-    out->len[i]    = 0;
-    out->symbol[i] = 0;
-  }
-
-  uint64_t version;
-  memcpy(&version, buf, 8);
-  if ((version >> 32) != FSST_VERSION_LO) return false;
-
-  uint32_t pos     = 17;
-  uint8_t zeroTerm = buf[8] & 1u;
-  uint8_t lenHisto[8];
-  for (uint32_t i = 0; i < 8u; ++i)
-    lenHisto[i] = buf[9 + i];
-
-  out->len[0]    = 1;
-  out->symbol[0] = 0;
-  uint32_t code  = zeroTerm;
-  if (zeroTerm) lenHisto[0]--;
-
-  for (uint32_t l = 1; l <= 8u; ++l) {
-    uint32_t hist_idx = l & 7u;         // 1,2,3,4,5,6,7,0
-    uint32_t sym_len  = (l & 7u) + 1u;  // 2,3,4,5,6,7,8,1
-    for (uint32_t i = 0; i < lenHisto[hist_idx]; ++i, ++code) {
-      out->len[code] = static_cast<uint8_t>(sym_len);
-      uint64_t sym   = 0;
-      for (uint32_t j = 0; j < sym_len; ++j)
-        sym |= uint64_t(buf[pos + j]) << (8u * j);
-      out->symbol[code] = sym;
-      pos += sym_len;
-    }
-  }
-  while (code < 255u) {
-    out->symbol[code] = FSST_CORRUPT;
-    out->len[code++]  = 8u;
-  }
-  return true;
-}
-
-// Forward decl — definition lives further down with the other FSST kernels.
-__device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
-                                                  uint32_t limit,
-                                                  fsst_header_t* hdr);
-
-/// One CTA per segment: coalesced LDG of the symtab into shmem first, then
-/// thread 0 parses from shmem into the decoder slot. A naive one-thread-per-
-/// segment grid suffers ~3-5× from scattered LDG across distinct segment
-/// addresses (each thread reads ~300 B of symtab from a different region of
-/// device memory). Coalesced load amortizes that cost across 256 lanes; the
-/// parse itself is inherently serial (each symbol's start depends on the
-/// previous symbol's length) so we leave that to thread 0.
-__global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
-  string_chunk_desc const* __restrict__ descs,
-  uint32_t num_segments,
-  fsst_decoder_compact* __restrict__ d_decoders)
-{
-  auto const seg_idx = blockIdx.x;
-  auto const desc    = descs[seg_idx];
-
-  __shared__ uint8_t sm_ok;
-  __shared__ fsst_header_t sm_hdr;
-  __shared__ uint8_t sm_symtab[FSST_SYMTAB_MAX_BYTES];
-
-  if (threadIdx.x == 0) {
-    sm_ok = parse_fsst_header(desc.d_bytes, desc.bytes_size, &sm_hdr) ? 1u : 0u;
-  }
-  __syncthreads();
-
-  if (!sm_ok) {
-    for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
-      d_decoders[seg_idx].len[i]    = 0;
-      d_decoders[seg_idx].symbol[i] = 0;
-    }
-    return;
-  }
-
-  uint32_t const symtab_off = sm_hdr.fsst_symbol_table_offset;
-  uint32_t symtab_size      = desc.bytes_size - symtab_off;
-  if (symtab_size > FSST_SYMTAB_MAX_BYTES) symtab_size = FSST_SYMTAB_MAX_BYTES;
-  uint8_t const* sym_src = desc.d_bytes + symtab_off;
-  for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x)
-    sm_symtab[i] = sym_src[i];
-  __syncthreads();
-
-  if (threadIdx.x == 0) device_fsst_import(sm_symtab, &d_decoders[seg_idx]);
-}
-
-/// TODO: refactor as utility function
-template <typename T>
-__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
-{
-  if (width == 0) return T(0);
-  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
-  uint32_t word_idx = static_cast<uint32_t>(bit_pos / 32);
-  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31);
-  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
-  if (bit_off + width > 32) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
-  uint64_t result = combined >> bit_off;
-  if constexpr (sizeof(T) > 4) {
-    if (bit_off > 0 && bit_off + width > 64) {
-      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
-    }
-  }
-  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
-  return static_cast<T>(result & mask);
-}
-
-/// DuckDB's BitpackingPrimitives uses 32-element bit-dense groups on 32-bit
-/// boundaries; an 8-byte straddling load is still safe for widths ≤ 32.
-template <typename T>
-inline T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
-{
-  if (width == 0) return T(0);
-  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
-  uint32_t byte_off = static_cast<uint32_t>(bit_pos >> 3);
-  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 7u);
-  uint64_t combined;
-  std::memcpy(&combined, packed + byte_off, sizeof(uint64_t));
-  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
-  return static_cast<T>((combined >> bit_off) & mask);
-}
-
-/// Count decoded length without emitting output (used to size predecode offsets).
-inline size_t fsst_decompressed_length_host(fsst_decoder_compact const& dec,
-                                            uint8_t const* src,
-                                            size_t src_len)
-{
-  size_t pos = 0, dec_len = 0;
-  while (pos < src_len) {
-    uint8_t code = src[pos++];
-    if (code < FSST_ESC) {
-      dec_len += dec.len[code];
-    } else {
-      ++pos;
-      ++dec_len;
-    }
-  }
-  return dec_len;
-}
 
 /// Two waves of full occupancy at BLOCK_DIM threads, per current device.
 uint32_t get_target_ctas()
@@ -351,7 +209,7 @@ uint32_t get_target_ctas()
 }
 
 /// Split per-segment descriptors into smaller row sub-ranges so the kernel
-/// grid fills available SMs. Below MIN_CHUNK_ROW the per-CTA overhead
+/// grid fills available SMs. Below MIN_ROWS_PER_CHUNK the per-CTA overhead
 /// dominates and we keep the original shape. Used for per-row work
 /// (compute_lengths, gather); per-dict work (predecode, mark_nulls) keeps
 /// one-CTA-per-segment so dictionaries are not decoded per chunk.
@@ -388,8 +246,93 @@ std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_
   return out;
 }
 
+/// Bit-packed value reader. DuckDB's BitpackingPrimitives uses 32-element
+/// bit-dense groups on 32-bit boundaries; an 8-byte straddling load is still
+/// safe for widths ≤ 32. For T larger than 4 bytes we may need a third word.
+template <typename T>
+__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
+{
+  if (width == 0) return T(0);
+  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
+  uint32_t word_idx = static_cast<uint32_t>(bit_pos / 32);
+  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31);
+  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
+  if (bit_off + width > 32) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
+  uint64_t result = combined >> bit_off;
+  if constexpr (sizeof(T) > 4) {
+    if (bit_off > 0 && bit_off + width > 64) {
+      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
+    }
+  }
+  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+  return static_cast<T>(result & mask);
+}
+
+/// Host-side counterpart to `unpack_value` — byte-addressed, used during
+/// `prepare_dict_fsst` to walk header regions copied to host.
+template <typename T>
+inline T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
+{
+  if (width == 0) return T(0);
+  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
+  uint32_t byte_off = static_cast<uint32_t>(bit_pos >> 3);
+  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 7u);
+  uint64_t combined;
+  std::memcpy(&combined, packed + byte_off, sizeof(uint64_t));
+  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+  return static_cast<T>((combined >> bit_off) & mask);
+}
+
+/// false on malformed metadata; callers zero-fill.
+__device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
+                                                  uint32_t limit,
+                                                  dict_header_t* hdr)
+{
+  if (limit < sizeof(dict_header_t)) return false;
+  memcpy(hdr, base, sizeof(*hdr));
+  return hdr->index_buffer_offset + hdr->index_buffer_count * sizeof(uint32_t) <= limit &&
+         hdr->dict_end <= limit && hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
+}
+
+/// false on malformed metadata; callers zero-fill.
+__device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
+                                                  uint32_t limit,
+                                                  fsst_header_t* hdr)
+{
+  if (limit < sizeof(fsst_header_t)) return false;
+  memcpy(hdr, base, sizeof(fsst_header_t));
+  return hdr->dict_end <= limit && hdr->fsst_symbol_table_offset < hdr->dict_end &&
+         hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
+}
+
+//----- Per-codec prepared-data struct types ---------------------------------
+// Each codec's prepare_* returns one of these; gpu_decode_strings_column
+// aggregates them across runs before launching kernels.
+
+struct prepared_dict {
+  std::vector<string_chunk_desc> descs_short;  ///< max_string_length < DICT_WARP_COOP_MIN_LEN
+  std::vector<string_chunk_desc> descs_long;   ///< max_string_length >= DICT_WARP_COOP_MIN_LEN
+};
+
+struct prepared_fsst {
+  std::vector<string_chunk_desc> length_descs;  ///< pass-1 A+B (per segment)
+  std::vector<fsst_chunk_desc> gather_chunks;   ///< pass-1 phase-C + pass-2 (per chunk)
+  std::vector<fsst_decoder_compact> decoders;   ///< symbol tables (per segment)
+  std::vector<uint32_t> row_starts;             ///< prefix sum of FSST row counts
+  uint32_t total_fsst_row_count;
+};
+
+struct prepared_dict_fsst {
+  std::vector<dict_fsst_desc> descs;
+  std::vector<fsst_decoder_compact> decoders;
+  std::vector<uint32_t> byte_offsets;     ///< per-segment, dict_count+1 entries each
+  std::vector<uint32_t> decoded_offsets;  ///< per-segment, dict_count+1 entries each
+  bool any_inline_nulls;
+  uint32_t total_predecode_bytes;  ///< sum of mode-1 dict-decoded bytes
+};
+
 //===----------------------------------------------------------------------===//
-// DICTIONARY codec.
+// 2. DICTIONARY codec
 //
 //   offset 0                                                      seg_end
 //   +--------+------------------+------------------+---------------------+
@@ -447,20 +390,20 @@ __global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
 {
   auto const chunk_id = blockIdx.x;
   if (chunk_id >= num_chunks) return;
-  auto const desc  = descs[chunk_id];
-  auto const* base = desc.d_bytes;
+  auto const desc          = descs[chunk_id];
+  auto const* segment_base = desc.d_bytes;
 
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ dict_header_t sm_hdr;
-  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  if (threadIdx.x == 0) { sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
   // Pass 1 already zero-filled lengths on malformed metadata — d_offsets[i+1]
   // == d_offsets[i] for those rows, so nothing to write here.
   if (!sm_ok) return;
 
-  uint32_t const* d_sel   = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
-  uint32_t const* d_idx   = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
-  uint8_t const* dict_end = base + sm_hdr.dict_end;
+  auto const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
+  auto const* d_idx = reinterpret_cast<uint32_t const*>(segment_base + sm_hdr.index_buffer_offset);
+  auto const* dict_end = segment_base + sm_hdr.dict_end;
 
   for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
     uint32_t seg_i = desc.seg_row_start + i;
@@ -483,18 +426,20 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
 {
   uint32_t cid = blockIdx.x;
   if (cid >= num_chunks) return;
-  auto const desc     = descs[cid];
-  uint8_t const* base = desc.d_bytes;
+  auto const desc             = descs[cid];
+  uint8_t const* segment_base = desc.d_bytes;
 
   __shared__ uint8_t sm_ok;
   __shared__ dict_header_t sm_hdr;
-  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  if (threadIdx.x == 0)
+    sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr) ? 1 : 0;
   __syncthreads();
   if (!sm_ok) return;
 
-  uint32_t const* d_sel   = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
-  uint32_t const* d_idx   = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
-  uint8_t const* dict_end = base + sm_hdr.dict_end;
+  uint32_t const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
+  uint32_t const* d_idx =
+    reinterpret_cast<uint32_t const*>(segment_base + sm_hdr.index_buffer_offset);
+  uint8_t const* dict_end = segment_base + sm_hdr.dict_end;
 
   uint32_t const lane          = threadIdx.x & (WARP_THREADS - 1u);
   uint32_t const warp_id       = threadIdx.x / WARP_THREADS;
@@ -523,123 +468,151 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
   }
 }
 
+prepared_dict prepare_dict(gpu_string_codec_run const& run)
+{
+  prepared_dict out;
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    string_chunk_desc d{
+      seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start};
+    auto& bucket =
+      (seg.max_string_length < DICT_WARP_COOP_MIN_LEN) ? out.descs_short : out.descs_long;
+    bucket.push_back(d);
+  }
+  return out;
+}
+
 //===----------------------------------------------------------------------===//
-// FSST codec.
+// 3. FSST codec
 //
 //   offset 0                                                       seg_end
 //   +--------+--------------------+---------------+------------------------+
 //   | header | compressed_lengths |  symbol table |  FSST-compressed bytes |
 //   |  16B   |  bitpacked per row |  opaque blob  |  rows packed in        |
 //   |        |  -> comp_len       |  imported on  |  REVERSE order ending  |
-//   |        |                    |  host         |  at dict_end           |
+//   |        |                    |  device       |  at dict_end           |
 //   +--------+--------------------+---------------+------------------------+
 //   0        16                   ^                                        ^
 //                                 hdr.fsst_symbol_table_offset             hdr.dict_end
 //
-// Pass 1 is split into A+B (per-segment) and C (chunked):
-//   A — unpack compressed_lengths into d_comp_offsets[fsst_base..]
-//   B — in-CTA InclusiveSum producing per-row cumulative compressed bytes
-//   C — for each row, walk its compressed bytes summing decoded lengths
-// A+B owns per-segment prefix-sum state (one CTA per segment); C partitions
-// a segment across CTAs into 'chunks' and performs a serial byte scan.
+// Decode pipeline (in launch order):
+//   kernel_build_fsst_decoders               — parse opaque symtab into
+//                                              fsst_decoder_compact on device
+//   kernel_compute_compressed_offsets_fsst   — Pass-1 A+B: per-segment
+//                                              prefix sum of compressed
+//                                              lengths -> d_comp_offsets
+//   kernel_compute_decompressed_lengths_fsst — Pass-1 C: per-row byte-walk
+//                                              to compute decoded length
+//   kernel_gather_fsst_chunked               — Pass-2: per-row decode +
+//                                              emit to d_chars
 //
-// Pass 2 gather walks the compressed bytes to emit the decoded strings,
-// using 1 warp per row and the same chunking as phase C to partition work
-// across segments.
+// Pass-1 A+B owns per-segment prefix-sum state (one CTA per segment);
+// Pass-1 C and Pass-2 partition each segment across CTAs into chunks.
+// The warp-decode helper `warp_decode_fsst` is also used by DICT_FSST
+// mode 2 (inline-decompress per row).
 //===----------------------------------------------------------------------===//
 
-//===----------HOST logic----------===//
-struct prepared_fsst {
-  std::vector<string_chunk_desc> length_descs;  ///< pass-1 A+B (per segment)
-  std::vector<fsst_chunk_desc> gather_chunks;   ///< pass-1 phase-C + pass-2 (per chunk)
-  std::vector<fsst_decoder_compact> decoders;   ///< symbol tables (per segment)
-  std::vector<uint32_t> row_starts;             ///< prefix sum of FSST row counts
-  uint32_t total_fsst_row_count;
-};
+//----- On-device FSST symbol-table import -----------------------------------
 
-prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
+/// Device port of duckdb_fsst_import (libfsst.cpp:429). Same opaque blob
+/// layout (8B version | 1B zeroTerminated | 8B lenHisto | packed symbols by
+/// length group 1..8,1). CUDA targets are always little-endian so the
+/// host-side swap64_if_be is a no-op here. Used by kernel_build_fsst_decoders
+/// to populate per-segment decoders without round-tripping through host.
+constexpr uint32_t FSST_VERSION_LO        = 20190218u;
+constexpr unsigned long long FSST_CORRUPT = 32774747032022883ull;  // "corrupt" in LE
+
+__device__ __forceinline__ bool device_fsst_import(uint8_t const* buf, fsst_decoder_compact* out)
 {
-  prepared_fsst out;
-  out.total_fsst_row_count = 0;
-  out.length_descs.reserve(run.segments.size());
-  out.row_starts.reserve(run.segments.size());
-
-  // Segment descriptors for pass-1 A+B
-  for (auto const& seg : run.segments) {
-    if (seg.row_count == 0) continue;
-    out.row_starts.push_back(out.total_fsst_row_count);
-    out.total_fsst_row_count += seg.row_count;
-    out.length_descs.push_back(
-      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
+  // Zero first so a bad header / corrupted symtab leaves a deterministic
+  // (all-zero-length) decoder.
+  for (uint32_t i = 0; i < FSST_NUM_SYMBOLS; ++i) {
+    out->len[i]    = 0;
+    out->symbol[i] = 0;
   }
-  auto const segment_count = out.length_descs.size();
-  out.decoders.resize(segment_count);
 
-  // Chunked descriptors for phase-C + gather. Split per-segment only when
-  // total segments < target_ctas (else one-chunk-per-segment fills SMs already).
-  auto const target_ctas         = get_target_ctas();
-  uint32_t target_rows_per_chunk = 0;
-  if (segment_count < target_ctas && out.total_fsst_row_count > 0) {
-    target_rows_per_chunk = std::max(out.total_fsst_row_count / target_ctas, MIN_ROWS_PER_CHUNK);
-    target_rows_per_chunk = (target_rows_per_chunk / 32) * 32;  // Ensure multiple of 32
-    if (target_rows_per_chunk == 0) target_rows_per_chunk = 32;
-  }
-  for (uint32_t segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
-    auto const& seg          = out.length_descs[segment_idx];
-    auto const fsst_base_row = out.row_starts[segment_idx];
-    if (target_rows_per_chunk == 0) {
-      // No chunking: one CTA per segment
-      out.gather_chunks.push_back({seg.d_bytes,
-                                   seg.bytes_size,
-                                   seg.row_count,
-                                   seg.global_row_start,
-                                   fsst_base_row,
-                                   segment_idx,
-                                   1,
-                                   {0, 0, 0}});
-    } else {
-      // Chunking: one CTA per chunk (slice of a segment)
-      auto remaining                    = seg.row_count;
-      uint32_t offset                   = 0;
-      uint8_t is_first_chunk_in_segment = 1;
-      while (remaining > 0) {
-        auto const chunk_row_count = std::min(remaining, target_rows_per_chunk);
-        out.gather_chunks.push_back({seg.d_bytes,
-                                     seg.bytes_size,
-                                     chunk_row_count,
-                                     seg.global_row_start + offset,
-                                     fsst_base_row + offset,
-                                     segment_idx,
-                                     is_first_chunk_in_segment,
-                                     {0, 0, 0}});
-        offset += chunk_row_count;
-        remaining -= chunk_row_count;
-        is_first_chunk_in_segment = 0;
-      }
+  uint64_t version;
+  memcpy(&version, buf, 8);
+  if ((version >> 32) != FSST_VERSION_LO) return false;
+
+  uint32_t pos     = 17;
+  uint8_t zeroTerm = buf[8] & 1u;
+  uint8_t lenHisto[8];
+  for (uint32_t i = 0; i < 8u; ++i)
+    lenHisto[i] = buf[9 + i];
+
+  out->len[0]    = 1;
+  out->symbol[0] = 0;
+  uint32_t code  = zeroTerm;
+  if (zeroTerm) lenHisto[0]--;
+
+  for (uint32_t l = 1; l <= 8u; ++l) {
+    uint32_t hist_idx = l & 7u;         // 1,2,3,4,5,6,7,0
+    uint32_t sym_len  = (l & 7u) + 1u;  // 2,3,4,5,6,7,8,1
+    for (uint32_t i = 0; i < lenHisto[hist_idx]; ++i, ++code) {
+      out->len[code] = static_cast<uint8_t>(sym_len);
+      uint64_t sym   = 0;
+      for (uint32_t j = 0; j < sym_len; ++j)
+        sym |= uint64_t(buf[pos + j]) << (8u * j);
+      out->symbol[code] = sym;
+      pos += sym_len;
     }
   }
-  return out;
+  while (code < 255u) {
+    out->symbol[code] = FSST_CORRUPT;
+    out->len[code++]  = 8u;
+  }
+  return true;
 }
 
-//===----------DEVICE logic----------===//
-/**
- * @brief Copy FSST header @p hdr into @p base, bounded by the buffer size @p limit.
- * @return true if the header was successfully copied (i.e. the header fits within the buffer), and
- * if the header metadata is valid; false otherwise.
- */
-__device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
-                                                  uint32_t limit,
-                                                  fsst_header_t* hdr)
+/// One CTA per segment: coalesced LDG of the symtab into shmem first, then
+/// thread 0 parses from shmem into the decoder slot. A naive one-thread-per-
+/// segment grid suffers ~3-5× from scattered LDG across distinct segment
+/// addresses (each thread reads ~300 B of symtab from a different region of
+/// device memory). Coalesced load amortizes that cost across 256 lanes; the
+/// parse itself is inherently serial (each symbol's start depends on the
+/// previous symbol's length) so we leave that to thread 0.
+__global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
+  string_chunk_desc const* __restrict__ descs,
+  uint32_t num_segments,
+  fsst_decoder_compact* __restrict__ d_decoders)
 {
-  if (limit < sizeof(fsst_header_t)) return false;
-  memcpy(hdr, base, sizeof(fsst_header_t));
-  return hdr->dict_end <= limit && hdr->fsst_symbol_table_offset < hdr->dict_end &&
-         hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
+  auto const seg_idx = blockIdx.x;
+  auto const desc    = descs[seg_idx];
+
+  __shared__ uint8_t sm_ok;
+  __shared__ fsst_header_t sm_hdr;
+  __shared__ uint8_t sm_symtab[FSST_SYMTAB_MAX_BYTES];
+
+  if (threadIdx.x == 0) {
+    sm_ok = parse_fsst_header(desc.d_bytes, desc.bytes_size, &sm_hdr) ? 1u : 0u;
+  }
+  __syncthreads();
+
+  if (!sm_ok) {
+    for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
+      d_decoders[seg_idx].len[i]    = 0;
+      d_decoders[seg_idx].symbol[i] = 0;
+    }
+    return;
+  }
+
+  uint32_t const symtab_off = sm_hdr.fsst_symbol_table_offset;
+  uint32_t symtab_size      = desc.bytes_size - symtab_off;
+  if (symtab_size > FSST_SYMTAB_MAX_BYTES) symtab_size = FSST_SYMTAB_MAX_BYTES;
+  uint8_t const* sym_src = desc.d_bytes + symtab_off;
+  for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x)
+    sm_symtab[i] = sym_src[i];
+  __syncthreads();
+
+  if (threadIdx.x == 0) device_fsst_import(sm_symtab, &d_decoders[seg_idx]);
 }
 
-/**
- * @brief Compute the per-row offsets into the FSST compressed byte stream for an FSST segment.
- */
+//----- Pass 1 (A+B): per-row compressed-byte offsets ------------------------
+
+/// Compute the per-row offsets into the FSST compressed byte stream for an
+/// FSST segment. One CTA per segment; in-CTA cub::BlockScan over per-thread
+/// chunk sums produces the inclusive prefix sum the gather kernel reads.
 __global__ void kernel_compute_compressed_offsets_fsst(
   uint32_t* __restrict__ d_comp_offsets,
   string_chunk_desc const* __restrict__ descs,
@@ -652,7 +625,6 @@ __global__ void kernel_compute_compressed_offsets_fsst(
   __shared__ bool sm_ok;
   __shared__ fsst_header_t sm_hdr;
 
-  // CTA <-> segment mapping
   auto const seg_idx = blockIdx.x;
   if (seg_idx >= num_segments) return;
   auto const desc  = descs[seg_idx];
@@ -666,7 +638,7 @@ __global__ void kernel_compute_compressed_offsets_fsst(
   auto* segment_comp_offsets   = d_comp_offsets + segment_base;
 
   if (!sm_ok) {
-    // Zero the offsets for the segment so phase-C emits empty strings
+    // Zero the offsets for the segment so phase-C emits empty strings.
     for (uint32_t i = threadIdx.x; i < segment_row_count; i += blockDim.x)
       segment_comp_offsets[i] = 0;
     return;
@@ -699,11 +671,12 @@ __global__ void kernel_compute_compressed_offsets_fsst(
   }
 }
 
-/**
- * @brief Compute the compressed length of a row in the FSST compressed stream, where @p comp_ptr
- * points to the start of the compressed bytes for that row, and @p sm_len is the symbol length
- * table from the FSST header.
- */
+//----- Pass 1 (C): per-row decompressed lengths -----------------------------
+
+/// One warp cooperatively walks `comp_len` bytes of one row's compressed
+/// stream, returning the row's total decoded-byte count. Per-lane
+/// contribution is the symbol length looked up from `sm_len`, with the
+/// escape-sentinel/literal pair handled via a shfl_up of `is_esc`.
 __device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __restrict__ comp_ptr,
                                                             uint32_t comp_len,
                                                             uint8_t const* __restrict__ sm_len,
@@ -732,7 +705,7 @@ __device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __res
       }
     }
 
-    // Scan the lengths
+    // Warp-reduce per-lane lengths.
 #pragma unroll
     for (uint32_t s = WARP_THREADS / 2; s > 0; s /= 2) {
       my_len += __shfl_xor_sync(FULL_MASK, my_len, s);
@@ -746,9 +719,10 @@ __device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __res
   return total;
 }
 
-/**
- * @brief Compute the decompressed lengths for each row in the FSST compressed stream.
- */
+/// Compute the decompressed length per row. Adaptive per CTA: thread-per-row
+/// for short rows (lower warp-coord tax dominates), warp-per-row for longer
+/// rows (coalesced LDG dominates). 2 × WARP_THREADS = 64 B / row crossover
+/// matches the empirical sweet spot.
 __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_lengths_fsst(
   fsst_chunk_desc const* __restrict__ descs,
   uint32_t* __restrict__ d_lengths,
@@ -767,7 +741,7 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
   if (threadIdx.x == 0) { sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
 
-  // Zero-fill lengths for the chunk if the metadata is malformed
+  // Zero-fill lengths for the chunk if the metadata is malformed.
   if (!sm_ok) {
     for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
       d_lengths[desc.global_row_start + i] = 0;
@@ -784,15 +758,14 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
   auto const* dict_end_ptr          = base + sm_hdr.dict_end;
   auto const* compressed_cumsum_ptr = d_comp_offsets + desc.fsst_row_start;
 
-  // Dispatch on the chunk's average compressed-byte/row: thread-per-row for short rows,
-  // warp-per-row for longer rows, split on whether the average length spans 2 rows in the
-  // warp-per-row path.
+  // Compute the chunk's average compressed-byte/row to dispatch between
+  // thread-per-row and warp-per-row strategies.
   auto const start           = desc.is_first_chunk ? 0 : *(compressed_cumsum_ptr - 1);
   auto const end             = compressed_cumsum_ptr[desc.row_count - 1];
   auto const avg_comp_length = (end - start) / desc.row_count;
 
   if (avg_comp_length >= 2 * WARP_THREADS) {
-    // Warp-per-row
+    // Warp-per-row: 32 lanes coalesce LDG over a row's compressed bytes.
     auto const lane          = threadIdx.x % WARP_THREADS;
     auto const warp_id       = threadIdx.x / WARP_THREADS;
     auto const warps_per_cta = blockDim.x / WARP_THREADS;
@@ -809,7 +782,7 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
       if (lane == 0) { d_lengths[desc.global_row_start + i] = decomp_len; }
     }
   } else {
-    // Thread-per-row
+    // Thread-per-row: short rows; warp-coord tax of cooperative scan dominates.
     for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
       auto const cumsum      = compressed_cumsum_ptr[i];
       auto const prev_cumsum = (i > 0) ? compressed_cumsum_ptr[i - 1] : start;
@@ -835,17 +808,17 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_leng
   }
 }
 
+//----- Pass 2: gather (decode + emit) ---------------------------------------
+
 constexpr uint32_t FSST_SCRATCH_U32_PER_WARP   = 256;
 constexpr uint32_t FSST_SCRATCH_BYTES_PER_WARP = FSST_SCRATCH_U32_PER_WARP * sizeof(uint32_t);
 constexpr uint32_t FSST_MAX_CHUNK_EMIT =
-  WARP_THREADS * 8;  ///< max 8B symbol table entry per warp thread
+  WARP_THREADS * 8;  ///< worst-case bytes emitted per 32B input chunk (8B max symbol)
 constexpr uint32_t FSST_WARPS_PER_CTA = BLOCK_DIM / WARP_THREADS;
 
-/**
- * @brief Drain the per-warp scratch buffer to global memory, with warp lanes cooperating in
- * stride-4 chunks plus a per-byte cleanup for the last <4 bytes. Used in both the lazy-flush path
- * when scratch is full and the final drain at the end of a chunk.
- */
+/// Drain the per-warp scratch buffer to global memory, with warp lanes
+/// cooperating in stride-4 chunks plus a per-byte cleanup for the trailing
+/// 0–3 bytes. Used by both the lazy-flush path and the end-of-row drain.
 __device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
                                                    uint32_t const* __restrict__ scratch_u32,
                                                    uint8_t const* __restrict__ scratch_u8,
@@ -854,7 +827,7 @@ __device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
 {
   constexpr uint32_t WORD_BYTES = 4;
   auto const n_full_words       = n / WORD_BYTES;
-  auto word_id                  = lane;
+  auto word_id                  = lane;  // word index, stride = WARP_THREADS
   while (word_id < n_full_words) {
     auto const v = scratch_u32[word_id];
     memcpy(dst + word_id * WORD_BYTES, &v, WORD_BYTES);
@@ -865,15 +838,17 @@ __device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
   }
 }
 
-/**
- * @brief Decode a chunk of compressed bytes using the FSST algorithm.
- *
- * One warp decodes `comp_len` compressed bytes in 32-byte input chunks. Decoded symbols accumulate
- * in a per-warp scratch slab; we flush to `dst` only when the next chunk's worst-case emit (256 B)
- * would overflow scratch, or once at the end of the row.
- * `sm_sym` is split lo/hi so the common short-symbol load is one 4 B bank read.
- * `sm_sym_hi` is only read when len[code] > 4.
- */
+/// One warp decodes `comp_len` compressed bytes in 32-byte input chunks.
+/// Decoded symbols accumulate in a per-warp scratch slab; we flush to `dst`
+/// only when the next chunk's worst-case emit (256 B) would overflow scratch,
+/// or once at the end of the row. Multiple chunks share one __syncwarp() pair
+/// vs the old per-chunk drain. Direct lane-to-global stores were measured
+/// 30-68 % slower than the shmem-staged drain (small byte stores generated
+/// many partial L2 sectors).
+///
+/// `sm_sym` is split lo/hi so the common short-symbol load is one 4 B read on
+/// bank `c & 31` instead of straddling two banks; `sm_sym_hi` is only read
+/// when len[code] > 4. Reused by DICT_FSST mode-2 inline decompress.
 __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ comp_ptr,
                                                  uint32_t comp_len,
                                                  uint8_t* __restrict__ dst,
@@ -967,11 +942,10 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
   }
 }
 
-/**
- * @brief Gather kernel for FSST-compressed segments, with the same chunking as phase-C. Each warp
- * walks the compressed byte stream for its row, decodes on the fly into a per-warp scratch buffer,
- * and flushes to global when the next chunk's worst-case emit would overflow scratch.
- */
+/// Gather kernel for FSST-compressed segments, with the same chunking as
+/// phase-C. Each warp walks the compressed byte stream for its row, decodes
+/// on the fly into a per-warp scratch buffer, and flushes to global when the
+/// next chunk's worst-case emit would overflow scratch.
 __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   fsst_chunk_desc const* __restrict__ descs,
   int32_t const* __restrict__ d_offsets,
@@ -995,12 +969,12 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   auto const desc          = descs[chunk_id];
   auto const* segment_base = desc.d_bytes;
 
-  // Parse the segment header
+  // Parse the segment header.
   if (threadIdx.x == 0) { sm_ok = parse_fsst_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
   if (!sm_ok) return;  // pass-1 emitted zero lengths → nothing to gather
 
-  // Load the symbol table into SMEM
+  // Load the symbol table into SMEM.
   fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
   for (uint32_t i = threadIdx.x; i < FSST_SIZE; i += blockDim.x) {
     sm_len[i]          = (i < FSST_NUM_SYMBOLS) ? dec.len[i] : 0;
@@ -1011,8 +985,6 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   __syncthreads();
 
   // Warp-per-row gather + decode.
-  // Each warp walks the compressed byte stream for its row, decodes on the fly into the per-warp
-  // scratch, and flushes to global when the next chunk's worst-case emit would overflow scratch.
   auto const* dict_end_ptr  = segment_base + sm_hdr.dict_end;
   auto const* my_cumsum_ptr = d_comp_offsets + desc.fsst_row_start;
   auto const lane           = threadIdx.x % WARP_THREADS;
@@ -1039,8 +1011,96 @@ __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   }
 }
 
+//----- Host helpers + prepare_fsst ------------------------------------------
+
+/// Count FSST-decoded length without emitting output. Used by
+/// `prepare_dict_fsst` to size per-segment decoded-offset arrays for
+/// mode-1 DICT_FSST segments.
+inline size_t fsst_decompressed_length_host(fsst_decoder_compact const& dec,
+                                            uint8_t const* src,
+                                            size_t src_len)
+{
+  size_t pos = 0, dec_len = 0;
+  while (pos < src_len) {
+    uint8_t code = src[pos++];
+    if (code < FSST_ESC) {
+      dec_len += dec.len[code];
+    } else {
+      ++pos;
+      ++dec_len;
+    }
+  }
+  return dec_len;
+}
+
+prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
+{
+  prepared_fsst out;
+  out.total_fsst_row_count = 0;
+  out.length_descs.reserve(run.segments.size());
+  out.row_starts.reserve(run.segments.size());
+
+  // Segment descriptors for pass-1 A+B.
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    out.row_starts.push_back(out.total_fsst_row_count);
+    out.total_fsst_row_count += seg.row_count;
+    out.length_descs.push_back(
+      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
+  }
+  auto const segment_count = out.length_descs.size();
+  // decoders are populated on-device by kernel_build_fsst_decoders; here we
+  // just allocate the slots so the upload + kernel see the right size.
+  out.decoders.resize(segment_count);
+
+  // Chunked descriptors for phase-C + gather. Split per-segment only when
+  // total segments < target_ctas (else one-chunk-per-segment fills SMs already).
+  auto const target_ctas         = get_target_ctas();
+  uint32_t target_rows_per_chunk = 0;
+  if (segment_count < target_ctas && out.total_fsst_row_count > 0) {
+    target_rows_per_chunk = std::max(out.total_fsst_row_count / target_ctas, MIN_ROWS_PER_CHUNK);
+    target_rows_per_chunk = (target_rows_per_chunk / 32) * 32;  // multiple of 32 for coalescing
+    if (target_rows_per_chunk == 0) target_rows_per_chunk = 32;
+  }
+  for (uint32_t segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+    auto const& seg          = out.length_descs[segment_idx];
+    auto const fsst_base_row = out.row_starts[segment_idx];
+    if (target_rows_per_chunk == 0) {
+      // No chunking: one CTA per segment.
+      out.gather_chunks.push_back({seg.d_bytes,
+                                   seg.bytes_size,
+                                   seg.row_count,
+                                   seg.global_row_start,
+                                   fsst_base_row,
+                                   segment_idx,
+                                   1,
+                                   {0, 0, 0}});
+    } else {
+      // Chunking: one CTA per chunk (slice of a segment).
+      auto remaining                    = seg.row_count;
+      uint32_t offset                   = 0;
+      uint8_t is_first_chunk_in_segment = 1;
+      while (remaining > 0) {
+        auto const chunk_row_count = std::min(remaining, target_rows_per_chunk);
+        out.gather_chunks.push_back({seg.d_bytes,
+                                     seg.bytes_size,
+                                     chunk_row_count,
+                                     seg.global_row_start + offset,
+                                     fsst_base_row + offset,
+                                     segment_idx,
+                                     is_first_chunk_in_segment,
+                                     {0, 0, 0}});
+        offset += chunk_row_count;
+        remaining -= chunk_row_count;
+        is_first_chunk_in_segment = 0;
+      }
+    }
+  }
+  return out;
+}
+
 //===----------------------------------------------------------------------===//
-// DICT_FSST codec.
+// 4. DICT_FSST codec
 //
 //   +-----+------------+--------+----------------+--------------------+
 //   | hdr | dict bytes | symtab | string_lengths |    dict_indices    |
@@ -1216,7 +1276,7 @@ __global__ void kernel_gather_dict_fsst(dict_fsst_desc const* __restrict__ descs
       continue;
     }
 
-    // Mode 2: inline decompress.
+    // Mode 2: inline decompress via the FSST gather helper.
     uint32_t byte_start = dict_byte_off[idx];
     uint32_t comp_len   = dict_byte_off[idx + 1] - byte_start;
     if (comp_len == 0) continue;
@@ -1254,60 +1314,6 @@ __global__ void kernel_dict_fsst_mark_nulls(dict_fsst_desc const* __restrict__ d
     uint32_t row = desc.global_row_start + i;
     atomicAnd(d_mask_words + (row >> 5), ~(1u << (row & 31u)));
   }
-}
-
-/// Sibling to `dispatch_validity_run` in gpu_native_decode.cu.
-void overlay_validity_run(gpu_codec_run const& run, uint8_t* d_mask, rmm::cuda_stream_view stream)
-{
-  if (run.codec != duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
-    throw std::runtime_error(
-      "gpu_decode_strings_column: viability invariant violated — "
-      "validity codec " +
-      std::to_string(static_cast<int>(run.codec)) + " not implemented");
-  }
-  for (auto const& seg : run.segments) {
-    if (seg.row_count == 0) continue;
-    if (seg.row_offset % 8 != 0) {
-      throw std::runtime_error("gpu_decode_strings_column: validity row_offset (" +
-                               std::to_string(seg.row_offset) + ") not byte-aligned");
-    }
-    size_t bytes = (size_t{seg.row_count} + 7) / 8;
-    if (size_t{seg.bytes_size} < bytes) {
-      throw std::runtime_error("gpu_decode_strings_column: validity segment bytes_size (" +
-                               std::to_string(seg.bytes_size) + ") < required " +
-                               std::to_string(bytes));
-    }
-    RMM_CUDA_TRY(cudaMemcpyAsync(
-      d_mask + seg.row_offset / 8, seg.d_bytes, bytes, cudaMemcpyDeviceToDevice, stream.value()));
-  }
-}
-
-struct prepared_dict {
-  std::vector<string_chunk_desc> descs_short;  ///< max_string_length < DICT_WARP_COOP_MIN_LEN
-  std::vector<string_chunk_desc> descs_long;   ///< max_string_length >= DICT_WARP_COOP_MIN_LEN
-};
-
-struct prepared_dict_fsst {
-  std::vector<dict_fsst_desc> descs;
-  std::vector<fsst_decoder_compact> decoders;
-  std::vector<uint32_t> byte_offsets;     ///< per-segment, dict_count+1 entries each
-  std::vector<uint32_t> decoded_offsets;  ///< per-segment, dict_count+1 entries each
-  bool any_inline_nulls;
-  uint32_t total_predecode_bytes;  ///< sum of mode-1 dict-decoded bytes
-};
-
-prepared_dict prepare_dict(gpu_string_codec_run const& run)
-{
-  prepared_dict out;
-  for (auto const& seg : run.segments) {
-    if (seg.row_count == 0) continue;
-    string_chunk_desc d{
-      seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start};
-    auto& bucket =
-      (seg.max_string_length < DICT_WARP_COOP_MIN_LEN) ? out.descs_short : out.descs_long;
-    bucket.push_back(d);
-  }
-  return out;
 }
 
 /// Stub descriptor for malformed segments — kernel zero-fills these rows.
@@ -1446,6 +1452,41 @@ prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
   return out;
 }
 
+//===----------------------------------------------------------------------===//
+// 5. Orchestrator
+//
+// `gpu_decode_strings_column` aggregates per-codec `prepared_*` state across
+// all runs in a column, uploads descriptors, dispatches the codec kernels in
+// the correct order (lengths → prefix sum → gather), and assembles the cudf
+// strings column.
+//===----------------------------------------------------------------------===//
+
+/// Sibling to `dispatch_validity_run` in gpu_native_decode.cu.
+void overlay_validity_run(gpu_codec_run const& run, uint8_t* d_mask, rmm::cuda_stream_view stream)
+{
+  if (run.codec != duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
+    throw std::runtime_error(
+      "gpu_decode_strings_column: viability invariant violated — "
+      "validity codec " +
+      std::to_string(static_cast<int>(run.codec)) + " not implemented");
+  }
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    if (seg.row_offset % 8 != 0) {
+      throw std::runtime_error("gpu_decode_strings_column: validity row_offset (" +
+                               std::to_string(seg.row_offset) + ") not byte-aligned");
+    }
+    size_t bytes = (size_t{seg.row_count} + 7) / 8;
+    if (size_t{seg.bytes_size} < bytes) {
+      throw std::runtime_error("gpu_decode_strings_column: validity segment bytes_size (" +
+                               std::to_string(seg.bytes_size) + ") < required " +
+                               std::to_string(bytes));
+    }
+    RMM_CUDA_TRY(cudaMemcpyAsync(
+      d_mask + seg.row_offset / 8, seg.d_bytes, bytes, cudaMemcpyDeviceToDevice, stream.value()));
+  }
+}
+
 }  // namespace
 
 std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode_input const& col,
@@ -1546,8 +1587,6 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   // Allocate output and intermediate buffers.
   rmm::device_uvector<uint32_t> d_lengths(size_t{total_rows} + 1, stream, mr);
   rmm::device_uvector<int32_t> d_offsets(size_t{total_rows} + 1, stream, mr);
-  // RMM_CUDA_TRY(cudaMemsetAsync(
-  //   d_lengths.data(), 0, (size_t{total_rows} + 1) * sizeof(uint32_t), stream.value()));
   rmm::device_buffer d_comp_offsets(prep_fsst.total_fsst_row_count * sizeof(uint32_t), stream, mr);
 
   // Per-row kernels take chunked descriptors; predecode + mark_nulls stay
@@ -1604,7 +1643,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   auto* d_byte_off_p         = static_cast<uint32_t*>(d_byte_offsets_buf.data());
   auto* d_decoded_off_p      = static_cast<uint32_t*>(d_decoded_offsets_buf.data());
 
-  // Pass 1: lengths. Same kernel for short/long — only gather forks.
+  // Pass 1: lengths. Same kernel for short/long DICTIONARY — only gather forks.
   if (!dict_chunks_short.empty()) {
     kernel_compute_lengths_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),
                                   BLOCK_DIM,
@@ -1678,6 +1717,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
     }
   }
 
+  // Prefix-sum lengths → byte offsets per row.
   size_t cub_bytes = 0;
   int const scan_n = static_cast<int>(total_rows) + 1;
   cub::DeviceScan::ExclusiveSum(nullptr,

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -85,6 +85,7 @@ enum : uint8_t {
 };
 
 /// 255 codes (0..254); byte 255 is the escape sentinel.
+constexpr uint32_t FSST_SIZE        = 256;
 constexpr uint32_t FSST_NUM_SYMBOLS = 255;
 constexpr uint8_t FSST_ESC          = 255;
 static_assert(FSST_ESC == FSST_NUM_SYMBOLS);
@@ -149,11 +150,13 @@ struct alignas(8) dict_fsst_desc {
   uint8_t _pad[6];
 };
 
-constexpr uint32_t BLOCK_DIM              = 256;  // see FSST_WARPS_PER_CTA static_assert
-constexpr uint32_t MIN_CHUNK_ROW          = 64;
-constexpr uint32_t WARP_SIZE              = 32;
+constexpr uint32_t BLOCK_DIM = 256;  // see FSST_WARPS_PER_CTA static_assert
+constexpr uint32_t MIN_ROWS_PER_CHUNK =
+  64;  ///< The minimum number of rows for a segment chunk;
+       ///< BLOCK_DIM=256 threads -> 8 warps per chunk -> 8 rows per warp.
+constexpr uint32_t WARP_THREADS           = 32;
 constexpr uint32_t FULL_MASK              = 0xFFFFFFFFu;
-constexpr uint32_t WARP_BULK_STRIDE_BYTES = WARP_SIZE * 4u;
+constexpr uint32_t WARP_BULK_STRIDE_BYTES = WARP_THREADS * 4u;
 /// Above this, take the exact-total sync rather than trust the host upper
 /// bound — a pathological max_string_length could otherwise force a GB-class
 /// over-allocation.
@@ -163,6 +166,7 @@ constexpr size_t HOST_UPPER_BOUND_LIMIT = size_t{512} * 1024u * 1024u;
 /// (launch-bound at short rows) to warp-cooperative (bandwidth-bound at long
 /// rows). Mirrors cuDF's strings-gather split (32B) with headroom.
 constexpr uint32_t DICT_WARP_COOP_MIN_LEN = 64u;
+constexpr uint32_t MAX_BITPACKING_WIDTH   = 32;
 
 /// DuckDB's AlignValue<idx_t>.
 constexpr uint32_t align_up8(uint32_t n) { return (n + 7u) & ~7u; }
@@ -175,19 +179,109 @@ __device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
   if (limit < sizeof(dict_header_t)) return false;
   memcpy(hdr, base, sizeof(*hdr));
   return hdr->index_buffer_offset + hdr->index_buffer_count * sizeof(uint32_t) <= limit &&
-         hdr->dict_end <= limit && hdr->bitpacking_width <= 32u;
+         hdr->dict_end <= limit && hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
 }
 
+/// Device port of duckdb_fsst_import (libfsst.cpp:429). Same opaque blob
+/// layout (8B version | 1B zeroTerminated | 8B lenHisto | packed symbols by
+/// length group 1..8,1). CUDA targets are always little-endian so the
+/// host-side swap64_if_be is a no-op here. Used by kernel_build_fsst_decoders
+/// to populate per-segment decoders without round-tripping through host.
+constexpr uint32_t FSST_VERSION_LO        = 20190218u;
+constexpr unsigned long long FSST_CORRUPT = 32774747032022883ull;  // "corrupt" in LE
+
+__device__ __forceinline__ bool device_fsst_import(uint8_t const* buf, fsst_decoder_compact* out)
+{
+  // Zero first so a bad header / corrupted symtab leaves a deterministic
+  // (all-zero-length) decoder.
+  for (uint32_t i = 0; i < FSST_NUM_SYMBOLS; ++i) {
+    out->len[i]    = 0;
+    out->symbol[i] = 0;
+  }
+
+  uint64_t version;
+  memcpy(&version, buf, 8);
+  if ((version >> 32) != FSST_VERSION_LO) return false;
+
+  uint32_t pos     = 17;
+  uint8_t zeroTerm = buf[8] & 1u;
+  uint8_t lenHisto[8];
+  for (uint32_t i = 0; i < 8u; ++i)
+    lenHisto[i] = buf[9 + i];
+
+  out->len[0]    = 1;
+  out->symbol[0] = 0;
+  uint32_t code  = zeroTerm;
+  if (zeroTerm) lenHisto[0]--;
+
+  for (uint32_t l = 1; l <= 8u; ++l) {
+    uint32_t hist_idx = l & 7u;         // 1,2,3,4,5,6,7,0
+    uint32_t sym_len  = (l & 7u) + 1u;  // 2,3,4,5,6,7,8,1
+    for (uint32_t i = 0; i < lenHisto[hist_idx]; ++i, ++code) {
+      out->len[code] = static_cast<uint8_t>(sym_len);
+      uint64_t sym   = 0;
+      for (uint32_t j = 0; j < sym_len; ++j)
+        sym |= uint64_t(buf[pos + j]) << (8u * j);
+      out->symbol[code] = sym;
+      pos += sym_len;
+    }
+  }
+  while (code < 255u) {
+    out->symbol[code] = FSST_CORRUPT;
+    out->len[code++]  = 8u;
+  }
+  return true;
+}
+
+// Forward decl — definition lives further down with the other FSST kernels.
 __device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
                                                   uint32_t limit,
-                                                  fsst_header_t* hdr)
+                                                  fsst_header_t* hdr);
+
+/// One CTA per segment: coalesced LDG of the symtab into shmem first, then
+/// thread 0 parses from shmem into the decoder slot. A naive one-thread-per-
+/// segment grid suffers ~3-5× from scattered LDG across distinct segment
+/// addresses (each thread reads ~300 B of symtab from a different region of
+/// device memory). Coalesced load amortizes that cost across 256 lanes; the
+/// parse itself is inherently serial (each symbol's start depends on the
+/// previous symbol's length) so we leave that to thread 0.
+__global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
+  string_chunk_desc const* __restrict__ descs,
+  uint32_t num_segments,
+  fsst_decoder_compact* __restrict__ d_decoders)
 {
-  if (limit < sizeof(fsst_header_t)) return false;
-  memcpy(hdr, base, sizeof(*hdr));
-  return hdr->dict_end <= limit && hdr->fsst_symbol_table_offset < hdr->dict_end &&
-         hdr->bitpacking_width <= 32u;
+  auto const seg_idx = blockIdx.x;
+  auto const desc    = descs[seg_idx];
+
+  __shared__ uint8_t sm_ok;
+  __shared__ fsst_header_t sm_hdr;
+  __shared__ uint8_t sm_symtab[FSST_SYMTAB_MAX_BYTES];
+
+  if (threadIdx.x == 0) {
+    sm_ok = parse_fsst_header(desc.d_bytes, desc.bytes_size, &sm_hdr) ? 1u : 0u;
+  }
+  __syncthreads();
+
+  if (!sm_ok) {
+    for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
+      d_decoders[seg_idx].len[i]    = 0;
+      d_decoders[seg_idx].symbol[i] = 0;
+    }
+    return;
+  }
+
+  uint32_t const symtab_off = sm_hdr.fsst_symbol_table_offset;
+  uint32_t symtab_size      = desc.bytes_size - symtab_off;
+  if (symtab_size > FSST_SYMTAB_MAX_BYTES) symtab_size = FSST_SYMTAB_MAX_BYTES;
+  uint8_t const* sym_src = desc.d_bytes + symtab_off;
+  for (uint32_t i = threadIdx.x; i < symtab_size; i += blockDim.x)
+    sm_symtab[i] = sym_src[i];
+  __syncthreads();
+
+  if (threadIdx.x == 0) device_fsst_import(sm_symtab, &d_decoders[seg_idx]);
 }
 
+/// TODO: refactor as utility function
 template <typename T>
 __device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
 {
@@ -270,10 +364,10 @@ std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_
   if (descs.size() >= target_ctas || total_rows == 0) return descs;
 
   uint32_t chunk_size = total_rows / target_ctas;
-  chunk_size          = std::max(chunk_size, MIN_CHUNK_ROW);
+  chunk_size          = std::max(chunk_size, MIN_ROWS_PER_CHUNK);
   // Round down to warp size for store coalescing within a chunk.
-  chunk_size = (chunk_size / WARP_SIZE) * WARP_SIZE;
-  if (chunk_size == 0) chunk_size = WARP_SIZE;
+  chunk_size = (chunk_size / WARP_THREADS) * WARP_THREADS;
+  if (chunk_size == 0) chunk_size = WARP_THREADS;
 
   std::vector<Desc> out;
   out.reserve(target_ctas + descs.size());
@@ -400,9 +494,9 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
   uint32_t const* d_idx   = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
   uint8_t const* dict_end = base + sm_hdr.dict_end;
 
-  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
-  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
-  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+  uint32_t const lane          = threadIdx.x & (WARP_THREADS - 1u);
+  uint32_t const warp_id       = threadIdx.x / WARP_THREADS;
+  uint32_t const warps_per_cta = blockDim.x / WARP_THREADS;
 
   for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
     uint32_t seg_i = desc.seg_row_start + i;
@@ -421,7 +515,7 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
       memcpy(d_chars + op + k, &v, 4);
       k += WARP_BULK_STRIDE_BYTES;
     }
-    for (uint32_t t = n4 + lane; t < str_len; t += WARP_SIZE) {
+    for (uint32_t t = n4 + lane; t < str_len; t += WARP_THREADS) {
       d_chars[op + t] = src[t];
     }
   }
@@ -444,133 +538,340 @@ __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ de
 //   A — unpack compressed_lengths into d_comp_offsets[fsst_base..]
 //   B — in-CTA InclusiveSum producing per-row cumulative compressed bytes
 //   C — for each row, walk its compressed bytes summing decoded lengths
-// A+B owns per-segment prefix-sum state (one CTA per segment); C is the
-// expensive serial byte-scan and chunks across CTAs. The same compressed-
-// offset array is reused by the gather pass.
+// A+B owns per-segment prefix-sum state (one CTA per segment); C partitions
+// a segment across CTAs into 'chunks' and performs a serial byte scan.
+//
+// Pass 2 gather walks the compressed bytes to emit the decoded strings,
+// using 1 warp per row and the same chunking as phase C to partition work
+// across segments.
 //===----------------------------------------------------------------------===//
 
-__global__ void kernel_compute_lengths_fsst(string_chunk_desc const* __restrict__ descs,
-                                            uint32_t* __restrict__ d_comp_offsets,
-                                            uint32_t const* __restrict__ d_fsst_row_starts,
-                                            uint32_t num_segments)
-{
-  uint32_t seg_idx = blockIdx.x;
-  if (seg_idx >= num_segments) return;
-  auto const desc     = descs[seg_idx];
-  uint8_t const* base = desc.d_bytes;
+//===----------HOST logic----------===//
+struct prepared_fsst {
+  std::vector<string_chunk_desc> length_descs;  ///< pass-1 A+B (per segment)
+  std::vector<fsst_chunk_desc> gather_chunks;   ///< pass-1 phase-C + pass-2 (per chunk)
+  std::vector<fsst_decoder_compact> decoders;   ///< symbol tables (per segment)
+  std::vector<uint32_t> row_starts;             ///< prefix sum of FSST row counts
+  uint32_t total_fsst_row_count;
+};
 
-  __shared__ uint8_t sm_ok;
+prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
+{
+  prepared_fsst out;
+  out.total_fsst_row_count = 0;
+  out.length_descs.reserve(run.segments.size());
+  out.row_starts.reserve(run.segments.size());
+
+  // Segment descriptors for pass-1 A+B
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    out.row_starts.push_back(out.total_fsst_row_count);
+    out.total_fsst_row_count += seg.row_count;
+    out.length_descs.push_back(
+      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
+  }
+  auto const segment_count = out.length_descs.size();
+  out.decoders.resize(segment_count);
+
+  // Chunked descriptors for phase-C + gather. Split per-segment only when
+  // total segments < target_ctas (else one-chunk-per-segment fills SMs already).
+  auto const target_ctas         = get_target_ctas();
+  uint32_t target_rows_per_chunk = 0;
+  if (segment_count < target_ctas && out.total_fsst_row_count > 0) {
+    target_rows_per_chunk = std::max(out.total_fsst_row_count / target_ctas, MIN_ROWS_PER_CHUNK);
+    target_rows_per_chunk = (target_rows_per_chunk / 32) * 32;  // Ensure multiple of 32
+    if (target_rows_per_chunk == 0) target_rows_per_chunk = 32;
+  }
+  for (uint32_t segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+    auto const& seg          = out.length_descs[segment_idx];
+    auto const fsst_base_row = out.row_starts[segment_idx];
+    if (target_rows_per_chunk == 0) {
+      // No chunking: one CTA per segment
+      out.gather_chunks.push_back({seg.d_bytes,
+                                   seg.bytes_size,
+                                   seg.row_count,
+                                   seg.global_row_start,
+                                   fsst_base_row,
+                                   segment_idx,
+                                   1,
+                                   {0, 0, 0}});
+    } else {
+      // Chunking: one CTA per chunk (slice of a segment)
+      auto remaining                    = seg.row_count;
+      uint32_t offset                   = 0;
+      uint8_t is_first_chunk_in_segment = 1;
+      while (remaining > 0) {
+        auto const chunk_row_count = std::min(remaining, target_rows_per_chunk);
+        out.gather_chunks.push_back({seg.d_bytes,
+                                     seg.bytes_size,
+                                     chunk_row_count,
+                                     seg.global_row_start + offset,
+                                     fsst_base_row + offset,
+                                     segment_idx,
+                                     is_first_chunk_in_segment,
+                                     {0, 0, 0}});
+        offset += chunk_row_count;
+        remaining -= chunk_row_count;
+        is_first_chunk_in_segment = 0;
+      }
+    }
+  }
+  return out;
+}
+
+//===----------DEVICE logic----------===//
+/**
+ * @brief Copy FSST header @p hdr into @p base, bounded by the buffer size @p limit.
+ * @return true if the header was successfully copied (i.e. the header fits within the buffer), and
+ * if the header metadata is valid; false otherwise.
+ */
+__device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
+                                                  uint32_t limit,
+                                                  fsst_header_t* hdr)
+{
+  if (limit < sizeof(fsst_header_t)) return false;
+  memcpy(hdr, base, sizeof(fsst_header_t));
+  return hdr->dict_end <= limit && hdr->fsst_symbol_table_offset < hdr->dict_end &&
+         hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
+}
+
+/**
+ * @brief Compute the per-row offsets into the FSST compressed byte stream for an FSST segment.
+ */
+__global__ void kernel_compute_compressed_offsets_fsst(
+  uint32_t* __restrict__ d_comp_offsets,
+  string_chunk_desc const* __restrict__ descs,
+  uint32_t const* __restrict__ d_fsst_row_starts,
+  uint32_t num_segments)
+{
+  using BlockScanT = cub::BlockScan<uint32_t, BLOCK_DIM>;
+
+  __shared__ typename BlockScanT::TempStorage scan_temp;
+  __shared__ bool sm_ok;
   __shared__ fsst_header_t sm_hdr;
-  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+
+  // CTA <-> segment mapping
+  auto const seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc  = descs[seg_idx];
+  auto const* base = desc.d_bytes;
+
+  if (threadIdx.x == 0) { sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
 
-  uint32_t fsst_base = d_fsst_row_starts[seg_idx];
-  uint32_t row_count = desc.row_count;
-  uint32_t* my_comp  = d_comp_offsets + fsst_base;
+  auto const segment_base      = d_fsst_row_starts[seg_idx];
+  auto const segment_row_count = desc.row_count;
+  auto* segment_comp_offsets   = d_comp_offsets + segment_base;
 
   if (!sm_ok) {
-    // Zero the slice so phase-C emits empty strings — chars buffer stays valid.
-    for (uint32_t i = threadIdx.x; i < row_count; i += blockDim.x)
-      my_comp[i] = 0u;
+    // Zero the offsets for the segment so phase-C emits empty strings
+    for (uint32_t i = threadIdx.x; i < segment_row_count; i += blockDim.x)
+      segment_comp_offsets[i] = 0;
     return;
   }
 
-  // Phase A: unpack compressed lengths.
-  uint32_t const* packed = reinterpret_cast<uint32_t const*>(base + sizeof(fsst_header_t));
-  for (uint32_t i = threadIdx.x; i < row_count; i += blockDim.x) {
-    my_comp[i] = unpack_value<uint32_t>(packed, i, sm_hdr.bitpacking_width);
+  // Phase A: unpack compressed lengths from the bitpacked length stream after the header.
+  auto const* packed = reinterpret_cast<uint32_t const*>(base + sizeof(fsst_header_t));
+  for (uint32_t i = threadIdx.x; i < segment_row_count; i += blockDim.x) {
+    segment_comp_offsets[i] = unpack_value<uint32_t>(packed, i, sm_hdr.bitpacking_width);
   }
   __syncthreads();
 
   // Phase B: per-thread sequential scan + BlockScan over per-thread totals.
-  using BlockScanT = cub::BlockScan<uint32_t, BLOCK_DIM>;
-  __shared__ typename BlockScanT::TempStorage scan_temp;
-  uint32_t chunk_size = (row_count + blockDim.x - 1u) / blockDim.x;
-  uint32_t start      = threadIdx.x * chunk_size;
-  uint32_t end        = min(start + chunk_size, row_count);
-  uint32_t local_sum  = 0;
-  for (uint32_t i = start; i < end; ++i) {
-    local_sum += my_comp[i];
-    my_comp[i] = local_sum;
+  auto const max_rows_per_thread = ::cuda::ceil_div(segment_row_count, blockDim.x);
+  auto const start               = threadIdx.x * max_rows_per_thread;
+  auto const end                 = ::cuda::std::min(start + max_rows_per_thread, segment_row_count);
+  uint32_t thread_sum            = 0;
+  for (int i = start; i < end; ++i) {
+    /// WARNING: uncoalesced GMEM access pattern
+    thread_sum += segment_comp_offsets[i];
+    segment_comp_offsets[i] = thread_sum;
   }
-  uint32_t scanned;
-  BlockScanT(scan_temp).ExclusiveSum(local_sum, scanned);
-  if (scanned > 0) {
-    for (uint32_t i = start; i < end; ++i)
-      my_comp[i] += scanned;
+  uint32_t exclusive_sum = 0;
+  BlockScanT(scan_temp).ExclusiveSum(thread_sum, exclusive_sum);
+  if (exclusive_sum > 0) {
+    for (int i = start; i < end; ++i) {
+      /// WARNING: uncoalesced GMEM access pattern
+      segment_comp_offsets[i] += exclusive_sum;
+    }
   }
 }
 
-__global__ void kernel_compute_lengths_fsst_phase_c(
+/**
+ * @brief Compute the compressed length of a row in the FSST compressed stream, where @p comp_ptr
+ * points to the start of the compressed bytes for that row, and @p sm_len is the symbol length
+ * table from the FSST header.
+ */
+__device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __restrict__ comp_ptr,
+                                                            uint32_t comp_len,
+                                                            uint8_t const* __restrict__ sm_len,
+                                                            uint32_t lane)
+{
+  uint32_t total             = 0;
+  int prev_chunk_last_is_esc = 0;
+  for (uint32_t off = 0; off < comp_len; off += WARP_THREADS) {
+    auto const bytes_in_chunk = ::cuda::std::min(comp_len - off, uint32_t{WARP_THREADS});
+    auto const is_active      = lane < bytes_in_chunk;
+    uint8_t const my_byte     = is_active ? comp_ptr[off + lane] : 0;
+    int const is_esc          = is_active && my_byte == FSST_ESC ? 1 : 0;
+
+    auto const neighbor_is_esc = __shfl_up_sync(FULL_MASK, is_esc, 1);
+    auto const prev_is_esc     = (lane == 0) ? prev_chunk_last_is_esc : neighbor_is_esc;
+
+    // Per-lane contribution: 0 for inactive / escape-sentinel;
+    //                        1 for the literal byte that follows an escape;
+    //                        sm_len[code] otherwise.
+    uint32_t my_len = 0;
+    if (is_active) {
+      if (prev_is_esc) {
+        my_len = 1;
+      } else if (!is_esc) {
+        my_len = sm_len[my_byte];
+      }
+    }
+
+    // Scan the lengths
+#pragma unroll
+    for (uint32_t s = WARP_THREADS / 2; s > 0; s /= 2) {
+      my_len += __shfl_xor_sync(FULL_MASK, my_len, s);
+    }
+    total += my_len;
+
+    // Broadcast whether the last byte in this 32B stripe was an escape for the next stripe.
+    auto const last_active_lane = bytes_in_chunk - 1;
+    prev_chunk_last_is_esc      = __shfl_sync(FULL_MASK, is_esc, last_active_lane);
+  }
+  return total;
+}
+
+/**
+ * @brief Compute the decompressed lengths for each row in the FSST compressed stream.
+ */
+__global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_lengths_fsst(
   fsst_chunk_desc const* __restrict__ descs,
   uint32_t* __restrict__ d_lengths,
   uint32_t const* __restrict__ d_comp_offsets,
   fsst_decoder_compact const* __restrict__ d_decoders,
   uint32_t num_chunks)
 {
-  uint32_t cid = blockIdx.x;
-  if (cid >= num_chunks) return;
-  auto const desc     = descs[cid];
-  uint8_t const* base = desc.d_bytes;
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc  = descs[chunk_id];
+  auto const* base = desc.d_bytes;
 
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ fsst_header_t sm_hdr;
   __shared__ uint8_t sm_len[FSST_NUM_SYMBOLS];
-  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  if (threadIdx.x == 0) { sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
 
+  // Zero-fill lengths for the chunk if the metadata is malformed
   if (!sm_ok) {
     for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-      d_lengths[desc.global_row_start + i] = 0u;
+      d_lengths[desc.global_row_start + i] = 0;
     }
     return;
   }
 
   fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
-  for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x)
+  for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
     sm_len[i] = dec.len[i];
+  }
   __syncthreads();
 
-  uint8_t const* dict_end_ptr = base + sm_hdr.dict_end;
-  uint32_t const* my_comp     = d_comp_offsets + desc.fsst_row_start;
+  auto const* dict_end_ptr          = base + sm_hdr.dict_end;
+  auto const* compressed_cumsum_ptr = d_comp_offsets + desc.fsst_row_start;
 
-  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-    uint32_t cum      = my_comp[i];
-    uint32_t prev     = (i > 0) ? my_comp[i - 1] : (desc.is_first_chunk ? 0u : *(my_comp - 1));
-    uint32_t comp_len = cum - prev;
-    if (comp_len == 0) {
-      d_lengths[desc.global_row_start + i] = 0u;
-      continue;
-    }
-    uint8_t const* comp_ptr = dict_end_ptr - cum;
-    uint32_t decomp_len     = 0;
-    uint32_t pos            = 0;
-    while (pos < comp_len) {
-      uint8_t code = comp_ptr[pos++];
-      if (code < FSST_ESC) {
-        decomp_len += sm_len[code];
-      } else {
-        ++pos;
-        ++decomp_len;
+  // Dispatch on the chunk's average compressed-byte/row: thread-per-row for short rows,
+  // warp-per-row for longer rows, split on whether the average length spans 2 rows in the
+  // warp-per-row path.
+  auto const start           = desc.is_first_chunk ? 0 : *(compressed_cumsum_ptr - 1);
+  auto const end             = compressed_cumsum_ptr[desc.row_count - 1];
+  auto const avg_comp_length = (end - start) / desc.row_count;
+
+  if (avg_comp_length >= 2 * WARP_THREADS) {
+    // Warp-per-row
+    auto const lane          = threadIdx.x % WARP_THREADS;
+    auto const warp_id       = threadIdx.x / WARP_THREADS;
+    auto const warps_per_cta = blockDim.x / WARP_THREADS;
+    for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
+      auto const cumsum      = compressed_cumsum_ptr[i];
+      auto const prev_cumsum = (i > 0) ? compressed_cumsum_ptr[i - 1] : start;
+      auto const comp_len    = cumsum - prev_cumsum;
+      if (comp_len == 0) {
+        if (lane == 0) { d_lengths[desc.global_row_start + i] = 0; }
+        continue;
       }
+      auto const* comp_length_ptr = dict_end_ptr - cumsum;
+      uint32_t decomp_len = warp_compute_decomp_len(comp_length_ptr, comp_len, sm_len, lane);
+      if (lane == 0) { d_lengths[desc.global_row_start + i] = decomp_len; }
     }
-    d_lengths[desc.global_row_start + i] = decomp_len;
+  } else {
+    // Thread-per-row
+    for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+      auto const cumsum      = compressed_cumsum_ptr[i];
+      auto const prev_cumsum = (i > 0) ? compressed_cumsum_ptr[i - 1] : start;
+      auto const comp_len    = cumsum - prev_cumsum;
+      if (comp_len == 0) {
+        d_lengths[desc.global_row_start + i] = 0u;
+        continue;
+      }
+      auto const* comp_ptr = dict_end_ptr - cumsum;
+      int decomp_len       = 0;
+      int pos              = 0;
+      while (pos < comp_len) {
+        auto const code = comp_ptr[pos++];
+        if (code < FSST_ESC) {
+          decomp_len += sm_len[code];
+        } else {
+          ++pos;
+          ++decomp_len;
+        }
+      }
+      d_lengths[desc.global_row_start + i] = decomp_len;
+    }
   }
 }
 
-/// 32 input bytes × max 8B symbol = 256B; 64 u32 keeps ld.shared.u32 aligned.
-constexpr uint32_t FSST_SCRATCH_U32_PER_WARP = 64u;
-constexpr uint32_t FSST_WARPS_PER_CTA        = 8u;
-static_assert(FSST_WARPS_PER_CTA == BLOCK_DIM / WARP_SIZE);
+constexpr uint32_t FSST_SCRATCH_U32_PER_WARP   = 256;
+constexpr uint32_t FSST_SCRATCH_BYTES_PER_WARP = FSST_SCRATCH_U32_PER_WARP * sizeof(uint32_t);
+constexpr uint32_t FSST_MAX_CHUNK_EMIT =
+  WARP_THREADS * 8;  ///< max 8B symbol table entry per warp thread
+constexpr uint32_t FSST_WARPS_PER_CTA = BLOCK_DIM / WARP_THREADS;
 
-/// One warp decodes `comp_len` compressed bytes in 32-byte input chunks:
-/// warp-scan for per-lane output offsets → scatter decoded bytes into a
-/// per-warp shmem slab → coalesced stride-4 drain to `dst`. Per-chunk flush
-/// caps shmem use at 256B/warp.
-///
-/// `sm_sym` is split lo/hi so the common short-symbol load is one 4B read on
-/// bank `c & 31` instead of straddling two banks; `sm_sym_hi` is only read
-/// when len[code] > 4.
+/**
+ * @brief Drain the per-warp scratch buffer to global memory, with warp lanes cooperating in
+ * stride-4 chunks plus a per-byte cleanup for the last <4 bytes. Used in both the lazy-flush path
+ * when scratch is full and the final drain at the end of a chunk.
+ */
+__device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
+                                                   uint32_t const* __restrict__ scratch_u32,
+                                                   uint8_t const* __restrict__ scratch_u8,
+                                                   uint32_t n,
+                                                   uint32_t lane)
+{
+  constexpr uint32_t WORD_BYTES = 4;
+  auto const n_full_words       = n / WORD_BYTES;
+  auto word_id                  = lane;
+  while (word_id < n_full_words) {
+    auto const v = scratch_u32[word_id];
+    memcpy(dst + word_id * WORD_BYTES, &v, WORD_BYTES);
+    word_id += WARP_THREADS;
+  }
+  for (uint32_t t = n_full_words * WORD_BYTES + lane; t < n; t += WARP_THREADS) {
+    dst[t] = scratch_u8[t];
+  }
+}
+
+/**
+ * @brief Decode a chunk of compressed bytes using the FSST algorithm.
+ *
+ * One warp decodes `comp_len` compressed bytes in 32-byte input chunks. Decoded symbols accumulate
+ * in a per-warp scratch slab; we flush to `dst` only when the next chunk's worst-case emit (256 B)
+ * would overflow scratch, or once at the end of the row.
+ * `sm_sym` is split lo/hi so the common short-symbol load is one 4 B bank read.
+ * `sm_sym_hi` is only read when len[code] > 4.
+ */
 __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ comp_ptr,
                                                  uint32_t comp_len,
                                                  uint8_t* __restrict__ dst,
@@ -580,141 +881,154 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
                                                  uint32_t* __restrict__ warp_scratch_u32,
                                                  uint32_t lane)
 {
-  uint8_t* warp_scratch_u8        = reinterpret_cast<uint8_t*>(warp_scratch_u32);
-  uint32_t cumulative_out_off     = 0;
+  auto* warp_scratch_u8           = reinterpret_cast<uint8_t*>(warp_scratch_u32);
+  uint32_t cumulative_out_offset  = 0;  ///< bytes already flushed to dst
+  uint32_t scratch_used           = 0;  ///< bytes pending in scratch
   uint32_t prev_chunk_last_is_esc = 0;
 
-  for (uint32_t off = 0; off < comp_len; off += WARP_SIZE) {
-    uint32_t bytes_in_chunk = comp_len - off;
-    if (bytes_in_chunk > WARP_SIZE) bytes_in_chunk = WARP_SIZE;
+  for (uint32_t off = 0; off < comp_len; off += WARP_THREADS) {
+    auto const bytes_in_chunk = ::cuda::std::min(comp_len - off, WARP_THREADS);
+    auto const active         = lane < bytes_in_chunk;
+    uint8_t const my_byte     = active ? comp_ptr[off + lane] : 0;
+    int const is_esc          = (active && my_byte == FSST_ESC) ? 1 : 0;
+    auto const neighbor_esc   = __shfl_up_sync(FULL_MASK, is_esc, 1);
+    auto const prev_was_esc   = (lane == 0) ? prev_chunk_last_is_esc : neighbor_esc;
 
-    uint8_t my_byte = (lane < bytes_in_chunk) ? comp_ptr[off + lane] : 0u;
-    uint32_t active = (lane < bytes_in_chunk) ? 1u : 0u;
-    uint32_t is_esc = (active && my_byte == FSST_ESC) ? 1u : 0u;
-
-    uint32_t neighbor_esc = __shfl_up_sync(FULL_MASK, is_esc, 1);
-    uint32_t prev_was_esc = (lane == 0) ? prev_chunk_last_is_esc : neighbor_esc;
-
-    uint32_t my_len       = 0u;
-    uint32_t my_sym_lo    = 0u;
-    uint32_t my_sym_hi    = 0u;
-    uint32_t my_emit_kind = 0u;
+    // Decode the symbol for this lane, if active and not an escape byte.
+    // my_len == 0 → no write (inactive or unresolved escape sentinel).
+    // my_sym_lo holds `my_byte` directly for escape-literal lanes.
+    uint32_t my_len    = 0;
+    uint32_t my_sym_lo = 0;
+    uint32_t my_sym_hi = 0;
     if (active) {
       if (prev_was_esc) {
-        my_len       = 1u;
-        my_sym_lo    = my_byte;
-        my_emit_kind = 2u;
+        my_len    = 1;
+        my_sym_lo = my_byte;
       } else if (!is_esc) {
-        uint8_t code = my_byte;
-        my_len       = sm_len[code];
-        my_sym_lo    = sm_sym_lo[code];
-        if (my_len > 4u) my_sym_hi = sm_sym_hi[code];
-        my_emit_kind = 1u;
+        auto const code = my_byte;
+        my_len          = sm_len[code];
+        my_sym_lo       = sm_sym_lo[code];
+        if (my_len > 4) { my_sym_hi = sm_sym_hi[code]; }
       }
     }
 
-    uint32_t scan = my_len;
+    // Determine the write offsets into the scratch pad for this lane's decoded symbol via an
+    // inclusive scan of the decoded lengths.
+    auto scan = my_len;
 #pragma unroll
-    for (uint32_t step = 1u; step < WARP_SIZE; step <<= 1) {
-      uint32_t add = __shfl_up_sync(FULL_MASK, scan, step);
-      if (lane >= step) scan += add;
+    for (uint32_t step = 1; step < WARP_THREADS; step /= 2) {
+      auto const add = __shfl_up_sync(FULL_MASK, scan, step);
+      if (lane >= step) { scan += add; }
     }
-    uint32_t exclusive = scan - my_len;
+    auto const exclusive   = scan - my_len;
+    auto const base        = scratch_used + exclusive;
+    auto const chunk_total = __shfl_sync(FULL_MASK, scan, WARP_THREADS - 1);
 
-    if (my_emit_kind == 1u) {
+    // Copy the decoded symbol into the scratch pad at the offset computed from the scan.
+    if (my_len > 0) {
       switch (my_len) {
-        case 1: warp_scratch_u8[exclusive] = static_cast<uint8_t>(my_sym_lo); break;
-        case 2: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 2); break;
-        case 3: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 3); break;
-        case 4: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 4); break;
+        case 1: warp_scratch_u8[base] = static_cast<uint8_t>(my_sym_lo); break;
+        case 2: memcpy(warp_scratch_u8 + base, &my_sym_lo, 2); break;
+        case 3: memcpy(warp_scratch_u8 + base, &my_sym_lo, 3); break;
+        case 4: memcpy(warp_scratch_u8 + base, &my_sym_lo, 4); break;
         default: {
-          memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 4);
-          uint32_t const tail = my_len - 4u;
-          memcpy(warp_scratch_u8 + exclusive + 4u, &my_sym_hi, tail);
+          memcpy(warp_scratch_u8 + base, &my_sym_lo, 4);
+          auto const tail_bytes = my_len - 4;
+          memcpy(warp_scratch_u8 + base + 4, &my_sym_hi, tail_bytes);
           break;
         }
       }
-    } else if (my_emit_kind == 2u) {
-      warp_scratch_u8[exclusive] = static_cast<uint8_t>(my_sym_lo);
     }
 
-    uint32_t chunk_total = __shfl_sync(FULL_MASK, scan, WARP_SIZE - 1u);
+    scratch_used += chunk_total;
+    auto const last_active_lane = bytes_in_chunk - 1;
+    prev_chunk_last_is_esc      = __shfl_sync(FULL_MASK, is_esc, last_active_lane);
 
+    // Lazy flush: only when the next chunk might overflow scratch.
+    auto const more_chunks = (off + WARP_THREADS) < comp_len;
+    if (more_chunks && scratch_used + FSST_MAX_CHUNK_EMIT > FSST_SCRATCH_BYTES_PER_WARP) {
+      __syncwarp();
+      warp_drain_scratch(
+        dst + cumulative_out_offset, warp_scratch_u32, warp_scratch_u8, scratch_used, lane);
+      __syncwarp();
+      cumulative_out_offset += scratch_used;
+      scratch_used = 0;
+    }
+  }
+
+  // Final flush at end of row — always required, scratch holds the tail.
+  if (scratch_used > 0) {
     __syncwarp();
-
-    uint32_t const n  = chunk_total;
-    uint32_t const n4 = n & ~3u;
-    uint32_t k        = lane * 4u;
-    while (k < n4) {
-      uint32_t v = warp_scratch_u32[k >> 2];
-      memcpy(dst + cumulative_out_off + k, &v, 4);
-      k += WARP_BULK_STRIDE_BYTES;
-    }
-    for (uint32_t t = n4 + lane; t < n; t += WARP_SIZE) {
-      dst[cumulative_out_off + t] = warp_scratch_u8[t];
-    }
-
+    warp_drain_scratch(
+      dst + cumulative_out_offset, warp_scratch_u32, warp_scratch_u8, scratch_used, lane);
     __syncwarp();
-    cumulative_out_off += chunk_total;
-
-    uint32_t last_active_lane = bytes_in_chunk - 1u;
-    prev_chunk_last_is_esc    = __shfl_sync(FULL_MASK, is_esc, last_active_lane);
   }
 }
 
-__global__ void kernel_gather_fsst_chunked(fsst_chunk_desc const* __restrict__ descs,
-                                           int32_t const* __restrict__ d_offsets,
-                                           uint8_t* __restrict__ d_chars,
-                                           uint32_t const* __restrict__ d_comp_offsets,
-                                           fsst_decoder_compact const* __restrict__ d_decoders,
-                                           uint32_t num_chunks)
+/**
+ * @brief Gather kernel for FSST-compressed segments, with the same chunking as phase-C. Each warp
+ * walks the compressed byte stream for its row, decodes on the fly into a per-warp scratch buffer,
+ * and flushes to global when the next chunk's worst-case emit would overflow scratch.
+ */
+__global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
+  fsst_chunk_desc const* __restrict__ descs,
+  int32_t const* __restrict__ d_offsets,
+  uint8_t* __restrict__ d_chars,
+  uint32_t const* __restrict__ d_comp_offsets,
+  fsst_decoder_compact const* __restrict__ d_decoders,
+  uint32_t num_chunks)
 {
-  uint32_t cid = blockIdx.x;
-  if (cid >= num_chunks) return;
-  auto const desc     = descs[cid];
-  uint8_t const* base = desc.d_bytes;
-
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ fsst_header_t sm_hdr;
-  __shared__ uint8_t sm_len[256];
-  __shared__ uint32_t sm_sym_lo[256];
-  __shared__ uint32_t sm_sym_hi[256];
-  __shared__ uint32_t sm_scratch_u32[FSST_WARPS_PER_CTA][FSST_SCRATCH_U32_PER_WARP];
+  __shared__ uint8_t sm_len[FSST_SIZE];
+  __shared__ uint32_t sm_sym_lo[FSST_SIZE];  ///< The lower 4B of the symbol
+  __shared__ uint32_t sm_sym_hi[FSST_SIZE];  ///< The upper 4B of the symbol (only used if len > 4)
+  __shared__ uint32_t
+    sm_scratch_u32[FSST_WARPS_PER_CTA]
+                  [FSST_SCRATCH_U32_PER_WARP];  ///< Per-warp scratch for decoding symbols before
+                                                ///< flushing to global
 
-  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc          = descs[chunk_id];
+  auto const* segment_base = desc.d_bytes;
+
+  // Parse the segment header
+  if (threadIdx.x == 0) { sm_ok = parse_fsst_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
   if (!sm_ok) return;  // pass-1 emitted zero lengths → nothing to gather
 
+  // Load the symbol table into SMEM
   fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
-  for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) {
-    sm_len[i]    = (i < FSST_NUM_SYMBOLS) ? dec.len[i] : uint8_t{0};
-    uint64_t sym = (i < FSST_NUM_SYMBOLS) ? dec.symbol[i] : 0ull;
-    sm_sym_lo[i] = static_cast<uint32_t>(sym);
-    sm_sym_hi[i] = static_cast<uint32_t>(sym >> 32);
+  for (uint32_t i = threadIdx.x; i < FSST_SIZE; i += blockDim.x) {
+    sm_len[i]          = (i < FSST_NUM_SYMBOLS) ? dec.len[i] : 0;
+    uint64_t const sym = (i < FSST_NUM_SYMBOLS) ? dec.symbol[i] : 0;
+    sm_sym_lo[i]       = static_cast<uint32_t>(sym);
+    sm_sym_hi[i]       = static_cast<uint32_t>(sym >> 32);
   }
   __syncthreads();
 
-  uint8_t const* dict_end_ptr = base + sm_hdr.dict_end;
-  uint32_t const* my_comp     = d_comp_offsets + desc.fsst_row_start;
-
-  // 1 warp per row. `*(my_comp - 1)` is safe within a segment for non-first
-  // chunks: chunking happens within a segment, so my_comp[-1] reads the
-  // prior in-segment row's cumulative compressed bytes.
-  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
-  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
-  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+  // Warp-per-row gather + decode.
+  // Each warp walks the compressed byte stream for its row, decodes on the fly into the per-warp
+  // scratch, and flushes to global when the next chunk's worst-case emit would overflow scratch.
+  auto const* dict_end_ptr  = segment_base + sm_hdr.dict_end;
+  auto const* my_cumsum_ptr = d_comp_offsets + desc.fsst_row_start;
+  auto const lane           = threadIdx.x % WARP_THREADS;
+  auto const warp_id        = threadIdx.x / WARP_THREADS;
+  auto const warps_per_cta  = blockDim.x / WARP_THREADS;
 
   for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
-    uint32_t cum      = my_comp[i];
-    uint32_t prev     = (i > 0) ? my_comp[i - 1] : (desc.is_first_chunk ? 0u : *(my_comp - 1));
-    uint32_t comp_len = cum - prev;
+    auto const my_cumsum = my_cumsum_ptr[i];
+    auto const prev_cumsum =
+      (i > 0) ? my_cumsum_ptr[i - 1] : (desc.is_first_chunk ? 0 : *(my_cumsum_ptr - 1));
+    auto const comp_len = my_cumsum - prev_cumsum;
     if (comp_len == 0) continue;
 
-    uint8_t const* comp_ptr = dict_end_ptr - cum;
-    uint32_t out_base       = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
+    auto const* comp_ptr       = dict_end_ptr - my_cumsum;
+    auto const out_base_offset = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
     warp_decode_fsst(comp_ptr,
                      comp_len,
-                     d_chars + out_base,
+                     d_chars + out_base_offset,
                      sm_len,
                      sm_sym_lo,
                      sm_sym_hi,
@@ -870,9 +1184,9 @@ __global__ void kernel_gather_dict_fsst(dict_fsst_desc const* __restrict__ descs
   uint8_t const* memcpy_src =
     mode_dict_fsst ? (predecode_buf + desc.predecode_seg_offset) : (base + desc.dict_data_offset);
 
-  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
-  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
-  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+  uint32_t const lane          = threadIdx.x & (WARP_THREADS - 1u);
+  uint32_t const warp_id       = threadIdx.x / WARP_THREADS;
+  uint32_t const warps_per_cta = blockDim.x / WARP_THREADS;
 
   for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
     uint32_t seg_i = desc.seg_row_start + i;
@@ -894,7 +1208,7 @@ __global__ void kernel_gather_dict_fsst(dict_fsst_desc const* __restrict__ descs
         memcpy(d_chars + op + k, &v, 4);
         k += WARP_BULK_STRIDE_BYTES;
       }
-      for (uint32_t t = n4 + lane; t < entry_len; t += WARP_SIZE) {
+      for (uint32_t t = n4 + lane; t < entry_len; t += WARP_THREADS) {
         d_chars[op + t] = src[t];
       }
       continue;
@@ -971,14 +1285,6 @@ struct prepared_dict {
   std::vector<string_chunk_desc> descs_long;   ///< max_string_length >= DICT_WARP_COOP_MIN_LEN
 };
 
-struct prepared_fsst {
-  std::vector<string_chunk_desc> length_descs;  ///< pass-1 A+B (per segment)
-  std::vector<fsst_chunk_desc> gather_chunks;   ///< pass-1 phase-C + pass-2 chunks
-  std::vector<fsst_decoder_compact> decoders;
-  std::vector<uint32_t> row_starts;  ///< prefix sum of FSST row counts
-  uint32_t total_fsst_rows;
-};
-
 struct prepared_dict_fsst {
   std::vector<dict_fsst_desc> descs;
   std::vector<fsst_decoder_compact> decoders;
@@ -998,93 +1304,6 @@ prepared_dict prepare_dict(gpu_string_codec_run const& run)
     auto& bucket =
       (seg.max_string_length < DICT_WARP_COOP_MIN_LEN) ? out.descs_short : out.descs_long;
     bucket.push_back(d);
-  }
-  return out;
-}
-
-prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
-{
-  prepared_fsst out;
-  out.total_fsst_rows = 0;
-  out.length_descs.reserve(run.segments.size());
-  out.decoders.reserve(run.segments.size());
-  out.row_starts.reserve(run.segments.size());
-
-  for (size_t si = 0; si < run.segments.size(); ++si) {
-    auto const& seg = run.segments[si];
-    if (seg.row_count == 0) continue;
-    out.row_starts.push_back(out.total_fsst_rows);
-    out.total_fsst_rows += seg.row_count;
-    out.length_descs.push_back(
-      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
-
-    // Per-segment D2H of header + symbol table — opaque format needs host import.
-    fsst_header_t hdr{};
-    if (seg.bytes_size < sizeof(hdr)) {
-      out.decoders.emplace_back();
-      continue;
-    }
-    RMM_CUDA_TRY(cudaMemcpy(&hdr, seg.d_bytes, sizeof(hdr), cudaMemcpyDeviceToHost));
-    if (hdr.fsst_symbol_table_offset >= seg.bytes_size ||
-        hdr.fsst_symbol_table_offset >= hdr.dict_end || hdr.dict_end > seg.bytes_size) {
-      out.decoders.emplace_back();
-      continue;
-    }
-    size_t symtab_max =
-      std::min<size_t>(seg.bytes_size - hdr.fsst_symbol_table_offset, FSST_SYMTAB_MAX_BYTES);
-    std::vector<uint8_t> symtab(symtab_max);
-    RMM_CUDA_TRY(cudaMemcpy(symtab.data(),
-                            seg.d_bytes + hdr.fsst_symbol_table_offset,
-                            symtab_max,
-                            cudaMemcpyDeviceToHost));
-    fsst_decoder_full full{};
-    duckdb_fsst_import(&full, symtab.data());
-    fsst_decoder_compact compact;
-    std::memcpy(compact.len, full.len, sizeof(compact.len));
-    std::memcpy(compact.symbol, full.symbol, sizeof(compact.symbol));
-    out.decoders.push_back(compact);
-  }
-
-  // Chunked descriptors for phase-C + gather. Split per-segment only when
-  // total segments < target_ctas (else one-chunk-per-segment fills SMs already).
-  uint32_t target_ctas     = get_target_ctas();
-  uint32_t chunk_size_fsst = 0;
-  if (out.length_descs.size() < target_ctas && out.total_fsst_rows > 0) {
-    chunk_size_fsst = std::max(out.total_fsst_rows / target_ctas, MIN_CHUNK_ROW);
-    chunk_size_fsst = (chunk_size_fsst / 32u) * 32u;
-    if (chunk_size_fsst == 0) chunk_size_fsst = 32u;
-  }
-  for (size_t si = 0; si < out.length_descs.size(); ++si) {
-    auto const& seg        = out.length_descs[si];
-    uint32_t fsst_base_row = out.row_starts[si];
-    if (chunk_size_fsst == 0) {
-      out.gather_chunks.push_back({seg.d_bytes,
-                                   seg.bytes_size,
-                                   seg.row_count,
-                                   seg.global_row_start,
-                                   fsst_base_row,
-                                   static_cast<uint32_t>(si),
-                                   uint8_t{1},
-                                   {0, 0, 0}});
-    } else {
-      uint32_t remaining = seg.row_count;
-      uint32_t off       = 0;
-      bool first         = true;
-      while (remaining > 0) {
-        uint32_t n = std::min(remaining, chunk_size_fsst);
-        out.gather_chunks.push_back({seg.d_bytes,
-                                     seg.bytes_size,
-                                     n,
-                                     seg.global_row_start + off,
-                                     fsst_base_row + off,
-                                     static_cast<uint32_t>(si),
-                                     uint8_t(first ? 1 : 0),
-                                     {0, 0, 0}});
-        off += n;
-        remaining -= n;
-        first = false;
-      }
-    }
   }
   return out;
 }
@@ -1225,7 +1444,7 @@ prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
   return out;
 }
 
-}  // anonymous namespace
+}  // namespace
 
 std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode_input const& col,
                                                         rmm::cuda_stream_view stream,
@@ -1258,13 +1477,14 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
       case duckdb::CompressionType::COMPRESSION_FSST: {
         auto p = prepare_fsst(run);
         // Rebase row_starts + decoder indices into the merged FSST set.
-        uint32_t row_base     = prep_fsst.total_fsst_rows;
-        uint32_t decoder_base = static_cast<uint32_t>(prep_fsst.decoders.size());
-        for (auto& s : p.row_starts)
-          s += row_base;
+        auto const row_count_base     = prep_fsst.total_fsst_row_count;
+        auto const decoder_count_base = static_cast<uint32_t>(prep_fsst.decoders.size());
+        for (auto& s : p.row_starts) {
+          s += row_count_base;
+        }
         for (auto& c : p.gather_chunks) {
-          c.fsst_row_start += row_base;
-          c.seg_decoder_idx += decoder_base;
+          c.fsst_row_start += row_count_base;
+          c.seg_decoder_idx += decoder_count_base;
         }
         prep_fsst.length_descs.insert(
           prep_fsst.length_descs.end(), p.length_descs.begin(), p.length_descs.end());
@@ -1273,7 +1493,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
         prep_fsst.decoders.insert(prep_fsst.decoders.end(), p.decoders.begin(), p.decoders.end());
         prep_fsst.gather_chunks.insert(
           prep_fsst.gather_chunks.end(), p.gather_chunks.begin(), p.gather_chunks.end());
-        prep_fsst.total_fsst_rows += p.total_fsst_rows;
+        prep_fsst.total_fsst_row_count += p.total_fsst_row_count;
         break;
       }
       case duckdb::CompressionType::COMPRESSION_DICT_FSST: {
@@ -1321,16 +1541,19 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
     }
   }
 
-  // N+1-sized with the tail zero so CUB writes offsets[total_rows] = total
-  // chars naturally; zero-init also covers NULL rows skipped by codec kernels.
-  rmm::device_uvector<uint32_t> d_lengths(size_t{total_rows} + 1u, stream, mr);
-  rmm::device_uvector<int32_t> d_offsets(size_t{total_rows} + 1u, stream, mr);
-  RMM_CUDA_TRY(cudaMemsetAsync(
-    d_lengths.data(), 0, (size_t{total_rows} + 1u) * sizeof(uint32_t), stream.value()));
+  // Allocate output and intermediate buffers.
+  rmm::device_uvector<uint32_t> d_lengths(size_t{total_rows} + 1, stream, mr);
+  rmm::device_uvector<int32_t> d_offsets(size_t{total_rows} + 1, stream, mr);
+  // RMM_CUDA_TRY(cudaMemsetAsync(
+  //   d_lengths.data(), 0, (size_t{total_rows} + 1) * sizeof(uint32_t), stream.value()));
+  rmm::device_buffer d_comp_offsets(prep_fsst.total_fsst_row_count * sizeof(uint32_t), stream, mr);
 
-  rmm::device_buffer comp_offsets_buf(
-    prep_fsst.total_fsst_rows > 0 ? prep_fsst.total_fsst_rows * sizeof(uint32_t) : 0, stream, mr);
-  uint32_t* d_comp_offsets = static_cast<uint32_t*>(comp_offsets_buf.data());
+  // Per-row kernels take chunked descriptors; predecode + mark_nulls stay
+  // per-segment via prep_dict_fsst.descs.
+  auto const target_ctas       = get_target_ctas();
+  auto const dict_chunks_short = expand_chunks(prep_dict.descs_short, target_ctas);
+  auto const dict_chunks_long  = expand_chunks(prep_dict.descs_long, target_ctas);
+  auto const dict_fsst_chunks  = expand_chunks(prep_dict_fsst.descs, target_ctas);
 
   auto upload = [&](void const* src, size_t bytes) {
     rmm::device_buffer buf(bytes, stream, mr);
@@ -1339,14 +1562,6 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
     }
     return buf;
   };
-
-  // Per-row kernels take chunked descriptors; predecode + mark_nulls stay
-  // per-segment via prep_dict_fsst.descs.
-  uint32_t target_ctas   = get_target_ctas();
-  auto dict_chunks_short = expand_chunks(prep_dict.descs_short, target_ctas);
-  auto dict_chunks_long  = expand_chunks(prep_dict.descs_long, target_ctas);
-  auto dict_fsst_chunks  = expand_chunks(prep_dict_fsst.descs, target_ctas);
-
   rmm::device_buffer d_dict_short_buf =
     upload(dict_chunks_short.data(), dict_chunks_short.size() * sizeof(string_chunk_desc));
   rmm::device_buffer d_dict_long_buf =
@@ -1374,6 +1589,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
   // Pageable host sources — sync before kernels consume to avoid free-mid-copy.
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
 
+  auto* d_comp_offsets_p     = static_cast<uint32_t*>(d_comp_offsets.data());
   auto* d_dict_short_p       = static_cast<string_chunk_desc*>(d_dict_short_buf.data());
   auto* d_dict_long_p        = static_cast<string_chunk_desc*>(d_dict_long_buf.data());
   auto* d_fsst_lengths_p     = static_cast<string_chunk_desc*>(d_fsst_lengths_buf.data());
@@ -1402,22 +1618,30 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
       d_dict_long_p, d_lengths.data(), static_cast<uint32_t>(dict_chunks_long.size()));
   }
   if (!prep_fsst.length_descs.empty()) {
+    // On-device symbol-table parse: one CTA per segment, coalesced symtab
+    // load into shmem then serial host-style parse. Replaces the per-segment
+    // sync D2H + duckdb_fsst_import that used to happen in prepare_fsst.
+    auto const n_decoders = static_cast<uint32_t>(prep_fsst.length_descs.size());
+    kernel_build_fsst_decoders<<<n_decoders, BLOCK_DIM, 0, stream.value()>>>(
+      d_fsst_lengths_p, n_decoders, d_fsst_decs_p);
+
     // A+B per-segment (prefix-sum state lives in one CTA); C per-chunk.
-    kernel_compute_lengths_fsst<<<static_cast<uint32_t>(prep_fsst.length_descs.size()),
-                                  BLOCK_DIM,
-                                  0,
-                                  stream.value()>>>(
+    kernel_compute_compressed_offsets_fsst<<<static_cast<uint32_t>(prep_fsst.length_descs.size()),
+                                             BLOCK_DIM,
+                                             0,
+                                             stream.value()>>>(
+      d_comp_offsets_p,
       d_fsst_lengths_p,
-      d_comp_offsets,
       d_fsst_starts_p,
       static_cast<uint32_t>(prep_fsst.length_descs.size()));
-    kernel_compute_lengths_fsst_phase_c<<<static_cast<uint32_t>(prep_fsst.gather_chunks.size()),
-                                          BLOCK_DIM,
-                                          0,
-                                          stream.value()>>>(
+    kernel_compute_decompressed_lengths_fsst<<<static_cast<uint32_t>(
+                                                 prep_fsst.gather_chunks.size()),
+                                               BLOCK_DIM,
+                                               0,
+                                               stream.value()>>>(
       d_fsst_chunks_p,
       d_lengths.data(),
-      d_comp_offsets,
+      d_comp_offsets_p,
       d_fsst_decs_p,
       static_cast<uint32_t>(prep_fsst.gather_chunks.size()));
   }
@@ -1515,7 +1739,7 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
       d_fsst_chunks_p,
       d_offsets.data(),
       d_chars_p,
-      d_comp_offsets,
+      d_comp_offsets_p,
       d_fsst_decs_p,
       static_cast<uint32_t>(prep_fsst.gather_chunks.size()));
   }

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-// String-codec decode kernels and orchestrator. See gpu_decode_strings.cuh.
-//
-// File layout (top to bottom):
-//   1. Shared core      — on-disk headers, decoder types, descriptor structs,
-//                         tuning constants, helpers used across codecs, and
-//                         the `prepared_*` types each codec produces.
-//   2. DICTIONARY codec — kernels + prepare_dict().
-//   3. FSST codec       — kernels + prepare_fsst(). The warp-decode helper
-//                         `warp_decode_fsst` is reused by DICT_FSST mode 2.
-//   4. DICT_FSST codec  — kernels + prepare_dict_fsst().
-//   5. Orchestrator     — `gpu_decode_strings_column` + validity overlay.
-
 #include "cuda/scan/gpu_decode_strings.cuh"
 
 #include <cudf/column/column.hpp>
@@ -63,8 +51,7 @@ namespace {
 //                                                     (DICT_FSST)
 //===----------------------------------------------------------------------===//
 
-//----- On-disk headers ------------------------------------------------------
-
+//----- On-disk headers ------------------------------------------------------//
 struct dict_header_t {
   uint32_t dict_size;
   uint32_t dict_end;
@@ -96,15 +83,13 @@ enum : uint8_t {
   DICT_FSST_MODE_FSST_ONLY  = 2,
 };
 
-//----- FSST decoder types (shared: FSST + DICT_FSST modes 1+2) --------------
+//----- FSST decoder types (shared: FSST + DICT_FSST modes 1+2) --------------//
 
 /// 255 codes (0..254); byte 255 is the escape sentinel.
-constexpr uint32_t FSST_SIZE        = 256;
-constexpr uint32_t FSST_NUM_SYMBOLS = 255;
-constexpr uint8_t FSST_ESC          = 255;
-static_assert(FSST_ESC == FSST_NUM_SYMBOLS);
-
-constexpr size_t FSST_SYMTAB_MAX_BYTES = 8192u;  // opaque serialized blob
+constexpr uint32_t FSST_SIZE           = 256;
+constexpr uint32_t FSST_NUM_SYMBOLS    = 255;
+constexpr uint8_t FSST_ESC             = 255;
+constexpr size_t FSST_SYMTAB_MAX_BYTES = 8192;  // opaque serialized blob
 
 /// Trimmed `duckdb_fsst_decoder_t`: drops `version` + `zeroTerminated`.
 /// `len` + `symbol` arrays are ABI-compatible with `_full` for the import memcpy.
@@ -166,7 +151,7 @@ struct alignas(8) dict_fsst_desc {
   uint8_t _pad[6];
 };
 
-//----- Tuning constants -----------------------------------------------------
+//----- Tuning constants -----------------------------------------------------//
 
 constexpr uint32_t BLOCK_DIM = 256;  // see FSST_WARPS_PER_CTA static_assert
 constexpr uint32_t MIN_ROWS_PER_CHUNK =
@@ -187,7 +172,7 @@ constexpr size_t HOST_UPPER_BOUND_LIMIT = size_t{512} * 1024u * 1024u;
 /// rows). Mirrors cuDF's strings-gather split (32B) with headroom.
 constexpr uint32_t DICT_WARP_COOP_MIN_LEN = 64u;
 
-//----- Helpers --------------------------------------------------------------
+//----- Helpers --------------------------------------------------------------//
 
 /// DuckDB's AlignValue<idx_t>.
 constexpr uint32_t align_up8(uint32_t n) { return (n + 7u) & ~7u; }
@@ -294,7 +279,11 @@ __device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
          hdr->dict_end <= limit && hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
 }
 
-/// false on malformed metadata; callers zero-fill.
+/**
+ * @brief Copy FSST header @p hdr into @p base, bounded by the buffer size @p limit.
+ * @return true if the header was successfully copied (i.e. the header fits within the buffer), and
+ * if the header metadata is valid; false otherwise.
+ */
 __device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
                                                   uint32_t limit,
                                                   fsst_header_t* hdr)
@@ -305,7 +294,7 @@ __device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
          hdr->bitpacking_width <= MAX_BITPACKING_WIDTH;
 }
 
-//----- Per-codec prepared-data struct types ---------------------------------
+//----- Per-codec prepared-data struct types ---------------------------------//
 // Each codec's prepare_* returns one of these; gpu_decode_strings_column
 // aggregates them across runs before launching kernels.
 
@@ -343,12 +332,18 @@ struct prepared_dict_fsst {
 //   0        20                 ^                                        ^
 //                               hdr.index_buffer_offset                  hdr.dict_end
 //
-// Index 0 is reserved for NULL (decoded length 0). Length(i) =
-// idx_buf[i] - idx_buf[i-1]; bytes for entry i live in
-// `[dict_end - idx_buf[i], dict_end - idx_buf[i-1])`.
+// Index 0 is reserved for NULL (decoded length 0).
+// Length(i) = idx_buf[i] - idx_buf[i-1].
+// Bytes for entry i live in `[dict_end - idx_buf[i], dict_end - idx_buf[i-1])`.
 // One CTA per chunk, grid-stride within the chunk.
 //===----------------------------------------------------------------------===//
 
+/**
+ * @brief Compute decoded string lengths for a DICTIONARY segment.
+ *
+ * Walks the selection buffer to get dictionary indices, looks up lengths from the index buffer, and
+ * writes per-row lengths to d_lengths.
+ */
 __global__ void kernel_compute_lengths_dict(string_chunk_desc const* __restrict__ descs,
                                             uint32_t* __restrict__ d_lengths,
                                             uint32_t num_chunks)
@@ -383,6 +378,13 @@ __global__ void kernel_compute_lengths_dict(string_chunk_desc const* __restrict_
   }
 }
 
+/**
+ * @brief Gather DICTIONARY segment strings to the output chars buffer.
+ *
+ * Walk the selection buffer to get dict indices, look up offsets from the index buffer, then copy
+ * from the dict bytes to the output chars buffer at positions from d_offsets.
+ * Work granularity is one thread per row.
+ */
 __global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
                                    int32_t const* __restrict__ d_offsets,
                                    uint8_t* __restrict__ d_chars,
@@ -397,8 +399,6 @@ __global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
   __shared__ dict_header_t sm_hdr;
   if (threadIdx.x == 0) { sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
-  // Pass 1 already zero-filled lengths on malformed metadata — d_offsets[i+1]
-  // == d_offsets[i] for those rows, so nothing to write here.
   if (!sm_ok) return;
 
   auto const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
@@ -406,64 +406,68 @@ __global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
   auto const* dict_end = segment_base + sm_hdr.dict_end;
 
   for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-    uint32_t seg_i = desc.seg_row_start + i;
-    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
+    auto const segment_idx = desc.seg_row_start + i;
+    auto const sel         = unpack_value<uint32_t>(d_sel, segment_idx, sm_hdr.bitpacking_width);
     if (sel == 0) continue;
-    uint32_t end_off   = d_idx[sel];
-    uint32_t str_len   = end_off - d_idx[sel - 1];
-    int32_t out_pos    = d_offsets[desc.global_row_start + i];
-    uint8_t const* src = dict_end - end_off;
+    auto const end_off = d_idx[sel];
+    auto const str_len = end_off - d_idx[sel - 1];
+    auto const out_pos = d_offsets[desc.global_row_start + i];
+    auto const* src    = dict_end - end_off;
     memcpy(d_chars + out_pos, src, str_len);
   }
 }
 
-/// Warp-cooperative DICTIONARY gather: 1 warp per row, stride-4 byte copy.
-/// See DICT_WARP_COOP_MIN_LEN for when this kernel is selected.
+/**
+ * @brief Gather DICTIONARY segment strings to the output chars buffer.
+ *
+ * Similar to kernel_gather_dict but with warp-cooperative copying for long strings.
+ */
 __global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ descs,
                                         int32_t const* __restrict__ d_offsets,
                                         uint8_t* __restrict__ d_chars,
                                         uint32_t num_chunks)
 {
-  uint32_t cid = blockIdx.x;
-  if (cid >= num_chunks) return;
-  auto const desc             = descs[cid];
+  auto const chunk_id = blockIdx.x;
+  if (chunk_id >= num_chunks) return;
+  auto const desc             = descs[chunk_id];
   uint8_t const* segment_base = desc.d_bytes;
 
-  __shared__ uint8_t sm_ok;
+  __shared__ bool sm_ok;
   __shared__ dict_header_t sm_hdr;
-  if (threadIdx.x == 0)
-    sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  if (threadIdx.x == 0) { sm_ok = parse_dict_header(segment_base, desc.bytes_size, &sm_hdr); }
   __syncthreads();
   if (!sm_ok) return;
 
-  uint32_t const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
-  uint32_t const* d_idx =
-    reinterpret_cast<uint32_t const*>(segment_base + sm_hdr.index_buffer_offset);
-  uint8_t const* dict_end = segment_base + sm_hdr.dict_end;
+  auto const* d_sel = reinterpret_cast<uint32_t const*>(segment_base + sizeof(dict_header_t));
+  auto const* d_idx = reinterpret_cast<uint32_t const*>(segment_base + sm_hdr.index_buffer_offset);
+  auto const* dict_end = segment_base + sm_hdr.dict_end;
 
-  uint32_t const lane          = threadIdx.x & (WARP_THREADS - 1u);
+  uint32_t const lane          = threadIdx.x % WARP_THREADS;
   uint32_t const warp_id       = threadIdx.x / WARP_THREADS;
   uint32_t const warps_per_cta = blockDim.x / WARP_THREADS;
 
   for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
-    uint32_t seg_i = desc.seg_row_start + i;
-    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
+    auto const segment_idx = desc.seg_row_start + i;
+    auto const sel         = unpack_value<uint32_t>(d_sel, segment_idx, sm_hdr.bitpacking_width);
     if (sel == 0) continue;
-    uint32_t end_off   = d_idx[sel];
-    uint32_t str_len   = end_off - d_idx[sel - 1];
-    uint32_t op        = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
-    uint8_t const* src = dict_end - end_off;
+    auto const end_off    = d_idx[sel];
+    auto const str_len    = end_off - d_idx[sel - 1];
+    auto const offset_ptr = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
+    auto const* src       = dict_end - end_off;
 
-    uint32_t n4 = str_len & ~3u;
-    uint32_t k  = lane * 4u;
-    while (k < n4) {
+    // Try to concentrate stores in 4B/word.
+    constexpr uint32_t WORD_BYTES = 4;
+    auto const n_full_words       = str_len / WORD_BYTES;
+    auto word_id                  = lane;  // word index, stride = WARP_THREADS
+    while (word_id < n_full_words) {
       uint32_t v;
-      memcpy(&v, src + k, 4);
-      memcpy(d_chars + op + k, &v, 4);
-      k += WARP_BULK_STRIDE_BYTES;
+      memcpy(&v, src + word_id * WORD_BYTES, WORD_BYTES);
+      memcpy(d_chars + offset_ptr + word_id * WORD_BYTES, &v, WORD_BYTES);
+      word_id += WARP_THREADS;
     }
-    for (uint32_t t = n4 + lane; t < str_len; t += WARP_THREADS) {
-      d_chars[op + t] = src[t];
+    // Trailing bytes
+    for (uint32_t t = n_full_words * WORD_BYTES + lane; t < str_len; t += WARP_THREADS) {
+      d_chars[offset_ptr + t] = src[t];
     }
   }
 }
@@ -610,9 +614,12 @@ __global__ __launch_bounds__(BLOCK_DIM, 4) void kernel_build_fsst_decoders(
 
 //----- Pass 1 (A+B): per-row compressed-byte offsets ------------------------
 
-/// Compute the per-row offsets into the FSST compressed byte stream for an
-/// FSST segment. One CTA per segment; in-CTA cub::BlockScan over per-thread
-/// chunk sums produces the inclusive prefix sum the gather kernel reads.
+/**
+ * @brief Compute the per-row offsets into the FSST compressed byte stream for an FSST segment.
+ *
+ * One CTA per segment; in-CTA cub::BlockScan over per-thread chunk sums produces the inclusive
+ * prefix sum the gather kernel reads.
+ */
 __global__ void kernel_compute_compressed_offsets_fsst(
   uint32_t* __restrict__ d_comp_offsets,
   string_chunk_desc const* __restrict__ descs,
@@ -673,10 +680,11 @@ __global__ void kernel_compute_compressed_offsets_fsst(
 
 //----- Pass 1 (C): per-row decompressed lengths -----------------------------
 
-/// One warp cooperatively walks `comp_len` bytes of one row's compressed
-/// stream, returning the row's total decoded-byte count. Per-lane
-/// contribution is the symbol length looked up from `sm_len`, with the
-/// escape-sentinel/literal pair handled via a shfl_up of `is_esc`.
+/**
+ * @brief Compute the compressed length of a row in the FSST compressed stream, where @p comp_ptr
+ * points to the start of the compressed bytes for that row, and @p sm_len is the symbol length
+ * table from the FSST header.
+ */
 __device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __restrict__ comp_ptr,
                                                             uint32_t comp_len,
                                                             uint8_t const* __restrict__ sm_len,
@@ -719,10 +727,13 @@ __device__ __forceinline__ uint32_t warp_compute_decomp_len(uint8_t const* __res
   return total;
 }
 
-/// Compute the decompressed length per row. Adaptive per CTA: thread-per-row
-/// for short rows (lower warp-coord tax dominates), warp-per-row for longer
-/// rows (coalesced LDG dominates). 2 × WARP_THREADS = 64 B / row crossover
-/// matches the empirical sweet spot.
+/**
+ * @brief Compute the decompressed lengths for each row in the FSST compressed stream.
+ *
+ * Adaptive per CTA: thread-per-row for short rows (lower warp-coord tax dominates), warp-per-row
+ * for longer rows (coalesced LDG dominates). 2 × WARP_THREADS = 64 B / row crossover matches the
+ * empirical sweet spot.
+ */
 __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_compute_decompressed_lengths_fsst(
   fsst_chunk_desc const* __restrict__ descs,
   uint32_t* __restrict__ d_lengths,
@@ -816,9 +827,11 @@ constexpr uint32_t FSST_MAX_CHUNK_EMIT =
   WARP_THREADS * 8;  ///< worst-case bytes emitted per 32B input chunk (8B max symbol)
 constexpr uint32_t FSST_WARPS_PER_CTA = BLOCK_DIM / WARP_THREADS;
 
-/// Drain the per-warp scratch buffer to global memory, with warp lanes
-/// cooperating in stride-4 chunks plus a per-byte cleanup for the trailing
-/// 0–3 bytes. Used by both the lazy-flush path and the end-of-row drain.
+/**
+ * @brief Drain the per-warp scratch buffer to global memory, with warp lanes cooperating in
+ * stride-4 chunks plus a per-byte cleanup for the last <4 bytes. Used in both the lazy-flush path
+ * when scratch is full and the final drain at the end of a chunk.
+ */
 __device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
                                                    uint32_t const* __restrict__ scratch_u32,
                                                    uint8_t const* __restrict__ scratch_u8,
@@ -838,17 +851,19 @@ __device__ __forceinline__ void warp_drain_scratch(uint8_t* __restrict__ dst,
   }
 }
 
-/// One warp decodes `comp_len` compressed bytes in 32-byte input chunks.
-/// Decoded symbols accumulate in a per-warp scratch slab; we flush to `dst`
-/// only when the next chunk's worst-case emit (256 B) would overflow scratch,
-/// or once at the end of the row. Multiple chunks share one __syncwarp() pair
-/// vs the old per-chunk drain. Direct lane-to-global stores were measured
-/// 30-68 % slower than the shmem-staged drain (small byte stores generated
-/// many partial L2 sectors).
-///
-/// `sm_sym` is split lo/hi so the common short-symbol load is one 4 B read on
-/// bank `c & 31` instead of straddling two banks; `sm_sym_hi` is only read
-/// when len[code] > 4. Reused by DICT_FSST mode-2 inline decompress.
+/**
+ * @brief Decode a chunk of compressed bytes using the FSST algorithm.
+ *
+ * One warp decodes `comp_len` compressed bytes in 32-byte input chunks. Decoded symbols accumulate
+ * in a per-warp scratch slab; we flush to `dst` only when the next chunk's worst-case emit (256 B)
+ * would overflow scratch, or once at the end of the row.
+ * `sm_sym` is split lo/hi so the common short-symbol load is one 4 B bank read.
+ * `sm_sym_hi` is only read when len[code] > 4.
+ *
+ * @note Reused by DICT_FSST mode-2 inline decompress.
+ * @note Direct lane-to-global stores were measured 30-68 % slower than the shmem-staged drain
+ * (small byte stores generated many partial L2 sectors).
+ */
 __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ comp_ptr,
                                                  uint32_t comp_len,
                                                  uint8_t* __restrict__ dst,
@@ -942,10 +957,11 @@ __device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ com
   }
 }
 
-/// Gather kernel for FSST-compressed segments, with the same chunking as
-/// phase-C. Each warp walks the compressed byte stream for its row, decodes
-/// on the fly into a per-warp scratch buffer, and flushes to global when the
-/// next chunk's worst-case emit would overflow scratch.
+/**
+ * @brief Gather kernel for FSST-compressed segments, with the same chunking as phase-C. Each warp
+ * walks the compressed byte stream for its row, decodes on the fly into a per-warp scratch buffer,
+ * and flushes to global when the next chunk's worst-case emit would overflow scratch.
+ */
 __global__ __launch_bounds__(BLOCK_DIM, 8) void kernel_gather_fsst_chunked(
   fsst_chunk_desc const* __restrict__ descs,
   int32_t const* __restrict__ d_offsets,

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -329,10 +329,10 @@ __global__ void kernel_compute_lengths_uncomp(string_chunk_desc const* __restric
 {
   auto const chunk_id = blockIdx.x;
   if (chunk_id >= num_chunks) return;
-  auto const desc      = descs[chunk_id];
-  auto const* base     = desc.d_bytes;
-  auto const limit     = desc.bytes_size;
-  auto const end_row   = desc.seg_row_start + desc.row_count;
+  auto const desc    = descs[chunk_id];
+  auto const* base   = desc.d_bytes;
+  auto const limit   = desc.bytes_size;
+  auto const end_row = desc.seg_row_start + desc.row_count;
 
   __shared__ bool sm_ok;
   if (threadIdx.x == 0) { sm_ok = (limit >= 8u + size_t{end_row} * 4u); }
@@ -346,11 +346,11 @@ __global__ void kernel_compute_lengths_uncomp(string_chunk_desc const* __restric
 
   auto const* duck_offsets = reinterpret_cast<int32_t const*>(base + 8);
   for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
-    auto const seg_i = desc.seg_row_start + i;
-    auto const cur   = duck_offsets[seg_i];
-    auto const prev  = (seg_i > 0) ? duck_offsets[seg_i - 1] : 0;
-    auto const abs_cur  = static_cast<uint32_t>(cur >= 0 ? cur : -cur);
-    auto const abs_prev = static_cast<uint32_t>(prev >= 0 ? prev : -prev);
+    auto const seg_i                     = desc.seg_row_start + i;
+    auto const cur                       = duck_offsets[seg_i];
+    auto const prev                      = (seg_i > 0) ? duck_offsets[seg_i - 1] : 0;
+    auto const abs_cur                   = static_cast<uint32_t>(cur >= 0 ? cur : -cur);
+    auto const abs_prev                  = static_cast<uint32_t>(prev >= 0 ? prev : -prev);
     d_lengths[desc.global_row_start + i] = abs_cur - abs_prev;
   }
 }
@@ -2192,10 +2192,8 @@ std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode
     kernel_gather_uncomp<<<static_cast<uint32_t>(uncomp_chunks.size()),
                            BLOCK_DIM,
                            0,
-                           stream.value()>>>(d_uncomp_chunks_p,
-                                             d_offsets.data(),
-                                             d_chars_p,
-                                             static_cast<uint32_t>(uncomp_chunks.size()));
+                           stream.value()>>>(
+      d_uncomp_chunks_p, d_offsets.data(), d_chars_p, static_cast<uint32_t>(uncomp_chunks.size()));
   }
   if (!dict_chunks_short.empty()) {
     kernel_gather_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),

--- a/src/cuda/scan/gpu_decode_strings.cu
+++ b/src/cuda/scan/gpu_decode_strings.cu
@@ -1,0 +1,1575 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// String-codec decode kernels and orchestrator. See gpu_decode_strings.cuh.
+
+#include "cuda/scan/gpu_decode_strings.cuh"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/detail/error.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <cub/cub.cuh>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace sirius::cuda::scan {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// On-disk header structs.
+//
+// Layouts mirror duckdb's compression headers. Sizes / field meanings are
+// authoritative from the references in:
+//   duckdb/src/storage/compression/dictionary.cpp     (DICTIONARY)
+//   duckdb/src/storage/compression/fsst.cpp           (FSST)
+//   duckdb/src/storage/compression/dict_fsst/{compression,decompression}.cpp
+//                                                     (DICT_FSST)
+//===----------------------------------------------------------------------===//
+
+struct dict_header_t {
+  uint32_t dict_size;
+  uint32_t dict_end;
+  uint32_t index_buffer_offset;  ///< to forward-cumulative dict-byte index
+  uint32_t index_buffer_count;
+  uint32_t bitpacking_width;  ///< selection buffer
+};
+
+struct fsst_header_t {
+  uint32_t dict_size;
+  uint32_t dict_end;
+  uint32_t bitpacking_width;
+  uint32_t fsst_symbol_table_offset;
+};
+
+struct dict_fsst_header_t {
+  uint32_t dict_size;
+  uint32_t dict_count;  ///< includes reserved idx 0 (NULL, length 0)
+  uint8_t mode;         ///< 0=DICTIONARY, 1=DICT_FSST, 2=FSST_ONLY
+  uint8_t string_lengths_width;
+  uint8_t dictionary_indices_width;
+  uint8_t _pad;
+  uint32_t symbol_table_size;
+};
+
+enum : uint8_t {
+  DICT_FSST_MODE_DICTIONARY = 0,
+  DICT_FSST_MODE_DICT_FSST  = 1,
+  DICT_FSST_MODE_FSST_ONLY  = 2,
+};
+
+/// 255 codes (0..254); byte 255 is the escape sentinel.
+constexpr uint32_t FSST_NUM_SYMBOLS = 255;
+constexpr uint8_t FSST_ESC          = 255;
+static_assert(FSST_ESC == FSST_NUM_SYMBOLS);
+
+constexpr size_t FSST_SYMTAB_MAX_BYTES = 8192u;  // opaque serialized blob
+
+/// Trimmed `duckdb_fsst_decoder_t`: drops `version` + `zeroTerminated`.
+/// `len` + `symbol` arrays are ABI-compatible with `_full` for the import memcpy.
+struct fsst_decoder_compact {
+  uint8_t len[FSST_NUM_SYMBOLS];
+  unsigned long long symbol[FSST_NUM_SYMBOLS];
+};
+
+/// `duckdb_fsst_decoder_t` layout — opaque outside the import → memcpy step.
+struct fsst_decoder_full {
+  unsigned long long version;
+  unsigned char zeroTerminated;
+  unsigned char len[FSST_NUM_SYMBOLS];
+  unsigned long long symbol[FSST_NUM_SYMBOLS];
+};
+static_assert(sizeof(fsst_decoder_compact::len) == sizeof(fsst_decoder_full::len));
+static_assert(sizeof(fsst_decoder_compact::symbol) == sizeof(fsst_decoder_full::symbol));
+
+// Declared locally to avoid pulling the libduckdb FSST header into the CUDA TU.
+extern "C" unsigned int duckdb_fsst_import(void* decoder, unsigned char* buf);
+
+/// Descriptor for DICTIONARY chunks and FSST length-pass segments.
+/// FSST length pass can't chunk: the in-CTA prefix sum is per-segment.
+struct alignas(8) string_chunk_desc {
+  uint8_t const* d_bytes;
+  uint32_t bytes_size;
+  uint32_t row_count;
+  uint32_t global_row_start;  ///< output position
+  uint32_t seg_row_start;     ///< rows skipped at segment head when chunked
+};
+
+struct alignas(8) fsst_chunk_desc {
+  uint8_t const* d_bytes;
+  uint32_t bytes_size;
+  uint32_t row_count;
+  uint32_t global_row_start;
+  uint32_t fsst_row_start;  ///< offset into d_comp_offsets
+  uint32_t seg_decoder_idx;
+  uint8_t is_first_chunk;  ///< gates the my_comp[-1] read
+  uint8_t _pad[3];
+};
+
+struct alignas(8) dict_fsst_desc {
+  uint8_t const* d_bytes;
+  uint32_t bytes_size;
+  uint32_t row_count;
+  uint32_t global_row_start;
+  uint32_t seg_row_start;
+  uint32_t dict_data_offset;      ///< raw/FSST-compressed dict bytes
+  uint32_t dict_indices_offset;   ///< bitpacked dictionary_indices
+  uint32_t seg_dict_offset_base;  ///< base into d_byte_offsets / d_decoded_offsets
+  uint32_t seg_decoder_idx;       ///< unused for mode 0
+  uint32_t dict_count;            ///< includes reserved idx 0
+  uint32_t predecode_seg_offset;  ///< mode-1 only
+  uint8_t dict_indices_width;
+  uint8_t mode;
+  uint8_t _pad[6];
+};
+
+constexpr uint32_t BLOCK_DIM              = 256;  // see FSST_WARPS_PER_CTA static_assert
+constexpr uint32_t MIN_CHUNK_ROW          = 64;
+constexpr uint32_t WARP_SIZE              = 32;
+constexpr uint32_t FULL_MASK              = 0xFFFFFFFFu;
+constexpr uint32_t WARP_BULK_STRIDE_BYTES = WARP_SIZE * 4u;
+/// Above this, take the exact-total sync rather than trust the host upper
+/// bound — a pathological max_string_length could otherwise force a GB-class
+/// over-allocation.
+constexpr size_t HOST_UPPER_BOUND_LIMIT = size_t{512} * 1024u * 1024u;
+
+/// Per-segment threshold for switching DICTIONARY gather from thread-per-row
+/// (launch-bound at short rows) to warp-cooperative (bandwidth-bound at long
+/// rows). Mirrors cuDF's strings-gather split (32B) with headroom.
+constexpr uint32_t DICT_WARP_COOP_MIN_LEN = 64u;
+
+/// DuckDB's AlignValue<idx_t>.
+constexpr uint32_t align_up8(uint32_t n) { return (n + 7u) & ~7u; }
+
+/// false on malformed metadata; callers zero-fill.
+__device__ __forceinline__ bool parse_dict_header(uint8_t const* base,
+                                                  uint32_t limit,
+                                                  dict_header_t* hdr)
+{
+  if (limit < sizeof(dict_header_t)) return false;
+  memcpy(hdr, base, sizeof(*hdr));
+  return hdr->index_buffer_offset + hdr->index_buffer_count * sizeof(uint32_t) <= limit &&
+         hdr->dict_end <= limit && hdr->bitpacking_width <= 32u;
+}
+
+__device__ __forceinline__ bool parse_fsst_header(uint8_t const* base,
+                                                  uint32_t limit,
+                                                  fsst_header_t* hdr)
+{
+  if (limit < sizeof(fsst_header_t)) return false;
+  memcpy(hdr, base, sizeof(*hdr));
+  return hdr->dict_end <= limit && hdr->fsst_symbol_table_offset < hdr->dict_end &&
+         hdr->bitpacking_width <= 32u;
+}
+
+template <typename T>
+__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
+{
+  if (width == 0) return T(0);
+  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
+  uint32_t word_idx = static_cast<uint32_t>(bit_pos / 32);
+  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 31);
+  uint64_t combined = static_cast<uint64_t>(packed[word_idx]);
+  if (bit_off + width > 32) { combined |= static_cast<uint64_t>(packed[word_idx + 1]) << 32; }
+  uint64_t result = combined >> bit_off;
+  if constexpr (sizeof(T) > 4) {
+    if (bit_off > 0 && bit_off + width > 64) {
+      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
+    }
+  }
+  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+  return static_cast<T>(result & mask);
+}
+
+/// DuckDB's BitpackingPrimitives uses 32-element bit-dense groups on 32-bit
+/// boundaries; an 8-byte straddling load is still safe for widths ≤ 32.
+template <typename T>
+inline T host_unpack_bitpacked(uint8_t const* packed, uint32_t idx, uint32_t width)
+{
+  if (width == 0) return T(0);
+  uint64_t bit_pos  = static_cast<uint64_t>(idx) * width;
+  uint32_t byte_off = static_cast<uint32_t>(bit_pos >> 3);
+  uint32_t bit_off  = static_cast<uint32_t>(bit_pos & 7u);
+  uint64_t combined;
+  std::memcpy(&combined, packed + byte_off, sizeof(uint64_t));
+  uint64_t mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+  return static_cast<T>((combined >> bit_off) & mask);
+}
+
+/// Count decoded length without emitting output (used to size predecode offsets).
+inline size_t fsst_decompressed_length_host(fsst_decoder_compact const& dec,
+                                            uint8_t const* src,
+                                            size_t src_len)
+{
+  size_t pos = 0, dec_len = 0;
+  while (pos < src_len) {
+    uint8_t code = src[pos++];
+    if (code < FSST_ESC) {
+      dec_len += dec.len[code];
+    } else {
+      ++pos;
+      ++dec_len;
+    }
+  }
+  return dec_len;
+}
+
+/// Two waves of full occupancy at BLOCK_DIM threads, per current device.
+uint32_t get_target_ctas()
+{
+  int device = 0;
+  RMM_CUDA_TRY(cudaGetDevice(&device));
+  static int cached_device = -1;
+  static uint32_t cached   = 0;
+  if (cached_device == device) return cached;
+  cudaDeviceProp prop;
+  RMM_CUDA_TRY(cudaGetDeviceProperties(&prop, device));
+  int occupancy_blocks = prop.maxThreadsPerMultiProcessor / BLOCK_DIM;
+  cached_device        = device;
+  cached               = static_cast<uint32_t>(prop.multiProcessorCount * occupancy_blocks * 2);
+  return cached;
+}
+
+/// Split per-segment descriptors into smaller row sub-ranges so the kernel
+/// grid fills available SMs. Below MIN_CHUNK_ROW the per-CTA overhead
+/// dominates and we keep the original shape. Used for per-row work
+/// (compute_lengths, gather); per-dict work (predecode, mark_nulls) keeps
+/// one-CTA-per-segment so dictionaries are not decoded per chunk.
+template <typename Desc>
+std::vector<Desc> expand_chunks(std::vector<Desc> const& descs, uint32_t target_ctas)
+{
+  uint32_t total_rows = 0;
+  for (auto const& d : descs)
+    total_rows += d.row_count;
+  if (descs.size() >= target_ctas || total_rows == 0) return descs;
+
+  uint32_t chunk_size = total_rows / target_ctas;
+  chunk_size          = std::max(chunk_size, MIN_CHUNK_ROW);
+  // Round down to warp size for store coalescing within a chunk.
+  chunk_size = (chunk_size / WARP_SIZE) * WARP_SIZE;
+  if (chunk_size == 0) chunk_size = WARP_SIZE;
+
+  std::vector<Desc> out;
+  out.reserve(target_ctas + descs.size());
+  for (auto const& seg : descs) {
+    uint32_t remaining = seg.row_count;
+    uint32_t off       = 0;
+    while (remaining > 0) {
+      uint32_t n             = std::min(remaining, chunk_size);
+      Desc chunk             = seg;
+      chunk.row_count        = n;
+      chunk.global_row_start = seg.global_row_start + off;
+      chunk.seg_row_start    = seg.seg_row_start + off;
+      out.push_back(chunk);
+      off += n;
+      remaining -= n;
+    }
+  }
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// DICTIONARY codec.
+//
+//   offset 0                                                      seg_end
+//   +--------+------------------+------------------+---------------------+
+//   | header | selection_buffer |   index_buffer   |     dict bytes      |
+//   |  20B   |  bitpacked per   |  forward-cumul   |  entries packed in  |
+//   |        |  row -> dict idx |  uint32 × count  |  REVERSE order      |
+//   +--------+------------------+------------------+---------------------+
+//   0        20                 ^                                        ^
+//                               hdr.index_buffer_offset                  hdr.dict_end
+//
+// Index 0 is reserved for NULL (decoded length 0). Length(i) =
+// idx_buf[i] - idx_buf[i-1]; bytes for entry i live in
+// `[dict_end - idx_buf[i], dict_end - idx_buf[i-1])`.
+// One CTA per chunk, grid-stride within the chunk.
+//===----------------------------------------------------------------------===//
+
+__global__ void kernel_compute_lengths_dict(string_chunk_desc const* __restrict__ descs,
+                                            uint32_t* __restrict__ d_lengths,
+                                            uint32_t num_chunks)
+{
+  uint32_t cid = blockIdx.x;
+  if (cid >= num_chunks) return;
+  auto const desc     = descs[cid];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ dict_header_t sm_hdr;
+  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+
+  // Malformed metadata → zero-fill using the trusted descriptor row count.
+  if (!sm_ok) {
+    for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+      d_lengths[desc.global_row_start + i] = 0u;
+    }
+    return;
+  }
+
+  uint32_t const* d_sel = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
+  uint32_t const* d_idx = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
+    uint32_t len   = (sel == 0) ? 0u : (d_idx[sel] - d_idx[sel - 1]);
+    d_lengths[desc.global_row_start + i] = len;
+  }
+}
+
+__global__ void kernel_gather_dict(string_chunk_desc const* __restrict__ descs,
+                                   int32_t const* __restrict__ d_offsets,
+                                   uint8_t* __restrict__ d_chars,
+                                   uint32_t num_chunks)
+{
+  uint32_t cid = blockIdx.x;
+  if (cid >= num_chunks) return;
+  auto const desc     = descs[cid];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ dict_header_t sm_hdr;
+  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+  // Pass 1 already zero-filled lengths on malformed metadata — d_offsets[i+1]
+  // == d_offsets[i] for those rows, so nothing to write here.
+  if (!sm_ok) return;
+
+  uint32_t const* d_sel   = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
+  uint32_t const* d_idx   = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
+  uint8_t const* dict_end = base + sm_hdr.dict_end;
+
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
+    if (sel == 0) continue;
+    uint32_t end_off   = d_idx[sel];
+    uint32_t str_len   = end_off - d_idx[sel - 1];
+    int32_t out_pos    = d_offsets[desc.global_row_start + i];
+    uint8_t const* src = dict_end - end_off;
+    memcpy(d_chars + out_pos, src, str_len);
+  }
+}
+
+/// Warp-cooperative DICTIONARY gather: 1 warp per row, stride-4 byte copy.
+/// See DICT_WARP_COOP_MIN_LEN for when this kernel is selected.
+__global__ void kernel_gather_dict_warp(string_chunk_desc const* __restrict__ descs,
+                                        int32_t const* __restrict__ d_offsets,
+                                        uint8_t* __restrict__ d_chars,
+                                        uint32_t num_chunks)
+{
+  uint32_t cid = blockIdx.x;
+  if (cid >= num_chunks) return;
+  auto const desc     = descs[cid];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ dict_header_t sm_hdr;
+  if (threadIdx.x == 0) sm_ok = parse_dict_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+  if (!sm_ok) return;
+
+  uint32_t const* d_sel   = reinterpret_cast<uint32_t const*>(base + sizeof(dict_header_t));
+  uint32_t const* d_idx   = reinterpret_cast<uint32_t const*>(base + sm_hdr.index_buffer_offset);
+  uint8_t const* dict_end = base + sm_hdr.dict_end;
+
+  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
+  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
+  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+
+  for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t sel   = unpack_value<uint32_t>(d_sel, seg_i, sm_hdr.bitpacking_width);
+    if (sel == 0) continue;
+    uint32_t end_off   = d_idx[sel];
+    uint32_t str_len   = end_off - d_idx[sel - 1];
+    uint32_t op        = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
+    uint8_t const* src = dict_end - end_off;
+
+    uint32_t n4 = str_len & ~3u;
+    uint32_t k  = lane * 4u;
+    while (k < n4) {
+      uint32_t v;
+      memcpy(&v, src + k, 4);
+      memcpy(d_chars + op + k, &v, 4);
+      k += WARP_BULK_STRIDE_BYTES;
+    }
+    for (uint32_t t = n4 + lane; t < str_len; t += WARP_SIZE) {
+      d_chars[op + t] = src[t];
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// FSST codec.
+//
+//   offset 0                                                       seg_end
+//   +--------+--------------------+---------------+------------------------+
+//   | header | compressed_lengths |  symbol table |  FSST-compressed bytes |
+//   |  16B   |  bitpacked per row |  opaque blob  |  rows packed in        |
+//   |        |  -> comp_len       |  imported on  |  REVERSE order ending  |
+//   |        |                    |  host         |  at dict_end           |
+//   +--------+--------------------+---------------+------------------------+
+//   0        16                   ^                                        ^
+//                                 hdr.fsst_symbol_table_offset             hdr.dict_end
+//
+// Pass 1 is split into A+B (per-segment) and C (chunked):
+//   A — unpack compressed_lengths into d_comp_offsets[fsst_base..]
+//   B — in-CTA InclusiveSum producing per-row cumulative compressed bytes
+//   C — for each row, walk its compressed bytes summing decoded lengths
+// A+B owns per-segment prefix-sum state (one CTA per segment); C is the
+// expensive serial byte-scan and chunks across CTAs. The same compressed-
+// offset array is reused by the gather pass.
+//===----------------------------------------------------------------------===//
+
+__global__ void kernel_compute_lengths_fsst(string_chunk_desc const* __restrict__ descs,
+                                            uint32_t* __restrict__ d_comp_offsets,
+                                            uint32_t const* __restrict__ d_fsst_row_starts,
+                                            uint32_t num_segments)
+{
+  uint32_t seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc     = descs[seg_idx];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ fsst_header_t sm_hdr;
+  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+
+  uint32_t fsst_base = d_fsst_row_starts[seg_idx];
+  uint32_t row_count = desc.row_count;
+  uint32_t* my_comp  = d_comp_offsets + fsst_base;
+
+  if (!sm_ok) {
+    // Zero the slice so phase-C emits empty strings — chars buffer stays valid.
+    for (uint32_t i = threadIdx.x; i < row_count; i += blockDim.x)
+      my_comp[i] = 0u;
+    return;
+  }
+
+  // Phase A: unpack compressed lengths.
+  uint32_t const* packed = reinterpret_cast<uint32_t const*>(base + sizeof(fsst_header_t));
+  for (uint32_t i = threadIdx.x; i < row_count; i += blockDim.x) {
+    my_comp[i] = unpack_value<uint32_t>(packed, i, sm_hdr.bitpacking_width);
+  }
+  __syncthreads();
+
+  // Phase B: per-thread sequential scan + BlockScan over per-thread totals.
+  using BlockScanT = cub::BlockScan<uint32_t, BLOCK_DIM>;
+  __shared__ typename BlockScanT::TempStorage scan_temp;
+  uint32_t chunk_size = (row_count + blockDim.x - 1u) / blockDim.x;
+  uint32_t start      = threadIdx.x * chunk_size;
+  uint32_t end        = min(start + chunk_size, row_count);
+  uint32_t local_sum  = 0;
+  for (uint32_t i = start; i < end; ++i) {
+    local_sum += my_comp[i];
+    my_comp[i] = local_sum;
+  }
+  uint32_t scanned;
+  BlockScanT(scan_temp).ExclusiveSum(local_sum, scanned);
+  if (scanned > 0) {
+    for (uint32_t i = start; i < end; ++i)
+      my_comp[i] += scanned;
+  }
+}
+
+__global__ void kernel_compute_lengths_fsst_phase_c(
+  fsst_chunk_desc const* __restrict__ descs,
+  uint32_t* __restrict__ d_lengths,
+  uint32_t const* __restrict__ d_comp_offsets,
+  fsst_decoder_compact const* __restrict__ d_decoders,
+  uint32_t num_chunks)
+{
+  uint32_t cid = blockIdx.x;
+  if (cid >= num_chunks) return;
+  auto const desc     = descs[cid];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ fsst_header_t sm_hdr;
+  __shared__ uint8_t sm_len[FSST_NUM_SYMBOLS];
+  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+
+  if (!sm_ok) {
+    for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+      d_lengths[desc.global_row_start + i] = 0u;
+    }
+    return;
+  }
+
+  fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
+  for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x)
+    sm_len[i] = dec.len[i];
+  __syncthreads();
+
+  uint8_t const* dict_end_ptr = base + sm_hdr.dict_end;
+  uint32_t const* my_comp     = d_comp_offsets + desc.fsst_row_start;
+
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    uint32_t cum      = my_comp[i];
+    uint32_t prev     = (i > 0) ? my_comp[i - 1] : (desc.is_first_chunk ? 0u : *(my_comp - 1));
+    uint32_t comp_len = cum - prev;
+    if (comp_len == 0) {
+      d_lengths[desc.global_row_start + i] = 0u;
+      continue;
+    }
+    uint8_t const* comp_ptr = dict_end_ptr - cum;
+    uint32_t decomp_len     = 0;
+    uint32_t pos            = 0;
+    while (pos < comp_len) {
+      uint8_t code = comp_ptr[pos++];
+      if (code < FSST_ESC) {
+        decomp_len += sm_len[code];
+      } else {
+        ++pos;
+        ++decomp_len;
+      }
+    }
+    d_lengths[desc.global_row_start + i] = decomp_len;
+  }
+}
+
+/// 32 input bytes × max 8B symbol = 256B; 64 u32 keeps ld.shared.u32 aligned.
+constexpr uint32_t FSST_SCRATCH_U32_PER_WARP = 64u;
+constexpr uint32_t FSST_WARPS_PER_CTA        = 8u;
+static_assert(FSST_WARPS_PER_CTA == BLOCK_DIM / WARP_SIZE);
+
+/// One warp decodes `comp_len` compressed bytes in 32-byte input chunks:
+/// warp-scan for per-lane output offsets → scatter decoded bytes into a
+/// per-warp shmem slab → coalesced stride-4 drain to `dst`. Per-chunk flush
+/// caps shmem use at 256B/warp.
+///
+/// `sm_sym` is split lo/hi so the common short-symbol load is one 4B read on
+/// bank `c & 31` instead of straddling two banks; `sm_sym_hi` is only read
+/// when len[code] > 4.
+__device__ __forceinline__ void warp_decode_fsst(uint8_t const* __restrict__ comp_ptr,
+                                                 uint32_t comp_len,
+                                                 uint8_t* __restrict__ dst,
+                                                 uint8_t const* __restrict__ sm_len,
+                                                 uint32_t const* __restrict__ sm_sym_lo,
+                                                 uint32_t const* __restrict__ sm_sym_hi,
+                                                 uint32_t* __restrict__ warp_scratch_u32,
+                                                 uint32_t lane)
+{
+  uint8_t* warp_scratch_u8        = reinterpret_cast<uint8_t*>(warp_scratch_u32);
+  uint32_t cumulative_out_off     = 0;
+  uint32_t prev_chunk_last_is_esc = 0;
+
+  for (uint32_t off = 0; off < comp_len; off += WARP_SIZE) {
+    uint32_t bytes_in_chunk = comp_len - off;
+    if (bytes_in_chunk > WARP_SIZE) bytes_in_chunk = WARP_SIZE;
+
+    uint8_t my_byte = (lane < bytes_in_chunk) ? comp_ptr[off + lane] : 0u;
+    uint32_t active = (lane < bytes_in_chunk) ? 1u : 0u;
+    uint32_t is_esc = (active && my_byte == FSST_ESC) ? 1u : 0u;
+
+    uint32_t neighbor_esc = __shfl_up_sync(FULL_MASK, is_esc, 1);
+    uint32_t prev_was_esc = (lane == 0) ? prev_chunk_last_is_esc : neighbor_esc;
+
+    uint32_t my_len       = 0u;
+    uint32_t my_sym_lo    = 0u;
+    uint32_t my_sym_hi    = 0u;
+    uint32_t my_emit_kind = 0u;
+    if (active) {
+      if (prev_was_esc) {
+        my_len       = 1u;
+        my_sym_lo    = my_byte;
+        my_emit_kind = 2u;
+      } else if (!is_esc) {
+        uint8_t code = my_byte;
+        my_len       = sm_len[code];
+        my_sym_lo    = sm_sym_lo[code];
+        if (my_len > 4u) my_sym_hi = sm_sym_hi[code];
+        my_emit_kind = 1u;
+      }
+    }
+
+    uint32_t scan = my_len;
+#pragma unroll
+    for (uint32_t step = 1u; step < WARP_SIZE; step <<= 1) {
+      uint32_t add = __shfl_up_sync(FULL_MASK, scan, step);
+      if (lane >= step) scan += add;
+    }
+    uint32_t exclusive = scan - my_len;
+
+    if (my_emit_kind == 1u) {
+      switch (my_len) {
+        case 1: warp_scratch_u8[exclusive] = static_cast<uint8_t>(my_sym_lo); break;
+        case 2: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 2); break;
+        case 3: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 3); break;
+        case 4: memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 4); break;
+        default: {
+          memcpy(warp_scratch_u8 + exclusive, &my_sym_lo, 4);
+          uint32_t const tail = my_len - 4u;
+          memcpy(warp_scratch_u8 + exclusive + 4u, &my_sym_hi, tail);
+          break;
+        }
+      }
+    } else if (my_emit_kind == 2u) {
+      warp_scratch_u8[exclusive] = static_cast<uint8_t>(my_sym_lo);
+    }
+
+    uint32_t chunk_total = __shfl_sync(FULL_MASK, scan, WARP_SIZE - 1u);
+
+    __syncwarp();
+
+    uint32_t const n  = chunk_total;
+    uint32_t const n4 = n & ~3u;
+    uint32_t k        = lane * 4u;
+    while (k < n4) {
+      uint32_t v = warp_scratch_u32[k >> 2];
+      memcpy(dst + cumulative_out_off + k, &v, 4);
+      k += WARP_BULK_STRIDE_BYTES;
+    }
+    for (uint32_t t = n4 + lane; t < n; t += WARP_SIZE) {
+      dst[cumulative_out_off + t] = warp_scratch_u8[t];
+    }
+
+    __syncwarp();
+    cumulative_out_off += chunk_total;
+
+    uint32_t last_active_lane = bytes_in_chunk - 1u;
+    prev_chunk_last_is_esc    = __shfl_sync(FULL_MASK, is_esc, last_active_lane);
+  }
+}
+
+__global__ void kernel_gather_fsst_chunked(fsst_chunk_desc const* __restrict__ descs,
+                                           int32_t const* __restrict__ d_offsets,
+                                           uint8_t* __restrict__ d_chars,
+                                           uint32_t const* __restrict__ d_comp_offsets,
+                                           fsst_decoder_compact const* __restrict__ d_decoders,
+                                           uint32_t num_chunks)
+{
+  uint32_t cid = blockIdx.x;
+  if (cid >= num_chunks) return;
+  auto const desc     = descs[cid];
+  uint8_t const* base = desc.d_bytes;
+
+  __shared__ uint8_t sm_ok;
+  __shared__ fsst_header_t sm_hdr;
+  __shared__ uint8_t sm_len[256];
+  __shared__ uint32_t sm_sym_lo[256];
+  __shared__ uint32_t sm_sym_hi[256];
+  __shared__ uint32_t sm_scratch_u32[FSST_WARPS_PER_CTA][FSST_SCRATCH_U32_PER_WARP];
+
+  if (threadIdx.x == 0) sm_ok = parse_fsst_header(base, desc.bytes_size, &sm_hdr) ? 1 : 0;
+  __syncthreads();
+  if (!sm_ok) return;  // pass-1 emitted zero lengths → nothing to gather
+
+  fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
+  for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) {
+    sm_len[i]    = (i < FSST_NUM_SYMBOLS) ? dec.len[i] : uint8_t{0};
+    uint64_t sym = (i < FSST_NUM_SYMBOLS) ? dec.symbol[i] : 0ull;
+    sm_sym_lo[i] = static_cast<uint32_t>(sym);
+    sm_sym_hi[i] = static_cast<uint32_t>(sym >> 32);
+  }
+  __syncthreads();
+
+  uint8_t const* dict_end_ptr = base + sm_hdr.dict_end;
+  uint32_t const* my_comp     = d_comp_offsets + desc.fsst_row_start;
+
+  // 1 warp per row. `*(my_comp - 1)` is safe within a segment for non-first
+  // chunks: chunking happens within a segment, so my_comp[-1] reads the
+  // prior in-segment row's cumulative compressed bytes.
+  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
+  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
+  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+
+  for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
+    uint32_t cum      = my_comp[i];
+    uint32_t prev     = (i > 0) ? my_comp[i - 1] : (desc.is_first_chunk ? 0u : *(my_comp - 1));
+    uint32_t comp_len = cum - prev;
+    if (comp_len == 0) continue;
+
+    uint8_t const* comp_ptr = dict_end_ptr - cum;
+    uint32_t out_base       = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
+    warp_decode_fsst(comp_ptr,
+                     comp_len,
+                     d_chars + out_base,
+                     sm_len,
+                     sm_sym_lo,
+                     sm_sym_hi,
+                     &sm_scratch_u32[warp_id][0],
+                     lane);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// DICT_FSST codec.
+//
+//   +-----+------------+--------+----------------+--------------------+
+//   | hdr | dict bytes | symtab | string_lengths |    dict_indices    |
+//   | 16B |            |        |                |  (absent: mode 2)  |
+//   +-----+------------+--------+----------------+--------------------+
+//   0     off_dict     off_symtab               off_slens         off_didx
+//
+// All regions 8-byte aligned (DuckDB AlignValue).
+//
+// Modes (hdr.mode):
+//   0 DICTIONARY  — dict bytes raw; gather is memcpy.
+//   1 DICT_FSST   — dict bytes FSST-compressed; predecode kernel decompresses
+//                   each dict entry once into a per-segment buffer; gather
+//                   memcpys from there.
+//   2 FSST_ONLY   — all rows unique; row i → dict entry i+1; no dict_indices
+//                   region; gather inline-decompresses each row.
+//
+// dict_idx == 0 = NULL. DuckDB ships COMPRESSION_EMPTY validity for these,
+// which the overlay path skips — mark_nulls folds them in.
+//===----------------------------------------------------------------------===//
+
+__global__ void kernel_compute_lengths_dict_fsst(dict_fsst_desc const* __restrict__ descs,
+                                                 uint32_t* __restrict__ d_lengths,
+                                                 uint32_t const* __restrict__ d_decoded_offsets,
+                                                 uint32_t num_segments)
+{
+  uint32_t seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc         = descs[seg_idx];
+  uint32_t const* dec_off = d_decoded_offsets + desc.seg_dict_offset_base;
+  uint32_t const* d_idx =
+    reinterpret_cast<uint32_t const*>(desc.d_bytes + desc.dict_indices_offset);
+  bool const fsst_only = (desc.mode == DICT_FSST_MODE_FSST_ONLY);
+
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t idx =
+      fsst_only ? (seg_i + 1u) : unpack_value<uint32_t>(d_idx, seg_i, desc.dict_indices_width);
+    uint32_t len                         = (idx == 0u) ? 0u : (dec_off[idx + 1] - dec_off[idx]);
+    d_lengths[desc.global_row_start + i] = len;
+  }
+}
+
+/// Mode-1 only: one thread per dict entry decompresses once into predecode_buf;
+/// per-row gather is then a memcpy. Avoids row_count×dict redundant FSST work.
+__global__ void kernel_predecode_dict_fsst(dict_fsst_desc const* __restrict__ descs,
+                                           uint32_t const* __restrict__ d_byte_offsets,
+                                           uint32_t const* __restrict__ d_decoded_offsets,
+                                           fsst_decoder_compact const* __restrict__ d_decoders,
+                                           uint8_t* __restrict__ predecode_buf,
+                                           uint32_t num_segments)
+{
+  uint32_t seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc = descs[seg_idx];
+  if (desc.mode != DICT_FSST_MODE_DICT_FSST) return;
+  if (desc.dict_count <= 1u) return;  // only entry 0 = NULL, nothing to decode
+
+  __shared__ uint8_t sm_len[FSST_NUM_SYMBOLS];
+  __shared__ unsigned long long sm_sym[FSST_NUM_SYMBOLS];
+
+  fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
+  for (uint32_t i = threadIdx.x; i < FSST_NUM_SYMBOLS; i += blockDim.x) {
+    sm_len[i] = dec.len[i];
+    sm_sym[i] = dec.symbol[i];
+  }
+  __syncthreads();
+
+  uint8_t const* dict_data = desc.d_bytes + desc.dict_data_offset;
+  uint32_t const* byte_off = d_byte_offsets + desc.seg_dict_offset_base;
+  uint32_t const* dec_off  = d_decoded_offsets + desc.seg_dict_offset_base;
+  uint8_t* out_base        = predecode_buf + desc.predecode_seg_offset;
+
+  // Skip k=0 (reserved NULL slot, length 0). One thread per dict entry.
+  for (uint32_t k = threadIdx.x + 1u; k < desc.dict_count; k += blockDim.x) {
+    uint32_t comp_start = byte_off[k];
+    uint32_t comp_end   = byte_off[k + 1];
+    uint32_t comp_len   = comp_end - comp_start;
+    uint32_t out_pos    = dec_off[k];
+
+    uint8_t const* comp_ptr = dict_data + comp_start;
+    uint8_t* out_ptr        = out_base + out_pos;
+    uint32_t pos            = 0;
+    uint32_t op             = 0;
+    while (pos < comp_len) {
+      uint8_t code = comp_ptr[pos++];
+      if (code < FSST_ESC) {
+        unsigned long long sym = sm_sym[code];
+        uint8_t sym_len        = sm_len[code];
+        switch (sym_len) {
+          case 1: out_ptr[op] = static_cast<uint8_t>(sym); break;
+          case 2: memcpy(out_ptr + op, &sym, 2); break;
+          case 3: memcpy(out_ptr + op, &sym, 3); break;
+          case 4: memcpy(out_ptr + op, &sym, 4); break;
+          default: memcpy(out_ptr + op, &sym, sym_len); break;
+        }
+        op += sym_len;
+      } else {
+        out_ptr[op++] = comp_ptr[pos++];
+      }
+    }
+  }
+}
+
+/// Per-row gather for all three DICT_FSST modes (see codec banner above).
+__global__ void kernel_gather_dict_fsst(dict_fsst_desc const* __restrict__ descs,
+                                        int32_t const* __restrict__ d_offsets,
+                                        uint8_t* __restrict__ d_chars,
+                                        uint32_t const* __restrict__ d_byte_offsets,
+                                        uint32_t const* __restrict__ d_decoded_offsets,
+                                        uint8_t const* __restrict__ predecode_buf,
+                                        fsst_decoder_compact const* __restrict__ d_decoders,
+                                        uint32_t num_segments)
+{
+  uint32_t seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc               = descs[seg_idx];
+  uint8_t const* base           = desc.d_bytes;
+  uint32_t const* dict_byte_off = d_byte_offsets + desc.seg_dict_offset_base;
+  uint32_t const* dict_dec_off  = d_decoded_offsets + desc.seg_dict_offset_base;
+  uint32_t const* d_idx     = reinterpret_cast<uint32_t const*>(base + desc.dict_indices_offset);
+  bool const fsst_only      = (desc.mode == DICT_FSST_MODE_FSST_ONLY);
+  bool const mode_dict_fsst = (desc.mode == DICT_FSST_MODE_DICT_FSST);
+
+  __shared__ uint8_t sm_len[256];
+  __shared__ uint32_t sm_sym_lo[256];
+  __shared__ uint32_t sm_sym_hi[256];
+  __shared__ uint32_t sm_scratch_u32[FSST_WARPS_PER_CTA][FSST_SCRATCH_U32_PER_WARP];
+
+  if (fsst_only) {  // mode 2 inline decompresses; needs the symtab in shmem
+    fsst_decoder_compact const& dec = d_decoders[desc.seg_decoder_idx];
+    for (uint32_t i = threadIdx.x; i < 256u; i += blockDim.x) {
+      sm_len[i]    = (i < FSST_NUM_SYMBOLS) ? dec.len[i] : uint8_t{0};
+      uint64_t sym = (i < FSST_NUM_SYMBOLS) ? dec.symbol[i] : 0ull;
+      sm_sym_lo[i] = static_cast<uint32_t>(sym);
+      sm_sym_hi[i] = static_cast<uint32_t>(sym >> 32);
+    }
+    __syncthreads();
+  }
+
+  // Modes 0/1 share the same warp-cooperative memcpy; only (offsets, source) differ.
+  uint32_t const* memcpy_off = mode_dict_fsst ? dict_dec_off : dict_byte_off;
+  uint8_t const* memcpy_src =
+    mode_dict_fsst ? (predecode_buf + desc.predecode_seg_offset) : (base + desc.dict_data_offset);
+
+  uint32_t const lane          = threadIdx.x & (WARP_SIZE - 1u);
+  uint32_t const warp_id       = threadIdx.x / WARP_SIZE;
+  uint32_t const warps_per_cta = blockDim.x / WARP_SIZE;
+
+  for (uint32_t i = warp_id; i < desc.row_count; i += warps_per_cta) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t idx =
+      fsst_only ? (seg_i + 1u) : unpack_value<uint32_t>(d_idx, seg_i, desc.dict_indices_width);
+    if (idx == 0u) continue;  // NULL — pass-1 emitted length 0
+
+    uint32_t op = static_cast<uint32_t>(d_offsets[desc.global_row_start + i]);
+
+    if (!fsst_only) {
+      uint32_t entry_start = memcpy_off[idx];
+      uint32_t entry_len   = memcpy_off[idx + 1] - entry_start;
+      uint8_t const* src   = memcpy_src + entry_start;
+      uint32_t n4          = entry_len & ~3u;
+      uint32_t k           = lane * 4u;
+      while (k < n4) {
+        uint32_t v;
+        memcpy(&v, src + k, 4);
+        memcpy(d_chars + op + k, &v, 4);
+        k += WARP_BULK_STRIDE_BYTES;
+      }
+      for (uint32_t t = n4 + lane; t < entry_len; t += WARP_SIZE) {
+        d_chars[op + t] = src[t];
+      }
+      continue;
+    }
+
+    // Mode 2: inline decompress.
+    uint32_t byte_start = dict_byte_off[idx];
+    uint32_t comp_len   = dict_byte_off[idx + 1] - byte_start;
+    if (comp_len == 0) continue;
+    warp_decode_fsst(memcpy_src + byte_start,
+                     comp_len,
+                     d_chars + op,
+                     sm_len,
+                     sm_sym_lo,
+                     sm_sym_hi,
+                     &sm_scratch_u32[warp_id][0],
+                     lane);
+  }
+}
+
+/// Fold inline NULLs (idx==0) into the column mask — DuckDB ships
+/// COMPRESSION_EMPTY validity for these, which the overlay path skips.
+__global__ void kernel_dict_fsst_mark_nulls(dict_fsst_desc const* __restrict__ descs,
+                                            uint8_t* __restrict__ d_mask,
+                                            uint32_t num_segments)
+{
+  uint32_t seg_idx = blockIdx.x;
+  if (seg_idx >= num_segments) return;
+  auto const desc = descs[seg_idx];
+  uint32_t const* d_idx =
+    reinterpret_cast<uint32_t const*>(desc.d_bytes + desc.dict_indices_offset);
+
+  // FSST_ONLY can't encode NULL via idx==0 (row i → entry i+1 always non-zero).
+  if (desc.mode == DICT_FSST_MODE_FSST_ONLY) return;
+
+  auto* d_mask_words = reinterpret_cast<unsigned int*>(d_mask);
+  for (uint32_t i = threadIdx.x; i < desc.row_count; i += blockDim.x) {
+    uint32_t seg_i = desc.seg_row_start + i;
+    uint32_t idx   = unpack_value<uint32_t>(d_idx, seg_i, desc.dict_indices_width);
+    if (idx != 0u) continue;
+    uint32_t row = desc.global_row_start + i;
+    atomicAnd(d_mask_words + (row >> 5), ~(1u << (row & 31u)));
+  }
+}
+
+/// Sibling to `dispatch_validity_run` in gpu_native_decode.cu.
+void overlay_validity_run(gpu_codec_run const& run, uint8_t* d_mask, rmm::cuda_stream_view stream)
+{
+  if (run.codec != duckdb::CompressionType::COMPRESSION_UNCOMPRESSED) {
+    throw std::runtime_error(
+      "gpu_decode_strings_column: viability invariant violated — "
+      "validity codec " +
+      std::to_string(static_cast<int>(run.codec)) + " not implemented");
+  }
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    if (seg.row_offset % 8 != 0) {
+      throw std::runtime_error("gpu_decode_strings_column: validity row_offset (" +
+                               std::to_string(seg.row_offset) + ") not byte-aligned");
+    }
+    size_t bytes = (size_t{seg.row_count} + 7) / 8;
+    if (size_t{seg.bytes_size} < bytes) {
+      throw std::runtime_error("gpu_decode_strings_column: validity segment bytes_size (" +
+                               std::to_string(seg.bytes_size) + ") < required " +
+                               std::to_string(bytes));
+    }
+    RMM_CUDA_TRY(cudaMemcpyAsync(
+      d_mask + seg.row_offset / 8, seg.d_bytes, bytes, cudaMemcpyDeviceToDevice, stream.value()));
+  }
+}
+
+struct prepared_dict {
+  std::vector<string_chunk_desc> descs_short;  ///< max_string_length < DICT_WARP_COOP_MIN_LEN
+  std::vector<string_chunk_desc> descs_long;   ///< max_string_length >= DICT_WARP_COOP_MIN_LEN
+};
+
+struct prepared_fsst {
+  std::vector<string_chunk_desc> length_descs;  ///< pass-1 A+B (per segment)
+  std::vector<fsst_chunk_desc> gather_chunks;   ///< pass-1 phase-C + pass-2 chunks
+  std::vector<fsst_decoder_compact> decoders;
+  std::vector<uint32_t> row_starts;  ///< prefix sum of FSST row counts
+  uint32_t total_fsst_rows;
+};
+
+struct prepared_dict_fsst {
+  std::vector<dict_fsst_desc> descs;
+  std::vector<fsst_decoder_compact> decoders;
+  std::vector<uint32_t> byte_offsets;     ///< per-segment, dict_count+1 entries each
+  std::vector<uint32_t> decoded_offsets;  ///< per-segment, dict_count+1 entries each
+  bool any_inline_nulls;
+  uint32_t total_predecode_bytes;  ///< sum of mode-1 dict-decoded bytes
+};
+
+prepared_dict prepare_dict(gpu_string_codec_run const& run)
+{
+  prepared_dict out;
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    string_chunk_desc d{
+      seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start};
+    auto& bucket =
+      (seg.max_string_length < DICT_WARP_COOP_MIN_LEN) ? out.descs_short : out.descs_long;
+    bucket.push_back(d);
+  }
+  return out;
+}
+
+prepared_fsst prepare_fsst(gpu_string_codec_run const& run)
+{
+  prepared_fsst out;
+  out.total_fsst_rows = 0;
+  out.length_descs.reserve(run.segments.size());
+  out.decoders.reserve(run.segments.size());
+  out.row_starts.reserve(run.segments.size());
+
+  for (size_t si = 0; si < run.segments.size(); ++si) {
+    auto const& seg = run.segments[si];
+    if (seg.row_count == 0) continue;
+    out.row_starts.push_back(out.total_fsst_rows);
+    out.total_fsst_rows += seg.row_count;
+    out.length_descs.push_back(
+      {seg.d_bytes, seg.bytes_size, seg.row_count, seg.row_offset, seg.seg_row_start});
+
+    // Per-segment D2H of header + symbol table — opaque format needs host import.
+    fsst_header_t hdr{};
+    if (seg.bytes_size < sizeof(hdr)) {
+      out.decoders.emplace_back();
+      continue;
+    }
+    RMM_CUDA_TRY(cudaMemcpy(&hdr, seg.d_bytes, sizeof(hdr), cudaMemcpyDeviceToHost));
+    if (hdr.fsst_symbol_table_offset >= seg.bytes_size ||
+        hdr.fsst_symbol_table_offset >= hdr.dict_end || hdr.dict_end > seg.bytes_size) {
+      out.decoders.emplace_back();
+      continue;
+    }
+    size_t symtab_max =
+      std::min<size_t>(seg.bytes_size - hdr.fsst_symbol_table_offset, FSST_SYMTAB_MAX_BYTES);
+    std::vector<uint8_t> symtab(symtab_max);
+    RMM_CUDA_TRY(cudaMemcpy(symtab.data(),
+                            seg.d_bytes + hdr.fsst_symbol_table_offset,
+                            symtab_max,
+                            cudaMemcpyDeviceToHost));
+    fsst_decoder_full full{};
+    duckdb_fsst_import(&full, symtab.data());
+    fsst_decoder_compact compact;
+    std::memcpy(compact.len, full.len, sizeof(compact.len));
+    std::memcpy(compact.symbol, full.symbol, sizeof(compact.symbol));
+    out.decoders.push_back(compact);
+  }
+
+  // Chunked descriptors for phase-C + gather. Split per-segment only when
+  // total segments < target_ctas (else one-chunk-per-segment fills SMs already).
+  uint32_t target_ctas     = get_target_ctas();
+  uint32_t chunk_size_fsst = 0;
+  if (out.length_descs.size() < target_ctas && out.total_fsst_rows > 0) {
+    chunk_size_fsst = std::max(out.total_fsst_rows / target_ctas, MIN_CHUNK_ROW);
+    chunk_size_fsst = (chunk_size_fsst / 32u) * 32u;
+    if (chunk_size_fsst == 0) chunk_size_fsst = 32u;
+  }
+  for (size_t si = 0; si < out.length_descs.size(); ++si) {
+    auto const& seg        = out.length_descs[si];
+    uint32_t fsst_base_row = out.row_starts[si];
+    if (chunk_size_fsst == 0) {
+      out.gather_chunks.push_back({seg.d_bytes,
+                                   seg.bytes_size,
+                                   seg.row_count,
+                                   seg.global_row_start,
+                                   fsst_base_row,
+                                   static_cast<uint32_t>(si),
+                                   uint8_t{1},
+                                   {0, 0, 0}});
+    } else {
+      uint32_t remaining = seg.row_count;
+      uint32_t off       = 0;
+      bool first         = true;
+      while (remaining > 0) {
+        uint32_t n = std::min(remaining, chunk_size_fsst);
+        out.gather_chunks.push_back({seg.d_bytes,
+                                     seg.bytes_size,
+                                     n,
+                                     seg.global_row_start + off,
+                                     fsst_base_row + off,
+                                     static_cast<uint32_t>(si),
+                                     uint8_t(first ? 1 : 0),
+                                     {0, 0, 0}});
+        off += n;
+        remaining -= n;
+        first = false;
+      }
+    }
+  }
+  return out;
+}
+
+/// Stub descriptor for malformed segments — kernel zero-fills these rows.
+inline dict_fsst_desc make_stub_dict_fsst_desc(gpu_string_segment_desc const& seg)
+{
+  return {seg.d_bytes,
+          seg.bytes_size,
+          seg.row_count,
+          seg.row_offset,
+          seg.seg_row_start,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          {0, 0, 0, 0, 0, 0}};
+}
+
+prepared_dict_fsst prepare_dict_fsst(gpu_string_codec_run const& run)
+{
+  prepared_dict_fsst out;
+  out.any_inline_nulls      = false;
+  out.total_predecode_bytes = 0;
+  out.descs.reserve(run.segments.size());
+  out.decoders.reserve(run.segments.size());
+
+  for (auto const& seg : run.segments) {
+    if (seg.row_count == 0) continue;
+    if (seg.bytes_size < sizeof(dict_fsst_header_t)) {
+      out.descs.push_back(make_stub_dict_fsst_desc(seg));
+      continue;
+    }
+
+    // Two targeted D2H reads — dict_indices stays on device.
+    dict_fsst_header_t hdr;
+    RMM_CUDA_TRY(cudaMemcpy(&hdr, seg.d_bytes, sizeof(hdr), cudaMemcpyDeviceToHost));
+
+    if (hdr.mode > DICT_FSST_MODE_FSST_ONLY) {
+      out.descs.push_back(make_stub_dict_fsst_desc(seg));
+      continue;
+    }
+
+    // Region offsets; each region 8-byte aligned (DuckDB AlignValue).
+    uint32_t off_dict   = align_up8(static_cast<uint32_t>(sizeof(hdr)));
+    uint32_t off_symtab = align_up8(off_dict + hdr.dict_size);
+    uint32_t off_slens  = (hdr.mode == DICT_FSST_MODE_DICTIONARY)
+                            ? off_dict + align_up8(hdr.dict_size)
+                            : align_up8(off_symtab + hdr.symbol_table_size);
+    uint32_t slens_bits = hdr.dict_count * hdr.string_lengths_width;
+    uint32_t off_didx   = align_up8(off_slens + (slens_bits + 7u) / 8u);
+
+    if (off_didx > seg.bytes_size && hdr.mode != DICT_FSST_MODE_FSST_ONLY) {
+      out.descs.push_back(make_stub_dict_fsst_desc(seg));
+      continue;
+    }
+
+    // +7B pad: host_unpack_bitpacked reads 8B at a time at the tail.
+    uint32_t prefix_bytes = std::min(off_didx, seg.bytes_size);
+    std::vector<uint8_t> host_bytes_vec(size_t{prefix_bytes} + 7u, 0u);
+    uint8_t* host_bytes = host_bytes_vec.data();
+    RMM_CUDA_TRY(cudaMemcpy(host_bytes, seg.d_bytes, prefix_bytes, cudaMemcpyDeviceToHost));
+
+    // entry_lens[k] = bitpacked length of dict entry k (compressed in FSST modes).
+    std::vector<uint32_t> entry_lens(hdr.dict_count, 0);
+    uint8_t const* slens_ptr = host_bytes + off_slens;
+    for (uint32_t k = 0; k < hdr.dict_count; ++k) {
+      entry_lens[k] = host_unpack_bitpacked<uint32_t>(slens_ptr, k, hdr.string_lengths_width);
+    }
+
+    // byte_offsets[k] = cumulative compressed-byte position of entry k.
+    uint32_t base_off = static_cast<uint32_t>(out.byte_offsets.size());
+    out.byte_offsets.resize(base_off + hdr.dict_count + 1u);
+    out.byte_offsets[base_off] = 0u;
+    for (uint32_t k = 0; k < hdr.dict_count; ++k) {
+      out.byte_offsets[base_off + k + 1] = out.byte_offsets[base_off + k] + entry_lens[k];
+    }
+
+    // decoded_offsets[k]: same as byte_offsets in mode 0, FSST-walked otherwise.
+    fsst_decoder_compact compact{};
+    if (hdr.mode != DICT_FSST_MODE_DICTIONARY) {
+      fsst_decoder_full full{};
+      duckdb_fsst_import(&full, host_bytes + off_symtab);
+      std::memcpy(compact.len, full.len, sizeof(compact.len));
+      std::memcpy(compact.symbol, full.symbol, sizeof(compact.symbol));
+    }
+    out.decoders.push_back(compact);
+
+    out.decoded_offsets.resize(base_off + hdr.dict_count + 1u);
+    out.decoded_offsets[base_off] = 0u;
+    if (hdr.mode == DICT_FSST_MODE_DICTIONARY) {
+      // Raw dict — decoded == compressed.
+      for (uint32_t k = 0; k <= hdr.dict_count; ++k) {
+        out.decoded_offsets[base_off + k] = out.byte_offsets[base_off + k];
+      }
+    } else {
+      uint8_t const* dict_bytes = host_bytes + off_dict;
+      for (uint32_t k = 0; k < hdr.dict_count; ++k) {
+        size_t comp_start = out.byte_offsets[base_off + k];
+        size_t comp_len   = entry_lens[k];
+        size_t dec_len =
+          (k == 0) ? 0 : fsst_decompressed_length_host(compact, dict_bytes + comp_start, comp_len);
+        out.decoded_offsets[base_off + k + 1] =
+          out.decoded_offsets[base_off + k] + static_cast<uint32_t>(dec_len);
+      }
+    }
+
+    // dict_count>1 + entry_lens[0]==0 => inline-NULL encoding used.
+    out.any_inline_nulls = out.any_inline_nulls || (hdr.mode != DICT_FSST_MODE_FSST_ONLY &&
+                                                    hdr.dict_count > 1 && entry_lens[0] == 0u);
+
+    // Mode-1 only reserves predecode-buffer space.
+    uint32_t predecode_off = 0u;
+    if (hdr.mode == DICT_FSST_MODE_DICT_FSST) {
+      predecode_off = out.total_predecode_bytes;
+      out.total_predecode_bytes += out.decoded_offsets[base_off + hdr.dict_count];
+    }
+
+    out.descs.push_back({seg.d_bytes,
+                         seg.bytes_size,
+                         seg.row_count,
+                         seg.row_offset,
+                         seg.seg_row_start,
+                         off_dict,
+                         (hdr.mode == DICT_FSST_MODE_FSST_ONLY) ? 0u : off_didx,
+                         base_off,
+                         static_cast<uint32_t>(out.decoders.size() - 1u),
+                         hdr.dict_count,
+                         predecode_off,
+                         hdr.dictionary_indices_width,
+                         hdr.mode,
+                         {0, 0, 0, 0, 0, 0}});
+  }
+  return out;
+}
+
+}  // anonymous namespace
+
+std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode_input const& col,
+                                                        rmm::cuda_stream_view stream,
+                                                        rmm::device_async_resource_ref mr)
+{
+  uint32_t const total_rows = col.total_rows;
+  if (total_rows == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
+  if (total_rows > static_cast<uint32_t>(std::numeric_limits<cudf::size_type>::max())) {
+    throw std::runtime_error("gpu_decode_strings_column: total_rows (" +
+                             std::to_string(total_rows) + ") > cudf::size_type max");
+  }
+
+  prepared_dict prep_dict;
+  prepared_fsst prep_fsst;
+  prepared_dict_fsst prep_dict_fsst;
+  prep_dict_fsst.any_inline_nulls      = false;
+  prep_dict_fsst.total_predecode_bytes = 0;
+  size_t cum_chars_upper               = 0;
+  bool needs_exact_total               = false;
+  for (auto const& run : col.data) {
+    switch (run.codec) {
+      case duckdb::CompressionType::COMPRESSION_DICTIONARY: {
+        auto p = prepare_dict(run);
+        prep_dict.descs_short.insert(
+          prep_dict.descs_short.end(), p.descs_short.begin(), p.descs_short.end());
+        prep_dict.descs_long.insert(
+          prep_dict.descs_long.end(), p.descs_long.begin(), p.descs_long.end());
+        break;
+      }
+      case duckdb::CompressionType::COMPRESSION_FSST: {
+        auto p = prepare_fsst(run);
+        // Rebase row_starts + decoder indices into the merged FSST set.
+        uint32_t row_base     = prep_fsst.total_fsst_rows;
+        uint32_t decoder_base = static_cast<uint32_t>(prep_fsst.decoders.size());
+        for (auto& s : p.row_starts)
+          s += row_base;
+        for (auto& c : p.gather_chunks) {
+          c.fsst_row_start += row_base;
+          c.seg_decoder_idx += decoder_base;
+        }
+        prep_fsst.length_descs.insert(
+          prep_fsst.length_descs.end(), p.length_descs.begin(), p.length_descs.end());
+        prep_fsst.row_starts.insert(
+          prep_fsst.row_starts.end(), p.row_starts.begin(), p.row_starts.end());
+        prep_fsst.decoders.insert(prep_fsst.decoders.end(), p.decoders.begin(), p.decoders.end());
+        prep_fsst.gather_chunks.insert(
+          prep_fsst.gather_chunks.end(), p.gather_chunks.begin(), p.gather_chunks.end());
+        prep_fsst.total_fsst_rows += p.total_fsst_rows;
+        break;
+      }
+      case duckdb::CompressionType::COMPRESSION_DICT_FSST: {
+        auto p                  = prepare_dict_fsst(run);
+        uint32_t bo_base        = static_cast<uint32_t>(prep_dict_fsst.byte_offsets.size());
+        uint32_t dec_base       = static_cast<uint32_t>(prep_dict_fsst.decoders.size());
+        uint32_t predecode_base = prep_dict_fsst.total_predecode_bytes;
+        for (auto& d : p.descs) {
+          d.seg_dict_offset_base += bo_base;
+          d.seg_decoder_idx += dec_base;
+          if (d.mode == DICT_FSST_MODE_DICT_FSST) { d.predecode_seg_offset += predecode_base; }
+        }
+        prep_dict_fsst.byte_offsets.insert(
+          prep_dict_fsst.byte_offsets.end(), p.byte_offsets.begin(), p.byte_offsets.end());
+        prep_dict_fsst.decoded_offsets.insert(
+          prep_dict_fsst.decoded_offsets.end(), p.decoded_offsets.begin(), p.decoded_offsets.end());
+        prep_dict_fsst.decoders.insert(
+          prep_dict_fsst.decoders.end(), p.decoders.begin(), p.decoders.end());
+        prep_dict_fsst.descs.insert(prep_dict_fsst.descs.end(), p.descs.begin(), p.descs.end());
+        prep_dict_fsst.any_inline_nulls = prep_dict_fsst.any_inline_nulls || p.any_inline_nulls;
+        prep_dict_fsst.total_predecode_bytes += p.total_predecode_bytes;
+        break;
+      }
+      case duckdb::CompressionType::COMPRESSION_UNCOMPRESSED: {
+        // Legacy `decode_string_column_batched` handles this codec — reaching
+        // here means upstream viability check let one through.
+        throw std::runtime_error(
+          "gpu_decode_strings_column: UNCOMPRESSED varchar codec "
+          "should route to the legacy varchar path; "
+          "upstream viability check missed it");
+      }
+      default:
+        throw std::runtime_error(
+          "gpu_decode_strings_column: viability invariant violated — "
+          "data codec " +
+          std::to_string(static_cast<int>(run.codec)) + " not implemented");
+    }
+    // Upper-bound from walker stats; 0 means unknown → take the sync path.
+    for (auto const& seg : run.segments) {
+      if (seg.max_string_length == 0u) {
+        needs_exact_total = true;
+        continue;
+      }
+      cum_chars_upper += size_t{seg.row_count} * seg.max_string_length;
+    }
+  }
+
+  // N+1-sized with the tail zero so CUB writes offsets[total_rows] = total
+  // chars naturally; zero-init also covers NULL rows skipped by codec kernels.
+  rmm::device_uvector<uint32_t> d_lengths(size_t{total_rows} + 1u, stream, mr);
+  rmm::device_uvector<int32_t> d_offsets(size_t{total_rows} + 1u, stream, mr);
+  RMM_CUDA_TRY(cudaMemsetAsync(
+    d_lengths.data(), 0, (size_t{total_rows} + 1u) * sizeof(uint32_t), stream.value()));
+
+  rmm::device_buffer comp_offsets_buf(
+    prep_fsst.total_fsst_rows > 0 ? prep_fsst.total_fsst_rows * sizeof(uint32_t) : 0, stream, mr);
+  uint32_t* d_comp_offsets = static_cast<uint32_t*>(comp_offsets_buf.data());
+
+  auto upload = [&](void const* src, size_t bytes) {
+    rmm::device_buffer buf(bytes, stream, mr);
+    if (bytes > 0) {
+      RMM_CUDA_TRY(cudaMemcpyAsync(buf.data(), src, bytes, cudaMemcpyHostToDevice, stream.value()));
+    }
+    return buf;
+  };
+
+  // Per-row kernels take chunked descriptors; predecode + mark_nulls stay
+  // per-segment via prep_dict_fsst.descs.
+  uint32_t target_ctas   = get_target_ctas();
+  auto dict_chunks_short = expand_chunks(prep_dict.descs_short, target_ctas);
+  auto dict_chunks_long  = expand_chunks(prep_dict.descs_long, target_ctas);
+  auto dict_fsst_chunks  = expand_chunks(prep_dict_fsst.descs, target_ctas);
+
+  rmm::device_buffer d_dict_short_buf =
+    upload(dict_chunks_short.data(), dict_chunks_short.size() * sizeof(string_chunk_desc));
+  rmm::device_buffer d_dict_long_buf =
+    upload(dict_chunks_long.data(), dict_chunks_long.size() * sizeof(string_chunk_desc));
+  rmm::device_buffer d_dict_fsst_chunks_buf =
+    upload(dict_fsst_chunks.data(), dict_fsst_chunks.size() * sizeof(dict_fsst_desc));
+  rmm::device_buffer d_fsst_lengths_buf = upload(
+    prep_fsst.length_descs.data(), prep_fsst.length_descs.size() * sizeof(string_chunk_desc));
+  rmm::device_buffer d_fsst_chunks_buf = upload(
+    prep_fsst.gather_chunks.data(), prep_fsst.gather_chunks.size() * sizeof(fsst_chunk_desc));
+  rmm::device_buffer d_fsst_starts_buf =
+    upload(prep_fsst.row_starts.data(), prep_fsst.row_starts.size() * sizeof(uint32_t));
+  rmm::device_buffer d_fsst_decoders_buf =
+    upload(prep_fsst.decoders.data(), prep_fsst.decoders.size() * sizeof(fsst_decoder_compact));
+  rmm::device_buffer d_dict_fsst_descs_buf =
+    upload(prep_dict_fsst.descs.data(), prep_dict_fsst.descs.size() * sizeof(dict_fsst_desc));
+  rmm::device_buffer d_dict_fsst_decoders_buf = upload(
+    prep_dict_fsst.decoders.data(), prep_dict_fsst.decoders.size() * sizeof(fsst_decoder_compact));
+  rmm::device_buffer d_byte_offsets_buf = upload(
+    prep_dict_fsst.byte_offsets.data(), prep_dict_fsst.byte_offsets.size() * sizeof(uint32_t));
+  rmm::device_buffer d_decoded_offsets_buf =
+    upload(prep_dict_fsst.decoded_offsets.data(),
+           prep_dict_fsst.decoded_offsets.size() * sizeof(uint32_t));
+
+  // Pageable host sources — sync before kernels consume to avoid free-mid-copy.
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+
+  auto* d_dict_short_p       = static_cast<string_chunk_desc*>(d_dict_short_buf.data());
+  auto* d_dict_long_p        = static_cast<string_chunk_desc*>(d_dict_long_buf.data());
+  auto* d_fsst_lengths_p     = static_cast<string_chunk_desc*>(d_fsst_lengths_buf.data());
+  auto* d_fsst_chunks_p      = static_cast<fsst_chunk_desc*>(d_fsst_chunks_buf.data());
+  auto* d_fsst_starts_p      = static_cast<uint32_t*>(d_fsst_starts_buf.data());
+  auto* d_fsst_decs_p        = static_cast<fsst_decoder_compact*>(d_fsst_decoders_buf.data());
+  auto* d_dict_fsst_p        = static_cast<dict_fsst_desc*>(d_dict_fsst_descs_buf.data());
+  auto* d_dict_fsst_chunks_p = static_cast<dict_fsst_desc*>(d_dict_fsst_chunks_buf.data());
+  auto* d_dict_fsst_decs_p   = static_cast<fsst_decoder_compact*>(d_dict_fsst_decoders_buf.data());
+  auto* d_byte_off_p         = static_cast<uint32_t*>(d_byte_offsets_buf.data());
+  auto* d_decoded_off_p      = static_cast<uint32_t*>(d_decoded_offsets_buf.data());
+
+  // Pass 1: lengths. Same kernel for short/long — only gather forks.
+  if (!dict_chunks_short.empty()) {
+    kernel_compute_lengths_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),
+                                  BLOCK_DIM,
+                                  0,
+                                  stream.value()>>>(
+      d_dict_short_p, d_lengths.data(), static_cast<uint32_t>(dict_chunks_short.size()));
+  }
+  if (!dict_chunks_long.empty()) {
+    kernel_compute_lengths_dict<<<static_cast<uint32_t>(dict_chunks_long.size()),
+                                  BLOCK_DIM,
+                                  0,
+                                  stream.value()>>>(
+      d_dict_long_p, d_lengths.data(), static_cast<uint32_t>(dict_chunks_long.size()));
+  }
+  if (!prep_fsst.length_descs.empty()) {
+    // A+B per-segment (prefix-sum state lives in one CTA); C per-chunk.
+    kernel_compute_lengths_fsst<<<static_cast<uint32_t>(prep_fsst.length_descs.size()),
+                                  BLOCK_DIM,
+                                  0,
+                                  stream.value()>>>(
+      d_fsst_lengths_p,
+      d_comp_offsets,
+      d_fsst_starts_p,
+      static_cast<uint32_t>(prep_fsst.length_descs.size()));
+    kernel_compute_lengths_fsst_phase_c<<<static_cast<uint32_t>(prep_fsst.gather_chunks.size()),
+                                          BLOCK_DIM,
+                                          0,
+                                          stream.value()>>>(
+      d_fsst_chunks_p,
+      d_lengths.data(),
+      d_comp_offsets,
+      d_fsst_decs_p,
+      static_cast<uint32_t>(prep_fsst.gather_chunks.size()));
+  }
+  // Predecode buffer holds decoded dict bytes for mode-1 segments.
+  rmm::device_buffer d_predecode_buf(
+    prep_dict_fsst.total_predecode_bytes > 0 ? prep_dict_fsst.total_predecode_bytes : 1u,
+    stream,
+    mr);
+  auto* d_predecode_p = static_cast<uint8_t*>(d_predecode_buf.data());
+
+  if (!prep_dict_fsst.descs.empty()) {
+    // Lengths chunk for SM-fill; predecode stays per-segment (one decode/dict).
+    kernel_compute_lengths_dict_fsst<<<static_cast<uint32_t>(dict_fsst_chunks.size()),
+                                       BLOCK_DIM,
+                                       0,
+                                       stream.value()>>>(
+      d_dict_fsst_chunks_p,
+      d_lengths.data(),
+      d_decoded_off_p,
+      static_cast<uint32_t>(dict_fsst_chunks.size()));
+    if (prep_dict_fsst.total_predecode_bytes > 0) {
+      kernel_predecode_dict_fsst<<<static_cast<uint32_t>(prep_dict_fsst.descs.size()),
+                                   BLOCK_DIM,
+                                   0,
+                                   stream.value()>>>(
+        d_dict_fsst_p,
+        d_byte_off_p,
+        d_decoded_off_p,
+        d_dict_fsst_decs_p,
+        d_predecode_p,
+        static_cast<uint32_t>(prep_dict_fsst.descs.size()));
+    }
+  }
+
+  size_t cub_bytes = 0;
+  int const scan_n = static_cast<int>(total_rows) + 1;
+  cub::DeviceScan::ExclusiveSum(nullptr,
+                                cub_bytes,
+                                d_lengths.data(),
+                                reinterpret_cast<uint32_t*>(d_offsets.data()),
+                                scan_n,
+                                stream.value());
+  rmm::device_buffer cub_temp_buf(cub_bytes, stream, mr);
+  cub::DeviceScan::ExclusiveSum(cub_temp_buf.data(),
+                                cub_bytes,
+                                d_lengths.data(),
+                                reinterpret_cast<uint32_t*>(d_offsets.data()),
+                                scan_n,
+                                stream.value());
+
+  // cudf strings offsets are int32; reject up front if the upper bound exceeds it.
+  constexpr size_t INT32_MAX_SIZE = static_cast<size_t>(std::numeric_limits<int32_t>::max());
+  if (!needs_exact_total && cum_chars_upper > INT32_MAX_SIZE) {
+    throw std::runtime_error("gpu_decode_strings_column: estimated total_chars (" +
+                             std::to_string(cum_chars_upper) + ") exceeds int32 max");
+  }
+  size_t alloc_chars = 0;
+  if (!needs_exact_total && cum_chars_upper <= HOST_UPPER_BOUND_LIMIT) {
+    alloc_chars = cum_chars_upper;
+  } else {
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+    uint32_t total_chars_u = 0;
+    RMM_CUDA_TRY(cudaMemcpy(
+      &total_chars_u, d_offsets.data() + total_rows, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    if (total_chars_u > static_cast<uint32_t>(INT32_MAX_SIZE)) {
+      throw std::runtime_error("gpu_decode_strings_column: total_chars (" +
+                               std::to_string(total_chars_u) + ") exceeds int32 max");
+    }
+    alloc_chars = total_chars_u;
+  }
+
+  rmm::device_buffer d_chars(alloc_chars > 0 ? alloc_chars : 1u, stream, mr);
+  auto* d_chars_p = static_cast<uint8_t*>(d_chars.data());
+
+  // Pass 2: gather. See DICT_WARP_COOP_MIN_LEN for the partition rationale.
+  if (!dict_chunks_short.empty()) {
+    kernel_gather_dict<<<static_cast<uint32_t>(dict_chunks_short.size()),
+                         BLOCK_DIM,
+                         0,
+                         stream.value()>>>(
+      d_dict_short_p, d_offsets.data(), d_chars_p, static_cast<uint32_t>(dict_chunks_short.size()));
+  }
+  if (!dict_chunks_long.empty()) {
+    kernel_gather_dict_warp<<<static_cast<uint32_t>(dict_chunks_long.size()),
+                              BLOCK_DIM,
+                              0,
+                              stream.value()>>>(
+      d_dict_long_p, d_offsets.data(), d_chars_p, static_cast<uint32_t>(dict_chunks_long.size()));
+  }
+  if (!prep_fsst.gather_chunks.empty()) {
+    kernel_gather_fsst_chunked<<<static_cast<uint32_t>(prep_fsst.gather_chunks.size()),
+                                 BLOCK_DIM,
+                                 0,
+                                 stream.value()>>>(
+      d_fsst_chunks_p,
+      d_offsets.data(),
+      d_chars_p,
+      d_comp_offsets,
+      d_fsst_decs_p,
+      static_cast<uint32_t>(prep_fsst.gather_chunks.size()));
+  }
+  if (!prep_dict_fsst.descs.empty()) {
+    kernel_gather_dict_fsst<<<static_cast<uint32_t>(dict_fsst_chunks.size()),
+                              BLOCK_DIM,
+                              0,
+                              stream.value()>>>(d_dict_fsst_chunks_p,
+                                                d_offsets.data(),
+                                                d_chars_p,
+                                                d_byte_off_p,
+                                                d_decoded_off_p,
+                                                d_predecode_p,
+                                                d_dict_fsst_decs_p,
+                                                static_cast<uint32_t>(dict_fsst_chunks.size()));
+  }
+
+  // All-valid → overlay UNCOMPRESSED validity → fold in DICT_FSST inline NULLs.
+  rmm::device_buffer null_mask{};
+  cudf::size_type null_count = 0;
+  bool need_mask             = col.has_nulls || prep_dict_fsst.any_inline_nulls;
+  if (need_mask) {
+    null_mask = cudf::create_null_mask(
+      static_cast<cudf::size_type>(total_rows), cudf::mask_state::ALL_VALID, stream, mr);
+    for (auto const& run : col.validity) {
+      overlay_validity_run(run, static_cast<uint8_t*>(null_mask.data()), stream);
+    }
+    if (prep_dict_fsst.any_inline_nulls && !prep_dict_fsst.descs.empty()) {
+      kernel_dict_fsst_mark_nulls<<<static_cast<uint32_t>(prep_dict_fsst.descs.size()),
+                                    BLOCK_DIM,
+                                    0,
+                                    stream.value()>>>(
+        d_dict_fsst_p,
+        static_cast<uint8_t*>(null_mask.data()),
+        static_cast<uint32_t>(prep_dict_fsst.descs.size()));
+    }
+    null_count = cudf::null_count(static_cast<cudf::bitmask_type const*>(null_mask.data()),
+                                  0,
+                                  static_cast<cudf::size_type>(total_rows),
+                                  stream);
+  }
+
+  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                    static_cast<cudf::size_type>(total_rows + 1u),
+                                                    d_offsets.release(),
+                                                    rmm::device_buffer{0, stream, mr},
+                                                    0);
+
+  RMM_CUDA_TRY(cudaPeekAtLastError());
+  return cudf::make_strings_column(static_cast<cudf::size_type>(total_rows),
+                                   std::move(offsets_col),
+                                   std::move(d_chars),
+                                   null_count,
+                                   std::move(null_mask));
+}
+
+}  // namespace sirius::cuda::scan

--- a/src/include/cuda/scan/gpu_decode_strings.cuh
+++ b/src/include/cuda/scan/gpu_decode_strings.cuh
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// String-codec decode entry for the GPU-native scan path. Sibling to
+// `gpu_decode_table` for fixed-width columns. Codecs: DICTIONARY, FSST,
+// DICT_FSST. Headers parse on device; FSST symbol tables go through the
+// opaque `duckdb_fsst_import` on host before upload.
+
+#include "cuda/scan/gpu_native_decode.cuh"
+
+#include <cudf/column/column.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <duckdb/common/enums/compression_type.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace sirius::cuda::scan {
+
+/// Per-segment descriptor. Mirrors `gpu_segment_desc` plus `seg_row_start`
+/// for the chunking path. Codec-specific metadata is parsed on device.
+struct gpu_string_segment_desc {
+  uint8_t const* d_bytes;      ///< device pointer to the segment's first byte
+  uint32_t bytes_size;         ///< size of the buffer behind d_bytes
+  uint32_t row_offset;         ///< column-relative starting row index
+  uint32_t row_count;          ///< rows produced by this segment (or chunk slice)
+  uint32_t seg_row_start;      ///< rows skipped at the segment head when chunked
+  uint32_t max_string_length;  ///< DuckDB segment-stat upper bound on decoded
+                               ///  chars per row; 0 = unknown (forces a sync)
+};
+
+/// A run of segments sharing one codec.
+struct gpu_string_codec_run {
+  duckdb::CompressionType codec;
+  std::vector<gpu_string_segment_desc> segments;
+};
+
+/// Inputs for one varchar column. Mixed-codec columns share one prefix sum
+/// across all runs. `validity` is UNCOMPRESSED-only, matching the fixed-
+/// width dispatcher's contract.
+struct gpu_string_column_decode_input {
+  std::vector<gpu_string_codec_run> data;
+  std::vector<gpu_codec_run> validity;
+  uint32_t total_rows;
+  bool has_nulls;
+};
+
+/// Decode one varchar column to a cudf strings column. Async modulo at most
+/// one host sync (the chars-buffer sizing read-back, which only fires when
+/// the per-segment length upper bound is unknown or pathological). Throws
+/// on malformed segment metadata or unsupported codecs.
+std::unique_ptr<cudf::column> gpu_decode_strings_column(gpu_string_column_decode_input const& col,
+                                                        rmm::cuda_stream_view stream,
+                                                        rmm::device_async_resource_ref mr);
+
+}  // namespace sirius::cuda::scan

--- a/src/include/cuda/scan/unpack_value.cuh
+++ b/src/include/cuda/scan/unpack_value.cuh
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda/std/numeric>
+
+#include <cstdint>
+
+namespace sirius::cuda::scan {
+
+/// Read one width-bit value from `packed[]` at logical index `idx`. Values
+/// are stored LSB-first within 32-bit words.
+///
+/// For T wider than 32 bits a value can span three 32-bit words when both
+/// `bit_off > 0` and `bit_off + width > 64` (e.g. width=50, bit_off=20 reads
+/// bits 20..69, which crosses two 32-bit boundaries). Callers must ensure
+/// `packed[]` has one guard word past the live data so that third-word read
+/// is in-bounds; the kernel writes the guard word itself.
+template <typename T>
+__device__ __forceinline__ T unpack_value(uint32_t const* packed, uint32_t idx, uint32_t width)
+{
+  auto constexpr WORD_BITS  = ::cuda::std::numeric_limits<uint32_t>::digits;
+  auto constexpr WORD_BYTES = sizeof(uint32_t);
+  if (width == 0) return T(0);
+
+  auto const bit_pos  = static_cast<uint64_t>(idx) * width;
+  auto const word_idx = static_cast<uint32_t>(bit_pos / WORD_BITS);
+  auto const bit_off  = static_cast<uint32_t>(bit_pos % WORD_BITS);
+
+  // We need to upcast in case we need bits from the next word.
+  auto result = static_cast<uint64_t>(packed[word_idx]);
+  if (bit_off + width > WORD_BITS) {
+    result |= static_cast<uint64_t>(packed[word_idx + 1]) << WORD_BITS;
+  }
+  result >>= bit_off;
+
+  // For 8B types, we may need bits from the second next word.
+  if constexpr (sizeof(T) > WORD_BYTES) {
+    if (bit_off > 0 && bit_off + width > 2 * WORD_BITS) {
+      result |= static_cast<uint64_t>(packed[word_idx + 2]) << (64 - bit_off);
+    }
+  }
+
+  auto const mask = (width >= 64) ? ~uint64_t{0} : (uint64_t{1} << width) - 1;
+  return static_cast<T>(result & mask);
+}
+
+}  // namespace sirius::cuda::scan

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -501,7 +501,7 @@ std::vector<uint8_t> load_fixture_bytes(char const* var_name)
   if (sz <= 0) return {};
   f.seekg(0);
   std::vector<uint8_t> bytes(static_cast<size_t>(sz));
-  f.read(reinterpret_cast<char*>(bytes.data()), sz);
+  f.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(sz));
   return bytes;
 }
 

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -961,3 +961,97 @@ TEST_CASE("bench DICT_FSST mode 1 1M rows / TPC-H-like dict", "[!benchmark][scan
     double(rows) / sec / 1e6,
     double(rows) * avg_dict_len / sec / GIB);
 }
+
+TEST_CASE("bench DICT_FSST realistic multi-segment mode 1",
+          "[!benchmark][scan][decode][strings]")
+{
+  // Realistic DuckDB layout: DICT_FSST segments cap at Storage::DEFAULT_BLOCK_SIZE
+  // (~256 KiB). For TPC-H-like comments and mode-1 dicts this gives roughly
+  // 1-4 K rows per segment depending on dict reuse; 1 M rows therefore split
+  // into many segments and exercise the per-segment host work in
+  // prepare_dict_fsst (2 sync D2H per segment) as well as kernel scaling.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  double peak_d2d_gbs = measure_peak_d2d_gbs(stream, mr);
+  std::printf("[bench] peak D2D bandwidth (measured): %.1f GB/s\n", peak_d2d_gbs);
+
+  uint32_t const rows = 1u << 20;
+  std::vector<std::string> synth(rows);
+  size_t total_input_bytes = 0;
+  for (uint32_t i = 0; i < rows; ++i) {
+    synth[i] = sirius::test::decode::strings::make_tpch_like_comment(
+      static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ull, 5u, 150u);
+    total_input_bytes += synth[i].size();
+  }
+  auto seg_blobs =
+    sirius::test::decode::strings::make_dict_fsst_segments_chunked(synth, /*mode=*/1);
+
+  size_t total_seg_bytes = 0;
+  uint32_t max_seg_rows  = 0;
+  uint32_t max_seg_bytes = 0;
+  for (auto const& [b, rc] : seg_blobs) {
+    total_seg_bytes += b.size();
+    max_seg_rows  = std::max(max_seg_rows, rc);
+    max_seg_bytes = std::max(max_seg_bytes, static_cast<uint32_t>(b.size()));
+  }
+  double avg_seg_rows  = double(rows) / seg_blobs.size();
+  double avg_seg_bytes = double(total_seg_bytes) / seg_blobs.size();
+
+  // Pad each segment up to 8 B so its on-device base stays 8-aligned (header
+  // read at d_bytes[0..16) crosses no alignment boundary).
+  constexpr size_t SEG_ALIGN = 8;
+  std::vector<size_t> seg_offsets(seg_blobs.size());
+  size_t alloc_bytes = 0;
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    seg_offsets[k] = alloc_bytes;
+    alloc_bytes += (seg_blobs[k].first.size() + SEG_ALIGN - 1) & ~(SEG_ALIGN - 1);
+  }
+  rmm::device_buffer d_all(alloc_bytes, stream.view());
+  std::vector<sirius::cuda::scan::gpu_string_segment_desc> segs;
+  segs.reserve(seg_blobs.size());
+  uint32_t row_cursor = 0;
+  auto const* d_base  = static_cast<uint8_t const*>(d_all.data());
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    auto const& [b, rc] = seg_blobs[k];
+    cudaMemcpyAsync(const_cast<uint8_t*>(d_base) + seg_offsets[k],
+                    b.data(),
+                    b.size(),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    segs.push_back({d_base + seg_offsets[k],
+                    static_cast<uint32_t>(b.size()),
+                    row_cursor,
+                    rc,
+                    /*seg_row_start=*/0,
+                    /*max_string_length=*/160u});
+    row_cursor += rc;
+  }
+  cudaStreamSynchronize(stream.value());
+
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_DICT_FSST, std::move(segs)});
+
+  double sec      = bench_strings_seconds(stream, col, mr);
+  double avg_len  = double(total_input_bytes) / rows;
+  double out_gbs  = double(rows) * avg_len / sec / 1e9;
+  double pct_peak = 100.0 * out_gbs / peak_d2d_gbs;
+
+  std::printf(
+    "[bench] DICT_FSST realistic mode-1 %.0fB avg, %zu segs (avg %.0f rows / %.0f B), "
+    "max %u rows / %u B:\n",
+    avg_len,
+    seg_blobs.size(),
+    avg_seg_rows,
+    avg_seg_bytes,
+    max_seg_rows,
+    max_seg_bytes);
+  std::printf(
+    "[bench]   %.6fs  decode=%.1f Mr/s  output write=%.1f GB/s  (%.1f%% of measured peak D2D)\n",
+    sec,
+    double(rows) / sec / 1e6,
+    out_gbs,
+    pct_peak);
+}

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -21,11 +21,17 @@
 
 #include "scan/bitpacking_synth.hpp"
 #include "scan/decode_test_utils.hpp"
+#include "scan/strings_synth.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
 #include <cuda/scan/gpu_decode_bitpacking.cuh>
+#include <cuda/scan/gpu_decode_strings.cuh>
 #include <cuda_runtime.h>
 
 #include <catch.hpp>
@@ -33,7 +39,10 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <string>
 #include <vector>
 
 using duckdb::CompressionType;
@@ -444,4 +453,298 @@ TEST_CASE("bench BITPACKING int32 DELTA_FOR width=8 128M rows", "[!benchmark][sc
   std::printf("[bench] BITPACKING   int32 DELTA_FOR w=8 128M rows: %.6fs  write=%.1f GiB/s\n",
               sec,
               bytes_w / sec / GIB);
+}
+
+//===----------------------------------------------------------------------===//
+// String-codec benches. Segments are synthesized via strings_synth.hpp
+// (FSST / DICT_FSST go through `duckdb_fsst_create`). FSST / DICT_FSST
+// benches accept a fixture override via `SIRIUS_BENCH_<CODEC>_FIXTURE` +
+// `_ROWS` env vars to run against a real DuckDB-extracted segment.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+double bench_strings_seconds(rmm::cuda_stream& stream,
+                             sirius::cuda::scan::gpu_string_column_decode_input const& col,
+                             rmm::mr::cuda_async_memory_resource& mr,
+                             int iters  = 10,
+                             int warmup = 3)
+{
+  for (int i = 0; i < warmup; ++i)
+    (void)sirius::cuda::scan::gpu_decode_strings_column(col, stream.view(), mr);
+  cudaStreamSynchronize(stream.value());
+
+  cudaEvent_t s, e;
+  cudaEventCreate(&s);
+  cudaEventCreate(&e);
+  cudaEventRecord(s, stream.value());
+  for (int i = 0; i < iters; ++i)
+    (void)sirius::cuda::scan::gpu_decode_strings_column(col, stream.view(), mr);
+  cudaEventRecord(e, stream.value());
+  cudaEventSynchronize(e);
+  float ms = 0.0f;
+  cudaEventElapsedTime(&ms, s, e);
+  cudaEventDestroy(s);
+  cudaEventDestroy(e);
+  return (ms / 1000.0) / iters;
+}
+
+/// Load raw segment bytes from a path in env var `var_name`. Returns empty
+/// vector if the var is unset or the file isn't readable.
+std::vector<uint8_t> load_fixture_bytes(char const* var_name)
+{
+  char const* path = std::getenv(var_name);
+  if (path == nullptr || *path == '\0') return {};
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  if (!f) return {};
+  auto sz = f.tellg();
+  if (sz <= 0) return {};
+  f.seekg(0);
+  std::vector<uint8_t> bytes(static_cast<size_t>(sz));
+  f.read(reinterpret_cast<char*>(bytes.data()), sz);
+  return bytes;
+}
+
+}  // namespace
+
+TEST_CASE("bench DICTIONARY 1M rows / 1024 dict / 16-byte avg",
+          "[!benchmark][scan][decode][strings]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  constexpr uint32_t DICT_COUNT = 1024;
+  constexpr uint32_t ROWS       = 1u << 20;
+  std::vector<std::string> dict(DICT_COUNT);
+  dict[0] = "";  // index 0 = NULL sentinel
+  for (uint32_t k = 1; k < DICT_COUNT; ++k) {
+    dict[k] = std::string(16, static_cast<char>('a' + (k % 26)));
+  }
+  std::vector<uint32_t> sel(ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i)
+    sel[i] = 1u + (i % (DICT_COUNT - 1u));
+  auto bytes = sirius::test::decode::strings::make_dict_segment(dict, sel);
+
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  sirius::cuda::scan::gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                                                  static_cast<uint32_t>(d_seg.size()),
+                                                  0,
+                                                  ROWS,
+                                                  0,
+                                                  /*max_string_length=*/16u};
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = ROWS;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_DICTIONARY, {seg}});
+
+  double sec           = bench_strings_seconds(stream, col, mr);
+  double bytes_decoded = double(ROWS) * 16.0;
+  std::printf(
+    "[bench] DICTIONARY    1M/1024d/16B:       %.6fs  decode=%.1f Mr/s  write=%.1f GiB/s\n",
+    sec,
+    double(ROWS) / sec / 1e6,
+    bytes_decoded / sec / GIB);
+}
+
+TEST_CASE("bench DICTIONARY low-cardinality / 2 entries × 2000B",
+          "[!benchmark][scan][decode][strings]")
+{
+  // DuckDB caps DICTIONARY at <4096B total dict (DICTIONARY_ENCODE_THRESHOLD,
+  // dict_fsst/compression.cpp:34). Low-cardinality long-string columns
+  // (log-template variants, status descriptions) stay DICTIONARY at
+  // per-entry sizes up to ~2KB. Stresses the gather pattern at lengths the
+  // 16B fixture can't reach.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  constexpr uint32_t DICT_COUNT = 3;  // [0]=NULL + 2 real entries × 2000B = 4000B < 4096
+  constexpr uint32_t ENTRY_LEN  = 2000;
+  constexpr uint32_t ROWS       = 128u * 1024u;  // 128K × 2000B = 256MB output
+  std::vector<std::string> dict(DICT_COUNT);
+  dict[0] = "";
+  for (uint32_t k = 1; k < DICT_COUNT; ++k) {
+    dict[k] = sirius::test::decode::strings::make_tpch_like_comment(
+      static_cast<uint64_t>(k) * 0x9E3779B97F4A7C15ull, ENTRY_LEN, ENTRY_LEN + 1u);
+  }
+  std::vector<uint32_t> sel(ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i)
+    sel[i] = 1u + (i % (DICT_COUNT - 1u));
+  auto bytes = sirius::test::decode::strings::make_dict_segment(dict, sel);
+
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  sirius::cuda::scan::gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                                                  static_cast<uint32_t>(d_seg.size()),
+                                                  0,
+                                                  ROWS,
+                                                  0,
+                                                  ENTRY_LEN + 1u};
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = ROWS;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_DICTIONARY, {seg}});
+
+  double sec           = bench_strings_seconds(stream, col, mr);
+  double bytes_decoded = double(ROWS) * double(ENTRY_LEN);
+  std::printf(
+    "[bench] DICT-2KB      128K/2d/2000B:        %.6fs  decode=%.1f Mr/s  write=%.1f GiB/s\n",
+    sec,
+    double(ROWS) / sec / 1e6,
+    bytes_decoded / sec / GIB);
+}
+
+TEST_CASE("bench FSST 1M rows / TPC-H-like comments", "[!benchmark][scan][decode][strings]")
+{
+  // TPC-H-style l_comment workload: 5-150 byte comments built from dbgen's
+  // grammar (nouns/verbs/adjectives/adverbs/prepositions). High redundancy
+  // of common words ("the", "carefully", "pending"). FSST symbol-table
+  // coverage and length distribution match what production varchar columns
+  // actually look like — much more demanding of the gather kernel than
+  // structured "row_N_payload_X" strings.
+  // Override with SIRIUS_BENCH_FSST_FIXTURE + SIRIUS_BENCH_FSST_ROWS.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  uint32_t rows = 1u << 20;
+  std::vector<uint8_t> bytes;
+  size_t total_input_bytes = 0;
+  auto override_bytes      = load_fixture_bytes("SIRIUS_BENCH_FSST_FIXTURE");
+  if (!override_bytes.empty()) {
+    char const* rows_str = std::getenv("SIRIUS_BENCH_FSST_ROWS");
+    if (rows_str != nullptr) rows = static_cast<uint32_t>(std::atol(rows_str));
+    bytes = std::move(override_bytes);
+  } else {
+    std::vector<std::string> synth(rows);
+    for (uint32_t i = 0; i < rows; ++i) {
+      synth[i] = sirius::test::decode::strings::make_tpch_like_comment(
+        static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ull, 5u, 150u);
+      total_input_bytes += synth[i].size();
+    }
+    bytes = sirius::test::decode::strings::make_fsst_segment(synth);
+  }
+
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  sirius::cuda::scan::gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                                                  static_cast<uint32_t>(d_seg.size()),
+                                                  0,
+                                                  rows,
+                                                  0,
+                                                  /*max_string_length=*/160u};
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_FSST, {seg}});
+
+  double sec     = bench_strings_seconds(stream, col, mr);
+  double avg_len = total_input_bytes ? double(total_input_bytes) / rows : 0.0;
+  std::printf(
+    "[bench] FSST          TPC-H-like %.0fB avg: %.6fs  decode=%.1f Mr/s  write=%.1f GiB/s\n",
+    avg_len,
+    sec,
+    double(rows) / sec / 1e6,
+    double(rows) * avg_len / sec / GIB);
+}
+
+TEST_CASE("bench FSST 1M rows / long comments", "[!benchmark][scan][decode][strings]")
+{
+  // Long-row variant: 200-800 byte comments built from the same TPC-H
+  // grammar, mean ~500B. Stress for the per-row warp-cooperative path
+  // where a single warp may spend many chunks of work on one row.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  uint32_t rows = 1u << 20;
+  std::vector<uint8_t> bytes;
+  size_t total_input_bytes = 0;
+  auto override_bytes      = load_fixture_bytes("SIRIUS_BENCH_FSST_LONG_FIXTURE");
+  if (!override_bytes.empty()) {
+    char const* rows_str = std::getenv("SIRIUS_BENCH_FSST_LONG_ROWS");
+    if (rows_str != nullptr) rows = static_cast<uint32_t>(std::atol(rows_str));
+    bytes = std::move(override_bytes);
+  } else {
+    std::vector<std::string> synth(rows);
+    for (uint32_t i = 0; i < rows; ++i) {
+      synth[i] = sirius::test::decode::strings::make_tpch_like_comment(
+        static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ull, 200u, 800u);
+      total_input_bytes += synth[i].size();
+    }
+    bytes = sirius::test::decode::strings::make_fsst_segment(synth);
+  }
+
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  sirius::cuda::scan::gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                                                  static_cast<uint32_t>(d_seg.size()),
+                                                  0,
+                                                  rows,
+                                                  0,
+                                                  /*max_string_length=*/800u};
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_FSST, {seg}});
+
+  double sec     = bench_strings_seconds(stream, col, mr);
+  double avg_len = total_input_bytes ? double(total_input_bytes) / rows : 0.0;
+  std::printf(
+    "[bench] FSST-long     %.0fB avg:            %.6fs  decode=%.1f Mr/s  write=%.1f GiB/s\n",
+    avg_len,
+    sec,
+    double(rows) / sec / 1e6,
+    double(rows) * avg_len / sec / GIB);
+}
+
+TEST_CASE("bench DICT_FSST mode 1 1M rows / TPC-H-like dict", "[!benchmark][scan][decode][strings]")
+{
+  // DICT_FSST mode 1 with a TPC-H-like dict: ~50K unique l_comments collapse
+  // to a 50K-entry dict in a real lineitem segment, but DuckDB caps a
+  // segment's dict at the bitpacking-width-fits-in-segment limit, so per
+  // segment ~256-2048 entries. We use 1024 entries here. Real comment shape
+  // (5-150 byte words from dbgen grammar) gives realistic FSST behavior.
+  // Override via SIRIUS_BENCH_DICT_FSST_FIXTURE / _ROWS.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  uint32_t const DICT = 1024;
+  uint32_t rows       = 1u << 20;
+  std::vector<uint8_t> bytes;
+  size_t total_dict_bytes = 0;
+  auto override_bytes     = load_fixture_bytes("SIRIUS_BENCH_DICT_FSST_FIXTURE");
+  if (!override_bytes.empty()) {
+    char const* rows_str = std::getenv("SIRIUS_BENCH_DICT_FSST_ROWS");
+    if (rows_str != nullptr) rows = static_cast<uint32_t>(std::atol(rows_str));
+    bytes = std::move(override_bytes);
+  } else {
+    std::vector<std::string> dict(DICT);
+    dict[0] = "";  // reserved NULL
+    for (uint32_t k = 1; k < DICT; ++k) {
+      dict[k] = sirius::test::decode::strings::make_tpch_like_comment(
+        static_cast<uint64_t>(k) * 0xBF58476D1CE4E5B9ull, 5u, 150u);
+      total_dict_bytes += dict[k].size();
+    }
+    std::vector<uint32_t> sel(rows);
+    for (uint32_t i = 0; i < rows; ++i)
+      sel[i] = (i % (DICT - 1u)) + 1u;
+    bytes = sirius::test::decode::strings::make_dict_fsst_segment(dict, sel, /*mode=*/1);
+  }
+
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  sirius::cuda::scan::gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                                                  static_cast<uint32_t>(d_seg.size()),
+                                                  0,
+                                                  rows,
+                                                  0,
+                                                  /*max_string_length=*/160u};
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_DICT_FSST, {seg}});
+
+  double sec          = bench_strings_seconds(stream, col, mr);
+  double avg_dict_len = total_dict_bytes ? double(total_dict_bytes) / (DICT - 1u) : 0.0;
+  std::printf(
+    "[bench] DICT_FSST mode-1 TPC-H-like %.0fB avg dict: %.6fs  decode=%.1f Mr/s  write=%.1f "
+    "GiB/s\n",
+    avg_dict_len,
+    sec,
+    double(rows) / sec / 1e6,
+    double(rows) * avg_dict_len / sec / GIB);
 }

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -692,6 +692,219 @@ TEST_CASE("bench FSST 1M rows / long comments", "[!benchmark][scan][decode][stri
     double(rows) * avg_len / sec / GIB);
 }
 
+namespace {
+
+/// Measured D2D bandwidth — sets the practical bandwidth ceiling against
+/// which decoder write throughput is reported. 256 MiB transfer is large
+/// enough to saturate the controller while staying inside RMM pool budgets.
+double measure_peak_d2d_gbs(rmm::cuda_stream& stream,
+                            rmm::mr::cuda_async_memory_resource& mr,
+                            int iters  = 10,
+                            int warmup = 3)
+{
+  constexpr size_t COPY_BYTES = size_t{256} << 20;
+  rmm::device_buffer src(COPY_BYTES, stream, mr);
+  rmm::device_buffer dst(COPY_BYTES, stream, mr);
+  for (int i = 0; i < warmup; ++i)
+    cudaMemcpyAsync(dst.data(), src.data(), COPY_BYTES, cudaMemcpyDeviceToDevice, stream.value());
+  cudaStreamSynchronize(stream.value());
+  cudaEvent_t s, e;
+  cudaEventCreate(&s);
+  cudaEventCreate(&e);
+  cudaEventRecord(s, stream.value());
+  for (int i = 0; i < iters; ++i)
+    cudaMemcpyAsync(dst.data(), src.data(), COPY_BYTES, cudaMemcpyDeviceToDevice, stream.value());
+  cudaEventRecord(e, stream.value());
+  cudaEventSynchronize(e);
+  float ms = 0.0f;
+  cudaEventElapsedTime(&ms, s, e);
+  cudaEventDestroy(s);
+  cudaEventDestroy(e);
+  // D2D copy moves 2× bytes across the bus (1 read + 1 write).
+  double sec     = (ms / 1000.0) / iters;
+  double bytes_x = 2.0 * double(COPY_BYTES);
+  return bytes_x / sec / 1e9;  // GB/s (decimal, matching spec sheets)
+}
+
+}  // namespace
+
+TEST_CASE("bench FSST realistic multi-segment / TPC-H-like comments",
+          "[!benchmark][scan][decode][strings]")
+{
+  // Realistic DuckDB layout: FSST segments cap at Storage::DEFAULT_BLOCK_SIZE
+  // (~256 KiB). For TPC-H l_comment (~78 B avg), that's ~5–7 K rows/segment.
+  // 1 M rows therefore split into ~150–200 segments, which is the regime the
+  // Phase A+B kernel's grid = num_segments is sized for.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  double peak_d2d_gbs = measure_peak_d2d_gbs(stream, mr);
+  std::printf("[bench] peak D2D bandwidth (measured): %.1f GB/s\n", peak_d2d_gbs);
+
+  uint32_t const rows = 1u << 20;
+  std::vector<std::string> synth(rows);
+  size_t total_input_bytes = 0;
+  for (uint32_t i = 0; i < rows; ++i) {
+    synth[i] = sirius::test::decode::strings::make_tpch_like_comment(
+      static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ull, 5u, 150u);
+    total_input_bytes += synth[i].size();
+  }
+  auto seg_blobs = sirius::test::decode::strings::make_fsst_segments_chunked(synth);
+
+  size_t total_seg_bytes  = 0;
+  uint32_t max_seg_rows   = 0;
+  uint32_t max_seg_bytes  = 0;
+  for (auto const& [b, rc] : seg_blobs) {
+    total_seg_bytes += b.size();
+    max_seg_rows  = std::max(max_seg_rows, rc);
+    max_seg_bytes = std::max(max_seg_bytes, static_cast<uint32_t>(b.size()));
+  }
+  double avg_seg_rows  = double(rows) / seg_blobs.size();
+  double avg_seg_bytes = double(total_seg_bytes) / seg_blobs.size();
+
+  // Pad each segment up to 8 B so its on-device base is 8 B aligned — kernel
+  // reads `packed = reinterpret_cast<uint32_t const*>(base + 16)` and Phase A
+  // reads 64-bit windows out of it.
+  constexpr size_t SEG_ALIGN = 8;
+  std::vector<size_t> seg_offsets(seg_blobs.size());
+  size_t alloc_bytes = 0;
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    seg_offsets[k] = alloc_bytes;
+    alloc_bytes += (seg_blobs[k].first.size() + SEG_ALIGN - 1) & ~(SEG_ALIGN - 1);
+  }
+  rmm::device_buffer d_all(alloc_bytes, stream.view());
+  std::vector<sirius::cuda::scan::gpu_string_segment_desc> segs;
+  segs.reserve(seg_blobs.size());
+  uint32_t row_cursor     = 0;
+  auto const* d_base      = static_cast<uint8_t const*>(d_all.data());
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    auto const& [b, rc] = seg_blobs[k];
+    cudaMemcpyAsync(const_cast<uint8_t*>(d_base) + seg_offsets[k],
+                    b.data(),
+                    b.size(),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    segs.push_back({d_base + seg_offsets[k],
+                    static_cast<uint32_t>(b.size()),
+                    row_cursor,
+                    rc,
+                    /*seg_row_start=*/0,
+                    /*max_string_length=*/160u});
+    row_cursor += rc;
+  }
+  cudaStreamSynchronize(stream.value());
+
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_FSST, std::move(segs)});
+
+  double sec      = bench_strings_seconds(stream, col, mr);
+  double avg_len  = double(total_input_bytes) / rows;
+  double out_gbs  = double(rows) * avg_len / sec / 1e9;  // decimal GB/s
+  double pct_peak = 100.0 * out_gbs / peak_d2d_gbs;
+
+  std::printf(
+    "[bench] FSST realistic  %.0fB avg, %zu segs (avg %.0f rows / %.0f B), max %u rows / %u B:\n",
+    avg_len,
+    seg_blobs.size(),
+    avg_seg_rows,
+    avg_seg_bytes,
+    max_seg_rows,
+    max_seg_bytes);
+  std::printf(
+    "[bench]   %.6fs  decode=%.1f Mr/s  output write=%.1f GB/s  (%.1f%% of measured peak D2D)\n",
+    sec,
+    double(rows) / sec / 1e6,
+    out_gbs,
+    pct_peak);
+}
+
+TEST_CASE("bench FSST realistic multi-segment / long comments",
+          "[!benchmark][scan][decode][strings]")
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+
+  double peak_d2d_gbs = measure_peak_d2d_gbs(stream, mr);
+  std::printf("[bench] peak D2D bandwidth (measured): %.1f GB/s\n", peak_d2d_gbs);
+
+  uint32_t const rows = 1u << 20;
+  std::vector<std::string> synth(rows);
+  size_t total_input_bytes = 0;
+  for (uint32_t i = 0; i < rows; ++i) {
+    synth[i] = sirius::test::decode::strings::make_tpch_like_comment(
+      static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ull, 200u, 800u);
+    total_input_bytes += synth[i].size();
+  }
+  auto seg_blobs = sirius::test::decode::strings::make_fsst_segments_chunked(synth);
+
+  size_t total_seg_bytes  = 0;
+  uint32_t max_seg_rows   = 0;
+  uint32_t max_seg_bytes  = 0;
+  for (auto const& [b, rc] : seg_blobs) {
+    total_seg_bytes += b.size();
+    max_seg_rows  = std::max(max_seg_rows, rc);
+    max_seg_bytes = std::max(max_seg_bytes, static_cast<uint32_t>(b.size()));
+  }
+  double avg_seg_rows  = double(rows) / seg_blobs.size();
+  double avg_seg_bytes = double(total_seg_bytes) / seg_blobs.size();
+
+  constexpr size_t SEG_ALIGN = 8;
+  std::vector<size_t> seg_offsets(seg_blobs.size());
+  size_t alloc_bytes = 0;
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    seg_offsets[k] = alloc_bytes;
+    alloc_bytes += (seg_blobs[k].first.size() + SEG_ALIGN - 1) & ~(SEG_ALIGN - 1);
+  }
+  rmm::device_buffer d_all(alloc_bytes, stream.view());
+  std::vector<sirius::cuda::scan::gpu_string_segment_desc> segs;
+  segs.reserve(seg_blobs.size());
+  uint32_t row_cursor     = 0;
+  auto const* d_base      = static_cast<uint8_t const*>(d_all.data());
+  for (size_t k = 0; k < seg_blobs.size(); ++k) {
+    auto const& [b, rc] = seg_blobs[k];
+    cudaMemcpyAsync(const_cast<uint8_t*>(d_base) + seg_offsets[k],
+                    b.data(),
+                    b.size(),
+                    cudaMemcpyHostToDevice,
+                    stream.value());
+    segs.push_back({d_base + seg_offsets[k],
+                    static_cast<uint32_t>(b.size()),
+                    row_cursor,
+                    rc,
+                    0,
+                    /*max_string_length=*/800u});
+    row_cursor += rc;
+  }
+  cudaStreamSynchronize(stream.value());
+
+  sirius::cuda::scan::gpu_string_column_decode_input col;
+  col.total_rows = rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_FSST, std::move(segs)});
+
+  double sec      = bench_strings_seconds(stream, col, mr);
+  double avg_len  = double(total_input_bytes) / rows;
+  double out_gbs  = double(rows) * avg_len / sec / 1e9;
+  double pct_peak = 100.0 * out_gbs / peak_d2d_gbs;
+
+  std::printf(
+    "[bench] FSST realistic-long %.0fB avg, %zu segs (avg %.0f rows / %.0f B), max %u rows / %u B:\n",
+    avg_len,
+    seg_blobs.size(),
+    avg_seg_rows,
+    avg_seg_bytes,
+    max_seg_rows,
+    max_seg_bytes);
+  std::printf(
+    "[bench]   %.6fs  decode=%.1f Mr/s  output write=%.1f GB/s  (%.1f%% of measured peak D2D)\n",
+    sec,
+    double(rows) / sec / 1e6,
+    out_gbs,
+    pct_peak);
+}
+
 TEST_CASE("bench DICT_FSST mode 1 1M rows / TPC-H-like dict", "[!benchmark][scan][decode][strings]")
 {
   // DICT_FSST mode 1 with a TPC-H-like dict: ~50K unique l_comments collapse

--- a/test/cpp/scan/bench_decode_codecs.cpp
+++ b/test/cpp/scan/bench_decode_codecs.cpp
@@ -1071,9 +1071,9 @@ TEST_CASE("bench FSST realistic multi-segment / TPC-H-like comments",
   }
   auto seg_blobs = sirius::test::decode::strings::make_fsst_segments_chunked(synth);
 
-  size_t total_seg_bytes  = 0;
-  uint32_t max_seg_rows   = 0;
-  uint32_t max_seg_bytes  = 0;
+  size_t total_seg_bytes = 0;
+  uint32_t max_seg_rows  = 0;
+  uint32_t max_seg_bytes = 0;
   for (auto const& [b, rc] : seg_blobs) {
     total_seg_bytes += b.size();
     max_seg_rows  = std::max(max_seg_rows, rc);
@@ -1095,8 +1095,8 @@ TEST_CASE("bench FSST realistic multi-segment / TPC-H-like comments",
   rmm::device_buffer d_all(alloc_bytes, stream.view());
   std::vector<sirius::cuda::scan::gpu_string_segment_desc> segs;
   segs.reserve(seg_blobs.size());
-  uint32_t row_cursor     = 0;
-  auto const* d_base      = static_cast<uint8_t const*>(d_all.data());
+  uint32_t row_cursor = 0;
+  auto const* d_base  = static_cast<uint8_t const*>(d_all.data());
   for (size_t k = 0; k < seg_blobs.size(); ++k) {
     auto const& [b, rc] = seg_blobs[k];
     cudaMemcpyAsync(const_cast<uint8_t*>(d_base) + seg_offsets[k],
@@ -1159,9 +1159,9 @@ TEST_CASE("bench FSST realistic multi-segment / long comments",
   }
   auto seg_blobs = sirius::test::decode::strings::make_fsst_segments_chunked(synth);
 
-  size_t total_seg_bytes  = 0;
-  uint32_t max_seg_rows   = 0;
-  uint32_t max_seg_bytes  = 0;
+  size_t total_seg_bytes = 0;
+  uint32_t max_seg_rows  = 0;
+  uint32_t max_seg_bytes = 0;
   for (auto const& [b, rc] : seg_blobs) {
     total_seg_bytes += b.size();
     max_seg_rows  = std::max(max_seg_rows, rc);
@@ -1180,8 +1180,8 @@ TEST_CASE("bench FSST realistic multi-segment / long comments",
   rmm::device_buffer d_all(alloc_bytes, stream.view());
   std::vector<sirius::cuda::scan::gpu_string_segment_desc> segs;
   segs.reserve(seg_blobs.size());
-  uint32_t row_cursor     = 0;
-  auto const* d_base      = static_cast<uint8_t const*>(d_all.data());
+  uint32_t row_cursor = 0;
+  auto const* d_base  = static_cast<uint8_t const*>(d_all.data());
   for (size_t k = 0; k < seg_blobs.size(); ++k) {
     auto const& [b, rc] = seg_blobs[k];
     cudaMemcpyAsync(const_cast<uint8_t*>(d_base) + seg_offsets[k],
@@ -1210,7 +1210,8 @@ TEST_CASE("bench FSST realistic multi-segment / long comments",
   double pct_peak = 100.0 * out_gbs / peak_d2d_gbs;
 
   std::printf(
-    "[bench] FSST realistic-long %.0fB avg, %zu segs (avg %.0f rows / %.0f B), max %u rows / %u B:\n",
+    "[bench] FSST realistic-long %.0fB avg, %zu segs (avg %.0f rows / %.0f B), max %u rows / %u "
+    "B:\n",
     avg_len,
     seg_blobs.size(),
     avg_seg_rows,
@@ -1282,8 +1283,7 @@ TEST_CASE("bench DICT_FSST mode 1 1M rows / TPC-H-like dict", "[!benchmark][scan
     double(rows) * avg_dict_len / sec / GIB);
 }
 
-TEST_CASE("bench DICT_FSST realistic multi-segment mode 1",
-          "[!benchmark][scan][decode][strings]")
+TEST_CASE("bench DICT_FSST realistic multi-segment mode 1", "[!benchmark][scan][decode][strings]")
 {
   // Realistic DuckDB layout: DICT_FSST segments cap at Storage::DEFAULT_BLOCK_SIZE
   // (~256 KiB). For TPC-H-like comments and mode-1 dicts this gives roughly

--- a/test/cpp/scan/strings_synth.hpp
+++ b/test/cpp/scan/strings_synth.hpp
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Synthetic on-disk segment builders for the strings-decode tests.
+// FSST / DICT_FSST go through libduckdb's host FSST encoder so the segment
+// bytes match DuckDB's on-disk format byte-for-byte.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// libduckdb FSST encoder API (signatures at duckdb/third_party/fsst/fsst.h).
+extern "C" {
+typedef void* duckdb_fsst_encoder_t;
+duckdb_fsst_encoder_t* duckdb_fsst_create(size_t n,
+                                          size_t len_in[],
+                                          unsigned char* string_in[],
+                                          int zeroTerminated);
+void duckdb_fsst_destroy(duckdb_fsst_encoder_t*);
+unsigned int duckdb_fsst_export(duckdb_fsst_encoder_t* encoder, unsigned char* buf);
+size_t duckdb_fsst_compress(duckdb_fsst_encoder_t* encoder,
+                            size_t nstrings,
+                            size_t len_in[],
+                            unsigned char* string_in[],
+                            size_t outsize,
+                            unsigned char* output,
+                            size_t len_out[],
+                            unsigned char* string_out[]);
+}
+
+namespace sirius::test::decode::strings {
+
+/// Bits needed to represent [0, count).
+inline uint32_t bitpack_width_for_count(uint32_t count)
+{
+  if (count <= 1) return 0;
+  uint32_t w = 0;
+  uint32_t v = count - 1;
+  while (v > 0) {
+    ++w;
+    v >>= 1;
+  }
+  return w;
+}
+
+/// Inverse of unpack_value in gpu_decode_strings.cu (LSB-first into uint32 stream).
+inline std::vector<uint32_t> pack_uint32(std::vector<uint32_t> const& values, uint32_t width)
+{
+  if (width == 0 || values.empty()) {
+    return std::vector<uint32_t>(1, 0);  // one guard word for unpack_value
+  }
+  size_t total_bits = size_t{values.size()} * width;
+  size_t words      = (total_bits + 31) / 32;
+  std::vector<uint32_t> out(words + 1, 0);  // +1 guard word
+  for (size_t i = 0; i < values.size(); ++i) {
+    uint64_t pos      = uint64_t{i} * width;
+    uint32_t word_idx = static_cast<uint32_t>(pos / 32);
+    uint32_t bit_off  = static_cast<uint32_t>(pos & 31);
+    uint64_t v        = static_cast<uint64_t>(values[i]) &
+                 ((width == 64) ? ~uint64_t{0} : (uint64_t{1} << width) - 1);
+    out[word_idx] |= static_cast<uint32_t>(v << bit_off);
+    if (bit_off + width > 32) { out[word_idx + 1] |= static_cast<uint32_t>(v >> (32 - bit_off)); }
+  }
+  return out;
+}
+
+/// `dict_strings[0]` reserved for NULL; `selections[i] == 0` means NULL.
+inline std::vector<uint8_t> make_dict_segment(std::vector<std::string> const& dict_strings,
+                                              std::vector<uint32_t> const& selections)
+{
+  uint32_t const dict_count = static_cast<uint32_t>(dict_strings.size());
+
+  std::vector<uint32_t> idx_buf(dict_count, 0);
+  uint32_t cum = 0;
+  for (uint32_t k = 0; k < dict_count; ++k) {
+    cum += static_cast<uint32_t>(dict_strings[k].size());
+    idx_buf[k] = cum;
+  }
+  uint32_t const dict_size = cum;
+  uint32_t const width     = bitpack_width_for_count(dict_count);
+  auto sel_packed          = pack_uint32(selections, width);
+
+  uint32_t const header_size  = 20;
+  uint32_t const sel_buf_off  = header_size;
+  uint32_t const sel_buf_size = static_cast<uint32_t>(sel_packed.size() * sizeof(uint32_t));
+  uint32_t const idx_buf_off  = sel_buf_off + sel_buf_size;
+  uint32_t const idx_buf_size = dict_count * sizeof(uint32_t);
+  uint32_t const dict_off     = idx_buf_off + idx_buf_size;
+  uint32_t const dict_end     = dict_off + dict_size;
+  uint32_t const total        = dict_end;
+
+  std::vector<uint8_t> bytes(total, 0);
+  uint32_t hdr[5] = {dict_size, dict_end, idx_buf_off, dict_count, width};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  if (sel_buf_size > 0) {
+    std::memcpy(bytes.data() + sel_buf_off, sel_packed.data(), sel_buf_size);
+  }
+  std::memcpy(bytes.data() + idx_buf_off, idx_buf.data(), idx_buf_size);
+  // Dict bytes packed in REVERSE: entry K starts at dict_end - idx_buf[K].
+  uint8_t* dict_region = bytes.data() + dict_off;
+  for (uint32_t k = 0; k < dict_count; ++k) {
+    uint32_t offset_from_dict_end = idx_buf[k];
+    uint32_t entry_size           = static_cast<uint32_t>(dict_strings[k].size());
+    uint8_t* dst                  = dict_region + dict_size - offset_from_dict_end;
+    if (entry_size > 0) std::memcpy(dst, dict_strings[k].data(), entry_size);
+  }
+  return bytes;
+}
+
+// dbgen-style grammar — produces TPC-H-shaped comments (5-150B, high common-
+// word repetition) so FSST microbenches see realistic symbol-table coverage.
+
+namespace tpch_grammar {
+inline char const* nouns[] = {
+  "deposits",  "packages",   "accounts",    "ideas",     "instructions",   "requests",
+  "platelets", "asymptotes", "theodolites", "courts",    "hockey players", "pinto beans",
+  "excuses",   "frets",      "frays",       "warhorses", "dependencies",   "attainments",
+  "warthogs",  "pearls",     "dolphins",    "epitaphs",  "patterns",       "foxes",
+  "packages",  "deposits",   "accounts",    "requests",  "ideas",
+};
+inline char const* verbs[] = {
+  "haggle",  "boost",  "are",  "sleep",  "wake",  "cajole", "thrash",
+  "promise", "engage", "hang", "hinder", "x-ray", "use",    "integrate",
+  "snooze",  "doze",   "nag",  "doubt",  "have",  "kindle", "play",
+};
+inline char const* adjectives[] = {
+  "regular", "special", "ironic",    "even",     "bold",      "final",    "express",
+  "thin",    "silent",  "pending",   "blithe",   "permanent", "unusual",  "furious",
+  "quiet",   "fluffy",  "busy",      "stealthy", "careful",   "ruthless", "sly",
+  "daring",  "brave",   "carefully", "slyly",    "boldly",    "blithely",
+};
+inline char const* adverbs[] = {
+  "carefully",
+  "slyly",
+  "boldly",
+  "quickly",
+  "permanently",
+  "fluffily",
+  "ruthlessly",
+  "regularly",
+  "ironically",
+  "blithely",
+  "furiously",
+  "even",
+  "quietly",
+  "always",
+  "never",
+  "stealthily",
+  "finally",
+  "silently",
+};
+inline char const* prepositions[] = {
+  "above the",       "according to the", "across the", "after the",   "against the",
+  "along the",       "alongside of the", "around the", "before the",  "between the",
+  "beyond the",      "by the",           "during the", "for the",     "from the",
+  "in place of the", "instead of the",   "on the",     "outside the", "to the",
+  "toward the",      "without the",
+};
+inline char const* auxiliaries[] = {
+  "do",
+  "may",
+  "might",
+  "shall",
+  "will",
+  "would",
+  "should",
+  "can",
+  "could",
+  "must",
+  "ought to",
+  "have to",
+};
+}  // namespace tpch_grammar
+
+/// Pick from a const char* array using a simple LCG seeded by `state`.
+/// Updates `state` in-place.
+template <size_t N>
+inline char const* pick(char const* (&arr)[N], uint64_t& state)
+{
+  state = state * 6364136223846793005ull + 1442695040888963407ull;
+  return arr[(state >> 33) % N];
+}
+
+/// Build one TPC-H-style sentence and append to `out`. Returns appended length.
+inline size_t append_tpch_sentence(std::string& out, uint64_t& seed)
+{
+  using namespace tpch_grammar;
+  size_t before = out.size();
+  // Form: "<adj> <noun> <verb> <prep> <adj> <noun>"
+  // e.g. "carefully ironic deposits boost regular accounts"
+  out.append(pick(adjectives, seed));
+  out.push_back(' ');
+  out.append(pick(nouns, seed));
+  out.push_back(' ');
+  out.append(pick(verbs, seed));
+  out.push_back(' ');
+  out.append(pick(prepositions, seed));
+  out.push_back(' ');
+  out.append(pick(adjectives, seed));
+  out.push_back(' ');
+  out.append(pick(nouns, seed));
+  return out.size() - before;
+}
+
+/// Build a TPC-H-like comment of length in [min_len, max_len], deterministic
+/// from `seed`. Uses the simple grammar above; concatenates sentences until
+/// the length budget is reached. Truncates if the next sentence would
+/// overshoot. Lengths follow the TPC-H l_comment distribution shape: 5-150
+/// bytes, mean ~30, higher density at the long end.
+inline std::string make_tpch_like_comment(uint64_t seed,
+                                          uint32_t min_len = 5,
+                                          uint32_t max_len = 150)
+{
+  std::string out;
+  out.reserve(max_len);
+  uint32_t target =
+    min_len + static_cast<uint32_t>((seed * 2654435769ull) % (max_len - min_len + 1));
+  uint64_t s = seed ^ 0x9E3779B97F4A7C15ull;
+  while (out.size() < target) {
+    if (!out.empty()) {
+      out.append((s % 3 == 0) ? ". " : " ");
+      s = s * 1103515245ull + 12345ull;
+    }
+    append_tpch_sentence(out, s);
+    if (out.size() >= target) {
+      out.resize(target);
+      break;
+    }
+  }
+  return out;
+}
+
+/// Round n up to the nearest multiple of 8 (matches DuckDB AlignValue<idx_t>).
+inline uint32_t synth_align_up8(uint32_t n) { return (n + 7u) & ~7u; }
+
+/// Bit-width needed to represent `max_value` losslessly. Returns 0 for 0.
+inline uint32_t bitpack_width_for_value(uint32_t max_value)
+{
+  if (max_value == 0) return 0;
+  uint32_t w = 0;
+  while (max_value > 0) {
+    ++w;
+    max_value >>= 1;
+  }
+  return w;
+}
+
+/// Layout matches src/storage/compression/fsst.cpp. Rows are stored
+/// REVERSE-order in the compressed-bytes region.
+inline std::vector<uint8_t> make_fsst_segment(std::vector<std::string> const& strings)
+{
+  uint32_t const row_count = static_cast<uint32_t>(strings.size());
+  if (row_count == 0) return std::vector<uint8_t>(16, 0);
+
+  std::vector<size_t> lens(row_count);
+  std::vector<unsigned char*> ptrs(row_count);
+  for (uint32_t i = 0; i < row_count; ++i) {
+    lens[i] = strings[i].size();
+    ptrs[i] = reinterpret_cast<unsigned char*>(const_cast<char*>(strings[i].data()));
+  }
+  duckdb_fsst_encoder_t* enc = duckdb_fsst_create(row_count, lens.data(), ptrs.data(), 0);
+  if (!enc) throw std::runtime_error("make_fsst_segment: duckdb_fsst_create returned null");
+
+  size_t total_in = 0;
+  for (size_t l : lens)
+    total_in += l;
+  size_t comp_buf_size = 7 + 2 * total_in + 16 * row_count;  // conservative bound
+  std::vector<unsigned char> comp_buf(comp_buf_size);
+  std::vector<size_t> lenOut(row_count);
+  std::vector<unsigned char*> strOut(row_count);
+  size_t n_compressed = duckdb_fsst_compress(enc,
+                                             row_count,
+                                             lens.data(),
+                                             ptrs.data(),
+                                             comp_buf_size,
+                                             comp_buf.data(),
+                                             lenOut.data(),
+                                             strOut.data());
+  if (n_compressed != row_count) {
+    duckdb_fsst_destroy(enc);
+    throw std::runtime_error("make_fsst_segment: duckdb_fsst_compress fit fewer rows than asked");
+  }
+
+  std::vector<unsigned char> symtab_buf(8 + 1 + 8 + 2048 + 1);  // FSST_MAXHEADER
+  unsigned int symtab_size = duckdb_fsst_export(enc, symtab_buf.data());
+  duckdb_fsst_destroy(enc);
+
+  uint32_t max_comp_len = 0;
+  for (size_t l : lenOut)
+    max_comp_len = std::max(max_comp_len, static_cast<uint32_t>(l));
+  uint32_t bitpacking_width = std::max(1u, bitpack_width_for_value(max_comp_len));
+
+  uint32_t const header_size = 16;
+  uint32_t const lengths_off = header_size;
+  size_t lengths_total_bits  = size_t{row_count} * bitpacking_width;
+  uint32_t lengths_bytes_raw = static_cast<uint32_t>((lengths_total_bits + 31u) / 32u * 4u);
+  uint32_t lengths_padded    = lengths_bytes_raw + 4u;  // +1 word: unpack_value reads 8B
+  uint32_t symtab_off        = synth_align_up8(lengths_off + lengths_padded);
+  uint32_t comp_bytes_off    = synth_align_up8(symtab_off + symtab_size);
+
+  size_t total_comp_bytes = 0;
+  for (size_t l : lenOut)
+    total_comp_bytes += l;
+  uint32_t dict_end = comp_bytes_off + static_cast<uint32_t>(total_comp_bytes);
+
+  std::vector<uint8_t> bytes(dict_end, 0);
+  uint32_t hdr[4] = {
+    static_cast<uint32_t>(total_comp_bytes), dict_end, bitpacking_width, symtab_off};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  std::vector<uint32_t> lengths_u32(row_count);
+  for (uint32_t i = 0; i < row_count; ++i)
+    lengths_u32[i] = static_cast<uint32_t>(lenOut[i]);
+  auto packed_lengths = pack_uint32(lengths_u32, bitpacking_width);
+  std::memcpy(bytes.data() + lengths_off,
+              packed_lengths.data(),
+              std::min(packed_lengths.size() * sizeof(uint32_t), size_t{lengths_padded}));
+  std::memcpy(bytes.data() + symtab_off, symtab_buf.data(), symtab_size);
+  uint32_t cum_from_end = 0;
+  for (uint32_t i = 0; i < row_count; ++i) {  // rows stored in reverse
+    cum_from_end += static_cast<uint32_t>(lenOut[i]);
+    uint8_t* dst = bytes.data() + dict_end - cum_from_end;
+    if (lenOut[i] > 0) std::memcpy(dst, strOut[i], lenOut[i]);
+  }
+  return bytes;
+}
+
+/// `mode`: 0=DICTIONARY, 1=DICT_FSST, 2=FSST_ONLY (row i -> dict idx i+1).
+/// `unique_strings[0]` reserved for NULL; `selections` ignored for mode 2.
+/// Layout matches dict_fsst/compression.cpp.
+inline std::vector<uint8_t> make_dict_fsst_segment(std::vector<std::string> const& unique_strings,
+                                                   std::vector<uint32_t> const& selections,
+                                                   uint8_t mode)
+{
+  uint32_t const dict_count = static_cast<uint32_t>(unique_strings.size());
+  uint32_t const row_count  = (mode == 2) ? static_cast<uint32_t>(unique_strings.size() - 1)
+                                          : static_cast<uint32_t>(selections.size());
+
+  // FSST modes only — encoder skips idx 0 (the reserved NULL slot).
+  std::vector<unsigned char> symtab_buf(8 + 1 + 8 + 2048 + 1);
+  unsigned int symtab_size = 0;
+  std::vector<size_t> entry_lens(dict_count, 0);
+  std::vector<std::vector<uint8_t>> entry_bytes(dict_count);
+
+  if (mode != 0 && dict_count > 1) {
+    std::vector<size_t> lens;
+    std::vector<unsigned char*> ptrs;
+    for (uint32_t k = 1; k < dict_count; ++k) {
+      lens.push_back(unique_strings[k].size());
+      ptrs.push_back(reinterpret_cast<unsigned char*>(const_cast<char*>(unique_strings[k].data())));
+    }
+    duckdb_fsst_encoder_t* enc = duckdb_fsst_create(lens.size(), lens.data(), ptrs.data(), 0);
+    if (!enc) throw std::runtime_error("make_dict_fsst_segment: fsst_create returned null");
+
+    size_t total_in = 0;
+    for (size_t l : lens)
+      total_in += l;
+    size_t comp_buf_size = 7 + 2 * total_in + 16 * lens.size();
+    std::vector<unsigned char> comp_buf(comp_buf_size);
+    std::vector<size_t> lenOut(lens.size());
+    std::vector<unsigned char*> strOut(lens.size());
+    size_t n_compressed = duckdb_fsst_compress(enc,
+                                               lens.size(),
+                                               lens.data(),
+                                               ptrs.data(),
+                                               comp_buf_size,
+                                               comp_buf.data(),
+                                               lenOut.data(),
+                                               strOut.data());
+    if (n_compressed != lens.size()) {
+      duckdb_fsst_destroy(enc);
+      throw std::runtime_error(
+        "make_dict_fsst_segment: fsst_compress fit fewer entries than asked");
+    }
+    symtab_size = duckdb_fsst_export(enc, symtab_buf.data());
+    duckdb_fsst_destroy(enc);
+
+    for (uint32_t k = 1; k < dict_count; ++k) {
+      size_t i       = static_cast<size_t>(k - 1);
+      entry_lens[k]  = lenOut[i];
+      entry_bytes[k] = std::vector<uint8_t>(strOut[i], strOut[i] + lenOut[i]);
+    }
+  } else {
+    for (uint32_t k = 0; k < dict_count; ++k) {  // mode 0: raw bytes
+      entry_lens[k]  = unique_strings[k].size();
+      entry_bytes[k] = std::vector<uint8_t>(unique_strings[k].begin(), unique_strings[k].end());
+    }
+  }
+
+  uint32_t max_entry_len = 0;
+  for (uint32_t k = 0; k < dict_count; ++k) {
+    max_entry_len = std::max(max_entry_len, static_cast<uint32_t>(entry_lens[k]));
+  }
+  uint32_t string_lengths_width = std::max(1u, bitpack_width_for_value(max_entry_len));
+  uint32_t dict_indices_width   = std::max(1u, bitpack_width_for_value(dict_count - 1));
+
+  uint32_t dict_size = 0;
+  for (size_t l : entry_lens)
+    dict_size += static_cast<uint32_t>(l);
+
+  // Region offsets mirror prepare_dict_fsst in gpu_decode_strings.cu.
+  uint32_t const header_size = 16;
+  uint32_t off_dict          = synth_align_up8(header_size);
+  uint32_t off_symtab        = (mode == 0) ? 0 : synth_align_up8(off_dict + dict_size);
+  uint32_t off_slens =
+    (mode == 0) ? off_dict + synth_align_up8(dict_size) : synth_align_up8(off_symtab + symtab_size);
+  uint32_t slens_bits = dict_count * string_lengths_width;
+  uint32_t off_didx   = synth_align_up8(off_slens + (slens_bits + 7u) / 8u);
+  uint32_t total =
+    (mode == 2) ? off_didx : synth_align_up8(off_didx + (row_count * dict_indices_width + 7u) / 8u);
+
+  std::vector<uint8_t> bytes(total, 0);
+  // Header (matches dict_fsst_header_t in gpu_decode_strings.cu).
+  std::memcpy(bytes.data(), &dict_size, 4);
+  std::memcpy(bytes.data() + 4, &dict_count, 4);
+  bytes[8]  = mode;
+  bytes[9]  = static_cast<uint8_t>(string_lengths_width);
+  bytes[10] = static_cast<uint8_t>(dict_indices_width);
+  bytes[11] = 0;
+  std::memcpy(bytes.data() + 12, &symtab_size, 4);
+
+  // Dict region — entries laid forward (entry 0 first), tightly packed.
+  uint32_t cursor = off_dict;
+  for (uint32_t k = 0; k < dict_count; ++k) {
+    if (entry_lens[k] > 0) {
+      std::memcpy(bytes.data() + cursor, entry_bytes[k].data(), entry_lens[k]);
+    }
+    cursor += static_cast<uint32_t>(entry_lens[k]);
+  }
+  if (mode != 0) { std::memcpy(bytes.data() + off_symtab, symtab_buf.data(), symtab_size); }
+  std::vector<uint32_t> lengths_u32(dict_count);
+  for (uint32_t k = 0; k < dict_count; ++k)
+    lengths_u32[k] = static_cast<uint32_t>(entry_lens[k]);
+  auto packed_lengths = pack_uint32(lengths_u32, string_lengths_width);
+  std::memcpy(bytes.data() + off_slens,
+              packed_lengths.data(),
+              std::min(packed_lengths.size() * sizeof(uint32_t), size_t{(slens_bits + 7u) / 8u}));
+  if (mode != 2) {
+    auto packed_didx = pack_uint32(selections, dict_indices_width);
+    size_t didx_bytes_to_copy =
+      std::min(packed_didx.size() * sizeof(uint32_t), size_t{total - off_didx});
+    std::memcpy(bytes.data() + off_didx, packed_didx.data(), didx_bytes_to_copy);
+  }
+  return bytes;
+}
+
+}  // namespace sirius::test::decode::strings

--- a/test/cpp/scan/strings_synth.hpp
+++ b/test/cpp/scan/strings_synth.hpp
@@ -126,6 +126,41 @@ inline std::vector<uint8_t> make_dict_segment(std::vector<std::string> const& di
   return bytes;
 }
 
+/// UNCOMPRESSED varchar segment. Layout:
+///   [dict_size:4] [dict_end:4] [offsets:4*N] [chars]
+/// offsets[i] is positive cumulative byte length through row i, and the chars
+/// region grows backward from dict_end so row i starts at `dict_end - offsets[i]`.
+inline std::vector<uint8_t> make_uncompressed_segment(std::vector<std::string> const& strings)
+{
+  uint32_t const row_count = static_cast<uint32_t>(strings.size());
+
+  std::vector<int32_t> offsets(row_count);
+  uint32_t cum = 0;
+  for (uint32_t i = 0; i < row_count; ++i) {
+    cum += static_cast<uint32_t>(strings[i].size());
+    offsets[i] = static_cast<int32_t>(cum);
+  }
+  uint32_t const total_chars  = cum;
+  uint32_t const header_size  = 8;
+  uint32_t const offsets_size = row_count * 4;
+  uint32_t const total        = header_size + offsets_size + total_chars;
+  uint32_t const dict_end     = total;
+  uint32_t const dict_size    = 0;  // unused by the UNCOMPRESSED varchar decoder
+
+  std::vector<uint8_t> bytes(total, 0);
+  std::memcpy(bytes.data(), &dict_size, 4);
+  std::memcpy(bytes.data() + 4, &dict_end, 4);
+  if (offsets_size > 0) { std::memcpy(bytes.data() + 8, offsets.data(), offsets_size); }
+  for (uint32_t i = 0; i < row_count; ++i) {
+    uint32_t length = static_cast<uint32_t>(strings[i].size());
+    if (length > 0) {
+      std::memcpy(
+        bytes.data() + dict_end - static_cast<uint32_t>(offsets[i]), strings[i].data(), length);
+    }
+  }
+  return bytes;
+}
+
 // dbgen-style grammar — produces TPC-H-shaped comments (5-150B, high common-
 // word repetition) so FSST microbenches see realistic symbol-table coverage.
 

--- a/test/cpp/scan/strings_synth.hpp
+++ b/test/cpp/scan/strings_synth.hpp
@@ -342,6 +342,49 @@ inline std::vector<uint8_t> make_fsst_segment(std::vector<std::string> const& st
   return bytes;
 }
 
+/// Split `strings` into multiple FSST segments, each fitting within
+/// `block_size_bytes` (mirrors DuckDB FSSTCompressionState::HasEnoughSpace,
+/// which flushes a segment the moment `required_size > info.GetBlockSize()`).
+/// Produces a `(segment_bytes, row_count)` pair per segment. Starts from a
+/// row-count target derived from input byte budget; if the produced segment
+/// overflows the cap, halves the target and retries — so one pathological
+/// batch can't cause runaway segment count.
+inline std::vector<std::pair<std::vector<uint8_t>, uint32_t>> make_fsst_segments_chunked(
+  std::vector<std::string> const& strings, uint32_t block_size_bytes = 262136u)
+{
+  std::vector<std::pair<std::vector<uint8_t>, uint32_t>> out;
+  uint32_t const total_rows = static_cast<uint32_t>(strings.size());
+  if (total_rows == 0) return out;
+
+  // Target an input byte budget that empirically fits within block_size_bytes
+  // for TPC-H-like data: FSST ~50% compression + ~8 KiB symbol table + ~1 B
+  // bitpacked length per row + 16 B header. Use ~2x block size as input
+  // budget for the initial guess; let the retry loop shrink if needed.
+  uint32_t i = 0;
+  while (i < total_rows) {
+    // Initial row count from average length.
+    size_t avg_byte = 0;
+    for (uint32_t k = i; k < std::min(i + 64u, total_rows); ++k)
+      avg_byte += strings[k].size();
+    avg_byte = std::max<size_t>(1u, avg_byte / std::min(64u, total_rows - i));
+    uint32_t batch_rows =
+      std::max(32u, static_cast<uint32_t>((size_t{block_size_bytes} * 2u) / (avg_byte + 4u)));
+    batch_rows = std::min(batch_rows, total_rows - i);
+
+    while (true) {
+      std::vector<std::string> slice(strings.begin() + i, strings.begin() + i + batch_rows);
+      auto seg_bytes = make_fsst_segment(slice);
+      if (seg_bytes.size() <= block_size_bytes || batch_rows == 1) {
+        out.emplace_back(std::move(seg_bytes), batch_rows);
+        i += batch_rows;
+        break;
+      }
+      batch_rows = std::max(1u, batch_rows / 2u);
+    }
+  }
+  return out;
+}
+
 /// `mode`: 0=DICTIONARY, 1=DICT_FSST, 2=FSST_ONLY (row i -> dict idx i+1).
 /// `unique_strings[0]` reserved for NULL; `selections` ignored for mode 2.
 /// Layout matches dict_fsst/compression.cpp.

--- a/test/cpp/scan/strings_synth.hpp
+++ b/test/cpp/scan/strings_synth.hpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // libduckdb FSST encoder API (signatures at duckdb/third_party/fsst/fsst.h).
@@ -385,6 +386,16 @@ inline std::vector<std::pair<std::vector<uint8_t>, uint32_t>> make_fsst_segments
   return out;
 }
 
+/// Split a row-vector into multiple DICT_FSST segments, each fitting within
+/// DuckDB's `Storage::DEFAULT_BLOCK_SIZE` (~256 KiB). Per segment we build a
+/// local dictionary from unique strings, generate selections, and call
+/// `make_dict_fsst_segment`. If the resulting segment overflows the cap, we
+/// halve the row budget and retry — bounding pathological cases.
+///
+/// Mirrors `make_fsst_segments_chunked` for the FSST codec.
+inline std::vector<std::pair<std::vector<uint8_t>, uint32_t>> make_dict_fsst_segments_chunked(
+  std::vector<std::string> const& strings, uint8_t mode, uint32_t block_size_bytes = 262136u);
+
 /// `mode`: 0=DICTIONARY, 1=DICT_FSST, 2=FSST_ONLY (row i -> dict idx i+1).
 /// `unique_strings[0]` reserved for NULL; `selections` ignored for mode 2.
 /// Layout matches dict_fsst/compression.cpp.
@@ -502,6 +513,51 @@ inline std::vector<uint8_t> make_dict_fsst_segment(std::vector<std::string> cons
     std::memcpy(bytes.data() + off_didx, packed_didx.data(), didx_bytes_to_copy);
   }
   return bytes;
+}
+
+inline std::vector<std::pair<std::vector<uint8_t>, uint32_t>> make_dict_fsst_segments_chunked(
+  std::vector<std::string> const& strings, uint8_t mode, uint32_t block_size_bytes)
+{
+  std::vector<std::pair<std::vector<uint8_t>, uint32_t>> out;
+  uint32_t const total_rows = static_cast<uint32_t>(strings.size());
+  if (total_rows == 0) return out;
+
+  // Initial row budget: a real DICT_FSST segment fits ~5K rows of TPC-H-like
+  // comments inside the 256 KiB block once the dict is FSST-compressed. Use
+  // 4096 as a safe starting target; the retry loop halves on overflow.
+  uint32_t i = 0;
+  while (i < total_rows) {
+    uint32_t batch_rows = std::min(4096u, total_rows - i);
+    while (true) {
+      // Build a local dictionary (entry 0 reserved for NULL).
+      std::unordered_map<std::string, uint32_t> dict_map;
+      std::vector<std::string> dict;
+      dict.reserve(batch_rows + 1);
+      dict.emplace_back();  // NULL slot
+      std::vector<uint32_t> selections;
+      selections.reserve(batch_rows);
+      for (uint32_t r = i; r < i + batch_rows; ++r) {
+        auto it = dict_map.find(strings[r]);
+        uint32_t idx;
+        if (it == dict_map.end()) {
+          idx                  = static_cast<uint32_t>(dict.size());
+          dict_map[strings[r]] = idx;
+          dict.push_back(strings[r]);
+        } else {
+          idx = it->second;
+        }
+        selections.push_back(idx);
+      }
+      auto seg_bytes = make_dict_fsst_segment(dict, selections, mode);
+      if (seg_bytes.size() <= block_size_bytes || batch_rows == 1) {
+        out.emplace_back(std::move(seg_bytes), batch_rows);
+        i += batch_rows;
+        break;
+      }
+      batch_rows = std::max(1u, batch_rows / 2u);
+    }
+  }
+  return out;
 }
 
 }  // namespace sirius::test::decode::strings

--- a/test/cpp/scan/test_gpu_decode_strings.cpp
+++ b/test/cpp/scan/test_gpu_decode_strings.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// String-codec decode tests: happy-path round-trips + malformed-segment
+// guards (kernels must emit zero-length rows, never read OOB).
+
+#include "scan/decode_test_utils.hpp"
+#include "scan/strings_synth.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+
+#include <cuda/scan/gpu_decode_strings.cuh>
+
+#include <catch.hpp>
+#include <duckdb/common/enums/compression_type.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using duckdb::CompressionType;
+using sirius::cuda::scan::gpu_codec_run;
+using sirius::cuda::scan::gpu_decode_strings_column;
+using sirius::cuda::scan::gpu_segment_desc;
+using sirius::cuda::scan::gpu_string_codec_run;
+using sirius::cuda::scan::gpu_string_column_decode_input;
+using sirius::cuda::scan::gpu_string_segment_desc;
+using sirius::test::decode::download;
+using sirius::test::decode::strings::make_dict_fsst_segment;
+using sirius::test::decode::strings::make_dict_segment;
+using sirius::test::decode::strings::make_fsst_segment;
+
+namespace {
+
+/// Stage segment bytes on device; build a single-segment string column input
+/// and run it through `gpu_decode_strings_column`. Returns the decoded
+/// strings as a vector<string> for direct comparison.
+std::vector<std::string> decode_one_dict(std::vector<uint8_t> const& bytes,
+                                         uint32_t row_count,
+                                         uint32_t max_string_length)
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                              static_cast<uint32_t>(d_seg.size()),
+                              0,
+                              row_count,
+                              0,
+                              max_string_length};
+  gpu_string_column_decode_input col;
+  col.total_rows = row_count;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_DICTIONARY, {seg}});
+
+  auto column = gpu_decode_strings_column(col, stream.view(), mr);
+  cudf::strings_column_view scv(column->view());
+
+  std::vector<int32_t> offsets =
+    download<int32_t>(scv.offsets().data<int32_t>(), row_count + 1, stream.value());
+  std::vector<uint8_t> chars =
+    download<uint8_t>(scv.chars_begin(stream), scv.chars_size(stream), stream.value());
+
+  std::vector<std::string> out(row_count);
+  for (uint32_t i = 0; i < row_count; ++i) {
+    int32_t s = offsets[i];
+    int32_t e = offsets[i + 1];
+    out[i].assign(reinterpret_cast<char const*>(chars.data() + s), static_cast<size_t>(e - s));
+  }
+  return out;
+}
+
+/// Decode one synth segment to host strings. FSST / DICT_FSST round-trips.
+std::vector<std::string> decode_one_segment(std::vector<uint8_t> const& bytes,
+                                            duckdb::CompressionType codec,
+                                            uint32_t row_count,
+                                            uint32_t max_string_length)
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                              static_cast<uint32_t>(d_seg.size()),
+                              0,
+                              row_count,
+                              0,
+                              max_string_length};
+  gpu_string_column_decode_input col;
+  col.total_rows = row_count;
+  col.has_nulls  = false;
+  col.data.push_back({codec, {seg}});
+
+  auto column = gpu_decode_strings_column(col, stream.view(), mr);
+  cudf::strings_column_view scv(column->view());
+
+  std::vector<int32_t> offsets =
+    download<int32_t>(scv.offsets().data<int32_t>(), row_count + 1, stream.value());
+  std::vector<std::string> out(row_count);
+  if (scv.chars_size(stream) > 0) {
+    std::vector<uint8_t> chars =
+      download<uint8_t>(scv.chars_begin(stream), scv.chars_size(stream), stream.value());
+    for (uint32_t i = 0; i < row_count; ++i) {
+      int32_t s = offsets[i];
+      int32_t e = offsets[i + 1];
+      out[i].assign(reinterpret_cast<char const*>(chars.data() + s), static_cast<size_t>(e - s));
+    }
+  }
+  return out;
+}
+
+/// Pre-fill the chars buffer with a 0xCC canary, run a malformed segment
+/// through the orchestrator, return decoded chars. Caller asserts every
+/// canary byte was overwritten to 0 (or the row was emitted as empty).
+std::vector<std::string> decode_invalid_with_canary(std::vector<uint8_t> const& bytes,
+                                                    duckdb::CompressionType codec,
+                                                    uint32_t row_count)
+{
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  gpu_string_segment_desc seg{static_cast<uint8_t const*>(d_seg.data()),
+                              static_cast<uint32_t>(d_seg.size()),
+                              0,
+                              row_count,
+                              0,
+                              16u};  // upper-bound stub; chars buffer sized from this
+  gpu_string_column_decode_input col;
+  col.total_rows = row_count;
+  col.has_nulls  = false;
+  col.data.push_back({codec, {seg}});
+
+  auto column = gpu_decode_strings_column(col, stream.view(), mr);
+  cudf::strings_column_view scv(column->view());
+  std::vector<int32_t> offsets =
+    download<int32_t>(scv.offsets().data<int32_t>(), row_count + 1, stream.value());
+
+  std::vector<std::string> out(row_count);
+  if (scv.chars_size(stream) > 0) {
+    std::vector<uint8_t> chars =
+      download<uint8_t>(scv.chars_begin(stream), scv.chars_size(stream), stream.value());
+    for (uint32_t i = 0; i < row_count; ++i) {
+      int32_t s = offsets[i];
+      int32_t e = offsets[i + 1];
+      out[i].assign(reinterpret_cast<char const*>(chars.data() + s), static_cast<size_t>(e - s));
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+// --- DICTIONARY happy path ---
+
+TEST_CASE("gpu_decode_strings DICTIONARY - basic round-trip", "[scan][decode][strings][dictionary]")
+{
+  std::vector<std::string> dict = {"", "alpha", "beta", "gamma"};
+  std::vector<uint32_t> sel     = {1, 2, 3, 1, 2, 3, 1};
+  auto bytes                    = make_dict_segment(dict, sel);
+  auto out = decode_one_dict(bytes, static_cast<uint32_t>(sel.size()), /*max_len=*/8u);
+  REQUIRE(out.size() == sel.size());
+  REQUIRE(out[0] == "alpha");
+  REQUIRE(out[1] == "beta");
+  REQUIRE(out[2] == "gamma");
+  REQUIRE(out[3] == "alpha");
+  REQUIRE(out[4] == "beta");
+  REQUIRE(out[5] == "gamma");
+  REQUIRE(out[6] == "alpha");
+}
+
+TEST_CASE("gpu_decode_strings DICTIONARY - NULL via index 0", "[scan][decode][strings][dictionary]")
+{
+  std::vector<std::string> dict = {"", "x"};  // entry 0 = NULL
+  std::vector<uint32_t> sel     = {0, 1, 0, 1, 1};
+  auto bytes                    = make_dict_segment(dict, sel);
+  auto out = decode_one_dict(bytes, static_cast<uint32_t>(sel.size()), /*max_len=*/4u);
+  REQUIRE(out[0].empty());
+  REQUIRE(out[1] == "x");
+  REQUIRE(out[2].empty());
+  REQUIRE(out[3] == "x");
+  REQUIRE(out[4] == "x");
+}
+
+TEST_CASE("gpu_decode_strings DICTIONARY - empty dict, all NULL",
+          "[scan][decode][strings][dictionary]")
+{
+  std::vector<std::string> dict = {""};
+  std::vector<uint32_t> sel     = {0, 0, 0};
+  auto bytes                    = make_dict_segment(dict, sel);
+  auto out = decode_one_dict(bytes, static_cast<uint32_t>(sel.size()), /*max_len=*/4u);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+// --- Defensive: malformed segments must emit empty rows, not OOB reads. ---
+
+TEST_CASE("gpu_decode_strings DICTIONARY - corrupt index_buffer_offset zero-fills",
+          "[scan][decode][strings][dictionary][defensive]")
+{
+  std::vector<uint8_t> bytes(64, 0);
+  uint32_t hdr[5] = {/*dict_size=*/4u,
+                     /*dict_end=*/64u,
+                     /*idx_buf_off=*/1u << 30,
+                     /*idx_buf_count=*/2u,
+                     /*width=*/1u};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_DICTIONARY, 8);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings DICTIONARY - bitpacking_width > 32 zero-fills",
+          "[scan][decode][strings][dictionary][defensive]")
+{
+  std::vector<uint8_t> bytes(128, 0);
+  uint32_t hdr[5] = {0u, 64u, 28u, 1u, /*width=*/100u};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_DICTIONARY, 4);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings FSST - corrupt dict_end > segment_size zero-fills",
+          "[scan][decode][strings][fsst][defensive]")
+{
+  std::vector<uint8_t> bytes(64, 0);
+  uint32_t hdr[4] = {/*dict_size=*/100u,
+                     /*dict_end=*/1u << 30,
+                     /*bitpacking_width=*/8u,
+                     /*fsst_symbol_table_offset=*/16u};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_FSST, 8);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings FSST - bitpacking_width > 32 zero-fills",
+          "[scan][decode][strings][fsst][defensive]")
+{
+  std::vector<uint8_t> bytes(64, 0);
+  uint32_t hdr[4] = {/*dict_size=*/8u, /*dict_end=*/40u, /*bitpacking_width=*/64u, /*sym_off=*/16u};
+  std::memcpy(bytes.data(), hdr, sizeof(hdr));
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_FSST, 4);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings DICT_FSST - mode > 2 zero-fills",
+          "[scan][decode][strings][dict_fsst][defensive]")
+{
+  std::vector<uint8_t> bytes(128, 0);
+  uint32_t dict_size = 0, dict_count = 1;
+  uint8_t mode = 9, slens_w = 0, didx_w = 0, _pad = 0;
+  uint32_t symtab_size = 0;
+  std::memcpy(bytes.data(), &dict_size, 4);
+  std::memcpy(bytes.data() + 4, &dict_count, 4);
+  bytes[8]  = mode;
+  bytes[9]  = slens_w;
+  bytes[10] = didx_w;
+  bytes[11] = _pad;
+  std::memcpy(bytes.data() + 12, &symtab_size, 4);
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_DICT_FSST, 4);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings DICT_FSST - bytes_size below header throws nothing, zero-fills",
+          "[scan][decode][strings][dict_fsst][defensive]")
+{
+  std::vector<uint8_t> bytes(8, 0xAB);
+  auto out = decode_invalid_with_canary(bytes, CompressionType::COMPRESSION_DICT_FSST, 3);
+  for (auto& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings - unsupported codec throws", "[scan][decode][strings][defensive]")
+{
+  std::vector<uint8_t> bytes(16, 0);
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+  gpu_string_segment_desc seg{
+    static_cast<uint8_t const*>(d_seg.data()), static_cast<uint32_t>(d_seg.size()), 0, 4, 0, 8u};
+  gpu_string_column_decode_input col;
+  col.total_rows = 4;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_CONSTANT, {seg}});
+  REQUIRE_THROWS_WITH(gpu_decode_strings_column(col, stream.view(), mr),
+                      Catch::Contains("viability invariant violated"));
+}
+
+// --- FSST happy path (synthetic segments via libduckdb FSST encoder) ---
+
+TEST_CASE("gpu_decode_strings FSST - basic round-trip", "[scan][decode][strings][fsst]")
+{
+  std::vector<std::string> rows = {
+    "the quick brown fox jumps over the lazy dog",
+    "the quick brown fox jumps over the lazy cat",
+    "the rain in spain falls mainly on the plain",
+    "the quick brown fox jumps over the lazy dog",
+    "lorem ipsum dolor sit amet consectetur adipiscing",
+  };
+  auto bytes = make_fsst_segment(rows);
+  auto out   = decode_one_segment(
+    bytes, CompressionType::COMPRESSION_FSST, static_cast<uint32_t>(rows.size()), /*max_len=*/64u);
+  REQUIRE(out.size() == rows.size());
+  for (size_t i = 0; i < rows.size(); ++i)
+    REQUIRE(out[i] == rows[i]);
+}
+
+TEST_CASE("gpu_decode_strings FSST - many distinct strings", "[scan][decode][strings][fsst]")
+{
+  uint32_t const ROWS = 10000;  // bench-scale verify
+  std::vector<std::string> rows(ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i) {
+    rows[i] = "row_" + std::to_string(i) + "_data_" + std::to_string(i * 31u);
+  }
+  auto bytes = make_fsst_segment(rows);
+  auto out   = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_FSST,
+                                ROWS,
+                                /*max_len=*/64u);
+  REQUIRE(out.size() == ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i) {
+    if (out[i] != rows[i]) {
+      FAIL("FSST round-trip mismatch at row=" << i << " expected='" << rows[i] << "' got='"
+                                              << out[i] << "'");
+    }
+  }
+}
+
+// --- DICT_FSST happy path: modes 0 (raw dict), 1 (FSST dict), 2 (no dict) ---
+
+TEST_CASE("gpu_decode_strings DICT_FSST mode 0 (DICTIONARY) - basic round-trip",
+          "[scan][decode][strings][dict_fsst]")
+{
+  std::vector<std::string> dict = {"", "alpha", "beta", "gamma"};
+  std::vector<uint32_t> sel     = {1, 2, 3, 0, 1, 2};
+  auto bytes                    = make_dict_fsst_segment(dict, sel, /*mode=*/0);
+  auto out                      = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_DICT_FSST,
+                                static_cast<uint32_t>(sel.size()),
+                                /*max_len=*/8u);
+  REQUIRE(out.size() == sel.size());
+  REQUIRE(out[0] == "alpha");
+  REQUIRE(out[1] == "beta");
+  REQUIRE(out[2] == "gamma");
+  REQUIRE(out[3].empty());  // sel=0 → NULL/empty
+  REQUIRE(out[4] == "alpha");
+  REQUIRE(out[5] == "beta");
+}
+
+TEST_CASE("gpu_decode_strings DICT_FSST mode 1 (DICT_FSST) - basic round-trip",
+          "[scan][decode][strings][dict_fsst]")
+{
+  std::vector<std::string> dict = {
+    "", "the quick brown fox jumps", "the lazy dog sleeps", "lorem ipsum dolor sit amet"};
+  std::vector<uint32_t> sel = {1, 2, 3, 1, 0, 2};
+  auto bytes                = make_dict_fsst_segment(dict, sel, /*mode=*/1);
+  auto out                  = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_DICT_FSST,
+                                static_cast<uint32_t>(sel.size()),
+                                /*max_len=*/64u);
+  REQUIRE(out.size() == sel.size());
+  REQUIRE(out[0] == dict[1]);
+  REQUIRE(out[1] == dict[2]);
+  REQUIRE(out[2] == dict[3]);
+  REQUIRE(out[3] == dict[1]);
+  REQUIRE(out[4].empty());  // sel=0 → NULL/empty
+  REQUIRE(out[5] == dict[2]);
+}
+
+TEST_CASE("gpu_decode_strings DICT_FSST mode 2 (FSST_ONLY) - basic round-trip",
+          "[scan][decode][strings][dict_fsst]")
+{
+  std::vector<std::string> rows = {
+    "alpha apple",
+    "beta banana",
+    "gamma grape",
+    "delta dragonfruit",
+  };
+  std::vector<std::string> entries(rows.size() + 1);
+  entries[0] = "";
+  for (size_t i = 0; i < rows.size(); ++i)
+    entries[i + 1] = rows[i];
+  auto bytes = make_dict_fsst_segment(entries, /*selections=*/{}, /*mode=*/2);
+  auto out   = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_DICT_FSST,
+                                static_cast<uint32_t>(rows.size()),
+                                /*max_len=*/32u);
+  REQUIRE(out.size() == rows.size());
+  for (size_t i = 0; i < rows.size(); ++i)
+    REQUIRE(out[i] == rows[i]);
+}
+
+TEST_CASE("gpu_decode_strings DICT_FSST mode 1 - bench-scale verify",
+          "[scan][decode][strings][dict_fsst][verify]")
+{
+  uint32_t const DICT = 256;
+  uint32_t const ROWS = 50000;
+  std::vector<std::string> dict(DICT);
+  dict[0] = "";
+  for (uint32_t k = 1; k < DICT; ++k) {
+    dict[k] = "entry_" + std::to_string(k) + "_payload_" + std::to_string(k * 17u);
+  }
+  std::vector<uint32_t> sel(ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i)
+    sel[i] = (i % (DICT - 1u)) + 1u;
+  auto bytes = make_dict_fsst_segment(dict, sel, /*mode=*/1);
+  auto out   = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_DICT_FSST,
+                                ROWS,
+                                /*max_len=*/64u);
+  REQUIRE(out.size() == ROWS);
+  for (uint32_t i = 0; i < ROWS; ++i) {
+    if (out[i] != dict[sel[i]]) {
+      FAIL("DICT_FSST mode-1 mismatch at row=" << i << " sel=" << sel[i] << " expected='"
+                                               << dict[sel[i]] << "' got='" << out[i] << "'");
+    }
+  }
+}

--- a/test/cpp/scan/test_gpu_decode_strings.cpp
+++ b/test/cpp/scan/test_gpu_decode_strings.cpp
@@ -50,6 +50,7 @@ using sirius::test::decode::download;
 using sirius::test::decode::strings::make_dict_fsst_segment;
 using sirius::test::decode::strings::make_dict_segment;
 using sirius::test::decode::strings::make_fsst_segment;
+using sirius::test::decode::strings::make_uncompressed_segment;
 
 namespace {
 
@@ -131,9 +132,9 @@ std::vector<std::string> decode_one_segment(std::vector<uint8_t> const& bytes,
   return out;
 }
 
-/// Pre-fill the chars buffer with a 0xCC canary, run a malformed segment
-/// through the orchestrator, return decoded chars. Caller asserts every
-/// canary byte was overwritten to 0 (or the row was emitted as empty).
+/// Run a malformed segment through the orchestrator and return the decoded
+/// strings. Caller asserts every row is empty — the malformed-header path
+/// zero-fills lengths so no chars are emitted.
 std::vector<std::string> decode_invalid_with_canary(std::vector<uint8_t> const& bytes,
                                                     duckdb::CompressionType codec,
                                                     uint32_t row_count)
@@ -172,6 +173,77 @@ std::vector<std::string> decode_invalid_with_canary(std::vector<uint8_t> const& 
 }
 
 }  // namespace
+
+// --- UNCOMPRESSED happy path ---
+
+TEST_CASE("gpu_decode_strings UNCOMPRESSED - all empty strings",
+          "[scan][decode][strings][uncompressed]")
+{
+  std::vector<std::string> rows(8, "");
+  auto bytes = make_uncompressed_segment(rows);
+  auto out   = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_UNCOMPRESSED,
+                                static_cast<uint32_t>(rows.size()),
+                                /*max_len=*/4u);
+  REQUIRE(out.size() == rows.size());
+  for (auto const& s : out)
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("gpu_decode_strings UNCOMPRESSED - varied lengths including empty",
+          "[scan][decode][strings][uncompressed]")
+{
+  std::vector<std::string> rows = {"", "x", "", "abcd", "longer-string-here", "", "z"};
+  auto bytes                    = make_uncompressed_segment(rows);
+  auto out                      = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_UNCOMPRESSED,
+                                static_cast<uint32_t>(rows.size()),
+                                /*max_len=*/32u);
+  REQUIRE(out.size() == rows.size());
+  for (size_t i = 0; i < rows.size(); ++i) {
+    REQUIRE(out[i] == rows[i]);
+  }
+}
+
+TEST_CASE("gpu_decode_strings UNCOMPRESSED - many rows across multiple CTAs",
+          "[scan][decode][strings][uncompressed]")
+{
+  // 4096 rows exercises multi-CTA dispatch + cumulative offset growth.
+  std::vector<std::string> rows;
+  rows.reserve(4096);
+  for (uint32_t i = 0; i < 4096; ++i) {
+    rows.push_back("row_" + std::to_string(i));
+  }
+  auto bytes = make_uncompressed_segment(rows);
+  auto out   = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_UNCOMPRESSED,
+                                static_cast<uint32_t>(rows.size()),
+                                /*max_len=*/16u);
+  REQUIRE(out.size() == rows.size());
+  for (size_t i = 0; i < rows.size(); ++i) {
+    REQUIRE(out[i] == rows[i]);
+  }
+}
+
+// --- UNCOMPRESSED defensive path ---
+
+TEST_CASE("gpu_decode_strings UNCOMPRESSED - segment_size below header zero-fills",
+          "[scan][decode][strings][uncompressed][defensive]")
+{
+  // Build a valid segment then truncate below the [dict_size:4][dict_end:4] + offsets
+  // region. The kernel's bounds check (`limit >= 8u + end_row * 4u`) should
+  // detect this and zero-fill all lengths.
+  std::vector<std::string> rows = {"abc", "defg", "hi"};
+  auto bytes                    = make_uncompressed_segment(rows);
+  bytes.resize(8);  // header only; offsets array missing
+  auto out = decode_one_segment(bytes,
+                                CompressionType::COMPRESSION_UNCOMPRESSED,
+                                static_cast<uint32_t>(rows.size()),
+                                /*max_len=*/8u);
+  REQUIRE(out.size() == rows.size());
+  for (auto const& s : out)
+    REQUIRE(s.empty());
+}
 
 // --- DICTIONARY happy path ---
 


### PR DESCRIPTION
# Summary

GPU decode kernels for DuckDB's four on-disk varchar formats (UNCOMPRESSED / DICTIONARY / FSST / DICT_FSST) into a cudf strings column. Two-pass shape per column: per-codec length kernel → `cub::DeviceScan::ExclusiveSum` over the unified lengths array → per-codec gather. One column's mixed codecs share one prefix sum. Sibling of #737, #764, #773; stacks on #736.

## DuckDB UNCOMPRESSED varchar on-disk format

```
byte 0   4         8                               dict_end           seg_end
│        │         │                               │                  │
├─uint32─┼─uint32──┼── int32[end_row] ─────────────┼── packed chars ──┤
│ dict   │ dict_   │  backward-cumulative offsets, │  written in      │
│ size   │ end     │  signed (sign bit unused for  │  REVERSE order   │
│        │         │  storage scans → take abs())  │  ending at dict_end
└─offset 0
```

Length(i) = `|offsets[i]| - |offsets[i-1]|`. Bytes for row i live in `[dict_end - |offsets[i]|, dict_end - |offsets[i-1]|)`.

## DuckDB DICTIONARY on-disk format

```
byte 0       20                                                       seg_end
│            │                                                        │
├── header ──┼── selection ──┼── index_buffer ──┼────── dict ─────────┤
│   20 B     │  bitpacked    │  forward-cumul   │  entries packed     │
│            │  row → idx    │  uint32[count]   │  in REVERSE order   │
│            │               │                  │  ending at dict_end
└─offset 0   └─sizeof(hdr)   └─hdr.index_buffer_offset       hdr.dict_end ─┘
```

`idx == 0` is reserved for NULL (length 0). Length(i) = `idx_buf[i] - idx_buf[i-1]`; bytes for entry i live in `[dict_end - idx_buf[i], dict_end - idx_buf[i-1])`.

## DuckDB FSST on-disk format

```
byte 0       16                                                       seg_end
│            │                                                        │
├── header ──┼── comp_lengths ──┼── symbol_table ──┼── compressed ────┤
│   16 B     │  bitpacked per   │  opaque blob,    │  rows packed in  │
│            │  row → comp_len  │  imported via    │  REVERSE order   │
│            │                  │  duckdb_fsst_    │  ending at dict_end
│            │                  │  import (host)
└─offset 0
                                ^                                     ^
                                hdr.fsst_symbol_table_offset          hdr.dict_end
```

Compressed bytes are not row-addressable on their own — pass 1 walks the bitpacked comp_lengths to build a per-row cumulative compressed-byte offset, then pass 2 reads `[dict_end - cum[i], dict_end - cum[i-1])` for row i.

## DuckDB DICT_FSST on-disk format

```
byte 0       16
│            │
├── header ──┼── dict ──┼── symtab ──┼── string_lengths ──┼── dict_indices ──┤
│   16 B     │          │            │  bitpacked per     │  bitpacked per   │
│            │          │            │  dict entry        │  row → dict idx  │
│            │          │            │                    │  (absent in mode-2)
└─offset 0   └─off_dict └─off_symtab └─off_slens          └─off_didx
```

All four regions are 8-byte aligned (DuckDB `AlignValue`). Three modes (`hdr.mode`):

| mode | name | dict bytes | gather |
|---|---|---|---|
| 0 | DICTIONARY | raw | memcpy from dict |
| 1 | DICT_FSST | FSST-compressed | predecode kernel decompresses dict once; row gather is memcpy from predecode buffer |
| 2 | FSST_ONLY | FSST-compressed | no `dict_indices` — row i → entry i+1; per-row inline FSST decompress |

`dict_idx == 0` ⇒ NULL (modes 0/1). DuckDB ships `COMPRESSION_EMPTY` validity for these segments, which the overlay path skips — `kernel_dict_fsst_mark_nulls` folds them into the column mask.

## The decode in one picture

```
gpu_string_column_decode_input  (mixed-codec runs for one column)
   │
   │  prepare_*   ─────────────►  D2H header + symbol-table reads (FSST only)
   │              host             host import of opaque symtab blobs
   ▼
prepared_{uncomp, dict, fsst, dict_fsst}   ── upload to device ──┐
                                                                  │
   pass 1  (lengths)                                              │
   ───────────────                                                │
   kernel_compute_lengths_uncomp        per chunk                 │
   kernel_compute_lengths_dict          per chunk                 │
   kernel_compute_lengths_fsst          per segment (A: unpack    │
                                          comp_len, B: in-CTA     │
                                          BlockScan)              │
   kernel_compute_lengths_fsst_phase_c  per chunk (walk           │
                                          compressed bytes → len) │
   kernel_compute_lengths_dict_fsst     per chunk                 │
                                                                  │
        all kernels write into d_lengths[total_rows + 1]          │
                                                                  ▼
                          cub::DeviceScan::ExclusiveSum   ►  d_offsets[total_rows + 1]
                          (one scan over the merged array — d_offsets[total_rows]
                           naturally lands at total chars)
                                                                  │
   pass 2  (gather)                                               │
   ──────────────                                                 │
   kernel_gather_uncomp                                           │
   kernel_gather_dict           (short rows: thread-per-row)      │
   kernel_gather_dict_warp      (long rows:  warp-per-row, stride-4)
   kernel_predecode_dict_fsst   (mode 1 only — one decode per dict entry)
   kernel_gather_fsst_chunked   (warp_decode_fsst per row)
   kernel_gather_dict_fsst      (modes 0/1 memcpy; mode 2 inline warp_decode_fsst)
                                                                  │
                                                                  ▼
                                                              d_chars
                                                                  │
   validity                                                       │
   ────────                                                       │
   overlay_validity_run (UNCOMPRESSED validity → null mask)       │
   kernel_dict_fsst_mark_nulls (fold idx==0 NULLs)                │
                                                                  ▼
                                                  cudf::make_strings_column
```

## Pass-1 vs pass-2 chunking

```
HOST                                          STREAM
─────                                         ─────────────
expand_chunks(descs, target_ctas)
  splits per-segment descriptors into
  row sub-ranges so the kernel grid fills
  the SMs at small-segment counts.
  chunk_size rounded down to a multiple of
  WARP_SIZE for store coalescing.
                                              pass 1 → d_lengths
descriptors uploaded once               H2D   pass 2 → d_chars
                                              (same chunked descriptors
                                               reused for both passes)
```

Per-row work (lengths, gather) is chunked. Per-dict work (FSST length-pass A+B, DICT_FSST predecode, mark_nulls) stays one-CTA-per-segment so dictionaries are not redecoded per chunk.

## DICTIONARY gather — hybrid kernel choice

Dictionary gather is a memcpy; the design question is how many threads cooperate per row. Two kernels, picked per-segment from walker-supplied `max_string_length`, cutover at 64 B (mirrors cuDF's strings-gather split with headroom):

```
short rows  (max_string_length < 64):
  kernel_gather_dict
    1 thread per row, 256 rows per CTA, grid-stride within the CTA
    launch-bound — many small copies per CTA amortise the launch cost

long rows  (max_string_length >= 64):
  kernel_gather_dict_warp
    1 warp per row; lanes coalesce into stride-4 (128 B) byte copies
    bandwidth-bound — each row is a real memory-bound copy
```

Same length kernel for both; only pass 2 forks.

## FSST per-warp decode (`warp_decode_fsst`)

Each compressed row is decoded by one warp in 32-byte input chunks. Per chunk: warp-scan for per-lane output offsets → scatter symbols into a per-warp shmem slab (256 B max) → coalesced stride-4 drain to `dst`. The shmem-slab flush per chunk caps shmem use; if the cumulative output exceeds 32 B we just do more chunks.

The opaque FSST symbol table (`unsigned long long symbol[255]`) is split lo/hi into two `uint32` shmem arrays so the common ≤ 4-byte symbol load is one bank read instead of two. `sm_sym_hi` is only read when `len[code] > 4`.

Escape handling: `code == 255` is the escape sentinel — the following raw byte is the literal output. The decoder uses one `__shfl_up_sync` per chunk to broadcast "was the lane to my left an escape?" so the literal-after-escape lane can emit a 1-byte symbol; `prev_chunk_last_is_esc` carries the state across chunk boundaries.

## Malformed input → zero-fill

The orchestrator never throws on malformed segment metadata — header parsers return `false`, kernels zero-fill the trusted descriptor row count, the prefix sum sees length 0 for those rows, and the gather pass writes nothing for them. Throws on:

- `total_rows > cudf::size_type::max`
- validity codec ≠ UNCOMPRESSED (viability-checker invariant)
- per-segment chars-upper-bound > `INT32_MAX` (cudf strings offset limit)
- post-scan `total_chars > INT32_MAX` after the chars-buffer sync path

| Codec | Detected by | Condition |
|---|---|---|
| UNCOMPRESSED | length pass | `bytes_size < 8 + end_row * 4` |
| DICTIONARY | header parse | `dict_end > limit`, `index_buffer_offset + index_buffer_count*4 > limit`, `bw > 32` |
| DICTIONARY | per-row | `sel >= index_buffer_count` (sel == 0 ⇒ NULL, not malformed) |
| FSST | header parse | `dict_end > limit`, `fsst_symbol_table_offset >= dict_end`, `bw > 32` |
| FSST | per-row in phase C | `cum > dict_end` or `prev > cum` (corrupt prefix sum) |
| FSST | per-row in phase C | trailing escape with no literal byte (drops the escape, stays in sync with gather) |
| DICT_FSST | header / region parse | `mode > 2`, region offsets land past `bytes_size` (mode ≠ FSST_ONLY) |
| DICT_FSST | per-row | `idx >= dict_count` (idx == 0 ⇒ NULL in modes 0/1, not malformed) |

Output buffer (`d_chars`) is allocated uninitialised; the zero-fill discipline is the only thing between a corrupt segment and leaking prior device contents.

## Chars-buffer sizing

`alloc_chars` is taken from the host-side upper bound `Σ row_count × max_string_length` when it's both below `INT32_MAX` and below 512 MiB (avoids the sync). Above 512 MiB, or when any segment ships `max_string_length == 0` (walker-unknown), the path syncs and reads `d_offsets[total_rows]` for the exact total. The 512 MiB threshold guards against a pathological `max_string_length` forcing a GB-class over-allocation.

## Test plan

`test/cpp/scan/test_gpu_decode_strings.cpp` — 20 catch2 tests under `[scan][decode][strings]`:

- Round-trip per codec: UNCOMPRESSED, DICTIONARY (short and long rows), FSST, DICT_FSST modes 0 / 1 / 2
- NULL handling: dict-idx-0 path, inline NULLs in DICT_FSST modes 0/1, all-NULL column, mixed valid/null
- Malformed-segment defensive paths: every row in the table above has a canary test that pre-fills `d_chars` with `0xCC` and requires every output byte to be zero post-decode
- Mixed-codec single column (DICTIONARY + FSST + DICT_FSST runs share one prefix sum)

`test/cpp/scan/bench_decode_codecs.cpp` — string-codec microbenches under `[!benchmark][scan][decode][strings]` (5 cases: 2× DICTIONARY shapes, 2× FSST shapes, 1× DICT_FSST mode-1). Real-segment fixtures loadable via per-codec env vars (`SIRIUS_BENCH_FSST_FIXTURE` + `SIRIUS_BENCH_FSST_ROWS`, `SIRIUS_BENCH_FSST_LONG_FIXTURE` + `_ROWS`, `SIRIUS_BENCH_DICT_FSST_FIXTURE` + `_ROWS`) for production-shape numbers.
