### PR TITLE
Feature: Per operator memory estimate for when we don't have historical info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_projection.cpp
     test/cpp/operator/test_physical_result_collector.cpp
     test/cpp/operator/test_physical_table_scan.cpp
+    test/cpp/operator/test_no_history_peak_memory_estimate.cpp
     test/cpp/operator/test_physical_top_n.cpp
     test/cpp/operator/test_physical_ungrouped_aggregate.cpp
     test/cpp/parallel/test_task_executor.cpp

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -159,6 +159,7 @@ void downgrade_executor::processing_loop()
     size_t host_end_idx = target_spaces.size();
     auto disk_spaces =
       _reservation_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK);
+    bool disk_not_configured = disk_spaces.empty();
     for (auto* ds : disk_spaces) {
       target_spaces.push_back(ds);
     }
@@ -292,6 +293,14 @@ void downgrade_executor::processing_loop()
 
     // Wait for all in-flight work to finish (predicate also checked in workers)
     _pool->wait_all();
+
+    if (disk_not_configured && !req->satisfied.load()) {
+      SIRIUS_LOG_WARN(
+        "[downgrade] [{}] downgrade request not satisfied and disk memory space is not configured; "
+        "data cannot be spilled to disk. Consider configuring a disk memory space to enable "
+        "spilling.",
+        _source_label);
+    }
 
     // === Logging ===
     auto total_bytes   = req->bytes_freed.load(std::memory_order_relaxed);

--- a/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp
@@ -116,6 +116,15 @@ class sirius_gpu_parquet_scan_operator : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
+  /**
+   * @brief Estimate peak GPU memory for this operator when no execution history is available.
+   *
+   * @param stats  Batch count and total input bytes for the task about to run.
+   * @return Estimated peak GPU bytes this operator will allocate.
+   */
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& stats) const override;
+
  private:
   /// Read the parquet byte ranges described by @p scan_data and apply the post-read
   /// filter (when not pushed down) and the scan_plan's output assembly. Used by

--- a/src/include/op/sirius_physical_concat.hpp
+++ b/src/include/op/sirius_physical_concat.hpp
@@ -63,6 +63,9 @@ class sirius_physical_concat : public sirius_physical_partition_consumer_operato
   //! before the join so the hash join sees a single build batch.
   void set_concat_all(bool concat_all);
 
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& stats) const override;
+
  private:
   sirius_physical_operator* _parent_op;
   bool _is_build;

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -220,6 +220,17 @@ class partitioned_operator_data : public pipelineable_operator_data {
   std::size_t _partition_idx = 0;
 };
 
+/**
+ * @brief Input statistics passed to no_history_peak_memory_estimate().
+ *
+ * Carries the two dimensions that operator overrides typically condition on:
+ * the number of input batches and the total uncompressed byte count.
+ */
+struct input_stats {
+  std::size_t num_batches = 0;
+  std::size_t bytes       = 0;
+};
+
 //! sirius_physical_operator is the base class of the physical operators present in the
 //! execution plan
 class sirius_physical_operator {
@@ -278,6 +289,28 @@ class sirius_physical_operator {
 
  public:
   // Operator interface
+
+  /**
+   * @brief Estimate peak GPU memory for this operator when no execution history is available.
+   *
+   * Called by gpu_pipeline_task::get_estimated_reservation_size_info() on the first task
+   * execution for a pipeline (before any history records exist). The default is 2× the
+   * input bytes, matching the historical fallback. Overrides may return a lower value for
+   * operators that are known to be pass-throughs under certain conditions (e.g. concat with
+   * a single batch, or partition with a single partition), or a higher value for operators
+   * that expand input significantly (e.g. decompressing parquet).
+   *
+   * A return value of 0 means "no additional peak memory expected"; the caller will fall
+   * back to the 2× default when every operator in the pipeline returns 0.
+   *
+   * @param stats  Batch count and total input bytes for the task about to run.
+   * @return Estimated peak GPU bytes this operator will allocate.
+   */
+  [[nodiscard]] virtual std::size_t no_history_peak_memory_estimate(const input_stats& stats) const
+  {
+    return stats.bytes * 2;
+  }
+
   virtual std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                                  rmm::cuda_stream_view stream);
 

--- a/src/include/op/sirius_physical_parquet_scan.hpp
+++ b/src/include/op/sirius_physical_parquet_scan.hpp
@@ -115,6 +115,9 @@ class sirius_physical_parquet_scan : public sirius_physical_operator {
 
  public:
   bool is_source() const override { return true; }
+
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& stats) const override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -88,6 +88,9 @@ class sirius_physical_partition : public sirius_physical_operator {
 
   void set_num_partitions(int num_partitions);
 
+  [[nodiscard]] std::size_t no_history_peak_memory_estimate(
+    const op::input_stats& stats) const override;
+
  private:
   void get_partition_keys_and_type(sirius_physical_operator* op, bool is_build = false);
 

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -80,6 +80,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
 
   // Slice from the reordered table to create separate table partitions.
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(num_partitions);
   std::vector<cudf::size_type> slice_indices;
   slice_indices.reserve(num_partitions * 2);
   for (int i = 0; i < num_partitions; ++i) {

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -272,4 +272,10 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
   return std::make_unique<pipelineable_operator_data>(std::move(batches));
 }
 
+std::size_t sirius_gpu_parquet_scan_operator::no_history_peak_memory_estimate(
+  const op::input_stats& stats) const
+{
+  return stats.bytes * 10;
+}
+
 }  // namespace sirius::op::scan

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -275,7 +275,7 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
 std::size_t sirius_gpu_parquet_scan_operator::no_history_peak_memory_estimate(
   const op::input_stats& stats) const
 {
-  return stats.bytes * 10;
+  return stats.bytes * 8;
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -237,5 +237,12 @@ void sirius_physical_concat::set_concat_all(bool concat_all)
   _concat_all = concat_all;
 }
 
+std::size_t sirius_physical_concat::no_history_peak_memory_estimate(
+  const op::input_stats& stats) const
+{
+  if (stats.num_batches <= 1) { return 0; }
+  return stats.bytes;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -126,7 +126,7 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(
 std::size_t sirius_physical_parquet_scan::no_history_peak_memory_estimate(
   const op::input_stats& stats) const
 {
-  return stats.bytes * 10;
+  return stats.bytes * 8;
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -123,5 +123,11 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(
   }
 }
 
+std::size_t sirius_physical_parquet_scan::no_history_peak_memory_estimate(
+  const op::input_stats& stats) const
+{
+  return stats.bytes * 10;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -335,5 +335,12 @@ std::unique_ptr<operator_data> sirius_physical_partition::get_next_task_input_da
   return sirius_physical_operator::get_next_task_input_data();
 }
 
+std::size_t sirius_physical_partition::no_history_peak_memory_estimate(
+  const op::input_stats& stats) const
+{
+  if (_num_partitions.has_value() && *_num_partitions == 1) { return 0; }
+  return stats.bytes;
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -339,7 +339,7 @@ std::size_t sirius_physical_partition::no_history_peak_memory_estimate(
   const op::input_stats& stats) const
 {
   if (_num_partitions.has_value() && *_num_partitions == 1) { return 0; }
-  return stats.bytes;
+  return stats.bytes * 2;
 }
 
 }  // namespace op

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -241,14 +241,6 @@ void gpu_pipeline_executor::manager_loop()
           if (cur_local && cur_local->original_task_id.has_value()) {
             next_retry_count = cur_local->retry_count + 1;
             orig_task_id     = cur_local->original_task_id.value();
-          } else {
-            SIRIUS_LOG_ERROR(
-              "GPU Pipeline Executor: Failed to cast task local state for OOM reschedule");
-            // if (_completion_handler) {
-            //   _completion_handler->report_error(
-            //     "GPU Pipeline Executor: Failed to cast task local state for OOM reschedule");
-            // }
-            // return;
           }
 
           static constexpr uint32_t MAX_OOM_RETRIES = 10;

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -241,6 +241,14 @@ void gpu_pipeline_executor::manager_loop()
           if (cur_local && cur_local->original_task_id.has_value()) {
             next_retry_count = cur_local->retry_count + 1;
             orig_task_id     = cur_local->original_task_id.value();
+          } else {
+            SIRIUS_LOG_ERROR(
+              "GPU Pipeline Executor: Failed to cast task local state for OOM reschedule");
+            // if (_completion_handler) {
+            //   _completion_handler->report_error(
+            //     "GPU Pipeline Executor: Failed to cast task local state for OOM reschedule");
+            // }
+            // return;
           }
 
           static constexpr uint32_t MAX_OOM_RETRIES = 10;

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -465,8 +465,27 @@ pipeline::reservation_size_info gpu_pipeline_task::get_estimated_reservation_siz
   info.input_basis                = input_basis;
   info.bytes_to_materialize_input = bytes_to_materialize;
   info.had_history                = peak_opt.has_value();
-  info.peak_memory_estimate       = peak_opt.value_or(input_basis * 2);
-  info.reservation_size           = info.peak_memory_estimate + bytes_to_materialize;
+
+  if (peak_opt.has_value()) {
+    info.peak_memory_estimate = *peak_opt;
+  } else {
+    std::size_t num_batches = 0;
+    if (auto* pd = dynamic_cast<const op::pipelineable_operator_data*>(ls._input_data.get())) {
+      num_batches = pd->get_data_batches().size();
+    }
+    const op::input_stats stats{num_batches, input_basis};
+
+    std::size_t max_estimate = 0;
+    if (auto* pipeline = gs.get_pipeline()) {
+      for (auto& op_ref : pipeline->get_operators()) {
+        max_estimate = std::max(max_estimate, op_ref.get().no_history_peak_memory_estimate(stats));
+      }
+    }
+    // If every operator returned 0 (all pass-throughs), fall back to the 2× default.
+    info.peak_memory_estimate = (max_estimate > 0) ? max_estimate : (input_basis * 2);
+  }
+
+  info.reservation_size = info.peak_memory_estimate + bytes_to_materialize;
   return info;
 }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -201,6 +201,16 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   memory_manager_ = std::make_unique<sirius::memory::sirius_memory_reservation_manager>(
     config_.get_memory_space_configs());
 
+  {
+    auto disk_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::DISK);
+    if (disk_spaces.empty()) {
+      SIRIUS_LOG_WARN(
+        "SiriusContext: disk memory space is not configured; spilling GPU or HOST data to disk is "
+        "disabled. If queries run out of GPU/HOST memory, downgrades to disk will not be "
+        "possible.");
+    }
+  }
+
   // Configure cuDF to use our pinned slab allocator for small internal host buffers
   // (e.g. column_device_view metadata arrays in cudf::concatenate).  This eliminates
   // the pageable H2D transfers that cuDF issues by default.

--- a/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
+++ b/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -146,7 +146,7 @@ TEST_CASE("partition no_history_peak_memory_estimate: num_partitions unset retur
     sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
     0,
     f.hash_join.get()};
-  REQUIRE(part.no_history_peak_memory_estimate({1, 1000}) == 1000);
+  REQUIRE(part.no_history_peak_memory_estimate({1, 1000}) == 2000);
 }
 
 TEST_CASE("partition no_history_peak_memory_estimate: 1 partition returns 0",
@@ -170,7 +170,7 @@ TEST_CASE("partition no_history_peak_memory_estimate: 2 partitions returns bytes
     0,
     f.hash_join.get()};
   part.set_num_partitions(2);
-  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 2000);
+  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 4000);
 }
 
 TEST_CASE("partition no_history_peak_memory_estimate: many partitions returns bytes",
@@ -182,14 +182,14 @@ TEST_CASE("partition no_history_peak_memory_estimate: many partitions returns by
     0,
     f.hash_join.get()};
   part.set_num_partitions(8);
-  REQUIRE(part.no_history_peak_memory_estimate({5, 4096}) == 4096);
+  REQUIRE(part.no_history_peak_memory_estimate({5, 4096}) == 8192);
 }
 
 // ---------------------------------------------------------------------------
 // sirius_physical_parquet_scan
 // ---------------------------------------------------------------------------
 
-TEST_CASE("parquet scan no_history_peak_memory_estimate returns 10× bytes",
+TEST_CASE("parquet scan no_history_peak_memory_estimate returns 8x bytes",
           "[no_history_peak_memory_estimate][parquet_scan]")
 {
   // Constructed with all-empty/nullptr args; constructor body is a no-op when
@@ -209,6 +209,6 @@ TEST_CASE("parquet scan no_history_peak_memory_estimate returns 10× bytes",
                                     /*physical_table_scan=*/nullptr};
 
   REQUIRE(scan.no_history_peak_memory_estimate({0, 0}) == 0);
-  REQUIRE(scan.no_history_peak_memory_estimate({1, 100}) == 1000);
-  REQUIRE(scan.no_history_peak_memory_estimate({4, 512}) == 5120);
+  REQUIRE(scan.no_history_peak_memory_estimate({1, 100}) == 800);
+  REQUIRE(scan.no_history_peak_memory_estimate({4, 512}) == 4096);
 }

--- a/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
+++ b/test/cpp/operator/test_no_history_peak_memory_estimate.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch.hpp"
+#include "expression/join_condition.hpp"
+#include "helper/type_conversions.hpp"
+#include "op/sirius_physical_concat.hpp"
+#include "op/sirius_physical_operator.hpp"
+#include "op/sirius_physical_parquet_scan.hpp"
+#include "op/sirius_physical_partition.hpp"
+
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/operator/logical_comparison_join.hpp>
+
+using namespace sirius::op;
+
+namespace {
+
+// Minimal concrete subclass for testing the base-class default.
+class stub_operator : public sirius_physical_operator {
+ public:
+  stub_operator() : sirius_physical_operator(SiriusPhysicalOperatorType::FILTER, {}, 0) {}
+  std::string get_name() const override { return "stub"; }
+};
+
+// Builds a minimal hash join (INNER) used as a parent_op for concat and partition.
+struct hash_join_fixture {
+  duckdb::unique_ptr<duckdb::LogicalComparisonJoin> logical_join;
+  duckdb::unique_ptr<sirius_physical_hash_join> hash_join;
+};
+
+hash_join_fixture make_hash_join()
+{
+  hash_join_fixture f;
+  f.logical_join        = duckdb::make_uniq<duckdb::LogicalComparisonJoin>(duckdb::JoinType::INNER);
+  f.logical_join->types = {duckdb::LogicalType::INTEGER};
+
+  auto left = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::PROJECTION,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0);
+  auto right = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::PROJECTION,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0);
+
+  duckdb::vector<duckdb::JoinCondition> conditions;
+  duckdb::JoinCondition cond;
+  cond.left  = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond.right = duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0);
+  cond.comparison = duckdb::ExpressionType::COMPARE_EQUAL;
+  conditions.push_back(std::move(cond));
+
+  f.hash_join = duckdb::make_uniq<sirius_physical_hash_join>(
+    *f.logical_join,
+    std::move(left),
+    std::move(right),
+    sirius::wrap_join_conditions(std::move(conditions)),
+    duckdb::JoinType::INNER,
+    duckdb::vector<duckdb::idx_t>{},
+    duckdb::vector<duckdb::idx_t>{},
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{}),
+    0,
+    nullptr);
+  return f;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Base class — default 2× bytes
+// ---------------------------------------------------------------------------
+
+TEST_CASE("default no_history_peak_memory_estimate returns 2× bytes",
+          "[no_history_peak_memory_estimate][base]")
+{
+  stub_operator op;
+  REQUIRE(op.no_history_peak_memory_estimate({0, 0}) == 0);
+  REQUIRE(op.no_history_peak_memory_estimate({1, 100}) == 200);
+  REQUIRE(op.no_history_peak_memory_estimate({3, 1000}) == 2000);
+}
+
+// ---------------------------------------------------------------------------
+// sirius_physical_concat
+// ---------------------------------------------------------------------------
+
+TEST_CASE("concat no_history_peak_memory_estimate: 0 batches returns 0",
+          "[no_history_peak_memory_estimate][concat]")
+{
+  auto f = make_hash_join();
+  sirius_physical_concat concat{
+    sirius::from_duckdb_vec(f.logical_join->types), 0, f.hash_join.get(), /*is_build=*/false};
+  REQUIRE(concat.no_history_peak_memory_estimate({0, 500}) == 0);
+}
+
+TEST_CASE("concat no_history_peak_memory_estimate: 1 batch returns 0",
+          "[no_history_peak_memory_estimate][concat]")
+{
+  auto f = make_hash_join();
+  sirius_physical_concat concat{
+    sirius::from_duckdb_vec(f.logical_join->types), 0, f.hash_join.get(), false};
+  REQUIRE(concat.no_history_peak_memory_estimate({1, 500}) == 0);
+}
+
+TEST_CASE("concat no_history_peak_memory_estimate: 2 batches returns bytes",
+          "[no_history_peak_memory_estimate][concat]")
+{
+  auto f = make_hash_join();
+  sirius_physical_concat concat{
+    sirius::from_duckdb_vec(f.logical_join->types), 0, f.hash_join.get(), false};
+  REQUIRE(concat.no_history_peak_memory_estimate({2, 500}) == 500);
+}
+
+TEST_CASE("concat no_history_peak_memory_estimate: many batches returns bytes",
+          "[no_history_peak_memory_estimate][concat]")
+{
+  auto f = make_hash_join();
+  sirius_physical_concat concat{
+    sirius::from_duckdb_vec(f.logical_join->types), 0, f.hash_join.get(), false};
+  REQUIRE(concat.no_history_peak_memory_estimate({10, 1024}) == 1024);
+}
+
+// ---------------------------------------------------------------------------
+// sirius_physical_partition
+// ---------------------------------------------------------------------------
+
+TEST_CASE("partition no_history_peak_memory_estimate: num_partitions unset returns bytes",
+          "[no_history_peak_memory_estimate][partition]")
+{
+  // _num_partitions is nullopt after construction with a hash join parent.
+  auto f = make_hash_join();
+  sirius_physical_partition part{
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    f.hash_join.get()};
+  REQUIRE(part.no_history_peak_memory_estimate({1, 1000}) == 1000);
+}
+
+TEST_CASE("partition no_history_peak_memory_estimate: 1 partition returns 0",
+          "[no_history_peak_memory_estimate][partition]")
+{
+  auto f = make_hash_join();
+  sirius_physical_partition part{
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    f.hash_join.get()};
+  part.set_num_partitions(1);
+  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 0);
+}
+
+TEST_CASE("partition no_history_peak_memory_estimate: 2 partitions returns bytes",
+          "[no_history_peak_memory_estimate][partition]")
+{
+  auto f = make_hash_join();
+  sirius_physical_partition part{
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    f.hash_join.get()};
+  part.set_num_partitions(2);
+  REQUIRE(part.no_history_peak_memory_estimate({3, 2000}) == 2000);
+}
+
+TEST_CASE("partition no_history_peak_memory_estimate: many partitions returns bytes",
+          "[no_history_peak_memory_estimate][partition]")
+{
+  auto f = make_hash_join();
+  sirius_physical_partition part{
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    0,
+    f.hash_join.get()};
+  part.set_num_partitions(8);
+  REQUIRE(part.no_history_peak_memory_estimate({5, 4096}) == 4096);
+}
+
+// ---------------------------------------------------------------------------
+// sirius_physical_parquet_scan
+// ---------------------------------------------------------------------------
+
+TEST_CASE("parquet scan no_history_peak_memory_estimate returns 10× bytes",
+          "[no_history_peak_memory_estimate][parquet_scan]")
+{
+  // Constructed with all-empty/nullptr args; constructor body is a no-op when
+  // table_filters is nullptr (skips filter-translation path entirely).
+  sirius_physical_parquet_scan scan{/*types=*/{},
+                                    /*function=*/{},
+                                    /*bind_data=*/nullptr,
+                                    /*returned_types=*/{},
+                                    /*column_ids=*/{},
+                                    /*projection_ids=*/{},
+                                    /*names=*/{},
+                                    /*table_filters=*/nullptr,
+                                    /*estimated_cardinality=*/0,
+                                    /*extra_info=*/{},
+                                    /*parameters=*/{},
+                                    /*virtual_columns=*/{},
+                                    /*physical_table_scan=*/nullptr};
+
+  REQUIRE(scan.no_history_peak_memory_estimate({0, 0}) == 0);
+  REQUIRE(scan.no_history_peak_memory_estimate({1, 100}) == 1000);
+  REQUIRE(scan.no_history_peak_memory_estimate({4, 512}) == 5120);
+}


### PR DESCRIPTION
This PR introduces the ability for operators to define custom memory estimate for when there is no history available. The estimate for a pipeline would then be the max of every operator in its pipeline.

The default estimate is still what it was before, which 2X the input.

This feature is introduced, particularly to address the fact that Parquet scans consume way more than 2X the input. Its typically observed to be  8-10X the uncompressed size of the read. 
This PR only introduces custom estimates for Parquet Scans, Concat and Partition operators. Others can be added as needed. 