### PR TITLE
Use s3 for sccache in check workflow for all jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,6 @@ jobs:
 
   build:
     env:
-      SCCACHE_GHA_ENABLED: true
       CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
     strategy:
@@ -85,7 +84,10 @@ jobs:
     runs-on: >-
       ${{ matrix.environment == 'vcpkg'
         && fromJSON('["self-hosted", "ubuntu-24.04", "cpu-xl"]')
-        || format('ubuntu-24.04{0}', case(matrix.arch == 'arm64', '-arm', '')) }}
+        || matrix.arch == 'x64'
+        && fromJSON('["self-hosted", "ubuntu-24.04", "cpu-lg"]')
+        || matrix.arch == 'arm64'
+        && fromJSON('["self-hosted", "ubuntu-24.04", "arm-lg"]') }}
     timeout-minutes: ${{ case(matrix.environment == 'vcpkg', 240, 60) }}
     continue-on-error: ${{ matrix.cudf-channel == 'nightly' }}
     steps:


### PR DESCRIPTION
This should help us to better utilize the 10GB GitHub actions cache for other cache entries.