### PR TITLE
CI: Switch GPU testing to L4 GPUs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build
         env:
-          CUDAARCHS: "75" # For Turing, T4 capability
+          CUDAARCHS: "89" # 75 for T4 capability; 89 for L4 capability
         run: make -j$(nproc)
 
       - name: Package build artifacts
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build
         env:
-          CUDAARCHS: "75" # For Turing, T4 capability
+          CUDAARCHS: "89" # 75 for T4 capability; 89 for L4 capability
         run: make -j$(nproc)
 
       - name: Package build artifacts
@@ -114,7 +114,7 @@ jobs:
           retention-days: 1
 
   test-cuda-13:
-    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-2xt4]
+    runs-on: [self-hosted, ubuntu-24.04, cuda-13, gpu-2xl4]
     needs: build-cuda-13
     if: needs.build-cuda-13.result == 'success'
     timeout-minutes: 60
@@ -190,7 +190,7 @@ jobs:
           retention-days: 14
 
   test-cuda-12:
-    runs-on: [self-hosted, ubuntu-22.04, cuda-12, gpu-2xt4]
+    runs-on: [self-hosted, ubuntu-22.04, cuda-12, gpu-2xl4]
     needs: build-cuda-12
     if: needs.build-cuda-12.result == 'success'
     timeout-minutes: 60


### PR DESCRIPTION
This PR changes the default GPU used for CI testing from T4s to L4s. Making this change also changes our [compute capability](https://developer.nvidia.com/cuda/gpus) from `75` using T4s to `89` using L4s. L4s also have 50% VRAM than T4s.

## Research & Testing
### Hourly Pricing
| Number of GPUs | T4 Cost | L4 Cost | Cost Diff |
| --- | --- | --- | --- |
| 1 GPU | $1.204/hr | $1.3232/hr | +9.9% - $0.1192/hr |
| 4 GPUs (2x runners 2x each OR 1x runner all GPUs) | $3.912/hr | $4.6016 | +17.6% - $0.6896/hr |

### Estimated Cost Increase
Usage (last 7 days):** ~38 completed runs that ran long enough (>15 min) to include GPU tests. That's the baseline cadence.

**Per-run cost (our gpu-2xt4/2xl4 co-scheduling setup — both cuda-12 + cuda-13 share one node):**
| | T4 (g4dn.12xlarge) | L4 (g6.12xlarge) | Diff |
|---|---|---|---|
| Instance rate | $3.912/hr | $4.6016/hr | +17.6% |
| GPU test runtime | ~18m15s | ~17m27s | −48s |
| Cost per run | ~$1.19 | ~$1.34 | **+$0.15** |

**Projected additional cost:**
| Period | Additional |
|---|---|
| Per week (38 runs) | ~$5.70 |
| Per month | ~$25 |
| Per year | ~$295 |

### GPU Test Runtimes
| GPU Test | `gpu-2xt4` Current | `gpu-2xl4` This PR | Runtime Diff |
| --- | --- | --- | --- |
| `test-cuda12` | ~18m20s | 17m56s | ~24s faster |
| `test-cuda13` | ~18m10s | 16m58s | ~1m12s faster |