### PR TITLE
ENH Update Pixi CUDAARCHS to include 89 for Ada Lovelace (L4)

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -44,7 +44,7 @@ jobs:
       build_duckdb_shell: false
       vcpkg_overlay_ports: 'vcpkg_ports'
       vcpkg_overlay_triplets: 'vcpkg_triplets'
-      cuda_archs: '75-real;80-real;86-real;90a-real;100f-real;120a-real;120'
+      cuda_archs: '75-real;80-real;86-real;89-real;90a-real;100f-real;120a-real;120'
       cuda_version: '13'
       artifact_postfix: '-cuda13'
       runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "cuda-13", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "cuda-13", "arm-xl"]}'
@@ -67,7 +67,7 @@ jobs:
       build_duckdb_shell: false
       vcpkg_overlay_ports: 'vcpkg_ports'
       vcpkg_overlay_triplets: 'vcpkg_triplets'
-      cuda_archs: '75-real;80-real;86-real;90a-real'
+      cuda_archs: '75-real;80-real;86-real;89-real;90a-real'
       cuda_version: '12'
       artifact_postfix: '-cuda12'
       runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "cuda-12", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "cuda-12", "arm-xl"]}'

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,8 +54,8 @@ cuda-version = "13.2.*"
 libcudf = "26.04.*"
 
 [feature.cuda13.activation.env]
-# GPU architectures: Turing through Blackwell (75, 80, 86, 90a, 100f, 120a, 120)
-CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real;120a-real;120"
+# GPU architectures: Turing through Blackwell (75, 80, 86, 89, 90a, 100f, 120a, 120)
+CUDAARCHS = "75-real;80-real;86-real;89-real;90a-real;100f-real;120a-real;120"
 VCPKG_CUDA_VERSION = "13"
 
 [feature.cuda12.system-requirements]
@@ -66,8 +66,8 @@ cuda-version = "12.*"
 libcudf = "26.04.*"
 
 [feature.cuda12.activation.env]
-# GPU architectures: Turing through Hopper (75, 80, 86, 90a)
-CUDAARCHS = "75-real;80-real;86-real;90a-real"
+# GPU architectures: Turing through Hopper (75, 80, 86, 89, 90a)
+CUDAARCHS = "75-real;80-real;86-real;89-real;90a-real"
 VCPKG_CUDA_VERSION = "12"
 
 [feature.vcpkg.dependencies]


### PR DESCRIPTION
Currently we don't build for Ada Lovelace or any other 8.9 compute capability. This adds the missing CUDA architecture so a Sirius build can run on L4s in the cloud. This couples with our recent change to L4s for GPU testing where developers may want to reproduce the work on an L4 instance.