### PR TITLE
Fixed GPU PARQUET SCAN no history memory estimation when the data is pinned cached 

### DIFF
--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -127,6 +127,11 @@ class parquet_scan_data : public op::operator_data {
   {
   }
 
+  [[nodiscard]] op::operator_data_type get_type() const override
+  {
+    return op::operator_data_type::PARQUET_SCAN;
+  }
+
   /**
    * @brief Capture the task's reserved memory space so that
    *        sirius_gpu_parquet_scan_operator::execute() can tag its output batches with it.
@@ -203,6 +208,11 @@ class scan_cached_operator_data : public op::operator_data {
       filter_expression(std::move(filter_expression)),
       plan(std::move(plan))
   {
+  }
+
+  [[nodiscard]] op::operator_data_type get_type() const override
+  {
+    return op::operator_data_type::SCAN_CACHED;
   }
 
   /**

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -56,6 +56,21 @@ struct task_creation_hint {
 };
 
 /**
+ * @brief Tag identifying the concrete operator_data subclass.
+ *
+ * Returned by operator_data::get_type() so callers can branch on the runtime
+ * type without a dynamic_cast. Each subclass overrides get_type() to return
+ * its own value; BASE is the default for the unspecialized base class.
+ */
+enum class operator_data_type : uint8_t {
+  BASE,
+  PIPELINEABLE,
+  PARTITIONED,
+  PARQUET_SCAN,
+  SCAN_CACHED,
+};
+
+/**
  * @brief Generic base class for operator input/output data.
  *
  * This is an intentionally minimal base class with no opinion on what the
@@ -70,6 +85,14 @@ class operator_data {
   operator_data& operator=(const operator_data&) = default;
   operator_data(operator_data&&)                 = default;
   operator_data& operator=(operator_data&&)      = default;
+
+  /**
+   * @brief Identify the concrete subclass at runtime.
+   *
+   * Subclasses override to return their own operator_data_type. The base
+   * implementation returns operator_data_type::BASE.
+   */
+  [[nodiscard]] virtual operator_data_type get_type() const { return operator_data_type::BASE; }
 
   /**
    * @brief Per-task preparation hook invoked before the operator consumes this data.
@@ -146,6 +169,11 @@ class pipelineable_operator_data : public operator_data {
   {
   }
 
+  [[nodiscard]] operator_data_type get_type() const override
+  {
+    return operator_data_type::PIPELINEABLE;
+  }
+
   /**
    * @brief Get idle data batch pointers, lazily populating from read-only batches if needed.
    */
@@ -210,6 +238,11 @@ class partitioned_operator_data : public pipelineable_operator_data {
   {
   }
 
+  [[nodiscard]] operator_data_type get_type() const override
+  {
+    return operator_data_type::PARTITIONED;
+  }
+
   /**
    * @brief Get the partition index.
    * @return Partition index
@@ -223,12 +256,15 @@ class partitioned_operator_data : public pipelineable_operator_data {
 /**
  * @brief Input statistics passed to no_history_peak_memory_estimate().
  *
- * Carries the two dimensions that operator overrides typically condition on:
- * the number of input batches and the total uncompressed byte count.
+ * Carries the dimensions that operator overrides typically condition on: the
+ * number of input batches, the total uncompressed byte count, and the runtime
+ * type of the operator_data feeding the task (so overrides can branch on the
+ * concrete input shape without a dynamic_cast).
  */
 struct input_stats {
   std::size_t num_batches = 0;
   std::size_t bytes       = 0;
+  operator_data_type type = operator_data_type::BASE;
 };
 
 //! sirius_physical_operator is the base class of the physical operators present in the

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -275,6 +275,7 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
 std::size_t sirius_gpu_parquet_scan_operator::no_history_peak_memory_estimate(
   const op::input_stats& stats) const
 {
+  if (stats.type == op::operator_data_type::SCAN_CACHED) { return stats.bytes; }
   return stats.bytes * 8;
 }
 

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -473,7 +473,9 @@ pipeline::reservation_size_info gpu_pipeline_task::get_estimated_reservation_siz
     if (auto* pd = dynamic_cast<const op::pipelineable_operator_data*>(ls._input_data.get())) {
       num_batches = pd->get_data_batches().size();
     }
-    const op::input_stats stats{num_batches, input_basis};
+    const auto input_type =
+      ls._input_data ? ls._input_data->get_type() : op::operator_data_type::BASE;
+    const op::input_stats stats{num_batches, input_basis, input_type};
 
     std::size_t max_estimate = 0;
     if (auto* pipeline = gs.get_pipeline()) {


### PR DESCRIPTION
In this PR I add an enum operator_data_type, so that we can get the type of an operator data without having to dynamic cast it. I am passing that into the input stats struct, used by the no history operator memory estimation function. This way, GPU PARQUET SCAN can provide an accurate (and much smaller) estimate