### PR TITLE
Restore some scan behavior to pre-multi-gpu

### DIFF
--- a/docs/super-sirius/multi-gpu-architecture.md
+++ b/docs/super-sirius/multi-gpu-architecture.md
@@ -172,16 +172,18 @@ The probe runs once at startup per (src, dst) pair: allocate small buffers on ea
 
 ## Multi-GPU-Safe Parquet I/O
 
-The I/O path is **kvikio-free** (GATE-22.1-A invariant). The reasoning: cudf's bundled `file_source` factory uses kvikio, which binds the file handle to whichever CUDA context was active at construction time. In multi-GPU execution that's a hidden source of corruption — a file_handle bound to GPU 0 will silently funnel reads through GPU 0 even when the consumer is on GPU 1.
+The multi-GPU I/O path is **kvikio-free**. The reasoning: cudf's bundled `file_source` factory uses kvikio, which binds the file handle to whichever CUDA context was active at construction time. In multi-GPU execution that's a hidden source of corruption — a file_handle bound to GPU 0 will silently funnel reads through GPU 0 even when the consumer is on GPU 1. `sirius_config::enforce_sirius_datasource_for_multi_gpu()` therefore forces `scan_manager_config::use_sirius_datasource = true` whenever more than one GPU memory space is configured, and emits a warning if the user-supplied value was `false`.
+
+Single-GPU configurations may still opt out via `use_sirius_datasource=false`; the per-FileHandle context binding is harmless with only one CUDA context in play, and the engine routes those reads through `cudf::io::datasource::create` (kvikio) at the same sites that would otherwise use `sirius_datasource`. The rest of this section describes the multi-GPU (`use_sirius_datasource=true`) path.
 
 The Sirius path:
 
-1. **All file reads go through `sirius_ioctx::make_datasource(io_object)`.** Never `cudf::io::datasource::create(path)` and never `cudf::io::source_info{path}`. A grep gate enforces this in `src/`.
+1. **All file reads go through `sirius_ioctx::make_datasource(io_object)`.** Never `cudf::io::datasource::create(path)` and never `cudf::io::source_info{path}`. Single-GPU `use_sirius_datasource=false` is the only configuration that takes the cudf-bundled path.
 2. **`sirius_ioctx` is per-GPU.** Construction binds `cudaSetDevice(gpu_id)` via RAII; the underlying `uring_reactor` runs in a worker thread that holds that device's context.
 3. **Schemes are resolved through `datasource_registry_`.** A scan task that wants to read `file:///path/to/x.parquet` passes the URL to the registry, which returns a factory bound to the per-GPU `sirius_ioctx`. No silent fallback.
 4. **Pin-table chunk reads route through the owning GPU's ioctx.** Chunk `i` reads through `gpu_ioctxs_.at(chunk_memory_spaces[i]->get_device_id())`. The read lands directly in the target GPU's pinned memory region.
 
-The 7 historical sites that bypassed this contract (kvikio-fallback in `sirius_gpu_parquet_scan_operator`, `sirius_extension`, `iceberg_metadata_reader`, `datasource_factory`, `parquet_split_provider`) were all migrated to `sirius_ioctx::make_datasource` over Phase 22.1. The unit-test fallback in `parquet_split_provider:295` (D-08 site #7) was deleted outright.
+The 7 historical sites that bypassed this contract (kvikio-fallback in `sirius_gpu_parquet_scan_operator`, `sirius_extension`, `iceberg_metadata_reader`, `datasource_factory`, `parquet_split_provider`) were all migrated to `sirius_ioctx::make_datasource` over Phase 22.1; the remaining `cudf::io::datasource::create` callsites are reached only under the single-GPU `use_sirius_datasource=false` opt-out.
 
 ## Memory Pressure: Reservations and Downgrade
 
@@ -211,7 +213,7 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 | `_per_thread_init` in `downgrade_executor` gated on `tier == GPU` | `src/downgrade/downgrade_executor.cpp` (Phase 22.2 K.6) | HOST-tier workers must not call `cudaSetDevice(-1)` |
 | `chunk_memory_spaces[i]` parallel to `data_batches_by_column[col][i]` | `src/include/scan_manager/sirius_scan_manager.hpp` | Pin-table merge must preserve owning-space per chunk (Phase 22 Pitfall 3) |
 | HYG-02 invariant: 0 new `rmm::cuda_stream_default` in `src/` outside `legacy/` | grep gate | Default-stream usage breaks per-task-device contract under SCHED-RR |
-| GATE-22.1-A: 0 `cudf::io::datasource::create(path)` / `source_info{path}` in `src/` | grep gate | Any file-path datasource silently uses kvikio |
+| Multi-GPU runs use `sirius_datasource` everywhere | `sirius_config::enforce_sirius_datasource_for_multi_gpu()` forces `use_sirius_datasource=true` when >1 GPU is configured | Any file-path datasource via cudf silently uses kvikio, which binds to a single CUDA context |
 
 ## Hardware Caveats
 
@@ -228,7 +230,7 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 | `src/memory/sirius_memory_reservation_manager.{hpp,cpp}` | Extends `cucascade::memory_reservation_manager`; sets cudf device resource refs per GPU; synchronizes on destruction |
 | `src/include/scan_manager/sirius_scan_manager.hpp` | `pinned_entry`, `chunk_memory_spaces` invariant |
 | `src/scan_manager/parquet_split_provider.cpp` + `cached_split_provider.cpp` | Per-chunk memory_space lookup, GPU-mode + host-mode split providers |
-| `src/io/datasource_factory.{hpp,cpp}` | Strict scheme registry, kvikio-free file resolution |
+| `src/io/datasource_factory.{hpp,cpp}` | Strict scheme registry; routes every resolved URI through a registered `sirius_ioctx`. Used when `use_sirius_datasource=true` (always in multi-GPU). |
 | `src/io/uring/uring_reactor.cpp` | Per-GPU `uring_reactor` with RAII `cudaSetDevice` |
 | `src/op/scan/sirius_gpu_parquet_scan_operator.cpp` | Multi-GPU-aware GPU parquet scan |
 | `src/op/scan/duckdb_scan_executor.cpp` | NUMA-preference reservation requests |

--- a/src/include/io/datasource_factory.hpp
+++ b/src/include/io/datasource_factory.hpp
@@ -122,19 +122,24 @@ class datasource_factory {
   /**
    * @brief Create a @c cudf::io::datasource for @p uri.
    *
-   * Dispatch (kvikio-free invariant):
+   * Dispatch:
    *   - Every URI scheme MUST resolve through the registry to a registered
    *     @c sirius_ioctx whose @c make_datasource builds a @c sirius_datasource.
    *     The factory NEVER falls back to cudf's bundled @c file_source factory
-   *     (kvikio-backed) — that path is forbidden because kvikio's per-FileHandle
-   *     CUDA-context binding breaks multi-GPU residency.
+   *     (kvikio-backed) from inside @c create — single-GPU users that opt out
+   *     of @c sirius_datasource bypass this factory entirely instead of routing
+   *     a kvikio fallback through it. In multi-GPU mode kvikio is forbidden
+   *     because its per-FileHandle CUDA-context binding breaks multi-GPU
+   *     residency; @c sirius_config::enforce_sirius_datasource_for_multi_gpu()
+   *     ensures @c use_sirius_datasource is true whenever >1 GPU is configured.
    *   - Local file paths (@c "/data/foo.parquet", @c "file:///data/foo.parquet")
    *     route through @c kFileScheme, which is registered in
-   *     @c SiriusContext::initialize() with a uring-backed @c sirius_ioctx.
+   *     @c SiriusContext::initialize() with a uring-backed @c sirius_ioctx
+   *     (registration is skipped when @c use_sirius_datasource is false in a
+   *     single-GPU configuration).
    *   - Object-store schemes (@c s3://, etc.) require their backend to register
    *     a @c sirius_ioctx for that scheme at startup. If no ioctx is registered,
-   *     the factory throws "kvikio path is forbidden" rather than silently
-   *     falling back.
+   *     the factory throws rather than silently falling back to kvikio.
    *
    * @param uri      The resource URI (e.g. @c "/data/file.parquet",
    *                 @c "file:///data/file.parquet", @c "s3://bucket/key").
@@ -164,7 +169,9 @@ class datasource_factory {
    *     paths like @c "test/cpp/integration/data/...parquet".
    *   - Anything else (absolute path, @c file:///..., @c s3://..., object-store
    *     schemes): delegate to the strict @c create above. Every path resolves
-   *     through the registry to a @c sirius_ioctx — no kvikio fallback.
+   *     through the registry to a @c sirius_ioctx — this factory does not emit
+   *     a kvikio fallback (single-GPU @c use_sirius_datasource=false routing
+   *     uses cudf's datasource directly outside this factory).
    *
    * The strict @c create keeps its parser-strict contract — prefer it for
    * callers that should reject unscheme'd input as a real bug.

--- a/src/include/scan_manager/parquet_split_provider.hpp
+++ b/src/include/scan_manager/parquet_split_provider.hpp
@@ -23,6 +23,10 @@
 
 // Per-GPU sirius_ioctx for routing parquet reads through io_uring
 // (sirius_datasource) instead of cudf's bundled kvikio-backed file_source.
+// Required whenever more than one GPU is configured (enforced by
+// sirius_config::enforce_sirius_datasource_for_multi_gpu()); a single-GPU
+// configuration may opt out via use_sirius_datasource=false and fall back to
+// the bundled cudf file_source instead.
 // <io/types.hpp> declares sirius_ioctx; the uring_io_object concrete type is
 // referenced only in the .cpp via <io/uring/uring_reactor.hpp> (LAST among
 // sirius headers — liburing's BLOCK_SIZE macro collides with
@@ -98,16 +102,23 @@ class parquet_split_provider : public split_provider {
    *                                of cudf's bundled file_source factory —
    *                                the latter routes through kvikio and
    *                                bypasses the io_uring + per-GPU
-   *                                CUDA-context binding.
+   *                                CUDA-context binding (the per-GPU binding
+   *                                is what makes kvikio unsafe under multi-GPU;
+   *                                see
+   *                                sirius_config::enforce_sirius_datasource_for_multi_gpu()).
    */
   /// No-scan_manager overload (dev #732 + tests). @c _scan_manager stays
   /// nullptr; local reads route through @p gpu_ioctxs (per-GPU local backends,
   /// injected by tests via @c make_test_gpu_ioctxs). When both @p gpu_ioctxs is
-  /// empty AND there is no scan_manager, @c run_batch throws (the cudf/kvikio
-  /// local file_source is forbidden under the multi-GPU model) — so this
-  /// overload requires a non-empty @p gpu_ioctxs. The @c cudf::io::datasource
-  /// fallback now only triggers when a scan_manager is wired but reports no
-  /// backend for a local path (e.g. @c use_sirius_datasource=false).
+  /// empty AND there is no scan_manager, @c run_batch throws — so this overload
+  /// requires a non-empty @p gpu_ioctxs. (Production single-GPU runs with
+  /// @c use_sirius_datasource=false reach @c cudf::io::datasource::create
+  /// through the scan_manager branch below, not this overload.) The
+  /// @c cudf::io::datasource fallback triggers when a scan_manager is wired
+  /// but reports no backend for a local path (i.e. single-GPU
+  /// @c use_sirius_datasource=false; multi-GPU mode forces
+  /// @c use_sirius_datasource=true via
+  /// @c sirius_config::enforce_sirius_datasource_for_multi_gpu()).
   parquet_split_provider(
     duckdb::vector<sirius::logical_type> const& returned_types,
     std::vector<std::string> const& file_paths,

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -68,7 +68,11 @@ namespace sirius::scan_manager {
  * @c use_sirius_datasource controls whether the manager builds a
  * @c sirius_ioctx and routes parquet reads through @c sirius_datasource.
  * Set to @c false to fall back to @c cudf::io::datasource::create() at
- * every read site (e.g. when the sirius IO path is misbehaving).
+ * every read site (e.g. when the sirius IO path is misbehaving). Only
+ * valid in single-GPU configurations — when more than one GPU is
+ * configured, @c sirius_config::enforce_sirius_datasource_for_multi_gpu()
+ * forces this field to @c true because kvikio's per-FileHandle CUDA-context
+ * binding breaks multi-GPU residency.
  */
 struct scan_manager_config {
   exec::thread_pool_config thread_pool{.num_threads = 8, .thread_name_prefix = "scan_manager"};
@@ -230,9 +234,14 @@ class sirius_scan_manager {
   ///                     reads route through io_uring instead of cudf's
   ///                     bundled kvikio path. Empty map is permitted for
   ///                     callers (test harnesses) that pre-populate scan_info
-  ///                     another way; production callers
+  ///                     another way, and for the single-GPU
+  ///                     @c use_sirius_datasource=false configuration where
+  ///                     footer reads intentionally fall back to cudf's
+  ///                     kvikio datasource. Production callers
   ///                     (SiriusContext::create_query) MUST pass the map
-  ///                     from SiriusContext::get_gpu_ioctxs().
+  ///                     from SiriusContext::get_gpu_ioctxs(); multi-GPU
+  ///                     runs always populate it (enforced by
+  ///                     @c sirius_config::enforce_sirius_datasource_for_multi_gpu()).
   /// @param gpu_memory_spaces device_id -> GPU memory_space lookup used by the
   ///                     HOST-tier cached_split_provider to materialize host
   ///                     chunks onto the executing GPU. Empty map disables the

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -142,6 +142,12 @@ struct sirius_config {
   sirius::io::object_store_config object_store_config{};
 
  private:
+  /// When @c _memory_space_configs contains more than one GPU memory space,
+  /// force @c _scan_manager_config.use_sirius_datasource to true (sirius
+  /// datasource is required for multi-GPU IO routing). Emits a WARNING when
+  /// the override takes effect. Called from the end of @ref load_from_file.
+  void enforce_sirius_datasource_for_multi_gpu();
+
   cucascade::memory::system_topology_info _hw_topology{.num_gpus = 1};
   std::vector<cucascade::memory::memory_space_config> _memory_space_configs;
   exec::thread_pool_config _task_creator_config{.num_threads        = 2,

--- a/src/io/datasource_factory.cpp
+++ b/src/io/datasource_factory.cpp
@@ -109,8 +109,11 @@ std::unique_ptr<cudf::io::datasource> datasource_factory::create_for_parquet_sca
   std::string_view uri, datasource_registry const& registry, sirius_config const& config)
 {
   // Relative bare paths normalize to file:///<absolute> and dispatch through
-  // create(). Bypassing to cudf's default datasource would route through
-  // libkvikio internally — the forbidden kvikio path.
+  // create(). We do not emit a cudf-default fallback here: callers that want
+  // the bundled kvikio path use cudf::io::datasource::create directly outside
+  // this factory (single-GPU use_sirius_datasource=false). In multi-GPU mode
+  // kvikio is forbidden — sirius_config::enforce_sirius_datasource_for_multi_gpu()
+  // forces use_sirius_datasource=true whenever >1 GPU is configured.
   //
   // DuckDB's iceberg / hive fixtures hand out paths like
   // "test/cpp/integration/data/...parquet"; we resolve those against the
@@ -137,15 +140,20 @@ std::unique_ptr<cudf::io::datasource> datasource_factory::create(
 {
   auto p = parse(uri);
 
-  // ALL schemes (including kFileScheme) MUST be resolved via the registry.
-  // Bypassing kFileScheme to the cudf default datasource would route through
-  // libkvikio internally (binds a single CUDA context per FileHandle, breaks
-  // multi-GPU residency). SiriusContext::initialize() registers kFileScheme
-  // -> sirius_ioctx so this lookup succeeds.
+  // ALL schemes (including kFileScheme) MUST be resolved via the registry —
+  // this factory does not silently fall back to the cudf default datasource
+  // (which routes through libkvikio and binds a single CUDA context per
+  // FileHandle, breaking multi-GPU residency). SiriusContext::initialize()
+  // registers kFileScheme -> sirius_ioctx whenever use_sirius_datasource is
+  // true; in a single-GPU configuration with use_sirius_datasource=false the
+  // file scheme is intentionally not registered and callers route through
+  // cudf::io::datasource::create directly instead of invoking this factory.
+  // Multi-GPU mode always uses sirius_datasource (enforced by
+  // sirius_config::enforce_sirius_datasource_for_multi_gpu()).
   auto ioctx = registry.lookup(p.scheme);
   if (!ioctx) {
     throw std::runtime_error("datasource_factory: no ioctx registered for scheme '" + p.scheme +
-                             "' — kvikio path is forbidden (uri=" + std::string{uri} + ")");
+                             "' (uri=" + std::string{uri} + ")");
   }
 
   return ioctx->open_datasource(std::move(p.path));

--- a/src/op/scan/iceberg_metadata_reader.cpp
+++ b/src/op/scan/iceberg_metadata_reader.cpp
@@ -209,7 +209,10 @@ struct equality_delete_read_result {
  *
  * Routes both cudf::io::read_parquet (table) and cudf::io::read_parquet_footers
  * (field-id extraction) through the supplied single-GPU sirius_ioctx. The
- * caller MUST provide a non-null ioctx — the kvikio bypass path is forbidden.
+ * caller MUST provide a non-null ioctx — this entry point does not implement
+ * a kvikio bypass (callers that want the bundled cudf datasource use it
+ * directly outside this helper; multi-GPU mode requires sirius_datasource and
+ * is enforced by sirius_config::enforce_sirius_datasource_for_multi_gpu()).
  */
 equality_delete_read_result read_equality_delete_file(std::string const& delete_file_path,
                                                       sirius::io::sirius_ioctx& ioctx)
@@ -431,8 +434,8 @@ std::shared_ptr<const IcebergDeleteData> read_iceberg_delete_data(
 
   if (!metadata_ioctx) {
     throw std::invalid_argument(
-      "[iceberg] read_iceberg_delete_data: metadata_ioctx is null (kvikio path is forbidden; "
-      "caller must provide a sirius_ioctx).");
+      "[iceberg] read_iceberg_delete_data: metadata_ioctx is null; caller must provide a "
+      "sirius_ioctx (this entry point does not implement a kvikio fallback).");
   }
 
   try {

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -185,7 +185,7 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
   std::vector<std::shared_ptr<sirius::io::sirius_io_object>> io_objects;
   io_objects.reserve(scan_data.rg_slices.size());
   for (auto const& slice : scan_data.rg_slices) {
-    if (kvikio_fallback_mode || (!slice.io_ctx && !slice.io_object)) {
+    if (kvikio_fallback_mode || !slice.io_ctx) {
       // use_sirius_datasource=false path: use cudf's bundled datasource (kvikio).
       sources.push_back(cudf::io::datasource::create(slice.file_path));
     } else {

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -74,6 +74,12 @@ sirius_gpu_parquet_scan_operator::~sirius_gpu_parquet_scan_operator() = default;
 // route each parquet open through ioctx->make_datasource(uring_io_object), which
 // avoids the cudf-bundled file_source factory that bypasses the ioctx framework
 // and routes through libkvikio (a source of cross-GPU context binding races).
+//
+// _gpu_ioctxs is empty in single-GPU mode with use_sirius_datasource=false; in
+// that case read_table_from_metadata falls back to cudf::io::datasource::create
+// (kvikio) since with only one GPU the per-FileHandle context binding is
+// harmless. Multi-GPU mode always populates this map — enforced by
+// sirius_config::enforce_sirius_datasource_for_multi_gpu().
 void sirius_gpu_parquet_scan_operator::set_gpu_ioctxs(
   std::unordered_map<int, std::shared_ptr<sirius::io::sirius_ioctx>> ioctxs)
 {
@@ -145,13 +151,16 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
   // by the chunk's memory_space->get_device_id(). The cudf-bundled
   // file_source factory bypasses the ioctx framework and routes through
   // libkvikio's per-FileHandle CUDA-context binding, breaking multi-GPU
-  // residency.
+  // residency. Multi-GPU configurations therefore always supply a populated
+  // _gpu_ioctxs map (enforced by
+  // sirius_config::enforce_sirius_datasource_for_multi_gpu(), which forces
+  // use_sirius_datasource=true whenever >1 GPU is configured).
   //
-  // When use_sirius_datasource=false, the scan_manager hands the operator an
-  // empty _gpu_ioctxs map and the provider emits slices with null io_ctx /
-  // io_object. In that case we deliberately use cudf::io::datasource::create
-  // for every slice (single-GPU mode by definition — kvikio binds one CUDA
-  // context per FileHandle).
+  // When use_sirius_datasource=false (single-GPU only), the scan_manager
+  // hands the operator an empty _gpu_ioctxs map and the provider emits
+  // slices with null io_ctx / io_object. In that case we use
+  // cudf::io::datasource::create for every slice — kvikio's per-FileHandle
+  // CUDA-context binding is harmless with only one GPU in play.
   bool const kvikio_fallback_mode = _gpu_ioctxs.empty();
   std::unordered_map<int, std::shared_ptr<sirius::io::sirius_ioctx>>::const_iterator ioctx_it =
     _gpu_ioctxs.end();

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -146,24 +146,29 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
   // file_source factory bypasses the ioctx framework and routes through
   // libkvikio's per-FileHandle CUDA-context binding, breaking multi-GPU
   // residency.
-  if (_gpu_ioctxs.empty()) {
-    throw std::runtime_error(
-      "[sirius_gpu_parquet_scan_operator::read_table_from_metadata] _gpu_ioctxs is empty; "
-      "set_gpu_ioctxs() must be called by sirius_scan_manager::create_provider_for() before "
-      "execute().");
-  }
-  if (scan_data.gpu_memory_space == nullptr) {
-    throw std::runtime_error(
-      "[sirius_gpu_parquet_scan_operator::read_table_from_metadata] scan_data.gpu_memory_space "
-      "is null; cannot select per-chunk ioctx.");
-  }
-  int const target_device_id = scan_data.gpu_memory_space->get_device_id();
-  auto ioctx_it              = _gpu_ioctxs.find(target_device_id);
-  if (ioctx_it == _gpu_ioctxs.end()) {
-    throw std::out_of_range(
-      "[sirius_gpu_parquet_scan_operator::read_table_from_metadata] no sirius_ioctx for "
-      "device_id=" +
-      std::to_string(target_device_id) + ".");
+  //
+  // When use_sirius_datasource=false, the scan_manager hands the operator an
+  // empty _gpu_ioctxs map and the provider emits slices with null io_ctx /
+  // io_object. In that case we deliberately use cudf::io::datasource::create
+  // for every slice (single-GPU mode by definition — kvikio binds one CUDA
+  // context per FileHandle).
+  bool const kvikio_fallback_mode = _gpu_ioctxs.empty();
+  std::unordered_map<int, std::shared_ptr<sirius::io::sirius_ioctx>>::const_iterator ioctx_it =
+    _gpu_ioctxs.end();
+  if (!kvikio_fallback_mode) {
+    if (scan_data.gpu_memory_space == nullptr) {
+      throw std::runtime_error(
+        "[sirius_gpu_parquet_scan_operator::read_table_from_metadata] scan_data.gpu_memory_space "
+        "is null; cannot select per-chunk ioctx.");
+    }
+    int const target_device_id = scan_data.gpu_memory_space->get_device_id();
+    ioctx_it                   = _gpu_ioctxs.find(target_device_id);
+    if (ioctx_it == _gpu_ioctxs.end()) {
+      throw std::out_of_range(
+        "[sirius_gpu_parquet_scan_operator::read_table_from_metadata] no sirius_ioctx for "
+        "device_id=" +
+        std::to_string(target_device_id) + ".");
+    }
   }
   // Hold uring_io_object shared_ptrs for the duration of the read so the
   // sirius_datasources keep a valid handle (sirius_datasource holds a raw
@@ -171,26 +176,31 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
   std::vector<std::shared_ptr<sirius::io::sirius_io_object>> io_objects;
   io_objects.reserve(scan_data.rg_slices.size());
   for (auto const& slice : scan_data.rg_slices) {
-    // Two-dimensional ioctx selection (multi-GPU #732 × multi-backend-S3).
-    // slice.io_ctx is the backend that minted slice.io_object:
-    //   * per-GPU LOCAL backend (one of _gpu_ioctxs) → rebind the read to the
-    //     *target* GPU's local ioctx so it binds to the executing GPU's CUDA
-    //     context (dev #732 residency); the planning-time GPU may differ.
-    //   * shared REMOTE backend (e.g. the single s3_ioctx) → read through
-    //     slice.io_ctx directly; S3 is network→host and not per-GPU.
-    auto const is_per_gpu_local = [&] {
-      for (auto const& [dev, ctx] : _gpu_ioctxs) {
-        if (ctx == slice.io_ctx) { return true; }
-      }
-      return false;
-    }();
-    auto const ds_ioctx = (slice.io_ctx && !is_per_gpu_local) ? slice.io_ctx : ioctx_it->second;
-    if (slice.io_object) {
-      sources.push_back(ds_ioctx->make_datasource(slice.io_object));
+    if (kvikio_fallback_mode || (!slice.io_ctx && !slice.io_object)) {
+      // use_sirius_datasource=false path: use cudf's bundled datasource (kvikio).
+      sources.push_back(cudf::io::datasource::create(slice.file_path));
     } else {
-      auto io_object = ds_ioctx->create_io_object(slice.file_path);
-      sources.push_back(ds_ioctx->make_datasource(io_object));
-      io_objects.push_back(std::move(io_object));
+      // Two-dimensional ioctx selection (multi-GPU #732 × multi-backend-S3).
+      // slice.io_ctx is the backend that minted slice.io_object:
+      //   * per-GPU LOCAL backend (one of _gpu_ioctxs) → rebind the read to the
+      //     *target* GPU's local ioctx so it binds to the executing GPU's CUDA
+      //     context (dev #732 residency); the planning-time GPU may differ.
+      //   * shared REMOTE backend (e.g. the single s3_ioctx) → read through
+      //     slice.io_ctx directly; S3 is network→host and not per-GPU.
+      auto const is_per_gpu_local = [&] {
+        for (auto const& [dev, ctx] : _gpu_ioctxs) {
+          if (ctx == slice.io_ctx) { return true; }
+        }
+        return false;
+      }();
+      auto const ds_ioctx = (slice.io_ctx && !is_per_gpu_local) ? slice.io_ctx : ioctx_it->second;
+      if (slice.io_object) {
+        sources.push_back(ds_ioctx->make_datasource(slice.io_object));
+      } else {
+        auto io_object = ds_ioctx->create_io_object(slice.file_path);
+        sources.push_back(ds_ioctx->make_datasource(io_object));
+        io_objects.push_back(std::move(io_object));
+      }
     }
     metadatas.push_back(*slice.file_metadata);  // copy unavoidable: cudf takes by value
     rg_per_src.push_back(slice.row_group_indices);

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -668,13 +668,13 @@ void parquet_split_provider::run_batch(file_batch const& batch,
       cur_rgs.push_back(rg_idx);
     }
     seal_current_file();
-    // Emit at least one split per file so source pipelines (GPU_PARQUET_SCAN
-    // -> ...) generate multiple gpu_pipeline_tasks when scanning multiple
-    // files. The task_scheduler's round-robin counter then distributes those
-    // tasks across GPUs. Without this flush, small workloads bundle all files
-    // under the _approximate_batch_size threshold into one split → one task →
-    // one GPU.
-    flush();
+    // Multi-GPU only: emit at least one split per file so source pipelines
+    // (GPU_PARQUET_SCAN -> ...) generate multiple gpu_pipeline_tasks when
+    // scanning multiple files. The task_scheduler's round-robin counter then
+    // distributes those tasks across GPUs. On a single-GPU system there is no
+    // GPU to balance across, so we keep the BASE byte-budget bundling (more
+    // tasks just add pipeline-start overhead without parallelism benefit).
+    if (_gpu_ioctxs.size() > 1) { flush(); }
   }
   flush();
 }

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -386,9 +386,12 @@ void parquet_split_provider::run_batch(file_batch const& batch,
     //     Footer reads are GPU-agnostic; per-GPU column placement is decided
     //     downstream by the scan operator's task affinity, so any GPU's ioctx
     //     is safe for planning, and routing through io_uring (not cudf's kvikio
-    //     file_source) preserves per-GPU CUDA-context binding.
-    //   * neither (legacy test fixture with no scan_manager and empty
-    //     gpu_ioctxs) → cudf::io::datasource::create.
+    //     file_source) preserves per-GPU CUDA-context binding. Multi-GPU runs
+    //     always reach this branch — enforced by
+    //     sirius_config::enforce_sirius_datasource_for_multi_gpu().
+    //   * neither (single-GPU use_sirius_datasource=false, or legacy test
+    //     fixture with no scan_manager and empty gpu_ioctxs) →
+    //     cudf::io::datasource::create (kvikio is safe with one GPU).
     //
     // Path normalization: uring_reactor::supports / create_io_object only
     // accept bare absolute paths (they call is_regular_file on the raw
@@ -428,8 +431,12 @@ void parquet_split_provider::run_batch(file_batch const& batch,
       // Local file → dev #732's per-GPU planning ioctx.
       file_io_ctx = planning_ioctx_it->second;
     } else if (_scan_manager != nullptr) {
-      // Local file, no gpu_ioctxs injected → scan_manager's uring backend
-      // (still keeps the read off cudf's kvikio file_source).
+      // Local file, no gpu_ioctxs injected → scan_manager's uring backend.
+      // Used when use_sirius_datasource=true was requested but no per-GPU map
+      // was forwarded; routes the read through sirius_datasource instead of
+      // cudf's bundled kvikio file_source. In single-GPU mode with
+      // use_sirius_datasource=false, the scan_manager reports no backend for
+      // local paths and dispatch falls through to the cudf datasource below.
       file_io_ctx = _scan_manager->io_ctx_shared_for(lookup_path);
     }
     std::shared_ptr<sirius::io::sirius_io_object> file_io_object;

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -246,11 +246,13 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   auto info = op->take_scan_info();
   if (!info) { return nullptr; }
 
-  // When use_sirius_datasource=false, suppress the per-GPU uring map. The
-  // provider then routes local files through cudf::io::datasource::create
-  // (kvikio fallback), and the operator reads slices without any sirius_ioctx.
-  // S3 paths are unaffected — they dispatch through the scan_manager's
-  // _io_ctxs vector independently.
+  // When use_sirius_datasource=false (single-GPU only — multi-GPU runs are
+  // forced to true by sirius_config::enforce_sirius_datasource_for_multi_gpu()),
+  // suppress the per-GPU uring map. The provider then routes local files
+  // through cudf::io::datasource::create (kvikio fallback, safe with one GPU),
+  // and the operator reads slices without any sirius_ioctx. S3 paths are
+  // unaffected — they dispatch through the scan_manager's _io_ctxs vector
+  // independently.
   std::unordered_map<int, std::shared_ptr<sirius::io::sirius_ioctx>> const empty_gpu_ioctxs;
   auto const& effective_gpu_ioctxs = _config.use_sirius_datasource ? gpu_ioctxs : empty_gpu_ioctxs;
 

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -246,10 +246,18 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   auto info = op->take_scan_info();
   if (!info) { return nullptr; }
 
+  // When use_sirius_datasource=false, suppress the per-GPU uring map. The
+  // provider then routes local files through cudf::io::datasource::create
+  // (kvikio fallback), and the operator reads slices without any sirius_ioctx.
+  // S3 paths are unaffected — they dispatch through the scan_manager's
+  // _io_ctxs vector independently.
+  std::unordered_map<int, std::shared_ptr<sirius::io::sirius_ioctx>> const empty_gpu_ioctxs;
+  auto const& effective_gpu_ioctxs = _config.use_sirius_datasource ? gpu_ioctxs : empty_gpu_ioctxs;
+
   // Inject the per-GPU ioctx map into the operator before any provider returns —
   // read_table_from_metadata needs it before its first invocation, and
   // prepare_for_query runs before any execute().
-  op->set_gpu_ioctxs(gpu_ioctxs);
+  op->set_gpu_ioctxs(effective_gpu_ioctxs);
 
   // Cache short-circuit lives on the manager (format-agnostic); on miss,
   // dispatch through the polymorphic make_provider.
@@ -259,7 +267,7 @@ std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(
   // Combined-runtime: pass *this so the format provider can route per-path
   // (s3:// -> s3_ioctx via io_ctx_shared_for, local -> per-GPU uring). Upstream
   // #749's make_provider(gpu_ioctxs) only wired local; S3 needs the scan_manager.
-  return info->make_provider(*this, gpu_ioctxs);
+  return info->make_provider(*this, effective_gpu_ioctxs);
 }
 
 std::unique_ptr<split_provider> sirius_scan_manager::create_provider_for(

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -443,10 +443,9 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
 
 void sirius_config::enforce_sirius_datasource_for_multi_gpu()
 {
-  size_t num_gpus = 0;
-  for (auto const& space : _memory_space_configs) {
-    if (std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space)) { ++num_gpus; }
-  }
+  size_t num_gpus = std::ranges::count_if(_memory_space_configs, [](auto const& space) {
+    return std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space);
+  });
   if (num_gpus > 1 && !_scan_manager_config.use_sirius_datasource) {
     SIRIUS_LOG_WARN(
       "sirius_config: use_sirius_datasource was false but {} GPUs are configured; "

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -17,6 +17,7 @@
 #include "sirius_config.hpp"
 
 #include "exec/config.hpp"
+#include "log/logging.hpp"
 #include "yaml_reader.hpp"
 
 #include <cucascade/memory/config.hpp>
@@ -432,9 +433,27 @@ void sirius_config::load_from_file(const std::filesystem::path& config_path)
       _memory_space_configs = builder.build(_hw_topology);
     }
 
+    enforce_sirius_datasource_for_multi_gpu();
+
   } catch (const std::exception& e) {
     throw std::runtime_error("Failed to load config from " + config_path.string() + ": " +
                              e.what());
+  }
+}
+
+void sirius_config::enforce_sirius_datasource_for_multi_gpu()
+{
+  size_t num_gpus = 0;
+  for (auto const& space : _memory_space_configs) {
+    if (std::holds_alternative<cucascade::memory::gpu_memory_space_config>(space)) { ++num_gpus; }
+  }
+  if (num_gpus > 1 && !_scan_manager_config.use_sirius_datasource) {
+    SIRIUS_LOG_WARN(
+      "sirius_config: use_sirius_datasource was false but {} GPUs are configured; "
+      "the sirius datasource is required for multi-GPU IO routing. Overriding "
+      "use_sirius_datasource to true.",
+      num_gpus);
+    _scan_manager_config.use_sirius_datasource = true;
   }
 }
 

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -671,11 +671,15 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
     prefetch_buffer_pool_ = std::make_unique<sirius::io::buffer_pool>(*host_fsmr, max_slabs);
     // Initialize the cache on the REAL read-path backends: the per-NUMA urings
     // (gpu_ioctxs_ alias these, so covering numa_ioctxs_ covers every per-GPU
-    // local read path) and the s3_ioctx.
-    for (auto& kv : numa_ioctxs_) {
-      if (kv.second) {
-        kv.second->initialize_cache(*prefetch_buffer_pool_,
-                                    scan_cfg.prefetch_inflight_budget_chunks);
+    // local read path) and the s3_ioctx. Skip the per-NUMA urings when the
+    // sirius local read path is disabled — local reads will go through
+    // cudf::io::datasource::create and never touch this cache.
+    if (scan_cfg.use_sirius_datasource) {
+      for (auto& kv : numa_ioctxs_) {
+        if (kv.second) {
+          kv.second->initialize_cache(*prefetch_buffer_pool_,
+                                      scan_cfg.prefetch_inflight_budget_chunks);
+        }
       }
     }
     if (s3_ioctx_) {
@@ -686,8 +690,11 @@ void SiriusContext::initialize(const sirius::sirius_config& config)
   // (lowest-GPU uring, matching datasource_registry's kFileScheme target) plus
   // the s3_ioctx when configured. The scan_manager dispatches over these but
   // does not own them — SiriusContext releases them in terminate().
+  // When use_sirius_datasource=false, omit the local uring so the scan_manager
+  // reports no backend for local paths and parquet_split_provider falls through
+  // to cudf::io::datasource::create. S3 still routes through its own backend.
   std::vector<std::shared_ptr<sirius::io::sirius_ioctx>> borrowed_io_ctxs;
-  if (!gpu_ioctxs_.empty()) {
+  if (scan_cfg.use_sirius_datasource && !gpu_ioctxs_.empty()) {
     auto const lowest =
       std::min_element(gpu_ioctxs_.begin(), gpu_ioctxs_.end(), [](auto const& a, auto const& b) {
         return a.first < b.first;

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -354,7 +354,8 @@ void sirius_engine::prefetch_iceberg_delete_data(op::sirius_physical_operator& p
   if (gpu_ioctxs.empty()) {
     throw std::runtime_error(
       "[sirius_engine] read_iceberg_delete_data: SiriusContext has no GPU sirius_ioctxs "
-      "(kvikio path is forbidden).");
+      "(read_iceberg_delete_data routes through sirius_datasource and does not implement "
+      "a kvikio fallback).");
   }
   // Pick the lowest-numbered GPU id (deterministic ordering — get_gpu_ioctxs
   // returns an unordered_map, so use std::min_element rather than .begin()).

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -73,7 +73,10 @@ extern "C" int cudaProfilerStop();
 
 // PinTableFunction routes parquet reads through the per-GPU sirius_ioctx
 // instead of cudf's bundled file_source factory (which uses kvikio internally
-// and binds to a single CUDA context).
+// and binds to a single CUDA context). This is mandatory in multi-GPU
+// configurations (enforced by sirius_config::enforce_sirius_datasource_for_multi_gpu()).
+// Single-GPU users may still opt out via use_sirius_datasource=false; the
+// pin pipeline always routes through sirius_ioctx when one is available.
 //
 // Ordering rule: include uring_reactor LAST among sirius headers — liburing.h
 // transitively pulled by uring_reactor.hpp defines a BLOCK_SIZE preprocessor
@@ -970,7 +973,9 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
     // instead of cudf's bundled file_source factory (kvikio). The string-form
     // source_info routes reads through libkvikio's FileHandle which binds a
     // single CUDA context per file, breaking multi-GPU residency (the columns
-    // end up on the wrong GPU under sanitizer races).
+    // end up on the wrong GPU under sanitizer races). Use of sirius_ioctx is
+    // mandatory whenever more than one GPU is configured — enforced upstream
+    // by sirius_config::enforce_sirius_datasource_for_multi_gpu().
     auto target_ioctx = sirius_ctx->get_ioctx_for(target_gpu_id);
     if (!target_ioctx) {
       throw InvalidInputException("pin_table: no sirius_ioctx for target GPU " +

--- a/test/cpp/io/test_datasource_factory.cpp
+++ b/test/cpp/io/test_datasource_factory.cpp
@@ -250,9 +250,14 @@ TEST_CASE("datasource_factory strict create rejects malformed input", "[datasour
 // Phase 22.1 D-07/D-09/D-10 made datasource_factory::create() strict — every scheme
 // (including kFileScheme) MUST be resolved via the registry. The pre-22.1 cudf-default
 // fallback for file:// paths was removed because it routed through libkvikio which
-// binds a single CUDA context per FileHandle and breaks multi-GPU residency. Production
-// code registers kFileScheme via SiriusContext::initialize (sirius_context.cpp:334);
-// these tests intentionally do NOT register one and assert that strict policy fires.
+// binds a single CUDA context per FileHandle and breaks multi-GPU residency.
+// Single-GPU users that opt out via use_sirius_datasource=false bypass this factory
+// entirely and call cudf::io::datasource::create directly instead of routing kvikio
+// through here; multi-GPU mode is always required to use sirius_datasource (see
+// sirius_config::enforce_sirius_datasource_for_multi_gpu()). Production code
+// registers kFileScheme via SiriusContext::initialize whenever use_sirius_datasource
+// is true; these tests intentionally do NOT register one and assert that strict
+// policy fires.
 TEST_CASE("datasource_factory create rejects file paths without registered file ioctx",
           "[datasource_factory]")
 {

--- a/test/cpp/operator/mgpu_test_utils.hpp
+++ b/test/cpp/operator/mgpu_test_utils.hpp
@@ -96,6 +96,8 @@ inline void write_mgpu_yaml(std::filesystem::path const& yaml_path,
        "      pool_size: 512\n"
        "      block_size: 1048576\n"
        "  executor:\n"
+       "    scan_manager:\n"
+       "      use_sirius_datasource: true\n"
        "    pipeline:\n"
        "      num_threads: "
     << params.pipeline_num_threads


### PR DESCRIPTION
I had observed that after the multi-gpu PR we were getting more scan tasks and i also noticed that setting the use_sirius_data_source flag did not really change performance.  So this PR fixes a couple things:
1. It makes the  use_sirius_data_source be useful again. In the post multi-gpu the flag was effectively being ignored
2. The multi-gpu PR made it so that we were always splitting scans based on files, so that they could be uniformly distributed between GPUs. This was resulting in more scan tasks and not always following the target scan task size. Now, that behavior will only apply if we actually have multiple GPUs. 
3. The config option scan_task_batch_size is now actually being used in parquet reads from the parquet provider (this, turns out was not working from even before the multi gpu PR)