### PR TITLE
Enable vcpkg binary cache for distribution workflow

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -11,6 +11,7 @@
 #   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
 #   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
 #      project-level allowlist above before merging
+
 name: Distribution
 
 on:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -35,6 +35,7 @@ jobs:
       extra_toolchains: 'cuda;rust;protobuf'
       vcpkg_url: 'https://github.com/microsoft/vcpkg.git'
       vcpkg_commit: 'ffc071e0c08432c60c9b64f00334c0227667931b'
+      vcpkg_binary_cache_enabled: true
       skip_tests: true
       reduced_ci_mode: 'disabled'
       override_ci_tools_repository: 'sirius-db/extension-ci-tools'
@@ -57,6 +58,7 @@ jobs:
       extra_toolchains: 'cuda;rust;protobuf'
       vcpkg_url: 'https://github.com/microsoft/vcpkg.git'
       vcpkg_commit: 'ffc071e0c08432c60c9b64f00334c0227667931b'
+      vcpkg_binary_cache_enabled: true
       skip_tests: true
       reduced_ci_mode: 'disabled'
       override_ci_tools_repository: 'sirius-db/extension-ci-tools'

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -11,7 +11,6 @@
 #   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
 #   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
 #      project-level allowlist above before merging
-
 name: Distribution
 
 on:


### PR DESCRIPTION
Enables the cache support added in https://github.com/sirius-db/extension-ci-tools/commit/a25563106f19aa45cf02c88eade8e9fb0ac29996.