### PR TITLE
feat: dual-path gpu_expression_executor (Phase 5 of #666 — closes #698)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ set(TEST_SOURCES
     test/cpp/expression/test_join_condition.cpp
     test/cpp/expression/test_value.cpp
     test/cpp/expression_executor/test_gpu_expression_executor.cpp
+    test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
     test/cpp/expression_executor/test_gpu_expression_translator.cpp
     test/cpp/helper/test_logical_type.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(EXTENSION_SOURCES
     src/expression/from_duckdb.cpp
     src/expression/function_id.cpp
     src/expression/join_condition.cpp
+    src/expression/to_duckdb.cpp
     src/expression/value.cpp
     src/expression_executor/expression_executor_strategy.cpp
     src/expression_executor/gpu_expression_executor.cpp
@@ -435,6 +436,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/expression/test_ast_from_duckdb.cpp
     test/cpp/expression/test_ast_scaffold.cpp
+    test/cpp/expression/test_ast_to_duckdb.cpp
     test/cpp/expression/test_expression.cpp
     test/cpp/expression/test_function_id.cpp
     test/cpp/expression/test_join_condition.cpp

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -169,8 +169,8 @@ std::unique_ptr<duckdb::Expression> to_duckdb(cast const& alt)
                                                      duckdb::BoundCastInfo{nullptr},
                                                      /*is_try_cast=*/true));
   }
-  return from_duck_ptr(duckdb::BoundCastExpression::AddDefaultCastToType(std::move(child),
-                                                                         std::move(target_type)));
+  return from_duck_ptr(
+    duckdb::BoundCastExpression::AddDefaultCastToType(std::move(child), std::move(target_type)));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(unary_op const& alt)
@@ -201,8 +201,7 @@ std::unique_ptr<duckdb::Expression> to_duckdb(coalesce const& alt)
   // executor specialization re-derives this from the children at evaluation
   // time; INTEGER is a safe placeholder for this stub.
   auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
-    duckdb::ExpressionType::OPERATOR_COALESCE,
-    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
+    duckdb::ExpressionType::OPERATOR_COALESCE, duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
   for (auto const& child : alt.children) {
     out->children.push_back(to_duck_ptr(to_duckdb(*child)));
   }

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "expression/ast/to_duckdb.hpp"
+
+// sirius
+#include "expression/ast/between.hpp"
+#include "expression/ast/case_expr.hpp"
+#include "expression/ast/cast.hpp"
+#include "expression/ast/coalesce.hpp"
+#include "expression/ast/comparison.hpp"
+#include "expression/ast/conjunction.hpp"
+#include "expression/ast/constant.hpp"
+#include "expression/ast/function_call.hpp"
+#include "expression/ast/in_list.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
+#include "expression/ast/unary_op.hpp"
+#include "expression/function_id.hpp"
+#include "expression/join_condition.hpp"  // sirius::to_duckdb(comparison_type)
+#include "expression/value.hpp"           // sirius::to_duckdb(value, logical_type)
+#include "helper/type_conversions.hpp"    // sirius::to_duckdb(logical_type)
+
+// duckdb
+#include <duckdb/common/enums/expression_type.hpp>
+#include <duckdb/common/exception.hpp>
+#include <duckdb/function/scalar_function.hpp>
+#include <duckdb/planner/expression.hpp>
+#include <duckdb/planner/expression/bound_between_expression.hpp>
+#include <duckdb/planner/expression/bound_case_expression.hpp>
+#include <duckdb/planner/expression/bound_cast_expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+// standard library
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace sirius::ast {
+
+namespace {
+
+// DuckDB has its own unique_ptr typedef (duckdb::unique_ptr<T,...>) distinct from
+// std::unique_ptr; the DuckDB Bound*Expression ctors only accept the DuckDB form.
+// These small adapters convert between the two without copying — both share the
+// std::default_delete<T> deleter so a release/wrap round-trip is well-defined.
+duckdb::unique_ptr<duckdb::Expression> to_duck_ptr(std::unique_ptr<duckdb::Expression> p)
+{
+  return duckdb::unique_ptr<duckdb::Expression>(p.release());
+}
+
+std::unique_ptr<duckdb::Expression> from_duck_ptr(duckdb::unique_ptr<duckdb::Expression> p)
+{
+  return std::unique_ptr<duckdb::Expression>(p.release());
+}
+
+template <class T>
+std::unique_ptr<duckdb::Expression> from_duck_derived_ptr(duckdb::unique_ptr<T> p)
+{
+  // T derives from duckdb::Expression; static_cast widens the pointer.
+  return std::unique_ptr<duckdb::Expression>(p.release());
+}
+
+}  // namespace
+
+std::unique_ptr<duckdb::Expression> to_duckdb(reference const& alt)
+{
+  // Sirius reference carries only column_index. The downstream consumer
+  // (executor specialization) resolves the type from the input table_view,
+  // not from the reconstructed BoundReferenceExpression — so INTEGER is a
+  // safe placeholder.
+  return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
+    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER},
+    static_cast<duckdb::idx_t>(alt.column_index)));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(constant const& alt)
+{
+  auto duck_value = sirius::to_duckdb(alt.payload, alt.return_type);
+  return from_duck_derived_ptr(
+    duckdb::make_uniq<duckdb::BoundConstantExpression>(std::move(duck_value)));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(comparison const& alt)
+{
+  auto left  = to_duck_ptr(to_duckdb(*alt.left));
+  auto right = to_duck_ptr(to_duckdb(*alt.right));
+  return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundComparisonExpression>(
+    sirius::to_duckdb(alt.op), std::move(left), std::move(right)));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(conjunction const& alt)
+{
+  duckdb::ExpressionType etype;
+  switch (alt.op) {
+    case conjunction::kind::op_and: etype = duckdb::ExpressionType::CONJUNCTION_AND; break;
+    case conjunction::kind::op_or: etype = duckdb::ExpressionType::CONJUNCTION_OR; break;
+    case conjunction::kind::invalid:
+    default:
+      throw duckdb::InternalException(
+        "[sirius::ast::to_duckdb] conjunction with kind::invalid is unreachable; the "
+        "Sirius AST translator filters this case before construction");
+  }
+  auto out = duckdb::make_uniq<duckdb::BoundConjunctionExpression>(etype);
+  for (auto const& child : alt.children) {
+    out->children.push_back(to_duck_ptr(to_duckdb(*child)));
+  }
+  return from_duck_derived_ptr(std::move(out));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(between const& alt)
+{
+  return from_duck_derived_ptr(
+    duckdb::make_uniq<duckdb::BoundBetweenExpression>(to_duck_ptr(to_duckdb(*alt.input)),
+                                                      to_duck_ptr(to_duckdb(*alt.lower)),
+                                                      to_duck_ptr(to_duckdb(*alt.upper)),
+                                                      alt.lower_inclusive,
+                                                      alt.upper_inclusive));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt)
+{
+  // case_expr carries no top-level return_type; INTEGER placeholder is safe —
+  // the executor's BoundCaseExpression specialization derives the type from
+  // the THEN branches at evaluation time, not from this stub.
+  auto out = duckdb::make_uniq<duckdb::BoundCaseExpression>(
+    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
+  out->case_checks.reserve(alt.cases.size());
+  for (auto const& wt : alt.cases) {
+    duckdb::BoundCaseCheck check;
+    check.when_expr = to_duck_ptr(to_duckdb(*wt.when_));
+    check.then_expr = to_duck_ptr(to_duckdb(*wt.then_));
+    out->case_checks.push_back(std::move(check));
+  }
+  out->else_expr = to_duck_ptr(to_duckdb(*alt.else_));
+  return from_duck_derived_ptr(std::move(out));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(cast const& alt)
+{
+  auto child       = to_duck_ptr(to_duckdb(*alt.child));
+  auto target_type = sirius::to_duckdb(alt.target_type);
+  if (alt.try_cast) {
+    // Try-cast surface uses the full ctor with is_try_cast=true.
+    // (BoundCastExpression::AddDefaultCastToType always sets is_try_cast=false.)
+    return from_duck_derived_ptr(
+      duckdb::make_uniq<duckdb::BoundCastExpression>(std::move(child),
+                                                     std::move(target_type),
+                                                     duckdb::BoundCastInfo{nullptr},
+                                                     /*is_try_cast=*/true));
+  }
+  return from_duck_ptr(duckdb::BoundCastExpression::AddDefaultCastToType(std::move(child),
+                                                                         std::move(target_type)));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(unary_op const& alt)
+{
+  duckdb::ExpressionType etype;
+  switch (alt.op) {
+    case unary_op::kind::op_not: etype = duckdb::ExpressionType::OPERATOR_NOT; break;
+    case unary_op::kind::op_is_null: etype = duckdb::ExpressionType::OPERATOR_IS_NULL; break;
+    case unary_op::kind::op_is_not_null:
+      etype = duckdb::ExpressionType::OPERATOR_IS_NOT_NULL;
+      break;
+    case unary_op::kind::op_try: etype = duckdb::ExpressionType::OPERATOR_TRY; break;
+    case unary_op::kind::invalid:
+    default:
+      throw duckdb::InternalException(
+        "[sirius::ast::to_duckdb] unary_op with kind::invalid is unreachable; the "
+        "Sirius AST translator filters this case before construction");
+  }
+  auto out =
+    duckdb::make_uniq<duckdb::BoundOperatorExpression>(etype, duckdb::LogicalType::BOOLEAN);
+  out->children.push_back(to_duck_ptr(to_duckdb(*alt.child)));
+  return from_duck_derived_ptr(std::move(out));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(coalesce const& alt)
+{
+  // COALESCE result type is the common type of its children. The downstream
+  // executor specialization re-derives this from the children at evaluation
+  // time; INTEGER is a safe placeholder for this stub.
+  auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
+    duckdb::ExpressionType::OPERATOR_COALESCE,
+    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
+  for (auto const& child : alt.children) {
+    out->children.push_back(to_duck_ptr(to_duckdb(*child)));
+  }
+  return from_duck_derived_ptr(std::move(out));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(in_list const& alt)
+{
+  auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
+    alt.negated ? duckdb::ExpressionType::COMPARE_NOT_IN : duckdb::ExpressionType::COMPARE_IN,
+    duckdb::LogicalType::BOOLEAN);
+  out->children.push_back(to_duck_ptr(to_duckdb(*alt.probe)));
+  for (auto const& value : alt.values) {
+    out->children.push_back(to_duck_ptr(to_duckdb(*value)));
+  }
+  return from_duck_derived_ptr(std::move(out));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(function_call const& alt)
+{
+  auto return_type = sirius::to_duckdb(alt.return_type());
+
+  // Minimal ScalarFunction stub: name + empty argument-types + return_type +
+  // null function pointer. The downstream executor specialization
+  // (gpu_execute_function.cpp) dispatches via the function-name lookup, never
+  // invokes function_ptr_t or inspects arguments().
+  auto name = std::string{sirius::to_duckdb_function_name(alt.function())};
+  duckdb::ScalarFunction stub_fn(
+    std::move(name), duckdb::vector<duckdb::LogicalType>{}, return_type, /*function=*/nullptr);
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.reserve(alt.arguments().size());
+  for (auto const& arg : alt.arguments()) {
+    children.push_back(to_duck_ptr(to_duckdb(*arg)));
+  }
+
+  return from_duck_derived_ptr(
+    duckdb::make_uniq<duckdb::BoundFunctionExpression>(std::move(return_type),
+                                                       std::move(stub_fn),
+                                                       std::move(children),
+                                                       /*bind_info=*/nullptr));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(node const& expr)
+{
+  return std::visit([](auto const& alt) { return to_duckdb(alt); }, expr.v);
+}
+
+}  // namespace sirius::ast

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,81 +519,80 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::reference const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::reference const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::reference shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::constant const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::constant shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::comparison const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::comparison const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::comparison shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::conjunction shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::between const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::between shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::case_expr shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::cast const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::cast shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::unary_op shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::coalesce shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::in_list const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::in_list const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::in_list shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::function_call const& /*alt*/,
-                                                execution_mode /*mode*/)
+execute_result gpu_expression_executor::execute(sirius::ast::function_call const& alt,
+                                                execution_mode mode)
 {
-  throw duckdb::NotImplementedException(
-    "[gpu_expression_executor] sirius::ast::function_call shim not yet implemented");
+  auto duck_expr = sirius::ast::to_duckdb(alt);
+  return execute(*duck_expr, mode);
 }
 
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -17,7 +17,7 @@
 // sirius
 #include <cudf/cudf_utils.hpp>
 
-#include <expression/ast/node.hpp>       // sirius::ast::node + 11 alternatives
+#include <expression/ast/node.hpp>  // sirius::ast::node + 11 alternatives
 #include <expression/ast/to_duckdb.hpp>  // sirius::ast::to_duckdb (per-alternative overloads + node dispatcher)
 #include <expression/expression_internal.hpp>
 #include <expression/function_id.hpp>

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -17,6 +17,8 @@
 // sirius
 #include <cudf/cudf_utils.hpp>
 
+#include <expression/ast/node.hpp>       // sirius::ast::node + 11 alternatives
+#include <expression/ast/to_duckdb.hpp>  // sirius::ast::to_duckdb (per-alternative overloads + node dispatcher)
 #include <expression/expression_internal.hpp>
 #include <expression/function_id.hpp>
 #include <expression_executor/ast_supported_types.hpp>
@@ -53,6 +55,7 @@
 
 // standard library
 #include <numeric>
+#include <variant>
 
 namespace {
 /// Returns true if cudf::cast supports this type (fixed-width only; no STRING/LIST/STRUCT/etc.).
@@ -199,6 +202,16 @@ gpu_expression_executor::gpu_expression_executor(duckdb::Expression const* expre
   _expressions.push_back(expression);
 }
 
+gpu_expression_executor::gpu_expression_executor(sirius::ast::node const* expression,
+                                                 rmm::device_async_resource_ref resource_ref,
+                                                 rmm::cuda_stream_view stream,
+                                                 expression_executor_strategy strategy,
+                                                 std::size_t min_ast_size)
+  : _strategy(strategy), _mr(resource_ref), _stream(stream), _min_ast_size(min_ast_size)
+{
+  _ast_expressions.push_back(expression);
+}
+
 std::unique_ptr<cudf::column> gpu_expression_executor::execute_ast(expr_ref root_expr)
 {
   std::vector<cudf::column_view> combined_column_views;
@@ -266,9 +279,9 @@ void gpu_expression_executor::release_temporaries(
 
 std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view input)
 {
-  D_ASSERT(!_expressions.empty());
+  D_ASSERT(_expressions.empty() != _ast_expressions.empty());
   _output_columns.clear();
-  _output_columns.reserve(_expressions.size());
+  _output_columns.reserve(std::max(_expressions.size(), _ast_expressions.size()));
 
   // Reset AST state from any previous invocation so that the tree, temp scalars, and temp columns
   // do not accumulate stale nodes across calls.
@@ -279,11 +292,11 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
   // Get the table_view from the input_batch
   _input_table = std::move(input);
 
-  // Execute the expressions and emit results into _output_columns
-  for (auto& _expression : _expressions) {
-    auto const& expr = *_expression;
-    auto result      = execute(expr, execution_mode::MATERIALIZE);
-
+  // Per-result column post-processing — shared between the DuckDB and the
+  // AST branches below. The DuckDB-typed expression is the parity reference;
+  // the AST branch round-trips through sirius::ast::to_duckdb to recover the
+  // expression_class + return_type fields for the same post-processing path.
+  auto post_process = [this](duckdb::Expression const& expr, execute_result result) {
     if (expr.expression_class == duckdb::ExpressionClass::BOUND_REF) {
       // BOUND_REF: pass column through without type check
       _output_columns.push_back(
@@ -316,6 +329,25 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
       }
       _output_columns.push_back(std::move(result_column));
     }
+  };
+
+  if (!_ast_expressions.empty()) {
+    // AST path: iterate _ast_expressions and route through the std::visit dispatcher.
+    // The per-result post-processing recovers expression_class + return_type by
+    // round-tripping through sirius::ast::to_duckdb so the column post-processing
+    // matches the DuckDB branch exactly.
+    for (auto const* ast_expr : _ast_expressions) {
+      auto result    = execute(*ast_expr, execution_mode::MATERIALIZE);
+      auto duck_expr = sirius::ast::to_duckdb(*ast_expr);
+      post_process(*duck_expr, std::move(result));
+    }
+  } else {
+    // DuckDB path: existing call sites unchanged.
+    for (auto& _expression : _expressions) {
+      auto const& expr = *_expression;
+      auto result      = execute(expr, execution_mode::MATERIALIZE);
+      post_process(expr, std::move(result));
+    }
   }
 
   return std::make_unique<cudf::table>(std::move(_output_columns), _stream, _mr);
@@ -323,9 +355,17 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
 
 std::unique_ptr<cudf::table> gpu_expression_executor::select(cudf::table_view input)
 {
-  D_ASSERT(_expressions.size() == 1);
-  auto const& expr = *_expressions[0];
-  D_ASSERT(expr.return_type == duckdb::LogicalType::BOOLEAN);
+  D_ASSERT(_expressions.empty() != _ast_expressions.empty());
+  D_ASSERT(_expressions.size() + _ast_expressions.size() == 1);
+  if (!_ast_expressions.empty()) {
+    // AST branch: round-trip the single node through sirius::ast::to_duckdb so the
+    // BOOLEAN return-type assertion matches the DuckDB branch exactly (debug-only).
+    auto duck_expr = sirius::ast::to_duckdb(*_ast_expressions[0]);
+    D_ASSERT(duck_expr->return_type == duckdb::LogicalType::BOOLEAN);
+  } else {
+    auto const& expr = *_expressions[0];
+    D_ASSERT(expr.return_type == duckdb::LogicalType::BOOLEAN);
+  }
 
   // Call execute(input_batch) to set _input_table and produce the boolean mask as a single column
   auto mask_batch = execute(input);
@@ -472,4 +512,96 @@ std::size_t gpu_expression_executor::count_ast_ops(duckdb::Expression const& exp
         static_cast<int>(expr.GetExpressionClass()));
   }
 }
+
+execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, execution_mode mode)
+{
+  return std::visit(
+    [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::reference const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::reference shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::constant const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::constant shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::comparison const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::comparison shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::conjunction shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::between const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::between shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::case_expr shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::cast const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::cast shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::unary_op shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::coalesce shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::in_list const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::in_list shim not yet implemented");
+}
+
+execute_result gpu_expression_executor::execute(sirius::ast::function_call const& /*alt*/,
+                                                execution_mode /*mode*/)
+{
+  throw duckdb::NotImplementedException(
+    "[gpu_expression_executor] sirius::ast::function_call shim not yet implemented");
+}
+
+std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
+{
+  // Round-trip shim — the per-specialization migration phase
+  // (https://github.com/sirius-db/sirius/issues/699) replaces this with native
+  // AST traversal one specialization at a time.
+  return count_ast_ops(*sirius::ast::to_duckdb(expr));
+}
+
 }  // namespace sirius

--- a/src/include/expression/ast/to_duckdb.hpp
+++ b/src/include/expression/ast/to_duckdb.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// sirius
+#include "expression/ast/node.hpp"  // sirius::ast::node + 11 alternatives
+
+// standard library
+#include <memory>
+
+namespace duckdb {
+class Expression;
+}  // namespace duckdb
+
+namespace sirius::ast {
+
+/**
+ * @brief Reconstruct a DuckDB bound expression tree from a Sirius AST tree.
+ *
+ * Recursively walks @p expr, dispatching on its variant alternative via
+ * std::visit to the matching per-alternative overload. Returns a freshly-
+ * allocated duckdb::Expression tree that the caller owns. The output is
+ * structurally equivalent to the input that sirius::ast::from_duckdb would
+ * have produced the AST from; round-tripping a tree through from_duckdb ->
+ * to_duckdb -> executor yields outputs identical to executing the original
+ * DuckDB expression.
+ *
+ * @throws duckdb::InternalException if a function_call carries a function_id
+ *         enum value with no DuckDB name mapping (should be impossible — every
+ *         enum value is registered in sirius::to_duckdb_function_name).
+ */
+std::unique_ptr<duckdb::Expression> to_duckdb(node const& expr);
+
+// Per-alternative overloads — called directly by gpu_expression_executor shims
+// to sidestep node's move-only constraint. The top-level to_duckdb(node) above
+// dispatches to these via std::visit.
+std::unique_ptr<duckdb::Expression> to_duckdb(between const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(cast const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(coalesce const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(comparison const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(conjunction const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(constant const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(function_call const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(in_list const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(reference const& alt);
+std::unique_ptr<duckdb::Expression> to_duckdb(unary_op const& alt);
+
+}  // namespace sirius::ast

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include <config.hpp>
+#include <expression/ast/node.hpp>  // sirius::ast::node + 11 alternative types
 #include <expression/expression.hpp>
 #include <expression_executor/expression_executor_strategy.hpp>
 
@@ -320,6 +321,21 @@ class gpu_expression_executor {
     std::size_t min_ast_size                    = 2);
 
   /**
+   * @brief Non-owning ctor for call sites that hold a raw sirius::ast::node pointer.
+   *
+   * The caller retains ownership; the executor only reads from the node tree.
+   * Parallel to the duckdb::Expression const* ctor above. The class invariant
+   * after construction is that exactly one of _expressions / _ast_expressions
+   * is non-empty.
+   */
+  gpu_expression_executor(
+    sirius::ast::node const* expression,
+    rmm::device_async_resource_ref resource_ref = cudf::get_current_device_resource_ref(),
+    rmm::cuda_stream_view stream                = cudf::get_default_stream(),
+    expression_executor_strategy strategy       = strategy_from_config(),
+    std::size_t min_ast_size                    = 2);
+
+  /**
    * @brief Executes the current set of expressions against the given input batch and emits a new
    * output batch with the results.
    *
@@ -336,8 +352,30 @@ class gpu_expression_executor {
    */
   std::unique_ptr<cudf::table> select(cudf::table_view input);
 
+  /**
+   * @brief Evaluate a single Sirius AST node and return its execution result.
+   *
+   * Dispatches via std::visit over @p expr's variant to the matching private
+   * per-alternative overload. The per-alternative overloads currently round-
+   * trip back to the existing DuckDB-typed execute() via sirius::ast::to_duckdb;
+   * subsequent commits replace the round-trip with native Sirius-AST evaluation
+   * one specialization at a time. See
+   * https://github.com/sirius-db/sirius/issues/699 for the per-specialization
+   * migration plan.
+   *
+   * @param expr The Sirius AST node to evaluate.
+   * @param mode AST hint vs. MATERIALIZE hint; honored only where the node kind
+   *             supports AST mode. AST breakers (case_expr, coalesce, op_try,
+   *             etc.) always materialize regardless of the hint.
+   */
+  execute_result execute(sirius::ast::node const& expr,
+                         execution_mode mode = execution_mode::AST);
+
  private:
   std::vector<duckdb::Expression const*> _expressions;  ///< The expressions to execute
+  std::vector<sirius::ast::node const*>
+    _ast_expressions;  ///< AST expressions (additive dual-path surface). Mutually exclusive with
+                       ///< _expressions per the class invariant.
   expression_executor_strategy _strategy;  ///< The strategy to use for expression evaluation
   rmm::device_async_resource_ref _mr;  ///< The allocator to pass to cudf APIs for any allocations
   rmm::cuda_stream_view _stream;       ///< The stream in which to execute any cuDF operations
@@ -393,10 +431,29 @@ class gpu_expression_executor {
   execute_result execute(duckdb::BoundFunctionExpression const& expr, execution_mode mode);
   execute_result execute(duckdb::BoundOperatorExpression const& expr, execution_mode mode);
 
+  // Leaf Sirius-AST nodes — dispatch targets for the std::visit-based
+  // execute(sirius::ast::node, mode) above.
+  execute_result execute(sirius::ast::reference const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::constant const& expr, execution_mode mode);
+
+  // Interior Sirius-AST nodes — 11 alternatives total. Compared to the 9
+  // DuckDB-typed overloads, Sirius AST splits BOUND_OPERATOR's kinds across
+  // 3 alternative types (unary_op, coalesce, in_list).
+  execute_result execute(sirius::ast::between const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::case_expr const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::cast const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::comparison const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::conjunction const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::function_call const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::unary_op const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::coalesce const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::in_list const& expr, execution_mode mode);
+
   // Counts the number of AST nodes that would be generated for the given expression if we
   // added it to the AST tree. This is used to determine whether we should execute in AST mode or
   // MATERIALIZE mode for the expression (by comparing the count to `min_ast_size`).
   [[nodiscard]] std::size_t count_ast_ops(duckdb::Expression const& expr) const;
+  [[nodiscard]] std::size_t count_ast_ops(sirius::ast::node const& expr) const;
 };
 
 }  // namespace sirius

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -368,8 +368,7 @@ class gpu_expression_executor {
    *             supports AST mode. AST breakers (case_expr, coalesce, op_try,
    *             etc.) always materialize regardless of the hint.
    */
-  execute_result execute(sirius::ast::node const& expr,
-                         execution_mode mode = execution_mode::AST);
+  execute_result execute(sirius::ast::node const& expr, execution_mode mode = execution_mode::AST);
 
  private:
   std::vector<duckdb::Expression const*> _expressions;  ///< The expressions to execute

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -1,0 +1,908 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for sirius::ast::to_duckdb — the inverse-direction Sirius->DuckDB
+// expression translator.
+//
+// Covers the full sirius::ast::node dispatch surface via direct construction
+// of each variant alternative, mapped to its matching duckdb::BoundXxx
+// expression. Each section also validates the structural shape of the
+// reconstructed DuckDB tree (expression class, operator type, child counts,
+// payload fidelity). A self-equivalence sweep then runs every alternative
+// through from_duckdb(*to_duckdb(node)) and confirms structural equivalence
+// with the original Sirius AST.
+
+#include "catch.hpp"
+#include "expression/ast/from_duckdb.hpp"
+#include "expression/ast/to_duckdb.hpp"
+
+// sirius — node accessors and per-node struct types
+#include "expression/ast/between.hpp"
+#include "expression/ast/case_expr.hpp"
+#include "expression/ast/cast.hpp"
+#include "expression/ast/coalesce.hpp"
+#include "expression/ast/comparison.hpp"
+#include "expression/ast/conjunction.hpp"
+#include "expression/ast/constant.hpp"
+#include "expression/ast/function_call.hpp"
+#include "expression/ast/in_list.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
+#include "expression/ast/unary_op.hpp"
+#include "expression/function_id.hpp"
+#include "expression/join_condition.hpp"  // sirius::comparison_type
+#include "expression/value.hpp"           // sirius::value, sirius::null_value
+#include "helper/logical_type.hpp"        // sirius::logical_type
+
+// duckdb — direct-ctor + downstream introspection surface
+#include <duckdb/common/enums/expression_type.hpp>
+#include <duckdb/common/types/value.hpp>
+#include <duckdb/planner/expression.hpp>
+#include <duckdb/planner/expression/bound_between_expression.hpp>
+#include <duckdb/planner/expression/bound_case_expression.hpp>
+#include <duckdb/planner/expression/bound_cast_expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using duckdb::BoundBetweenExpression;
+using duckdb::BoundCaseExpression;
+using duckdb::BoundCastExpression;
+using duckdb::BoundComparisonExpression;
+using duckdb::BoundConjunctionExpression;
+using duckdb::BoundConstantExpression;
+using duckdb::BoundFunctionExpression;
+using duckdb::BoundOperatorExpression;
+using duckdb::BoundReferenceExpression;
+using duckdb::ExpressionClass;
+using duckdb::ExpressionType;
+using duckdb::LogicalType;
+using duckdb::LogicalTypeId;
+using duckdb::Value;
+
+using sirius::ast::between;
+using sirius::ast::case_expr;
+using sirius::ast::cast;
+using sirius::ast::coalesce;
+using sirius::ast::comparison;
+using sirius::ast::conjunction;
+using sirius::ast::constant;
+using sirius::ast::function_call;
+using sirius::ast::in_list;
+using sirius::ast::node;
+using sirius::ast::reference;
+using sirius::ast::unary_op;
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Helpers — small node-construction shortcuts for the test bodies.
+// ----------------------------------------------------------------------------
+
+std::unique_ptr<node> make_ref(uint32_t idx) { return std::make_unique<node>(reference{idx}); }
+
+std::unique_ptr<node> make_int_const(int32_t v)
+{
+  return std::make_unique<node>(constant{
+    /*payload=*/sirius::value{v},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  });
+}
+
+std::unique_ptr<node> make_str_const(std::string s)
+{
+  return std::make_unique<node>(constant{
+    /*payload=*/sirius::value{std::move(s)},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::VARCHAR),
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Structural-equality helpers — used by the self-equivalence sweep below to
+// compare the original node tree against from_duckdb(*to_duckdb(orig)).
+// ----------------------------------------------------------------------------
+
+bool same_node(node const& a, node const& b);  // forward declaration
+
+bool same_reference(node const& a, node const& b)
+{
+  return a.holds<reference>() && b.holds<reference>() &&
+         a.get<reference>().column_index == b.get<reference>().column_index;
+}
+
+bool same_constant(node const& a, node const& b)
+{
+  if (!a.holds<constant>() || !b.holds<constant>()) return false;
+  auto const& ca = a.get<constant>();
+  auto const& cb = b.get<constant>();
+  if (ca.return_type.id() != cb.return_type.id()) return false;
+  // sirius::value alternatives do not all expose operator==; compare via the
+  // variant index plus a targeted check for the primitive alternatives the
+  // self-equivalence sweep exercises (int32_t covers the BoundConstantExpression
+  // round-trip used here; other alternatives are compared structurally only).
+  if (ca.payload.index() != cb.payload.index()) return false;
+  if (std::holds_alternative<int32_t>(ca.payload)) {
+    return std::get<int32_t>(ca.payload) == std::get<int32_t>(cb.payload);
+  }
+  if (std::holds_alternative<std::string>(ca.payload)) {
+    return std::get<std::string>(ca.payload) == std::get<std::string>(cb.payload);
+  }
+  if (std::holds_alternative<bool>(ca.payload)) {
+    return std::get<bool>(ca.payload) == std::get<bool>(cb.payload);
+  }
+  if (std::holds_alternative<int64_t>(ca.payload)) {
+    return std::get<int64_t>(ca.payload) == std::get<int64_t>(cb.payload);
+  }
+  if (std::holds_alternative<double>(ca.payload)) {
+    return std::get<double>(ca.payload) == std::get<double>(cb.payload);
+  }
+  // Other alternatives (null_value, date/timestamp, decimal*) — variant index
+  // match is sufficient evidence of structural equivalence for the
+  // self-equivalence sweep; payload fidelity is already covered by Phase 2's
+  // value round-trip tests.
+  return true;
+}
+
+bool same_comparison(node const& a, node const& b)
+{
+  if (!a.holds<comparison>() || !b.holds<comparison>()) return false;
+  auto const& ca = a.get<comparison>();
+  auto const& cb = b.get<comparison>();
+  if (ca.op != cb.op) return false;
+  if (!ca.left || !cb.left || !ca.right || !cb.right) return false;
+  return same_node(*ca.left, *cb.left) && same_node(*ca.right, *cb.right);
+}
+
+bool same_conjunction(node const& a, node const& b)
+{
+  if (!a.holds<conjunction>() || !b.holds<conjunction>()) return false;
+  auto const& ca = a.get<conjunction>();
+  auto const& cb = b.get<conjunction>();
+  if (ca.op != cb.op) return false;
+  if (ca.children.size() != cb.children.size()) return false;
+  for (size_t i = 0; i < ca.children.size(); ++i) {
+    if (!ca.children[i] || !cb.children[i]) return false;
+    if (!same_node(*ca.children[i], *cb.children[i])) return false;
+  }
+  return true;
+}
+
+bool same_between(node const& a, node const& b)
+{
+  if (!a.holds<between>() || !b.holds<between>()) return false;
+  auto const& ba = a.get<between>();
+  auto const& bb = b.get<between>();
+  if (ba.lower_inclusive != bb.lower_inclusive) return false;
+  if (ba.upper_inclusive != bb.upper_inclusive) return false;
+  if (!ba.input || !bb.input || !ba.lower || !bb.lower || !ba.upper || !bb.upper) return false;
+  return same_node(*ba.input, *bb.input) && same_node(*ba.lower, *bb.lower) &&
+         same_node(*ba.upper, *bb.upper);
+}
+
+bool same_case_expr(node const& a, node const& b)
+{
+  if (!a.holds<case_expr>() || !b.holds<case_expr>()) return false;
+  auto const& ca = a.get<case_expr>();
+  auto const& cb = b.get<case_expr>();
+  if (ca.cases.size() != cb.cases.size()) return false;
+  for (size_t i = 0; i < ca.cases.size(); ++i) {
+    if (!ca.cases[i].when_ || !cb.cases[i].when_) return false;
+    if (!ca.cases[i].then_ || !cb.cases[i].then_) return false;
+    if (!same_node(*ca.cases[i].when_, *cb.cases[i].when_)) return false;
+    if (!same_node(*ca.cases[i].then_, *cb.cases[i].then_)) return false;
+  }
+  if (!ca.else_ || !cb.else_) return false;
+  return same_node(*ca.else_, *cb.else_);
+}
+
+bool same_cast(node const& a, node const& b)
+{
+  if (!a.holds<cast>() || !b.holds<cast>()) return false;
+  auto const& ca = a.get<cast>();
+  auto const& cb = b.get<cast>();
+  if (ca.try_cast != cb.try_cast) return false;
+  if (ca.target_type.id() != cb.target_type.id()) return false;
+  if (!ca.child || !cb.child) return false;
+  return same_node(*ca.child, *cb.child);
+}
+
+bool same_unary_op(node const& a, node const& b)
+{
+  if (!a.holds<unary_op>() || !b.holds<unary_op>()) return false;
+  auto const& ua = a.get<unary_op>();
+  auto const& ub = b.get<unary_op>();
+  if (ua.op != ub.op) return false;
+  if (!ua.child || !ub.child) return false;
+  return same_node(*ua.child, *ub.child);
+}
+
+bool same_coalesce(node const& a, node const& b)
+{
+  if (!a.holds<coalesce>() || !b.holds<coalesce>()) return false;
+  auto const& ca = a.get<coalesce>();
+  auto const& cb = b.get<coalesce>();
+  if (ca.children.size() != cb.children.size()) return false;
+  for (size_t i = 0; i < ca.children.size(); ++i) {
+    if (!ca.children[i] || !cb.children[i]) return false;
+    if (!same_node(*ca.children[i], *cb.children[i])) return false;
+  }
+  return true;
+}
+
+bool same_in_list(node const& a, node const& b)
+{
+  if (!a.holds<in_list>() || !b.holds<in_list>()) return false;
+  auto const& ia = a.get<in_list>();
+  auto const& ib = b.get<in_list>();
+  if (ia.negated != ib.negated) return false;
+  if (ia.values.size() != ib.values.size()) return false;
+  if (!ia.probe || !ib.probe) return false;
+  if (!same_node(*ia.probe, *ib.probe)) return false;
+  for (size_t i = 0; i < ia.values.size(); ++i) {
+    if (!ia.values[i] || !ib.values[i]) return false;
+    if (!same_node(*ia.values[i], *ib.values[i])) return false;
+  }
+  return true;
+}
+
+bool same_function_call(node const& a, node const& b)
+{
+  if (!a.holds<function_call>() || !b.holds<function_call>()) return false;
+  auto const& fa = a.get<function_call>();
+  auto const& fb = b.get<function_call>();
+  if (fa.function() != fb.function()) return false;
+  if (fa.return_type().id() != fb.return_type().id()) return false;
+  if (fa.arguments().size() != fb.arguments().size()) return false;
+  for (size_t i = 0; i < fa.arguments().size(); ++i) {
+    if (!fa.arguments()[i] || !fb.arguments()[i]) return false;
+    if (!same_node(*fa.arguments()[i], *fb.arguments()[i])) return false;
+  }
+  return true;
+}
+
+bool same_node(node const& a, node const& b)
+{
+  if (a.v.index() != b.v.index()) return false;
+  if (a.holds<reference>()) return same_reference(a, b);
+  if (a.holds<constant>()) return same_constant(a, b);
+  if (a.holds<comparison>()) return same_comparison(a, b);
+  if (a.holds<conjunction>()) return same_conjunction(a, b);
+  if (a.holds<between>()) return same_between(a, b);
+  if (a.holds<case_expr>()) return same_case_expr(a, b);
+  if (a.holds<cast>()) return same_cast(a, b);
+  if (a.holds<unary_op>()) return same_unary_op(a, b);
+  if (a.holds<coalesce>()) return same_coalesce(a, b);
+  if (a.holds<in_list>()) return same_in_list(a, b);
+  if (a.holds<function_call>()) return same_function_call(a, b);
+  return false;
+}
+
+}  // namespace
+
+// ============================================================================
+// reference
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - reference translates to BoundReferenceExpression (column 3)",
+          "[ast_to_duckdb]")
+{
+  node orig{reference{/*column_index=*/3}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_REF);
+  auto const& ref = out->Cast<BoundReferenceExpression>();
+  REQUIRE(ref.index == 3);
+}
+
+// ============================================================================
+// constant
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - constant INTEGER round-trips to BoundConstantExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{constant{
+    /*payload=*/sirius::value{int32_t{42}},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+  auto const& bc = out->Cast<BoundConstantExpression>();
+  REQUIRE(bc.value == Value::INTEGER(42));
+}
+
+TEST_CASE("ast_to_duckdb - constant VARCHAR round-trips to BoundConstantExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{constant{
+    /*payload=*/sirius::value{std::string{"hello"}},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::VARCHAR),
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+  auto const& bc = out->Cast<BoundConstantExpression>();
+  REQUIRE(bc.value == Value("hello"));
+}
+
+TEST_CASE("ast_to_duckdb - constant typed NULL (INTEGER) round-trips to BoundConstantExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{constant{
+    /*payload=*/sirius::value{},  // null_value default
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+  auto const& bc = out->Cast<BoundConstantExpression>();
+  REQUIRE(bc.value.IsNull());
+  REQUIRE(bc.value.type().id() == LogicalTypeId::INTEGER);
+}
+
+TEST_CASE("ast_to_duckdb - constant DECIMAL64 round-trips to BoundConstantExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{constant{
+    /*payload=*/sirius::value{sirius::decimal64{/*value=*/12345, /*scale=*/2}},
+    /*return_type=*/sirius::logical_type::make_decimal(/*precision=*/18, /*scale=*/2),
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+  auto const& bc = out->Cast<BoundConstantExpression>();
+  REQUIRE(bc.value.type().id() == LogicalTypeId::DECIMAL);
+}
+
+// ============================================================================
+// comparison — one TEST_CASE per supported subtype.
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - comparison EQUAL translates to COMPARE_EQUAL", "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_EQUAL);
+  auto const& cmp = out->Cast<BoundComparisonExpression>();
+  REQUIRE(cmp.left);
+  REQUIRE(cmp.right);
+  REQUIRE(cmp.left->GetExpressionClass() == ExpressionClass::BOUND_REF);
+  REQUIRE(cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+}
+
+TEST_CASE("ast_to_duckdb - comparison NOT_EQUAL translates to COMPARE_NOTEQUAL", "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::not_equal, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL);
+}
+
+TEST_CASE("ast_to_duckdb - comparison LT translates to COMPARE_LESSTHAN", "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::lt, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_LESSTHAN);
+}
+
+TEST_CASE("ast_to_duckdb - comparison LE translates to COMPARE_LESSTHANOREQUALTO",
+          "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::le, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_LESSTHANOREQUALTO);
+}
+
+TEST_CASE("ast_to_duckdb - comparison GT translates to COMPARE_GREATERTHAN", "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::gt, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_GREATERTHAN);
+}
+
+TEST_CASE("ast_to_duckdb - comparison GE translates to COMPARE_GREATERTHANOREQUALTO",
+          "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::ge, make_ref(0), make_int_const(3)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_GREATERTHANOREQUALTO);
+}
+
+// ============================================================================
+// conjunction
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - conjunction AND translates to BoundConjunctionExpression (AND)",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_ref(1));
+  node orig{conjunction{conjunction::kind::op_and, std::move(children)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::CONJUNCTION_AND);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION);
+  auto const& conj = out->Cast<BoundConjunctionExpression>();
+  REQUIRE(conj.children.size() == 2);
+}
+
+TEST_CASE("ast_to_duckdb - conjunction OR (3 children) translates to BoundConjunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_ref(1));
+  children.push_back(make_ref(2));
+  node orig{conjunction{conjunction::kind::op_or, std::move(children)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::CONJUNCTION_OR);
+  auto const& conj = out->Cast<BoundConjunctionExpression>();
+  REQUIRE(conj.children.size() == 3);
+}
+
+// ============================================================================
+// between
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - between translates to BoundBetweenExpression (inclusive bounds)",
+          "[ast_to_duckdb]")
+{
+  node orig{between{
+    /*input=*/make_ref(0),
+    /*lower=*/make_int_const(1),
+    /*upper=*/make_int_const(10),
+    /*lower_inclusive=*/true,
+    /*upper_inclusive=*/true,
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_BETWEEN);
+  auto const& bt = out->Cast<BoundBetweenExpression>();
+  REQUIRE(bt.lower_inclusive == true);
+  REQUIRE(bt.upper_inclusive == true);
+  REQUIRE(bt.input);
+  REQUIRE(bt.lower);
+  REQUIRE(bt.upper);
+}
+
+// ============================================================================
+// case_expr
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - case_expr (single WHEN/THEN + ELSE) translates to BoundCaseExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<case_expr::when_then> cases;
+  cases.push_back(case_expr::when_then{
+    /*when_=*/std::make_unique<node>(
+      comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}),
+    /*then_=*/make_int_const(10),
+  });
+  node orig{case_expr{std::move(cases), /*else_=*/make_int_const(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
+  auto const& ce = out->Cast<BoundCaseExpression>();
+  REQUIRE(ce.case_checks.size() == 1);
+  REQUIRE(ce.case_checks[0].when_expr);
+  REQUIRE(ce.case_checks[0].then_expr);
+  REQUIRE(ce.else_expr);
+}
+
+TEST_CASE("ast_to_duckdb - case_expr (two WHEN/THEN + ELSE) translates to BoundCaseExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<case_expr::when_then> cases;
+  cases.push_back(case_expr::when_then{
+    std::make_unique<node>(
+      comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}),
+    make_int_const(10),
+  });
+  cases.push_back(case_expr::when_then{
+    std::make_unique<node>(
+      comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(2)}),
+    make_int_const(20),
+  });
+  node orig{case_expr{std::move(cases), make_int_const(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
+  auto const& ce = out->Cast<BoundCaseExpression>();
+  REQUIRE(ce.case_checks.size() == 2);
+}
+
+// ============================================================================
+// cast
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - cast INTEGER->BIGINT (default) translates to BoundCastExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{cast{
+    /*child=*/make_ref(0),
+    /*target_type=*/sirius::logical_type::make(sirius::type_id::BIGINT),
+    /*try_cast=*/false,
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CAST);
+  auto const& ct = out->Cast<BoundCastExpression>();
+  REQUIRE(ct.try_cast == false);
+  REQUIRE(ct.return_type.id() == LogicalTypeId::BIGINT);
+}
+
+TEST_CASE("ast_to_duckdb - cast INTEGER->BIGINT (try_cast=true) translates to BoundCastExpression",
+          "[ast_to_duckdb]")
+{
+  node orig{cast{
+    /*child=*/make_ref(0),
+    /*target_type=*/sirius::logical_type::make(sirius::type_id::BIGINT),
+    /*try_cast=*/true,
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CAST);
+  auto const& ct = out->Cast<BoundCastExpression>();
+  REQUIRE(ct.try_cast == true);
+  REQUIRE(ct.return_type.id() == LogicalTypeId::BIGINT);
+}
+
+// ============================================================================
+// unary_op — one TEST_CASE per kind.
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - unary_op op_not translates to OPERATOR_NOT", "[ast_to_duckdb]")
+{
+  node orig{unary_op{unary_op::kind::op_not, make_ref(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_NOT);
+  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 1);
+}
+
+TEST_CASE("ast_to_duckdb - unary_op op_is_null translates to OPERATOR_IS_NULL", "[ast_to_duckdb]")
+{
+  node orig{unary_op{unary_op::kind::op_is_null, make_ref(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_IS_NULL);
+}
+
+TEST_CASE("ast_to_duckdb - unary_op op_is_not_null translates to OPERATOR_IS_NOT_NULL",
+          "[ast_to_duckdb]")
+{
+  node orig{unary_op{unary_op::kind::op_is_not_null, make_ref(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL);
+}
+
+TEST_CASE("ast_to_duckdb - unary_op op_try translates to OPERATOR_TRY", "[ast_to_duckdb]")
+{
+  node orig{unary_op{unary_op::kind::op_try, make_ref(0)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_TRY);
+}
+
+// ============================================================================
+// coalesce
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - coalesce (3 args) translates to OPERATOR_COALESCE", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_ref(1));
+  children.push_back(make_int_const(0));
+  node orig{coalesce{std::move(children)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_COALESCE);
+  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 3);
+}
+
+// ============================================================================
+// in_list
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - in_list (negated=false) translates to COMPARE_IN", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> values;
+  values.push_back(make_int_const(2));
+  values.push_back(make_int_const(5));
+  values.push_back(make_int_const(8));
+  node orig{in_list{
+    /*probe=*/make_ref(0),
+    /*values=*/std::move(values),
+    /*negated=*/false,
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_IN);
+  // probe + 3 values = 4 children.
+  REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 4);
+}
+
+TEST_CASE("ast_to_duckdb - in_list (negated=true) translates to COMPARE_NOT_IN", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> values;
+  values.push_back(make_int_const(2));
+  values.push_back(make_int_const(4));
+  node orig{in_list{
+    /*probe=*/make_ref(0),
+    /*values=*/std::move(values),
+    /*negated=*/true,
+  }};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::COMPARE_NOT_IN);
+}
+
+// ============================================================================
+// function_call — sweep across a representative function in each category.
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - function_call add translates to BoundFunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  node orig{function_call{
+    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+  auto const& fn = out->Cast<BoundFunctionExpression>();
+  REQUIRE(fn.function.name == "+");
+  REQUIRE(fn.children.size() == 2);
+  REQUIRE(fn.return_type.id() == LogicalTypeId::INTEGER);
+}
+
+TEST_CASE("ast_to_duckdb - function_call substring translates to BoundFunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(1));
+  args.push_back(make_int_const(3));
+  node orig{function_call{
+    sirius::function_id::substring, std::move(args), sirius::logical_type::make(sirius::type_id::VARCHAR)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+  auto const& fn = out->Cast<BoundFunctionExpression>();
+  REQUIRE(fn.function.name == "substring");
+  REQUIRE(fn.children.size() == 3);
+}
+
+TEST_CASE("ast_to_duckdb - function_call like translates to BoundFunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_str_const("x%"));
+  node orig{function_call{
+    sirius::function_id::like, std::move(args), sirius::logical_type::make(sirius::type_id::BOOLEAN)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+  auto const& fn = out->Cast<BoundFunctionExpression>();
+  REQUIRE(fn.function.name == "~~");
+  REQUIRE(fn.children.size() == 2);
+}
+
+TEST_CASE("ast_to_duckdb - function_call regexp_replace translates to BoundFunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_str_const("a"));
+  args.push_back(make_str_const("b"));
+  node orig{function_call{sirius::function_id::regexp_replace,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::VARCHAR)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+  auto const& fn = out->Cast<BoundFunctionExpression>();
+  REQUIRE(fn.function.name == "regexp_replace");
+  REQUIRE(fn.children.size() == 3);
+}
+
+TEST_CASE("ast_to_duckdb - function_call year translates to BoundFunctionExpression",
+          "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  node orig{function_call{
+    sirius::function_id::year, std::move(args), sirius::logical_type::make(sirius::type_id::BIGINT)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
+  auto const& fn = out->Cast<BoundFunctionExpression>();
+  REQUIRE(fn.function.name == "year");
+  REQUIRE(fn.children.size() == 1);
+}
+
+// ============================================================================
+// Self-equivalence sweep — for every alternative, round-trip through
+// from_duckdb(*to_duckdb(node)) and check structural equivalence with the
+// original node tree.
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - reference self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{reference{/*column_index=*/7}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_reference(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - constant self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{constant{
+    /*payload=*/sirius::value{int32_t{99}},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  }};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_constant(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - comparison self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{comparison{sirius::comparison_type::lt, make_ref(0), make_int_const(5)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_comparison(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - conjunction self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(std::make_unique<node>(
+    comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}));
+  children.push_back(std::make_unique<node>(
+    comparison{sirius::comparison_type::equal, make_ref(1), make_int_const(2)}));
+  node orig{conjunction{conjunction::kind::op_and, std::move(children)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_conjunction(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - between self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{between{
+    make_ref(0), make_int_const(1), make_int_const(10),
+    /*lower_inclusive=*/true,
+    /*upper_inclusive=*/true,
+  }};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_between(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - case_expr self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  std::vector<case_expr::when_then> cases;
+  cases.push_back(case_expr::when_then{
+    std::make_unique<node>(
+      comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}),
+    make_int_const(10),
+  });
+  node orig{case_expr{std::move(cases), make_int_const(0)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_case_expr(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - cast self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{cast{
+    make_ref(0),
+    sirius::logical_type::make(sirius::type_id::BIGINT),
+    /*try_cast=*/false,
+  }};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_cast(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - unary_op self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  node orig{unary_op{unary_op::kind::op_is_null, make_ref(0)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_unary_op(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - coalesce self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_ref(1));
+  children.push_back(make_int_const(0));
+  node orig{coalesce{std::move(children)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_coalesce(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - in_list self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> values;
+  values.push_back(make_int_const(2));
+  values.push_back(make_int_const(5));
+  node orig{in_list{make_ref(0), std::move(values), /*negated=*/true}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_in_list(orig, *round));
+}
+
+TEST_CASE("ast_to_duckdb - function_call self-equivalence via from_duckdb", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  node orig{function_call{
+    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)}};
+  auto duck_expr = sirius::ast::to_duckdb(orig);
+  REQUIRE(duck_expr);
+  auto round = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(round);
+  REQUIRE(same_function_call(orig, *round));
+}

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -681,8 +681,9 @@ TEST_CASE("ast_to_duckdb - function_call add translates to BoundFunctionExpressi
   std::vector<std::unique_ptr<node>> args;
   args.push_back(make_ref(0));
   args.push_back(make_int_const(3));
-  node orig{function_call{
-    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)}};
+  node orig{function_call{sirius::function_id::add,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
@@ -699,8 +700,9 @@ TEST_CASE("ast_to_duckdb - function_call substring translates to BoundFunctionEx
   args.push_back(make_ref(0));
   args.push_back(make_int_const(1));
   args.push_back(make_int_const(3));
-  node orig{function_call{
-    sirius::function_id::substring, std::move(args), sirius::logical_type::make(sirius::type_id::VARCHAR)}};
+  node orig{function_call{sirius::function_id::substring,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::VARCHAR)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
@@ -715,8 +717,9 @@ TEST_CASE("ast_to_duckdb - function_call like translates to BoundFunctionExpress
   std::vector<std::unique_ptr<node>> args;
   args.push_back(make_ref(0));
   args.push_back(make_str_const("x%"));
-  node orig{function_call{
-    sirius::function_id::like, std::move(args), sirius::logical_type::make(sirius::type_id::BOOLEAN)}};
+  node orig{function_call{sirius::function_id::like,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::BOOLEAN)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
@@ -748,8 +751,9 @@ TEST_CASE("ast_to_duckdb - function_call year translates to BoundFunctionExpress
 {
   std::vector<std::unique_ptr<node>> args;
   args.push_back(make_ref(0));
-  node orig{function_call{
-    sirius::function_id::year, std::move(args), sirius::logical_type::make(sirius::type_id::BIGINT)}};
+  node orig{function_call{sirius::function_id::year,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::BIGINT)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION);
@@ -815,7 +819,9 @@ TEST_CASE("ast_to_duckdb - conjunction self-equivalence via from_duckdb", "[ast_
 TEST_CASE("ast_to_duckdb - between self-equivalence via from_duckdb", "[ast_to_duckdb]")
 {
   node orig{between{
-    make_ref(0), make_int_const(1), make_int_const(10),
+    make_ref(0),
+    make_int_const(1),
+    make_int_const(10),
     /*lower_inclusive=*/true,
     /*upper_inclusive=*/true,
   }};
@@ -898,8 +904,9 @@ TEST_CASE("ast_to_duckdb - function_call self-equivalence via from_duckdb", "[as
   std::vector<std::unique_ptr<node>> args;
   args.push_back(make_ref(0));
   args.push_back(make_int_const(3));
-  node orig{function_call{
-    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)}};
+  node orig{function_call{sirius::function_id::add,
+                          std::move(args),
+                          sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto duck_expr = sirius::ast::to_duckdb(orig);
   REQUIRE(duck_expr);
   auto round = sirius::ast::from_duckdb(*duck_expr);

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -223,8 +223,10 @@ cudf::table_view get_table_view(std::shared_ptr<data_batch> const& batch)
 // Run a non-owning executor over the given expression pointer and return the
 // resulting output table.
 template <class ExprPtr>
-std::unique_ptr<cudf::table> run_one(
-  memory_space& space, ExprPtr expr_ptr, cudf::table_view tv, exp_strategy_enum strategy)
+std::unique_ptr<cudf::table> run_one(memory_space& space,
+                                     ExprPtr expr_ptr,
+                                     cudf::table_view tv,
+                                     exp_strategy_enum strategy)
 {
   exp_executor executor(expr_ptr, get_resource_ref(space), cudf::get_default_stream(), strategy);
   return executor.execute(tv);
@@ -247,9 +249,9 @@ std::unique_ptr<sirius::ast::node> int_const_node(int32_t v)
 // DuckDB-side BoundReferenceExpression with INTEGER placeholder.
 duckdb::unique_ptr<Expression> duck_int_ref(uint32_t idx)
 {
-  return duckdb::unique_ptr<Expression>(duckdb::make_uniq<BoundReferenceExpression>(
-                                          LogicalType{LogicalTypeId::INTEGER}, idx)
-                                          .release());
+  return duckdb::unique_ptr<Expression>(
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, idx)
+      .release());
 }
 
 duckdb::unique_ptr<Expression> duck_int_const(int32_t v)
@@ -274,7 +276,7 @@ TEST_CASE("ast_equivalence - reference identity round-trip", "[gpu_expression_ex
 
   auto duck_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::reference{0});
+  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::reference{0});
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
@@ -304,8 +306,8 @@ TEST_CASE("ast_equivalence - constant INTEGER", "[gpu_expression_executor_ast]")
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
   auto tv = get_table_view(input);
 
-  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
-  auto hand_ast  = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+  auto duck_expr      = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
+  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::constant{
     sirius::value{int32_t{42}}, sirius::logical_type::make(sirius::type_id::INTEGER)});
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -329,8 +331,8 @@ TEST_CASE("ast_equivalence - constant VARCHAR", "[gpu_expression_executor_ast]")
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
   auto tv = get_table_view(input);
 
-  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value("hello"));
-  auto hand_ast  = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+  auto duck_expr      = duckdb::make_uniq<BoundConstantExpression>(Value("hello"));
+  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::constant{
     sirius::value{std::string{"hello"}}, sirius::logical_type::make(sirius::type_id::VARCHAR)});
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -355,8 +357,8 @@ TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[gpu_expression_e
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
@@ -381,8 +383,8 @@ TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[gpu_expression
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
@@ -407,8 +409,8 @@ TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[gpu_expressio
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
@@ -437,16 +439,15 @@ TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_ex
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
   auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
-  auto duck_expr =
-    duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+  auto duck_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
   duck_expr->children.push_back(std::move(duck_lhs));
   duck_expr->children.push_back(std::move(duck_rhs));
 
@@ -476,16 +477,15 @@ TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[gpu_expression_
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
   auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
-  auto duck_expr =
-    duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+  auto duck_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
   duck_expr->children.push_back(std::move(duck_lhs));
   duck_expr->children.push_back(std::move(duck_rhs));
 
@@ -519,14 +519,14 @@ TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[gpu_expression_executor_a
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 20}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 20}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundBetweenExpression>(
     duck_int_ref(0), duck_int_const(5), duck_int_const(15), /*lo=*/true, /*hi=*/true);
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::between{
-    ref_node(0), int_const_node(5), int_const_node(15), true, true});
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::between{ref_node(0), int_const_node(5), int_const_node(15), true, true});
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
@@ -550,8 +550,8 @@ TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_when = duckdb::make_uniq<BoundComparisonExpression>(
@@ -596,13 +596,13 @@ TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[gpu_expressi
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
   auto duck_expr =
     BoundCastExpression::AddDefaultCastToType(duck_int_ref(0), LogicalType{LogicalTypeId::BIGINT});
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::cast{
+  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::cast{
     ref_node(0), sirius::logical_type::make(sirius::type_id::BIGINT), /*try_cast=*/false});
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -627,8 +627,8 @@ TEST_CASE("ast_equivalence - unary_op NOT (MATERIALIZE)", "[gpu_expression_execu
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
   // Need a BOOLEAN-producing child; use a comparison.
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_inner = duckdb::make_uniq<BoundComparisonExpression>(
@@ -661,8 +661,8 @@ TEST_CASE("ast_equivalence - unary_op IS_NULL (MATERIALIZE)", "[gpu_expression_e
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
@@ -690,12 +690,12 @@ TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[gpu_expressi
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
-  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(
-    ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
   duck_expr->children.push_back(duck_int_ref(0));
 
   auto hand_ast = std::make_unique<sirius::ast::node>(
@@ -715,8 +715,7 @@ TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[gpu_expressi
   REQUIRE(hand_host == translated_host);
 }
 
-TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)",
-          "[gpu_expression_executor_ast]")
+TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)", "[gpu_expression_executor_ast]")
 {
   // OPERATOR_TRY is recognized by the AST surface but not executable by the
   // current gpu_expression_executor (it throws on dispatch through
@@ -731,8 +730,7 @@ TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)",
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
   REQUIRE(translated_ast->holds<sirius::ast::unary_op>());
-  REQUIRE(translated_ast->get<sirius::ast::unary_op>().op ==
-          sirius::ast::unary_op::kind::op_try);
+  REQUIRE(translated_ast->get<sirius::ast::unary_op>().op == sirius::ast::unary_op::kind::op_try);
 
   auto round_trip = sirius::ast::to_duckdb(*translated_ast);
   REQUIRE(round_trip);
@@ -747,20 +745,19 @@ TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[gpu_expression_executor_
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
-  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(
-    ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
+                                                              LogicalType{LogicalTypeId::INTEGER});
   duck_expr->children.push_back(duck_int_ref(0));
   duck_expr->children.push_back(duck_int_const(0));
 
   std::vector<std::unique_ptr<sirius::ast::node>> children;
   children.push_back(ref_node(0));
   children.push_back(int_const_node(0));
-  auto hand_ast =
-    std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -784,8 +781,8 @@ TEST_CASE("ast_equivalence - in_list IN (MATERIALIZE)", "[gpu_expression_executo
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
@@ -820,8 +817,8 @@ TEST_CASE("ast_equivalence - in_list IN (AST_INTERPRET)", "[gpu_expression_execu
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
@@ -860,16 +857,14 @@ TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
     LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction("+",
-                   {LogicalType::INTEGER, LogicalType::INTEGER},
-                   LogicalType::INTEGER,
-                   nullptr),
+    ScalarFunction(
+      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
     duckdb::vector<duckdb::unique_ptr<Expression>>{},
     nullptr);
   duck_expr->children.push_back(duck_int_ref(0));
@@ -878,8 +873,10 @@ TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_
   std::vector<std::unique_ptr<sirius::ast::node>> args;
   args.push_back(ref_node(0));
   args.push_back(int_const_node(3));
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::function_call{
-    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::function_call{sirius::function_id::add,
+                               std::move(args),
+                               sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -899,16 +896,14 @@ TEST_CASE("ast_equivalence - function_call add (AST_INTERPRET)", "[gpu_expressio
 {
   auto* space = get_default_gpu_space();
   REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
   auto tv = get_table_view(input);
 
   auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
     LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction("+",
-                   {LogicalType::INTEGER, LogicalType::INTEGER},
-                   LogicalType::INTEGER,
-                   nullptr),
+    ScalarFunction(
+      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
     duckdb::vector<duckdb::unique_ptr<Expression>>{},
     nullptr);
   duck_expr->children.push_back(duck_int_ref(0));
@@ -917,8 +912,10 @@ TEST_CASE("ast_equivalence - function_call add (AST_INTERPRET)", "[gpu_expressio
   std::vector<std::unique_ptr<sirius::ast::node>> args;
   args.push_back(ref_node(0));
   args.push_back(int_const_node(3));
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::function_call{
-    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::function_call{sirius::function_id::add,
+                               std::move(args),
+                               sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -1,0 +1,935 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Three-leg byte-equivalence tests for the dual-path gpu_expression_executor.
+//
+// For each Sirius AST alternative, the test constructs the same expression
+// three ways:
+//   1. directly as a duckdb::BoundXxxExpression (DuckDB-direct leg)
+//   2. as a hand-built sirius::ast::node{<alt>{...}}            (hand-AST leg)
+//   3. via sirius::ast::from_duckdb(*duck_expr)                 (translator leg)
+//
+// All three are executed against the same input table and the output columns
+// are asserted byte-equivalent pairwise on host. Confirms the new
+// sirius::ast::node-typed executor surface produces identical output to the
+// existing duckdb::Expression-typed surface for every alternative.
+
+// test
+#include <catch.hpp>
+#include <utils/utils.hpp>
+
+// sirius — AST types + translators + executor
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <data/data_batch_utils.hpp>
+#include <data/sirius_converter_registry.hpp>
+#include <expression/ast/between.hpp>
+#include <expression/ast/case_expr.hpp>
+#include <expression/ast/cast.hpp>
+#include <expression/ast/coalesce.hpp>
+#include <expression/ast/comparison.hpp>
+#include <expression/ast/conjunction.hpp>
+#include <expression/ast/constant.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/function_call.hpp>
+#include <expression/ast/in_list.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/ast/reference.hpp>
+#include <expression/ast/to_duckdb.hpp>
+#include <expression/ast/unary_op.hpp>
+#include <expression/function_id.hpp>
+#include <expression/join_condition.hpp>
+#include <expression/value.hpp>
+#include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/logical_type.hpp>
+#include <memory/sirius_memory_reservation_manager.hpp>
+
+// duckdb
+#include <duckdb/common/helper.hpp>
+#include <duckdb/planner/expression/bound_between_expression.hpp>
+#include <duckdb/planner/expression/bound_case_expression.hpp>
+#include <duckdb/planner/expression/bound_cast_expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+// cudf
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
+#include <cuda_runtime_api.h>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace duckdb;
+using namespace cucascade;
+using namespace cucascade::memory;
+
+namespace {
+
+using memory_mgr = ::sirius::memory::sirius_memory_reservation_manager;
+
+std::unique_ptr<memory_mgr> initialize_memory_manager()
+{
+  ::sirius::converter_registry::reset_for_testing();
+  reservation_manager_configurator builder;
+  auto constexpr gpu_capacity  = 256ull << 20;  // 256MB
+  auto constexpr host_capacity = 512ull << 20;  // 512MB
+  auto constexpr limit_ratio   = 0.75;
+  builder.set_number_of_gpus(1)
+    .set_gpu_usage_limit(gpu_capacity)
+    .set_reservation_fraction_per_gpu(limit_ratio)
+    .set_per_host_capacity(host_capacity)
+    .use_host_per_gpu()
+    .set_reservation_fraction_per_host(limit_ratio);
+  auto configs = builder.build();
+  auto manager = std::make_unique<memory_mgr>(std::move(configs));
+  ::sirius::converter_registry::initialize();
+  return manager;
+}
+
+memory_space* get_default_gpu_space()
+{
+  static auto manager = initialize_memory_manager();
+  return const_cast<memory_space*>(manager->get_memory_space(Tier::GPU, 0));
+}
+
+rmm::device_async_resource_ref get_resource_ref(memory_space& space)
+{
+  return space.get_default_allocator();
+}
+
+template <typename T>
+std::vector<T> copy_column_to_host(const cudf::column_view& col)
+{
+  std::vector<T> host(col.size());
+  if (col.size() > 0) {
+    cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+std::vector<uint8_t> copy_bool_column_to_host(const cudf::column_view& col)
+{
+  std::vector<uint8_t> host(col.size());
+  if (col.size() > 0) {
+    cudaMemcpy(host.data(), col.head(), sizeof(uint8_t) * col.size(), cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+std::vector<std::string> copy_string_column_to_host(const cudf::column_view& col)
+{
+  std::vector<std::string> host;
+  if (col.size() == 0) { return host; }
+
+  cudf::strings_column_view str_col(col);
+  std::vector<cudf::size_type> offsets(col.size() + 1);
+  cudaMemcpy(offsets.data(),
+             str_col.offsets().data<cudf::size_type>(),
+             (col.size() + 1) * sizeof(cudf::size_type),
+             cudaMemcpyDeviceToHost);
+
+  std::vector<char> chars(offsets.back());
+  if (!chars.empty()) {
+    cudaMemcpy(chars.data(),
+               str_col.chars_begin(cudf::get_default_stream()),
+               offsets.back(),
+               cudaMemcpyDeviceToHost);
+  }
+
+  host.reserve(col.size());
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    auto start = offsets[i];
+    auto end   = offsets[i + 1];
+    if (chars.empty()) {
+      host.emplace_back();
+    } else {
+      host.emplace_back(chars.data() + start, chars.data() + end);
+    }
+  }
+  return host;
+}
+
+std::vector<bool> copy_valids_to_host(const cudf::column_view& col)
+{
+  std::vector<bool> valids(col.size(), true);
+  if (!col.nullable() || col.null_count() == 0) { return valids; }
+  auto const num_words = cudf::num_bitmask_words(col.size());
+  std::vector<cudf::bitmask_type> host_mask(num_words);
+  cudaMemcpy(host_mask.data(),
+             col.null_mask(),
+             num_words * sizeof(cudf::bitmask_type),
+             cudaMemcpyDeviceToHost);
+  constexpr auto bits_per_word = sizeof(cudf::bitmask_type) * 8;
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    auto word = host_mask[i / bits_per_word];
+    auto bit  = i % bits_per_word;
+    valids[i] = ((word >> bit) & 1U) != 0U;
+  }
+  return valids;
+}
+
+std::shared_ptr<data_batch> make_input_batch(
+  memory_space& space,
+  const std::vector<cudf::data_type>& column_types,
+  const std::vector<std::optional<std::pair<int, int>>>& ranges)
+{
+  auto mr    = get_resource_ref(space);
+  auto table = ::sirius::create_cudf_table_with_random_data(
+    128, column_types, ranges, cudf::get_default_stream(), mr);
+  auto gpu_repr =
+    std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
+  auto batch_id = ::sirius::get_next_batch_id();
+  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+}
+
+using exp_executor      = ::sirius::gpu_expression_executor;
+using exp_strategy_enum = ::sirius::expression_executor_strategy;
+auto constexpr MAT      = exp_strategy_enum::MATERIALIZE;
+auto constexpr AST_I    = exp_strategy_enum::AST_INTERPRET;
+
+// Helper — pull the cudf::table_view out of a data_batch's read-only handle.
+cudf::table_view get_table_view(std::shared_ptr<data_batch> const& batch)
+{
+  auto input_ro = batch->to_read_only();
+  return input_ro.get_data()->cast<gpu_table_representation>().get_table_view();
+}
+
+// Run a non-owning executor over the given expression pointer and return the
+// resulting output table.
+template <class ExprPtr>
+std::unique_ptr<cudf::table> run_one(
+  memory_space& space, ExprPtr expr_ptr, cudf::table_view tv, exp_strategy_enum strategy)
+{
+  exp_executor executor(expr_ptr, get_resource_ref(space), cudf::get_default_stream(), strategy);
+  return executor.execute(tv);
+}
+
+// Small-node construction shortcuts.
+std::unique_ptr<sirius::ast::node> ref_node(uint32_t idx)
+{
+  return std::make_unique<sirius::ast::node>(sirius::ast::reference{idx});
+}
+
+std::unique_ptr<sirius::ast::node> int_const_node(int32_t v)
+{
+  return std::make_unique<sirius::ast::node>(sirius::ast::constant{
+    /*payload=*/sirius::value{v},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  });
+}
+
+// DuckDB-side BoundReferenceExpression with INTEGER placeholder.
+duckdb::unique_ptr<Expression> duck_int_ref(uint32_t idx)
+{
+  return duckdb::unique_ptr<Expression>(duckdb::make_uniq<BoundReferenceExpression>(
+                                          LogicalType{LogicalTypeId::INTEGER}, idx)
+                                          .release());
+}
+
+duckdb::unique_ptr<Expression> duck_int_const(int32_t v)
+{
+  return duckdb::unique_ptr<Expression>(
+    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(v)).release());
+}
+
+}  // namespace
+
+// ============================================================================
+// reference
+// ============================================================================
+
+TEST_CASE("ast_equivalence - reference identity round-trip", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr =
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::reference{0});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+  REQUIRE(duck_out);
+  REQUIRE(hand_out);
+  REQUIRE(translated_out);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// constant — INTEGER and VARCHAR variants.
+// ============================================================================
+
+TEST_CASE("ast_equivalence - constant INTEGER", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
+  auto hand_ast  = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+    sirius::value{int32_t{42}}, sirius::logical_type::make(sirius::type_id::INTEGER)});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - constant VARCHAR", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value("hello"));
+  auto hand_ast  = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+    sirius::value{std::string{"hello"}}, sirius::logical_type::make(sirius::type_id::VARCHAR)});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_string_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_string_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_string_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// comparison — three variants: MATERIALIZE EQUAL, AST_INTERPRET EQUAL,
+// MATERIALIZE LESSTHAN.
+// ============================================================================
+
+TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(5));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(5)});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// conjunction — AND (MATERIALIZE + AST_INTERPRET).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
+  auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
+  auto duck_expr =
+    duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+  duck_expr->children.push_back(std::move(duck_lhs));
+  duck_expr->children.push_back(std::move(duck_rhs));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> children;
+  children.push_back(std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::gt, ref_node(0), int_const_node(1)}));
+  children.push_back(std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(9)}));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::conjunction{sirius::ast::conjunction::kind::op_and, std::move(children)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
+  auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
+  auto duck_expr =
+    duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+  duck_expr->children.push_back(std::move(duck_lhs));
+  duck_expr->children.push_back(std::move(duck_rhs));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> children;
+  children.push_back(std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::gt, ref_node(0), int_const_node(1)}));
+  children.push_back(std::make_unique<sirius::ast::node>(
+    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(9)}));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::conjunction{sirius::ast::conjunction::kind::op_and, std::move(children)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// between — BoundBetweenExpression with INTEGER bounds (MATERIALIZE).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 20}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundBetweenExpression>(
+    duck_int_ref(0), duck_int_const(5), duck_int_const(15), /*lo=*/true, /*hi=*/true);
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::between{
+    ref_node(0), int_const_node(5), int_const_node(15), true, true});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// case_expr — single WHEN/THEN + ELSE (MATERIALIZE — AST breaker).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
+          "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_when = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
+  auto duck_then = duck_int_const(10);
+  auto duck_else = duck_int_const(0);
+  BoundCaseCheck check;
+  check.when_expr = std::move(duck_when);
+  check.then_expr = std::move(duck_then);
+  auto duck_expr  = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
+  duck_expr->case_checks.push_back(std::move(check));
+  duck_expr->else_expr = std::move(duck_else);
+
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.push_back(sirius::ast::case_expr::when_then{
+    std::make_unique<sirius::ast::node>(
+      sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)}),
+    int_const_node(10),
+  });
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::case_expr{std::move(cases), int_const_node(0)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// cast — INTEGER -> BIGINT (MATERIALIZE).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr =
+    BoundCastExpression::AddDefaultCastToType(duck_int_ref(0), LogicalType{LogicalTypeId::BIGINT});
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::cast{
+    ref_node(0), sirius::logical_type::make(sirius::type_id::BIGINT), /*try_cast=*/false});
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_column_to_host<int64_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int64_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int64_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// unary_op — one TEST_CASE per kind (MATERIALIZE).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - unary_op NOT (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  // Need a BOOLEAN-producing child; use a comparison.
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_inner = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
+  duck_expr->children.push_back(std::move(duck_inner));
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::unary_op{
+    sirius::ast::unary_op::kind::op_not,
+    std::make_unique<sirius::ast::node>(
+      sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)}),
+  });
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - unary_op IS_NULL (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
+  duck_expr->children.push_back(duck_int_ref(0));
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_null, ref_node(0)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(
+    ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
+  duck_expr->children.push_back(duck_int_ref(0));
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_not_null, ref_node(0)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)",
+          "[gpu_expression_executor_ast]")
+{
+  // OPERATOR_TRY is recognized by the AST surface but not executable by the
+  // current gpu_expression_executor (it throws on dispatch through
+  // gpu_execute_operator.cpp). Verify only the translation half of the contract
+  // for this kind: the three legs translate to AST shapes with matching unary_op
+  // kinds. Execution coverage is intentionally omitted until the underlying
+  // OPERATOR_TRY specialization lands.
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
+                                                              LogicalType{LogicalTypeId::INTEGER});
+  duck_expr->children.push_back(duck_int_ref(0));
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+  REQUIRE(translated_ast->holds<sirius::ast::unary_op>());
+  REQUIRE(translated_ast->get<sirius::ast::unary_op>().op ==
+          sirius::ast::unary_op::kind::op_try);
+
+  auto round_trip = sirius::ast::to_duckdb(*translated_ast);
+  REQUIRE(round_trip);
+  REQUIRE(round_trip->GetExpressionType() == ExpressionType::OPERATOR_TRY);
+}
+
+// ============================================================================
+// coalesce — 3-arg INTEGER (MATERIALIZE — AST breaker).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(
+    ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
+  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->children.push_back(duck_int_const(0));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> children;
+  children.push_back(ref_node(0));
+  children.push_back(int_const_node(0));
+  auto hand_ast =
+    std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// in_list — IN + NOT IN (MATERIALIZE + AST_INTERPRET).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - in_list IN (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
+  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->children.push_back(duck_int_const(2));
+  duck_expr->children.push_back(duck_int_const(5));
+  duck_expr->children.push_back(duck_int_const(8));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> values;
+  values.push_back(int_const_node(2));
+  values.push_back(int_const_node(5));
+  values.push_back(int_const_node(8));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::in_list{ref_node(0), std::move(values), /*negated=*/false});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - in_list IN (AST_INTERPRET)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
+  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->children.push_back(duck_int_const(2));
+  duck_expr->children.push_back(duck_int_const(5));
+  duck_expr->children.push_back(duck_int_const(8));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> values;
+  values.push_back(int_const_node(2));
+  values.push_back(int_const_node(5));
+  values.push_back(int_const_node(8));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::in_list{ref_node(0), std::move(values), /*negated=*/false});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
+
+  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
+  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
+  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+// ============================================================================
+// function_call — add (MATERIALIZE + AST_INTERPRET).
+// ============================================================================
+
+TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
+    LogicalType{LogicalTypeId::INTEGER},
+    ScalarFunction("+",
+                   {LogicalType::INTEGER, LogicalType::INTEGER},
+                   LogicalType::INTEGER,
+                   nullptr),
+    duckdb::vector<duckdb::unique_ptr<Expression>>{},
+    nullptr);
+  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->children.push_back(duck_int_const(3));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> args;
+  args.push_back(ref_node(0));
+  args.push_back(int_const_node(3));
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::function_call{
+    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}
+
+TEST_CASE("ast_equivalence - function_call add (AST_INTERPRET)", "[gpu_expression_executor_ast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(
+    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
+  auto tv = get_table_view(input);
+
+  auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
+    LogicalType{LogicalTypeId::INTEGER},
+    ScalarFunction("+",
+                   {LogicalType::INTEGER, LogicalType::INTEGER},
+                   LogicalType::INTEGER,
+                   nullptr),
+    duckdb::vector<duckdb::unique_ptr<Expression>>{},
+    nullptr);
+  duck_expr->children.push_back(duck_int_ref(0));
+  duck_expr->children.push_back(duck_int_const(3));
+
+  std::vector<std::unique_ptr<sirius::ast::node>> args;
+  args.push_back(ref_node(0));
+  args.push_back(int_const_node(3));
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::function_call{
+    sirius::function_id::add, std::move(args), sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
+  REQUIRE(translated_ast);
+
+  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
+  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
+
+  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
+  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
+  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
+  REQUIRE(duck_host == hand_host);
+  REQUIRE(hand_host == translated_host);
+}


### PR DESCRIPTION
Phase 5 of #666 — closes #698. Depends on #796.

## What

`gpu_expression_executor` grows a Sirius-AST surface alongside the existing DuckDB one. Both paths coexist; no caller migrated this PR.

- New non-owning ctor `gpu_expression_executor(sirius::ast::node const*, ...)`
- New `execute(sirius::ast::node const&, execution_mode)` + `count_ast_ops(sirius::ast::node const&) const`, dispatched via `std::visit` over the 11-alternative variant
- New translator `sirius::ast::to_duckdb(node)` — symmetric inverse of #796's `from_duckdb`, with per-alternative public overloads
- 11 per-alternative executor shims round-trip via `to_duckdb` to the existing DuckDB-typed specializations
- `D_ASSERT(_expressions.empty() != _ast_expressions.empty())` in `execute(table_view)` / `select(table_view)` enforces single-path-per-instance

#699 (Phase 6) replaces each shim with a native Sirius-AST implementation, one `gpu_execute_*.cpp` at a time.

## Tests

- `[ast_to_duckdb]`: 41 cases (direct-ctor matrix + `from_duckdb(to_duckdb(node))` self-equivalence per alternative)
- `[gpu_expression_executor_ast]`: 20 cases (three-leg equivalence — DuckDB-direct × hand-built Sirius AST × #796-translated Sirius AST, byte-equal output columns)
- Full `sirius_unittest`: 1,512 cases / 41,431,375 assertions PASS
- Existing tags (`[gpu_expression_executor]`, `[gpu_expression_translator]`, etc.): no count regression

## Acceptance

- [x] Both paths produce identical outputs on identical inputs
- [x] No existing caller migrated
- [x] `sirius_unittest` passes
- [x] `src/legacy/` and `test/sql/tpch-sirius.test` unchanged
- [ ] TPC-H SF1 no-regression — to be verified by CI / reviewer