### PR TITLE
Bugfix desc null fix + add tpcds fixture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,24 @@ endif()
 
 add_executable(sirius_unittest ${TEST_SOURCES})
 
+# TPC-DS integration test fixture, generated at build time (opt-in target). The
+# database is not committed; run `cmake --build . --target tpcds-fixture` once
+# before the TPC-DS integration tests. Requires the duckdb CLI (or python3 with
+# the duckdb module) on PATH; both are provided by the pixi environment.
+set(TPCDS_FIXTURE_DIR ${CMAKE_BINARY_DIR}/test-fixtures)
+set(TPCDS_FIXTURE ${TPCDS_FIXTURE_DIR}/tpcds.duckdb)
+set(TPCDS_FIXTURE_SCRIPT
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/integration/data/duckdb/generate_tpcds_duckdb.sh
+)
+add_custom_command(
+  OUTPUT ${TPCDS_FIXTURE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TPCDS_FIXTURE_DIR}
+  COMMAND bash ${TPCDS_FIXTURE_SCRIPT} ${TPCDS_FIXTURE}
+  DEPENDS ${TPCDS_FIXTURE_SCRIPT}
+  COMMENT "Generating TPC-DS test fixture (SF 0.01) at ${TPCDS_FIXTURE}"
+  VERBATIM)
+add_custom_target(tpcds-fixture DEPENDS ${TPCDS_FIXTURE})
+
 if(VCPKG_BUILD)
   set_target_properties(sirius_unittest PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
   target_include_directories(sirius_unittest BEFORE PRIVATE ${_VCPKG_INC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,7 @@ set(TEST_SOURCES
     test/cpp/helper/test_logical_type.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
+    test/cpp/integration/test_gpu_execution_order_nulls.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/integration/test_gpu_execution_tpch_mgpu_audit.cpp
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp

--- a/src/include/op/cudf_sort_order.hpp
+++ b/src/include/op/cudf_sort_order.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "duckdb/common/enums/order_type.hpp"
+
+#include <cudf/types.hpp>
+
+namespace sirius {
+namespace op {
+
+/// Map a DuckDB ORDER BY direction to a cuDF sort order.
+inline cudf::order to_cudf_order(duckdb::OrderType order_type)
+{
+  return order_type == duckdb::OrderType::DESCENDING ? cudf::order::DESCENDING
+                                                     : cudf::order::ASCENDING;
+}
+
+/// Map a DuckDB NULLS FIRST/LAST to a cuDF null_order, honoring SQL semantics for both directions.
+///
+/// Single source of truth for the cuDF DESC-null contract: cuDF applies null_order in the ascending
+/// frame and then *reverses* it for a DESCENDING column, so the naive NULLS_FIRST?BEFORE:AFTER
+/// mapping mis-places NULLs for descending keys (e.g. `ORDER BY x DESC NULLS LAST` would put NULLs
+/// first). We compensate by flipping BEFORE<->AFTER for a descending key, so NULLS FIRST/LAST is
+/// honored as an absolute position matching DuckDB CPU. Used by every sort/top-n/window path that
+/// feeds null_precedence to cuDF sorting.
+inline cudf::null_order to_cudf_null_order(duckdb::OrderType order_type,
+                                           duckdb::OrderByNullType null_type)
+{
+  cudf::null_order result = (null_type == duckdb::OrderByNullType::NULLS_FIRST)
+                              ? cudf::null_order::BEFORE
+                              : cudf::null_order::AFTER;
+  if (order_type == duckdb::OrderType::DESCENDING) {
+    result =
+      (result == cudf::null_order::BEFORE) ? cudf::null_order::AFTER : cudf::null_order::BEFORE;
+  }
+  return result;
+}
+
+}  // namespace op
+}  // namespace sirius

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -19,6 +19,7 @@
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
+#include "op/cudf_sort_order.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 #include "sirius/exception.hpp"
 
@@ -134,11 +135,8 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
     }
     auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
     order_key_idx.push_back(idx);
-    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                    : cudf::order::DESCENDING);
-    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                                ? cudf::null_order::BEFORE
-                                : cudf::null_order::AFTER);
+    column_order.push_back(to_cudf_order(ord.type));
+    null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));
   }
 
   auto merged_batch = gpu_merge_impl::merge_order_by(

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -18,6 +18,7 @@
 
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "op/cudf_sort_order.hpp"
 #include "op/order/gpu_order_impl.hpp"
 #include "sirius/exception.hpp"
 
@@ -60,11 +61,8 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
     }
     auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
     order_key_idx.push_back(idx);
-    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                    : cudf::order::DESCENDING);
-    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                                ? cudf::null_order::BEFORE
-                                : cudf::null_order::AFTER);
+    column_order.push_back(to_cudf_order(ord.type));
+    null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));
   }
 
   std::vector<int> proj_idx(projections.begin(), projections.end());

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -20,6 +20,7 @@
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
+#include "op/cudf_sort_order.hpp"
 #include "op/sirius_physical_sort_sample.hpp"
 #include "sirius/exception.hpp"
 
@@ -84,11 +85,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
     }
     auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
     order_key_idx.push_back(idx);
-    column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                    : cudf::order::DESCENDING);
-    null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                                ? cudf::null_order::BEFORE
-                                : cudf::null_order::AFTER);
+    column_order.push_back(to_cudf_order(ord.type));
+    null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -20,6 +20,7 @@
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
+#include "op/cudf_sort_order.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
 
@@ -148,11 +149,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
       }
       auto idx = static_cast<int>(ord.expression->Cast<duckdb::BoundReferenceExpression>().index);
       order_key_idx.push_back(idx);
-      column_order.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                      : cudf::order::DESCENDING);
-      null_precedence.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                                  ? cudf::null_order::BEFORE
-                                  : cudf::null_order::AFTER);
+      column_order.push_back(to_cudf_order(ord.type));
+      null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));
     }
 
     // 4. Sort the concatenated sample by sort keys

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -19,6 +19,7 @@
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
+#include "op/cudf_sort_order.hpp"
 #include "op/sirius_physical_order.hpp"
 #include "op/sirius_physical_top_n_merge.hpp"
 #include "sirius/exception.hpp"
@@ -69,21 +70,33 @@ std::unique_ptr<cudf::table> compute_top_n_table(
       throw internal_exception("TopN order index out of range");
     }
 
-    auto order =
-      ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING : cudf::order::DESCENDING;
-    auto null_ord = ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                      ? cudf::null_order::BEFORE
-                      : cudf::null_order::AFTER;
-    auto indices  = cudf::top_k_order(input.column(idx), keep_rows, order, stream, memory_resource);
-    auto gathered = cudf::gather(
-      input, indices->view(), cudf::out_of_bounds_policy::DONT_CHECK, stream, memory_resource);
-    // top_k_order does not guarantee sorted output — sort the gathered rows
-    kept = cudf::sort_by_key(gathered->view(),
-                             cudf::table_view({gathered->view().column(idx)}),
-                             {order},
-                             {null_ord},
-                             stream,
-                             memory_resource);
+    auto order    = to_cudf_order(ord.type);
+    auto null_ord = to_cudf_null_order(ord.type, ord.null_order);
+    if (input.column(idx).has_nulls()) {
+      // cudf::top_k_order takes no null_order, so it cannot honor SQL NULLS FIRST/LAST when
+      // selecting which rows are in the top k (it treats NULLs as the largest value). For a
+      // nullable key, fall back to a full sort that honors null placement, then slice the top k.
+      auto sorted = cudf::sort_by_key(
+        input, cudf::table_view({input.column(idx)}), {order}, {null_ord}, stream, memory_resource);
+      if (keep_rows == sorted->num_rows()) {
+        kept = std::move(sorted);
+      } else {
+        auto slices = cudf::slice(sorted->view(), {0, keep_rows}, stream);
+        kept        = std::make_unique<cudf::table>(slices.front(), stream, memory_resource);
+      }
+    } else {
+      auto indices =
+        cudf::top_k_order(input.column(idx), keep_rows, order, stream, memory_resource);
+      auto gathered = cudf::gather(
+        input, indices->view(), cudf::out_of_bounds_policy::DONT_CHECK, stream, memory_resource);
+      // top_k_order does not guarantee sorted output — sort the gathered rows
+      kept = cudf::sort_by_key(gathered->view(),
+                               cudf::table_view({gathered->view().column(idx)}),
+                               {order},
+                               {null_ord},
+                               stream,
+                               memory_resource);
+    }
   } else {
     // Multi-key: fall back to full sort_by_key
     std::vector<cudf::column_view> key_views;
@@ -103,11 +116,8 @@ std::unique_ptr<cudf::table> compute_top_n_table(
         throw internal_exception("TopN order index out of range");
       }
       key_views.push_back(input.column(idx));
-      key_orders.push_back(ord.type == duckdb::OrderType::ASCENDING ? cudf::order::ASCENDING
-                                                                    : cudf::order::DESCENDING);
-      null_orders.push_back(ord.null_order == duckdb::OrderByNullType::NULLS_FIRST
-                              ? cudf::null_order::BEFORE
-                              : cudf::null_order::AFTER);
+      key_orders.push_back(to_cudf_order(ord.type));
+      null_orders.push_back(to_cudf_null_order(ord.type, ord.null_order));
     }
 
     auto keys_table = cudf::table_view(key_views);

--- a/test/cpp/integration/data/duckdb/generate_tpcds_duckdb.sh
+++ b/test/cpp/integration/data/duckdb/generate_tpcds_duckdb.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+db_path="${1:-"${script_dir}/tpcds.duckdb"}"
+sf="${TPCDS_SF:-0.01}"
+
+rm -f "${db_path}" "${db_path}.wal"
+
+if command -v duckdb >/dev/null 2>&1; then
+  duckdb "${db_path}" <<SQL
+INSTALL tpcds;
+LOAD tpcds;
+CALL dsdgen(sf=${sf});
+CHECKPOINT;
+SQL
+  exit 0
+fi
+
+python3 - "${db_path}" "${sf}" <<'PY'
+import sys
+
+import duckdb
+
+db_path = sys.argv[1]
+sf = sys.argv[2]
+
+con = duckdb.connect(db_path)
+con.execute("INSTALL tpcds")
+con.execute("LOAD tpcds")
+con.execute(f"CALL dsdgen(sf={sf})")
+con.execute("CHECKPOINT")
+con.close()
+PY

--- a/test/cpp/integration/test_gpu_execution_order_nulls.cpp
+++ b/test/cpp/integration/test_gpu_execution_order_nulls.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+
+void require_ok(duckdb::Connection& con, const std::string& sql)
+{
+  auto result = con.Query(sql);
+  REQUIRE(result);
+  if (result->HasError()) { UNSCOPED_INFO(result->GetError()); }
+  REQUIRE_FALSE(result->HasError());
+}
+
+std::string strip_trailing_sql(const std::string& sql)
+{
+  auto clean = sql;
+  while (!clean.empty() && (clean.back() == ';' || clean.back() == ' ' || clean.back() == '\n' ||
+                            clean.back() == '\t')) {
+    clean.pop_back();
+  }
+  return clean;
+}
+
+std::string sql_string_literal(const std::string& value)
+{
+  std::string escaped = "'";
+  for (char c : value) {
+    if (c == '\'') { escaped += '\''; }
+    escaped += c;
+  }
+  escaped += "'";
+  return escaped;
+}
+
+std::string query_single_value(duckdb::Connection& con, const std::string& sql)
+{
+  auto result = con.Query(sql);
+  REQUIRE(result);
+  if (result->HasError()) { UNSCOPED_INFO(result->GetError()); }
+  REQUIRE_FALSE(result->HasError());
+  return result->GetValue(0, 0).ToString();
+}
+
+class runtime_setting_guard {
+ public:
+  runtime_setting_guard(duckdb::Connection& con, std::string setting, uint64_t value)
+    : con(con),
+      setting(std::move(setting)),
+      old_value(query_single_value(
+        con, "SELECT value FROM duckdb_settings() WHERE name = '" + this->setting + "'"))
+  {
+    require_ok(con, "SET " + this->setting + " = " + std::to_string(value));
+  }
+
+  ~runtime_setting_guard() { restore(); }
+
+ private:
+  void restore()
+  {
+    auto result = con.Query("SET " + setting + " = " + old_value);
+    if (!result || result->HasError()) {
+      WARN("Failed to restore " << setting << " to " << old_value
+                                << (result ? ": " + result->GetError() : ""));
+    }
+  }
+
+  duckdb::Connection& con;
+  std::string setting;
+  std::string old_value;
+};
+
+struct null_order_case {
+  std::string sort_direction;
+  std::string null_position;
+};
+
+const null_order_case kNullOrderCases[] = {
+  {"ASC", "FIRST"},
+  {"ASC", "LAST"},
+  {"DESC", "FIRST"},
+  {"DESC", "LAST"},
+};
+
+std::string case_name(const null_order_case& order_case)
+{
+  return order_case.sort_direction + " NULLS " + order_case.null_position;
+}
+
+class OrderNullsGPUExecutionFixture {
+ public:
+  OrderNullsGPUExecutionFixture()
+  {
+    REQUIRE(sirius::test::g_integration_env != nullptr);
+    REQUIRE(sirius::test::g_integration_env->is_active());
+    con = std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+
+    require_ok(*con, "SET enable_duckdb_fallback = false");
+    require_ok(*con,
+               "CREATE TEMP TABLE ord_n AS "
+               "SELECT CASE WHEN i % 7 = 0 THEN NULL ELSE CAST(i % 100 AS INTEGER) END AS k, "
+               "       CAST(i AS INTEGER) AS id "
+               "FROM range(30000) AS t(i)");
+  }
+
+  void compare_gpu_vs_cpu_ordered(const std::string& query)
+  {
+    const auto clean_query = strip_trailing_sql(query);
+    require_ok(*con, "DROP TABLE IF EXISTS order_nulls_gpu_result");
+    require_ok(*con, "DROP TABLE IF EXISTS order_nulls_cpu_result");
+    require_ok(*con,
+               "CREATE TEMP TABLE order_nulls_gpu_result AS "
+               "SELECT row_number() OVER () AS observed_position, * "
+               "FROM gpu_execution(" +
+                 sql_string_literal(clean_query) + ")");
+    require_ok(*con,
+               "CREATE TEMP TABLE order_nulls_cpu_result AS "
+               "SELECT row_number() OVER () AS observed_position, * "
+               "FROM (" +
+                 clean_query + ") cpu_result");
+    require_empty(
+      "SELECT * FROM order_nulls_gpu_result "
+      "EXCEPT ALL "
+      "SELECT * FROM order_nulls_cpu_result",
+      "GPU minus CPU");
+    require_empty(
+      "SELECT * FROM order_nulls_cpu_result "
+      "EXCEPT ALL "
+      "SELECT * FROM order_nulls_gpu_result",
+      "CPU minus GPU");
+  }
+
+ private:
+  void require_empty(const std::string& sql, const std::string& direction)
+  {
+    auto result = con->Query("SELECT count(*) FROM (" + sql + ") diff");
+    REQUIRE(result);
+    if (result->HasError()) { UNSCOPED_INFO(direction << ": " << result->GetError()); }
+    REQUIRE_FALSE(result->HasError());
+
+    const auto count = result->GetValue(0, 0).GetValue<int64_t>();
+    if (count != 0) { UNSCOPED_INFO(direction << " returned " << count << " unexpected rows"); }
+    REQUIRE(count == 0);
+  }
+
+ public:
+  std::unique_ptr<duckdb::Connection> con;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(OrderNullsGPUExecutionFixture,
+                 "gpu_execution ORDER BY places NULLs correctly for ASC and DESC",
+                 "[integration][gpu_execution][order_by][nulls]")
+{
+  runtime_setting_guard max_sort_partition_bytes(*con, "max_sort_partition_bytes", 65536);
+
+  for (const auto& order_case : kNullOrderCases) {
+    DYNAMIC_SECTION(case_name(order_case))
+    {
+      compare_gpu_vs_cpu_ordered(
+        "SELECT k, id "
+        "FROM ord_n "
+        "ORDER BY k " +
+        order_case.sort_direction + " NULLS " + order_case.null_position + ", id ASC");
+    }
+  }
+}
+
+TEST_CASE_METHOD(OrderNullsGPUExecutionFixture,
+                 "gpu_execution TOP-N single-key places NULLs correctly for ASC and DESC",
+                 "[integration][gpu_execution][top_n][nulls]")
+{
+  for (const auto& order_case : kNullOrderCases) {
+    DYNAMIC_SECTION(case_name(order_case))
+    {
+      compare_gpu_vs_cpu_ordered(
+        "SELECT k "
+        "FROM ord_n "
+        "ORDER BY k " +
+        order_case.sort_direction + " NULLS " + order_case.null_position +
+        " "
+        "LIMIT 50");
+    }
+  }
+}
+
+TEST_CASE_METHOD(OrderNullsGPUExecutionFixture,
+                 "gpu_execution TOP-N multi-key places NULLs correctly for ASC and DESC",
+                 "[integration][gpu_execution][top_n][nulls]")
+{
+  for (const auto& order_case : kNullOrderCases) {
+    DYNAMIC_SECTION(case_name(order_case))
+    {
+      compare_gpu_vs_cpu_ordered(
+        "SELECT k, id "
+        "FROM ord_n "
+        "ORDER BY k " +
+        order_case.sort_direction + " NULLS " + order_case.null_position +
+        ", id ASC "
+        "LIMIT 50");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Split out from #806 per @wmalpica review comment.


This PR contains two independent pieces:

1. Fix GPU `ORDER BY` / `TOP-N` correctness for `DESC ... NULLS FIRST/LAST`.
2. Add a reusable SF0.01 TPC-DS DuckDB fixture for integration / plan-translation tests.

## RCA: DESC NULL ordering bug

DuckDB SQL treats `NULLS FIRST` / `NULLS LAST` as the final, absolute placement of NULLs in the result:

- `DESC NULLS FIRST` => NULLs first, then values descending
- `DESC NULLS LAST` => values descending, then NULLs last

Sirius previously mapped SQL null ordering directly to cuDF:

```cpp
NULLS_FIRST -> cudf::null_order::BEFORE
NULLS_LAST  -> cudf::null_order::AFTER
```

That is correct for `ASC`, but wrong for `DESC`: cuDF applies `null_order` in its sort-direction frame, so DESC effectively reverses the NULL placement. As a result, GPU `ORDER BY k DESC NULLS LAST` could place NULLs first, disagreeing with DuckDB CPU.

The same naive mapping was duplicated across the distributed sort path:

- `ORDER_BY`
- `SORT_SAMPLE`
- `SORT_PARTITION`
- `MERGE_SORT`
- `TOP_N`

There was one additional TOP-N issue: `cudf::top_k_order` has no `null_order` parameter, so single-key TOP-N on a nullable key could select the wrong top-k rows before any final sorting step.

## Fix

- Added `src/include/op/cudf_sort_order.hpp` as the single source of truth:
  - `to_cudf_order(...)`
  - `to_cudf_null_order(...)`
- `to_cudf_null_order(...)` flips `BEFORE` / `AFTER` for descending keys so SQL `NULLS FIRST/LAST` matches DuckDB semantics.
- Routed all sort/top-n operators through the helper.
- For single-key TOP-N:
  - keep `cudf::top_k_order` fast path when the key has no NULLs
  - use `sort_by_key + slice` when the key is nullable, so NULL placement is honored

## TPC-DS fixture

Update (reworked per @mbrobbel's review): Dropped the committed 12 MB tpcds.duckdb binary. The fixture is now generated at build time via an opt-in CMake target tpcds-fixture (runs generate_tpcds_duckdb.sh into ${CMAKE_BINARY_DIR}/test-fixtures/, SF 0.01 via DuckDB's dsdgen). Run cmake --build . --target tpcds-fixture once before the TPC-DS integration tests. 


## Tests

Added `test_gpu_execution_order_nulls.cpp`:

- `ORDER BY`
- `TOP-N single-key`
- `TOP-N multi-key`
- `ASC/DESC × NULLS FIRST/LAST`

The test materializes GPU output once, adds `observed_position` to make ordering differences visible, and compares against DuckDB CPU with bidirectional `EXCEPT ALL`.

Validation:

```bash
pre-commit run --all-files
pixi run -e default make release
build/release/extension/sirius/test/cpp/sirius_unittest "[nulls]"
```