### PR TITLE
feat: native Sirius AST in per-specialization executors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ set(EXTENSION_SOURCES
     src/expression/to_duckdb.cpp
     src/expression/value.cpp
     src/expression_executor/expression_executor_strategy.cpp
+    src/expression_executor/ast_op_counter.cpp
     src/expression_executor/gpu_expression_executor.cpp
     src/expression_executor/gpu_expression_translator.cpp
     src/expression_executor/regex/regex_playground.cpp

--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -72,16 +72,18 @@ std::unique_ptr<node> translate_constant(duckdb::BoundConstantExpression const& 
 
 std::unique_ptr<node> translate_comparison(duckdb::BoundComparisonExpression const& expr)
 {
-  // Distinct-from / not-distinct-from are well-formed but not carried by the
-  // Sirius comparison node; signal fallback via nullptr before consulting the
-  // shared ExpressionType mapper.
+  // Filter the BoundComparisonExpression ExpressionType down to the set that the
+  // Sirius comparison node carries (sirius::comparison_type). The set mirrors
+  // sirius::from_duckdb(duckdb::ExpressionType) in src/expression/join_condition.cpp.
   switch (expr.GetExpressionType()) {
     case duckdb::ExpressionType::COMPARE_EQUAL:
     case duckdb::ExpressionType::COMPARE_NOTEQUAL:
     case duckdb::ExpressionType::COMPARE_LESSTHAN:
     case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
     case duckdb::ExpressionType::COMPARE_GREATERTHAN:
-    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO: break;
+    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+    case duckdb::ExpressionType::COMPARE_DISTINCT_FROM:
+    case duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM: break;
     default: return nullptr;
   }
   auto left  = from_duckdb(*expr.left);

--- a/src/expression_executor/ast_op_counter.cpp
+++ b/src/expression_executor/ast_op_counter.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// sirius
+#include <expression/ast/between.hpp>
+#include <expression/ast/case_expr.hpp>
+#include <expression/ast/cast.hpp>
+#include <expression/ast/coalesce.hpp>
+#include <expression/ast/comparison.hpp>
+#include <expression/ast/conjunction.hpp>
+#include <expression/ast/constant.hpp>
+#include <expression/ast/function_call.hpp>
+#include <expression/ast/in_list.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/ast/reference.hpp>
+#include <expression/ast/unary_op.hpp>
+#include <expression_executor/ast_supported_types.hpp>
+#include <sirius/exception.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstddef>
+#include <variant>
+
+// Single source of truth for "how many cuDF AST operators does this Sirius AST
+// alternative lower to, recursively." Drives the AST-vs-MATERIALIZE strategy
+// gate in each gpu_expression_executor::execute(alt, mode) body via the
+// `ast_op_count >= _min_ast_size` check.
+//
+// The method name carries the cuDF coupling: counts are tied to cuDF's
+// ast_operator set, supported_ast_cast_types, supported_ast_functions, and
+// known cuDF AST limitations (no CASE, no COALESCE, decimal-intermediate bug,
+// etc.). A new AST backend would need its own equivalent method, not a
+// generic rename.
+
+namespace sirius::ast {
+
+// Leaves — never contribute ops themselves.
+std::size_t reference::cudf_ast_op_count() const { return 0; }
+std::size_t constant::cudf_ast_op_count() const { return 0; }
+
+// cuDF AST does not support CASE or COALESCE — force materialize.
+std::size_t case_expr::cudf_ast_op_count() const { return 0; }
+std::size_t coalesce::cudf_ast_op_count() const { return 0; }
+
+std::size_t comparison::cudf_ast_op_count() const
+{
+  // DISTINCT_FROM lowers to NOT(NULL_EQUAL(...)) — two cuDF AST ops, not one.
+  // NOT_DISTINCT_FROM is a single NULL_EQUAL and stays at one.
+  std::size_t const self = (op == sirius::comparison_type::distinct_from) ? 2U : 1U;
+  return self + left->cudf_ast_op_count() + right->cudf_ast_op_count();
+}
+
+std::size_t conjunction::cudf_ast_op_count() const
+{
+  if (children.empty()) {
+    throw invalid_input_exception(
+      "[ast::conjunction::cudf_ast_op_count] no children — malformed AST.");
+  }
+  // Number of AND/OR cuDF ops is one less than number of children.
+  std::size_t count = children.size() - 1;
+  for (auto const& c : children) {
+    count += c->cudf_ast_op_count();
+  }
+  return count;
+}
+
+std::size_t between::cudf_ast_op_count() const
+{
+  // Lowers to (input >= lower) AND (input <= upper) — 2 comparison ops + 1 AND.
+  return 3 + input->cudf_ast_op_count() + lower->cudf_ast_op_count() + upper->cudf_ast_op_count();
+}
+
+std::size_t cast::cudf_ast_op_count() const
+{
+  // Only target types in supported_ast_cast_types_native lower to a single
+  // CAST_TO_* cuDF AST op; others force materialize.
+  bool const supported = std::find(supported_ast_cast_types_native.begin(),
+                                   supported_ast_cast_types_native.end(),
+                                   target_type.id()) != supported_ast_cast_types_native.end();
+  return supported ? 1 + child->cudf_ast_op_count() : 0;
+}
+
+std::size_t unary_op::cudf_ast_op_count() const
+{
+  switch (op) {
+    case kind::op_not: return 1 + child->cudf_ast_op_count();
+    case kind::op_is_null: return 1 + child->cudf_ast_op_count();
+    case kind::op_is_not_null: return 2 + child->cudf_ast_op_count();  // NOT(IS_NULL(...))
+    case kind::op_try:
+      throw not_implemented_exception(
+        "[ast::unary_op::cudf_ast_op_count] TRY operator is not implemented.");
+    default:
+      throw internal_exception("[ast::unary_op::cudf_ast_op_count] unknown kind: {}",
+                               static_cast<int>(op));
+  }
+}
+
+std::size_t in_list::cudf_ast_op_count() const
+{
+  if (values.empty()) {
+    throw invalid_input_exception("[ast::in_list::cudf_ast_op_count] no values — malformed AST.");
+  }
+  // children = [probe] + values; with N = values.size():
+  //   num_or = N - 1 ; num_eq = N ; +1 if negated.
+  auto const num_or = values.size() - 1;
+  auto const num_eq = values.size();
+  std::size_t count = num_or + num_eq + (negated ? 1U : 0U);
+  count += probe->cudf_ast_op_count();
+  for (auto const& v : values) {
+    count += v->cudf_ast_op_count();
+  }
+  return count;
+}
+
+std::size_t function_call::cudf_ast_op_count() const
+{
+  // DECIMAL output -> 0 (cuDF AST chokes on intermediate decimal results
+  // until https://github.com/rapidsai/cudf/pull/21996 lands).
+  if (return_type().id() == sirius::type_id::DECIMAL) { return 0; }
+  bool const supported =
+    std::find(supported_ast_functions.begin(), supported_ast_functions.end(), function()) !=
+    supported_ast_functions.end();
+  if (!supported) { return 0; }
+  std::size_t count = 1;
+  for (auto const& a : arguments()) {
+    count += a->cudf_ast_op_count();
+  }
+  return count;
+}
+
+std::size_t node::cudf_ast_op_count() const
+{
+  return std::visit([](auto const& alt) { return alt.cudf_ast_op_count(); }, v);
+}
+
+}  // namespace sirius::ast

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -555,6 +555,10 @@ std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr
           (alt.op == sirius::comparison_type::distinct_from) ? 2U : 1U;
         return self + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
       } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
+        if (alt.children.empty()) {
+          throw invalid_input_exception(
+            "[gpu_expression_executor:count_ast_ops] conjunction has no children — malformed AST.");
+        }
         // Number of AND/OR ops is one less than number of children.
         std::size_t count = alt.children.size() - 1;
         for (auto const& c : alt.children) {
@@ -594,6 +598,10 @@ std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr
         // COALESCE has no AST support.
         return 0;
       } else if constexpr (std::is_same_v<T, sirius::ast::in_list>) {
+        if (alt.values.empty()) {
+          throw invalid_input_exception(
+            "[gpu_expression_executor:count_ast_ops] in_list has no values — malformed AST.");
+        }
         // children = [probe] + values; with N = values.size():
         //   num_or = N - 1 ; num_eq = N ; +1 if negated.
         auto const num_or = alt.values.size() - 1;

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -526,13 +526,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& al
   return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::function_call const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
 {
   // Round-trip shim — the per-specialization migration phase

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -532,27 +532,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, ex
   return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
-execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
-execute_result gpu_expression_executor::execute(sirius::ast::in_list const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::function_call const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -551,8 +551,7 @@ std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr
       } else if constexpr (std::is_same_v<T, sirius::ast::comparison>) {
         // DISTINCT_FROM lowers to NOT(NULL_EQUAL(...)) — two AST ops, not one.
         // NOT_DISTINCT_FROM is a single NULL_EQUAL and stays at one.
-        std::size_t const self =
-          (alt.op == sirius::comparison_type::distinct_from) ? 2U : 1U;
+        std::size_t const self = (alt.op == sirius::comparison_type::distinct_from) ? 2U : 1U;
         return self + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
       } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
         if (alt.children.empty()) {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -516,7 +516,26 @@ std::size_t gpu_expression_executor::count_ast_ops(duckdb::Expression const& exp
 execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, execution_mode mode)
 {
   return std::visit(
-    [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
+    [this, mode](auto const& alt) -> execute_result {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
+                    std::is_same_v<T, sirius::ast::constant> ||
+                    std::is_same_v<T, sirius::ast::comparison> ||
+                    std::is_same_v<T, sirius::ast::conjunction> ||
+                    std::is_same_v<T, sirius::ast::between> ||
+                    std::is_same_v<T, sirius::ast::case_expr> ||
+                    std::is_same_v<T, sirius::ast::cast> ||
+                    std::is_same_v<T, sirius::ast::unary_op> ||
+                    std::is_same_v<T, sirius::ast::coalesce> ||
+                    std::is_same_v<T, sirius::ast::in_list> ||
+                    std::is_same_v<T, sirius::ast::function_call>) {
+        return this->execute(alt, mode);
+      } else {
+        static_assert(sizeof(T) == 0,
+                      "Unhandled sirius::ast alternative in execute(sirius::ast::node) dispatcher");
+      }
+    },
+    expr.v);
 }
 
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::reference const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -521,10 +521,84 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
 
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
 {
-  // Round-trip shim — the per-specialization migration phase
-  // (https://github.com/sirius-db/sirius/issues/699) replaces this with native
-  // AST traversal one specialization at a time.
-  return count_ast_ops(*sirius::ast::to_duckdb(expr));
+  return std::visit(
+    [this](auto const& alt) -> std::size_t {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
+                    std::is_same_v<T, sirius::ast::constant>) {
+        // Leaves — match BOUND_REF / BOUND_CONSTANT cases in the DuckDB-typed
+        // count_ast_ops, both of which return 0.
+        return 0;
+      } else if constexpr (std::is_same_v<T, sirius::ast::comparison>) {
+        return 1 + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
+      } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
+        // Number of AND/OR ops is one less than number of children.
+        std::size_t count = alt.children.size() - 1;
+        for (auto const& c : alt.children) {
+          count += count_ast_ops(*c);
+        }
+        return count;
+      } else if constexpr (std::is_same_v<T, sirius::ast::between>) {
+        // 2 comparison ops + 1 AND op + ops in the children.
+        return 3 + count_ast_ops(*alt.input) + count_ast_ops(*alt.lower) +
+               count_ast_ops(*alt.upper);
+      } else if constexpr (std::is_same_v<T, sirius::ast::case_expr>) {
+        // CASE has no AST support; matches the BOUND_CASE arm.
+        return 0;
+      } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
+        // CAST contributes 1 + child ops only if the target type is in the
+        // AST allowlist (UBIGINT / BIGINT / DOUBLE); otherwise 0.
+        bool const supported = alt.target_type.id() == sirius::type_id::UBIGINT ||
+                               alt.target_type.id() == sirius::type_id::BIGINT ||
+                               alt.target_type.id() == sirius::type_id::DOUBLE;
+        return supported ? 1 + count_ast_ops(*alt.child) : 0;
+      } else if constexpr (std::is_same_v<T, sirius::ast::unary_op>) {
+        switch (alt.op) {
+          case sirius::ast::unary_op::kind::op_not: return 1 + count_ast_ops(*alt.child);
+          case sirius::ast::unary_op::kind::op_is_null: return 1 + count_ast_ops(*alt.child);
+          case sirius::ast::unary_op::kind::op_is_not_null: return 2 + count_ast_ops(*alt.child);
+          case sirius::ast::unary_op::kind::op_try:
+            throw duckdb::NotImplementedException(
+              "[gpu_expression_executor] count_ast_ops called on an unsupported TRY operator "
+              "expression.");
+          default:
+            throw internal_exception(
+              "[gpu_expression_executor] count_ast_ops called on an operator expression with "
+              "unknown/unsupported unary_op kind: {}",
+              static_cast<int>(alt.op));
+        }
+      } else if constexpr (std::is_same_v<T, sirius::ast::coalesce>) {
+        // COALESCE has no AST support.
+        return 0;
+      } else if constexpr (std::is_same_v<T, sirius::ast::in_list>) {
+        // children = [probe] + values; with N = values.size():
+        //   num_or = N - 1 ; num_eq = N ; +1 if negated.
+        auto const num_or = alt.values.size() - 1;
+        auto const num_eq = alt.values.size();
+        std::size_t count = num_or + num_eq + (alt.negated ? 1U : 0U);
+        count += count_ast_ops(*alt.probe);
+        for (auto const& v : alt.values) {
+          count += count_ast_ops(*v);
+        }
+        return count;
+      } else if constexpr (std::is_same_v<T, sirius::ast::function_call>) {
+        // DECIMAL output -> 0 (cuDF AST chokes on intermediate decimal results).
+        if (alt.return_type().id() == sirius::type_id::DECIMAL) { return 0; }
+        // Supported AST function -> 1 + sum of arg counts; otherwise 0.
+        bool const supported = std::find(supported_ast_functions.begin(),
+                                         supported_ast_functions.end(),
+                                         alt.function()) != supported_ast_functions.end();
+        if (!supported) { return 0; }
+        std::size_t count = 1;
+        for (auto const& a : alt.arguments()) {
+          count += count_ast_ops(*a);
+        }
+        return count;
+      } else {
+        static_assert(sizeof(T) == 0, "Unhandled sirius::ast alternative in count_ast_ops");
+      }
+    },
+    expr.v);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
 {
   // Round-trip shim — the per-specialization migration phase

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -540,95 +540,9 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
 
 std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
 {
-  return std::visit(
-    [this](auto const& alt) -> std::size_t {
-      using T = std::decay_t<decltype(alt)>;
-      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
-                    std::is_same_v<T, sirius::ast::constant>) {
-        // Leaves — match BOUND_REF / BOUND_CONSTANT cases in the DuckDB-typed
-        // count_ast_ops, both of which return 0.
-        return 0;
-      } else if constexpr (std::is_same_v<T, sirius::ast::comparison>) {
-        // DISTINCT_FROM lowers to NOT(NULL_EQUAL(...)) — two AST ops, not one.
-        // NOT_DISTINCT_FROM is a single NULL_EQUAL and stays at one.
-        std::size_t const self = (alt.op == sirius::comparison_type::distinct_from) ? 2U : 1U;
-        return self + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
-      } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
-        if (alt.children.empty()) {
-          throw invalid_input_exception(
-            "[gpu_expression_executor:count_ast_ops] conjunction has no children — malformed AST.");
-        }
-        // Number of AND/OR ops is one less than number of children.
-        std::size_t count = alt.children.size() - 1;
-        for (auto const& c : alt.children) {
-          count += count_ast_ops(*c);
-        }
-        return count;
-      } else if constexpr (std::is_same_v<T, sirius::ast::between>) {
-        // 2 comparison ops + 1 AND op + ops in the children.
-        return 3 + count_ast_ops(*alt.input) + count_ast_ops(*alt.lower) +
-               count_ast_ops(*alt.upper);
-      } else if constexpr (std::is_same_v<T, sirius::ast::case_expr>) {
-        // CASE has no AST support; matches the BOUND_CASE arm.
-        return 0;
-      } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
-        // CAST contributes 1 + child ops only if the target type is in the
-        // AST allowlist (UBIGINT / BIGINT / DOUBLE); otherwise 0.
-        bool const supported = alt.target_type.id() == sirius::type_id::UBIGINT ||
-                               alt.target_type.id() == sirius::type_id::BIGINT ||
-                               alt.target_type.id() == sirius::type_id::DOUBLE;
-        return supported ? 1 + count_ast_ops(*alt.child) : 0;
-      } else if constexpr (std::is_same_v<T, sirius::ast::unary_op>) {
-        switch (alt.op) {
-          case sirius::ast::unary_op::kind::op_not: return 1 + count_ast_ops(*alt.child);
-          case sirius::ast::unary_op::kind::op_is_null: return 1 + count_ast_ops(*alt.child);
-          case sirius::ast::unary_op::kind::op_is_not_null: return 2 + count_ast_ops(*alt.child);
-          case sirius::ast::unary_op::kind::op_try:
-            throw not_implemented_exception(
-              "[gpu_expression_executor] count_ast_ops called on an unsupported TRY operator "
-              "expression.");
-          default:
-            throw internal_exception(
-              "[gpu_expression_executor] count_ast_ops called on an operator expression with "
-              "unknown/unsupported unary_op kind: {}",
-              static_cast<int>(alt.op));
-        }
-      } else if constexpr (std::is_same_v<T, sirius::ast::coalesce>) {
-        // COALESCE has no AST support.
-        return 0;
-      } else if constexpr (std::is_same_v<T, sirius::ast::in_list>) {
-        if (alt.values.empty()) {
-          throw invalid_input_exception(
-            "[gpu_expression_executor:count_ast_ops] in_list has no values — malformed AST.");
-        }
-        // children = [probe] + values; with N = values.size():
-        //   num_or = N - 1 ; num_eq = N ; +1 if negated.
-        auto const num_or = alt.values.size() - 1;
-        auto const num_eq = alt.values.size();
-        std::size_t count = num_or + num_eq + (alt.negated ? 1U : 0U);
-        count += count_ast_ops(*alt.probe);
-        for (auto const& v : alt.values) {
-          count += count_ast_ops(*v);
-        }
-        return count;
-      } else if constexpr (std::is_same_v<T, sirius::ast::function_call>) {
-        // DECIMAL output -> 0 (cuDF AST chokes on intermediate decimal results).
-        if (alt.return_type().id() == sirius::type_id::DECIMAL) { return 0; }
-        // Supported AST function -> 1 + sum of arg counts; otherwise 0.
-        bool const supported = std::find(supported_ast_functions.begin(),
-                                         supported_ast_functions.end(),
-                                         alt.function()) != supported_ast_functions.end();
-        if (!supported) { return 0; }
-        std::size_t count = 1;
-        for (auto const& a : alt.arguments()) {
-          count += count_ast_ops(*a);
-        }
-        return count;
-      } else {
-        static_assert(sizeof(T) == 0, "Unhandled sirius::ast alternative in count_ast_ops");
-      }
-    },
-    expr.v);
+  // Delegates to the single-source-of-truth implementation living next to the
+  // AST struct definitions; see src/expression_executor/ast_op_counter.cpp.
+  return expr.cudf_ast_op_count();
 }
 
 }  // namespace sirius

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::comparison const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -585,7 +585,7 @@ std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr
           case sirius::ast::unary_op::kind::op_is_null: return 1 + count_ast_ops(*alt.child);
           case sirius::ast::unary_op::kind::op_is_not_null: return 2 + count_ast_ops(*alt.child);
           case sirius::ast::unary_op::kind::op_try:
-            throw duckdb::NotImplementedException(
+            throw not_implemented_exception(
               "[gpu_expression_executor] count_ast_ops called on an unsupported TRY operator "
               "expression.");
           default:

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -526,12 +526,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& al
   return execute(*duck_expr, mode);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::function_call const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -530,7 +530,11 @@ std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr
         // count_ast_ops, both of which return 0.
         return 0;
       } else if constexpr (std::is_same_v<T, sirius::ast::comparison>) {
-        return 1 + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
+        // DISTINCT_FROM lowers to NOT(NULL_EQUAL(...)) — two AST ops, not one.
+        // NOT_DISTINCT_FROM is a single NULL_EQUAL and stays at one.
+        std::size_t const self =
+          (alt.op == sirius::comparison_type::distinct_from) ? 2U : 1U;
+        return self + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
       } else if constexpr (std::is_same_v<T, sirius::ast::conjunction>) {
         // Number of AND/OR ops is one less than number of children.
         std::size_t count = alt.children.size() - 1;

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -519,13 +519,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
     [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
-execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt,
-                                                execution_mode mode)
-{
-  auto duck_expr = sirius::ast::to_duckdb(alt);
-  return execute(*duck_expr, mode);
-}
-
 execute_result gpu_expression_executor::execute(sirius::ast::comparison const& alt,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_between.cpp
+++ b/src/expression_executor/specializations/gpu_execute_between.cpp
@@ -15,6 +15,8 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 
 // duckdb
@@ -28,37 +30,30 @@
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression const& expr,
+execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
                                                 execution_mode mode)
 {
-  if (_strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    auto comparison_type_switch_ast = [](duckdb::BoundBetweenExpression const& expr)
-      -> std::pair<cudf::ast::ast_operator, cudf::ast::ast_operator> {
-      cudf::ast::ast_operator lower_op;
-      cudf::ast::ast_operator upper_op;
-      if (expr.lower_inclusive) {
-        lower_op = cudf::ast::ast_operator::GREATER_EQUAL;
-      } else {
-        lower_op = cudf::ast::ast_operator::GREATER;
-      }
-      if (expr.upper_inclusive) {
-        upper_op = cudf::ast::ast_operator::LESS_EQUAL;
-      } else {
-        upper_op = cudf::ast::ast_operator::LESS;
-      }
-      return {lower_op, upper_op};
-    };
+  // Match the DuckDB-typed count_ast_ops contract for between:
+  // 2 comparison ops + 1 AND op + ops in input/lower/upper.
+  auto const ast_op_count =
+    3 + count_ast_ops(*alt.input) + count_ast_ops(*alt.lower) + count_ast_ops(*alt.upper);
 
-    auto input = execute(*expr.input, execution_mode::AST);
+  if (_strategy != expression_executor_strategy::MATERIALIZE &&
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    auto const lower_ast_op = alt.lower_inclusive ? cudf::ast::ast_operator::GREATER_EQUAL
+                                                  : cudf::ast::ast_operator::GREATER;
+    auto const upper_ast_op =
+      alt.upper_inclusive ? cudf::ast::ast_operator::LESS_EQUAL : cudf::ast::ast_operator::LESS;
+
+    auto input = execute(*alt.input, execution_mode::AST);
     D_ASSERT(!input.is_scalar());
-    auto lower                = execute(*expr.lower, execution_mode::AST);
-    auto upper                = execute(*expr.upper, execution_mode::AST);
-    auto [lower_op, upper_op] = comparison_type_switch_ast(expr);
+    auto lower = execute(*alt.lower, execution_mode::AST);
+    auto upper = execute(*alt.upper, execution_mode::AST);
+
     auto const& lower_expr =
-      _ast_tree.emplace<cudf::ast::operation>(lower_op, input.get_expr(), lower.get_expr());
+      _ast_tree.emplace<cudf::ast::operation>(lower_ast_op, input.get_expr(), lower.get_expr());
     auto const& upper_expr =
-      _ast_tree.emplace<cudf::ast::operation>(upper_op, input.get_expr(), upper.get_expr());
+      _ast_tree.emplace<cudf::ast::operation>(upper_ast_op, input.get_expr(), upper.get_expr());
     auto const& between_expr = _ast_tree.emplace<cudf::ast::operation>(
       cudf::ast::ast_operator::LOGICAL_AND, lower_expr, upper_expr);
 
@@ -74,7 +69,6 @@ execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression c
     }
 
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
-    // Evaluate the AST subtree
     auto result_column = execute_ast(between_expr);
     release_temporaries({input.get_temp_scalar_indices(),
                          lower.get_temp_scalar_indices(),
@@ -86,44 +80,32 @@ execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression c
   }
 
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
-  auto comparison_type_switch = [](duckdb::BoundBetweenExpression const& expr)
-    -> std::pair<cudf::binary_operator, cudf::binary_operator> {
-    cudf::binary_operator lower_op;
-    cudf::binary_operator upper_op;
-    if (expr.lower_inclusive) {
-      lower_op = cudf::binary_operator::GREATER_EQUAL;
-    } else {
-      lower_op = cudf::binary_operator::GREATER;
-    }
-    if (expr.upper_inclusive) {
-      upper_op = cudf::binary_operator::LESS_EQUAL;
-    } else {
-      upper_op = cudf::binary_operator::LESS;
-    }
-    return {lower_op, upper_op};
-  };
+  auto const lower_bin_op =
+    alt.lower_inclusive ? cudf::binary_operator::GREATER_EQUAL : cudf::binary_operator::GREATER;
+  auto const upper_bin_op =
+    alt.upper_inclusive ? cudf::binary_operator::LESS_EQUAL : cudf::binary_operator::LESS;
 
-  auto input                = execute(*expr.input, execution_mode::MATERIALIZE);
-  auto lower                = execute(*expr.lower, execution_mode::MATERIALIZE);
-  auto upper                = execute(*expr.upper, execution_mode::MATERIALIZE);
-  auto [lower_op, upper_op] = comparison_type_switch(expr);
-  auto const output_type    = GetCudfType(expr.return_type);
+  auto input = execute(*alt.input, execution_mode::MATERIALIZE);
+  auto lower = execute(*alt.lower, execution_mode::MATERIALIZE);
+  auto upper = execute(*alt.upper, execution_mode::MATERIALIZE);
+  // BETWEEN always returns BOOLEAN.
+  auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
 
   std::unique_ptr<cudf::column> lower_cmp;
   std::unique_ptr<cudf::column> upper_cmp;
   if (lower.is_scalar()) {
     lower_cmp = cudf::binary_operation(
-      input.get_column_view(), lower.get_scalar(), lower_op, output_type, _stream, _mr);
+      input.get_column_view(), lower.get_scalar(), lower_bin_op, output_type, _stream, _mr);
   } else {
     lower_cmp = cudf::binary_operation(
-      input.get_column_view(), lower.get_column_view(), lower_op, output_type, _stream, _mr);
+      input.get_column_view(), lower.get_column_view(), lower_bin_op, output_type, _stream, _mr);
   }
   if (upper.is_scalar()) {
     upper_cmp = cudf::binary_operation(
-      input.get_column_view(), upper.get_scalar(), upper_op, output_type, _stream, _mr);
+      input.get_column_view(), upper.get_scalar(), upper_bin_op, output_type, _stream, _mr);
   } else {
     upper_cmp = cudf::binary_operation(
-      input.get_column_view(), upper.get_column_view(), upper_op, output_type, _stream, _mr);
+      input.get_column_view(), upper.get_column_view(), upper_bin_op, output_type, _stream, _mr);
   }
   auto result_column = cudf::binary_operation(lower_cmp->view(),
                                               upper_cmp->view(),
@@ -132,6 +114,13 @@ execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression c
                                               _stream,
                                               _mr);
   return execute_result(std::move(result_column));
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_between.cpp
+++ b/src/expression_executor/specializations/gpu_execute_between.cpp
@@ -34,10 +34,7 @@ using execute_result = gpu_expression_executor::execute_result;
 execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
                                                 execution_mode mode)
 {
-  // Match the DuckDB-typed count_ast_ops contract for between:
-  // 2 comparison ops + 1 AND op + ops in input/lower/upper.
-  auto const ast_op_count =
-    3 + count_ast_ops(*alt.input) + count_ast_ops(*alt.lower) + count_ast_ops(*alt.upper);
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -117,6 +114,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
   return execute_result(std::move(result_column));
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_between.cpp
+++ b/src/expression_executor/specializations/gpu_execute_between.cpp
@@ -18,6 +18,7 @@
 #include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/planner/expression/bound_between_expression.hpp>
@@ -120,6 +121,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression c
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:between] BoundBetweenExpression could not be lowered to a "
+      "Sirius AST node (an embedded subexpression is unsupported).");
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_case.cpp
+++ b/src/expression_executor/specializations/gpu_execute_case.cpp
@@ -130,6 +130,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression cons
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:case] BoundCaseExpression could not be lowered to a Sirius AST "
+      "node (a WHEN, THEN, or ELSE subexpression is unsupported).");
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_case.cpp
+++ b/src/expression_executor/specializations/gpu_execute_case.cpp
@@ -30,6 +30,9 @@
 #include <cudf/cudf_utils.hpp>
 #include <cudf/reduction.hpp>
 
+// standard library
+#include <ranges>
+
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
@@ -45,13 +48,12 @@ execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& al
   // First, execute the ELSE
   auto current_result = execute(*alt.else_, execution_mode::MATERIALIZE);
 
-  // Loop backwards, so that the THEN of the first true WHEN is copied to the output column
-  auto const num_checks = static_cast<int32_t>(alt.cases.size());
-  D_ASSERT(num_checks > 0);
+  // Iterate in reverse so the THEN of the first true WHEN is copied to the
+  // output column last (overwrites any later match). SQL CASE semantics:
+  // first matching WHEN wins.
+  D_ASSERT(!alt.cases.empty());
 
-  for (int32_t i = num_checks - 1; i >= 0; --i) {
-    auto const& case_check = alt.cases[i];
-
+  for (auto const& case_check : std::views::reverse(alt.cases)) {
     // Execute the WHEN expression to get a boolean array intermediate.
     auto current_mask = execute(*case_check.when_, execution_mode::MATERIALIZE);
 
@@ -126,6 +128,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& al
   return current_result;
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_case.cpp
+++ b/src/expression_executor/specializations/gpu_execute_case.cpp
@@ -15,13 +15,14 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/function_id.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
-#include <duckdb/common/exception.hpp>
 #include <duckdb/planner/expression/bound_case_expression.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
 
 // cudf
 #include <cudf/ast/expressions.hpp>
@@ -29,12 +30,10 @@
 #include <cudf/cudf_utils.hpp>
 #include <cudf/reduction.hpp>
 
-// We need to handle implicit error checks inserted as CASE statements by DuckDB
-#define ERROR_FUNC_STR "error"
-
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
-execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression const& expr,
+
+execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& alt,
                                                 execution_mode mode)
 {
   //===----------MATERIALIZE (AST breaker)----------===//
@@ -44,24 +43,23 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression cons
   std::unique_ptr<cudf::column> output;
 
   // First, execute the ELSE
-  auto current_result = execute(*expr.else_expr, execution_mode::MATERIALIZE);
+  auto current_result = execute(*alt.else_, execution_mode::MATERIALIZE);
 
   // Loop backwards, so that the THEN of the first true WHEN is copied to the output column
-  auto const num_checks = static_cast<int32_t>(
-    expr.case_checks.size());  // This is sane, and needed for the descending loop index
+  auto const num_checks = static_cast<int32_t>(alt.cases.size());
   D_ASSERT(num_checks > 0);
 
   for (int32_t i = num_checks - 1; i >= 0; --i) {
-    auto& case_check = expr.case_checks[i];
+    auto const& case_check = alt.cases[i];
 
-    // Fist, execute the WHEN expression to get boolean array intermediate
-    auto current_mask = execute(*case_check.when_expr, execution_mode::MATERIALIZE);
+    // Execute the WHEN expression to get a boolean array intermediate.
+    auto current_mask = execute(*case_check.when_, execution_mode::MATERIALIZE);
 
-    // Check for error functions
-    if (case_check.then_expr->GetExpressionClass() == duckdb::ExpressionClass::BOUND_FUNCTION &&
-        case_check.then_expr->Cast<duckdb::BoundFunctionExpression>().function.name ==
-          ERROR_FUNC_STR) {
-      // If the THEN is true anywhere, throw error()
+    // Check for the implicit error() function that DuckDB inserts as a CASE THEN.
+    if (case_check.then_->holds<sirius::ast::function_call>() &&
+        case_check.then_->get<sirius::ast::function_call>().function() ==
+          sirius::function_id::error) {
+      // If the THEN is true anywhere, raise the error eagerly.
       bool throw_error = false;
       if (current_mask.is_scalar()) {
         auto const& bool_scalar =
@@ -76,7 +74,6 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression cons
         throw_error     = static_cast<cudf::scalar_type_t<bool>*>(any_result.get())->value(_stream);
       }
       if (throw_error) {
-        // Assume that this arises for the stated error
         throw internal_exception(
           "[gpu_expression_executor:case]: More than one row returned by a subquery used as an "
           "expression.");
@@ -84,8 +81,8 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression cons
       continue;
     }
 
-    // Otherwise, execute the THEN and selectively copy to the output
-    auto current_then = execute(*case_check.then_expr, execution_mode::MATERIALIZE);
+    // Otherwise, execute the THEN and selectively copy to the output.
+    auto current_then = execute(*case_check.then_, execution_mode::MATERIALIZE);
     if (current_result.is_scalar()) {
       // This can only possibly happen when i = num_checks - 1
       if (current_then.is_scalar()) {
@@ -128,4 +125,12 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression cons
   }
   return current_result;
 }
+
+execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
+}
+
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_cast.cpp
+++ b/src/expression_executor/specializations/gpu_execute_cast.cpp
@@ -17,6 +17,7 @@
 // sirius
 #include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
+#include <expression_executor/ast_supported_types.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <helper/logical_type.hpp>
 #include <sirius/exception.hpp>
@@ -30,18 +31,11 @@
 
 // standard library
 #include <algorithm>
-#include <array>
 
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
 namespace {
-
-// Sirius-typed allowlist mirroring supported_ast_cast_types in
-// expression_executor/ast_supported_types.hpp. CAST target types currently
-// safe to lower into a cuDF AST.
-constexpr std::array<sirius::type_id, 3> supported_ast_cast_types_native{
-  sirius::type_id::UBIGINT, sirius::type_id::BIGINT, sirius::type_id::DOUBLE};
 
 cudf::ast::ast_operator cast_op_to_ast(sirius::type_id id)
 {
@@ -51,8 +45,8 @@ cudf::ast::ast_operator cast_op_to_ast(sirius::type_id id)
     case sirius::type_id::DOUBLE: return cudf::ast::ast_operator::CAST_TO_FLOAT64;
     default:
       throw invalid_input_exception(
-        "[gpu_expression_executor] execute called on a CAST expression with unsupported return "
-        "type for AST execution: id={}",
+        "[cast_op_to_ast] unsupported CAST target type id={}; cuDF AST supports "
+        "UBIGINT, BIGINT, DOUBLE.",
         static_cast<int>(id));
   }
 }
@@ -66,9 +60,7 @@ execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, ex
               supported_ast_cast_types_native.end(),
               alt.target_type.id()) != supported_ast_cast_types_native.end();
 
-  // Match DuckDB-typed count_ast_ops contract for cast:
-  //   supported allowlist -> 1 + child ; unsupported -> 0.
-  auto const ast_op_count = ast_supported ? 1 + count_ast_ops(*alt.child) : 0;
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (ast_supported && _strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -100,6 +92,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, ex
   return execute_result(std::move(result_column));
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_cast.cpp
+++ b/src/expression_executor/specializations/gpu_execute_cast.cpp
@@ -15,8 +15,10 @@
  */
 
 // sirius
-#include <expression_executor/ast_supported_types.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/logical_type.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
@@ -26,35 +28,53 @@
 #include <cudf/cudf_utils.hpp>
 #include <cudf/unary.hpp>
 
+// standard library
+#include <algorithm>
+#include <array>
+
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression const& expr,
-                                                execution_mode mode)
+namespace {
+
+// Sirius-typed allowlist mirroring supported_ast_cast_types in
+// expression_executor/ast_supported_types.hpp. CAST target types currently
+// safe to lower into a cuDF AST.
+constexpr std::array<sirius::type_id, 3> supported_ast_cast_types_native{
+  sirius::type_id::UBIGINT, sirius::type_id::BIGINT, sirius::type_id::DOUBLE};
+
+cudf::ast::ast_operator cast_op_to_ast(sirius::type_id id)
 {
-  auto const ast_supported = std::find(supported_ast_cast_types.begin(),
-                                       supported_ast_cast_types.end(),
-                                       expr.return_type.id()) != supported_ast_cast_types.end();
+  switch (id) {
+    case sirius::type_id::UBIGINT: return cudf::ast::ast_operator::CAST_TO_UINT64;
+    case sirius::type_id::BIGINT: return cudf::ast::ast_operator::CAST_TO_INT64;
+    case sirius::type_id::DOUBLE: return cudf::ast::ast_operator::CAST_TO_FLOAT64;
+    default:
+      throw invalid_input_exception(
+        "[gpu_expression_executor] execute called on a CAST expression with unsupported return "
+        "type for AST execution: id={}",
+        static_cast<int>(id));
+  }
+}
+
+}  // namespace
+
+execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, execution_mode mode)
+{
+  auto const ast_supported =
+    std::find(supported_ast_cast_types_native.begin(),
+              supported_ast_cast_types_native.end(),
+              alt.target_type.id()) != supported_ast_cast_types_native.end();
+
+  // Match DuckDB-typed count_ast_ops contract for cast:
+  //   supported allowlist -> 1 + child ; unsupported -> 0.
+  auto const ast_op_count = ast_supported ? 1 + count_ast_ops(*alt.child) : 0;
 
   if (ast_supported && _strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    auto cast_type_switch = [](duckdb::LogicalTypeId type_id) -> cudf::ast::ast_operator {
-      using enum duckdb::LogicalTypeId;
-      switch (type_id) {
-        case UBIGINT: return cudf::ast::ast_operator::CAST_TO_UINT64;
-        case BIGINT: return cudf::ast::ast_operator::CAST_TO_INT64;
-        case DOUBLE: return cudf::ast::ast_operator::CAST_TO_FLOAT64;
-        default:
-          throw invalid_input_exception(
-            "[gpu_expression_executor] execute called on a CAST expression with unsupported return "
-            "type for AST execution: {}",
-            duckdb::LogicalTypeIdToString(type_id));
-      }
-    };
-
-    auto child            = execute(*expr.child, execution_mode::AST);
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    auto child            = execute(*alt.child, execution_mode::AST);
     auto const& cast_expr = _ast_tree.emplace<cudf::ast::operation>(
-      cast_type_switch(expr.return_type.id()), child.get_expr());
+      cast_op_to_ast(alt.target_type.id()), child.get_expr());
 
     if (mode == execution_mode::AST) {
       //===----------1: AST Mode----------===//
@@ -62,17 +82,15 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression cons
         ast_result(cast_expr, child.get_temp_scalar_indices(), child.get_temp_column_indices()));
     }
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
-    // Evaluate the AST subtree
     auto result_column = execute_ast(cast_expr);
 
-    // Release consumed temporaries
     release_temporaries(child.get_temp_scalar_indices(), child.get_temp_column_indices());
     return execute_result(std::move(result_column));
   }
 
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
-  auto const return_type = GetCudfType(expr.return_type);
-  auto child             = execute(*expr.child, execution_mode::MATERIALIZE);
+  auto const return_type = sirius::get_cudf_type(alt.target_type);
+  auto child             = execute(*alt.child, execution_mode::MATERIALIZE);
   D_ASSERT(!child.is_scalar());  // CAST should never be called on a scalar
   auto result_column = cudf::cast(child.get_column_view(), return_type, _stream, _mr);
   if (mode == execution_mode::AST) {
@@ -80,6 +98,13 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression cons
     return materialize_as_ast_column(std::move(result_column));
   }
   return execute_result(std::move(result_column));
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_cast.cpp
+++ b/src/expression_executor/specializations/gpu_execute_cast.cpp
@@ -104,6 +104,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression cons
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:cast] BoundCastExpression could not be lowered to a Sirius AST "
+      "node (the cast child is unsupported).");
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -79,7 +79,7 @@ cudf::binary_operator comparison_op_to_binary(sirius::comparison_type op)
 execute_result gpu_expression_executor::execute(sirius::ast::comparison const& alt,
                                                 execution_mode mode)
 {
-  auto const ast_op_count = 1 + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
+  auto const ast_op_count = alt.cudf_ast_op_count();
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
     auto left             = execute(*alt.left, execution_mode::AST);
@@ -134,6 +134,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::comparison const& a
   return execute_result(std::move(result_column));
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -15,15 +15,15 @@
  */
 
 // sirius
-#include <duckdb/common/enums/expression_type.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/join_condition.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/exception.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf
 #include <cudf/ast/ast_operator.hpp>
@@ -38,37 +38,57 @@
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpression const& expr,
+namespace {
+
+cudf::ast::ast_operator comparison_op_to_ast(sirius::comparison_type op)
+{
+  switch (op) {
+    case sirius::comparison_type::equal: return cudf::ast::ast_operator::EQUAL;
+    case sirius::comparison_type::gt: return cudf::ast::ast_operator::GREATER;
+    case sirius::comparison_type::ge: return cudf::ast::ast_operator::GREATER_EQUAL;
+    case sirius::comparison_type::lt: return cudf::ast::ast_operator::LESS;
+    case sirius::comparison_type::le: return cudf::ast::ast_operator::LESS_EQUAL;
+    case sirius::comparison_type::not_equal: return cudf::ast::ast_operator::NOT_EQUAL;
+    case sirius::comparison_type::distinct_from:  // fallthrough — wrapped in NOT below
+    case sirius::comparison_type::not_distinct_from: return cudf::ast::ast_operator::NULL_EQUAL;
+    default:
+      throw invalid_input_exception(
+        "[expression_executor:comparison] Unrecognized comparison type : {}", static_cast<int>(op));
+  }
+}
+
+cudf::binary_operator comparison_op_to_binary(sirius::comparison_type op)
+{
+  switch (op) {
+    case sirius::comparison_type::equal: return cudf::binary_operator::EQUAL;
+    case sirius::comparison_type::gt: return cudf::binary_operator::GREATER;
+    case sirius::comparison_type::ge: return cudf::binary_operator::GREATER_EQUAL;
+    case sirius::comparison_type::lt: return cudf::binary_operator::LESS;
+    case sirius::comparison_type::le: return cudf::binary_operator::LESS_EQUAL;
+    case sirius::comparison_type::not_equal: return cudf::binary_operator::NOT_EQUAL;
+    case sirius::comparison_type::distinct_from: return cudf::binary_operator::NULL_NOT_EQUALS;
+    case sirius::comparison_type::not_distinct_from: return cudf::binary_operator::NULL_EQUALS;
+    default:
+      throw invalid_input_exception(
+        "[expression_executor:comparison] Unrecognized comparison type : {}", static_cast<int>(op));
+  }
+}
+
+}  // namespace
+
+execute_result gpu_expression_executor::execute(sirius::ast::comparison const& alt,
                                                 execution_mode mode)
 {
+  auto const ast_op_count = 1 + count_ast_ops(*alt.left) + count_ast_ops(*alt.right);
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    auto comparison_type_switch_ast =
-      [](duckdb::BoundComparisonExpression const& expr) -> cudf::ast::ast_operator {
-      using enum duckdb::ExpressionType;
-      switch (expr.GetExpressionType()) {
-        case COMPARE_EQUAL: return cudf::ast::ast_operator::EQUAL;
-        case COMPARE_GREATERTHAN: return cudf::ast::ast_operator::GREATER;
-        case COMPARE_GREATERTHANOREQUALTO: return cudf::ast::ast_operator::GREATER_EQUAL;
-        case COMPARE_LESSTHAN: return cudf::ast::ast_operator::LESS;
-        case COMPARE_LESSTHANOREQUALTO: return cudf::ast::ast_operator::LESS_EQUAL;
-        case COMPARE_NOTEQUAL: return cudf::ast::ast_operator::NOT_EQUAL;
-        case COMPARE_DISTINCT_FROM:  // Fallthrough: special handling below
-        case COMPARE_NOT_DISTINCT_FROM: return cudf::ast::ast_operator::NULL_EQUAL;
-        default:
-          throw invalid_input_exception(
-            "[expression_executor:comparison] Unrecognized comparison type : {}",
-            static_cast<int>(expr.GetExpressionType()));
-      }
-    };
-
-    auto left             = execute(*expr.left, execution_mode::AST);
-    auto right            = execute(*expr.right, execution_mode::AST);
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    auto left             = execute(*alt.left, execution_mode::AST);
+    auto right            = execute(*alt.right, execution_mode::AST);
     auto const& comp_expr = _ast_tree.emplace<cudf::ast::operation>(
-      comparison_type_switch_ast(expr), left.get_expr(), right.get_expr());
-    // COMPARE_DISTINCT_FROM is semantically equivalent to NOT(NULL_EQUAL())
+      comparison_op_to_ast(alt.op), left.get_expr(), right.get_expr());
+    // DISTINCT_FROM is semantically equivalent to NOT(NULL_EQUAL())
     auto const& final_comp_expr =
-      expr.GetExpressionType() == duckdb::ExpressionType::COMPARE_DISTINCT_FROM
+      alt.op == sirius::comparison_type::distinct_from
         ? _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, comp_expr)
         : comp_expr;
 
@@ -81,10 +101,8 @@ execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpressio
     }
 
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
-    // Evaluate the AST subtree
     auto result_column = execute_ast(final_comp_expr);
 
-    // Release consumed temporaries
     release_temporaries({left.get_temp_scalar_indices(), right.get_temp_scalar_indices()},
                         {left.get_temp_column_indices(), right.get_temp_column_indices()});
     return execute_result(std::move(result_column));
@@ -92,55 +110,34 @@ execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpressio
 
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
   if (mode == execution_mode::AST) {
-    auto result = execute(expr, execution_mode::MATERIALIZE);
+    auto result = execute(alt, execution_mode::MATERIALIZE);
     return materialize_as_ast_column(result.release_column());
   }
-  auto comparison_type_switch =
-    [](duckdb::BoundComparisonExpression const& expr) -> cudf::binary_operator {
-    using enum duckdb::ExpressionType;
-    switch (expr.GetExpressionType()) {
-      case COMPARE_EQUAL: return cudf::binary_operator::EQUAL;
-      case COMPARE_GREATERTHAN: return cudf::binary_operator::GREATER;
-      case COMPARE_GREATERTHANOREQUALTO: return cudf::binary_operator::GREATER_EQUAL;
-      case COMPARE_LESSTHAN: return cudf::binary_operator::LESS;
-      case COMPARE_LESSTHANOREQUALTO: return cudf::binary_operator::LESS_EQUAL;
-      case COMPARE_NOTEQUAL: return cudf::binary_operator::NOT_EQUAL;
-      case COMPARE_DISTINCT_FROM: return cudf::binary_operator::NULL_NOT_EQUALS;
-      case COMPARE_NOT_DISTINCT_FROM: return cudf::binary_operator::NULL_EQUALS;
-      default:
-        throw invalid_input_exception(
-          "[expression_executor:comparison] Unrecognized comparison type : {}",
-          static_cast<int>(expr.GetExpressionType()));
-    }
-  };
 
-  auto left              = execute(*expr.left, execution_mode::MATERIALIZE);
-  auto right             = execute(*expr.right, execution_mode::MATERIALIZE);
-  auto const output_type = GetCudfType(expr.return_type);
+  auto left  = execute(*alt.left, execution_mode::MATERIALIZE);
+  auto right = execute(*alt.right, execution_mode::MATERIALIZE);
+  // Comparison ops always return BOOLEAN — no logical_type on the AST node, so use BOOL8 directly.
+  auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
+  auto const binary_op   = comparison_op_to_binary(alt.op);
 
   std::unique_ptr<cudf::column> result_column;
   if (left.is_scalar()) {
-    result_column = cudf::binary_operation(left.get_scalar(),
-                                           right.get_column_view(),
-                                           comparison_type_switch(expr),
-                                           output_type,
-                                           _stream,
-                                           _mr);
+    result_column = cudf::binary_operation(
+      left.get_scalar(), right.get_column_view(), binary_op, output_type, _stream, _mr);
   } else if (right.is_scalar()) {
-    result_column = cudf::binary_operation(left.get_column_view(),
-                                           right.get_scalar(),
-                                           comparison_type_switch(expr),
-                                           output_type,
-                                           _stream,
-                                           _mr);
+    result_column = cudf::binary_operation(
+      left.get_column_view(), right.get_scalar(), binary_op, output_type, _stream, _mr);
   } else {
-    result_column = cudf::binary_operation(left.get_column_view(),
-                                           right.get_column_view(),
-                                           comparison_type_switch(expr),
-                                           output_type,
-                                           _stream,
-                                           _mr);
+    result_column = cudf::binary_operation(
+      left.get_column_view(), right.get_column_view(), binary_op, output_type, _stream, _mr);
   }
   return execute_result(std::move(result_column));
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -138,6 +138,12 @@ execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpressio
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:comparison] BoundComparisonExpression with comparison type {} "
+      "could not be lowered to a Sirius AST node.",
+      static_cast<int>(expr.GetExpressionType()));
+  }
   return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -62,6 +62,10 @@ cudf::binary_operator conjunction_op_to_binary(sirius::ast::conjunction::kind op
 execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& alt,
                                                 execution_mode mode)
 {
+  if (alt.children.empty()) {
+    throw invalid_input_exception(
+      "[gpu_expression_executor:conjunction] conjunction has no children — malformed AST.");
+  }
   // Match the DuckDB-typed count_ast_ops contract for conjunction:
   // (num_children - 1) AND/OR ops + ops in every child.
   std::size_t ast_op_count = alt.children.size() - 1;

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -15,12 +15,13 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/exception.hpp>
-#include <duckdb/common/typedefs.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 
 // cudf
@@ -30,31 +31,54 @@
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpression const& expr,
+namespace {
+
+cudf::ast::ast_operator conjunction_op_to_ast(sirius::ast::conjunction::kind op)
+{
+  switch (op) {
+    case sirius::ast::conjunction::kind::op_and: return cudf::ast::ast_operator::LOGICAL_AND;
+    case sirius::ast::conjunction::kind::op_or: return cudf::ast::ast_operator::LOGICAL_OR;
+    default:
+      throw invalid_input_exception(
+        "[gpu_expression_executor:conjunction] unrecognized conjunction type {}",
+        static_cast<int>(op));
+  }
+}
+
+cudf::binary_operator conjunction_op_to_binary(sirius::ast::conjunction::kind op)
+{
+  switch (op) {
+    case sirius::ast::conjunction::kind::op_and: return cudf::binary_operator::LOGICAL_AND;
+    case sirius::ast::conjunction::kind::op_or: return cudf::binary_operator::LOGICAL_OR;
+    default:
+      throw invalid_input_exception(
+        "[gpu_expression_executor:conjunction] unrecognized conjunction type {}",
+        static_cast<int>(op));
+  }
+}
+
+}  // namespace
+
+execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& alt,
                                                 execution_mode mode)
 {
+  // Match the DuckDB-typed count_ast_ops contract for conjunction:
+  // (num_children - 1) AND/OR ops + ops in every child.
+  std::size_t ast_op_count = alt.children.size() - 1;
+  for (auto const& child : alt.children) {
+    ast_op_count += count_ast_ops(*child);
+  }
+
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    auto conjunction_type_switch_ast =
-      [](duckdb::BoundConjunctionExpression const& expr) -> cudf::ast::ast_operator {
-      using enum duckdb::ExpressionType;
-      switch (expr.GetExpressionType()) {
-        case CONJUNCTION_AND: return cudf::ast::ast_operator::LOGICAL_AND;
-        case CONJUNCTION_OR: return cudf::ast::ast_operator::LOGICAL_OR;
-        default:
-          throw invalid_input_exception(
-            "[gpu_expression_executor:conjunction] unrecognized conjunction type {}",
-            static_cast<int>(expr.GetExpressionType()));
-      }
-    };
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    auto const ast_op = conjunction_op_to_ast(alt.op);
 
-    auto output = execute(*expr.children[0], execution_mode::AST);
+    auto output = execute(*alt.children[0], execution_mode::AST);
 
-    for (duckdb::idx_t i = 1; i < expr.children.size(); i++) {
-      auto child = execute(*expr.children[i], execution_mode::AST);
-
-      auto const& output_expr = _ast_tree.emplace<cudf::ast::operation>(
-        conjunction_type_switch_ast(expr), output.get_expr(), child.get_expr());
+    for (std::size_t i = 1; i < alt.children.size(); ++i) {
+      auto child = execute(*alt.children[i], execution_mode::AST);
+      auto const& output_expr =
+        _ast_tree.emplace<cudf::ast::operation>(ast_op, output.get_expr(), child.get_expr());
       output = execute_result(
         ast_result(output_expr,
                    {output.get_temp_scalar_indices(), child.get_temp_scalar_indices()},
@@ -66,46 +90,36 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpressi
       return output;
     }
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
-    // Evaluate the AST subtree
     auto result_column = execute_ast(output.get_expr());
 
-    // Release consumed temporaries
     release_temporaries(output.get_temp_scalar_indices(), output.get_temp_column_indices());
     return execute_result(std::move(result_column));
   }
 
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
-  auto conjunction_type_switch =
-    [](duckdb::BoundConjunctionExpression const& expr) -> cudf::binary_operator {
-    using enum duckdb::ExpressionType;
-    switch (expr.GetExpressionType()) {
-      case CONJUNCTION_AND: return cudf::binary_operator::LOGICAL_AND;
-      case CONJUNCTION_OR: return cudf::binary_operator::LOGICAL_OR;
-      default:
-        throw invalid_input_exception(
-          "[gpu_expression_executor:conjunction] unrecognized conjunction type {}",
-          static_cast<int>(expr.GetExpressionType()));
-    }
-  };
-
-  auto const output_type = GetCudfType(expr.return_type);
+  auto const binary_op = conjunction_op_to_binary(alt.op);
+  // Conjunction ops always return BOOLEAN.
+  auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
 
   // Resolve the children incrementally into the output
-  auto output = execute(*expr.children[0], execution_mode::MATERIALIZE);
+  auto output = execute(*alt.children[0], execution_mode::MATERIALIZE);
   // DuckDB should prune all scalar conjuncts away
   D_ASSERT(!output.is_scalar());
-  for (duckdb::idx_t i = 1; i < expr.children.size(); i++) {
-    auto child = execute(*expr.children[i], execution_mode::MATERIALIZE);
+  for (std::size_t i = 1; i < alt.children.size(); ++i) {
+    auto child = execute(*alt.children[i], execution_mode::MATERIALIZE);
     D_ASSERT(!child.is_scalar());
-    auto output_column = cudf::binary_operation(output.get_column_view(),
-                                                child.get_column_view(),
-                                                conjunction_type_switch(expr),
-                                                output_type,
-                                                _stream,
-                                                _mr);
-    output             = execute_result(std::move(output_column));
+    auto output_column = cudf::binary_operation(
+      output.get_column_view(), child.get_column_view(), binary_op, output_type, _stream, _mr);
+    output = execute_result(std::move(output_column));
   }
   return output;
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -119,6 +119,12 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpressi
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:conjunction] BoundConjunctionExpression with conjunction type {} "
+      "could not be lowered to a Sirius AST node.",
+      static_cast<int>(expr.GetExpressionType()));
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -66,12 +66,7 @@ execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& 
     throw invalid_input_exception(
       "[gpu_expression_executor:conjunction] conjunction has no children — malformed AST.");
   }
-  // Match the DuckDB-typed count_ast_ops contract for conjunction:
-  // (num_children - 1) AND/OR ops + ops in every child.
-  std::size_t ast_op_count = alt.children.size() - 1;
-  for (auto const& child : alt.children) {
-    ast_op_count += count_ast_ops(*child);
-  }
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -119,6 +114,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& 
   return output;
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_constant.cpp
+++ b/src/expression_executor/specializations/gpu_execute_constant.cpp
@@ -206,6 +206,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt
   }
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_constant.cpp
+++ b/src/expression_executor/specializations/gpu_execute_constant.cpp
@@ -15,7 +15,11 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/logical_type.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
@@ -31,6 +35,10 @@
 
 // rmm
 #include <rmm/cuda_stream_view.hpp>
+
+// standard library
+#include <string>
+#include <variant>
 
 namespace {
 using execute_result = ::sirius::gpu_expression_executor::execute_result;
@@ -58,73 +66,71 @@ execute_result make_execute_result_from_scalar(
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression const& expr,
+execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt,
                                                 execution_mode mode)
 {
-  assert(expr.value.type() == expr.return_type);
-
-  auto const cudf_type = duckdb::GetCudfType(expr.value.type());
-  bool const is_valid  = !expr.value.IsNull();
+  auto const cudf_type = sirius::get_cudf_type(alt.return_type);
+  bool const is_valid  = !std::holds_alternative<sirius::null_value>(alt.payload);
 
   switch (cudf_type.id()) {
     case cudf::type_id::INT8: {
       auto scalar = std::make_unique<cudf::numeric_scalar<int8_t>>(
-        is_valid ? expr.value.GetValue<int8_t>() : int8_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<int8_t>(alt.payload) : int8_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::INT16: {
       auto scalar = std::make_unique<cudf::numeric_scalar<int16_t>>(
-        is_valid ? expr.value.GetValue<int16_t>() : int16_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<int16_t>(alt.payload) : int16_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::INT32: {
       auto scalar = std::make_unique<cudf::numeric_scalar<int32_t>>(
-        is_valid ? expr.value.GetValue<int32_t>() : int32_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<int32_t>(alt.payload) : int32_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::INT64: {
       auto scalar = std::make_unique<cudf::numeric_scalar<int64_t>>(
-        is_valid ? expr.value.GetValue<int64_t>() : int64_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<int64_t>(alt.payload) : int64_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::UINT8: {
       auto scalar = std::make_unique<cudf::numeric_scalar<uint8_t>>(
-        is_valid ? expr.value.GetValue<uint8_t>() : uint8_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<uint8_t>(alt.payload) : uint8_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::UINT16: {
       auto scalar = std::make_unique<cudf::numeric_scalar<uint16_t>>(
-        is_valid ? expr.value.GetValue<uint16_t>() : uint16_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<uint16_t>(alt.payload) : uint16_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::UINT32: {
       auto scalar = std::make_unique<cudf::numeric_scalar<uint32_t>>(
-        is_valid ? expr.value.GetValue<uint32_t>() : uint32_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<uint32_t>(alt.payload) : uint32_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::UINT64: {
       auto scalar = std::make_unique<cudf::numeric_scalar<uint64_t>>(
-        is_valid ? expr.value.GetValue<uint64_t>() : uint64_t{}, is_valid, _stream, _mr);
+        is_valid ? std::get<uint64_t>(alt.payload) : uint64_t{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::FLOAT32: {
-      auto scalar = std::make_unique<cudf::numeric_scalar<float_t>>(
-        is_valid ? expr.value.GetValue<float_t>() : float_t{}, is_valid, _stream, _mr);
+      auto scalar = std::make_unique<cudf::numeric_scalar<float>>(
+        is_valid ? std::get<float>(alt.payload) : float{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::FLOAT64: {
-      auto scalar = std::make_unique<cudf::numeric_scalar<double_t>>(
-        is_valid ? expr.value.GetValue<double_t>() : double_t{}, is_valid, _stream, _mr);
+      auto scalar = std::make_unique<cudf::numeric_scalar<double>>(
+        is_valid ? std::get<double>(alt.payload) : double{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::BOOL8: {
       auto scalar = std::make_unique<cudf::numeric_scalar<bool>>(
-        is_valid ? expr.value.GetValue<bool>() : false, is_valid, _stream, _mr);
+        is_valid ? std::get<bool>(alt.payload) : false, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::TIMESTAMP_DAYS: {
       auto scalar = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
-        cudf::duration_D{is_valid ? expr.value.GetValue<duckdb::date_t>().days : 0},
+        cudf::duration_D{is_valid ? std::get<sirius::date_value>(alt.payload).days : 0},
         is_valid,
         _stream,
         _mr);
@@ -132,7 +138,7 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression 
     }
     case cudf::type_id::TIMESTAMP_SECONDS: {
       auto scalar = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_s>>(
-        cudf::duration_s{is_valid ? expr.value.GetValue<duckdb::timestamp_sec_t>().value : 0},
+        cudf::duration_s{is_valid ? std::get<sirius::timestamp_sec_value>(alt.payload).value : 0},
         is_valid,
         _stream,
         _mr);
@@ -140,7 +146,7 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression 
     }
     case cudf::type_id::TIMESTAMP_MILLISECONDS: {
       auto scalar = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ms>>(
-        cudf::duration_ms{is_valid ? expr.value.GetValue<duckdb::timestamp_ms_t>().value : 0},
+        cudf::duration_ms{is_valid ? std::get<sirius::timestamp_ms_value>(alt.payload).value : 0},
         is_valid,
         _stream,
         _mr);
@@ -148,7 +154,7 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression 
     }
     case cudf::type_id::TIMESTAMP_MICROSECONDS: {
       auto scalar = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_us>>(
-        cudf::duration_us{is_valid ? expr.value.GetValue<duckdb::timestamp_tz_t>().value : 0},
+        cudf::duration_us{is_valid ? std::get<sirius::timestamp_us_value>(alt.payload).value : 0},
         is_valid,
         _stream,
         _mr);
@@ -156,41 +162,55 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression 
     }
     case cudf::type_id::TIMESTAMP_NANOSECONDS: {
       auto scalar = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ns>>(
-        cudf::duration_ns{is_valid ? expr.value.GetValue<duckdb::timestamp_ns_t>().value : 0},
+        cudf::duration_ns{is_valid ? std::get<sirius::timestamp_ns_value>(alt.payload).value : 0},
         is_valid,
         _stream,
         _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::DECIMAL32: {
-      auto const scale = numeric::scale_type{-duckdb::DecimalType::GetScale(expr.return_type)};
-      auto scalar      = std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
-        expr.value.GetValueUnsafe<numeric::decimal32::rep>(), scale, is_valid, _stream, _mr);
+      auto const scale =
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+      auto const rep =
+        is_valid ? std::get<sirius::decimal32>(alt.payload).value : numeric::decimal32::rep{};
+      auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
+        rep, scale, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::DECIMAL64: {
-      auto const scale = numeric::scale_type{-duckdb::DecimalType::GetScale(expr.return_type)};
-      auto scalar      = std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
-        expr.value.GetValueUnsafe<numeric::decimal64::rep>(), scale, is_valid, _stream, _mr);
+      auto const scale =
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+      auto const rep =
+        is_valid ? std::get<sirius::decimal64>(alt.payload).value : numeric::decimal64::rep{};
+      auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
+        rep, scale, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::DECIMAL128: {
-      auto const scale = numeric::scale_type{-duckdb::DecimalType::GetScale(expr.return_type)};
-      duckdb::hugeint_t hugeint_value = expr.value.GetValueUnsafe<duckdb::hugeint_t>();
-      __int128_t int128_value = (__int128_t(hugeint_value.upper) << 64) | hugeint_value.lower;
-      auto scalar             = std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
-        int128_value, scale, is_valid, _stream, _mr);
+      auto const scale =
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+      __int128_t const rep =
+        is_valid ? std::get<sirius::decimal128>(alt.payload).value : __int128_t{};
+      auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
+        rep, scale, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     case cudf::type_id::STRING: {
       auto scalar = std::make_unique<cudf::string_scalar>(
-        is_valid ? expr.value.GetValue<std::string>() : std::string{}, is_valid, _stream, _mr);
+        is_valid ? std::get<std::string>(alt.payload) : std::string{}, is_valid, _stream, _mr);
       return make_execute_result_from_scalar(_ast_tree, _temp_scalars, std::move(scalar), mode);
     }
     default:
       throw not_implemented_exception("[gpu_expression_executor] Unsupported scalar type: %s",
-                                      expr.return_type.ToString());
+                                      alt.return_type.to_string());
   }
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_constant.cpp
+++ b/src/expression_executor/specializations/gpu_execute_constant.cpp
@@ -210,6 +210,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression 
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:constant] BoundConstantExpression could not be lowered to a "
+      "Sirius AST node (sirius::ast::from_duckdb returned nullptr).");
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -15,19 +15,19 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
 #include <expression/function_id.hpp>
+#include <expression/value.hpp>
 #include <expression_executor/ast_supported_types.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <expression_executor/regex/regex_playground.hpp>
+#include <helper/logical_type.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/assert.hpp>
-#include <duckdb/common/exception.hpp>
-#include <duckdb/common/types.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf
 #include <cudf/binaryop.hpp>
@@ -45,36 +45,42 @@
 #include <cudf/unary.hpp>
 
 // standard library
+#include <algorithm>
 #include <regex>
 #include <string>
+#include <variant>
 
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression const& expr,
+execute_result gpu_expression_executor::execute(sirius::ast::function_call const& alt,
                                                 execution_mode mode)
 {
-  auto const& func_string    = expr.function.name;
-  auto const resolved_id_opt = sirius::from_duckdb_function_name(func_string);
-  if (!resolved_id_opt.has_value()) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:function] execute called on unsupported function: {}", func_string);
-  }
-  auto const resolved_id = *resolved_id_opt;
+  auto const resolved_id = alt.function();
+  auto const& args       = alt.arguments();
 
-  /// We disable AST if the output type is decimal, since cuDF ASTs choke on intermediate decimal
-  /// results currently.
-  /// TODO: Fix when the following bug fix is in:
-  /// https://github.com/rapidsai/cudf/pull/21996
-  auto const ast_supported =
-    (expr.return_type.id() != duckdb::LogicalTypeId::DECIMAL) &&
-    (std::find(supported_ast_functions.begin(), supported_ast_functions.end(), resolved_id) !=
-     supported_ast_functions.end());
+  // Disable AST mode when the output type is decimal — cuDF ASTs choke on
+  // intermediate decimal results currently.
+  // TODO: Fix when https://github.com/rapidsai/cudf/pull/21996 lands.
+  auto const skip_ast      = alt.return_type().id() == sirius::type_id::DECIMAL;
+  auto const ast_supported = !skip_ast && std::find(supported_ast_functions.begin(),
+                                                    supported_ast_functions.end(),
+                                                    resolved_id) != supported_ast_functions.end();
+
+  // Match DuckDB-typed count_ast_ops for function:
+  //   skip_ast OR unsupported -> 0 ; supported -> 1 + sum of arg counts.
+  std::size_t ast_op_count = 0;
+  if (ast_supported) {
+    ast_op_count = 1;
+    for (auto const& a : args) {
+      ast_op_count += count_ast_ops(*a);
+    }
+  }
 
   if (ast_supported && _strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    // Only numeric binary functions are supported in AST currently
-    D_ASSERT(expr.children.size() == 2);
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    // Only numeric binary functions are supported in AST currently.
+    D_ASSERT(args.size() == 2);
 
     auto function_type_switch_ast = [](function_id id) -> cudf::ast::ast_operator {
       switch (id) {
@@ -86,13 +92,13 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
         case function_id::mod: return cudf::ast::ast_operator::MOD;
         default:
           throw invalid_input_exception(
-            "[gpu_expression_executor:function] unsupported AST function type {}",
-            to_duckdb_function_name(id));
+            "[gpu_expression_executor:function] unsupported AST function id {}",
+            static_cast<int>(id));
       }
     };
 
-    auto left             = execute(*expr.children[0], execution_mode::AST);
-    auto right            = execute(*expr.children[1], execution_mode::AST);
+    auto left             = execute(*args[0], execution_mode::AST);
+    auto right            = execute(*args[1], execution_mode::AST);
     auto const& func_expr = _ast_tree.emplace<cudf::ast::operation>(
       function_type_switch_ast(resolved_id), left.get_expr(), right.get_expr());
 
@@ -105,37 +111,28 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
     }
 
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
-    // Evaluate the AST subtree
     auto result_column = execute_ast(func_expr);
-
-    // Release consumed temporaries
     release_temporaries({left.get_temp_scalar_indices(), right.get_temp_scalar_indices()},
                         {left.get_temp_column_indices(), right.get_temp_column_indices()});
     return execute_result(std::move(result_column));
   }
 
   //===----------3: MATERIALIZE Mode, evaluate node with solo operation----------===//
-  // If the caller requested AST mode but we fell through (unsupported function for AST),
-  // materialize the result and wrap it as a temp column for the parent's AST tree.
   if (mode == execution_mode::AST) {
-    // Re-enter execute with MATERIALIZE mode to get the result as a column, then add to the AST
-    // tree.
-    auto result = execute(expr, execution_mode::MATERIALIZE);
+    auto result = execute(alt, execution_mode::MATERIALIZE);
     if (!result.is_owned_column()) {
-      // Any function execution in MATERIALIZE mode should produce an owned column. Otherwise,
-      // something went wrong.
       throw internal_exception(
         "[gpu_expression_executor:function]: Expected an owned column after executing function "
         "expression.");
     }
     return materialize_as_ast_column(std::move(result.release_column()));
   }
-  auto const output_type = GetCudfType(expr.return_type);
+  auto const output_type = sirius::get_cudf_type(alt.return_type());
 
   //----------Numeric Binary Functions----------//
   auto execute_numeric_binary_func = [&](cudf::binary_operator op) -> execute_result {
-    auto left  = execute(*expr.children[0], execution_mode::MATERIALIZE);
-    auto right = execute(*expr.children[1], execution_mode::MATERIALIZE);
+    auto left  = execute(*args[0], execution_mode::MATERIALIZE);
+    auto right = execute(*args[1], execution_mode::MATERIALIZE);
     D_ASSERT(!left.is_scalar() || !right.is_scalar());  // Both sides cannot be scalars
     if (left.is_scalar()) {
       return execute_result(cudf::binary_operation(
@@ -166,18 +163,18 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
 
   //----------Substring Function----------//
   if (resolved_id == function_id::substring) {
-    auto input = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    auto input = execute(*args[0], execution_mode::MATERIALIZE);
 
-    // The start and len arguments of SUBSTRING are assumed to be constants
-    D_ASSERT(expr.children[1]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
-    D_ASSERT(expr.children[2]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
-    auto const& start_expr = expr.children[1]->Cast<duckdb::BoundConstantExpression>();
-    auto const& len_expr   = expr.children[2]->Cast<duckdb::BoundConstantExpression>();
+    // The start and len arguments of SUBSTRING are assumed to be INTEGER constants.
+    D_ASSERT(args[1]->holds<sirius::ast::constant>());
+    D_ASSERT(args[2]->holds<sirius::ast::constant>());
+    auto const start_raw = std::get<int32_t>(args[1]->get<sirius::ast::constant>().payload);
+    auto const len_raw   = std::get<int32_t>(args[2]->get<sirius::ast::constant>().payload);
 
     // The values provided by DuckDB must be modified to be 0-indexed and <start, stop> instead of
     // <start, len>
-    auto const start_val = start_expr.value.GetValue<cudf::size_type>() - 1;
-    auto const stop_val  = len_expr.value.GetValue<cudf::size_type>() + start_val;
+    auto const start_val = static_cast<cudf::size_type>(start_raw) - 1;
+    auto const stop_val  = static_cast<cudf::size_type>(len_raw) + start_val;
 
     auto result_column =
       cudf::strings::slice_strings(cudf::strings_column_view(input.get_column_view()),
@@ -191,13 +188,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
 
   //----------String Matching Functions----------//
   auto setup_string_matching = [&]() -> std::pair<execute_result, std::string> {
-    // Children should be <input column, comparator scalar>
-    D_ASSERT(expr.children.size() == 2);
-    D_ASSERT(expr.children[1]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
+    D_ASSERT(args.size() == 2);
+    D_ASSERT(args[1]->holds<sirius::ast::constant>());
 
-    auto input                 = execute(*expr.children[0], execution_mode::MATERIALIZE);
-    auto const& match_str_expr = expr.children[1]->Cast<duckdb::BoundConstantExpression>();
-    auto match_str             = match_str_expr.value.GetValue<std::string>();
+    auto input     = execute(*args[0], execution_mode::MATERIALIZE);
+    auto match_str = std::get<std::string>(args[1]->get<sirius::ast::constant>().payload);
     return {execute_result(std::move(input)), std::move(match_str)};
   };
   if (resolved_id == function_id::like || resolved_id == function_id::not_like) {
@@ -243,8 +238,8 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
   //----------DateTime Extraction Functions----------//
   auto execute_datetime_extract_func =
     [&](cudf::datetime::datetime_component component) -> execute_result {
-    D_ASSERT(expr.children.size() == 1);
-    auto input = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    D_ASSERT(args.size() == 1);
+    auto input = execute(*args[0], execution_mode::MATERIALIZE);
     auto result_column =
       cudf::datetime::extract_datetime_component(input.get_column_view(), component, _stream, _mr);
     return execute_result(std::move(result_column));
@@ -276,12 +271,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
 
   //----------Date Truncation Function----------//
   if (resolved_id == function_id::date_trunc) {
-    D_ASSERT(expr.children.size() == 2);
+    D_ASSERT(args.size() == 2);
     // The first child is the frequency, which should be a constant string
-    D_ASSERT(expr.children[0]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
-    auto const& freq_expr = expr.children[0]->Cast<duckdb::BoundConstantExpression>();
-    auto const& freq_str  = freq_expr.value.GetValue<std::string>();
-    auto input            = execute(*expr.children[1], execution_mode::MATERIALIZE);
+    D_ASSERT(args[0]->holds<sirius::ast::constant>());
+    auto const& freq_str = std::get<std::string>(args[0]->get<sirius::ast::constant>().payload);
+    auto input           = execute(*args[1], execution_mode::MATERIALIZE);
     D_ASSERT(!input.is_scalar());
 
     auto freq_string_switch =
@@ -312,33 +306,31 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
 
   //----------Unary Functions----------//
   if (resolved_id == function_id::strlen) {
-    D_ASSERT(expr.children.size() == 1);
-    auto input = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    D_ASSERT(args.size() == 1);
+    auto input = execute(*args[0], execution_mode::MATERIALIZE);
     auto result_column =
       cudf::strings::count_bytes(cudf::strings_column_view(input.get_column_view()), _stream, _mr);
     return execute_result(std::move(result_column));
   }
   if (resolved_id == function_id::length) {
-    D_ASSERT(expr.children.size() == 1);
-    auto input         = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    D_ASSERT(args.size() == 1);
+    auto input         = execute(*args[0], execution_mode::MATERIALIZE);
     auto result_column = cudf::strings::count_characters(
       cudf::strings_column_view(input.get_column_view()), _stream, _mr);
     return execute_result(std::move(result_column));
   }
   if (resolved_id == function_id::regexp_replace) {
     // The input should be <input column, pattern string scalar, replace string scalar>
-    D_ASSERT(expr.children.size() == 3);
-    D_ASSERT(expr.children[1]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
-    D_ASSERT(expr.children[2]->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT);
+    D_ASSERT(args.size() == 3);
+    D_ASSERT(args[1]->holds<sirius::ast::constant>());
+    D_ASSERT(args[2]->holds<sirius::ast::constant>());
 
-    auto input = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    auto input = execute(*args[0], execution_mode::MATERIALIZE);
     D_ASSERT(!input.is_scalar());
 
-    auto const& pattern_str =
-      expr.children[1]->Cast<duckdb::BoundConstantExpression>().value.GetValue<std::string>();
-    auto const& replace_str =
-      expr.children[2]->Cast<duckdb::BoundConstantExpression>().value.GetValue<std::string>();
-    auto regex_prog = cudf::strings::regex_program::create(std::string_view(pattern_str));
+    auto const& pattern_str = std::get<std::string>(args[1]->get<sirius::ast::constant>().payload);
+    auto const& replace_str = std::get<std::string>(args[2]->get<sirius::ast::constant>().payload);
+    auto regex_prog         = cudf::strings::regex_program::create(std::string_view(pattern_str));
 
     auto const has_backrefs = std::regex_search(replace_str, std::regex(R"(\\[0-9])"));
     if (has_backrefs) {
@@ -368,10 +360,10 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
   // row() and struct_pack() both construct a struct column from their child expressions.
   // row() is used by DuckDB for tuple constructors like (col1, col2).
   if (resolved_id == function_id::row || resolved_id == function_id::struct_pack) {
-    D_ASSERT(!expr.children.empty());
+    D_ASSERT(!args.empty());
     std::vector<std::unique_ptr<cudf::column>> child_cols;
-    for (const auto& expr : expr.children) {
-      auto result = execute(*expr, execution_mode::MATERIALIZE);
+    for (const auto& a : args) {
+      auto result = execute(*a, execution_mode::MATERIALIZE);
       if (result.is_scalar()) {
         child_cols.push_back(cudf::make_column_from_scalar(
           result.get_scalar(), _input_table.num_rows(), _stream, _mr));
@@ -387,22 +379,26 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
 
   // `error()` is a runtime-error-raising function. We deliberately do not
   // evaluate it on-device here; the upstream fallback path is expected to
-  // handle it on the CPU. (Phase 6 will revisit this once ERROR_FUNC_STR
-  // migrates)
+  // handle it on the CPU.
   if (resolved_id == function_id::error) {
     throw not_implemented_exception(
       "[gpu_expression_executor:function] error() is not dispatched on GPU; "
       "expected to fall back to CPU execution");
   }
 
-  // Invariant violation: `func_string` resolved to a valid function_id (so it
-  // passed the unsupported-name guard at the top of execute()), yet no dispatch
-  // arm above claimed it. This means an entry was added to `function_id`
-  // without a corresponding GPU handler here.
+  // Invariant violation: alt.function() returned a valid function_id but no
+  // dispatch arm above claimed it. This means an entry was added to
+  // function_id without a corresponding GPU handler here.
   throw internal_exception(
-    "[gpu_expression_executor:function]: registered function_id has no GPU "
-    "dispatch arm (function name: {})",
-    func_string);
+    "[gpu_expression_executor:function]: registered function_id has no GPU dispatch arm: id={}",
+    static_cast<int>(resolved_id));
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -165,14 +165,17 @@ execute_result gpu_expression_executor::execute(sirius::ast::function_call const
   if (resolved_id == function_id::substring) {
     auto input = execute(*args[0], execution_mode::MATERIALIZE);
 
-    // The start and len arguments of SUBSTRING are assumed to be INTEGER constants.
+    // DuckDB binds substring as (VARCHAR, BIGINT, BIGINT), so the start/len
+    // children are BIGINT constants — the payload variant holds int64_t.
     D_ASSERT(args[1]->holds<sirius::ast::constant>());
     D_ASSERT(args[2]->holds<sirius::ast::constant>());
-    auto const start_raw = std::get<int32_t>(args[1]->get<sirius::ast::constant>().payload);
-    auto const len_raw   = std::get<int32_t>(args[2]->get<sirius::ast::constant>().payload);
+    auto const start_raw = std::get<int64_t>(args[1]->get<sirius::ast::constant>().payload);
+    auto const len_raw   = std::get<int64_t>(args[2]->get<sirius::ast::constant>().payload);
 
-    // The values provided by DuckDB must be modified to be 0-indexed and <start, stop> instead of
-    // <start, len>
+    // Re-base to 0-indexed and convert <start, len> to <start, stop>. Narrow
+    // to cudf::size_type (int32_t) here because cudf::strings::slice_strings
+    // only accepts int32 bounds — the narrowing is a cudf API constraint,
+    // not a SUBSTRING semantic limit.
     auto const start_val = static_cast<cudf::size_type>(start_raw) - 1;
     auto const stop_val  = static_cast<cudf::size_type>(len_raw) + start_val;
 

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -398,6 +398,13 @@ execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression 
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:function] BoundFunctionExpression could not be lowered to a "
+      "Sirius AST node (function '{}' has no Sirius function_id mapping, or an argument is "
+      "unsupported).",
+      expr.function.name);
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -61,21 +61,15 @@ execute_result gpu_expression_executor::execute(sirius::ast::function_call const
 
   // Disable AST mode when the output type is decimal — cuDF ASTs choke on
   // intermediate decimal results currently.
-  // TODO: Fix when https://github.com/rapidsai/cudf/pull/21996 lands.
+  // TODO: Remove this special-case once Sirius pins cuDF >= 26.10 (cuDF PR
+  // https://github.com/rapidsai/cudf/pull/21996 merged after the 26.08 cut,
+  // so the fix will ship in 26.10).
   auto const skip_ast      = alt.return_type().id() == sirius::type_id::DECIMAL;
   auto const ast_supported = !skip_ast && std::find(supported_ast_functions.begin(),
                                                     supported_ast_functions.end(),
                                                     resolved_id) != supported_ast_functions.end();
 
-  // Match DuckDB-typed count_ast_ops for function:
-  //   skip_ast OR unsupported -> 0 ; supported -> 1 + sum of arg counts.
-  std::size_t ast_op_count = 0;
-  if (ast_supported) {
-    ast_op_count = 1;
-    for (auto const& a : args) {
-      ast_op_count += count_ast_ops(*a);
-    }
-  }
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (ast_supported && _strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -397,6 +391,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::function_call const
     static_cast<int>(resolved_id));
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_operator.cpp
+++ b/src/expression_executor/specializations/gpu_execute_operator.cpp
@@ -254,12 +254,7 @@ execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& alt
       "[gpu_expression_executor] execute called on an unsupported TRY operator expression.");
   }
 
-  // Match DuckDB-typed count_ast_ops:
-  //   OPERATOR_NOT      -> 1 + child
-  //   OPERATOR_IS_NULL  -> 1 + child
-  //   OPERATOR_IS_NOT_NULL -> 2 + child (NOT wrapping IS_NULL)
-  std::size_t const self_count = (alt.op == sirius::ast::unary_op::kind::op_is_not_null) ? 2 : 1;
-  auto const ast_op_count      = self_count + count_ast_ops(*alt.child);
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -348,17 +343,7 @@ execute_result gpu_expression_executor::execute(sirius::ast::in_list const& alt,
     throw invalid_input_exception(
       "[gpu_expression_executor:in_list] in_list has no values — malformed AST.");
   }
-  // Match DuckDB-typed count_ast_ops for COMPARE_IN/NOT_IN:
-  //   children = [probe] + values; num_or = N-2, num_eq = N-1, +1 if NOT_IN
-  auto const total_children = 1U + alt.values.size();
-  D_ASSERT(total_children > 1U);
-  std::size_t const num_or = total_children - 2U;
-  std::size_t const num_eq = total_children - 1U;
-  std::size_t ast_op_count = num_or + num_eq + (alt.negated ? 1U : 0U);
-  ast_op_count += count_ast_ops(*alt.probe);
-  for (auto const& v : alt.values) {
-    ast_op_count += count_ast_ops(*v);
-  }
+  auto const ast_op_count = alt.cudf_ast_op_count();
 
   if (_strategy != expression_executor_strategy::MATERIALIZE &&
       (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
@@ -596,6 +581,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& alt
 // public node dispatcher's std::visit over from_duckdb(expr).
 //===----------------------------------------------------------------------===//
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_operator.cpp
+++ b/src/expression_executor/specializations/gpu_execute_operator.cpp
@@ -344,6 +344,10 @@ execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& alt
 execute_result gpu_expression_executor::execute(sirius::ast::in_list const& alt,
                                                 execution_mode mode)
 {
+  if (alt.values.empty()) {
+    throw invalid_input_exception(
+      "[gpu_expression_executor:in_list] in_list has no values — malformed AST.");
+  }
   // Match DuckDB-typed count_ast_ops for COMPARE_IN/NOT_IN:
   //   children = [probe] + values; num_or = N-2, num_eq = N-1, +1 if NOT_IN
   auto const total_children = 1U + alt.values.size();

--- a/src/expression_executor/specializations/gpu_execute_operator.cpp
+++ b/src/expression_executor/specializations/gpu_execute_operator.cpp
@@ -15,18 +15,16 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/logical_type.hpp>
 #include <log/logging.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/assert.hpp>
-#include <duckdb/common/exception.hpp>
-#include <duckdb/common/types/date.hpp>
-#include <duckdb/common/types/decimal.hpp>
-#include <duckdb/common/types/hugeint.hpp>
-#include <duckdb/common/types/timestamp.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
 
 // cudf
@@ -43,18 +41,30 @@
 
 // standard library
 #include <algorithm>
+#include <string>
+#include <variant>
 
 namespace {
+
+// Read a typed constant from one of the values in a sirius::ast::in_list. Assumes
+// the AST translator has guaranteed every entry holds sirius::ast::constant.
 template <typename T>
-std::unique_ptr<cudf::column> execute_numeric_in(const duckdb::BoundOperatorExpression& expr,
-                                                 const cudf::column_view& input_view,
-                                                 rmm::device_async_resource_ref mr,
-                                                 rmm::cuda_stream_view stream)
+T const& get_const_payload(::sirius::ast::node const& n)
+{
+  auto const& c = n.get<::sirius::ast::constant>();
+  return std::get<T>(c.payload);
+}
+
+template <typename T>
+std::unique_ptr<cudf::column> execute_numeric_in_ast(const ::sirius::ast::in_list& alt,
+                                                     const cudf::column_view& input_view,
+                                                     rmm::device_async_resource_ref mr,
+                                                     rmm::cuda_stream_view stream)
 {
   std::vector<T> children_vals;
-  for (std::size_t child = 1; child < expr.children.size(); ++child) {
-    const auto& child_expression = expr.children[child]->Cast<duckdb::BoundConstantExpression>();
-    children_vals.push_back(child_expression.value.GetValue<T>());
+  children_vals.reserve(alt.values.size());
+  for (auto const& v : alt.values) {
+    children_vals.push_back(get_const_payload<T>(*v));
   }
   rmm::device_uvector<T> children_vals_d(children_vals.size(), stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(children_vals_d.data(),
@@ -71,24 +81,26 @@ std::unique_ptr<cudf::column> execute_numeric_in(const duckdb::BoundOperatorExpr
   return cudf::contains(children_view, input_view, stream, mr);
 }
 
-// For decimal (fixed_point) types. Uses GetValueUnsafe<Rep> to avoid lossy conversion through
-// double, and unpacks duckdb::hugeint_t into __int128_t for decimal128.
+// For decimal (fixed_point) types. Reads the rep directly from sirius::decimal{32,64,128}.
 template <typename DecimalT>
-std::unique_ptr<cudf::column> execute_decimal_in(const duckdb::BoundOperatorExpression& expr,
-                                                 const cudf::column_view& input_view,
-                                                 rmm::device_async_resource_ref mr,
-                                                 rmm::cuda_stream_view stream)
+std::unique_ptr<cudf::column> execute_decimal_in_ast(const ::sirius::ast::in_list& alt,
+                                                     const cudf::column_view& input_view,
+                                                     rmm::device_async_resource_ref mr,
+                                                     rmm::cuda_stream_view stream)
 {
   using Rep = typename DecimalT::rep;
   std::vector<Rep> children_vals;
-  children_vals.reserve(expr.children.size() - 1);
-  for (std::size_t child = 1; child < expr.children.size(); ++child) {
-    auto const& child_expression = expr.children[child]->Cast<duckdb::BoundConstantExpression>();
-    if constexpr (std::is_same_v<DecimalT, numeric::decimal128>) {
-      auto hugeint_value = child_expression.value.GetValueUnsafe<duckdb::hugeint_t>();
-      children_vals.push_back((__int128_t(hugeint_value.upper) << 64) | hugeint_value.lower);
+  children_vals.reserve(alt.values.size());
+  for (auto const& v : alt.values) {
+    auto const& payload = v->get<::sirius::ast::constant>().payload;
+    if constexpr (std::is_same_v<DecimalT, numeric::decimal32>) {
+      children_vals.push_back(std::get<::sirius::decimal32>(payload).value);
+    } else if constexpr (std::is_same_v<DecimalT, numeric::decimal64>) {
+      children_vals.push_back(std::get<::sirius::decimal64>(payload).value);
+    } else if constexpr (std::is_same_v<DecimalT, numeric::decimal128>) {
+      children_vals.push_back(std::get<::sirius::decimal128>(payload).value);
     } else {
-      children_vals.push_back(child_expression.value.GetValueUnsafe<Rep>());
+      static_assert(sizeof(DecimalT) == 0, "Unsupported decimal type");
     }
   }
   rmm::device_uvector<Rep> children_vals_d(children_vals.size(), stream, mr);
@@ -107,29 +119,28 @@ std::unique_ptr<cudf::column> execute_decimal_in(const duckdb::BoundOperatorExpr
   return cudf::contains(children_view, input_view, stream, mr);
 }
 
-// For timestamp types. Pulls the underlying integral count out of the duckdb wrapper struct
-// (date_t.days / timestamp_*_t.value) and uploads as the cudf timestamp's rep type.
+// For timestamp types. Pulls the underlying integral count out of the matching sirius wrapper.
 template <typename CudfTimestampT>
-std::unique_ptr<cudf::column> execute_timestamp_in(const duckdb::BoundOperatorExpression& expr,
-                                                   const cudf::column_view& input_view,
-                                                   rmm::device_async_resource_ref mr,
-                                                   rmm::cuda_stream_view stream)
+std::unique_ptr<cudf::column> execute_timestamp_in_ast(const ::sirius::ast::in_list& alt,
+                                                       const cudf::column_view& input_view,
+                                                       rmm::device_async_resource_ref mr,
+                                                       rmm::cuda_stream_view stream)
 {
   using Rep = typename CudfTimestampT::rep;
   std::vector<Rep> children_vals;
-  children_vals.reserve(expr.children.size() - 1);
-  for (std::size_t child = 1; child < expr.children.size(); ++child) {
-    const auto& child_expression = expr.children[child]->Cast<duckdb::BoundConstantExpression>();
+  children_vals.reserve(alt.values.size());
+  for (auto const& v : alt.values) {
+    auto const& payload = v->get<::sirius::ast::constant>().payload;
     if constexpr (std::is_same_v<CudfTimestampT, cudf::timestamp_D>) {
-      children_vals.push_back(child_expression.value.GetValue<duckdb::date_t>().days);
+      children_vals.push_back(std::get<::sirius::date_value>(payload).days);
     } else if constexpr (std::is_same_v<CudfTimestampT, cudf::timestamp_s>) {
-      children_vals.push_back(child_expression.value.GetValue<duckdb::timestamp_sec_t>().value);
+      children_vals.push_back(std::get<::sirius::timestamp_sec_value>(payload).value);
     } else if constexpr (std::is_same_v<CudfTimestampT, cudf::timestamp_ms>) {
-      children_vals.push_back(child_expression.value.GetValue<duckdb::timestamp_ms_t>().value);
+      children_vals.push_back(std::get<::sirius::timestamp_ms_value>(payload).value);
     } else if constexpr (std::is_same_v<CudfTimestampT, cudf::timestamp_us>) {
-      children_vals.push_back(child_expression.value.GetValue<duckdb::timestamp_tz_t>().value);
+      children_vals.push_back(std::get<::sirius::timestamp_us_value>(payload).value);
     } else if constexpr (std::is_same_v<CudfTimestampT, cudf::timestamp_ns>) {
-      children_vals.push_back(child_expression.value.GetValue<duckdb::timestamp_ns_t>().value);
+      children_vals.push_back(std::get<::sirius::timestamp_ns_value>(payload).value);
     } else {
       static_assert(sizeof(CudfTimestampT) == 0, "Unsupported cudf timestamp type");
     }
@@ -149,28 +160,53 @@ std::unique_ptr<cudf::column> execute_timestamp_in(const duckdb::BoundOperatorEx
   return cudf::contains(children_view, input_view, stream, mr);
 }
 
-std::unique_ptr<cudf::column> execute_string_in(const duckdb::BoundOperatorExpression& expr,
-                                                const cudf::column_view& input_view,
-                                                rmm::device_async_resource_ref mr,
-                                                rmm::cuda_stream_view stream)
+// BOOL8 has the cudf storage type uint8_t but the AST constant payload variant
+// holds the value as `bool`. Use a separate helper that reads `bool` from the
+// variant and uploads as uint8_t (matching the cudf BOOL8 storage convention).
+std::unique_ptr<cudf::column> execute_bool_in_ast(const ::sirius::ast::in_list& alt,
+                                                  const cudf::column_view& input_view,
+                                                  rmm::device_async_resource_ref mr,
+                                                  rmm::cuda_stream_view stream)
 {
-  auto const num_strings = static_cast<cudf::size_type>(expr.children.size() - 1);
+  std::vector<uint8_t> children_vals;
+  children_vals.reserve(alt.values.size());
+  for (auto const& v : alt.values) {
+    children_vals.push_back(get_const_payload<bool>(*v) ? uint8_t{1} : uint8_t{0});
+  }
+  rmm::device_uvector<uint8_t> children_vals_d(children_vals.size(), stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(children_vals_d.data(),
+                                children_vals.data(),
+                                children_vals.size() * sizeof(uint8_t),
+                                cudaMemcpyHostToDevice,
+                                stream));
+  cudf::column_view children_view(input_view.type(),
+                                  static_cast<cudf::size_type>(children_vals.size()),
+                                  children_vals_d.data(),
+                                  nullptr,
+                                  0,
+                                  0);
+  return cudf::contains(children_view, input_view, stream, mr);
+}
+
+std::unique_ptr<cudf::column> execute_string_in_ast(const ::sirius::ast::in_list& alt,
+                                                    const cudf::column_view& input_view,
+                                                    rmm::device_async_resource_ref mr,
+                                                    rmm::cuda_stream_view stream)
+{
+  auto const num_strings = static_cast<cudf::size_type>(alt.values.size());
   auto const num_offsets = num_strings + 1;
 
-  // We need to convert to cudf/arrow format...
   std::vector<char> chars;
   std::vector<cudf::size_type> offsets;
   cudf::size_type offset = 0;
-  for (std::size_t child = 1; child < expr.children.size(); ++child) {
-    const auto& child_expression = expr.children[child]->Cast<duckdb::BoundConstantExpression>();
-    const auto& child_string     = child_expression.value.GetValue<std::string>();
+  for (auto const& v : alt.values) {
+    auto const& child_string = get_const_payload<std::string>(*v);
     chars.insert(chars.end(), child_string.begin(), child_string.end());
     offsets.push_back(offset);
     offset += static_cast<cudf::size_type>(child_string.size());
   }
   offsets.push_back(offset);
 
-  // Allocate buffers and copy to device
   rmm::device_uvector<char> chars_buffer(offset, stream, mr);
   rmm::device_uvector<cudf::size_type> offsets_buffer(num_offsets, stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(chars_buffer.data(),
@@ -184,7 +220,6 @@ std::unique_ptr<cudf::column> execute_string_in(const duckdb::BoundOperatorExpre
                                 cudaMemcpyHostToDevice,
                                 stream));
 
-  // Make CuDF things
   auto offsets_col = std::make_unique<cudf::column>(cudf::data_type(cudf::type_id::INT32),
                                                     num_offsets,
                                                     std::move(offsets_buffer).release(),
@@ -199,7 +234,6 @@ std::unique_ptr<cudf::column> execute_string_in(const duckdb::BoundOperatorExpre
                                                        0,
                                                        std::move(children));
 
-  // Execute the search
   return cudf::contains(in_strings_col->view(), input_view, stream, mr);
 }
 
@@ -208,87 +242,58 @@ std::unique_ptr<cudf::column> execute_string_in(const duckdb::BoundOperatorExpre
 namespace sirius {
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression const& expr,
+//===----------------------------------------------------------------------===//
+// unary_op
+//===----------------------------------------------------------------------===//
+
+execute_result gpu_expression_executor::execute(sirius::ast::unary_op const& alt,
                                                 execution_mode mode)
 {
-  // COALESCE does not have AST support
-  auto const is_coalesce = expr.type == duckdb::ExpressionType::OPERATOR_COALESCE;
+  if (alt.op == sirius::ast::unary_op::kind::op_try) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor] execute called on an unsupported TRY operator expression.");
+  }
 
-  if (!is_coalesce && _strategy != expression_executor_strategy::MATERIALIZE &&
-      (mode == execution_mode::AST || count_ast_ops(expr) >= _min_ast_size)) {
-    auto operator_type_switch_ast =
-      [&](duckdb::BoundOperatorExpression const& expr) -> execute_result {
-      switch (expr.type) {
-        case duckdb::ExpressionType::COMPARE_IN:  // Fallthrough
-        case duckdb::ExpressionType::COMPARE_NOT_IN: {
-          D_ASSERT(expr.children.size() > 1);
-          auto test                = execute(*expr.children[0], execution_mode::AST);
-          auto comparator          = execute(*expr.children[1], execution_mode::AST);
-          expr_ref comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-            cudf::ast::ast_operator::EQUAL, test.get_expr(), comparator.get_expr());
-          auto output = execute_result(
-            ast_result(comparison_expr,
-                       {test.get_temp_scalar_indices(), comparator.get_temp_scalar_indices()},
-                       {test.get_temp_column_indices(), comparator.get_temp_column_indices()}));
+  // Match DuckDB-typed count_ast_ops:
+  //   OPERATOR_NOT      -> 1 + child
+  //   OPERATOR_IS_NULL  -> 1 + child
+  //   OPERATOR_IS_NOT_NULL -> 2 + child (NOT wrapping IS_NULL)
+  std::size_t const self_count = (alt.op == sirius::ast::unary_op::kind::op_is_not_null) ? 2 : 1;
+  auto const ast_op_count      = self_count + count_ast_ops(*alt.child);
 
-          // Build an OR tree of comparisons
-          for (std::size_t child_idx = 2; child_idx < expr.children.size(); ++child_idx) {
-            auto comparator               = execute(*expr.children[child_idx], execution_mode::AST);
-            expr_ref next_comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-              cudf::ast::ast_operator::EQUAL, test.get_expr(), comparator.get_expr());
-            comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-              cudf::ast::ast_operator::LOGICAL_OR, comparison_expr, next_comparison_expr);
-            output = execute_result(
-              ast_result(comparison_expr,
-                         {output.get_temp_scalar_indices(), comparator.get_temp_scalar_indices()},
-                         {output.get_temp_column_indices(), comparator.get_temp_column_indices()}));
-          }
+  if (_strategy != expression_executor_strategy::MATERIALIZE &&
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    auto child        = execute(*alt.child, execution_mode::AST);
+    auto build_output = [&](expr_ref const& produced) -> execute_result {
+      return execute_result(
+        ast_result(produced, child.get_temp_scalar_indices(), child.get_temp_column_indices()));
+    };
 
-          if (expr.type == duckdb::ExpressionType::COMPARE_IN) { return output; }
-          auto const& not_expr =
-            _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, comparison_expr);
-          return execute_result(ast_result(
-            not_expr, output.get_temp_scalar_indices(), output.get_temp_column_indices()));
-        }
-        case duckdb::ExpressionType::OPERATOR_COALESCE:
-          // Should be unreachable
-          throw internal_exception(
-            "[gpu_expression_executor] AST mode with COALESCE operator is not supported.");
-        case duckdb::ExpressionType::OPERATOR_TRY:
-          throw not_implemented_exception(
-            "[gpu_expression_executor] AST mode with TRY operator is not implemented.");
-        case duckdb::ExpressionType::OPERATOR_NOT: {
-          D_ASSERT(expr.children.size() == 1);
-          auto child = execute(*expr.children[0], execution_mode::AST);
+    execute_result output = [&]() -> execute_result {
+      switch (alt.op) {
+        case sirius::ast::unary_op::kind::op_not: {
           auto const& not_expr =
             _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, child.get_expr());
-          return execute_result(
-            ast_result(not_expr, child.get_temp_scalar_indices(), child.get_temp_column_indices()));
+          return build_output(not_expr);
         }
-        case duckdb::ExpressionType::OPERATOR_IS_NULL:  // Fallthrough
-        case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL: {
-          D_ASSERT(expr.children.size() == 1);
-          auto child               = execute(*expr.children[0], execution_mode::AST);
+        case sirius::ast::unary_op::kind::op_is_null: {
           auto const& is_null_expr = _ast_tree.emplace<cudf::ast::operation>(
             cudf::ast::ast_operator::IS_NULL, child.get_expr());
-          if (expr.type == duckdb::ExpressionType::OPERATOR_IS_NULL) {
-            return execute_result(ast_result(
-              is_null_expr, child.get_temp_scalar_indices(), child.get_temp_column_indices()));
-          } else {
-            auto const& not_expr =
-              _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, is_null_expr);
-            return execute_result(ast_result(
-              not_expr, child.get_temp_scalar_indices(), child.get_temp_column_indices()));
-          }
+          return build_output(is_null_expr);
+        }
+        case sirius::ast::unary_op::kind::op_is_not_null: {
+          auto const& is_null_expr = _ast_tree.emplace<cudf::ast::operation>(
+            cudf::ast::ast_operator::IS_NULL, child.get_expr());
+          auto const& not_expr =
+            _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, is_null_expr);
+          return build_output(not_expr);
         }
         default:
           throw internal_exception(
-            "[gpu_expression_executor] AST mode with unknown/unsupported operator type: {}",
-            static_cast<int>(expr.type));
+            "[gpu_expression_executor] AST mode with unknown/unsupported unary_op kind: {}",
+            static_cast<int>(alt.op));
       }
-    };
-
-    auto output = operator_type_switch_ast(expr);
+    }();
 
     if (mode == execution_mode::AST) {
       //===----------1: AST Mode----------===//
@@ -297,17 +302,13 @@ execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression 
 
     //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
     auto result_column = execute_ast(output.get_expr());
-
-    // Release consumed temporaries
     release_temporaries(output.get_temp_scalar_indices(), output.get_temp_column_indices());
     return execute_result(std::move(result_column));
   }
 
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
   if (mode == execution_mode::AST) {
-    auto result = execute(expr, execution_mode::MATERIALIZE);
-    // Executing an operator expression in MATERIALIZE mode should produce an owned column.
-    // Otherwise, something went wrong.
+    auto result = execute(alt, execution_mode::MATERIALIZE);
     if (!result.is_owned_column()) {
       throw internal_exception(
         "[gpu_expression_executor:operator]: Expected an owned column after executing operator "
@@ -315,199 +316,287 @@ execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression 
     }
     return materialize_as_ast_column(result.release_column());
   }
-  switch (expr.type) {
-    case duckdb::ExpressionType::COMPARE_IN:  // Fallthrough
-    case duckdb::ExpressionType::COMPARE_NOT_IN: {
-      D_ASSERT(expr.children.size() > 1);
-      auto test = execute(*expr.children[0], execution_mode::MATERIALIZE);
-      D_ASSERT(!test.is_scalar());  // IN with scalar LHS should have been already resolved
 
-      // Optimization: special handling for case where RHS are all constants
-      if (std::all_of(expr.children.begin() + 1, expr.children.end(), [](const auto& child) {
-            return child->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CONSTANT;
-          })) {
-        // All types should be the same. Mirrors the constant types supported in
-        // gpu_execute_constant.cpp.
-        std::unique_ptr<cudf::column> contains_column;
-        switch (test.get_column_view().type().id()) {
-          case cudf::type_id::INT8:
-            contains_column =
-              execute_numeric_in<int8_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::INT16:
-            contains_column =
-              execute_numeric_in<int16_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::INT32:
-            contains_column =
-              execute_numeric_in<int32_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::INT64:
-            contains_column =
-              execute_numeric_in<int64_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::UINT8:
-            contains_column =
-              execute_numeric_in<uint8_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::UINT16:
-            contains_column =
-              execute_numeric_in<uint16_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::UINT32:
-            contains_column =
-              execute_numeric_in<uint32_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::UINT64:
-            contains_column =
-              execute_numeric_in<uint64_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::FLOAT32:
-            contains_column =
-              execute_numeric_in<float_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::FLOAT64:
-            contains_column =
-              execute_numeric_in<double_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::BOOL8:
-            contains_column =
-              execute_numeric_in<uint8_t>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::DECIMAL32:
-            contains_column =
-              execute_decimal_in<numeric::decimal32>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::DECIMAL64:
-            contains_column =
-              execute_decimal_in<numeric::decimal64>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::DECIMAL128:
-            contains_column =
-              execute_decimal_in<numeric::decimal128>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::TIMESTAMP_DAYS:
-            contains_column =
-              execute_timestamp_in<cudf::timestamp_D>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::TIMESTAMP_SECONDS:
-            contains_column =
-              execute_timestamp_in<cudf::timestamp_s>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::TIMESTAMP_MILLISECONDS:
-            contains_column =
-              execute_timestamp_in<cudf::timestamp_ms>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::TIMESTAMP_MICROSECONDS:
-            contains_column =
-              execute_timestamp_in<cudf::timestamp_us>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::TIMESTAMP_NANOSECONDS:
-            contains_column =
-              execute_timestamp_in<cudf::timestamp_ns>(expr, test.get_column_view(), _mr, _stream);
-            break;
-          case cudf::type_id::STRING:
-            contains_column = execute_string_in(expr, test.get_column_view(), _mr, _stream);
-            break;
-          default:
-            throw not_implemented_exception(
-              "[gpu_expression_executor] execute IN called with unsupported scalar haystack type "
-              "{}",
-              static_cast<int>(test.get_column_view().type().id()));
-        }
-        if (expr.type == duckdb::ExpressionType::COMPARE_NOT_IN) {
-          contains_column =
-            cudf::unary_operation(contains_column->view(), cudf::unary_operator::NOT, _stream, _mr);
-        }
-        return execute_result(std::move(contains_column));
-      }
-
-      // Some hastack referent is not a scalar
-      auto const output_type = GetCudfType(expr.return_type);
-      auto comparator        = execute(*expr.children[1], execution_mode::MATERIALIZE);
-      auto comparison_column = cudf::binary_operation(test.get_column_view(),
-                                                      comparator.get_column_view(),
-                                                      cudf::binary_operator::EQUAL,
-                                                      output_type,
-                                                      _stream,
-                                                      _mr);
-      auto output            = execute_result(std::move(comparison_column));
-
-      // For every child, OR the result of the comparison with the left to get the overall result.
-      for (std::size_t child = 2; child < expr.children.size(); ++child) {
-        // Resolve the child
-        auto comparator        = execute(*expr.children[child], execution_mode::MATERIALIZE);
-        auto comparison_column = cudf::binary_operation(test.get_column_view(),
-                                                        comparator.get_column_view(),
-                                                        cudf::binary_operator::EQUAL,
-                                                        output_type,
-                                                        _stream,
-                                                        _mr);
-
-        auto combined_comparison_column = cudf::binary_operation(output.get_column_view(),
-                                                                 comparison_column->view(),
-                                                                 cudf::binary_operator::LOGICAL_OR,
-                                                                 output_type,
-                                                                 _stream,
-                                                                 _mr);
-        output                          = execute_result(std::move(combined_comparison_column));
-      }
-
-      if (expr.type == duckdb::ExpressionType::COMPARE_IN) { return output; }
-      auto not_comparison_column =
-        cudf::unary_operation(output.get_column_view(), cudf::unary_operator::NOT, _stream, _mr);
-      return execute_result(std::move(not_comparison_column));
-    }
-    case duckdb::ExpressionType::OPERATOR_COALESCE: {
-      D_ASSERT(expr.children.size() > 1);  // B/C optimizer should constant fold 1-child COALESCEs
-
-      auto current_result = execute(*expr.children[0], execution_mode::MATERIALIZE);
-      if (current_result.is_scalar()) {
-        current_result = execute_result(cudf::make_column_from_scalar(
-          current_result.get_scalar(), _input_table.num_rows(), _stream, _mr));
-      }
-
-      for (std::size_t child = 1; child < expr.children.size(); ++child) {
-        // Short-circuit if the null_count is zero
-        if (!current_result.get_column_view().has_nulls()) { break; }
-        auto replacement = execute(*expr.children[child], execution_mode::MATERIALIZE);
-        if (replacement.is_scalar()) {
-          current_result = execute_result(cudf::replace_nulls(
-            current_result.get_column_view(), replacement.get_scalar(), _stream, _mr));
-        } else {
-          current_result = execute_result(cudf::replace_nulls(
-            current_result.get_column_view(), replacement.get_column_view(), _stream, _mr));
-        }
-      }
-      return current_result;
-    }
-    case duckdb::ExpressionType::OPERATOR_TRY:
-      throw not_implemented_exception(
-        "[gpu_expression_executor] execute called on an unsupported TRY operator expression.");
-    case duckdb::ExpressionType::OPERATOR_NOT: {
-      D_ASSERT(expr.children.size() == 1);
-      auto child = execute(*expr.children[0], execution_mode::MATERIALIZE);
+  auto child = execute(*alt.child, execution_mode::MATERIALIZE);
+  switch (alt.op) {
+    case sirius::ast::unary_op::kind::op_not:
       return execute_result(
         cudf::unary_operation(child.get_column_view(), cudf::unary_operator::NOT, _stream, _mr));
-    }
-    case duckdb::ExpressionType::OPERATOR_IS_NULL:  // Fallthrough
-    case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL: {
-      D_ASSERT(expr.children.size() == 1);
-      auto child          = execute(*expr.children[0], execution_mode::MATERIALIZE);
+    case sirius::ast::unary_op::kind::op_is_null:
+      return execute_result(cudf::is_null(child.get_column_view(), _stream, _mr));
+    case sirius::ast::unary_op::kind::op_is_not_null: {
       auto is_null_result = cudf::is_null(child.get_column_view(), _stream, _mr);
-      if (expr.type == duckdb::ExpressionType::OPERATOR_IS_NULL) {
-        return execute_result(std::move(is_null_result));
-      }
       return execute_result(
         cudf::unary_operation(is_null_result->view(), cudf::unary_operator::NOT, _stream, _mr));
     }
     default:
       throw internal_exception(
-        "[gpu_expression_executor] execute called on an operator expression [{}] with "
-        "unknown/unsupported operator type: {}",
-        expr.ToString(),
-        static_cast<int>(expr.type));
+        "[gpu_expression_executor] execute called on an operator expression with "
+        "unknown/unsupported unary_op kind: {}",
+        static_cast<int>(alt.op));
   }
+}
+
+//===----------------------------------------------------------------------===//
+// in_list
+//===----------------------------------------------------------------------===//
+
+execute_result gpu_expression_executor::execute(sirius::ast::in_list const& alt,
+                                                execution_mode mode)
+{
+  // Match DuckDB-typed count_ast_ops for COMPARE_IN/NOT_IN:
+  //   children = [probe] + values; num_or = N-2, num_eq = N-1, +1 if NOT_IN
+  auto const total_children = 1U + alt.values.size();
+  D_ASSERT(total_children > 1U);
+  std::size_t const num_or = total_children - 2U;
+  std::size_t const num_eq = total_children - 1U;
+  std::size_t ast_op_count = num_or + num_eq + (alt.negated ? 1U : 0U);
+  ast_op_count += count_ast_ops(*alt.probe);
+  for (auto const& v : alt.values) {
+    ast_op_count += count_ast_ops(*v);
+  }
+
+  if (_strategy != expression_executor_strategy::MATERIALIZE &&
+      (mode == execution_mode::AST || ast_op_count >= _min_ast_size)) {
+    D_ASSERT(!alt.values.empty());
+
+    auto test                = execute(*alt.probe, execution_mode::AST);
+    auto comparator          = execute(*alt.values[0], execution_mode::AST);
+    expr_ref comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+      cudf::ast::ast_operator::EQUAL, test.get_expr(), comparator.get_expr());
+    auto output = execute_result(
+      ast_result(comparison_expr,
+                 {test.get_temp_scalar_indices(), comparator.get_temp_scalar_indices()},
+                 {test.get_temp_column_indices(), comparator.get_temp_column_indices()}));
+
+    for (std::size_t value_idx = 1; value_idx < alt.values.size(); ++value_idx) {
+      auto next_comparator          = execute(*alt.values[value_idx], execution_mode::AST);
+      expr_ref next_comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::EQUAL, test.get_expr(), next_comparator.get_expr());
+      comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LOGICAL_OR, comparison_expr, next_comparison_expr);
+      output = execute_result(
+        ast_result(comparison_expr,
+                   {output.get_temp_scalar_indices(), next_comparator.get_temp_scalar_indices()},
+                   {output.get_temp_column_indices(), next_comparator.get_temp_column_indices()}));
+    }
+
+    if (!alt.negated) {
+      // produce IN result (positive)
+      if (mode == execution_mode::AST) { return output; }
+      auto result_column = execute_ast(output.get_expr());
+      release_temporaries(output.get_temp_scalar_indices(), output.get_temp_column_indices());
+      return execute_result(std::move(result_column));
+    }
+    auto const& not_expr =
+      _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, comparison_expr);
+    auto not_output = execute_result(
+      ast_result(not_expr, output.get_temp_scalar_indices(), output.get_temp_column_indices()));
+
+    if (mode == execution_mode::AST) {
+      //===----------1: AST Mode----------===//
+      return not_output;
+    }
+
+    //===----------2: MATERIALIZE Mode, evaluate node with AST----------===//
+    auto result_column = execute_ast(not_output.get_expr());
+    release_temporaries(not_output.get_temp_scalar_indices(), not_output.get_temp_column_indices());
+    return execute_result(std::move(result_column));
+  }
+
+  //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
+  if (mode == execution_mode::AST) {
+    auto result = execute(alt, execution_mode::MATERIALIZE);
+    if (!result.is_owned_column()) {
+      throw internal_exception(
+        "[gpu_expression_executor:operator]: Expected an owned column after executing operator "
+        "expression.");
+    }
+    return materialize_as_ast_column(result.release_column());
+  }
+
+  D_ASSERT(!alt.values.empty());
+  auto test = execute(*alt.probe, execution_mode::MATERIALIZE);
+  D_ASSERT(!test.is_scalar());  // IN with scalar LHS should have been already resolved
+
+  // Optimization: special handling when every haystack entry is a constant.
+  auto const all_constants = std::all_of(alt.values.begin(), alt.values.end(), [](auto const& v) {
+    return v && v->template holds<sirius::ast::constant>();
+  });
+
+  if (all_constants) {
+    std::unique_ptr<cudf::column> contains_column;
+    switch (test.get_column_view().type().id()) {
+      case cudf::type_id::INT8:
+        contains_column = execute_numeric_in_ast<int8_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::INT16:
+        contains_column =
+          execute_numeric_in_ast<int16_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::INT32:
+        contains_column =
+          execute_numeric_in_ast<int32_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::INT64:
+        contains_column =
+          execute_numeric_in_ast<int64_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::UINT8:
+        contains_column =
+          execute_numeric_in_ast<uint8_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::UINT16:
+        contains_column =
+          execute_numeric_in_ast<uint16_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::UINT32:
+        contains_column =
+          execute_numeric_in_ast<uint32_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::UINT64:
+        contains_column =
+          execute_numeric_in_ast<uint64_t>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::FLOAT32:
+        contains_column = execute_numeric_in_ast<float>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::FLOAT64:
+        contains_column = execute_numeric_in_ast<double>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::BOOL8:
+        contains_column = execute_bool_in_ast(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::DECIMAL32:
+        contains_column =
+          execute_decimal_in_ast<numeric::decimal32>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::DECIMAL64:
+        contains_column =
+          execute_decimal_in_ast<numeric::decimal64>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::DECIMAL128:
+        contains_column =
+          execute_decimal_in_ast<numeric::decimal128>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::TIMESTAMP_DAYS:
+        contains_column =
+          execute_timestamp_in_ast<cudf::timestamp_D>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::TIMESTAMP_SECONDS:
+        contains_column =
+          execute_timestamp_in_ast<cudf::timestamp_s>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::TIMESTAMP_MILLISECONDS:
+        contains_column =
+          execute_timestamp_in_ast<cudf::timestamp_ms>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::TIMESTAMP_MICROSECONDS:
+        contains_column =
+          execute_timestamp_in_ast<cudf::timestamp_us>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::TIMESTAMP_NANOSECONDS:
+        contains_column =
+          execute_timestamp_in_ast<cudf::timestamp_ns>(alt, test.get_column_view(), _mr, _stream);
+        break;
+      case cudf::type_id::STRING:
+        contains_column = execute_string_in_ast(alt, test.get_column_view(), _mr, _stream);
+        break;
+      default:
+        throw not_implemented_exception(
+          "[gpu_expression_executor] execute IN called with unsupported scalar haystack type {}",
+          static_cast<int>(test.get_column_view().type().id()));
+    }
+    if (alt.negated) {
+      contains_column =
+        cudf::unary_operation(contains_column->view(), cudf::unary_operator::NOT, _stream, _mr);
+    }
+    return execute_result(std::move(contains_column));
+  }
+
+  // Some haystack referent is not a scalar — fall back to a chained OR of EQUAL comparisons.
+  auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
+  auto comparator        = execute(*alt.values[0], execution_mode::MATERIALIZE);
+  auto comparison_column = cudf::binary_operation(test.get_column_view(),
+                                                  comparator.get_column_view(),
+                                                  cudf::binary_operator::EQUAL,
+                                                  output_type,
+                                                  _stream,
+                                                  _mr);
+  auto output            = execute_result(std::move(comparison_column));
+
+  for (std::size_t value_idx = 1; value_idx < alt.values.size(); ++value_idx) {
+    auto next_comparator = execute(*alt.values[value_idx], execution_mode::MATERIALIZE);
+    auto next_eq_column  = cudf::binary_operation(test.get_column_view(),
+                                                 next_comparator.get_column_view(),
+                                                 cudf::binary_operator::EQUAL,
+                                                 output_type,
+                                                 _stream,
+                                                 _mr);
+    auto combined        = cudf::binary_operation(output.get_column_view(),
+                                           next_eq_column->view(),
+                                           cudf::binary_operator::LOGICAL_OR,
+                                           output_type,
+                                           _stream,
+                                           _mr);
+    output               = execute_result(std::move(combined));
+  }
+
+  if (!alt.negated) { return output; }
+  auto not_column =
+    cudf::unary_operation(output.get_column_view(), cudf::unary_operator::NOT, _stream, _mr);
+  return execute_result(std::move(not_column));
+}
+
+//===----------------------------------------------------------------------===//
+// coalesce — always materializes; no AST representation.
+//===----------------------------------------------------------------------===//
+
+execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& alt,
+                                                execution_mode mode)
+{
+  D_ASSERT(alt.children.size() > 1);
+
+  auto current_result = execute(*alt.children[0], execution_mode::MATERIALIZE);
+  if (current_result.is_scalar()) {
+    current_result = execute_result(cudf::make_column_from_scalar(
+      current_result.get_scalar(), _input_table.num_rows(), _stream, _mr));
+  }
+
+  for (std::size_t child_idx = 1; child_idx < alt.children.size(); ++child_idx) {
+    // Short-circuit if the null_count is zero
+    if (!current_result.get_column_view().has_nulls()) { break; }
+    auto replacement = execute(*alt.children[child_idx], execution_mode::MATERIALIZE);
+    if (replacement.is_scalar()) {
+      current_result = execute_result(cudf::replace_nulls(
+        current_result.get_column_view(), replacement.get_scalar(), _stream, _mr));
+    } else {
+      current_result = execute_result(cudf::replace_nulls(
+        current_result.get_column_view(), replacement.get_column_view(), _stream, _mr));
+    }
+  }
+
+  if (mode == execution_mode::AST) {
+    if (!current_result.is_owned_column()) {
+      throw internal_exception(
+        "[gpu_expression_executor:operator]: Expected an owned column after executing COALESCE "
+        "expression.");
+    }
+    return materialize_as_ast_column(current_result.release_column());
+  }
+  return current_result;
+}
+
+//===----------------------------------------------------------------------===//
+// DuckDB-typed entry — routes to one of the three native bodies via the
+// public node dispatcher's std::visit over from_duckdb(expr).
+//===----------------------------------------------------------------------===//
+
+execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_operator.cpp
+++ b/src/expression_executor/specializations/gpu_execute_operator.cpp
@@ -596,6 +596,12 @@ execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression 
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:operator] BoundOperatorExpression with operator type {} could "
+      "not be lowered to a Sirius AST node.",
+      static_cast<int>(expr.GetExpressionType()));
+  }
   return execute(*node, mode);
 }
 

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -15,6 +15,8 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 
 // duckdb
@@ -24,13 +26,20 @@ namespace sirius {
 using ast_result     = gpu_expression_executor::ast_result;
 using execute_result = gpu_expression_executor::execute_result;
 
-execute_result gpu_expression_executor::execute(duckdb::BoundReferenceExpression const& expr,
+execute_result gpu_expression_executor::execute(sirius::ast::reference const& alt,
                                                 execution_mode mode)
 {
   if (mode == execution_mode::AST) {
-    auto const& col_expr = _ast_tree.emplace<cudf::ast::column_reference>(expr.index);
+    auto const& col_expr = _ast_tree.emplace<cudf::ast::column_reference>(alt.column_index);
     return execute_result(ast_result(col_expr));
   }
-  return execute_result(_input_table.column(expr.index));
+  return execute_result(_input_table.column(alt.column_index));
+}
+
+execute_result gpu_expression_executor::execute(duckdb::BoundReferenceExpression const& expr,
+                                                execution_mode mode)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -37,6 +37,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::reference const& al
   return execute_result(_input_table.column(alt.column_index));
 }
 
+// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
+// directly into the executor; the eventual home for this from_duckdb step is
+// the planning stage so the executor sees only native sirius::ast types, but
+// until upstream call sites are migrated this overload (and the duckdb
+// includes it requires) must stay.
 execute_result gpu_expression_executor::execute(duckdb::BoundReferenceExpression const& expr,
                                                 execution_mode mode)
 {

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -18,6 +18,7 @@
 #include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
@@ -40,6 +41,11 @@ execute_result gpu_expression_executor::execute(duckdb::BoundReferenceExpression
                                                 execution_mode mode)
 {
   auto node = sirius::ast::from_duckdb(expr);
+  if (!node) {
+    throw not_implemented_exception(
+      "[gpu_expression_executor:reference] BoundReferenceExpression could not be lowered to a "
+      "Sirius AST node (sirius::ast::from_duckdb returned nullptr).");
+  }
   return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/include/expression/ast/between.hpp
+++ b/src/include/expression/ast/between.hpp
@@ -32,6 +32,8 @@ struct between {
   std::unique_ptr<node> upper;
   bool lower_inclusive{true};
   bool upper_inclusive{true};
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/case_expr.hpp
+++ b/src/include/expression/ast/case_expr.hpp
@@ -39,6 +39,8 @@ struct case_expr {
 
   std::vector<when_then> cases;
   std::unique_ptr<node> else_;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/cast.hpp
+++ b/src/include/expression/ast/cast.hpp
@@ -36,6 +36,8 @@ struct cast {
   std::unique_ptr<node> child;
   sirius::logical_type target_type;
   bool try_cast{false};
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/coalesce.hpp
+++ b/src/include/expression/ast/coalesce.hpp
@@ -34,6 +34,8 @@ struct node;
  */
 struct coalesce {
   std::vector<std::unique_ptr<node>> children;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/comparison.hpp
+++ b/src/include/expression/ast/comparison.hpp
@@ -36,6 +36,8 @@ struct comparison {
   sirius::comparison_type op{sirius::comparison_type::equal};
   std::unique_ptr<node> left;
   std::unique_ptr<node> right;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/conjunction.hpp
+++ b/src/include/expression/ast/conjunction.hpp
@@ -44,6 +44,8 @@ struct conjunction {
 
   kind op{kind::invalid};
   std::vector<std::unique_ptr<node>> children;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/constant.hpp
+++ b/src/include/expression/ast/constant.hpp
@@ -32,6 +32,8 @@ namespace sirius::ast {
 struct constant {
   sirius::value payload;
   sirius::logical_type return_type;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/function_call.hpp
+++ b/src/include/expression/ast/function_call.hpp
@@ -64,6 +64,8 @@ class function_call {
   }
   [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
 
+  [[nodiscard]] std::size_t cudf_ast_op_count() const;
+
  private:
   sirius::function_id function_;
   std::vector<std::unique_ptr<node>> arguments_;

--- a/src/include/expression/ast/in_list.hpp
+++ b/src/include/expression/ast/in_list.hpp
@@ -37,6 +37,8 @@ struct in_list {
   std::unique_ptr<node> probe;
   std::vector<std::unique_ptr<node>> values;
   bool negated{false};
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/node.hpp
+++ b/src/include/expression/ast/node.hpp
@@ -17,6 +17,8 @@
 #pragma once
 
 // standard library
+#include <concepts>
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -50,6 +52,29 @@ struct node;
 
 namespace sirius::ast {
 
+/// Compile-time contract: every alternative held in node::variant_t must
+/// implement `std::size_t cudf_ast_op_count() const`. Without this concept,
+/// a missing method only surfaces as a deep template-instantiation error
+/// when node::cudf_ast_op_count()'s std::visit fans out. The static_assert
+/// below uses this concept to produce a one-line, named error at the variant
+/// declaration site instead.
+template <class T>
+concept has_cudf_ast_op_count = requires(T const& t) {
+  { t.cudf_ast_op_count() } -> std::convertible_to<std::size_t>;
+};
+
+namespace detail {
+
+template <class Variant>
+struct all_have_cudf_ast_op_count;
+
+template <class... Ts>
+struct all_have_cudf_ast_op_count<std::variant<Ts...>> {
+  static constexpr bool value = (has_cudf_ast_op_count<Ts> && ...);
+};
+
+}  // namespace detail
+
 /**
  * @brief Sum type over every Sirius AST node kind.
  *
@@ -79,6 +104,11 @@ struct node {
                                  coalesce,
                                  in_list,
                                  function_call>;
+
+  static_assert(detail::all_have_cudf_ast_op_count<variant_t>::value,
+                "Every alternative in sirius::ast::node::variant_t must implement "
+                "std::size_t cudf_ast_op_count() const. Add the method to the "
+                "missing alternative struct.");
 
   variant_t v;
 
@@ -121,6 +151,8 @@ struct node {
   {
     return std::get<T>(v);
   }
+
+  [[nodiscard]] std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/reference.hpp
+++ b/src/include/expression/ast/reference.hpp
@@ -29,6 +29,8 @@ namespace sirius::ast {
  */
 struct reference {
   uint32_t column_index{0};
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/unary_op.hpp
+++ b/src/include/expression/ast/unary_op.hpp
@@ -51,6 +51,8 @@ struct unary_op {
 
   kind op{kind::invalid};
   std::unique_ptr<node> child;
+
+  std::size_t cudf_ast_op_count() const;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression_executor/ast_supported_types.hpp
+++ b/src/include/expression_executor/ast_supported_types.hpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include "expression/function_id.hpp"
+#include "helper/logical_type.hpp"  // sirius::type_id
 
 // duckdb
 #include <duckdb/common/types.hpp>
@@ -34,6 +35,11 @@ namespace sirius {
 /// CAST return types that are currently safe to lower into a cuDF AST.
 inline constexpr std::array<duckdb::LogicalTypeId, 3> supported_ast_cast_types{
   {duckdb::LogicalTypeId::UBIGINT, duckdb::LogicalTypeId::BIGINT, duckdb::LogicalTypeId::DOUBLE}};
+
+/// Sirius-typed mirror of supported_ast_cast_types — same set of CAST target
+/// types as above, expressed via sirius::type_id for native AST consumers.
+inline constexpr std::array<sirius::type_id, 3> supported_ast_cast_types_native{
+  {sirius::type_id::UBIGINT, sirius::type_id::BIGINT, sirius::type_id::DOUBLE}};
 
 /// BOUND_FUNCTION names that are currently safe to lower into a cuDF AST.
 inline constexpr std::array<function_id, 6> supported_ast_functions{function_id::add,

--- a/test/cpp/expression/test_ast_from_duckdb.cpp
+++ b/test/cpp/expression/test_ast_from_duckdb.cpp
@@ -648,7 +648,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT with unsupported child propagate
   // Wrapping it in NOT must propagate the nullptr up.
   auto bad_child = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_not"});
   auto not_expr  = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                                              LogicalType{LogicalTypeId::BOOLEAN});
+                                                             LogicalType{LogicalTypeId::BOOLEAN});
   not_expr->children.push_back(std::move(bad_child));
 
   REQUIRE(sirius::ast::from_duckdb(*not_expr) == nullptr);
@@ -659,7 +659,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe pr
 {
   auto bad_probe = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_in"});
   auto in_expr   = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                              LogicalType{LogicalTypeId::BOOLEAN});
+                                                            LogicalType{LogicalTypeId::BOOLEAN});
   in_expr->children.push_back(std::move(bad_probe));
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));

--- a/test/cpp/expression/test_ast_from_duckdb.cpp
+++ b/test/cpp/expression/test_ast_from_duckdb.cpp
@@ -254,13 +254,30 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHANOREQUALTO translates to
   REQUIRE(out->get<comparison>().op == sirius::comparison_type::ge);
 }
 
-TEST_CASE("ast_from_duckdb - BOUND_COMPARISON DISTINCT_FROM returns nullptr", "[ast_from_duckdb]")
+TEST_CASE("ast_from_duckdb - BOUND_COMPARISON DISTINCT_FROM translates to comparison node",
+          "[ast_from_duckdb]")
 {
   auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
   auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
-  REQUIRE(sirius::ast::from_duckdb(*expr) == nullptr);
+  auto out = sirius::ast::from_duckdb(*expr);
+  REQUIRE(out);
+  REQUIRE(out->holds<comparison>());
+  REQUIRE(out->get<comparison>().op == sirius::comparison_type::distinct_from);
+}
+
+TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOT_DISTINCT_FROM translates to comparison node",
+          "[ast_from_duckdb]")
+{
+  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left), std::move(right));
+  auto out = sirius::ast::from_duckdb(*expr);
+  REQUIRE(out);
+  REQUIRE(out->holds<comparison>());
+  REQUIRE(out->get<comparison>().op == sirius::comparison_type::not_distinct_from);
 }
 
 // ============================================================================
@@ -362,12 +379,9 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE WHEN/THEN/ELSE translates to case_expr",
 TEST_CASE("ast_from_duckdb - BOUND_CASE with unsupported WHEN propagates nullptr",
           "[ast_from_duckdb]")
 {
-  // The WHEN subexpression is COMPARE_DISTINCT_FROM (unsupported -> nullptr).
+  // The WHEN subexpression is a BoundParameterExpression (unsupported -> nullptr).
   // The whole CASE must collapse to nullptr.
-  auto bad_when = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+  auto bad_when  = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_when"});
   auto then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10));
 
   BoundCaseCheck case_check;
@@ -630,14 +644,11 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR unsupported ExpressionType returns n
 TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT with unsupported child propagates nullptr",
           "[ast_from_duckdb]")
 {
-  // COMPARE_DISTINCT_FROM is the canonical unsupported-comparison subtype that
-  // routes to nullptr; wrapping it in NOT must propagate the nullptr up.
-  auto bad_child = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                                             LogicalType{LogicalTypeId::BOOLEAN});
+  // BoundParameterExpression translates to nullptr (BOUND_PARAMETER class).
+  // Wrapping it in NOT must propagate the nullptr up.
+  auto bad_child = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_not"});
+  auto not_expr  = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
   not_expr->children.push_back(std::move(bad_child));
 
   REQUIRE(sirius::ast::from_duckdb(*not_expr) == nullptr);
@@ -646,12 +657,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT with unsupported child propagate
 TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe propagates nullptr",
           "[ast_from_duckdb]")
 {
-  auto bad_probe = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
+  auto bad_probe = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_in"});
+  auto in_expr   = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
+                                                              LogicalType{LogicalTypeId::BOOLEAN});
   in_expr->children.push_back(std::move(bad_probe));
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
@@ -662,10 +670,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe pr
 TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE with unsupported child propagates nullptr",
           "[ast_from_duckdb]")
 {
-  auto bad_child = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+  auto bad_child     = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_coalesce"});
   auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
   coalesce_expr->children.push_back(

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2357,3 +2357,25 @@ TEST_CASE("native_ast - coalesce (MATERIALIZE)", "[expression_executor_ast_nativ
     REQUIRE(out_host[i] == (valids[i] ? values[i] : 99));
   }
 }
+
+TEST_CASE("native_ast - cast INTEGER->BIGINT (MATERIALIZE)",
+          "[expression_executor_ast_native][cast]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::cast{ref_node_native(0),
+                      sirius::logical_type::make(sirius::type_id::BIGINT),
+                      /*try_cast=*/false});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_column_to_host<int64_t>(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == static_cast<int64_t>(in_host[i]));
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2143,3 +2143,43 @@ TEST_CASE("native_ast - constant VARCHAR", "[expression_executor_ast_native][con
   std::vector<std::string> expected(tv.num_rows(), "hello");
   REQUIRE(copy_string_column_to_host(out->view().column(0)) == expected);
 }
+
+TEST_CASE("native_ast - comparison EQUAL (MATERIALIZE)",
+          "[expression_executor_ast_native][comparison]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::equal, ref_node_native(0), int_const_node_native(42)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == (in_host[i] == 42 ? 1U : 0U));
+  }
+}
+
+TEST_CASE("native_ast - comparison LESS_THAN (AST_INTERPRET)",
+          "[expression_executor_ast_native][comparison]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::lt, ref_node_native(0), int_const_node_native(50)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, exp_strategy_enum::AST_INTERPRET);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == (in_host[i] < 50 ? 1U : 0U));
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2379,3 +2379,68 @@ TEST_CASE("native_ast - cast INTEGER->BIGINT (MATERIALIZE)",
     REQUIRE(out_host[i] == static_cast<int64_t>(in_host[i]));
   }
 }
+
+TEST_CASE("native_ast - function_call add (MATERIALIZE)",
+          "[expression_executor_ast_native][function_call]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  // 2-column INT32 batch.
+  auto input =
+    make_input_batch(*space,
+                     {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
+                     {std::pair<int, int>{0, 50}, std::pair<int, int>{0, 50}});
+  auto ro       = input->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  std::vector<std::unique_ptr<sirius::ast::node>> args;
+  args.push_back(ref_node_native(0));
+  args.push_back(ref_node_native(1));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::function_call{sirius::function_id::add,
+                               std::move(args),
+                               sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  auto c0       = copy_column_to_host<int32_t>(tv.column(0));
+  auto c1       = copy_column_to_host<int32_t>(tv.column(1));
+  auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
+  REQUIRE(out_host.size() == c0.size());
+  for (size_t i = 0; i < c0.size(); ++i) {
+    REQUIRE(out_host[i] == c0[i] + c1[i]);
+  }
+}
+
+TEST_CASE("native_ast - function_call add (AST_INTERPRET)",
+          "[expression_executor_ast_native][function_call]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input =
+    make_input_batch(*space,
+                     {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
+                     {std::pair<int, int>{0, 50}, std::pair<int, int>{0, 50}});
+  auto ro       = input->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  std::vector<std::unique_ptr<sirius::ast::node>> args;
+  args.push_back(ref_node_native(0));
+  args.push_back(ref_node_native(1));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::function_call{sirius::function_id::add,
+                               std::move(args),
+                               sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, exp_strategy_enum::AST_INTERPRET);
+  REQUIRE(out);
+  auto c0       = copy_column_to_host<int32_t>(tv.column(0));
+  auto c1       = copy_column_to_host<int32_t>(tv.column(1));
+  auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
+  REQUIRE(out_host.size() == c0.size());
+  for (size_t i = 0; i < c0.size(); ++i) {
+    REQUIRE(out_host[i] == c0[i] + c1[i]);
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2216,3 +2216,26 @@ TEST_CASE("native_ast - conjunction AND (MATERIALIZE)",
     REQUIRE(out_host[i] == ((c0[i] > 10 && c1[i] < 90) ? 1U : 0U));
   }
 }
+
+TEST_CASE("native_ast - between (MATERIALIZE)", "[expression_executor_ast_native][between]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast =
+    std::make_unique<sirius::ast::node>(sirius::ast::between{ref_node_native(0),
+                                                             int_const_node_native(5),
+                                                             int_const_node_native(15),
+                                                             /*lower_inclusive=*/true,
+                                                             /*upper_inclusive=*/true});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == ((in_host[i] >= 5 && in_host[i] <= 15) ? 1U : 0U));
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2109,3 +2109,37 @@ TEST_CASE("native_ast - reference identity", "[expression_executor_ast_native][r
   auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
   REQUIRE(out_host == in_host);
 }
+
+TEST_CASE("native_ast - constant INTEGER", "[expression_executor_ast_native][constant]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+    sirius::value{int32_t{42}}, sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  std::vector<int32_t> expected(in.view.num_rows(), 42);
+  REQUIRE(copy_column_to_host<int32_t>(out->view().column(0)) == expected);
+}
+
+TEST_CASE("native_ast - constant VARCHAR", "[expression_executor_ast_native][constant]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input =
+    make_input_batch(*space, {cudf::data_type{cudf::type_id::STRING}}, {std::pair<int, int>{1, 5}});
+  auto ro       = input->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::constant{
+    sirius::value{std::string{"hello"}}, sirius::logical_type::make(sirius::type_id::VARCHAR)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  std::vector<std::string> expected(tv.num_rows(), "hello");
+  REQUIRE(copy_string_column_to_host(out->view().column(0)) == expected);
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2183,3 +2183,36 @@ TEST_CASE("native_ast - comparison LESS_THAN (AST_INTERPRET)",
     REQUIRE(out_host[i] == (in_host[i] < 50 ? 1U : 0U));
   }
 }
+
+TEST_CASE("native_ast - conjunction AND (MATERIALIZE)",
+          "[expression_executor_ast_native][conjunction]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  // Build a 2-column INT32 batch with col0 in [0, 100) and col1 in [0, 100).
+  auto input =
+    make_input_batch(*space,
+                     {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
+                     {std::pair<int, int>{0, 100}, std::pair<int, int>{0, 100}});
+  auto ro       = input->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  std::vector<std::unique_ptr<sirius::ast::node>> children;
+  children.push_back(std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::gt, ref_node_native(0), int_const_node_native(10)}));
+  children.push_back(std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::lt, ref_node_native(1), int_const_node_native(90)}));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::conjunction{sirius::ast::conjunction::kind::op_and, std::move(children)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  auto c0       = copy_column_to_host<int32_t>(tv.column(0));
+  auto c1       = copy_column_to_host<int32_t>(tv.column(1));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == c0.size());
+  for (size_t i = 0; i < c0.size(); ++i) {
+    REQUIRE(out_host[i] == ((c0[i] > 10 && c1[i] < 90) ? 1U : 0U));
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2444,3 +2444,28 @@ TEST_CASE("native_ast - function_call add (AST_INTERPRET)",
     REQUIRE(out_host[i] == c0[i] + c1[i]);
   }
 }
+
+TEST_CASE("native_ast - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
+          "[expression_executor_ast_native][case_expr]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.emplace_back();
+  cases.back().when_ = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::equal, ref_node_native(0), int_const_node_native(5)});
+  cases.back().then_ = int_const_node_native(100);
+  auto hand_ast      = std::make_unique<sirius::ast::node>(
+    sirius::ast::case_expr{std::move(cases), int_const_node_native(0)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == (in_host[i] == 5 ? 100 : 0));
+  }
+}

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -30,6 +30,7 @@
 #include <expression/ast/comparison.hpp>
 #include <expression/ast/conjunction.hpp>
 #include <expression/ast/constant.hpp>
+#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/function_call.hpp>
 #include <expression/ast/in_list.hpp>
 #include <expression/ast/node.hpp>
@@ -2468,4 +2469,35 @@ TEST_CASE("native_ast - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
   for (size_t i = 0; i < in_host.size(); ++i) {
     REQUIRE(out_host[i] == (in_host[i] == 5 ? 100 : 0));
   }
+}
+
+// Translator-only TEST_CASE: verifies that the BoundComparisonExpression shim
+// path now produces a non-null sirius::ast::node for COMPARE_DISTINCT_FROM and
+// COMPARE_NOT_DISTINCT_FROM. The executor's downstream behaviour on these
+// comparison kinds is GPU-bound and asserted by the existing
+// [expression_executor_ast_native][comparison] cases — this case only proves
+// that the lowering pipeline no longer drops these comparison kinds at the
+// from_duckdb step (sirius-db/sirius#699).
+TEST_CASE("native_ast - BoundComparisonExpression DISTINCT_FROM translates without nullptr",
+          "[expression_executor_ast_native_translate][comparison]")
+{
+  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7));
+  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
+
+  auto node = sirius::ast::from_duckdb(*expr);
+  REQUIRE(node);
+  REQUIRE(node->holds<sirius::ast::comparison>());
+  REQUIRE(node->get<sirius::ast::comparison>().op == sirius::comparison_type::distinct_from);
+
+  auto left2  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto right2 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7));
+  auto expr2  = duckdb::make_uniq<BoundComparisonExpression>(
+    ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left2), std::move(right2));
+
+  auto node2 = sirius::ast::from_duckdb(*expr2);
+  REQUIRE(node2);
+  REQUIRE(node2->holds<sirius::ast::comparison>());
+  REQUIRE(node2->get<sirius::ast::comparison>().op == sirius::comparison_type::not_distinct_from);
 }

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -23,7 +23,23 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
+#include <expression/ast/between.hpp>
+#include <expression/ast/case_expr.hpp>
+#include <expression/ast/cast.hpp>
+#include <expression/ast/coalesce.hpp>
+#include <expression/ast/comparison.hpp>
+#include <expression/ast/conjunction.hpp>
+#include <expression/ast/constant.hpp>
+#include <expression/ast/function_call.hpp>
+#include <expression/ast/in_list.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/ast/reference.hpp>
+#include <expression/ast/unary_op.hpp>
+#include <expression/function_id.hpp>
+#include <expression/join_condition.hpp>
+#include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/logical_type.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
 
 // duckdb
@@ -2034,4 +2050,62 @@ TEMPLATE_TEST_CASE("execute mixed arithmetic and CASE projection",
     REQUIRE(out0[i] == in0[i] + in1[i]);
     REQUIRE(out1[i] == (in0[i] > 25 ? in1[i] * 2 : in1[i]));
   }
+}
+
+// ---------------------------------------------------------------------------
+// native_ast — exercise each migrated AST alternative through the non-owning
+// AST executor ctor, building the AST by hand (no DuckDB allocation involved).
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Build a single-column INT32 input batch [0..127] and return its table view.
+struct int32_batch {
+  std::shared_ptr<data_batch> batch;
+  cudf::table_view view;
+};
+
+int32_batch make_int32_input(memory_space& space)
+{
+  auto batch =
+    make_input_batch(space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
+  auto ro       = batch->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  return {batch, in_repr.get_table_view()};
+}
+
+std::unique_ptr<sirius::ast::node> ref_node_native(uint32_t idx)
+{
+  return std::make_unique<sirius::ast::node>(sirius::ast::reference{idx});
+}
+
+std::unique_ptr<sirius::ast::node> int_const_node_native(int32_t v)
+{
+  return std::make_unique<sirius::ast::node>(
+    sirius::ast::constant{sirius::value{v}, sirius::logical_type::make(sirius::type_id::INTEGER)});
+}
+
+std::unique_ptr<cudf::table> run_native_ast(memory_space& space,
+                                            sirius::ast::node const* expr_ptr,
+                                            cudf::table_view tv,
+                                            exp_strategy_enum strategy = MAT)
+{
+  exp_executor executor(expr_ptr, get_resource_ref(space), cudf::get_default_stream(), strategy);
+  return executor.execute(tv);
+}
+
+}  // namespace
+
+TEST_CASE("native_ast - reference identity", "[expression_executor_ast_native][reference]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto hand_ast = ref_node_native(0);
+  auto out      = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
+  REQUIRE(out_host == in_host);
 }

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2239,3 +2239,121 @@ TEST_CASE("native_ast - between (MATERIALIZE)", "[expression_executor_ast_native
     REQUIRE(out_host[i] == ((in_host[i] >= 5 && in_host[i] <= 15) ? 1U : 0U));
   }
 }
+
+TEST_CASE("native_ast - unary_op NOT (MATERIALIZE)", "[expression_executor_ast_native][unary_op]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  auto cmp      = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+    sirius::comparison_type::equal, ref_node_native(0), int_const_node_native(5)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_not, std::move(cmp)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    REQUIRE(out_host[i] == (in_host[i] != 5 ? 1U : 0U));
+  }
+}
+
+TEST_CASE("native_ast - unary_op IS_NULL (MATERIALIZE)",
+          "[expression_executor_ast_native][unary_op]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  std::vector<int32_t> values{1, 2, 3, 4, 5};
+  std::vector<bool> valids{true, false, true, false, true};
+  auto batch    = make_int32_batch_with_nulls(*space, values, valids);
+  auto ro       = batch->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_null, ref_node_native(0)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == valids.size());
+  for (size_t i = 0; i < valids.size(); ++i) {
+    REQUIRE(out_host[i] == (valids[i] ? 0U : 1U));
+  }
+}
+
+TEST_CASE("native_ast - unary_op IS_NOT_NULL (MATERIALIZE)",
+          "[expression_executor_ast_native][unary_op]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  std::vector<int32_t> values{10, 20, 30, 40};
+  std::vector<bool> valids{true, false, true, true};
+  auto batch    = make_int32_batch_with_nulls(*space, values, valids);
+  auto ro       = batch->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_not_null, ref_node_native(0)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == valids.size());
+  for (size_t i = 0; i < valids.size(); ++i) {
+    REQUIRE(out_host[i] == (valids[i] ? 1U : 0U));
+  }
+}
+
+TEST_CASE("native_ast - in_list IN (MATERIALIZE)", "[expression_executor_ast_native][in_list]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto in = make_int32_input(*space);
+
+  std::vector<std::unique_ptr<sirius::ast::node>> values;
+  values.push_back(int_const_node_native(1));
+  values.push_back(int_const_node_native(3));
+  values.push_back(int_const_node_native(5));
+  auto hand_ast = std::make_unique<sirius::ast::node>(
+    sirius::ast::in_list{ref_node_native(0), std::move(values), /*negated=*/false});
+
+  auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
+  REQUIRE(out);
+  auto in_host  = copy_column_to_host<int32_t>(in.view.column(0));
+  auto out_host = copy_bool_column_to_host(out->view().column(0));
+  REQUIRE(out_host.size() == in_host.size());
+  for (size_t i = 0; i < in_host.size(); ++i) {
+    bool const expected = (in_host[i] == 1 || in_host[i] == 3 || in_host[i] == 5);
+    REQUIRE(out_host[i] == (expected ? 1U : 0U));
+  }
+}
+
+TEST_CASE("native_ast - coalesce (MATERIALIZE)", "[expression_executor_ast_native][coalesce]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  std::vector<int32_t> values{7, 8, 9, 10, 11};
+  std::vector<bool> valids{true, false, true, false, true};
+  auto batch    = make_int32_batch_with_nulls(*space, values, valids);
+  auto ro       = batch->to_read_only();
+  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto tv       = in_repr.get_table_view();
+
+  std::vector<std::unique_ptr<sirius::ast::node>> children;
+  children.push_back(ref_node_native(0));
+  children.push_back(int_const_node_native(99));
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
+
+  auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
+  REQUIRE(out);
+  auto out_host = copy_column_to_host<int32_t>(out->view().column(0));
+  REQUIRE(out_host.size() == values.size());
+  for (size_t i = 0; i < values.size(); ++i) {
+    REQUIRE(out_host[i] == (valids[i] ? values[i] : 99));
+  }
+}


### PR DESCRIPTION
sub-issue of #666. Closes #699 

## Summary
- Invert 9 `gpu_execute_*` specializations so the primary `execute(...)` body takes `sirius::ast::<alt> const&`. The `duckdb::Bound*Expression const&` overload becomes a two-line `from_duckdb` shim.
- Replace the round-trip `count_ast_ops(sirius::ast::node const&)` shim with native `std::visit` traversal.
- 17 new test cases drive the non-owning AST executor constructor directly.

## Highlights
- Specializations inverted: `reference`, `constant`, `comparison`, `conjunction`, `between`, `operator` (`unary_op` + `in_list` + `coalesce`), `cast`, `function`, `case`.
- `from_duckdb` now translates `COMPARE_DISTINCT_FROM` and `COMPARE_NOT_DISTINCT_FROM`.
- Shims null-guard `from_duckdb` and throw `not_implemented_exception` on un-lowered expressions.
- Underflow guards added on `children.size() - 1` / `values.size() - 1` sites.

## Out of scope (follow-up PRs)
- Removing the DuckDB-typed `Bound*Expression` overloads.
- Removing `to_duckdb` from the executor TU.

## Test plan
- [x] AST + executor Catch2 tags green on `make` and `ENABLE_LEGACY_SIRIUS=ON make` (265 cases / 5187 assertions).
- [x] Full `sirius_unittest` green on both build configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)