### PR TITLE
Trigger distribution workflow for merge group

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - dev
+  merge_group:
   pull_request:
     paths:
       - .github/workflows/distribution.yml


### PR DESCRIPTION
With #817 distribution jobs should now be fast enough to build them in the merge group to avoid breaking these jobs on `dev`.