### PR TITLE
decode: leftover correctness fixes for rle / bitpacking (DuckDB format GPU-native Part 9)

### DIFF
--- a/src/cuda/scan/gpu_decode_bitpacking.cu
+++ b/src/cuda/scan/gpu_decode_bitpacking.cu
@@ -108,9 +108,15 @@ __global__ void kernel_decode_bitpacking(bp_group_desc const* __restrict__ descs
   auto const* seg_base = desc.d_segment;
   auto const seg_bytes = desc.segment_bytes;
 
-  // Note that d_output is 256B aligned (guaranteed by CUDA), and global_row_offset is a multiple of
-  // BP_META_GROUP_SIZE, so `out` is always 16B-aligned, and 16B vectorized stores are defined.
+  // `d_output` is 256B-aligned by CUDA, but `out` is only 16B-aligned when
+  // `global_row_offset * sizeof(T)` is a multiple of `sizeof(vec_t)`. That
+  // holds for the first segment in a column and any stacked segment whose
+  // prior-segment row count was a multiple of `sizeof(vec_t) / sizeof(T)` —
+  // not in general. CONSTANT and CONSTANT_DELTA branch on this and use
+  // scalar stores when unaligned (FOR / DELTA_FOR already store scalar).
   auto* out = d_output + desc.global_row_offset;
+  bool const out_vec_aligned =
+    (reinterpret_cast<::cuda::std::uintptr_t>(out) % sizeof(vec_t)) == 0;
 
   // Shared metadata — written by thread 0, read by all after the barrier.
   // `sm_aux` is overloaded by mode:
@@ -231,19 +237,25 @@ __global__ void kernel_decode_bitpacking(bp_group_desc const* __restrict__ descs
   if (mode == BitpackingMode::CONSTANT) {
     auto const val         = sm_aux;
     uint32_t constexpr TPV = sizeof(vec_t) / sizeof(T);
-    auto const vec_count   = rc / TPV;
-    auto* out4             = reinterpret_cast<vec_t*>(out);
-    vec_t packed;
-    auto* lanes = reinterpret_cast<T*>(&packed);
+    if (out_vec_aligned) {
+      auto const vec_count = rc / TPV;
+      auto* out4           = reinterpret_cast<vec_t*>(out);
+      vec_t packed;
+      auto* lanes = reinterpret_cast<T*>(&packed);
 #pragma unroll
-    for (uint32_t i = 0; i < TPV; ++i)
-      lanes[i] = val;
-    for (uint32_t v = threadIdx.x; v < vec_count; v += blockDim.x) {
-      __stcs(out4 + v, packed);
-    }
-    uint32_t tail_start = vec_count * TPV;
-    for (uint32_t i = tail_start + threadIdx.x; i < rc; i += blockDim.x) {
-      __stcs(out + i, val);
+      for (uint32_t i = 0; i < TPV; ++i)
+        lanes[i] = val;
+      for (uint32_t v = threadIdx.x; v < vec_count; v += blockDim.x) {
+        __stcs(out4 + v, packed);
+      }
+      uint32_t tail_start = vec_count * TPV;
+      for (uint32_t i = tail_start + threadIdx.x; i < rc; i += blockDim.x) {
+        __stcs(out + i, val);
+      }
+    } else {
+      for (uint32_t i = threadIdx.x; i < rc; i += blockDim.x) {
+        __stcs(out + i, val);
+      }
     }
     return;
   }
@@ -255,21 +267,27 @@ __global__ void kernel_decode_bitpacking(bp_group_desc const* __restrict__ descs
     auto const frame       = sm_frame;
     auto const delta       = sm_aux;
     uint32_t constexpr TPV = sizeof(vec_t) / sizeof(T);
-    auto const vec_count   = rc / TPV;
-    auto* out4             = reinterpret_cast<vec_t*>(out);
-    for (uint32_t v = threadIdx.x; v < vec_count; v += blockDim.x) {
-      vec_t packed;
-      auto* lanes       = reinterpret_cast<T*>(&packed);
-      auto const base_v = v * TPV;
+    if (out_vec_aligned) {
+      auto const vec_count = rc / TPV;
+      auto* out4           = reinterpret_cast<vec_t*>(out);
+      for (uint32_t v = threadIdx.x; v < vec_count; v += blockDim.x) {
+        vec_t packed;
+        auto* lanes       = reinterpret_cast<T*>(&packed);
+        auto const base_v = v * TPV;
 #pragma unroll
-      for (uint32_t i = 0; i < TPV; ++i) {
-        lanes[i] = static_cast<T>(frame + static_cast<T>(base_v + i) * delta);
+        for (uint32_t i = 0; i < TPV; ++i) {
+          lanes[i] = static_cast<T>(frame + static_cast<T>(base_v + i) * delta);
+        }
+        __stcs(out4 + v, packed);
       }
-      __stcs(out4 + v, packed);
-    }
-    auto const tail_start = vec_count * TPV;
-    for (uint32_t i = tail_start + threadIdx.x; i < rc; i += blockDim.x) {
-      __stcs(out + i, static_cast<T>(frame + static_cast<T>(i) * delta));
+      auto const tail_start = vec_count * TPV;
+      for (uint32_t i = tail_start + threadIdx.x; i < rc; i += blockDim.x) {
+        __stcs(out + i, static_cast<T>(frame + static_cast<T>(i) * delta));
+      }
+    } else {
+      for (uint32_t i = threadIdx.x; i < rc; i += blockDim.x) {
+        __stcs(out + i, static_cast<T>(frame + static_cast<T>(i) * delta));
+      }
     }
     return;
   }

--- a/src/cuda/scan/gpu_decode_bitpacking.cu
+++ b/src/cuda/scan/gpu_decode_bitpacking.cu
@@ -114,9 +114,8 @@ __global__ void kernel_decode_bitpacking(bp_group_desc const* __restrict__ descs
   // prior-segment row count was a multiple of `sizeof(vec_t) / sizeof(T)` —
   // not in general. CONSTANT and CONSTANT_DELTA branch on this and use
   // scalar stores when unaligned (FOR / DELTA_FOR already store scalar).
-  auto* out = d_output + desc.global_row_offset;
-  bool const out_vec_aligned =
-    (reinterpret_cast<::cuda::std::uintptr_t>(out) % sizeof(vec_t)) == 0;
+  auto* out                  = d_output + desc.global_row_offset;
+  bool const out_vec_aligned = (reinterpret_cast<::cuda::std::uintptr_t>(out) % sizeof(vec_t)) == 0;
 
   // Shared metadata — written by thread 0, read by all after the barrier.
   // `sm_aux` is overloaded by mode:

--- a/src/cuda/scan/gpu_decode_rle.cu
+++ b/src/cuda/scan/gpu_decode_rle.cu
@@ -89,6 +89,10 @@ struct rle_segment_desc {
   uint8_t const* d_bytes;
   uint32_t bytes_size;
   uint32_t segment_row_count;
+  /// Per-value byte width. DuckDB's `bytes_size` includes zero-padded slack
+  /// when the segment is the last in its block; `parse_rle_metadata` uses
+  /// `type_size` to bound iteration at the real-count boundary instead.
+  uint32_t type_size;
 };
 
 /**
@@ -132,7 +136,10 @@ struct BlockPrefixCallbackOp {
  */
 struct rle_parsed_metadata {
   rle_count_t const* counts_ptr;
-  uint32_t n_counts_max;
+  /// Real entry count of the counts[] region, computed from the values
+  /// region length (RLE has a 1:1 invariant between values and counts).
+  /// Stops iteration short of any zero-padded slack at the block tail.
+  uint32_t n_counts_real;
   bool is_malformed;
 };
 
@@ -156,9 +163,20 @@ __device__ __forceinline__ rle_parsed_metadata parse_rle_metadata(rle_segment_de
     md.is_malformed = true;
     return md;
   }
+  // Real entry count = values_region_bytes / type_size (1:1 invariant). If
+  // type_size is unset or doesn't divide cleanly, fall back to the bytes-
+  // derived bound and rely on the malformed-vs-match swap below to recover.
+  const uint64_t values_region_bytes = counts_offset - RLE_HEADER_SIZE;
+  const uint64_t counts_region_bytes = desc.bytes_size - counts_offset;
+  uint64_t n_real = 0;
+  if (desc.type_size > 0 && (values_region_bytes % desc.type_size) == 0) {
+    n_real = values_region_bytes / desc.type_size;
+  } else {
+    n_real = counts_region_bytes / sizeof(rle_count_t);
+  }
 
-  md.counts_ptr   = reinterpret_cast<rle_count_t const*>(desc.d_bytes + counts_offset);
-  md.n_counts_max = static_cast<uint32_t>((desc.bytes_size - counts_offset) / sizeof(rle_count_t));
+  md.counts_ptr    = reinterpret_cast<rle_count_t const*>(desc.d_bytes + counts_offset);
+  md.n_counts_real = static_cast<uint32_t>(n_real);
   return md;
 }
 
@@ -220,10 +238,10 @@ __global__ void kernel_build_rle(rle_segment_desc const* __restrict__ segment_de
 
   auto const n_segment_rows = segment_descriptor.segment_row_count;
   auto const* counts_ptr    = s_md.counts_ptr;
-  // (Defensively) cap iteration at the per-segment prefix-sum slot so BlockStore can't write past
-  // the slot.
+  // Bound by `n_counts_real` (skips block-tail zero slack) and clamp to the
+  // prefix-sum slot so BlockStore can't write past it.
   auto const n_counts_max = ::cuda::std::min(
-    s_md.n_counts_max, static_cast<uint32_t>(PREFIX_SUM_BUFFER_ENTRIES_PER_SEGMENT));
+    s_md.n_counts_real, static_cast<uint32_t>(PREFIX_SUM_BUFFER_ENTRIES_PER_SEGMENT));
   auto* prefix_sum_ptr =
     d_prefix_sums + static_cast<size_t>(segment_id) * PREFIX_SUM_BUFFER_ENTRIES_PER_SEGMENT;
 
@@ -292,12 +310,16 @@ __global__ void kernel_build_rle(rle_segment_desc const* __restrict__ segment_de
     if (threadIdx.x == 0) { s_first_match = tile_first_match; }
     __syncthreads();
 
-    if (s_is_malformed) {
-      if (threadIdx.x == 0) { d_counts[segment_id] = MALFORMED_FLAG; }
-      return;
-    }
+    // Match wins over malformed: once a tile entry's prefix sum hits
+    // n_segment_rows, the segment is well-formed up to that point. A zero
+    // count past that match comes from block-tail slack (encoder never
+    // emits count == 0 in real data), not corruption.
     if (s_first_match != NO_MATCH) {
       if (threadIdx.x == 0) { d_counts[segment_id] = s_first_match; }
+      return;
+    }
+    if (s_is_malformed) {
+      if (threadIdx.x == 0) { d_counts[segment_id] = MALFORMED_FLAG; }
       return;
     }
   }
@@ -501,8 +523,10 @@ void decode_rle_data(gpu_codec_run const& run,
   // Build per-segment build descriptors.
   std::vector<rle_segment_desc> h_build_descs(num_live_segments);
   for (size_t i = 0; i < num_live_segments; ++i) {
-    h_build_descs[i] = {
-      live_segments[i]->d_bytes, live_segments[i]->bytes_size, live_segments[i]->row_count};
+    h_build_descs[i] = {live_segments[i]->d_bytes,
+                        live_segments[i]->bytes_size,
+                        live_segments[i]->row_count,
+                        type_size};
   }
 
   // Worst-case allocation: 352 KiB/segment.

--- a/src/cuda/scan/gpu_decode_rle.cu
+++ b/src/cuda/scan/gpu_decode_rle.cu
@@ -168,7 +168,7 @@ __device__ __forceinline__ rle_parsed_metadata parse_rle_metadata(rle_segment_de
   // derived bound and rely on the malformed-vs-match swap below to recover.
   const uint64_t values_region_bytes = counts_offset - RLE_HEADER_SIZE;
   const uint64_t counts_region_bytes = desc.bytes_size - counts_offset;
-  uint64_t n_real = 0;
+  uint64_t n_real                    = 0;
   if (desc.type_size > 0 && (values_region_bytes % desc.type_size) == 0) {
     n_real = values_region_bytes / desc.type_size;
   } else {

--- a/test/cpp/scan/test_gpu_decode_bitpacking.cpp
+++ b/test/cpp/scan/test_gpu_decode_bitpacking.cpp
@@ -321,6 +321,66 @@ TEST_CASE("gpu_decode_table BITPACKING - multi-segment column", "[scan][decode][
     REQUIRE(out[50 + i] == 103);
 }
 
+TEST_CASE("gpu_decode_table BITPACKING - CONSTANT/CONSTANT_DELTA at unaligned dst row offset",
+          "[scan][decode][bitpacking]")
+{
+  // CONSTANT and CONSTANT_DELTA paths do 16B vector stores to
+  // out = d_output + global_row_offset. Alignment holds within a single
+  // segment (group offsets are multiples of BP_META_GROUP_SIZE = 2048) but
+  // breaks across stacked segments whose cumulative row count is not a
+  // multiple of sizeof(vec_t)/sizeof(T). The kernel must detect this and
+  // fall back to scalar stores; otherwise the vector store faults with
+  // cudaErrorMisalignedAddress.
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  // Segment A: 50 int32 rows = 200 bytes, not a multiple of 16. Segment B's
+  // destination then starts at byte offset 200 — unaligned for vec_t stores.
+  auto bytes_a = make_for_block<int32_t>(/*frame=*/0, /*width=*/4, std::vector<int32_t>(50, 1));
+  rmm::device_buffer d_a(bytes_a.data(), bytes_a.size(), stream.view());
+
+  SECTION("CONSTANT at unaligned row offset")
+  {
+    auto bytes_b = make_constant_block<int32_t>(77);
+    rmm::device_buffer d_b(bytes_b.data(), bytes_b.size(), stream.view());
+    gpu_column_decode_input col;
+    col.out_type   = I32;
+    col.total_rows = 100;
+    col.data.push_back(
+      {CompressionType::COMPRESSION_BITPACKING,
+       {gpu_segment_desc{
+          static_cast<uint8_t const*>(d_a.data()), static_cast<uint32_t>(d_a.size()), 0, 50},
+        gpu_segment_desc{
+          static_cast<uint8_t const*>(d_b.data()), static_cast<uint32_t>(d_b.size()), 50, 50}}});
+    auto t   = gpu_decode_table({col}, stream.view(), mr);
+    auto out = download<int32_t>(t->get_column(0).view().data<int32_t>(), 100, stream.value());
+    for (uint32_t i = 0; i < 50; ++i)
+      REQUIRE(out[i] == 1);
+    for (uint32_t i = 0; i < 50; ++i)
+      REQUIRE(out[50 + i] == 77);
+  }
+
+  SECTION("CONSTANT_DELTA at unaligned row offset")
+  {
+    auto bytes_b = make_constant_delta_block<int32_t>(/*frame=*/1000, /*delta=*/3);
+    rmm::device_buffer d_b(bytes_b.data(), bytes_b.size(), stream.view());
+    gpu_column_decode_input col;
+    col.out_type   = I32;
+    col.total_rows = 100;
+    col.data.push_back(
+      {CompressionType::COMPRESSION_BITPACKING,
+       {gpu_segment_desc{
+          static_cast<uint8_t const*>(d_a.data()), static_cast<uint32_t>(d_a.size()), 0, 50},
+        gpu_segment_desc{
+          static_cast<uint8_t const*>(d_b.data()), static_cast<uint32_t>(d_b.size()), 50, 50}}});
+    auto t   = gpu_decode_table({col}, stream.view(), mr);
+    auto out = download<int32_t>(t->get_column(0).view().data<int32_t>(), 100, stream.value());
+    for (uint32_t i = 0; i < 50; ++i)
+      REQUIRE(out[i] == 1);
+    for (uint32_t i = 0; i < 50; ++i)
+      REQUIRE(out[50 + i] == 1000 + static_cast<int32_t>(i) * 3);
+  }
+}
+
 TEST_CASE("gpu_decode_table BITPACKING - multi-group segment", "[scan][decode][bitpacking]")
 {
   // One segment that spans more than BP_META_GROUP_SIZE rows. The kernel

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -250,6 +250,23 @@ TEST_CASE("gpu_decode_table RLE - segment with on-disk padding", "[scan][decode]
     REQUIRE(out[10 + i] == 88);
 }
 
+TEST_CASE("gpu_decode_table RLE - trailing slack past counts decodes correctly",
+          "[scan][decode][rle]")
+{
+  // DuckDB's block allocator gives the last segment in a 256 KB block all
+  // remaining unused space — bytes past the real RLE data are zero-fill slack.
+  // The kernel must bound iteration on the values-region size; otherwise it
+  // walks the slack, hits a zero count, and zero-fills the column output.
+  std::vector<int32_t> values{1, 2, 3};
+  std::vector<uint16_t> counts{10, 20, 30};
+  auto bytes = sirius::test::decode::rle::make_rle_block<int32_t>(values, counts);
+  bytes.resize(bytes.size() + 4096, 0);
+
+  auto out      = decode_one<int32_t>(bytes, I32, 60);
+  auto expected = expand_runs<int32_t>(values, counts);
+  REQUIRE(out == expected);
+}
+
 // Defensive guards: pre-fill output with a 0xCC canary, call decode_rle_data
 // directly (skipping the dispatcher's allocate-fresh path), then assert
 // every byte is zero.
@@ -393,11 +410,13 @@ TEST_CASE("gpu_decode_table RLE - count walk overflows row_count zero-fills",
     REQUIRE(out[i] == 0);
 }
 
-TEST_CASE("gpu_decode_table RLE - zero count inside walk zero-fills",
+TEST_CASE("gpu_decode_table RLE - zero count with sum underflow zero-fills",
           "[scan][decode][rle][defensive]")
 {
-  // DuckDB never emits zero counts; treat them as malformed.
-  auto bytes = make_rle_block<int32_t>({1, 99, 2}, {10, 0, 10});
+  // An interior zero count is malformed only when the running sum never
+  // reaches n_segment_rows by the end of real counts — a present-and-zero
+  // count followed by a sum-match is legitimate (slack).
+  auto bytes = make_rle_block<int32_t>({1, 99, 2}, {10, 0, 5});  // sum = 15
 
   rmm::cuda_stream stream;
   rmm::mr::cuda_async_memory_resource mr;

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -446,11 +446,9 @@ TEST_CASE("gpu_decode_table RLE - count walk overflows row_count zero-fills",
 TEST_CASE("gpu_decode_table RLE - zero count with sum underflow zero-fills",
           "[scan][decode][rle][defensive]")
 {
-  // An interior zero count is malformed only when the running sum never
-  // reaches n_segment_rows by the end of the real-counts walk. Trailing
-  // zeros that appear AFTER the prefix-sum has already matched are slack
-  // and are absorbed by the match-vs-malformed reordering, not by the
-  // zero-count check.
+  // Interior zero count + sum never reaches n_segment_rows → malformed.
+  // (Zeros after the sum-match are slack — handled by match-over-malformed,
+  // not this check.)
   auto bytes = make_rle_block<int32_t>({1, 99, 2}, {10, 0, 5});  // sum = 15
 
   rmm::cuda_stream stream;

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -295,9 +295,9 @@ TEST_CASE("gpu_decode_table RLE - narrow-type alignment padding decodes correctl
   col.out_type   = U8;
   col.total_rows = total_rows;
   col.has_nulls  = false;
-  col.data.push_back({CompressionType::COMPRESSION_RLE,
-                      {gpu_segment_desc{
-                        static_cast<uint8_t const*>(d_seg.data()), seg_bytes, 0, total_rows}}});
+  col.data.push_back(
+    {CompressionType::COMPRESSION_RLE,
+     {gpu_segment_desc{static_cast<uint8_t const*>(d_seg.data()), seg_bytes, 0, total_rows}}});
 
   auto t   = gpu_decode_table({col}, stream.view(), mr);
   auto out = download<uint8_t>(t->get_column(0).view().data<uint8_t>(), total_rows, stream.value());

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -267,6 +267,44 @@ TEST_CASE("gpu_decode_table RLE - trailing slack past counts decodes correctly",
   REQUIRE(out == expected);
 }
 
+TEST_CASE("gpu_decode_table RLE - narrow-type alignment padding decodes correctly",
+          "[scan][decode][rle]")
+{
+  // The last segment per column can have entry_count not a multiple of 8,
+  // so for sizeof(T) < 8 DuckDB inserts 0..7 bytes of zero-fill alignment
+  // padding between values and counts. Worst case: T = uint8 with 3
+  // entries → minimal=11, aligned=16, padding=5. The kernel walks counts
+  // using the values-region bound (so it stops exactly at the real-count
+  // boundary) and the match-vs-malformed reordering absorbs any trailing
+  // bytes that get loaded into the same tile. Pin the contract by placing
+  // non-zero poison bytes immediately after the segment and asserting the
+  // decoded output is still correct.
+  std::vector<uint8_t> values{11, 22, 33};
+  std::vector<uint16_t> counts{5, 10, 15};  // sum = 30
+  auto seg                 = sirius::test::decode::rle::make_rle_block<uint8_t>(values, counts);
+  uint32_t const seg_bytes = static_cast<uint32_t>(seg.size());
+  std::vector<uint8_t> bytes(seg_bytes + 64, 0xFF);
+  std::memcpy(bytes.data(), seg.data(), seg_bytes);
+
+  rmm::cuda_stream stream;
+  rmm::mr::cuda_async_memory_resource mr;
+  rmm::device_buffer d_seg(bytes.data(), bytes.size(), stream.view());
+
+  uint32_t const total_rows = 30;
+  gpu_column_decode_input col;
+  col.out_type   = U8;
+  col.total_rows = total_rows;
+  col.has_nulls  = false;
+  col.data.push_back({CompressionType::COMPRESSION_RLE,
+                      {gpu_segment_desc{
+                        static_cast<uint8_t const*>(d_seg.data()), seg_bytes, 0, total_rows}}});
+
+  auto t   = gpu_decode_table({col}, stream.view(), mr);
+  auto out = download<uint8_t>(t->get_column(0).view().data<uint8_t>(), total_rows, stream.value());
+  auto expected = expand_runs<uint8_t>(values, counts);
+  REQUIRE(out == expected);
+}
+
 // Defensive guards: pre-fill output with a 0xCC canary, call decode_rle_data
 // directly (skipping the dispatcher's allocate-fresh path), then assert
 // every byte is zero.
@@ -414,8 +452,10 @@ TEST_CASE("gpu_decode_table RLE - zero count with sum underflow zero-fills",
           "[scan][decode][rle][defensive]")
 {
   // An interior zero count is malformed only when the running sum never
-  // reaches n_segment_rows by the end of real counts — a present-and-zero
-  // count followed by a sum-match is legitimate (slack).
+  // reaches n_segment_rows by the end of the real-counts walk. Trailing
+  // zeros that appear AFTER the prefix-sum has already matched are slack
+  // and are absorbed by the match-vs-malformed reordering, not by the
+  // zero-count check.
   auto bytes = make_rle_block<int32_t>({1, 99, 2}, {10, 0, 5});  // sum = 15
 
   rmm::cuda_stream stream;

--- a/test/cpp/scan/test_gpu_decode_rle.cpp
+++ b/test/cpp/scan/test_gpu_decode_rle.cpp
@@ -270,15 +270,10 @@ TEST_CASE("gpu_decode_table RLE - trailing slack past counts decodes correctly",
 TEST_CASE("gpu_decode_table RLE - narrow-type alignment padding decodes correctly",
           "[scan][decode][rle]")
 {
-  // The last segment per column can have entry_count not a multiple of 8,
-  // so for sizeof(T) < 8 DuckDB inserts 0..7 bytes of zero-fill alignment
-  // padding between values and counts. Worst case: T = uint8 with 3
-  // entries → minimal=11, aligned=16, padding=5. The kernel walks counts
-  // using the values-region bound (so it stops exactly at the real-count
-  // boundary) and the match-vs-malformed reordering absorbs any trailing
-  // bytes that get loaded into the same tile. Pin the contract by placing
-  // non-zero poison bytes immediately after the segment and asserting the
-  // decoded output is still correct.
+  // Narrow types (sizeof(T)<8) get 0..7 bytes of alignment padding between
+  // values and counts; worst case uint8 with 3 entries → 5 bytes. 0xFF
+  // poison after the segment proves the values-region bound + match-vs-
+  // malformed reordering absorb any over-read into the tile.
   std::vector<uint8_t> values{11, 22, 33};
   std::vector<uint16_t> counts{5, 10, 15};  // sum = 30
   auto seg                 = sirius::test::decode::rle::make_rle_block<uint8_t>(values, counts);


### PR DESCRIPTION
Two correctness fixes for code already merged via the decode-kernel PRs (#737 / #764), plus regression tests pinning each.

- **RLE values-region bound** (`gpu_decode_rle.cu`). DuckDB's block allocator gives the last segment in each 256 KiB block all remainingcunused space, even when the real RLE data is smaller; the trailingcslack is zero-filled. Pre-fix the kernel bounded counts iteration oncthe segment's `bytes_size`, walked into slack, hit a zero count, marked MALFORMED, and the expand kernel zero-filled output. Fix uses the RLE 1:1 values-counts invariant to compute the exact real-count entry count from `(counts_offset - RLE_HEADER_SIZE) / type_size`, and reorders the per-tile return so MATCH wins over MALFORMED.

- **Bitpacking unaligned-dst scalar fallback** (`gpu_decode_bitpacking.cu`). CONSTANT and CONSTANT_DELTA modes did `vec_t` (16B) stores assuming `out = d_output + global_row_offset` was 16B-aligned. That holds within a single segment (group offsets are multiples of `BP_META_GROUP_SIZE = 2048`) but breaks across stacked segments whose cumulative row count isn't a multiple of `sizeof(vec_t) / sizeof(T)` — kernel faulted with `cudaErrorMisalignedAddress`. Fix: branch on `out_vec_aligned` and fall back to scalar `__stcs` stores when unaligned.

Two regression tests added in `test/cpp/scan/`:
- `test_gpu_decode_rle.cpp`: RLE trailing-slack scenario (`gpu_decode_table RLE - trailing slack past counts decodes correctly`).
- `test_gpu_decode_bitpacking.cpp`: CONSTANT + CONSTANT_DELTA at unaligned dst row offset (50 int32 rows = 200 bytes ahead of the segment under test).

## Test plan
- `build/release/extension/sirius/test/cpp/sirius_unittest "[scan][decode][rle]"`
- `build/release/extension/sirius/test/cpp/sirius_unittest "[scan][decode][bitpacking]"`