### PR TITLE
Fix for racy SEGFAULT on query end

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -129,8 +129,10 @@ void task_creator::drain_pending_tasks()
 {
   // Drain any queued task creation requests that haven't been picked up yet
   _task_creation_queue.drain();
+  _task_creation_queue.interrupt();
   // Wait for any in-flight task creation lambdas to finish
   _bounded_pool->wait_all();
+  _task_creation_queue.reactivate();
 }
 
 void task_creator::reset(bool keep_parquet_metadata)
@@ -226,11 +228,10 @@ void task_creator::manager_loop()
       SIRIUS_LOG_INFO("Task Creator: pool interrupted, stopping manager loop");
       break;
     }
-
     auto request = _task_creation_queue.pop();
     if (!request) {
-      SIRIUS_LOG_INFO("Task Creator: task queue interrupted, stopping manager loop");
-      break;
+      // This is likely because the task creator was interrupted and the queue was drained
+      continue;
     }
 
     auto node = request->node;

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -128,8 +128,8 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
 void task_creator::drain_pending_tasks()
 {
   // Drain any queued task creation requests that haven't been picked up yet
-  _task_creation_queue.drain();
   _task_creation_queue.interrupt();
+  _task_creation_queue.drain();
   // Wait for any in-flight task creation lambdas to finish
   _bounded_pool->wait_all();
   _task_creation_queue.reactivate();

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -336,7 +336,10 @@ void gpu_pipeline_executor::manager_loop()
           }
         }
 
-        if (query_complete && _completion_handler) { _completion_handler->mark_completed(); }
+        if (query_complete && _completion_handler) {
+          _task_creator->drain_pending_tasks();
+          _completion_handler->mark_completed();
+        }
       });
   }
 }


### PR DESCRIPTION
implemented a fix for an issue which happens when a query ends and there is still a task creation request in the queue. When this happens the operator node objects have been freed, and resolving a task creation request results in a SEGFAULT.
The fix drains the task_creation queue and waits for it to be empty before setting the completion handler to task completed.