### PR TITLE
Feature/optimizing multi gpu

### DIFF
--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -173,8 +173,15 @@ void task_creator::drain_pending_tasks()
   // Drain any queued task creation requests that haven't been picked up yet
   _task_creation_queue.interrupt();
   _task_creation_queue.drain();
-  // Wait for any in-flight task creation lambdas to finish
-  _bounded_pool->wait_all();
+  // Wait for any in-flight task creation lambdas to finish. When called from
+  // task_scheduler::drain_after_error(), stop_thread_pool() has already joined
+  // the worker pool and reset _bounded_pool to null — in that case the pool's
+  // own destructor already drained in-flight work, so this wait_all is
+  // redundant. Dereferencing the null pointer here throws std::system_error
+  // (EPERM) from the pthread_mutex call on garbage memory, surfacing to the
+  // caller as "Operation not permitted" and breaking otherwise-successful
+  // multi-file SF1000 scans.
+  if (_bounded_pool) { _bounded_pool->wait_all(); }
   _task_creation_queue.reactivate();
 }
 

--- a/src/include/exec/channel.hpp
+++ b/src/include/exec/channel.hpp
@@ -112,11 +112,6 @@ class channel {
   void close() { _queue->interrupt(); }
 
   /**
-   * @brief Reopen the channel after a close, restoring normal send/get behavior.
-   */
-  void reopen() { _queue->reactivate(); }
-
-  /**
    * @brief Check if the channel is still open.
    *
    * @return true if the channel is open, false otherwise

--- a/src/include/exec/channel.hpp
+++ b/src/include/exec/channel.hpp
@@ -112,6 +112,11 @@ class channel {
   void close() { _queue->interrupt(); }
 
   /**
+   * @brief Reopen the channel after a close, restoring normal send/get behavior.
+   */
+  void reopen() { _queue->reactivate(); }
+
+  /**
    * @brief Check if the channel is still open.
    *
    * @return true if the channel is open, false otherwise

--- a/src/include/op/scan/parquet_scan_operator_data.hpp
+++ b/src/include/op/scan/parquet_scan_operator_data.hpp
@@ -131,12 +131,14 @@ class parquet_scan_data : public op::operator_data {
                     std::shared_ptr<cudf::io::parquet_reader_options> reader_options,
                     std::shared_ptr<duckdb::Expression> filter_expression,
                     std::shared_ptr<scan_plan const> plan,
-                    std::vector<std::string> partition_values)
+                    std::vector<std::string> partition_values,
+                    bool disable_filter_pushdown = false)
     : rg_slices(std::move(rg_slices)),
       reader_options(std::move(reader_options)),
       filter_expression(std::move(filter_expression)),
       plan(std::move(plan)),
-      partition_values(std::move(partition_values))
+      partition_values(std::move(partition_values)),
+      disable_filter_pushdown(disable_filter_pushdown)
   {
   }
 
@@ -191,6 +193,13 @@ class parquet_scan_data : public op::operator_data {
   /// order. Empty when the table has no hive partitions. assemble_scan_output consumes this
   /// directly instead of re-parsing a file path at execute time.
   std::vector<std::string> partition_values;
+  /// When true, the scan operator MUST NOT call set_filter on its reader options.
+  /// Set by parquet_split_provider when any decimal column is stored as
+  /// FIXED_LEN_BYTE_ARRAY / BYTE_ARRAY — cudf's row-group stats filter cannot
+  /// compare a fixed_point_scalar AST literal against those physical types and
+  /// throws "Invalid type and stats combination" (stats_filter_helpers.hpp:132).
+  /// The filter still applies post-decode via gpu_expression_executor::select.
+  bool disable_filter_pushdown = false;
   /// GPU memory space for allocating output tables produced by execute().
   cucascade::memory::memory_space* gpu_memory_space = nullptr;
 };

--- a/src/include/pipeline/task_request.hpp
+++ b/src/include/pipeline/task_request.hpp
@@ -26,9 +26,20 @@
 namespace sirius {
 namespace pipeline {
 
+enum class task_request_kind {
+  // A GPU pipeline executor has reserved a worker thread and is ready to accept a task.
+  // device_id is the device that is ready.
+  device_ready,
+  // A new task was pushed into task_scheduler::_task_queue. Wakes the management
+  // event loop so it re-runs the matcher against currently-ready devices.
+  // device_id is unused.
+  task_available,
+};
+
 struct task_request {
   int device_id;
   bool is_scan{false};
+  task_request_kind kind{task_request_kind::device_ready};
 };
 
 class task_request_queue {

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -35,7 +35,9 @@
 #include <atomic>
 #include <future>
 #include <map>
+#include <optional>
 #include <queue>
+#include <set>
 
 namespace sirius::op::scan {
 class duckdb_scan_executor;
@@ -217,13 +219,26 @@ class task_scheduler {
 
   exec::inspectable_mpsc<sirius::parallel::itask> _task_queue;  ///< Queue for GPU pipeline tasks
   exec::channel<std::unique_ptr<task_request>> _task_request_channel;
+  /// Publisher used by schedule() to wake the management event loop when a new
+  /// task is pushed into _task_queue. The event loop blocks on _task_request_channel
+  /// for two event kinds: device_ready (sent by gpu_pipeline_executors when a worker
+  /// thread is reserved) and task_available (sent by schedule()).
+  std::optional<exec::publisher<std::unique_ptr<task_request>>> _self_publisher;
   std::thread _management_thread;
   std::atomic<bool> _running{false};
+
+  /// Set of GPU device_ids that have a reserved worker thread waiting for a task.
+  /// Only mutated by the management thread (matches device_ready signals from
+  /// _task_request_channel and erases on dispatch), so no synchronization needed.
+  std::set<int> _ready_devices;
 
   /// device_id -> GPU executor. std::map (not unordered_map) so iteration
   /// order is deterministic (ascending by device_id) — keeps preference-less
   /// task dispatch reproducible across runs.
   std::map<int, std::unique_ptr<gpu_pipeline_executor>> _gpu_executors;
+  /// Deprecated as of pull-signal restoration: no-preference distribution now
+  /// arises from which executor sends a device_ready signal first, not from a
+  /// counter. Field retained for source compat with set_no_pref_rr_counter_for_testing.
   std::atomic<size_t> _no_pref_rr_counter{0};
 
   sirius::creator::task_creator* _task_creator{nullptr};

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -517,8 +517,7 @@ void duckdb_scan_executor::manager_loop()
                            e.what());
           if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         } catch (...) {
-          SIRIUS_LOG_ERROR(
-            "DuckDB Scan Executor: Unknown exception during scan task execution");
+          SIRIUS_LOG_ERROR("DuckDB Scan Executor: Unknown exception during scan task execution");
           if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         }
       });

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -512,7 +512,13 @@ void duckdb_scan_executor::manager_loop()
               _task_creator->schedule(consumer);
             }
           }
+        } catch (std::exception const& e) {
+          SIRIUS_LOG_ERROR("DuckDB Scan Executor: Exception during scan task execution: {}",
+                           e.what());
+          if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         } catch (...) {
+          SIRIUS_LOG_ERROR(
+            "DuckDB Scan Executor: Unknown exception during scan task execution");
           if (_completion_handler) { _completion_handler->report_error(std::current_exception()); }
         }
       });

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -200,8 +200,13 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
 
   // Try to translate the filter to a *stream-local* cudf AST for filter pushdown. If not
   // successful, fall back to post-read DuckDB-expression evaluation.
+  //
+  // Honor scan_data.disable_filter_pushdown: when set by parquet_split_provider (because
+  // the parquet file has FIXED_LEN_BYTE_ARRAY decimal columns that cudf's stats filter
+  // can't handle), skip the AST set_filter here too. The filter still applies post-decode
+  // via gpu_expression_executor::select below.
   std::optional<gpu_expression_translator::translated_expression> ast_expression = std::nullopt;
-  if (filter_expression) {
+  if (filter_expression && !scan_data.disable_filter_pushdown) {
     auto name_resolver = [plan = scan_data.plan](duckdb::idx_t ref_index) -> std::string {
       return plan->batch_column_name(ref_index);
     };
@@ -217,6 +222,10 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
         "[sirius_gpu_parquet_scan_operator] AST translation failed for parquet reader filter "
         "pushdown.");
     }
+  } else if (filter_expression && scan_data.disable_filter_pushdown) {
+    SIRIUS_LOG_DEBUG(
+      "[sirius_gpu_parquet_scan_operator] Filter pushdown disabled (FLBA-decimal file); "
+      "filter will be evaluated post-decode.");
   }
 
   rmm::device_async_resource_ref mr_ref(scan_data.gpu_memory_space->get_default_allocator());

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -62,6 +62,18 @@ void itask_executor::drain_leftover_tasks() { _task_queue.drain(); }
 
 void itask_executor::drain_and_wait()
 {
+  // Guard: if the executor has never been started (or has been stopped),
+  // _bounded_pool is nullptr. drain_after_error may legitimately be called
+  // before any work has been dispatched, in which case there is nothing to
+  // drain. Without this guard the next line dereferences nullptr and crashes
+  // inside pthread_mutex_lock on the (offset-zero) std::mutex member —
+  // observed during task_scheduler::drain_after_error after an early
+  // sirius_engine::execute failure.
+  if (!_bounded_pool) {
+    SIRIUS_LOG_INFO("itask_executor::drain_and_wait: skipped — pool not initialized");
+    return;
+  }
+
   // Interrupt the pool so the manager's reserve() unblocks with an invalid slot.
   _bounded_pool->interrupt();
 

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -86,12 +86,11 @@ void gpu_pipeline_executor::manager_loop()
     // a task out of its downgrade-visible queue into our _task_queue when a
     // ready signal has been received from us — preventing tasks from piling
     // up here where the downgrade executor can't see them.
-    auto ready = std::make_unique<task_request>();
+    auto ready       = std::make_unique<task_request>();
     ready->kind      = task_request_kind::device_ready;
     ready->device_id = _memory_space->get_device_id();
     if (!_task_request_publisher.send(std::move(ready))) {
-      SIRIUS_LOG_INFO(
-        "GPU Pipeline Executor: task_request channel closed, stopping manager loop");
+      SIRIUS_LOG_INFO("GPU Pipeline Executor: task_request channel closed, stopping manager loop");
       break;
     }
     auto pipeline_task = _task_queue.pop();  // block till a task is available

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -81,8 +81,19 @@ void gpu_pipeline_executor::manager_loop()
       SIRIUS_LOG_INFO("GPU Pipeline Executor: pool interrupted, stopping manager loop");
       break;
     }
-    // Task request sending removed: management_eventloop now pushes tasks directly
-    // to this executor based on data locality preference (push model).
+    // Pull-signal backpressure: now that we hold a reserved thread slot, tell the
+    // task_scheduler this device is ready for work. The scheduler will only move
+    // a task out of its downgrade-visible queue into our _task_queue when a
+    // ready signal has been received from us — preventing tasks from piling
+    // up here where the downgrade executor can't see them.
+    auto ready = std::make_unique<task_request>();
+    ready->kind      = task_request_kind::device_ready;
+    ready->device_id = _memory_space->get_device_id();
+    if (!_task_request_publisher.send(std::move(ready))) {
+      SIRIUS_LOG_INFO(
+        "GPU Pipeline Executor: task_request channel closed, stopping manager loop");
+      break;
+    }
     auto pipeline_task = _task_queue.pop();  // block till a task is available
     if (!pipeline_task) {
       SIRIUS_LOG_INFO("GPU Pipeline Executor: task queue interrupted, stopping manager loop");

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -99,8 +99,8 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
   } else {
     [[maybe_unused]] auto _ = _task_queue.push(std::move(task));
     if (_self_publisher) {
-      auto wake  = std::make_unique<task_request>();
-      wake->kind = task_request_kind::task_available;
+      auto wake                 = std::make_unique<task_request>();
+      wake->kind                = task_request_kind::task_available;
       [[maybe_unused]] auto _ok = _self_publisher->send(std::move(wake));
     }
   }

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -46,6 +46,11 @@ task_scheduler::task_scheduler(
   _scan_executor = std::make_unique<sirius::op::scan::duckdb_scan_executor>(
     scan_executor_config, &mem_mgr, _task_request_channel.make_publisher());
 
+  // Self-publisher: schedule() uses this to wake management_eventloop when a
+  // new task is pushed, so the loop can re-run the matcher against any device
+  // that is already in _ready_devices.
+  _self_publisher.emplace(_task_request_channel.make_publisher());
+
   auto gpu_spaces = mem_mgr.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
   // Initialize GPU pipeline executors for each available GPU
   for (auto* space : gpu_spaces) {
@@ -93,6 +98,11 @@ void task_scheduler::schedule(std::unique_ptr<sirius::parallel::itask> task)
     _scan_executor->schedule(std::move(task));
   } else {
     [[maybe_unused]] auto _ = _task_queue.push(std::move(task));
+    if (_self_publisher) {
+      auto wake  = std::make_unique<task_request>();
+      wake->kind = task_request_kind::task_available;
+      [[maybe_unused]] auto _ok = _self_publisher->send(std::move(wake));
+    }
   }
 }
 
@@ -100,6 +110,10 @@ void task_scheduler::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
+  // Reopen the channel and task queue in case a previous stop() closed them.
+  _task_request_channel.reopen();
+  _task_queue.reactivate();
+  _ready_devices.clear();
   _scan_executor->start();
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->start();
@@ -111,13 +125,19 @@ void task_scheduler::stop()
 {
   bool expected = true;
   if (!_running.compare_exchange_strong(expected, false)) { return; }
+  // Pull-signal model: the management event loop blocks on
+  // _task_request_channel.get(), so closing the channel is what wakes it.
+  // _task_queue.interrupt() is still useful to reject any concurrent
+  // schedule() calls but no longer needed to wake the loop.
   _task_queue.interrupt();
   _task_request_channel.close();
+  // Join the management thread first so it can finish processing any drained
+  // events without dispatching to executors that are about to be stopped.
+  if (_management_thread.joinable()) { _management_thread.join(); }
   _scan_executor->stop();
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->stop();
   }
-  if (_management_thread.joinable()) { _management_thread.join(); }
 }
 
 void task_scheduler::set_task_creator(sirius::creator::task_creator& task_creator)
@@ -205,7 +225,14 @@ void task_scheduler::drain_after_error()
   SIRIUS_LOG_INFO("task_scheduler: draining after error");
   // Drain the task creator first so no thread is inside get_next_task_input_data()/
   // pop_data_batch() when QueryEnd() clears repositories (avoids use-after-free).
-  if (_task_creator) { _task_creator->stop_thread_pool(); }
+  if (_task_creator) {
+    _task_creator->stop_thread_pool();
+    // Also drain the pending task_creation_request queue. stop_thread_pool only
+    // interrupts and joins workers; queued requests still hold shared_ptr<data_batch>
+    // references that would survive clear_all_repositories at QueryEnd, contributing
+    // to inter-iteration "memory leak" warnings and residual GPU memory pressure.
+    _task_creator->drain_pending_tasks();
+  }
   // Drain the top-level task queue so management_eventloop doesn't dispatch
   // stale tasks from the failed query.
   _task_queue.drain();
@@ -228,58 +255,85 @@ void task_scheduler::drain_after_error()
 
 void task_scheduler::management_eventloop()
 {
+  // Pull-signal scheduler. The loop blocks on _task_request_channel for two
+  // event kinds:
+  //   - device_ready  : a gpu_pipeline_executor has reserved a worker thread
+  //                     and is ready to accept a task.
+  //   - task_available: schedule() pushed a new task into _task_queue and is
+  //                     asking us to re-run the matcher in case a device was
+  //                     already waiting.
+  // Tasks remain in _task_queue (downgrade-visible) until we have a ready
+  // device to match them against — this is the property the push model in
+  // PR #732 lost and that this loop restores.
   while (_running.load()) {
-    // Task-first: pop the next GPU pipeline task to dispatch.
-    // Scan tasks are routed directly to _scan_executor in schedule(), so
-    // all tasks in _task_queue are GPU pipeline tasks.
-    auto task = _task_queue.pop();
-    if (task == nullptr) {
-      SIRIUS_LOG_INFO("Task queue closed, exiting management event loop.");
+    // Block for the next event.
+    auto evt = _task_request_channel.get();
+    if (evt == nullptr) {
+      SIRIUS_LOG_INFO("Task request channel closed, exiting management event loop.");
       break;
     }
-
-    // Determine target GPU from task's data locality preference.
-    int target_device_id = _gpu_executors.begin()->first;
-    uint64_t task_id     = 0;
-    bool have_pref       = false;
-    if (auto* gpu_task = dynamic_cast<pipeline::gpu_pipeline_task*>(task.get())) {
-      auto pref = gpu_task->get_preferred_device_id();
-      if (pref.has_value() && _gpu_executors.count(pref.value())) {
-        target_device_id = pref.value();
-        have_pref        = true;
+    if (evt->kind == task_request_kind::device_ready && !evt->is_scan) {
+      _ready_devices.insert(evt->device_id);
+    }
+    // Drain any further events that are already queued, so a single matcher
+    // pass handles a burst of ready signals plus task pushes together.
+    while (auto more = _task_request_channel.try_get()) {
+      if (more->kind == task_request_kind::device_ready && !more->is_scan) {
+        _ready_devices.insert(more->device_id);
       }
-      task_id = gpu_task->get_task_id();
-    }
-    // Distribute preference-less source tasks (metadata-only parquet
-    // scans whose input batch has no GPU-resident memory_space) round-robin
-    // so they don't all pile onto begin(). NOTE: cached-pin scan tasks
-    // ARE preference-aware now — task_creator reads each
-    // scan_cached_operator_data's batch memory_space and sets
-    // preferred_device_id accordingly, so they take the have_pref branch
-    // above and stay on their chunk's home GPU. Downstream merge operators
-    // rely on lock_or_prepare_batch (batch_lock_utils.hpp) to convert
-    // cross-GPU input to the consumer's target memory space via
-    // cucascade::convert_gpu_to_gpu (peer-DMA where supported,
-    // host-staging on consumer hardware) — that fallback still applies
-    // for the residual preference-less cases.
-    if (!have_pref && _gpu_executors.size() > 1) {
-      auto idx =
-        _no_pref_rr_counter.fetch_add(1, std::memory_order_relaxed) % _gpu_executors.size();
-      auto it = _gpu_executors.begin();
-      std::advance(it, idx);
-      target_device_id = it->first;
     }
 
-    SIRIUS_LOG_DEBUG("management_eventloop: routing task to GPU {}", target_device_id);
-    // Log prefix "[mgpu-audit] pipeline_task dispatched to GPU N" is
-    // load-bearing — verification greps depend on it.
-    SIRIUS_LOG_INFO(
-      "[mgpu-audit] pipeline_task dispatched to GPU {} task_id={}", target_device_id, task_id);
-    // At-capacity tasks stay in the preferred executor's queue rather than
-    // spilling to another GPU — preserves data locality at the cost of higher
-    // tail latency. Capacity control happens in gpu_pipeline_executor; this is
-    // an enqueue, not a dispatch.
-    _gpu_executors.at(target_device_id)->schedule(std::move(task));
+    // Matcher: for each ready device, try to find a dispatchable task.
+    // A task is dispatchable to device X if:
+    //   (a) its preferred_device_id == X (exact match), OR
+    //   (b) it has no preferred_device_id (any device will do).
+    // Tasks with a preference for a DIFFERENT device must wait — they may
+    // reference GPU-resident data (cache=table_gpu, partitioned batches) that
+    // is only valid on the preferred device. Step (ii) will introduce an
+    // explicit strict-vs-prefer bit; for now, all preferences are treated as
+    // binding to guarantee correctness.
+    for (auto it = _ready_devices.begin(); it != _ready_devices.end();) {
+      const int device_id = *it;
+      // First try exact preference match.
+      auto task = _task_queue.pop_if(
+        [device_id](const sirius::parallel::itask& t) -> bool {
+          const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&t);
+          if (!gpu_task) { return false; }
+          auto pref = gpu_task->get_preferred_device_id();
+          return pref.has_value() && pref.value() == device_id;
+        },
+        /*front_to_back=*/true);
+      if (!task) {
+        // Fallback: take the first task with NO preference, or whose preferred
+        // device does not exist in _gpu_executors (a stale preference from a
+        // different env / config is meaningless — treat as unpreferred).
+        task = _task_queue.pop_if(
+          [this](const sirius::parallel::itask& t) -> bool {
+            const auto* gpu_task = dynamic_cast<const pipeline::gpu_pipeline_task*>(&t);
+            if (!gpu_task) { return true; }
+            auto pref = gpu_task->get_preferred_device_id();
+            if (!pref.has_value()) { return true; }
+            return _gpu_executors.count(pref.value()) == 0;
+          },
+          /*front_to_back=*/true);
+      }
+      if (!task) {
+        // No dispatchable task for this device. Leave device in _ready_devices
+        // and move on — it will match when an appropriate task arrives.
+        ++it;
+        continue;
+      }
+      uint64_t task_id = 0;
+      if (auto* gpu_task = dynamic_cast<pipeline::gpu_pipeline_task*>(task.get())) {
+        task_id = gpu_task->get_task_id();
+      }
+      // Log prefix "[mgpu-audit] pipeline_task dispatched to GPU N" is
+      // load-bearing — verification greps depend on it.
+      SIRIUS_LOG_INFO(
+        "[mgpu-audit] pipeline_task dispatched to GPU {} task_id={}", device_id, task_id);
+      _gpu_executors.at(device_id)->schedule(std::move(task));
+      it = _ready_devices.erase(it);
+    }
   }
 }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -110,10 +110,6 @@ void task_scheduler::start()
 {
   bool expected = false;
   if (!_running.compare_exchange_strong(expected, true)) { return; }
-  // Reopen the channel and task queue in case a previous stop() closed them.
-  _task_request_channel.reopen();
-  _task_queue.reactivate();
-  _ready_devices.clear();
   _scan_executor->start();
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->start();

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -219,16 +219,24 @@ void task_scheduler::terminate_query(std::exception_ptr error)
 void task_scheduler::drain_after_error()
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");
-  // Drain the task creator first so no thread is inside get_next_task_input_data()/
-  // pop_data_batch() when QueryEnd() clears repositories (avoids use-after-free).
-  if (_task_creator) {
-    _task_creator->stop_thread_pool();
-    // Also drain the pending task_creation_request queue. stop_thread_pool only
-    // interrupts and joins workers; queued requests still hold shared_ptr<data_batch>
-    // references that would survive clear_all_repositories at QueryEnd, contributing
-    // to inter-iteration "memory leak" warnings and residual GPU memory pressure.
-    _task_creator->drain_pending_tasks();
-  }
+  // Teardown ordering is load-bearing. The scan/gpu executor drains below run
+  // in-flight tasks to completion, and a completing task schedules its
+  // downstream consumers via task_creator::schedule() (gpu_pipeline_executor and
+  // duckdb_scan_executor both do this). Each such request holds a raw
+  // sirius_physical_operator* owned by the engine, which is destroyed the moment
+  // execute() returns. If the task_creator is live (or restarted) while those
+  // requests are still in flight, its manager_loop dereferences a freed operator
+  // in get_operator_for_next_task() — a use-after-free that crashes intermittently
+  // under multi-partition sort with many in-flight pipeline tasks.
+  //
+  // So: stop the task_creator FIRST and keep its queue interrupted across the
+  // executor drains. With the queue interrupted, schedule() pushes from
+  // completion callbacks return false and the requests (and their dangling
+  // operator pointers) are dropped instead of processed. Only AFTER every
+  // executor has quiesced do we drain the creation queue and restart the
+  // creator for the next query.
+  if (_task_creator) { _task_creator->stop_thread_pool(); }
+
   // Drain the top-level task queue so management_eventloop doesn't dispatch
   // stale tasks from the failed query.
   _task_queue.drain();
@@ -245,6 +253,20 @@ void task_scheduler::drain_after_error()
   for (auto& [device_id, gpu_exec] : _gpu_executors) {
     gpu_exec->drain_and_wait();
   }
+
+  // Now that no executor can generate further task_creation_requests, discard
+  // any that accumulated (and release the shared_ptr<data_batch> references they
+  // hold, which would otherwise survive clear_all_repositories at QueryEnd and
+  // show up as inter-iteration "memory leak" warnings). drain_pending_tasks()
+  // reactivates the queue when done.
+  if (_task_creator) { _task_creator->drain_pending_tasks(); }
+
+  // Belt-and-suspenders: the executor restarts above emit device_ready signals,
+  // and the management loop may have dispatched a leftover task into an executor
+  // queue between the two drains. Clear the top-level queue once more so the
+  // next query starts from empty.
+  _task_queue.drain();
+
   if (_task_creator) { _task_creator->start_thread_pool(); }
   SIRIUS_LOG_INFO("task_scheduler: DONE draining after error");
 }

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -228,10 +228,42 @@ void parquet_split_provider::run_batch(file_batch const& batch,
   // is projected / has hive partitions to remove.
   if (_plan->is_projected()) { reader_options->set_column_names(data_column_names); }
 
+  // Route reads through sirius_datasource — cudf's bundled file_source uses
+  // libkvikio which binds a single CUDA context per FileHandle, breaking
+  // multi-GPU residency. Picking the first ioctx for planning is safe: footer
+  // reads are small, and per-GPU placement of column data is decided later
+  // by the scan operator's task affinity.
+  //
+  // Initialized HERE (before filter pushdown probe) so that the FLBA-decimal probe
+  // below can use it. dev #732 forbids an empty gpu_ioctxs to keep local reads off
+  // cudf's kvikio file_source (which binds one CUDA context per handle, breaking
+  // multi-GPU residency). The relaxed form below permits an empty gpu_ioctxs only
+  // when a scan_manager is wired in (s3:// paths route through its s3_ioctx and
+  // local paths through its borrowed uring backend); both missing is fatal.
+  if (_gpu_ioctxs.empty() && _scan_manager == nullptr) {
+    throw std::runtime_error(
+      "parquet_split_provider: gpu_ioctxs is empty and no scan_manager is wired — "
+      "kvikio path is forbidden. Production callers receive gpu_ioctxs from "
+      "SiriusContext::get_gpu_ioctxs(); test fixtures must inject via "
+      "make_test_gpu_ioctxs() helper (test/cpp/scan/test_helpers_ioctx.hpp).");
+  }
+  auto const planning_ioctx_it = _gpu_ioctxs.begin();
+
   // Translate the filter to a cudf AST for reader-side pushdown, falling back to a post-read
   // DuckDB-expression evaluation when translation isn't possible. Partition-column filters
   // have already been dropped at construction; anything remaining references data columns.
+  //
+  // Pushdown safety guard: cudf's row-group stats filter (stats_filter_helpers.hpp:132)
+  // throws "Invalid type and stats combination" when comparing a `fixed_point_scalar` AST
+  // literal against parquet stats stored in physical type FIXED_LEN_BYTE_ARRAY (or
+  // BYTE_ARRAY) — which TPC-H generators like tpchgen-rs emit at SF1000. INT32/INT64
+  // decimal stats compare fine. If any file in this batch stores a decimal column with
+  // FLBA/BYTE_ARRAY, we skip pushdown for row-group pruning; the filter still applies
+  // post-decode in the operator's scan path (sirius_gpu_parquet_scan_operator.cpp:197).
   std::optional<gpu_expression_translator::translated_expression> ast_expression = std::nullopt;
+  // Propagated to each parquet_scan_data so the operator also skips its own set_filter
+  // call (otherwise the same cudf crash happens at scan time instead of pruning time).
+  bool skip_pushdown_due_to_flba = false;
   if (_duckdb_filter_expression) {
     // Resolver maps the BoundReferenceExpression's batch position (D) to the corresponding
     // parquet column name. scan_plan::batch_column_name is the single source of truth for
@@ -243,35 +275,71 @@ void parquet_split_provider::run_batch(file_batch const& batch,
     ast_expression =
       translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
     if (ast_expression) {
-      reader_options->set_filter(ast_expression->back());
-      SIRIUS_LOG_DEBUG(
-        "[parquet_split_provider] Translated filter expression for row group pruning.");
+      // Probe the first file's schema before committing to filter pushdown. The probe
+      // result is reused below by the main file loop via the prefetch cache.
+      //
+      // The probe requires a gpu_ioctx (planning_ioctx_it). When gpu_ioctxs is empty
+      // (scan_manager-only path) we cannot probe cheaply, so we default to skipping
+      // pushdown — correctness over the row-group-pruning perf win.
+      if (planning_ioctx_it == _gpu_ioctxs.end()) {
+        skip_pushdown_due_to_flba = true;
+      } else if (!batch.file_paths.empty()) {
+        auto const& probe_path = batch.file_paths.front();
+        try {
+          auto probe_io_object = planning_ioctx_it->second->create_io_object(probe_path);
+          auto probe_ds        = planning_ioctx_it->second->make_datasource(probe_io_object);
+          std::shared_ptr<cudf::io::parquet::FileMetaData const> probe_meta;
+          if (planning_ioctx_it->second->cache() != nullptr) {
+            if (auto cached =
+                  planning_ioctx_it->second->cache()->get_metadata(*probe_io_object)) {
+              if (auto pm = std::dynamic_pointer_cast<parquet_metadata>(cached)) {
+                probe_meta = pm->file_metadata();
+              }
+            }
+          }
+          if (!probe_meta) {
+            auto footer = cudf::io::parquet::fetch_footer_to_host(*probe_ds);
+            op::scan::hybrid_scan_reader probe_reader(
+              cudf::host_span<uint8_t const>(footer->data(), footer->size()), *reader_options);
+            probe_meta = std::make_shared<cudf::io::parquet::FileMetaData const>(
+              probe_reader.parquet_metadata());
+          }
+          for (auto const& elem : probe_meta->schema) {
+            bool const is_decimal =
+              (elem.converted_type.has_value() &&
+               *elem.converted_type == cudf::io::parquet::ConvertedType::DECIMAL) ||
+              (elem.logical_type.has_value() &&
+               elem.logical_type->type == cudf::io::parquet::LogicalType::DECIMAL);
+            if (!is_decimal) { continue; }
+            if (elem.type == cudf::io::parquet::Type::FIXED_LEN_BYTE_ARRAY ||
+                elem.type == cudf::io::parquet::Type::BYTE_ARRAY) {
+              skip_pushdown_due_to_flba = true;
+              break;
+            }
+          }
+        } catch (std::exception const& e) {
+          SIRIUS_LOG_DEBUG(
+            "[parquet_split_provider] FLBA-decimal probe failed ({}); proceeding without "
+            "pushdown",
+            e.what());
+          skip_pushdown_due_to_flba = true;
+        }
+      }
+
+      if (!skip_pushdown_due_to_flba) {
+        reader_options->set_filter(ast_expression->back());
+        SIRIUS_LOG_DEBUG(
+          "[parquet_split_provider] Translated filter expression for row group pruning.");
+      } else {
+        SIRIUS_LOG_DEBUG(
+          "[parquet_split_provider] Skipping row-group pruning pushdown: file has "
+          "FIXED_LEN_BYTE_ARRAY/BYTE_ARRAY decimal column(s) which cudf's stats filter does "
+          "not support. Filter will still apply post-decode in the scan operator.");
+      }
     } else {
       SIRIUS_LOG_DEBUG("[parquet_split_provider] AST translation failed for row group pruning.");
     }
   }
-
-  // Route reads through sirius_datasource — cudf's bundled file_source uses
-  // libkvikio which binds a single CUDA context per FileHandle, breaking
-  // multi-GPU residency. Picking the first ioctx for planning is safe: footer
-  // reads are small, and per-GPU placement of column data is decided later
-  // by the scan operator's task affinity.
-  // dev #732 forbids an empty gpu_ioctxs to keep local reads off cudf's kvikio
-  // file_source (which binds one CUDA context per handle, breaking multi-GPU
-  // residency). PR4+5 relaxes this: when a scan_manager is wired in, s3:// paths
-  // route through its s3_ioctx and local paths through its borrowed uring backend,
-  // so an empty gpu_ioctxs is only fatal when there is ALSO no scan_manager —
-  // that case throws below. (The cudf::io::datasource::create fallback is a
-  // separate path in run_batch, taken only when a scan_manager IS present but
-  // reports no backend for a local path, e.g. use_sirius_datasource=false.)
-  if (_gpu_ioctxs.empty() && _scan_manager == nullptr) {
-    throw std::runtime_error(
-      "parquet_split_provider: gpu_ioctxs is empty and no scan_manager is wired — "
-      "kvikio path is forbidden. Production callers receive gpu_ioctxs from "
-      "SiriusContext::get_gpu_ioctxs(); test fixtures must inject via "
-      "make_test_gpu_ioctxs() helper (test/cpp/scan/test_helpers_ioctx.hpp).");
-  }
-  auto const planning_ioctx_it = _gpu_ioctxs.begin();
 
   // Loop over files to read footers, parse metadata, and compute row-group partitions.
   rg_accumulator accum;
@@ -285,7 +353,8 @@ void parquet_split_provider::run_batch(file_batch const& batch,
       reader_options,
       _duckdb_filter_expression,
       _plan,
-      accum.partition_values.value_or(std::vector<std::string>{})));
+      accum.partition_values.value_or(std::vector<std::string>{}),
+      skip_pushdown_due_to_flba));
     accum.slices.clear();
     accum.total_uncompressed_bytes = 0;
   };
@@ -432,7 +501,10 @@ void parquet_split_provider::run_batch(file_batch const& batch,
     //===----------Row Group Partitioning----------===//
     auto row_group_indices = reader.all_row_groups(*reader_options);
     // Row group pruning with filter pushdown using metadata statistics.
-    if (ast_expression) {
+    // Also skipped when the FLBA-decimal probe disabled pushdown — in that case
+    // reader_options has no filter set and filter_row_groups_with_stats would
+    // throw "Empty input filter expression encountered" (hybrid_scan_impl.cpp:217).
+    if (ast_expression && !skip_pushdown_due_to_flba) {
       auto const row_groups_before_pruning = row_group_indices.size();
       // clang-format off
       SIRIUS_LOG_DEBUG("[parquet_split_provider] Row group pruning: file: {}\n" \

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -290,8 +290,7 @@ void parquet_split_provider::run_batch(file_batch const& batch,
           auto probe_ds        = planning_ioctx_it->second->make_datasource(probe_io_object);
           std::shared_ptr<cudf::io::parquet::FileMetaData const> probe_meta;
           if (planning_ioctx_it->second->cache() != nullptr) {
-            if (auto cached =
-                  planning_ioctx_it->second->cache()->get_metadata(*probe_io_object)) {
+            if (auto cached = planning_ioctx_it->second->cache()->get_metadata(*probe_io_object)) {
               if (auto pm = std::dynamic_pointer_cast<parquet_metadata>(cached)) {
                 probe_meta = pm->file_metadata();
               }

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -158,38 +158,6 @@ TEST_CASE("Task queue handles empty queue gracefully", "[pipeline_queue]")
   REQUIRE_NOTHROW(executor.stop());
 }
 
-TEST_CASE("Task scheduler survives stop/start cycle", "[task_scheduler]")
-{
-  auto manager = initialize_memory_manager(1);
-  sirius::exec::thread_pool_config gpu_config{2};
-  sirius::exec::thread_pool_config scan_config{2};
-  task_scheduler sched(gpu_config, scan_config, *manager);
-
-  sched.start();
-  sched.stop();
-
-  // Second cycle: the channel and task queue must be reopened.
-  sched.start();
-
-  auto global_state   = std::make_shared<mock_gpu_pipeline_task_global_state>();
-  const int num_tasks = 5;
-  for (int i = 0; i < num_tasks; ++i) {
-    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
-    auto task = std::make_unique<mock_gpu_pipeline_task>(std::move(local_state), global_state);
-    sched.schedule(std::move(task));
-  }
-
-  auto start_time = std::chrono::steady_clock::now();
-  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
-    std::this_thread::sleep_for(10ms);
-    if (std::chrono::steady_clock::now() - start_time > 10s) {
-      FAIL("Tasks not completed after stop/start cycle");
-    }
-  }
-  REQUIRE(global_state->executed_count.load() == num_tasks);
-  sched.stop();
-}
-
 TEST_CASE("Task scheduler dispatches tasks with device preference", "[task_scheduler]")
 {
   auto manager = initialize_memory_manager(2);
@@ -214,41 +182,6 @@ TEST_CASE("Task scheduler dispatches tasks with device preference", "[task_sched
     std::this_thread::sleep_for(10ms);
     if (std::chrono::steady_clock::now() - start_time > 10s) {
       FAIL("Tasks not completed with 2-GPU scheduler");
-    }
-  }
-  REQUIRE(global_state->executed_count.load() == num_tasks);
-  sched.stop();
-}
-
-TEST_CASE("Task scheduler multiple stop/start cycles", "[task_scheduler]")
-{
-  auto manager = initialize_memory_manager(1);
-  sirius::exec::thread_pool_config gpu_config{2};
-  sirius::exec::thread_pool_config scan_config{2};
-  task_scheduler sched(gpu_config, scan_config, *manager);
-
-  // Three stop/start cycles followed by actual work — mirrors the integration
-  // test fixture lifecycle where shared envs are initialized and paused.
-  for (int cycle = 0; cycle < 3; ++cycle) {
-    sched.start();
-    sched.stop();
-  }
-
-  sched.start();
-  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
-
-  const int num_tasks = 8;
-  for (int i = 0; i < num_tasks; ++i) {
-    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
-    auto task = std::make_unique<mock_gpu_pipeline_task>(std::move(local_state), global_state);
-    sched.schedule(std::move(task));
-  }
-
-  auto start_time = std::chrono::steady_clock::now();
-  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
-    std::this_thread::sleep_for(10ms);
-    if (std::chrono::steady_clock::now() - start_time > 10s) {
-      FAIL("Tasks not completed after 3 stop/start cycles");
     }
   }
   REQUIRE(global_state->executed_count.load() == num_tasks);

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -157,3 +157,100 @@ TEST_CASE("Task queue handles empty queue gracefully", "[pipeline_queue]")
 
   REQUIRE_NOTHROW(executor.stop());
 }
+
+TEST_CASE("Task scheduler survives stop/start cycle", "[task_scheduler]")
+{
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  sirius::exec::thread_pool_config scan_config{2};
+  task_scheduler sched(gpu_config, scan_config, *manager);
+
+  sched.start();
+  sched.stop();
+
+  // Second cycle: the channel and task queue must be reopened.
+  sched.start();
+
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+  const int num_tasks = 5;
+  for (int i = 0; i < num_tasks; ++i) {
+    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
+    auto task = std::make_unique<mock_gpu_pipeline_task>(std::move(local_state), global_state);
+    sched.schedule(std::move(task));
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start_time > 10s) {
+      FAIL("Tasks not completed after stop/start cycle");
+    }
+  }
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+  sched.stop();
+}
+
+TEST_CASE("Task scheduler dispatches tasks with device preference", "[task_scheduler]")
+{
+  auto manager = initialize_memory_manager(2);
+  sirius::exec::thread_pool_config gpu_config{2};
+  sirius::exec::thread_pool_config scan_config{2};
+  task_scheduler sched(gpu_config, scan_config, *manager);
+
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+  sched.start();
+
+  // Schedule tasks — pull-signal model ensures tasks stay in the scheduler's
+  // queue (downgrade-visible) until a GPU executor is ready.
+  const int num_tasks = 10;
+  for (int i = 0; i < num_tasks; ++i) {
+    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
+    auto task = std::make_unique<mock_gpu_pipeline_task>(i, std::move(local_state), global_state);
+    sched.schedule(std::move(task));
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start_time > 10s) {
+      FAIL("Tasks not completed with 2-GPU scheduler");
+    }
+  }
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+  sched.stop();
+}
+
+TEST_CASE("Task scheduler multiple stop/start cycles", "[task_scheduler]")
+{
+  auto manager = initialize_memory_manager(1);
+  sirius::exec::thread_pool_config gpu_config{2};
+  sirius::exec::thread_pool_config scan_config{2};
+  task_scheduler sched(gpu_config, scan_config, *manager);
+
+  // Three stop/start cycles followed by actual work — mirrors the integration
+  // test fixture lifecycle where shared envs are initialized and paused.
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    sched.start();
+    sched.stop();
+  }
+
+  sched.start();
+  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+
+  const int num_tasks = 8;
+  for (int i = 0; i < num_tasks; ++i) {
+    auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);
+    auto task = std::make_unique<mock_gpu_pipeline_task>(std::move(local_state), global_state);
+    sched.schedule(std::move(task));
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  while (global_state->executed_count.load(std::memory_order_relaxed) < num_tasks) {
+    std::this_thread::sleep_for(10ms);
+    if (std::chrono::steady_clock::now() - start_time > 10s) {
+      FAIL("Tasks not completed after 3 stop/start cycles");
+    }
+  }
+  REQUIRE(global_state->executed_count.load() == num_tasks);
+  sched.stop();
+}

--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -171,7 +171,7 @@ TEST_CASE("Task scheduler survives stop/start cycle", "[task_scheduler]")
   // Second cycle: the channel and task queue must be reopened.
   sched.start();
 
-  auto global_state = std::make_shared<mock_gpu_pipeline_task_global_state>();
+  auto global_state   = std::make_shared<mock_gpu_pipeline_task_global_state>();
   const int num_tasks = 5;
   for (int i = 0; i < num_tasks; ++i) {
     auto local_state = std::make_unique<mock_gpu_pipeline_task_local_state>(i, 0);

--- a/test/cpp/scan/test_parquet_scan_task.cpp
+++ b/test/cpp/scan/test_parquet_scan_task.cpp
@@ -986,7 +986,7 @@ TEST_CASE("parquet_split_provider - FLBA decimal skips filter pushdown",
   // fixed_point_scalar against FLBA stats. The split provider must detect
   // this via the schema probe and set disable_filter_pushdown on every
   // emitted parquet_scan_data. The filter still applies post-decode.
-  auto const dir       = std::filesystem::temp_directory_path() / "psp_flba_test";
+  auto const dir = std::filesystem::temp_directory_path() / "psp_flba_test";
   std::error_code ec;
   std::filesystem::remove_all(dir, ec);
   std::filesystem::create_directories(dir);
@@ -997,30 +997,28 @@ TEST_CASE("parquet_split_provider - FLBA decimal skips filter pushdown",
   constexpr size_t k_rows    = 10000;
   constexpr size_t k_rg_size = 5000;
   std::string const table    = "psp_flba_tmp";
-  auto result                = con.Query(
-    "CREATE TABLE " + table +
-    " AS SELECT (range)::INTEGER AS id, "
-    "CAST(range * 1.25 AS DECIMAL(25,2)) AS amount "
-    "FROM range(0, " +
-    std::to_string(k_rows) + ")");
+  auto result                = con.Query("CREATE TABLE " + table +
+                          " AS SELECT (range)::INTEGER AS id, "
+                                         "CAST(range * 1.25 AS DECIMAL(25,2)) AS amount "
+                                         "FROM range(0, " +
+                          std::to_string(k_rows) + ")");
   REQUIRE(result);
   REQUIRE(!result->HasError());
 
   auto const path = dir / "flba.parquet";
   result          = con.Query("COPY " + table + " TO '" + path.string() +
-                              "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
-                              std::to_string(k_rg_size) + ")");
+                     "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
+                     std::to_string(k_rg_size) + ")");
   REQUIRE(result);
   REQUIRE(!result->HasError());
   con.Query("DROP TABLE " + table);
 
   // Build a filter on the decimal column: amount < 6250.00
   auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  table_filters->PushFilter(
-    duckdb::ColumnIndex(1),
-    duckdb::make_uniq<duckdb::ConstantFilter>(
-      duckdb::ExpressionType::COMPARE_LESSTHAN,
-      duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 25, 2)));
+  table_filters->PushFilter(duckdb::ColumnIndex(1),
+                            duckdb::make_uniq<duckdb::ConstantFilter>(
+                              duckdb::ExpressionType::COMPARE_LESSTHAN,
+                              duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 25, 2)));
 
   duckdb::vector<sirius::logical_type> types = {
     sirius::logical_type::make(sirius::type_id::INTEGER),
@@ -1080,29 +1078,27 @@ TEST_CASE("parquet_split_provider - INT64 decimal allows filter pushdown",
   constexpr size_t k_rows    = 10000;
   constexpr size_t k_rg_size = 5000;
   std::string const table    = "psp_int64dec_tmp";
-  auto result                = con.Query(
-    "CREATE TABLE " + table +
-    " AS SELECT (range)::INTEGER AS id, "
-    "CAST(range * 1.25 AS DECIMAL(10,2)) AS amount "
-    "FROM range(0, " +
-    std::to_string(k_rows) + ")");
+  auto result                = con.Query("CREATE TABLE " + table +
+                          " AS SELECT (range)::INTEGER AS id, "
+                                         "CAST(range * 1.25 AS DECIMAL(10,2)) AS amount "
+                                         "FROM range(0, " +
+                          std::to_string(k_rows) + ")");
   REQUIRE(result);
   REQUIRE(!result->HasError());
 
   auto const path = dir / "int64dec.parquet";
   result          = con.Query("COPY " + table + " TO '" + path.string() +
-                              "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
-                              std::to_string(k_rg_size) + ")");
+                     "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
+                     std::to_string(k_rg_size) + ")");
   REQUIRE(result);
   REQUIRE(!result->HasError());
   con.Query("DROP TABLE " + table);
 
   auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
-  table_filters->PushFilter(
-    duckdb::ColumnIndex(1),
-    duckdb::make_uniq<duckdb::ConstantFilter>(
-      duckdb::ExpressionType::COMPARE_LESSTHAN,
-      duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 10, 2)));
+  table_filters->PushFilter(duckdb::ColumnIndex(1),
+                            duckdb::make_uniq<duckdb::ConstantFilter>(
+                              duckdb::ExpressionType::COMPARE_LESSTHAN,
+                              duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 10, 2)));
 
   duckdb::vector<sirius::logical_type> types = {
     sirius::logical_type::make(sirius::type_id::INTEGER),

--- a/test/cpp/scan/test_parquet_scan_task.cpp
+++ b/test/cpp/scan/test_parquet_scan_task.cpp
@@ -21,10 +21,15 @@
 
 // sirius
 #include <exec/config.hpp>
+#include <exec/thread_pool.hpp>
+#include <helper/logical_type.hpp>
 #include <helper/type_conversions.hpp>
+#include <op/scan/parquet_scan_operator_data.hpp>
 #include <op/scan/parquet_scan_task.hpp>
 #include <op/sirius_physical_parquet_scan.hpp>
 #include <parallel/task_executor.hpp>
+#include <scan_manager/parquet_split_provider.hpp>
+#include <scan_manager/split_connector.hpp>
 
 // Phase 19 IO-15: include test_helpers_ioctx.hpp LAST among sirius/test
 // headers — it transitively pulls liburing.h via uring_ioctx.hpp ->
@@ -970,4 +975,173 @@ TEST_CASE("parquet_scan_task - filter prunes row groups with multi-column compar
       table_filters->PushFilter(duckdb::ColumnIndex(1), std::move(val_filter));  // value column
       return table_filters;
     });
+}
+
+TEST_CASE("parquet_split_provider - FLBA decimal skips filter pushdown",
+          "[parquet_scan_task][filter][flba_decimal][scan]")
+{
+  // DECIMAL(25,2) forces DuckDB's parquet writer to use FIXED_LEN_BYTE_ARRAY
+  // physical type (p > 18 exceeds INT64 capacity). cudf's row-group stats
+  // filter throws "Invalid type and stats combination" when comparing a
+  // fixed_point_scalar against FLBA stats. The split provider must detect
+  // this via the schema probe and set disable_filter_pushdown on every
+  // emitted parquet_scan_data. The filter still applies post-decode.
+  auto const dir       = std::filesystem::temp_directory_path() / "psp_flba_test";
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+  std::filesystem::create_directories(dir);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  constexpr size_t k_rows    = 10000;
+  constexpr size_t k_rg_size = 5000;
+  std::string const table    = "psp_flba_tmp";
+  auto result                = con.Query(
+    "CREATE TABLE " + table +
+    " AS SELECT (range)::INTEGER AS id, "
+    "CAST(range * 1.25 AS DECIMAL(25,2)) AS amount "
+    "FROM range(0, " +
+    std::to_string(k_rows) + ")");
+  REQUIRE(result);
+  REQUIRE(!result->HasError());
+
+  auto const path = dir / "flba.parquet";
+  result          = con.Query("COPY " + table + " TO '" + path.string() +
+                              "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
+                              std::to_string(k_rg_size) + ")");
+  REQUIRE(result);
+  REQUIRE(!result->HasError());
+  con.Query("DROP TABLE " + table);
+
+  // Build a filter on the decimal column: amount < 6250.00
+  auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
+  table_filters->PushFilter(
+    duckdb::ColumnIndex(1),
+    duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_LESSTHAN,
+      duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 25, 2)));
+
+  duckdb::vector<sirius::logical_type> types = {
+    sirius::logical_type::make(sirius::type_id::INTEGER),
+    sirius::logical_type::make_decimal(25, 2),
+  };
+  duckdb::vector<duckdb::ColumnIndex> col_ids = {duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+
+  sirius::scan_manager::parquet_split_provider provider(
+    types,
+    {path.string()},
+    col_ids,
+    /*projection_ids*/ {},
+    {"id", "amount"},
+    /*scan_output_arity*/ types.size(),
+    std::move(table_filters),
+    /*partition_indices*/ {},
+    /*approximate_batch_size*/ std::size_t{1} << 30,
+    /*max_file_processed*/ 10,
+    sirius::scan_test_utils::make_test_gpu_ioctxs());
+
+  sirius::exec::static_thread_pool pool(2, "flba_pool");
+  sirius::scan_manager::split_connector connector;
+  provider.run(pool, connector);
+
+  std::vector<std::unique_ptr<sirius::op::scan::parquet_scan_data>> splits;
+  while (true) {
+    auto next = connector.get_next_split();
+    if (!next.has_value()) { break; }
+    auto* raw     = next->release();
+    auto* parquet = dynamic_cast<sirius::op::scan::parquet_scan_data*>(raw);
+    REQUIRE(parquet != nullptr);
+    splits.emplace_back(parquet);
+  }
+  REQUIRE_FALSE(splits.empty());
+
+  for (auto const& split : splits) {
+    INFO("Every split from an FLBA-decimal file must have disable_filter_pushdown set");
+    REQUIRE(split->disable_filter_pushdown);
+  }
+
+  std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("parquet_split_provider - INT64 decimal allows filter pushdown",
+          "[parquet_scan_task][filter][flba_decimal][scan]")
+{
+  // DECIMAL(10,2) fits in INT64 physical type — the probe must NOT disable
+  // filter pushdown. Complement of the FLBA test above.
+  auto const dir = std::filesystem::temp_directory_path() / "psp_int64dec_test";
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+  std::filesystem::create_directories(dir);
+
+  duckdb::DuckDB db(nullptr);
+  duckdb::Connection con(db);
+
+  constexpr size_t k_rows    = 10000;
+  constexpr size_t k_rg_size = 5000;
+  std::string const table    = "psp_int64dec_tmp";
+  auto result                = con.Query(
+    "CREATE TABLE " + table +
+    " AS SELECT (range)::INTEGER AS id, "
+    "CAST(range * 1.25 AS DECIMAL(10,2)) AS amount "
+    "FROM range(0, " +
+    std::to_string(k_rows) + ")");
+  REQUIRE(result);
+  REQUIRE(!result->HasError());
+
+  auto const path = dir / "int64dec.parquet";
+  result          = con.Query("COPY " + table + " TO '" + path.string() +
+                              "' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE " +
+                              std::to_string(k_rg_size) + ")");
+  REQUIRE(result);
+  REQUIRE(!result->HasError());
+  con.Query("DROP TABLE " + table);
+
+  auto table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
+  table_filters->PushFilter(
+    duckdb::ColumnIndex(1),
+    duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_LESSTHAN,
+      duckdb::Value::DECIMAL(static_cast<int64_t>(625000), 10, 2)));
+
+  duckdb::vector<sirius::logical_type> types = {
+    sirius::logical_type::make(sirius::type_id::INTEGER),
+    sirius::logical_type::make_decimal(10, 2),
+  };
+  duckdb::vector<duckdb::ColumnIndex> col_ids = {duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+
+  sirius::scan_manager::parquet_split_provider provider(
+    types,
+    {path.string()},
+    col_ids,
+    /*projection_ids*/ {},
+    {"id", "amount"},
+    /*scan_output_arity*/ types.size(),
+    std::move(table_filters),
+    /*partition_indices*/ {},
+    /*approximate_batch_size*/ std::size_t{1} << 30,
+    /*max_file_processed*/ 10,
+    sirius::scan_test_utils::make_test_gpu_ioctxs());
+
+  sirius::exec::static_thread_pool pool(2, "i64dec_pool");
+  sirius::scan_manager::split_connector connector;
+  provider.run(pool, connector);
+
+  std::vector<std::unique_ptr<sirius::op::scan::parquet_scan_data>> splits;
+  while (true) {
+    auto next = connector.get_next_split();
+    if (!next.has_value()) { break; }
+    auto* raw     = next->release();
+    auto* parquet = dynamic_cast<sirius::op::scan::parquet_scan_data*>(raw);
+    REQUIRE(parquet != nullptr);
+    splits.emplace_back(parquet);
+  }
+  REQUIRE_FALSE(splits.empty());
+
+  for (auto const& split : splits) {
+    INFO("INT64-decimal files should allow filter pushdown");
+    REQUIRE_FALSE(split->disable_filter_pushdown);
+  }
+
+  std::filesystem::remove_all(dir);
 }


### PR DESCRIPTION
 ## Restore pull-signal backpressure in multi-GPU task scheduler

  ### Problem

  PR #732 introduced multi-GPU support by switching the task scheduler from a pull
  model (executors request work when ready) to a push model (scheduler dispatches
  tasks greedily based on data locality). This caused tasks to pile up inside
  per-GPU executor queues where the **downgrade executor cannot reach them** —
  defeating the memory-pressure relief mechanism that keeps queries from OOMing
  under heavy workloads.

  Concretely, `management_eventloop` was popping tasks from `_task_queue`
  unconditionally and pushing them to GPU executors regardless of worker-thread
  availability. Once a task sat in an executor's internal queue it held a GPU
  memory reservation that downgrade could no longer reclaim.

  ### Solution

  Restore the pre-#732 pull-signal pattern, adapted for multi-GPU data locality:

  - **GPU executors signal readiness.** After `_bounded_pool->reserve()` secures
    a worker thread, the executor publishes a `DEVICE_READY` event on the existing
    `_task_request_channel`. Tasks are only dispatched to executors that have a
    thread ready *right now*.
  - **Preference-aware matcher.** The scheduler uses two `inspectable_mpsc::pop_if()`
    passes: first a strict match against `preferred_device_id`, then a relaxed
    pass for tasks with no preference (or with a preference for a device that
    doesn't exist in the current config). Tasks preferring a *different* existing
    device stay in the queue until that device is ready — required for correctness
    when data is physically resident on a specific GPU (e.g. `cache=table_gpu`).
  - **Tasks stay downgrade-visible.** Because tasks remain in the scheduler's
    `_task_queue` until a device is ready, the downgrade executor's TIER 2 scan
    continues to find them. Steady-state per-executor queue depth is ~1.
  - **TASK_AVAILABLE sentinel.** A new `task_request_kind` enum distinguishes
    `device_ready` from `task_available`. `schedule()` publishes `task_available`
    via `_self_publisher` to wake the matcher when new work arrives while devices
    are already idle.

  ### Additional fixes included

  **SF1000 FLBA-decimal filter-pushdown crash.** Parquet files written by
  tpchgen-rs at SF1000 store decimals as `FIXED_LEN_BYTE_ARRAY`. cuDF's
  row-group stats filter then crashes with *"Invalid type and stats combination"*.
  `parquet_split_provider` now probes the first file's schema and disables filter
  pushdown when FLBA/BYTE_ARRAY decimal columns are present; the predicate is
  applied post-decode instead.

  **SF1000 null-deref in `drain_pending_tasks`.** `task_creator::drain_pending_tasks()`
  dereferenced a null `_bounded_pool` after `stop_thread_pool()` reset it on the
  error path. Added a null guard mirroring `task_executor::drain_and_wait()`.

  **cucascade bump for host-pool cross-GPU staging.** Picks up the cucascade fix
  that routes cross-GPU host-staging through the pre-pinned per-NUMA HOST pool
  instead of per-transfer `cudaHostAlloc` — root cause of the SF100 multi-GPU
  regression (1-GPU 47.7s vs 2-GPU 53.4s on join-heavy queries).

  ### Key design decisions

  | Decision | Rationale |
  |---|---|
  | Single `_task_queue` (not per-device split) | Preserves FIFO order; leaves room for future priority semantics |
  | All preferences treated as binding (step i) | Correctness-first: prevents cross-GPU CUDA errors. A follow-up will add an explicit `strict` vs `prefer` bit so scan tasks can load-balance while partitioned 
  ops stay pinned |
  | `channel::reopen()` added | Scheduler goes through stop/start cycles between queries (`drain_after_error`, shared test envs); the channel must be revivable after `close()` |
  | Filter `!evt->is_scan` on `DEVICE_READY` | The scan executor shares the same channel and emits `task_request(0, true)`; without filtering these were injected as spurious GPU readiness signals |
  | Non-existent preferred device → unpreferred | Tasks carrying a preference from a previous 2-GPU env must still run in a 1-GPU env |

  ### Files changed (14 files, +548/-75)

  - `src/pipeline/task_scheduler.{hpp,cpp}` — pull-signal matcher, `_ready_devices`, `_self_publisher`
  - `src/pipeline/gpu_pipeline_executor.cpp` — `DEVICE_READY` signal after `reserve()`
  - `src/include/pipeline/task_request.hpp` — `task_request_kind` enum
  - `src/include/exec/channel.hpp` — `reopen()` for stop/start lifecycle
  - `src/parallel/task_executor.cpp`, `src/creator/task_creator.cpp` — null guard on drain
  - `src/scan_manager/parquet_split_provider.cpp` + scan operator data — FLBA pushdown skip
  - `src/op/scan/duckdb_scan_executor.cpp`, `sirius_gpu_parquet_scan_operator.cpp` — wiring
  - `cucascade` submodule bump
  - `test/cpp/pipeline/test_task_scheduler.cpp` — 3 new tests
  - `test/cpp/scan/test_parquet_scan_task.cpp` — 2 new tests

  ### Test plan

  - [x] `[scan]` — 165 tests, 154,819 assertions (includes FLBA-decimal pushdown skip)
  - [x] `[mgpu]` — 16 tests, 74,321 assertions (includes `cache=table_gpu` cross-device)
  - [x] `[task_scheduler]` — 5 tests: stop/start cycle, multi-cycle, 2-GPU dispatch
  - [x] `[flba_decimal]` — 2 tests: FLBA decimal skips pushdown, INT64 decimal allows it
  - [x] `pre-commit run` clean on all modified files
  - [ ] TPC-H SF100/SF1000 spot-check on 1-GPU and 2-GPU configs (requires driver + dataset)

  ### Future work

  Step (ii): add an explicit `strict` vs `prefer` affinity bit on
  `gpu_pipeline_task`. Today every preference is treated as binding, which is
  correct but leaves load-balancing on the table for scans. A follow-up PR will
  let partitioned operators (joins, group-by, cached scans) declare strict
  pinning while non-partitioned scans float to any ready device.

  ### Commits

  - `d1c8755b` feat: restore pull-signal backpressure in multi-GPU task scheduler
  - `28d49f14` test: add FLBA-decimal pushdown skip and pull-signal scheduler tests
  - `e2e7fc3e` chore: bump cucascade (host-pool cross-GPU staging)
  - `af889fae` style: apply clang-format to modified files