### PR TITLE
Use tightened `data_batch`

### DIFF
--- a/src/debug_utils.cpp
+++ b/src/debug_utils.cpp
@@ -72,8 +72,8 @@ namespace {
 
 bool is_gpu_tier(cucascade::data_batch& batch, const char* func_name)
 {
-  auto ro    = batch.to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch.get_read_only();
+  auto* data = ro->get_data();
   if (data == nullptr) {
     SIRIUS_LOG_WARN("[SIRIUS_DIAG] {}: batch has no data", func_name);
     return false;

--- a/src/include/data/convertible_data.hpp
+++ b/src/include/data/convertible_data.hpp
@@ -45,7 +45,7 @@ namespace sirius {
  * implementations wrap either a data_batch or a gpu_pipeline_task.
  *
  * Implementations are responsible for:
- * - Acquiring mutable_data_batch via to_mutable() (blocking) or try_to_mutable() (non-blocking)
+ * - Acquiring mutable_data_batch via get_mutable() (blocking) or try_get_mutable() (non-blocking)
  * - Performing the actual data conversion via convert_to on the mutable accessor
  * - RAII automatic state restoration on all exit paths (success, failure, exception)
  */
@@ -64,8 +64,8 @@ class convertible_data {
    * @param target_spaces  Candidate memory spaces to convert into (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no conversion occurred.

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -44,8 +44,8 @@ namespace sirius {
  * @brief Concrete convertible_data wrapping a cucascade::data_batch.
  *
  * Implements the RAII mutable lock / convert / auto-release pattern for a single
- * data_batch. Acquires mutable_data_batch via to_mutable() (blocking) or
- * try_to_mutable() (non-blocking), calls convert_to on the accessor, and relies on
+ * data_batch. Acquires mutable_data_batch via get_mutable() (blocking) or
+ * try_get_mutable() (non-blocking), calls convert_to on the accessor, and relies on
  * the mutable_data_batch destructor to restore the batch to idle on all exit paths
  * (success, failure, exception). No manual state save/restore is needed.
  */
@@ -72,8 +72,8 @@ class convertible_data_batch : public convertible_data {
    * @param target_spaces  Candidate memory spaces to convert into (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no conversion occurred.
@@ -86,21 +86,20 @@ class convertible_data_batch : public convertible_data {
   {
     std::optional<cucascade::mutable_data_batch> mut_opt;
     if (blocking) {
-      mut_opt.emplace(_batch->to_mutable());
+      mut_opt.emplace(_batch->get_mutable());
     } else {
-      mut_opt = _batch->try_to_mutable();
+      mut_opt = _batch->try_get_mutable();
       if (!mut_opt) { return std::nullopt; }
     }
     auto& mut = *mut_opt;
 
     // Check if the batch is already in the target space
-    auto cur_space = mut.get_memory_space();
-    for (std::size_t idx = 0; idx < target_spaces.size(); ++idx) {
-      const auto* space = target_spaces[idx];
+    auto* cur_space = mut->get_memory_space();
+    for (const auto* space : target_spaces) {
       if (cur_space == space) { return std::nullopt; }
     }
 
-    auto data_size = mut.get_data()->get_size_in_bytes();
+    auto data_size = mut->get_data()->get_size_in_bytes();
 
     for (std::size_t idx = 0; idx < target_spaces.size(); ++idx) {
       const auto* space = target_spaces[idx];
@@ -115,15 +114,15 @@ class convertible_data_batch : public convertible_data {
 
       switch (space->get_tier()) {
         case cucascade::memory::Tier::GPU:
-          mut.convert_to<cucascade::gpu_table_representation>(
+          mut->convert_to<cucascade::gpu_table_representation>(
             converter_registry, mem_space, stream);
           break;
         case cucascade::memory::Tier::HOST:
-          mut.convert_to<cucascade::host_data_representation>(
+          mut->convert_to<cucascade::host_data_representation>(
             converter_registry, mem_space, stream);
           break;
         case cucascade::memory::Tier::DISK:
-          mut.convert_to<cucascade::disk_data_representation>(
+          mut->convert_to<cucascade::disk_data_representation>(
             converter_registry, mem_space, stream);
           break;
         default: continue;
@@ -150,8 +149,8 @@ class convertible_data_batch : public convertible_data {
    */
   std::size_t bytes_in_space(cucascade::memory::memory_space* space) const override
   {
-    auto ro = _batch->to_read_only();
-    if (ro.get_memory_space() == space) { return ro.get_data()->get_size_in_bytes(); }
+    auto ro = _batch->get_read_only();
+    if (ro->get_memory_space() == space) { return ro->get_data()->get_size_in_bytes(); }
     return 0;
   }
 
@@ -256,7 +255,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
    * @brief Get the total byte size of all batches in the given memory space.
    *
    * Iterates all partitions front-to-back, summing bytes for batches residing
-   * in the specified space. Accesses batch data via to_read_only() as required
+   * in the specified space. Accesses batch data via get_read_only() as required
    * by the new cucascade API.
    *
    * @param space The memory space to query.
@@ -272,8 +271,8 @@ class convertible_data_batch_provider : public convertible_data_provider {
       for (auto batch_id : batch_ids) {
         auto batch = _repo->get_data_batch_by_id(batch_id, p);
         if (!batch) { continue; }
-        auto ro = batch->to_read_only();
-        if (ro.get_memory_space() == space) { total += ro.get_data()->get_size_in_bytes(); }
+        auto ro = batch->get_read_only();
+        if (ro->get_memory_space() == space) { total += ro->get_data()->get_size_in_bytes(); }
       }
     }
 
@@ -285,7 +284,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
    * @brief Try to get a matching batch by id, checking idle state and memory space.
    *
    * Only considers batches in batch_state::idle. Accesses the memory space via
-   * to_read_only() as required by the new cucascade API (get_memory_space() is
+   * get_read_only() as required by the new cucascade API (get_memory_space() is
    * private on idle data_batch).
    *
    * @param batch_id       The batch ID to retrieve.
@@ -302,9 +301,9 @@ class convertible_data_batch_provider : public convertible_data_provider {
 
     if (batch->get_state() != cucascade::batch_state::idle) { return nullptr; }
 
-    auto ro = batch->try_to_read_only();
+    auto ro = batch->try_get_read_only();
     if (!ro) { return nullptr; }
-    if (ro->get_memory_space() == space) {
+    if ((*ro)->get_memory_space() == space) {
       return std::make_unique<convertible_data_batch>(std::move(batch));
     }
 

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -52,7 +52,7 @@ namespace sirius {
  * all code paths.
  *
  * The convert() method uses the RAII mutable lock pattern: for each data_batch in the
-   * task's input data, it acquires a mutable_data_batch via get_mutable() or try_get_mutable(),
+ * task's input data, it acquires a mutable_data_batch via get_mutable() or try_get_mutable(),
  * attempts conversion to a target memory space, and relies on the mutable_data_batch RAII
  * destructor to restore idle state on all exit paths (success, failure, exception).
  */

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -52,7 +52,7 @@ namespace sirius {
  * all code paths.
  *
  * The convert() method uses the RAII mutable lock pattern: for each data_batch in the
- * task's input data, it acquires a mutable_data_batch via to_mutable() or try_to_mutable(),
+   * task's input data, it acquires a mutable_data_batch via get_mutable() or try_get_mutable(),
  * attempts conversion to a target memory space, and relies on the mutable_data_batch RAII
  * destructor to restore idle state on all exit paths (success, failure, exception).
  */
@@ -98,8 +98,8 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * @param target_spaces  Candidate destination memory spaces (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no batches were converted.
@@ -122,8 +122,8 @@ class convertible_gpu_pipeline_task : public convertible_data {
 
       // Quick check: skip batches already at a target space (avoid unnecessary locking)
       {
-        auto ro           = batch->to_read_only();
-        auto* batch_space = ro.get_memory_space();
+        auto ro           = batch->get_read_only();
+        auto* batch_space = ro->get_memory_space();
         bool at_target    = false;
         for (const auto* ts : target_spaces) {
           if (batch_space == ts) {
@@ -134,7 +134,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
         if (at_target) { continue; }
       }
 
-      // Delegate to convertible_data_batch which handles to_mutable() internally
+      // Delegate to convertible_data_batch which handles get_mutable() internally
       sirius::convertible_data_batch batch_converter(batch);
       auto result = batch_converter.convert(target_spaces, stream, res_mgr, blocking);
       if (result) {
@@ -153,7 +153,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * @brief Get the size in bytes of this task's data in the specified memory space.
    *
    * Sums bytes across all data_batches in the task's input that reside in the
-   * given memory space. Accesses memory space via to_read_only() as required by
+   * given memory space. Accesses memory space via get_read_only() as required by
    * the new cucascade API.
    *
    * @param space The memory space to query.
@@ -166,7 +166,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
 
     std::size_t total = 0;
     for (const auto& ro : operator_data->get_read_only_batches(false)) {
-      if (ro.get_memory_space() == space) { total += ro.get_data()->get_size_in_bytes(); }
+      if (ro->get_memory_space() == space) { total += ro->get_data()->get_size_in_bytes(); }
     }
     return total;
   }
@@ -287,7 +287,7 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
    *        batch_state::idle?
    *
    * Lightweight -- only performs dynamic_casts and state checks. Accesses memory
-   * space via to_read_only().
+   * space via get_read_only().
    *
    * @param task  The task to inspect.
    * @param space The memory space to match.
@@ -302,9 +302,9 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
     for (const auto& batch : operator_data->get_data_batches()) {
       if (!batch) { continue; }
       if (batch->get_state() != cucascade::batch_state::idle) { continue; }
-      auto ro = batch->try_to_read_only();
+      auto ro = batch->try_get_read_only();
       if (!ro) { continue; }
-      if (ro->get_memory_space() == space) { return true; }
+      if ((*ro)->get_memory_space() == space) { return true; }
     }
 
     return false;

--- a/src/include/data/data_batch_utils.hpp
+++ b/src/include/data/data_batch_utils.hpp
@@ -52,7 +52,7 @@ inline uint64_t get_next_batch_id() { return g_next_batch_id++; }
  */
 inline cudf::table_view get_cudf_table_view(const cucascade::read_only_data_batch& batch)
 {
-  auto* data = batch.get_data();
+  auto* data = batch->get_data();
   if (data == nullptr) { throw std::runtime_error("data_batch has no data representation"); }
   return data->cast<cucascade::gpu_table_representation>().get_table_view();
 }
@@ -72,11 +72,11 @@ inline cudf::table_view get_cudf_table_view(const cucascade::read_only_data_batc
  * @param batch The idle data batch to extract the table view from.
  * @return cudf::table_view The underlying cudf table view.
  */
-// NOLINTNEXTLINE(readability-non-const-parameter) -- to_read_only() is non-const
+// NOLINTNEXTLINE(readability-non-const-parameter) -- get_read_only() is non-const
 inline cudf::table_view get_cudf_table_view(cucascade::data_batch& batch)
 {
-  auto ro    = batch.to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch.get_read_only();
+  auto* data = ro->get_data();
   if (data == nullptr) { throw std::runtime_error("data_batch has no data representation"); }
   return data->cast<cucascade::gpu_table_representation>().get_table_view();
 }
@@ -93,7 +93,7 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
 {
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), memory_space);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(gpu_repr));
 }
 
 /**
@@ -108,7 +108,7 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
 {
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), memory_space);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(gpu_repr));
 }
 
 }  // namespace sirius

--- a/src/include/legacy/print.hpp
+++ b/src/include/legacy/print.hpp
@@ -45,7 +45,7 @@ void print_table_contents(cudf::table_view const& table, cudf::size_type max_row
 /**
  * Print the contents of a cucascade::data_batch to stdout (printf).
  * Equivalent to printing the underlying cudf table view.
- * Note: takes non-const ref because to_read_only() acquires a shared lock (non-const).
+ * Note: takes non-const ref because get_read_only() acquires a shared lock (non-const).
  */
 // NOLINTNEXTLINE(readability-non-const-parameter)
 void print_data_batch_contents(cucascade::data_batch& batch, cudf::size_type max_rows = 20);

--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -218,12 +218,12 @@ class scan_cached_operator_data : public op::operator_data {
   {
     if (!batch || !requested_memory_space) { return; }
     {
-      auto ro = batch->to_read_only();
-      if (!ro.get_data() || ro.get_current_tier() == ::cucascade::memory::Tier::GPU) { return; }
+      auto ro = batch->get_read_only();
+      if (!ro->get_data() || ro->get_current_tier() == ::cucascade::memory::Tier::GPU) { return; }
     }
     auto& registry = ::sirius::converter_registry::get();
-    auto mut       = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, requested_memory_space, stream);
+    auto mut       = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, requested_memory_space, stream);
   }
 
   [[nodiscard]] std::size_t get_estimated_size_in_bytes() const override
@@ -232,8 +232,8 @@ class scan_cached_operator_data : public op::operator_data {
     // batches and host_data_representation batches that prepare_for_processing
     // will upgrade to GPU. Sizes are close enough between tiers to size the
     // task's memory reservation.
-    auto ro          = batch->to_read_only();
-    auto const* data = ro.get_data();
+    auto ro    = batch->get_read_only();
+    auto* data = ro->get_data();
     if (!data) { return 0; }
     return data->get_size_in_bytes();
   }

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -185,7 +185,7 @@ class pipelineable_operator_data : public operator_data {
     std::size_t total = 0;
     auto ro_batches   = get_read_only_batches(false);
     for (auto const& ro : ro_batches) {
-      if (ro.get_data()) { total += ro.get_data()->get_uncompressed_data_size_in_bytes(); }
+      if (ro->get_data()) { total += ro->get_data()->get_uncompressed_data_size_in_bytes(); }
     }
     return total;
   }

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -54,38 +54,39 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
   if (!batch) { return std::nullopt; }
 
   // Acquire a read-only lock
-  auto read_accessor = batch->to_read_only();
+  auto read_accessor = batch->get_read_only();
 
   // Determine the target memory space
   const auto* target_space =
-    requested_memory_space != nullptr ? requested_memory_space : read_accessor.get_memory_space();
+    requested_memory_space != nullptr ? requested_memory_space : read_accessor->get_memory_space();
   if (target_space == nullptr) { return std::nullopt; }
 
   // Memory space matches — return the read-only accessor directly
-  if (read_accessor.get_memory_space() != nullptr &&
-      read_accessor.get_memory_space()->get_id() == target_space->get_id()) {
+  if (read_accessor->get_memory_space() != nullptr &&
+      read_accessor->get_memory_space()->get_id() == target_space->get_id()) {
     return std::move(read_accessor);
   }
 
-  // Memory space mismatch — go to mutable, convert in-place, go back to read-only
+  // Memory space mismatch — release shared access, convert in-place, then reacquire shared access.
+  auto idle_batch   = cucascade::read_only_data_batch::to_idle(std::move(read_accessor));
   auto& registry    = sirius::converter_registry::get();
-  auto mut_accessor = cucascade::data_batch::readonly_to_mutable(std::move(read_accessor));
+  auto mut_accessor = idle_batch->get_mutable();
 
   switch (target_space->get_tier()) {
     case cucascade::memory::Tier::GPU:
-      mut_accessor.convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
+      mut_accessor->convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
       break;
     case cucascade::memory::Tier::HOST:
-      mut_accessor.convert_to<cucascade::host_data_representation>(registry, target_space, stream);
+      mut_accessor->convert_to<cucascade::host_data_representation>(registry, target_space, stream);
       break;
     default:
       SIRIUS_LOG_ERROR("lock_or_prepare_batch: unsupported target tier for batch {}",
-                       mut_accessor.get_batch_id());
+                       mut_accessor->get_batch_id());
       return std::nullopt;
   }
 
-  // Downgrade the exclusive lock back to a shared read-only lock
-  return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
+  idle_batch = cucascade::mutable_data_batch::to_idle(std::move(mut_accessor));
+  return idle_batch->get_read_only();
 }
 
 }  // namespace pipeline

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -91,8 +91,8 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
       dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
     if (pipelineable_input) {
       for (const auto& ro : pipelineable_input->get_read_only_batches(false)) {
-        if (ro.get_data() && ro.get_current_tier() != cucascade::memory::Tier::GPU) {
-          input_size += ro.get_data()->get_uncompressed_data_size_in_bytes();
+        if (ro->get_data() && ro->get_current_tier() != cucascade::memory::Tier::GPU) {
+          input_size += ro->get_data()->get_uncompressed_data_size_in_bytes();
         }
       }
     }

--- a/src/legacy/expression_executor/gpu_expression_executor.cpp
+++ b/src/legacy/expression_executor/gpu_expression_executor.cpp
@@ -257,8 +257,8 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
   output_columns.resize(expressions.size());
 
   // Retrieve the table_view from the data_batch
-  auto input_ro        = input_batch->to_read_only();
-  auto& input_data_rep = input_ro.get_data()->cast<cucascade::gpu_table_representation>();
+  auto input_ro        = input_batch->get_read_only();
+  auto& input_data_rep = input_ro->get_data()->cast<cucascade::gpu_table_representation>();
   input_table          = input_data_rep.get_table_view();
   input_count          = static_cast<cudf::size_type>(input_table.num_rows());
 
@@ -291,11 +291,11 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
     std::make_unique<cucascade::gpu_table_representation>(
       std::move(
         std::make_unique<cudf::table>(std::move(output_columns), execution_stream, resource_ref)),
-      *input_ro.get_memory_space());
+      *input_ro->get_memory_space());
 
   // Create the data batch and return
   auto const batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
+  return cucascade::data_batch::make(batch_id, std::move(output_data_rep));
 }
 
 void GpuExpressionExecutor::Select(GPUIntermediateRelation& input_relation,
@@ -343,8 +343,8 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
   output_columns.clear();
 
   // Retrieve the table_view from the data_batch via read-only accessor
-  auto input_ro        = input_batch->to_read_only();
-  auto& input_data_rep = input_ro.get_data()->cast<cucascade::gpu_table_representation>();
+  auto input_ro        = input_batch->get_read_only();
+  auto& input_data_rep = input_ro->get_data()->cast<cucascade::gpu_table_representation>();
   input_table          = input_data_rep.get_table_view();
   input_count          = static_cast<cudf::size_type>(input_table.num_rows());
 
@@ -358,11 +358,11 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
     cudf::apply_boolean_mask(input_table, bitmap->view(), execution_stream, resource_ref);
   std::unique_ptr<cucascade::idata_representation> output_data_rep =
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table),
-                                                          *input_ro.get_memory_space());
+                                                          *input_ro->get_memory_space());
 
   // Create the data batch and return
   auto const batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
+  return cucascade::data_batch::make(batch_id, std::move(output_data_rep));
 }
 
 std::unique_ptr<cudf::column> GpuExpressionExecutor::ExecuteExpression(idx_t expr_idx)

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -99,7 +99,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   // host allocation. allocate_multiple_blocks(0, ...) is not guaranteed to
   // return an allocation with a usable block, so skip it entirely.
   if (num_rows == 0 || num_cols == 0) {
-    return std::make_shared<cucascade::data_batch>(
+    return cucascade::data_batch::make(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
         host_table_allocation::create(
@@ -135,7 +135,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   }
 
   if (total_size == 0) {
-    return std::make_shared<cucascade::data_batch>(
+    return cucascade::data_batch::make(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
         host_table_allocation::create(
@@ -265,7 +265,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   auto table_allocation =
     host_table_allocation::create(std::move(allocation), std::move(columns), offset);
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), &mem_space);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(table));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(table));
 }
 
 pipeline::reservation_size_info cpu_source_task::get_estimated_reservation_size_info() const
@@ -368,8 +368,8 @@ void cpu_source_task::publish_output(op::operator_data& output_data, rmm::cuda_s
   for (auto& batch : pipelineable_output.get_data_batches()) {
     if (!batch) { continue; }
     {
-      auto ro = batch->to_read_only();
-      if (!ro.get_data()) { continue; }
+      auto ro = batch->get_read_only();
+      if (!ro->get_data()) { continue; }
     }
     _data_repo->add_data_batch(batch);
   }

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -183,20 +183,21 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
     cloned_batches.reserve(batches.size());
     if (is_duckdb_scan) {
       for (auto& batch : batches) {
-        auto ro = batch->to_read_only();
-        cloned_batches.push_back(ro.clone(get_next_batch_id(), stream));
+        auto ro = batch->get_read_only();
+        cloned_batches.push_back(ro->clone(get_next_batch_id(), stream));
       }
     } else if (is_parquet_scan) {
       for (auto& batch : batches) {
-        auto ro         = batch->to_read_only();
-        auto* idata_rep = ro.get_data();
+        auto ro         = batch->get_read_only();
+        auto* idata_rep = ro->get_data();
         if (auto* host_data = dynamic_cast<cached_host_data_representation*>(idata_rep);
             host_data) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
+          cloned_batches.push_back(cucascade::data_batch::make(
             get_next_batch_id(), host_data->shallow_clone()));
-        } else if (auto* parquet_rep = dynamic_cast<cached_host_parquet_representation*>(idata_rep);
+        } else if (auto* parquet_rep =
+                     dynamic_cast<cached_host_parquet_representation*>(idata_rep);
                    parquet_rep) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
+          cloned_batches.push_back(cucascade::data_batch::make(
             get_next_batch_id(), parquet_rep->shallow_clone()));
         } else {
           throw std::runtime_error("Invalid data representation type");

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -192,13 +192,12 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
         auto* idata_rep = ro->get_data();
         if (auto* host_data = dynamic_cast<cached_host_data_representation*>(idata_rep);
             host_data) {
-          cloned_batches.push_back(cucascade::data_batch::make(
-            get_next_batch_id(), host_data->shallow_clone()));
-        } else if (auto* parquet_rep =
-                     dynamic_cast<cached_host_parquet_representation*>(idata_rep);
+          cloned_batches.push_back(
+            cucascade::data_batch::make(get_next_batch_id(), host_data->shallow_clone()));
+        } else if (auto* parquet_rep = dynamic_cast<cached_host_parquet_representation*>(idata_rep);
                    parquet_rep) {
-          cloned_batches.push_back(cucascade::data_batch::make(
-            get_next_batch_id(), parquet_rep->shallow_clone()));
+          cloned_batches.push_back(
+            cucascade::data_batch::make(get_next_batch_id(), parquet_rep->shallow_clone()));
         } else {
           throw std::runtime_error("Invalid data representation type");
         }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -464,7 +464,7 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), _host_space);
 
   // Create the data batch and return
-  return std::make_shared<data_batch>(get_next_batch_id(), std::move(table));
+  return data_batch::make(get_next_batch_id(), std::move(table));
 }
 
 //===----------------------------------------------------------------------===//
@@ -540,8 +540,8 @@ void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
     std::size_t output_bytes       = 0;
     for (const auto& batch : pipelineable_output_data.get_data_batches()) {
       if (batch) {
-        auto ro = batch->to_read_only();
-        if (ro.get_data()) { output_bytes += ro.get_data()->get_size_in_bytes(); }
+        auto ro = batch->get_read_only();
+        if (ro->get_data()) { output_bytes += ro->get_data()->get_size_in_bytes(); }
       }
     }
     auto& g_state = _global_state->cast<duckdb_scan_task_global_state>();

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -913,8 +913,7 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
         get_next_batch_id(),
         std::make_unique<cached_host_parquet_representation>(std::move(parquet_representation)));
     } else {
-      batch = cucascade::data_batch::make(get_next_batch_id(),
-                                                      std::move(parquet_representation));
+      batch = cucascade::data_batch::make(get_next_batch_id(), std::move(parquet_representation));
     }
   }
   auto result = std::make_unique<op::pipelineable_operator_data>(

--- a/src/op/scan/parquet_scan_task.cpp
+++ b/src/op/scan/parquet_scan_task.cpp
@@ -774,8 +774,8 @@ void parquet_scan_task::execute(rmm::cuda_stream_view stream)
     std::size_t output_bytes       = 0;
     for (const auto& batch : pipelineable_output_data.get_data_batches()) {
       if (batch) {
-        auto ro = batch->to_read_only();
-        if (ro.get_data()) { output_bytes += ro.get_data()->get_size_in_bytes(); }
+        auto ro = batch->get_read_only();
+        if (ro->get_data()) { output_bytes += ro->get_data()->get_size_in_bytes(); }
       }
     }
     auto& g_state = this->_global_state->cast<parquet_scan_task_global_state>();
@@ -901,19 +901,19 @@ std::unique_ptr<op::operator_data> parquet_scan_task::compute_task(
     auto host_table = registry.convert<cucascade::host_data_representation>(
       *materialized_table, l_state.get_memory_space(), stream);
     if (_wrap_in_cache) {
-      batch = std::make_shared<cucascade::data_batch>(
+      batch = cucascade::data_batch::make(
         get_next_batch_id(),
         std::make_unique<cached_host_data_representation>(std::move(host_table)));
     } else {
-      batch = std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(host_table));
+      batch = cucascade::data_batch::make(get_next_batch_id(), std::move(host_table));
     }
   } else {
     if (_wrap_in_cache) {
-      batch = std::make_shared<cucascade::data_batch>(
+      batch = cucascade::data_batch::make(
         get_next_batch_id(),
         std::make_unique<cached_host_parquet_representation>(std::move(parquet_representation)));
     } else {
-      batch = std::make_shared<cucascade::data_batch>(get_next_batch_id(),
+      batch = cucascade::data_batch::make(get_next_batch_id(),
                                                       std::move(parquet_representation));
     }
   }

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -207,8 +207,8 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
     table     = read_table_from_metadata(*scan_data, stream);
     mem_space = scan_data->gpu_memory_space;
   } else if (auto const* cached = dynamic_cast<const scan_cached_operator_data*>(&input_data)) {
-    auto ro_batch    = cached->batch->to_read_only();
-    auto& gpu_rep    = ro_batch.get_data()->cast<cucascade::gpu_table_representation>();
+    auto ro_batch    = cached->batch->get_read_only();
+    auto& gpu_rep    = ro_batch->get_data()->cast<cucascade::gpu_table_representation>();
     auto cached_view = gpu_rep.get_table_view();
 
     // The cached path carries only a DuckDB-expression filter (AST translation /
@@ -258,7 +258,7 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
       SIRIUS_LOG_DEBUG("[sirius_gpu_parquet_scan_operator] Assembled cached batch to plan layout.");
     }
 
-    mem_space = ro_batch.get_memory_space();
+    mem_space = ro_batch->get_memory_space();
   } else {
     throw std::runtime_error(
       "[sirius_gpu_parquet_scan_operator] execute() called with unexpected operator_data type; "

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -101,8 +101,8 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
     size_t pulled_count     = 0;
     for (auto& batch_id : batch_ids) {
       auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
+      auto batch_ro   = batch_idle->get_read_only();
+      auto batch_size = batch_ro->get_data()->get_size_in_bytes();
       total_batch_size += batch_size;
       if (!_concat_all && total_batch_size > _concat_batch_bytes) {
         // This batch pushes us over the threshold — the loop would stop here.
@@ -142,8 +142,8 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
     size_t total_batch_size = 0;
     for (auto& batch_id : batch_ids) {
       auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
+      auto batch_ro   = batch_idle->get_read_only();
+      auto batch_size = batch_ro->get_data()->get_size_in_bytes();
       total_batch_size += batch_size;
       // Check if the batch size is already exceed the threshold
       if (!_concat_all && total_batch_size > _concat_batch_bytes) {
@@ -179,21 +179,20 @@ std::unique_ptr<operator_data> sirius_physical_concat::execute(const operator_da
     throw std::runtime_error(
       "sirius_physical_concat: input_data is not a partitioned_operator_data");
   }
-  const auto& input_batches = partitioned_input_data->get_read_only_batches();
-  auto partition_idx        = partitioned_input_data->get_partition_idx();
+  auto input_batches = partitioned_input_data->get_read_only_batches();
+  auto partition_idx = partitioned_input_data->get_partition_idx();
   if (input_batches.empty()) {
     return std::make_unique<partitioned_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{}, partition_idx);
   }
 
-  cucascade::memory::memory_space* space = input_batches[0].get_memory_space();
+  auto* space = input_batches[0]->get_memory_space();
   if (space == nullptr) { throw std::runtime_error("sirius_physical_concat: space is nullptr"); }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(1);
   if (input_batches.size() == 1) {
-    auto copy   = input_batches[0];
-    auto output = cucascade::data_batch::to_idle(std::move(copy));
+    auto output = cucascade::read_only_data_batch::to_idle(std::move(input_batches[0]));
     output_batches.push_back(std::move(output));
   } else {
     auto merged_batch = gpu_merge_impl::concat(input_batches, stream, *space);

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -54,9 +54,9 @@ std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_da
 
   for (auto const& batch : input_batches) {
     auto filtered_table = gpu_expression_executor.select(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
     output_batches.push_back(
-      sirius::make_data_batch(std::move(filtered_table), *batch.get_memory_space()));
+      sirius::make_data_batch(std::move(filtered_table), *batch->get_memory_space()));
   }
   return std::make_unique<pipelineable_operator_data>(output_batches);
 }

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
   const auto& input_batches = input.get_read_only_batches();
   std::vector<std::shared_ptr<::cucascade::data_batch>> results;
   for (auto const& input_batch : input_batches) {
-    auto* space = input_batch.get_memory_space();
+    auto* space = input_batch->get_memory_space();
     if (!space) { continue; }
     auto result = gpu_aggregate_impl::local_grouped_aggregate(input_batch,
                                                               group_idx,

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -167,7 +167,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_grouped_aggregate_merge::execute"};
   auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& input_batches = input.get_read_only_batches();
+  auto input_batches = input.get_read_only_batches();
   if (input_batches.size() == 0) {
     throw std::runtime_error(
       "We expect at least one input batch for grouped aggregate merge operator");
@@ -181,13 +181,13 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   // Merge multiple batches, or use single batch directly if only one
   std::shared_ptr<::cucascade::data_batch> merged;
   if (input_batches.size() == 1) {
-    merged = input_batches[0].clone(sirius::get_next_batch_id(), stream);
+    merged = input_batches[0]->clone(sirius::get_next_batch_id(), stream);
   } else {
     merged = gpu_merge_impl::merge_grouped_aggregate(input_batches,
                                                      group_idx.size(),
                                                      cudf_aggregates,
                                                      stream,
-                                                     *input_batches[0].get_memory_space());
+                                                     *input_batches[0]->get_memory_space());
   }
 
   // If no post-processing needed, return merged result directly
@@ -199,10 +199,11 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   // Post-merge projection: handle AVG (SUM/COUNT) and COUNT DISTINCT (list element count).
   // Release ownership of the merged table's columns so we can move (not copy) them.
   // Acquire EXCLUSIVE lock since release_table() is a mutating operation
-  auto merged_mut    = merged->to_mutable();
-  auto* space        = merged_mut.get_memory_space();
+  auto merged_mut    = merged->get_mutable();
+  auto* space        = merged_mut->get_memory_space();
   auto mr            = space->get_default_allocator();
-  auto& gpu_rep      = merged_mut.get_data()->cast<cucascade::gpu_table_representation>();
+  auto& gpu_rep      = merged_mut->get_data()
+                    ->cast<cucascade::gpu_table_representation>();
   auto merged_cols   = gpu_rep.release_table(stream)->release();
   int num_group_cols = static_cast<int>(group_idx.size());
 

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_grouped_aggregate_merge::execute"};
-  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto& input        = dynamic_cast<const pipelineable_operator_data&>(input_data);
   auto input_batches = input.get_read_only_batches();
   if (input_batches.size() == 0) {
     throw std::runtime_error(
@@ -202,8 +202,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   auto merged_mut    = merged->get_mutable();
   auto* space        = merged_mut->get_memory_space();
   auto mr            = space->get_default_allocator();
-  auto& gpu_rep      = merged_mut->get_data()
-                    ->cast<cucascade::gpu_table_representation>();
+  auto& gpu_rep      = merged_mut->get_data()->cast<cucascade::gpu_table_representation>();
   auto merged_cols   = gpu_rep.release_table(stream)->release();
   int num_group_cols = static_cast<int>(group_idx.size());
 

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -797,7 +797,7 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
   auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{
-      make_data_batch(std::move(output_cudf_table), *left_batch.get_memory_space())});
+      make_data_batch(std::move(output_cudf_table), *left_batch->get_memory_space())});
 }
 
 std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator_data& input_data,
@@ -836,7 +836,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       {
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
-        _build_table              = build_batch_ro;
+        _build_table.emplace(build_batch_ro.clone_read_only_access());
         if (unique_build_keys &&
             (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
           _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
@@ -866,7 +866,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
 
       left_full  = get_cudf_table_view(input_batches[0]);
       right_full = _build_table.value()
-                     .get_data()
+                     ->get_data()
                      ->cast<cucascade::gpu_table_representation>()
                      .get_table_view();
 
@@ -884,7 +884,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                   lhs_output_columns.col_idxs,
                                                   rhs_output_columns.col_idxs,
                                                   std::move(build_indices),
-                                                  *input_batches[0].get_memory_space(),
+                                                  *input_batches[0]->get_memory_space(),
                                                   stream);
         }
       } else {
@@ -1100,7 +1100,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                 lhs_output_columns.col_idxs,
                                                 rhs_output_columns.col_idxs,
                                                 std::move(build_indices),
-                                                *input_batches[0].get_memory_space(),
+                                                *input_batches[0]->get_memory_space(),
                                                 stream);
       }
     } else if (join_type == duckdb::JoinType::INNER) {
@@ -1159,7 +1159,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                             rhs_output_columns.col_idxs,
                             std::move(left_indices),
                             std::move(right_indices),
-                            *input_batches[0].get_memory_space(),
+                            *input_batches[0]->get_memory_space(),
                             stream);
 }
 

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
     // Check if limit is already exhausted
     if (_remaining_limit.load(std::memory_order_acquire) <= 0) { break; }
 
-    auto view     = batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    auto view     = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
     auto num_rows = static_cast<int64_t>(view.num_rows());
 
     if (num_rows == 0) { continue; }
@@ -108,13 +108,13 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
 
     // cudf::slice returns a vector of table_views; materialize into a table
     auto sliced_table = std::make_unique<cudf::table>(
-      slices.front(), stream, batch.get_memory_space()->get_default_allocator());
+      slices.front(), stream, batch->get_memory_space()->get_default_allocator());
+    auto* memory_space = batch->get_memory_space();
     std::unique_ptr<cucascade::idata_representation> output_data =
-      std::make_unique<cucascade::gpu_table_representation>(std::move(sliced_table),
-                                                            *batch.get_memory_space());
+      std::make_unique<cucascade::gpu_table_representation>(std::move(sliced_table), *memory_space);
 
     auto const batch_id = ::sirius::get_next_batch_id();
-    auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+    auto output_batch   = cucascade::data_batch::make(batch_id, std::move(output_data));
     output_batches.push_back(std::move(output_batch));
   }
 

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_merge_sort::execute"};
-  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto& input        = dynamic_cast<const pipelineable_operator_data&>(input_data);
   auto input_batches = input.get_read_only_batches();
 
   // Find memory space

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -81,12 +81,12 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_merge_sort::execute"};
   auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& input_batches = input.get_read_only_batches();
+  auto input_batches = input.get_read_only_batches();
 
   // Find memory space
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
-    if (!space) { space = batch.get_memory_space(); }
+    if (!space) { space = batch->get_memory_space(); }
   }
 
   if (input_batches.empty() || !space) {
@@ -113,7 +113,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
     std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
     if (_final_projections.empty()) {
       auto ro_vec = input.get_read_only_batches();
-      outputs.push_back(cucascade::data_batch::to_idle(std::move(ro_vec[0])));
+      outputs.push_back(cucascade::read_only_data_batch::to_idle(std::move(ro_vec[0])));
     } else {
       outputs.push_back(apply_final_projection(input_batches[0]));
     }
@@ -149,7 +149,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
     if (_final_projections.empty()) {
       outputs.push_back(std::move(merged_batch));
     } else {
-      auto ro = merged_batch->to_read_only();
+      auto ro = merged_batch->get_read_only();
       outputs.push_back(apply_final_projection(ro));
     }
   }

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -406,7 +406,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
   cudf::table_view left  = get_cudf_table_view(left_batch);
   cudf::table_view right = get_cudf_table_view(right_batch);
 
-  cucascade::memory::memory_space* space = left_batch.get_memory_space();
+  auto* space = left_batch->get_memory_space();
   if (!space) {
     SIRIUS_LOG_DEBUG(
       "Pipeline {}: nested loop join, 0 output batches because left batch had no memory space",

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -30,6 +30,21 @@
 namespace sirius {
 namespace op {
 
+namespace {
+
+std::vector<::cucascade::read_only_data_batch> clone_read_only_batch_accessors(
+  const std::vector<::cucascade::read_only_data_batch>& batches)
+{
+  std::vector<::cucascade::read_only_data_batch> cloned_batches;
+  cloned_batches.reserve(batches.size());
+  for (const auto& batch : batches) {
+    cloned_batches.push_back(batch.clone_read_only_access());
+  }
+  return cloned_batches;
+}
+
+}  // namespace
+
 //===--------------------------------------------------------------------===//
 // operator_data
 //===--------------------------------------------------------------------===//
@@ -44,8 +59,8 @@ pipelineable_operator_data::get_data_batches() const
     std::vector<std::shared_ptr<::cucascade::data_batch>> batches;
     batches.reserve(_read_only_data_batches->size());
     for (const auto& ro : *_read_only_data_batches) {
-      auto copy = ro;
-      batches.push_back(::cucascade::data_batch::to_idle(std::move(copy)));
+      auto copy = ro.clone_read_only_access();
+      batches.push_back(::cucascade::read_only_data_batch::to_idle(std::move(copy)));
     }
     _data_batches = std::move(batches);
   }
@@ -63,18 +78,19 @@ std::vector<::cucascade::read_only_data_batch> pipelineable_operator_data::get_r
     ro_batches.reserve(_data_batches->size());
     for (const auto& batch : *_data_batches) {
       if (batch) {
-        ro_batches.push_back(batch->to_read_only());
+        ro_batches.push_back(batch->get_read_only());
       } else {
         SIRIUS_LOG_WARN("pipelineable_operator_data: null batch encountered, skipping");
       }
     }
     if (leave_locked) {
       _read_only_data_batches = std::move(ro_batches);
+      return clone_read_only_batch_accessors(*_read_only_data_batches);
     } else {
       return std::move(ro_batches);
     }
   }
-  return *_read_only_data_batches;
+  return clone_read_only_batch_accessors(*_read_only_data_batches);
 }
 
 void pipelineable_operator_data::prepare_for_processing(

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
   output_batches.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
 
     auto sorted_batch = gpu_order_impl::local_order_by(

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
   }
 
   auto const& input_batch_ro = input_batches[0];
-  auto* space = input_batch_ro->get_memory_space();
+  auto* space                = input_batch_ro->get_memory_space();
 
   if (_num_partitions.value() < 2 || _partition_keys.empty()) {
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
   }
 
   auto const& input_batch_ro = input_batches[0];
-  auto* space                = input_batch_ro.get_memory_space();
+  auto* space = input_batch_ro->get_memory_space();
 
   if (_num_partitions.value() < 2 || _partition_keys.empty()) {
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
@@ -191,7 +191,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
         input_batch_ro, _num_partitions.value(), stream, *space);
       break;
     case PartitionType::NONE: {
-      partitioned_results = {input_batch_ro.clone(sirius::get_next_batch_id(), stream)};
+      partitioned_results = {input_batch_ro->clone(sirius::get_next_batch_id(), stream)};
       break;
     }
     case PartitionType::CUSTOM:
@@ -240,8 +240,8 @@ std::pair<int, uint64_t> sirius_physical_partition::determine_num_partitions()
   for (auto batch_id : batch_ids) {
     auto batch = repo->get_data_batch_by_id(batch_id, 0);
     if (batch) {
-      auto ro = batch->to_read_only();
-      if (ro.get_data()) { total_bytes += ro.get_data()->get_size_in_bytes(); }
+      auto ro = batch->get_read_only();
+      if (ro->get_data()) { total_bytes += ro->get_data()->get_size_in_bytes(); }
     }
   }
   int num_partitions = static_cast<int>(std::max(uint64_t{1}, total_bytes / s_partition_size));

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -57,9 +57,9 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
 
   for (auto const& batch : input_batches) {
     auto projected_table = gpu_expression_executor.execute(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
     output_batches.push_back(
-      sirius::make_data_batch(std::move(projected_table), *batch.get_memory_space()));
+      sirius::make_data_batch(std::move(projected_table), *batch->get_memory_space()));
   }
   return std::make_unique<pipelineable_operator_data>(output_batches);
 }

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -126,8 +126,8 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
   auto sink_single_batch = [this,
                             stream](std::shared_ptr<cucascade::data_batch> const& input_batch) {
     // Acquire read-only access to inspect the batch
-    auto ro    = input_batch->to_read_only();
-    auto* data = ro.get_data();
+    auto ro    = input_batch->get_read_only();
+    auto* data = ro->get_data();
 
     if (!data) {
       throw invalid_input_exception(
@@ -156,13 +156,13 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
 
       // clone_to: creates new batch with data converted to host_data_representation
-      auto result_batch = ro.clone_to<cucascade::host_data_representation>(
+      auto result_batch = ro->clone_to<cucascade::host_data_representation>(
         registry, next_batch_id, &mem_space, stream);
 
       // Access the result batch's data. Declared outside the if-block so result_ro outlives
       // the branch — data points into it and must not dangle when we reach the assert below.
-      result_ro_opt = result_batch->to_read_only();
-      data          = result_ro_opt->get_data();
+      result_ro_opt = result_batch->get_read_only();
+      data          = (*result_ro_opt)->get_data();
 
     } else if (data->get_current_tier() != cucascade::memory::Tier::HOST) {
       // Data must be in HOST tier (i.e., cannot currently reside in DISK tier)

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
     auto input_table = get_cudf_table_view(batch);
     auto num_rows    = input_table.num_rows();

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -110,8 +110,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   std::vector<::cucascade::read_only_data_batch> valid_batches;
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
-    if (!space) { space = batch.get_memory_space(); }
-    valid_batches.push_back(batch);
+    if (!space) { space = batch->get_memory_space(); }
+    valid_batches.push_back(batch.clone_read_only_access());
   }
 
   if (valid_batches.empty() || !space) {
@@ -129,7 +129,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     for (auto const& batch : valid_batches) {
       auto view = get_cudf_table_view(batch);
       sample_views.push_back(view);
-      total_sample_bytes += batch.get_data()->get_size_in_bytes();
+      total_sample_bytes += batch->get_data()->get_size_in_bytes();
     }
 
     auto concat_table = cudf::concatenate(sample_views, stream, space->get_default_allocator());

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -134,9 +134,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
       if (batch->get_data()) {
         auto& gpu_rep = batch->get_data()->cast<cucascade::gpu_table_representation>();
         table_views.push_back(gpu_rep.get_table_view());
-        if (!space) {
-          space = batch->get_memory_space();
-        }
+        if (!space) { space = batch->get_memory_space(); }
       }
     }
     if (table_views.size() > 1 && space) {
@@ -166,9 +164,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
       local_filter_expr, cudf::get_current_device_resource_ref(), stream);
     auto filtered_table = gpu_expression_executor.select(
       batch_ref->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
-    auto* output_space =
-      batch_ref->get_memory_space();
-    output_batch = sirius::make_data_batch(std::move(filtered_table), *output_space);
+    auto* output_space = batch_ref->get_memory_space();
+    output_batch       = sirius::make_data_batch(std::move(filtered_table), *output_space);
   } else {
     output_batch = ::cucascade::read_only_data_batch::to_idle(std::move(batch_ref));
   }
@@ -210,12 +207,10 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     cucascade::memory::memory_space* space = nullptr;
     {
       auto output_mut = output_batch->get_mutable();
-      space = output_mut->get_memory_space();
-      auto& gpu_rep =
-        output_mut->get_data()
-          ->cast<cucascade::gpu_table_representation>();
-      auto table = gpu_rep.release_table(stream);
-      columns        = table->release();
+      space           = output_mut->get_memory_space();
+      auto& gpu_rep   = output_mut->get_data()->cast<cucascade::gpu_table_representation>();
+      auto table      = gpu_rep.release_table(stream);
+      columns         = table->release();
     }  // mutable lock released here
 
     // Select output columns using the batch column map.

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -87,8 +87,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::get_next_task_input_d
     if (!batch) { break; }
     uint64_t batch_bytes = 0;
     {
-      auto ro = batch->to_read_only();
-      if (ro.get_data()) { batch_bytes = ro.get_data()->get_size_in_bytes(); }
+      auto ro = batch->get_read_only();
+      if (ro->get_data()) { batch_bytes = ro->get_data()->get_size_in_bytes(); }
     }
     accumulated_bytes += batch_bytes;
     input_batch.push_back(std::move(batch));
@@ -106,8 +106,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_table_scan::execute"};
-  auto& input                  = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& ro_input_batches = input.get_read_only_batches();
+  auto& input           = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto ro_input_batches = input.get_read_only_batches();
 
   // For parquet scan pipelines, filter and projection are already applied in
   // parquet_scan_task and the host_parquet_representation converters.
@@ -131,25 +131,27 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     table_views.reserve(ro_input_batches.size());
     cucascade::memory::memory_space* space = nullptr;
     for (const auto& batch : ro_input_batches) {
-      if (batch.get_data()) {
-        auto& gpu_rep = batch.get_data()->cast<cucascade::gpu_table_representation>();
+      if (batch->get_data()) {
+        auto& gpu_rep = batch->get_data()->cast<cucascade::gpu_table_representation>();
         table_views.push_back(gpu_rep.get_table_view());
-        if (!space) { space = batch.get_memory_space(); }
+        if (!space) {
+          space = batch->get_memory_space();
+        }
       }
     }
     if (table_views.size() > 1 && space) {
       auto concatenated = cudf::concatenate(table_views, stream, space->get_default_allocator());
       auto concat_rep =
         std::make_unique<cucascade::gpu_table_representation>(std::move(concatenated), *space);
-      single_batch = std::make_shared<cucascade::data_batch>(0, std::move(concat_rep));
+      single_batch = cucascade::data_batch::make(0, std::move(concat_rep));
     }
   }
 
   // After concatenation (or if only one batch), work with a single batch.
-  // For a concatenated batch (new idle), acquire read lock. For a single input batch, use directly.
+  // For a concatenated batch (new idle), acquire read lock. For a single input batch, clone access.
   ::cucascade::read_only_data_batch batch_ref =
-    single_batch ? single_batch->to_read_only() : ro_input_batches[0];
-  if (!batch_ref.get_data()) { return std::make_unique<pipelineable_operator_data>(); }
+    single_batch ? single_batch->get_read_only() : ro_input_batches[0].clone_read_only_access();
+  if (!batch_ref->get_data()) { return std::make_unique<pipelineable_operator_data>(); }
 
   // Apply table filters as a GPU expression if present.
   std::shared_ptr<cucascade::data_batch> output_batch;
@@ -163,11 +165,12 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     sirius::gpu_expression_executor gpu_expression_executor(
       local_filter_expr, cudf::get_current_device_resource_ref(), stream);
     auto filtered_table = gpu_expression_executor.select(
-      batch_ref.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
-    output_batch =
-      sirius::make_data_batch(std::move(filtered_table), *batch_ref.get_memory_space());
+      batch_ref->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+    auto* output_space =
+      batch_ref->get_memory_space();
+    output_batch = sirius::make_data_batch(std::move(filtered_table), *output_space);
   } else {
-    output_batch = ::cucascade::data_batch::to_idle(std::move(batch_ref));
+    output_batch = ::cucascade::read_only_data_batch::to_idle(std::move(batch_ref));
   }
 
   // After filtering, project away filter-only columns if the batch has more
@@ -182,8 +185,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   // Read batch column count under read-only lock, then release lock before mutation
   std::size_t num_batch_cols = 0;
   {
-    auto output_ro = output_batch->to_read_only();
-    auto& gpu_rep  = output_ro.get_data()->cast<cucascade::gpu_table_representation>();
+    auto output_ro = output_batch->get_read_only();
+    auto& gpu_rep  = output_ro->get_data()->cast<cucascade::gpu_table_representation>();
     num_batch_cols = static_cast<std::size_t>(gpu_rep.get_table_view().num_columns());
   }  // read lock released here
 
@@ -206,12 +209,14 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto batch_id                          = output_batch->get_batch_id();
     cucascade::memory::memory_space* space = nullptr;
     {
-      auto output_ro = output_batch->to_read_only();
-      space          = output_ro.get_memory_space();
-      auto& gpu_rep  = output_ro.get_data()->cast<cucascade::gpu_table_representation>();
-      auto table     = gpu_rep.release_table(stream);
+      auto output_mut = output_batch->get_mutable();
+      space = output_mut->get_memory_space();
+      auto& gpu_rep =
+        output_mut->get_data()
+          ->cast<cucascade::gpu_table_representation>();
+      auto table = gpu_rep.release_table(stream);
       columns        = table->release();
-    }  // read lock released here
+    }  // mutable lock released here
 
     // Select output columns using the batch column map.
     // projection_ids[0..expected_output_columns) are the output columns
@@ -235,7 +240,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto projected_table = std::make_unique<cudf::table>(std::move(selected));
     auto projected_rep =
       std::make_unique<cucascade::gpu_table_representation>(std::move(projected_table), *space);
-    output_batch = std::make_shared<cucascade::data_batch>(batch_id, std::move(projected_rep));
+    output_batch = cucascade::data_batch::make(batch_id, std::move(projected_rep));
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
                                                               rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n::execute"};
-  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto& input        = dynamic_cast<const pipelineable_operator_data&>(input_data);
   auto input_batches = input.get_read_only_batches();
   if (limit == 0) {
     return std::make_unique<pipelineable_operator_data>(
@@ -163,7 +163,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
   }
 
   auto const& input_batch = input_batches[0];
-  auto* space = input_batch->get_memory_space();
+  auto* space             = input_batch->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
@@ -214,7 +214,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
                                                                     rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n_merge::execute"};
-  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto& input        = dynamic_cast<const pipelineable_operator_data&>(input_data);
   auto input_batches = input.get_read_only_batches();
   if (limit == 0) {
     return std::make_unique<pipelineable_operator_data>(

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -150,7 +150,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n::execute"};
   auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& input_batches = input.get_read_only_batches();
+  auto input_batches = input.get_read_only_batches();
   if (limit == 0) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
@@ -162,15 +162,15 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     throw internal_exception("TopN expects a single input batch per execution");
   }
 
-  auto input_batch = input_batches[0];
-  auto* space      = input_batch.get_memory_space();
+  auto const& input_batch = input_batches[0];
+  auto* space = input_batch->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto input_table_view =
-    input_batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    input_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
   auto output_table = compute_top_n_table(
     input_table_view, orders, limit, offset, stream, space->get_default_allocator());
 
@@ -178,7 +178,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
-    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
+    cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(output_data)));
   return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
@@ -215,7 +215,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_top_n_merge::execute"};
   auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& input_batches = input.get_read_only_batches();
+  auto input_batches = input.get_read_only_batches();
   if (limit == 0) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
@@ -225,7 +225,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   // space in practice).
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
-    space = batch.get_memory_space();
+    space = batch->get_memory_space();
     break;
   }
   if (space == nullptr) {
@@ -237,7 +237,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   std::vector<cudf::table_view> concat_views;
   for (auto const& batch : input_batches) {
     concat_views.push_back(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
   }
 
   if (concat_views.empty()) {
@@ -269,7 +269,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space);
   outputs.push_back(
-    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
+    cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(output_data)));
   return std::make_unique<pipelineable_operator_data>(outputs);
 }
 

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -335,10 +335,10 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
   outputs.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
 
-    auto view = batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    auto view = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
 
     std::vector<std::unique_ptr<cudf::column>> cols;
     cols.reserve(layout.local_types.size());
@@ -435,7 +435,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
     std::unique_ptr<cucascade::idata_representation> output_data =
       std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
     auto const batch_id = ::sirius::get_next_batch_id();
-    outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
+    outputs.push_back(cucascade::data_batch::make(batch_id, std::move(output_data)));
   }
 
   return std::make_unique<pipelineable_operator_data>(outputs);
@@ -491,7 +491,8 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
-  cucascade::memory::memory_space* space = input_batches[0].get_memory_space();
+  auto* space =
+    input_batches[0]->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
@@ -500,7 +501,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   auto layout = build_aggregate_layout(aggregates);
   std::shared_ptr<cucascade::data_batch> merged_batch;
   if (input_batches.size() == 1) {
-    merged_batch = cucascade::data_batch::to_idle(std::move(input_batches[0]));
+    merged_batch = cucascade::read_only_data_batch::to_idle(std::move(input_batches[0]));
   } else {
     merged_batch = gpu_merge_impl::merge_ungrouped_aggregate(
       input_batches, layout.merge_kinds, layout.merge_nth_index, stream, *space);
@@ -512,9 +513,9 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   }
 
   // Acquire read access to merged batch to extract table
-  auto merged_ro = merged_batch->to_read_only();
+  auto merged_ro = merged_batch->get_read_only();
   auto merged_view =
-    merged_ro.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    merged_ro->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
 
   std::vector<std::unique_ptr<cudf::column>> output_cols;
   output_cols.reserve(layout.aggregates.size());
@@ -535,7 +536,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   std::unique_ptr<cucascade::idata_representation> output_data =
     std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space);
   auto const batch_id = ::sirius::get_next_batch_id();
-  auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+  auto output_batch   = cucascade::data_batch::make(batch_id, std::move(output_data));
 
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(output_batch)});

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -491,8 +491,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
-  auto* space =
-    input_batches[0]->get_memory_space();
+  auto* space = input_batches[0]->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -96,10 +96,10 @@ void log_operator_data(const op::sirius_physical_operator& op,
     const auto& batches = p_data->get_read_only_batches();
     num_batches         = batches.size();
     for (auto const& batch : batches) {
-      if (batch.get_data()) {
+      if (batch->get_data()) {
         auto view = get_cudf_table_view(batch);
         batch_rows += std::to_string(view.num_rows()) + "  ";
-        total_bytes += batch.get_data()->get_size_in_bytes();
+        total_bytes += batch->get_data()->get_size_in_bytes();
       }
     }
   } else {
@@ -417,7 +417,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       dynamic_cast<const op::pipelineable_operator_data*>(output_data.get());
     if (pipelineable_output) {
       for (const auto& batch : pipelineable_output->get_read_only_batches(false)) {
-        output_bytes += batch.get_data()->get_size_in_bytes();
+        output_bytes += batch->get_data()->get_size_in_bytes();
       }
     }
     auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
@@ -448,7 +448,7 @@ std::size_t gpu_pipeline_task::get_input_size() const
     dynamic_cast<const op::pipelineable_operator_data*>(local_state._input_data.get());
   if (!pipelineable_input) { return 0; }
   for (const auto& batch : pipelineable_input->get_read_only_batches(false)) {
-    input_size += batch.get_data()->get_size_in_bytes();
+    input_size += batch->get_data()->get_size_in_bytes();
   }
   return input_size;
 }

--- a/src/scan_manager/cached_split_provider.cpp
+++ b/src/scan_manager/cached_split_provider.cpp
@@ -79,7 +79,7 @@ std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
       }
       auto sliced = chunk->slice(_column_indices);
       auto batch =
-        std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(sliced));
+        cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(sliced));
       connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
         std::move(batch), _filter_expression, _plan));
     }
@@ -120,7 +120,7 @@ std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
     auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
       view, std::move(owner), alloc_size, *_memory_space);
     auto batch =
-      std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+      cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
     connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
       std::move(batch), _filter_expression, _plan));

--- a/src/scan_manager/cached_split_provider.cpp
+++ b/src/scan_manager/cached_split_provider.cpp
@@ -78,8 +78,7 @@ std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
           "[cached_split_provider] null host_data_representation in pinned chunks");
       }
       auto sliced = chunk->slice(_column_indices);
-      auto batch =
-        cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(sliced));
+      auto batch  = cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(sliced));
       connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
         std::move(batch), _filter_expression, _plan));
     }
@@ -119,8 +118,7 @@ std::future<void> cached_split_provider::start(exec::thread_pool& /*pool*/,
     cudf::table_view view(col_views);
     auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
       view, std::move(owner), alloc_size, *_memory_space);
-    auto batch =
-      cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
+    auto batch = cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
     connector.push_split(std::make_unique<op::scan::scan_cached_operator_data>(
       std::move(batch), _filter_expression, _plan));

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -615,7 +615,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to the repository so it's not empty
-//   auto batch = std::make_shared<cucascade::data_batch>(1, nullptr);
+//   auto batch = cucascade::data_batch::make(1, nullptr);
 //   data_repo->add_data_batch(batch);
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
@@ -635,8 +635,8 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to both repositories
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
-//   data_repo2->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
+//   data_repo2->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
 //     op, "input1", MemoryBarrierType::PIPELINE, data_repo1.get(), nullptr, nullptr);
@@ -658,7 +658,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data only to first repository
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 //   // data_repo2 is empty
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
@@ -827,7 +827,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to PIPELINE port's repo
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   // Create a mock pipeline that is finished for FULL barrier
 //   auto mock_pipeline = fixture.create_mock_pipeline();
@@ -855,7 +855,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to PIPELINE port's repo
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   // Create a mock pipeline that is NOT finished for FULL barrier
 //   auto mock_pipeline = fixture.create_mock_pipeline();

--- a/test/cpp/data/test_convertible_data_batch.cpp
+++ b/test/cpp/data/test_convertible_data_batch.cpp
@@ -61,23 +61,23 @@ test_env& env()
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 /// Helper: get the size in bytes of a data_batch's data using a temporary read-only lock.
 inline size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 /// Helper: compare batch's memory_space pointer (returns true if same as given space).
 inline bool batch_in_space(cucascade::data_batch& batch,
                            const cucascade::memory::memory_space* space)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space() == space;
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space() == space;
 }
 
 }  // anonymous namespace
@@ -139,7 +139,7 @@ TEST_CASE("convertible_data_batch_provider get_next_convertible returns last idl
   auto batch2_size = get_batch_size(*batch2);
 
   // Make batch3 non-idle by holding a read-only lock on it
-  auto batch3_lock = batch3->to_read_only();
+  auto batch3_lock = batch3->get_read_only();
 
   repo.add_data_batch(batch1);
   repo.add_data_batch(batch2);
@@ -168,7 +168,7 @@ TEST_CASE("convertible_data_batch_provider get_all_convertible returns all idle 
     *e.gpu_space, std::vector<int32_t>{6, 7, 8, 9}, cudf::type_id::INT32);
 
   // Make batch3 non-idle by holding a read-only lock on it
-  auto batch3_lock = batch3->to_read_only();
+  auto batch3_lock = batch3->get_read_only();
 
   repo.add_data_batch(batch1);
   repo.add_data_batch(batch2);
@@ -215,11 +215,11 @@ TEST_CASE("convertible_data_batch convert fails when batch exclusively locked",
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
 
-  // Hold an exclusive (mutable) lock so that try_to_mutable() inside convert() fails
-  auto exclusive_lock = batch->to_mutable();
+  // Hold an exclusive (mutable) lock so that try_get_mutable() inside convert() fails
+  auto exclusive_lock = batch->get_mutable();
 
   sirius::convertible_data_batch wrapper(batch);
-  // Non-blocking convert: uses try_to_mutable() internally, must return nullopt
+  // Non-blocking convert: uses try_get_mutable() internally, must return nullopt
   auto result = wrapper.convert({e.host_space}, e.stream(), *e.mgr, /*blocking=*/false);
 
   REQUIRE_FALSE(result.has_value());

--- a/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
+++ b/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
@@ -90,15 +90,15 @@ std::unique_ptr<sirius::pipeline::gpu_pipeline_task> make_test_gpu_task(
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 /// Helper: get the size in bytes of a data_batch's data using a temporary read-only lock.
 inline size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 }  // anonymous namespace
@@ -231,7 +231,7 @@ TEST_CASE("non-idle batch skipped by predicate", "[convertible_gpu_pipeline_task
   queue.push(std::move(task));
 
   // Hold an exclusive lock so batch is not idle — provider should skip it
-  auto exclusive_lock = batch->to_mutable();
+  auto exclusive_lock = batch->get_mutable();
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   auto cd = provider.get_next_convertible(e.gpu_space, false);

--- a/test/cpp/downgrade/test_downgrade_disk.cpp
+++ b/test/cpp/downgrade/test_downgrade_disk.cpp
@@ -49,8 +49,8 @@ namespace {
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 cucascade::memory::memory_space* get_gpu_space(

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -47,18 +47,18 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// Helper: get the memory tier of a data_batch via to_read_only()
+/// Helper: get the memory tier of a data_batch via get_read_only()
 cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
-/// Helper: get byte size of a data_batch via to_read_only()
+/// Helper: get byte size of a data_batch via get_read_only()
 size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
@@ -324,7 +324,7 @@ TEST_CASE("request_free_memory skips active partitions in first pass", "[downgra
   repo->add_data_batch(batch_p2, 2);
 
   // Lock batch_p1 in read_only state so downgrade executor skips it (state != idle)
-  auto batch_p1_lock = batch_p1->to_read_only();
+  auto batch_p1_lock = batch_p1->get_read_only();
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
   size_t three_batches = get_batch_size(*batch_p0) * 3;
@@ -370,8 +370,8 @@ TEST_CASE("request_free_memory skips batches already on HOST", "[downgrade_execu
   rmm::cuda_stream conv_stream;
   {
     // Acquire exclusive lock and convert to host representation
-    auto mut = gpu_batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
+    auto mut = gpu_batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
     // mut goes out of scope → releases exclusive lock, batch returns to idle
   }
   REQUIRE(get_batch_tier(*gpu_batch) == cucascade::memory::Tier::HOST);

--- a/test/cpp/downgrade/test_downgrade_lifecycle.cpp
+++ b/test/cpp/downgrade/test_downgrade_lifecycle.cpp
@@ -56,8 +56,8 @@ const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_test_memory_manager()

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -167,7 +167,7 @@ std::shared_ptr<data_batch> make_input_batch(
     128, column_types, ranges, cudf::get_default_stream(), mr);
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_int32_batch_with_nulls(memory_space& space,
@@ -202,7 +202,7 @@ std::shared_ptr<data_batch> make_int32_batch_with_nulls(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_two_int32_batch_with_nulls(memory_space& space,
@@ -241,7 +241,7 @@ std::shared_ptr<data_batch> make_two_int32_batch_with_nulls(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal64_batch(memory_space& space,
@@ -268,7 +268,7 @@ std::shared_ptr<data_batch> make_decimal64_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal64_two_col_batch(memory_space& space,
@@ -300,7 +300,7 @@ std::shared_ptr<data_batch> make_decimal64_two_col_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal32_batch(memory_space& space,
@@ -327,7 +327,7 @@ std::shared_ptr<data_batch> make_decimal32_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal128_batch(memory_space& space,
@@ -354,7 +354,7 @@ std::shared_ptr<data_batch> make_decimal128_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 using exp_executor      = ::sirius::gpu_expression_executor;
@@ -388,14 +388,14 @@ exec_result run_execute(memory_space& space,
 {
   auto wrapped = sirius::wrap_many(std::move(exprs));
   exp_executor executor(wrapped, get_resource_ref(space), cudf::get_default_stream(), strategy);
-  auto input_ro     = input_batch->to_read_only();
-  auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
+  auto input_ro     = input_batch->get_read_only();
+  auto& in_repr     = input_ro->get_data()->cast<gpu_table_representation>();
   auto output_table = executor.execute(in_repr.get_table_view());
   REQUIRE(output_table != nullptr);
   auto output_batch =
-    sirius::make_data_batch(std::move(output_table), *input_ro.get_memory_space());
-  auto output_ro = output_batch->to_read_only();
-  auto& out_repr = output_ro.get_data()->cast<gpu_table_representation>();
+    sirius::make_data_batch(std::move(output_table), *input_ro->get_memory_space());
+  auto output_ro = output_batch->get_read_only();
+  auto& out_repr = output_ro->get_data()->cast<gpu_table_representation>();
   return {input_batch, output_batch, in_repr.get_table_view(), out_repr.get_table_view()};
 }
 
@@ -406,14 +406,14 @@ exec_result run_select(memory_space& space,
 {
   auto wrapped = sirius::wrap_many(std::move(exprs));
   exp_executor executor(wrapped, get_resource_ref(space), cudf::get_default_stream(), strategy);
-  auto input_ro     = input_batch->to_read_only();
-  auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
+  auto input_ro     = input_batch->get_read_only();
+  auto& in_repr     = input_ro->get_data()->cast<gpu_table_representation>();
   auto output_table = executor.select(in_repr.get_table_view());
   REQUIRE(output_table != nullptr);
   auto output_batch =
-    sirius::make_data_batch(std::move(output_table), *input_ro.get_memory_space());
-  auto output_ro = output_batch->to_read_only();
-  auto& out_repr = output_ro.get_data()->cast<gpu_table_representation>();
+    sirius::make_data_batch(std::move(output_table), *input_ro->get_memory_space());
+  auto output_ro = output_batch->get_read_only();
+  auto& out_repr = output_ro->get_data()->cast<gpu_table_representation>();
   return {input_batch, output_batch, in_repr.get_table_view(), out_repr.get_table_view()};
 }
 

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -476,8 +476,7 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
     cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
-  auto batch =
-    cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
+  auto batch = cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {
@@ -606,8 +605,7 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
     cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
-  auto batch =
-    cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
+  auto batch = cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -345,12 +345,12 @@ cucascade::host_data_representation const& convert_to_host_table(
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
   }
 
-  auto ro    = batch->to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch->get_read_only();
+  auto* data = ro->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data after conversion"); }
   return data->cast<cucascade::host_data_representation>();
 }
@@ -477,12 +477,12 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =
-    std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
+    cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
   }
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);
@@ -607,12 +607,12 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
   auto batch =
-    std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
+    cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
   }
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);

--- a/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
@@ -180,7 +180,7 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -202,7 +202,7 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -224,7 +224,7 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::concat(ro, cudf::get_default_stream(), *mem_space),
                       std::runtime_error);
@@ -244,7 +244,7 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -266,7 +266,7 @@ TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merg
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -293,7 +293,7 @@ batches_with_handles create_batches_with_local_ungrouped_agg_result(
     aggregate_idx[i] = i;
   }
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_aggregate_impl::local_ungrouped_aggregate(
       ro_batch, aggregates, aggregate_idx, cudf::get_default_stream(), mem_space);
     result.batches.push_back(std::move(batch));
@@ -430,7 +430,7 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -454,7 +454,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_ungrouped_aggregate(
                         ro, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space),
@@ -471,7 +471,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_ungrouped_aggregate(
                         ro, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space),
@@ -500,7 +500,7 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -531,7 +531,7 @@ TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggreg
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -561,7 +561,7 @@ batches_with_handles create_batches_with_local_grouped_agg_result(
   // Compute local grouped aggregates
   batches_with_handles result;
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_aggregate_impl::local_grouped_aggregate(
       ro_batch, group_idx, aggregates, aggregate_idx, {}, cudf::get_default_stream(), mem_space);
     result.batches.push_back(std::move(batch));
@@ -707,7 +707,7 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -738,7 +738,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_grouped_aggregate(
                         ro, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space),
@@ -754,7 +754,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_grouped_aggregate(
                         ro, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space),
@@ -791,7 +791,7 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -830,7 +830,7 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -864,7 +864,7 @@ batches_with_handles create_batches_with_local_orderby_result(
     projections[i] = i;
   }
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_order_impl::local_order_by(ro_batch,
                                                 order_key_idx,
                                                 column_order,
@@ -939,7 +939,7 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,
@@ -978,7 +978,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(
       gpu_merge_impl::merge_order_by(
@@ -1000,7 +1000,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(
       gpu_merge_impl::merge_order_by(
@@ -1034,7 +1034,7 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,
@@ -1074,7 +1074,7 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -129,7 +129,7 @@ inline std::shared_ptr<cucascade::data_batch> concatenate_batches_horizontal(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(concatenated_table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename T>
@@ -208,7 +208,7 @@ inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 inline std::unique_ptr<cudf::column> make_string_column(const std::vector<std::string>& values,
@@ -273,7 +273,7 @@ inline std::shared_ptr<cucascade::data_batch> make_string_batch(
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
@@ -299,7 +299,7 @@ inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename T>
@@ -332,7 +332,7 @@ inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename TFirst, typename TSecond>
@@ -428,7 +428,7 @@ inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
 
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 }  // namespace sirius::test::operator_utils

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -179,7 +179,7 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
   auto input_batch =
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   {
-    auto ro = input_batch->to_read_only();
+    auto ro = input_batch->get_read_only();
     REQUIRE_THROWS_AS(
       gpu_partition_impl::hash_partition(
         ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space),
@@ -203,7 +203,7 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -230,7 +230,7 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -253,7 +253,7 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -323,7 +323,7 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -345,7 +345,7 @@ TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partitio
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -368,7 +368,7 @@ TEST_CASE("Evenly partition basic with num partitions larger than input size",
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -217,8 +217,8 @@ host_data_representation const& convert_to_host_table(
 {
   // Verify batch has data (use read-only accessor to check).
   {
-    auto ro = batch->to_read_only();
-    if (!ro.get_data()) { throw std::runtime_error("data_batch has no data representation"); }
+    auto ro = batch->get_read_only();
+    if (!ro->get_data()) { throw std::runtime_error("data_batch has no data representation"); }
   }
 
   auto& manager = sirius_ctx->get_memory_manager();
@@ -235,13 +235,13 @@ host_data_representation const& convert_to_host_table(
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<host_data_representation>(registry, host_space, stream);
   }
 
-  auto ro = batch->to_read_only();
-  if (!ro.get_data()) { throw std::runtime_error("data_batch has no data after conversion"); }
-  return ro.get_data()->cast<host_data_representation>();
+  auto ro = batch->get_read_only();
+  if (!ro->get_data()) { throw std::runtime_error("data_batch has no data after conversion"); }
+  return ro->get_data()->cast<host_data_representation>();
 }
 
 }  // namespace

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 // Helper: sort a batch using sirius_physical_order so it can be used as merge input

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), space);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 }  // namespace

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -102,9 +102,8 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
   columns.push_back(std::move(col1));
   auto table = std::make_unique<cudf::table>(std::move(columns));
 
-  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
-  auto input_batch =
-    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto gpu_repr    = std::make_unique<gpu_table_representation>(std::move(table), *space);
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
@@ -231,9 +230,8 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
   columns.push_back(std::move(col2));
   auto table = std::make_unique<cudf::table>(std::move(columns));
 
-  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
-  auto input_batch =
-    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto gpu_repr    = std::make_unique<gpu_table_representation>(std::move(table), *space);
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t partition_size = 10000000;
   // this cardinality is not real, we are setting here this large in order to force more partitions
@@ -320,9 +318,8 @@ TEST_CASE(
   columns.push_back(std::move(col1));
   auto table = std::make_unique<cudf::table>(std::move(columns));
 
-  auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
-  auto input_batch =
-    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto gpu_repr    = std::make_unique<gpu_table_representation>(std::move(table), *space);
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t estimated_cardinality = num_values;
 

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -104,7 +104,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
   auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
@@ -233,7 +233,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
   auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t partition_size = 10000000;
   // this cardinality is not real, we are setting here this large in order to force more partitions
@@ -322,7 +322,7 @@ TEST_CASE(
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(std::move(table), *space);
   auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+    data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t estimated_cardinality = num_values;
 

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -195,8 +195,8 @@ void convert_batch_to_host(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
   }
 }
 

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -456,7 +456,7 @@ TEST_CASE("parquet_scan with decimal filter sets table_scan passthrough",
   cols.push_back(std::move(col1));
   auto table    = std::make_unique<cudf::table>(std::move(cols));
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(std::move(table), *space);
-  auto input_batch = std::make_shared<cucascade::data_batch>(0, std::move(gpu_repr));
+  auto input_batch = cucascade::data_batch::make(0, std::move(gpu_repr));
 
   // Filter: col0 > 3.00 (decimal column-vs-literal comparisons translate to cuDF AST)
   auto table_filters   = duckdb::make_uniq<duckdb::TableFilterSet>();

--- a/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
@@ -127,27 +127,27 @@ TEST_CASE("DISK->GPU round-trip conversion via converter registry", "[gpu_pipeli
   rmm::cuda_stream stream;
 
   auto batch = make_gpu_batch(*gpu_space);
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // --- GPU -> DISK ---
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
+      mut->convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
   }
 
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
 
   // --- DISK -> GPU ---
   // This mirrors exactly what lock_or_prepare_batch Tier::GPU arm does when the batch is
   // disk-resident and the target memory space is GPU.
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
   }
 
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 }
 
 TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk]")
@@ -166,7 +166,7 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
 
   const size_t num_rows = 500;
   auto batch            = make_gpu_batch(*gpu_space, num_rows);
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // Snapshot column values before round-trip
   auto table_before = sirius::get_cudf_table_view(*batch);
@@ -177,26 +177,26 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
              cudaMemcpyDeviceToHost);
 
   const size_t size_before = [&batch]() {
-    auto ro = batch->to_read_only();
-    return ro.get_data()->get_size_in_bytes();
+    auto ro = batch->get_read_only();
+    return ro->get_data()->get_size_in_bytes();
   }();
   REQUIRE(size_before > 0);
 
   // GPU -> DISK
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
+      mut->convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
   }
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
 
   // DISK -> GPU
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
   }
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // Verify schema and shape
   auto table_after = sirius::get_cudf_table_view(*batch);
@@ -214,8 +214,8 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
 
   // Size should be unchanged (same data, same GPU format)
   const size_t size_after = [&batch]() {
-    auto ro = batch->to_read_only();
-    return ro.get_data()->get_size_in_bytes();
+    auto ro = batch->get_read_only();
+    return ro->get_data()->get_size_in_bytes();
   }();
   REQUIRE(size_after == size_before);
 }

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -136,15 +136,15 @@ struct pipeline_task_history_fixture {
 
     auto& registry = sirius::converter_registry::get();
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
     }
     stream.synchronize();
 
     {
-      auto ro = batch->to_read_only();
-      REQUIRE(ro.get_data() != nullptr);
-      REQUIRE(ro.get_data()->get_current_tier() == cucascade::memory::Tier::HOST);
+      auto ro = batch->get_read_only();
+      REQUIRE(ro->get_data() != nullptr);
+      REQUIRE(ro->get_data()->get_current_tier() == cucascade::memory::Tier::HOST);
     }
     return batch;
   }

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -204,8 +204,8 @@ inline void validate_scanned_batches(
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     }
     auto table_view = sirius::get_cudf_table_view(*batch);
 
@@ -293,8 +293,8 @@ inline void validate_projected_id_price_batches(
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     }
     auto table_view = sirius::get_cudf_table_view(*batch);
 


### PR DESCRIPTION
Migrate data_batch construction, locking, and accessor usage to cuCascade PR #120.

Adjust cached read-only accessors and pass-through paths for move-only lock handles