### PR TITLE
build: bump cucascade to latest main (e6dcdd37)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,9 +347,10 @@ target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
                       OpenSSL::Crypto)
 
 # Required by DuckDB's export set (duckdb_static -> sirius_extension ->
-# cucascade_static / telemetry_bridge)
+# cucascade_static / cucascade_topology_discovery_static / telemetry_bridge)
 install(
-  TARGETS sirius_extension cucascade_static telemetry_bridge
+  TARGETS sirius_extension cucascade_static cucascade_topology_discovery_static
+          telemetry_bridge
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")


### PR DESCRIPTION
## Summary

- Bumps the `cucascade` submodule from `9ceebaa7` to `e6dcdd37` (latest `main`), picking up 6 commits:
  - FIX: bug in io_worker shutdown causing deadlock (#131)
  - Work around nvml bug in static library too (#130)
  - Construct `io_worker` thread after all other fields (#129)
  - Various CMake improvements (#127)
  - Fix topology discovery linking (#128)
  - Split topology discovery into its own target and switch to static CUDA linking (#126)
- Adds `cucascade_topology_discovery_static` to the `install(TARGETS ...)` rule in the top-level `CMakeLists.txt`. cuCascade #126 split topology discovery into a separate static library that `cucascade_static` now publicly depends on, so it must live in the same DuckDB export set — otherwise CMake configure fails with `export called with target "cucascade_static" which requires target "cucascade_topology_discovery_static" that is not in any export set`.

## Test plan

- [x] Full pixi release build (`CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make`) — produces `build/release/extension/sirius/sirius.duckdb_extension` (~51 MB) and links the unit test binary cleanly.
- [ ] CI green on `sirius-db/sirius:dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)