### PR TITLE
feat: get_query_start_time helper (Phase 1 of #819)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ set(TEST_SOURCES
     test/cpp/expression_executor/test_gpu_expression_executor.cpp
     test/cpp/expression_executor/test_gpu_expression_translator.cpp
     test/cpp/helper/test_logical_type.cpp
+    test/cpp/helper/test_transaction_utils.cpp
     test/cpp/integration/test_gpu_execution_locality.cpp
     test/cpp/integration/test_gpu_execution_multi_format.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp

--- a/src/include/helper/transaction_utils.hpp
+++ b/src/include/helper/transaction_utils.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/common/typedefs.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/main/database_manager.hpp>
+#include <duckdb/transaction/duck_transaction.hpp>
+
+namespace sirius::helper {
+
+/// Returns the MVCC-domain start_time of the active query's DuckTransaction on
+/// the default-database catalog. Use this when you need the value that
+/// RowVersionManager::GetSelVector(ScanOptions{start_time}, ...) compares
+/// against per-row insert_id / delete_id for visibility.
+///
+/// Not the MetaTransaction value: MetaTransaction::start_timestamp is a
+/// wall-clock timestamp_t and MetaTransaction::global_transaction_id is the
+/// transaction's global identifier; neither lives in the MVCC start_time
+/// domain. Only DuckTransaction::start_time (per AttachedDatabase) does.
+///
+/// Multi-AttachedDatabase note: each DuckTransaction inside a MetaTransaction
+/// has its own start_time counter. This helper returns the default DB's value.
+/// Callers targeting a specific AttachedDatabase should call
+/// DuckTransaction::Get(context, that_catalog).start_time directly.
+inline duckdb::transaction_t get_query_start_time(duckdb::ClientContext& context)
+{
+  const auto& default_db_name = duckdb::DatabaseManager::Get(context).GetDefaultDatabase(context);
+  auto& default_catalog       = duckdb::Catalog::GetCatalog(context, default_db_name);
+  return duckdb::DuckTransaction::Get(context, default_catalog).start_time;
+}
+
+}  // namespace sirius::helper

--- a/test/cpp/helper/test_transaction_utils.cpp
+++ b/test/cpp/helper/test_transaction_utils.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "helper/transaction_utils.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/main/database_manager.hpp>
+#include <duckdb/transaction/duck_transaction.hpp>
+
+namespace {
+
+duckdb::Catalog& default_catalog_for(duckdb::ClientContext& context)
+{
+  const auto& name = duckdb::DatabaseManager::Get(context).GetDefaultDatabase(context);
+  return duckdb::Catalog::GetCatalog(context, name);
+}
+
+}  // namespace
+
+TEST_CASE("get_query_start_time matches DuckTransaction::start_time on the default catalog",
+          "[helper][transaction]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection conn(db);
+  auto& context = *conn.context;
+
+  conn.Query("BEGIN TRANSACTION");
+
+  auto& catalog = default_catalog_for(context);
+  auto expected = duckdb::DuckTransaction::Get(context, catalog).start_time;
+  auto helper_v = sirius::helper::get_query_start_time(context);
+
+  REQUIRE(helper_v == expected);
+
+  conn.Query("COMMIT");
+}
+
+TEST_CASE("get_query_start_time is monotonic across committed transactions",
+          "[helper][transaction]")
+{
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection conn(db);
+  auto& context = *conn.context;
+
+  conn.Query("BEGIN TRANSACTION");
+  // Touch the catalog so DuckDB bumps its transaction-id counter on commit,
+  // otherwise read-only transactions may share a start_time with the next one.
+  conn.Query("CREATE TABLE t (x INTEGER)");
+  auto first = sirius::helper::get_query_start_time(context);
+  conn.Query("COMMIT");
+
+  conn.Query("BEGIN TRANSACTION");
+  conn.Query("INSERT INTO t VALUES (1)");
+  auto second = sirius::helper::get_query_start_time(context);
+  conn.Query("COMMIT");
+
+  REQUIRE(second >= first);
+}


### PR DESCRIPTION
## Summary

- Adds `sirius::helper::get_query_start_time(ClientContext&)` returning the active `DuckTransaction::start_time` on the default-database catalog — the MVCC-domain value Phase 2's `duckdb_mvcc_delta_provider` will pass into `RowVersionManager::GetSelVector(ScanOptions{start_time}, …)`.
- Header docstring spells out the API choice (why not `MetaTransaction::start_timestamp` / `global_transaction_id`) and the multi-AttachedDatabase nuance.
- Foundation for sirius#819 (concurrent INSERT/DELETE via DuckDB with Sirius pin-table cache).

> Note on scope: the originally-planned Phase 1 diff ("plumb through `sirius_physical_table_scan`") turned out to be unnecessary — `duckdb_native_scan_info::context` (`src/include/op/scan/duckdb_native_scan_info.hpp:48`) already exposes `ClientContext` at the split-provider level where Phase 2's delta provider lives. The #819 issue body should be refactored toward a scan_manager-centric architecture; tracked as a follow-up.

## Test plan

- [x] CI: `sirius_unittest "[helper][transaction]"` — two new cases (equality with `DuckTransaction::Get(...).start_time`, monotonicity across committed transactions) pass.
- [x] CI: full `sirius_unittest` — no regressions.
- [x] Build verified locally (no GPU on this machine, so binary tests deferred to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)