### PR TITLE
CI: Change to gpu-2xt4 instead of gpu-4xt4 to improve GPU testing concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           retention-days: 1
 
   test-cuda-13:
-    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-4xt4]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-2xt4]
     needs: build-cuda-13
     if: needs.build-cuda-13.result == 'success'
     timeout-minutes: 60
@@ -188,7 +188,7 @@ jobs:
           retention-days: 14
 
   test-cuda-12:
-    runs-on: [self-hosted, ubuntu-22.04, cuda-12, gpu-4xt4]
+    runs-on: [self-hosted, ubuntu-22.04, cuda-12, gpu-2xt4]
     needs: build-cuda-12
     if: needs.build-cuda-12.result == 'success'
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,9 @@ jobs:
         run: tar -xf build.tar
 
       - name: Run C++ unit tests
-        run: timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+        run: |
+            nvidia-smi
+            timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
 
       - name: Upload unit test logs
         if: always()
@@ -212,7 +214,9 @@ jobs:
         run: tar -xf build.tar
 
       - name: Run C++ unit tests
-        run: timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
+        run: |
+            nvidia-smi
+            timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
 
       - name: Upload unit test logs
         if: always()


### PR DESCRIPTION
Realized there is a misconfiguration with `gpu-4xt4` that is reducing our testing throughput. This switches to new `gpu-2xt4` runners that can share a single GPU node with 4xT4s instead of using two 4xT4 nodes per test. This will increase the concurrency for GPU testing while allowing for SNMG testing required after the merge of #732