### PR TITLE
Move `task_id` to base `itask`

### DIFF
--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -410,8 +410,7 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
                    shared_data_repository* data_repo,
                    std::unique_ptr<duckdb_scan_task_local_state> l_state,
                    std::shared_ptr<duckdb_scan_task_global_state> g_state)
-    : sirius::pipeline::sirius_pipeline_itask(std::move(l_state), g_state),
-      _task_id(task_id),
+    : sirius::pipeline::sirius_pipeline_itask(task_id, std::move(l_state), g_state),
       _data_repo(data_repo)
   {
     g_state->_total_task_count.fetch_add(1);
@@ -509,7 +508,6 @@ class duckdb_scan_task : public sirius::pipeline::sirius_pipeline_itask {
  private:
   //===----------Fields----------===//
   shared_data_repository* _data_repo;  ///< Data repository to which to push batches
-  uint64_t _task_id;                   ///< The unique id of this scan task
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/parquet_scan_task.hpp
+++ b/src/include/op/scan/parquet_scan_task.hpp
@@ -703,9 +703,7 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
                     shared_data_repository* data_repo,
                     std::unique_ptr<parquet_scan_task_local_state> l_state,
                     std::shared_ptr<parquet_scan_task_global_state> g_state)
-    : pipeline::sirius_pipeline_itask(std::move(l_state), g_state),
-      _task_id(task_id),
-      _data_repo(data_repo)
+    : pipeline::sirius_pipeline_itask(task_id, std::move(l_state), g_state), _data_repo(data_repo)
   {
     if (auto pipeline = g_state->get_operator().get_pipeline()) { pipeline->mark_task_created(); }
   }
@@ -765,13 +763,6 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
   }
 
   /**
-   * @brief Get the unique ID of this task.
-   *
-   * @return The unique ID of this task.
-   */
-  [[nodiscard]] uint64_t get_task_id() const { return _task_id; }
-
-  /**
    * @brief Set whether this task should operate on materialized (decoded) columns.
    *
    * @param materialized_columns True to use materialized columns, false otherwise.
@@ -798,7 +789,6 @@ class parquet_scan_task : public pipeline::sirius_pipeline_itask {
                                   std::vector<std::future<std::size_t>>& read_futures);
 
   //===----------Fields----------===//
-  uint64_t _task_id;                   ///< The unique ID of this task
   shared_data_repository* _data_repo;  ///< The shared data repository to which to push batches
   std::shared_ptr<cudf::io::datasource> _datasource;  ///< The cudf datasource for the input file
   bool _wrap_in_cache{false};

--- a/src/include/parallel/task.hpp
+++ b/src/include/parallel/task.hpp
@@ -24,6 +24,7 @@
 
 #include <cucascade/memory/memory_reservation.hpp>
 
+#include <cstdint>
 #include <memory>
 
 namespace sirius {
@@ -78,9 +79,12 @@ class itask_global_state {
  */
 class itask {
  public:
-  itask(std::unique_ptr<itask_local_state> local_state,
+  itask(uint64_t task_id,
+        std::unique_ptr<itask_local_state> local_state,
         std::shared_ptr<itask_global_state> global_state)
-    : _local_state(std::move(local_state)), _global_state(std::move(global_state))
+    : _task_id(task_id),
+      _local_state(std::move(local_state)),
+      _global_state(std::move(global_state))
   {
   }
 
@@ -115,8 +119,10 @@ class itask {
 
   itask_local_state* local_state() noexcept { return _local_state.get(); }
   [[nodiscard]] itask_global_state* global_state() noexcept { return _global_state.get(); }
+  [[nodiscard]] uint64_t get_task_id() const noexcept { return _task_id; }
 
  protected:
+  uint64_t _task_id;
   std::unique_ptr<itask_local_state> _local_state;
   std::shared_ptr<itask_global_state> _global_state;
 };

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -170,13 +170,6 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
   }
 
   /**
-   * @brief Get the unique identifier for this task
-   *
-   * @return uint64_t The task ID
-   */
-  uint64_t get_task_id() const;
-
-  /**
    * @brief Get the GPU pipeline associated with this task
    *
    * @return const duckdb::sirius_pipeline* Pointer to the GPU pipeline
@@ -250,7 +243,6 @@ class gpu_pipeline_task : public sirius_pipeline_itask {
     uint64_t task_id, std::unique_ptr<sirius_pipeline_task_local_state> local_state);
 
  private:
-  uint64_t _task_id;
   std::vector<cucascade::shared_data_repository*> _data_repos;
   cucascade::memory::reservation_aware_resource_adaptor* _allocator = nullptr;
   /// Input data_batches held for subscribe/unsubscribe lifecycle

--- a/src/include/pipeline/sirius_pipeline_itask.hpp
+++ b/src/include/pipeline/sirius_pipeline_itask.hpp
@@ -26,6 +26,7 @@
 
 #include <cucascade/data/data_batch.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -105,12 +106,14 @@ class sirius_pipeline_itask : public parallel::itask {
   /**
    * @brief Protected constructor for derived classes.
    *
+   * @param task_id The unique identifier for this task
    * @param local_state The local state specific to this task
    * @param global_state The global state shared across multiple tasks
    */
-  sirius_pipeline_itask(std::unique_ptr<sirius_pipeline_task_local_state> local_state,
+  sirius_pipeline_itask(uint64_t task_id,
+                        std::unique_ptr<sirius_pipeline_task_local_state> local_state,
                         std::shared_ptr<sirius_pipeline_task_global_state> global_state)
-    : itask(std::move(local_state), std::move(global_state))
+    : itask(task_id, std::move(local_state), std::move(global_state))
   {
   }
 };

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -52,7 +52,8 @@ cpu_source_task::cpu_source_task(uint64_t task_id,
                                  cucascade::shared_data_repository* data_repo,
                                  std::unique_ptr<cpu_source_task_local_state> local_state,
                                  std::shared_ptr<cpu_source_task_global_state> global_state)
-  : sirius_pipeline_itask(std::move(local_state), std::move(global_state)), _data_repo(data_repo)
+  : sirius_pipeline_itask(task_id, std::move(local_state), std::move(global_state)),
+    _data_repo(data_repo)
 {
   if (auto* pipeline = _global_state->cast<cpu_source_task_global_state>().get_pipeline()) {
     pipeline->mark_task_created();

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -166,8 +166,7 @@ gpu_pipeline_task::gpu_pipeline_task(
   std::vector<cucascade::shared_data_repository*> data_repos,
   std::unique_ptr<sirius_pipeline_task_local_state> local_state,
   std::shared_ptr<sirius_pipeline_task_global_state> global_state)
-  : sirius_pipeline_itask(std::move(local_state), std::move(global_state)),
-    _task_id(task_id),
+  : sirius_pipeline_itask(task_id, std::move(local_state), std::move(global_state)),
     _data_repos(std::move(data_repos))
 {
   // Subscribe to all input data_batches
@@ -211,8 +210,6 @@ gpu_pipeline_task::~gpu_pipeline_task()
   _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline()->mark_task_completed();
 }
 
-uint64_t gpu_pipeline_task::get_task_id() const { return _task_id; }
-
 const sirius_pipeline* gpu_pipeline_task::get_pipeline() const
 {
   return _global_state->cast<gpu_pipeline_task_global_state>().get_pipeline();
@@ -229,7 +226,7 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
   if (start_index > 0) {
     SIRIUS_LOG_INFO("Pipeline {}: resuming task {} from operator index {} (of {})",
                     pipeline->get_pipeline_id(),
-                    _task_id,
+                    get_task_id(),
                     start_index,
                     operators.size());
   }
@@ -282,7 +279,7 @@ std::unique_ptr<op::operator_data> gpu_pipeline_task::compute_task(rmm::cuda_str
           (1024.0 * 1024.0),
         reservation_bytes,
         static_cast<double>(reservation_bytes) / (1024.0 * 1024.0),
-        _task_id);
+        get_task_id());
 
       auto input_basis = _local_state->cast<gpu_pipeline_task_local_state>()
                            .get_reservation_size_info()
@@ -342,7 +339,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
   auto sink_op = pipeline->get_sink();
   if (sink_op) { op_chain += std::format(" -> {}", sink_op->get_name()); }
   auto nvtx_label =
-    std::format("Pipeline {} Task {} [{}]", pipeline->get_pipeline_id(), _task_id, op_chain);
+    std::format("Pipeline {} Task {} [{}]", pipeline->get_pipeline_id(), get_task_id(), op_chain);
   nvtx3::scoped_range nvtx_range{nvtx_label.c_str()};
 
   auto const prepare_start = std::chrono::high_resolution_clock::now();

--- a/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
+++ b/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
@@ -66,7 +66,7 @@ test_env& env()
 class dummy_task_local_state : public sirius::parallel::itask_local_state {};
 class dummy_task : public sirius::parallel::itask {
  public:
-  dummy_task() : itask(std::make_unique<dummy_task_local_state>(), nullptr) {}
+  dummy_task() : itask(0, std::make_unique<dummy_task_local_state>(), nullptr) {}
   void execute(rmm::cuda_stream_view /*stream*/) override {}
 };
 

--- a/test/cpp/parallel/test_task_executor.cpp
+++ b/test/cpp/parallel/test_task_executor.cpp
@@ -40,9 +40,10 @@ struct dummy_task_local_state : public itask_local_state {
 
 class dummy_task : public itask {
  public:
-  dummy_task(std::unique_ptr<dummy_task_local_state> local_state,
+  dummy_task(uint64_t task_id,
+             std::unique_ptr<dummy_task_local_state> local_state,
              std::shared_ptr<dummy_task_global_state> global_state)
-    : itask(std::move(local_state), std::move(global_state))
+    : itask(task_id, std::move(local_state), std::move(global_state))
   {
   }
 
@@ -103,7 +104,8 @@ TEST_CASE("Executor executes scheduled tasks", "[task_executor]")
   // Schedule some tasks
   int num_tasks = 20;
   for (int i = 0; i < num_tasks; ++i) {
-    executor.schedule(std::make_unique<dummy_task>(std::make_unique<dummy_task_local_state>(i), g));
+    executor.schedule(
+      std::make_unique<dummy_task>(i, std::make_unique<dummy_task_local_state>(i), g));
   }
 
   // Wait for tasks to complete by polling the counter

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -65,9 +65,10 @@ class mock_gpu_pipeline_task_local_state : public gpu_pipeline_task_local_state 
 
 class mock_gpu_pipeline_task : public gpu_pipeline_task {
  public:
-  mock_gpu_pipeline_task(std::unique_ptr<mock_gpu_pipeline_task_local_state> local_state,
+  mock_gpu_pipeline_task(uint64_t task_id,
+                         std::unique_ptr<mock_gpu_pipeline_task_local_state> local_state,
                          std::shared_ptr<mock_gpu_pipeline_task_global_state> global_state)
-    : gpu_pipeline_task(0,
+    : gpu_pipeline_task(task_id,
                         std::vector<cucascade::shared_data_repository*>{},
                         std::move(local_state),
                         std::move(global_state))
@@ -119,7 +120,7 @@ TEST_CASE("Task scheduler executes tasks through pipeline_queue", "[task_schedul
   const int num_tasks = 10;
   for (int i = 0; i < num_tasks; ++i) {
     auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
-    auto task = std::make_unique<mock_gpu_pipeline_task>(std::move(local_state), global_state);
+    auto task = std::make_unique<mock_gpu_pipeline_task>(i, std::move(local_state), global_state);
     executor.schedule(std::move(task));
   }
 


### PR DESCRIPTION
Moves the `task_id` identifier to the base `itask` class to consolidate implementations. 