### PR TITLE
LanceDB PoC , DO NOT MERGE  (relational queries over lance_vector_search)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_gpu_execution_order_nulls.cpp
     test/cpp/integration/test_gpu_execution_tpch.cpp
     test/cpp/integration/test_gpu_execution_tpch_mgpu_audit.cpp
+    test/cpp/integration/test_lance_vector_search_transparent.cpp
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
     test/cpp/integration/test_transparent_execution.cpp
     test/cpp/io/s3/test_sigv4.cpp
@@ -498,6 +499,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_sirius_dynamic_filter.cpp
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
+    test/cpp/planner/test_lance_vector_search_routing.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_sirius_read_parquet_converter.cpp

--- a/src/op/sirius_physical_duckdb_scan.cpp
+++ b/src/op/sirius_physical_duckdb_scan.cpp
@@ -19,6 +19,7 @@
 #include "log/logging.hpp"
 
 #include <algorithm>
+#include <utility>
 
 namespace sirius {
 namespace op {
@@ -38,7 +39,13 @@ sirius_physical_duckdb_scan::sirius_physical_duckdb_scan(sirius_physical_table_s
   : sirius_physical_duckdb_scan(
       table_scan->types,
       table_scan->function,
-      table_scan->bind_data ? table_scan->bind_data->Copy() : nullptr,
+      // Move (not Copy) the bind data: the table_scan node is converted to a duckdb_scan exactly
+      // once and never reads bind_data afterwards, so transferring ownership is behavior-preserving
+      // and additionally supports table functions whose bind data is movable but not copyable (the
+      // DuckDB lance extension's lance_vector_search bind data does not implement Copy). The
+      // null-guard keeps a hypothetical double-conversion defined (nullptr) rather than UB. The
+      // parquet/iceberg scan ctors intentionally keep Copy().
+      table_scan->bind_data ? std::move(table_scan->bind_data) : nullptr,
       table_scan->returned_types,
       table_scan->column_ids,
       table_scan->projection_ids,

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -82,7 +82,8 @@ duckdb::unique_ptr<op::sirius_physical_operator> construct_sirius_specific_opera
         if (it != iceberg_cache->end()) { iceberg_scan->delete_data = it->second; }
       }
       return iceberg_scan;
-    } else if (scan_physical_op.function.name == "seq_scan") {
+    } else if (scan_physical_op.function.name == "seq_scan" ||
+               scan_physical_op.function.name == "lance_vector_search") {
       return duckdb::make_uniq<op::sirius_physical_duckdb_scan>(&scan_physical_op);
     } else {
       throw duckdb::NotImplementedException("Unsupported scan function: " +
@@ -386,7 +387,8 @@ void sirius_pipeline_converter::split_table_scan_source(
     return;
   }
 
-  if (scan_op.function.name == "seq_scan" || scan_op.function.name == "iceberg_scan") {
+  if (scan_op.function.name == "seq_scan" || scan_op.function.name == "iceberg_scan" ||
+      scan_op.function.name == "lance_vector_search") {
     auto new_pipeline = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
 
     auto new_scan_op = construct_sirius_specific_operator(scan_op, iceberg_cache_);
@@ -1278,7 +1280,8 @@ void sirius_pipeline_converter::log_pipeline_debug_info() const
       } else if (first_op.type == op::SiriusPhysicalOperatorType::TABLE_SCAN) {
         const auto& scan_name = first_op.Cast<op::sirius_physical_table_scan>().function.name;
         if (scan_name != "seq_scan" && scan_name != "parquet_scan" && scan_name != "read_parquet" &&
-            scan_name != "sirius_read_parquet" && scan_name != "iceberg_scan") {
+            scan_name != "sirius_read_parquet" && scan_name != "iceberg_scan" &&
+            scan_name != "lance_vector_search") {
           throw std::runtime_error("Unsupported scan function: " + scan_name);
         }
         // Scans have "scan" port

--- a/src/planner/sirius_plan_get.cpp
+++ b/src/planner/sirius_plan_get.cpp
@@ -24,9 +24,100 @@
 #include "op/sirius_physical_table_scan.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
 
+#include <duckdb/common/types/decimal.hpp>
+
 #include <unordered_set>
 
 namespace sirius::planner {
+
+namespace {
+
+bool is_lance_vector_search(const std::string& function_name)
+{
+  return function_name == "lance_vector_search";
+}
+
+void guard_lance_vector_search_projected_type(const duckdb::LogicalType& type,
+                                              const std::string& column_name)
+{
+  using duckdb::LogicalTypeId;
+
+  switch (type.id()) {
+    case LogicalTypeId::LIST:
+    case LogicalTypeId::ARRAY:
+    case LogicalTypeId::STRUCT:
+    case LogicalTypeId::HUGEINT:
+    case LogicalTypeId::UHUGEINT:
+      throw duckdb::NotImplementedException(
+        "lance_vector_search projected column '%s' has unsupported type %s for Sirius GPU "
+        "routing",
+        column_name,
+        type.ToString());
+    case LogicalTypeId::DECIMAL:
+      if (duckdb::DecimalType::GetWidth(type) > 18) {
+        throw duckdb::NotImplementedException(
+          "lance_vector_search projected column '%s' has unsupported type %s for Sirius GPU "
+          "routing",
+          column_name,
+          type.ToString());
+      }
+      break;
+    default: break;
+  }
+}
+
+void guard_lance_vector_search_projected_types(
+  const duckdb::LogicalGet& op, const duckdb::vector<duckdb::ColumnIndex>& column_ids)
+{
+  if (!is_lance_vector_search(op.function.name)) { return; }
+
+  auto check_projected_column = [&](std::size_t projection_id) {
+    const auto& column_id = column_ids[projection_id];
+    if (column_id.IsRowIdColumn()) { return; }
+
+    const auto returned_type_idx = column_id.GetPrimaryIndex();
+    guard_lance_vector_search_projected_type(op.returned_types[returned_type_idx],
+                                             op.names[returned_type_idx]);
+  };
+
+  if (!op.projection_ids.empty()) {
+    for (const auto projection_id : op.projection_ids) {
+      check_projected_column(projection_id);
+    }
+    return;
+  }
+
+  for (std::size_t i = 0; i < column_ids.size(); i++) {
+    check_projected_column(i);
+  }
+}
+
+// Convert a table function's full returned-type list to Sirius types, substituting a benign
+// placeholder for any column type Sirius cannot represent (e.g. ARRAY/FLOAT[N]).
+//
+// Used only for the lance_vector_search scan node. lance reports a full schema that always
+// includes its vector column (FLOAT[N] = ARRAY), but that column is never referenced by the
+// query (projection pushdown prunes column_ids to the selected scalar columns) and is therefore
+// never materialized. The projected-column guard above has already rejected any *projected*
+// unsupported type, so only un-referenced columns can be unconvertible here. The placeholder is
+// never read; positional indexing is preserved (column_ids index into this vector).
+duckdb::vector<sirius::logical_type> from_duckdb_vec_unprojected_tolerant(
+  const duckdb::vector<duckdb::LogicalType>& types)
+{
+  duckdb::vector<sirius::logical_type> result;
+  result.reserve(types.size());
+  for (const auto& type : types) {
+    try {
+      result.push_back(sirius::from_duckdb(type));
+    } catch (const std::exception&) {
+      // Unrepresentable un-referenced column (e.g. the lance vector column): placeholder only.
+      result.push_back(sirius::logical_type::make(sirius::type_id::LIST));
+    }
+  }
+  return result;
+}
+
+}  // namespace
 
 duckdb::unique_ptr<duckdb::TableFilterSet> create_table_filter_set(
   duckdb::TableFilterSet& table_filters, const duckdb::vector<duckdb::ColumnIndex>& column_ids)
@@ -57,10 +148,14 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
 
   // Only GPU-route known table scan functions; all others (pragma, system catalog
   // functions, etc.) must fall back to CPU.
-  static const std::unordered_set<std::string> kSupportedScanFunctions = {
-    "seq_scan", "parquet_scan", "read_parquet", "sirius_read_parquet", "iceberg_scan"};
+  static const std::unordered_set<std::string> kSupportedScanFunctions = {"seq_scan",
+                                                                          "parquet_scan",
+                                                                          "read_parquet",
+                                                                          "sirius_read_parquet",
+                                                                          "iceberg_scan",
+                                                                          "lance_vector_search"};
   if (kSupportedScanFunctions.find(op.function.name) == kSupportedScanFunctions.end()) {
-    throw duckdb::NotImplementedException("Table function '{}' is not supported in Sirius",
+    throw duckdb::NotImplementedException("Table function '%s' is not supported in Sirius",
                                           op.function.name);
   }
 
@@ -157,6 +252,7 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     }
   }
   op.ResolveOperatorTypes();
+  guard_lance_vector_search_projected_types(op, column_ids);
   // create the table scan node
   if (!op.function.projection_pushdown) {
     // function does not support projection pushdown
@@ -220,11 +316,18 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalGet& op)
     return std::move(projection);
   }
 
-  auto node = duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(
+  // lance_vector_search reports a full schema that includes an un-referenced ARRAY vector column
+  // Sirius cannot represent; tolerate it (placeholder) so plan generation does not abort. The
+  // column is pruned from column_ids by projection pushdown and is never materialized. Other
+  // functions keep the strict conversion.
+  auto scan_returned_types = is_lance_vector_search(op.function.name)
+                               ? from_duckdb_vec_unprojected_tolerant(op.returned_types)
+                               : sirius::from_duckdb_vec(op.returned_types);
+  auto node                = duckdb::make_uniq<sirius::op::sirius_physical_table_scan>(
     sirius::from_duckdb_vec(original_types),  // Use original types, not modified
     op.function,
     std::move(op.bind_data),
-    sirius::from_duckdb_vec(op.returned_types),
+    std::move(scan_returned_types),
     column_ids,
     op.projection_ids,
     op.names,

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -238,7 +238,8 @@ duckdb::unique_ptr<op::sirius_physical_operator> sirius_engine::construct_sirius
                                                                  std::move(gpu_device_ids));
     } else if (scan_physical_op.function.name == "iceberg_scan") {
       return construct_iceberg_scan_operator(scan_physical_op);
-    } else if (scan_physical_op.function.name == "seq_scan") {
+    } else if (scan_physical_op.function.name == "seq_scan" ||
+               scan_physical_op.function.name == "lance_vector_search") {
       return duckdb::make_uniq<op::sirius_physical_duckdb_scan>(&scan_physical_op);
     } else {
       throw std::runtime_error("Unsupported scan function: " + scan_physical_op.function.name);

--- a/test/cpp/integration/test_lance_vector_search_transparent.cpp
+++ b/test/cpp/integration/test_lance_vector_search_transparent.cpp
@@ -207,3 +207,39 @@ TEST_CASE_METHOD(LanceVectorSearchTransparentFixture,
 
   require_clean_fallback_and_cpu_parity(query);
 }
+
+TEST_CASE_METHOD(LanceVectorSearchTransparentFixture,
+                 "lance_vector_search self-contained e2e",
+                 "[.lance_e2e_selfcontained][integration]")
+{
+  if (!load_lance_extension()) { return; }
+
+  auto dir = fs::temp_directory_path() / "sirius_lance_e2e";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  const auto ds = (dir / "ds.lance").string();
+
+  auto copy_result = con->Query(
+    "COPY (SELECT i::BIGINT AS id, (i % 3)::INTEGER AS cat, "
+    "[random(), random(), random(), random()]::FLOAT[4] AS vec "
+    "FROM range(200) t(i)) "
+    "TO '" +
+    ds + "' (FORMAT lance, mode 'overwrite');");
+  REQUIRE(copy_result);
+  if (copy_result->HasError()) { UNSCOPED_INFO("COPY lance error: " << copy_result->GetError()); }
+  REQUIRE_FALSE(copy_result->HasError());
+
+  compare_gpu_vs_cpu(
+    "SELECT cat, count(*) AS n, avg(_distance) AS ad "
+    "FROM lance_vector_search('" +
+    ds +
+    "', 'vec', [0.1,0.2,0.3,0.4]::FLOAT[4], k=50) "
+    "GROUP BY cat ORDER BY cat");
+
+  require_clean_fallback_and_cpu_parity(
+    "SELECT id, vec "
+    "FROM lance_vector_search('" +
+    ds + "', 'vec', [0.1,0.2,0.3,0.4]::FLOAT[4], k=5)");
+
+  fs::remove_all(dir);
+}

--- a/test/cpp/integration/test_lance_vector_search_transparent.cpp
+++ b/test/cpp/integration/test_lance_vector_search_transparent.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_lance_vector_search_transparent.cpp
+ * @brief Self-skipping e2e hooks for the real DuckDB Lance extension.
+ */
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <utils/sirius_test_env.hpp>
+#include <utils/transparent_execution_test_utils.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct config_env_guard {
+  explicit config_env_guard(const std::string& path)
+  {
+    if (const char* current = std::getenv("SIRIUS_CONFIG_FILE")) {
+      had_original_value = true;
+      original_value     = current;
+    }
+    setenv("SIRIUS_CONFIG_FILE", path.c_str(), 1);
+  }
+
+  ~config_env_guard()
+  {
+    if (had_original_value) {
+      setenv("SIRIUS_CONFIG_FILE", original_value.c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_CONFIG_FILE");
+    }
+  }
+
+  std::string original_value;
+  bool had_original_value = false;
+};
+
+class LanceVectorSearchTransparentFixture {
+ public:
+  LanceVectorSearchTransparentFixture()
+  {
+    if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+      con =
+        std::make_unique<duckdb::Connection>(sirius::test::g_integration_env->make_connection());
+    } else {
+      auto cfg_path = fs::path(__FILE__).parent_path() / "integration.yaml";
+      REQUIRE(fs::exists(cfg_path));
+      config_guard = std::make_unique<config_env_guard>(cfg_path.string());
+
+      db  = std::make_unique<duckdb::DuckDB>(nullptr);
+      con = std::make_unique<duckdb::Connection>(*db);
+    }
+
+    con->Query("SET gpu_execution = true;");
+  }
+
+  bool load_lance_extension()
+  {
+    const char* extension_env        = std::getenv("SIRIUS_TEST_LANCE_EXTENSION");
+    const std::string extension_name = extension_env ? extension_env : "lance";
+
+    auto load_result = con->Query("LOAD " + extension_name + ";");
+    if (load_result && !load_result->HasError()) { return true; }
+
+    auto install_result = con->Query("INSTALL " + extension_name + ";");
+    if (!install_result || install_result->HasError()) {
+      WARN("Lance DuckDB extension unavailable; skipping: "
+           << (install_result ? install_result->GetError() : "null result"));
+      return false;
+    }
+
+    load_result = con->Query("LOAD " + extension_name + ";");
+    if (!load_result || load_result->HasError()) {
+      WARN("Lance DuckDB extension failed to load; skipping: "
+           << (load_result ? load_result->GetError() : "null result"));
+      return false;
+    }
+    return true;
+  }
+
+  static std::string require_env_query(const char* env_var)
+  {
+    const char* value = std::getenv(env_var);
+    if (!value || std::string(value).empty()) {
+      WARN(env_var << " is unset; skipping Lance vector-search e2e test");
+      return {};
+    }
+    std::string query(value);
+    if (query.find("lance_vector_search") == std::string::npos) {
+      WARN(env_var << " does not reference lance_vector_search; skipping");
+      return {};
+    }
+    return query;
+  }
+
+  static std::vector<std::vector<std::string>> collect_rows(duckdb::MaterializedQueryResult& result)
+  {
+    std::vector<std::vector<std::string>> rows;
+    for (duckdb::idx_t r = 0; r < result.RowCount(); r++) {
+      std::vector<std::string> row;
+      row.reserve(result.ColumnCount());
+      for (duckdb::idx_t c = 0; c < result.ColumnCount(); c++) {
+        row.push_back(result.GetValue(c, r).ToString());
+      }
+      rows.push_back(std::move(row));
+    }
+    std::sort(rows.begin(), rows.end());
+    return rows;
+  }
+
+  void compare_gpu_vs_cpu(const std::string& query)
+  {
+    auto before_gpu_stats = sirius::test::get_transparent_execution_stats(*con);
+    auto gpu_result       = con->Query(query);
+    REQUIRE(gpu_result);
+    if (gpu_result->HasError()) { UNSCOPED_INFO("GPU error: " << gpu_result->GetError()); }
+    REQUIRE_FALSE(gpu_result->HasError());
+    auto after_gpu_stats = sirius::test::get_transparent_execution_stats(*con);
+    sirius::test::require_transparent_execution_delta(before_gpu_stats, after_gpu_stats, 1, 0, 1);
+
+    con->Query("SET gpu_execution = false;");
+    auto cpu_result = con->Query(query);
+    con->Query("SET gpu_execution = true;");
+    REQUIRE(cpu_result);
+    if (cpu_result->HasError()) { UNSCOPED_INFO("CPU error: " << cpu_result->GetError()); }
+    REQUIRE_FALSE(cpu_result->HasError());
+
+    auto& gpu_mat = gpu_result->Cast<duckdb::MaterializedQueryResult>();
+    auto& cpu_mat = cpu_result->Cast<duckdb::MaterializedQueryResult>();
+    REQUIRE(collect_rows(gpu_mat) == collect_rows(cpu_mat));
+  }
+
+  void require_clean_fallback_and_cpu_parity(const std::string& query)
+  {
+    auto before_stats = sirius::test::get_transparent_execution_stats(*con);
+    auto gpu_result   = con->Query(query);
+    REQUIRE(gpu_result);
+    if (gpu_result->HasError()) {
+      UNSCOPED_INFO("fallback query error: " << gpu_result->GetError());
+    }
+    REQUIRE_FALSE(gpu_result->HasError());
+    auto after_stats = sirius::test::get_transparent_execution_stats(*con);
+    sirius::test::require_transparent_execution_delta(before_stats, after_stats, 0, 1, 0);
+
+    con->Query("SET gpu_execution = false;");
+    auto cpu_result = con->Query(query);
+    con->Query("SET gpu_execution = true;");
+    REQUIRE(cpu_result);
+    if (cpu_result->HasError()) { UNSCOPED_INFO("CPU error: " << cpu_result->GetError()); }
+    REQUIRE_FALSE(cpu_result->HasError());
+
+    auto& gpu_mat = gpu_result->Cast<duckdb::MaterializedQueryResult>();
+    auto& cpu_mat = cpu_result->Cast<duckdb::MaterializedQueryResult>();
+    REQUIRE(collect_rows(gpu_mat) == collect_rows(cpu_mat));
+  }
+
+ protected:
+  std::unique_ptr<config_env_guard> config_guard;
+  std::unique_ptr<duckdb::DuckDB> db;
+  std::unique_ptr<duckdb::Connection> con;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(LanceVectorSearchTransparentFixture,
+                 "lance_vector_search transparent e2e - scalar tail stays on GPU",
+                 "[lance_vector_search][transparent][integration]")
+{
+  auto query = require_env_query("SIRIUS_TEST_LANCE_SCALAR_QUERY");
+  if (query.empty()) { return; }
+  if (!load_lance_extension()) { return; }
+
+  compare_gpu_vs_cpu(query);
+}
+
+TEST_CASE_METHOD(LanceVectorSearchTransparentFixture,
+                 "lance_vector_search transparent e2e - projected vector cleanly falls back",
+                 "[lance_vector_search][transparent][integration]")
+{
+  auto query = require_env_query("SIRIUS_TEST_LANCE_VECTOR_QUERY");
+  if (query.empty()) { return; }
+  if (!load_lance_extension()) { return; }
+
+  require_clean_fallback_and_cpu_parity(query);
+}

--- a/test/cpp/planner/test_lance_vector_search_routing.cpp
+++ b/test/cpp/planner/test_lance_vector_search_routing.cpp
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_lance_vector_search_routing.cpp
+ * @brief Planner tests for routing DuckDB Lance vector-search table functions through Sirius.
+ */
+
+#include "op/sirius_physical_duckdb_scan.hpp"
+#include "op/sirius_physical_table_scan.hpp"
+#include "pipeline/sirius_pipeline_converter.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/common/types/decimal.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/function/table_function.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <initializer_list>
+#include <string>
+
+using namespace duckdb;
+
+namespace {
+
+duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
+  Connection& con, const std::string& query)
+{
+  auto& context = *con.context;
+
+  auto original_disabled = DBConfig::GetConfig(context).options.disabled_optimizers;
+  auto& disabled         = DBConfig::GetConfig(context).options.disabled_optimizers;
+  disabled.insert(OptimizerType::IN_CLAUSE);
+  disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+
+  con.Query("BEGIN TRANSACTION");
+
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> result;
+  try {
+    Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(!parser.statements.empty());
+
+    Planner planner(context);
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    auto plan = std::move(planner.plan);
+
+    if (context.config.enable_optimizer) {
+      Optimizer optimizer(*planner.binder, context);
+      plan = optimizer.Optimize(std::move(plan));
+    }
+
+    plan->ResolveOperatorTypes();
+
+    ColumnBindingResolver resolver;
+    ColumnBindingResolver::Verify(*plan);
+    resolver.VisitOperator(*plan);
+
+    sirius::planner::sirius_physical_plan_generator gen(context);
+    result = gen.create_plan(std::move(plan));
+  } catch (duckdb::InternalException&) {
+    con.Query("ROLLBACK");
+    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    return nullptr;
+  } catch (...) {
+    con.Query("ROLLBACK");
+    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    throw;
+  }
+
+  con.Query("COMMIT");
+  DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+  return result;
+}
+
+sirius::op::sirius_physical_table_scan* find_table_scan(sirius::op::sirius_physical_operator* root)
+{
+  if (!root) { return nullptr; }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::TABLE_SCAN) {
+    return &root->Cast<sirius::op::sirius_physical_table_scan>();
+  }
+  for (auto& child : root->children) {
+    auto* found = find_table_scan(child.get());
+    if (found) { return found; }
+  }
+  return nullptr;
+}
+
+void require_not_implemented_message(Connection& con,
+                                     const std::string& query,
+                                     std::initializer_list<std::string> expected_fragments)
+{
+  try {
+    auto plan = generate_sirius_plan(con, query);
+    (void)plan;
+  } catch (const duckdb::NotImplementedException& ex) {
+    const std::string message = ex.what();
+    for (const auto& fragment : expected_fragments) {
+      INFO("exception message: " << message);
+      REQUIRE(message.find(fragment) != std::string::npos);
+    }
+    return;
+  }
+  FAIL("expected duckdb::NotImplementedException");
+}
+
+LogicalType list_float_type() { return LogicalType::LIST(LogicalType::FLOAT); }
+
+LogicalType array_float_type() { return LogicalType::ARRAY(LogicalType::FLOAT, optional_idx(3)); }
+
+LogicalType struct_type()
+{
+  return LogicalType::STRUCT(
+    child_list_t<LogicalType>{{"label", LogicalType::VARCHAR}, {"weight", LogicalType::DOUBLE}});
+}
+
+void add_common_candidate_columns(vector<LogicalType>& return_types, vector<string>& names)
+{
+  return_types.push_back(LogicalType::BIGINT);
+  names.push_back("_rowid");
+  return_types.push_back(LogicalType::DOUBLE);
+  names.push_back("_distance");
+  return_types.push_back(LogicalType::DOUBLE);
+  names.push_back("_score");
+  return_types.push_back(LogicalType::INTEGER);
+  names.push_back("doc_id");
+}
+
+void add_schema_for_scenario(const std::string& scenario,
+                             vector<LogicalType>& return_types,
+                             vector<string>& names)
+{
+  add_common_candidate_columns(return_types, names);
+
+  if (scenario == "scalar") {
+    return_types.push_back(LogicalType::VARCHAR);
+    names.push_back("title");
+    return_types.push_back(LogicalType::DOUBLE);
+    names.push_back("rank_feature");
+  } else if (scenario == "nested") {
+    return_types.push_back(list_float_type());
+    names.push_back("embedding");
+    return_types.push_back(array_float_type());
+    names.push_back("embedding_array");
+    return_types.push_back(LogicalType::VARCHAR);
+    names.push_back("title");
+  } else if (scenario == "struct") {
+    return_types.push_back(struct_type());
+    names.push_back("attrs");
+  } else if (scenario == "wide_numeric") {
+    return_types.push_back(LogicalType::HUGEINT);
+    names.push_back("huge_value");
+    return_types.push_back(LogicalType::UHUGEINT);
+    names.push_back("uhuge_value");
+    return_types.push_back(LogicalType::DECIMAL(19, 2));
+    names.push_back("wide_decimal");
+    return_types.push_back(LogicalType::DECIMAL(18, 2));
+    names.push_back("ok_decimal");
+  } else if (scenario == "mixed") {
+    return_types.push_back(list_float_type());
+    names.push_back("embedding");
+    return_types.push_back(LogicalType::VARCHAR);
+    names.push_back("title");
+    return_types.push_back(LogicalType::DATE);
+    names.push_back("created_date");
+    return_types.push_back(LogicalType::TIMESTAMP);
+    names.push_back("created_ts");
+    return_types.push_back(LogicalType::DECIMAL(18, 2));
+    names.push_back("ok_decimal");
+  } else if (scenario == "pushdown_nested") {
+    return_types.push_back(array_float_type());
+    names.push_back("embedding_array");
+    return_types.push_back(list_float_type());
+    names.push_back("embedding_list");
+    return_types.push_back(LogicalType::VARCHAR);
+    names.push_back("title");
+    return_types.push_back(LogicalType::DOUBLE);
+    names.push_back("rank_feature");
+  } else {
+    throw InvalidInputException("unknown fake lance_vector_search scenario: {}", scenario);
+  }
+}
+
+struct FakeLanceBindData : TableFunctionData {
+  unique_ptr<FunctionData> Copy() const override
+  {
+    throw InternalException("Copy not supported for TableFunctionData");
+  }
+
+  bool Equals(const FunctionData&) const override { return true; }
+};
+
+unique_ptr<FunctionData> FakeLanceVectorSearchBind(ClientContext&,
+                                                   TableFunctionBindInput& input,
+                                                   vector<LogicalType>& return_types,
+                                                   vector<string>& names)
+{
+  const auto scenario =
+    input.inputs.empty() ? std::string("scalar") : input.inputs[0].GetValue<std::string>();
+  add_schema_for_scenario(scenario, return_types, names);
+  return make_uniq<FakeLanceBindData>();
+}
+
+void FakeLanceVectorSearchFunction(ClientContext&, TableFunctionInput&, DataChunk& output)
+{
+  output.SetCardinality(0);
+}
+
+void register_fake_vector_search(Catalog& catalog,
+                                 CatalogTransaction& transaction,
+                                 const std::string& name)
+{
+  TableFunction function(
+    name, {LogicalType::VARCHAR}, FakeLanceVectorSearchFunction, FakeLanceVectorSearchBind);
+  function.projection_pushdown = true;
+  CreateTableFunctionInfo info(function);
+  catalog.CreateTableFunction(transaction, info);
+}
+
+struct lance_vector_search_fixture {
+  lance_vector_search_fixture()
+  {
+    auto cfg = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "config" / "data" /
+               "minimal.yaml";
+    setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
+    unsetenv("SIRIUS_DISABLE");
+    db = std::make_unique<DuckDB>(nullptr);
+    setenv("SIRIUS_DISABLE", "1", 1);
+    con = std::make_unique<Connection>(*db);
+
+    auto& catalog    = Catalog::GetSystemCatalog(*db->instance);
+    auto transaction = CatalogTransaction::GetSystemTransaction(*db->instance);
+    register_fake_vector_search(catalog, transaction, "lance_vector_search");
+    register_fake_vector_search(catalog, transaction, "not_lance_vector_search");
+  }
+
+  ~lance_vector_search_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }
+
+  std::unique_ptr<DuckDB> db;
+  std::unique_ptr<Connection> con;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - non-whitelisted function still falls back",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  require_not_implemented_message(*con,
+                                  "SELECT doc_id FROM not_lance_vector_search('scalar')",
+                                  {"not_lance_vector_search", "not supported"});
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - scalar output plans as table scan",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  auto plan = generate_sirius_plan(*con,
+                                   "SELECT _rowid, _distance, _score, doc_id, title "
+                                   "FROM lance_vector_search('scalar') WHERE doc_id > 10");
+  REQUIRE(plan);
+
+  auto* scan = find_table_scan(plan.get());
+  REQUIRE(scan != nullptr);
+  REQUIRE(scan->function.name == "lance_vector_search");
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - projected LIST and ARRAY columns are rejected",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  require_not_implemented_message(
+    *con, "SELECT embedding FROM lance_vector_search('nested')", {"embedding", "unsupported type"});
+  require_not_implemented_message(*con,
+                                  "SELECT embedding_array FROM lance_vector_search('nested')",
+                                  {"embedding_array", "unsupported type"});
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - projected STRUCT columns are rejected",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  require_not_implemented_message(
+    *con, "SELECT attrs FROM lance_vector_search('struct')", {"attrs", "unsupported type"});
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - wide numeric guard keeps DECIMAL boundary",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  REQUIRE_THROWS_AS(
+    generate_sirius_plan(*con, "SELECT huge_value FROM lance_vector_search('wide_numeric')"),
+    duckdb::NotImplementedException);
+  REQUIRE_THROWS_AS(
+    generate_sirius_plan(*con, "SELECT uhuge_value FROM lance_vector_search('wide_numeric')"),
+    duckdb::NotImplementedException);
+  require_not_implemented_message(*con,
+                                  "SELECT wide_decimal FROM lance_vector_search('wide_numeric')",
+                                  {"wide_decimal", "unsupported type"});
+
+  auto plan =
+    generate_sirius_plan(*con, "SELECT ok_decimal FROM lance_vector_search('wide_numeric')");
+  REQUIRE(plan);
+  REQUIRE(find_table_scan(plan.get()) != nullptr);
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - unsupported unprojected columns do not over-reject",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  auto plan = generate_sirius_plan(*con,
+                                   "SELECT doc_id, title, created_date, created_ts, ok_decimal "
+                                   "FROM lance_vector_search('mixed')");
+  REQUIRE(plan);
+
+  auto* scan = find_table_scan(plan.get());
+  REQUIRE(scan != nullptr);
+  REQUIRE(scan->function.name == "lance_vector_search");
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - projection pushdown tolerates unprojected vectors",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  auto plan =
+    generate_sirius_plan(*con,
+                         "SELECT doc_id, title, rank_feature "
+                         "FROM lance_vector_search('pushdown_nested') WHERE rank_feature > 0.1");
+  REQUIRE(plan);
+
+  auto* scan = find_table_scan(plan.get());
+  REQUIRE(scan != nullptr);
+  REQUIRE(scan->function.name == "lance_vector_search");
+}
+
+TEST_CASE_METHOD(lance_vector_search_fixture,
+                 "lance_vector_search routing - pipeline factory uses generic DuckDB scan",
+                 "[lance_vector_search][planner][isolated_context]")
+{
+  auto plan = generate_sirius_plan(*con, "SELECT doc_id, title FROM lance_vector_search('scalar')");
+  REQUIRE(plan);
+
+  auto* scan = find_table_scan(plan.get());
+  REQUIRE(scan != nullptr);
+  REQUIRE(scan->function.name == "lance_vector_search");
+
+  auto routed = sirius::pipeline::construct_sirius_specific_operator(*scan, nullptr);
+  REQUIRE(routed);
+  REQUIRE(routed->type == sirius::op::SiriusPhysicalOperatorType::DUCKDB_SCAN);
+  REQUIRE(routed->Cast<sirius::op::sirius_physical_duckdb_scan>().function.name ==
+          "lance_vector_search");
+}


### PR DESCRIPTION
## Summary

Sirius now GPU-accelerates the relational work that follows a vector search over the DuckDB `lance` extension's `lance_vector_search(...)` table function. Previously any query whose source was `lance_vector_search` fell back to CPU wholesale; now the scan and everything after it (filter, projection, join, aggregation, sort) run on GPU.

**No LanceDB/Lance code is changed.** The integration lives entirely at the DuckDB extension boundary — see Design.

## Use case

Retrieval-heavy analytics — RAG candidate generation, recommendation recall — where a vector search returns a large candidate set and is followed by meaningful relational work:

```sql
LOAD lance;        -- DuckDB lance extension (vector retrieval, CPU)
LOAD sirius;       -- GPU SQL

CALL gpu_execution('
  SELECT cat, count(*) AS n, avg(_distance) AS ad
  FROM lance_vector_search(''/data/items.lance'', ''vec'', [...]::FLOAT[768], k => 10000)
  WHERE ...
  GROUP BY cat ORDER BY n DESC
');
```

Lance performs the vector search (CPU); Sirius runs the `GROUP BY`/filter/join on GPU. The win concentrates on **large candidate sets + heavy downstream relational work**; small top-k (10/20) RAG queries are already CPU-fast and are not the target.

## Design

Three independent pieces share one DuckDB process:

```
DuckDB process
├── lance extension   (INSTALL lance; LOAD lance)  ← separate, published; unmodified
│     exposes lance_vector_search(...) as a DuckDB table function
├── sirius extension  (LOAD sirius)                ← all changes in this PR
└── DuckDB core                                    ← parser/planner/glue
```

`lance_vector_search` is an ordinary DuckDB table function. When Sirius's physical-plan generator sees a `LogicalGet` whose `function.name == "lance_vector_search"`, it routes the scan through the **existing generic `DUCKDB_SCAN` path** (the same path `seq_scan` uses), which drives the table function on CPU, ingests its output rows to the GPU, and runs the rest of the plan on GPU. Production changes:

- **Routing** — add `lance_vector_search` to the supported-scan whitelist (`sirius_plan_get.cpp`) and dispatch it to `sirius_physical_duckdb_scan` in the engine and pipeline converter (`sirius_engine.cpp`, `sirius_pipeline_converter.cpp`).
- **Projected-type guard** — lance returns a full schema that always includes the vector column (`FLOAT[N]`). If a query *projects* an unsupported column type (LIST/ARRAY/STRUCT/HUGEINT/UHUGEINT/DECIMAL width>18) the plan throws `NotImplementedException` at plan time → clean CPU fallback (no execution error). Inspects projected columns only.
- See **Workarounds** for the two remaining hacks.

A **two-step form** also works with no special handling and is the recommended path when a query would otherwise project the vector column: materialize the scalar candidate columns into a temp table (excluding the vector), then `gpu_execution` over that table (an ordinary `seq_scan`).

## In scope / out of scope

**In:** single-query routing + GPU execution of the relational tail; clean fallback for unsupported projections; offline planner tests.

**Out:** GPU vector *search* itself (Lance still does retrieval on CPU); `lance_fts` / `lance_hybrid_search` (different column contract); consuming Lance index artifacts on GPU (that is the future Option B / Phase 2, which is the only direction that would touch the Lance side).

## Workarounds to follow up

**1. `bind_data` is moved, not copied (`sirius_physical_duckdb_scan.cpp`).** The real lance bind data does not implement `Copy()`, so the duckdb-scan ctor now `std::move`s it out of the table-scan node instead of copying. Verified safe today (the scan node is converted exactly once and never reads its bind data afterward; the null-guard keeps a hypothetical double-conversion defined rather than UB), but it leaves the original table-scan node with a null `bind_data`.
**Follow-up:** move ownership to a `shared_ptr` so the scan node and the duckdb-scan share one `FunctionData` — cleaner and immune to the double-conversion edge.

**2. Placeholder type for the un-referenced vector column (`sirius_plan_get.cpp`).** Sirius cannot represent `FLOAT[N]` (ARRAY). Because projection pushdown prunes the vector column from `column_ids` (it is never materialized), the scan node's `returned_types` conversion substitutes a benign placeholder for it so plan generation does not abort. Strict conversion is kept for all other functions.
**Follow-up:** this is the likely source of a benign runtime warning `gpu_pipeline_task: column count mismatch: got 4, expected 3` (an extra column — probably lance `_rowid` — flowing through the pipeline; results are correct). Properly prune/account for the un-referenced column.

## Test plan

- **Unit** (`test/cpp/planner/test_lance_vector_search_routing.cpp`, `[lance_vector_search]`): whitelist routing, the projected-type guard (incl. DECIMAL width boundary and no over-rejection of unprojected columns), tolerance of an unprojected ARRAY/LIST column, the bind-data move path — using an in-process fake table function so the suite runs offline. **10/10.**
- **Regression** (`[planner],[transparent]`): **19/19**, no change to seq_scan/parquet/iceberg routing.
- **End-to-end** (manual, real lance dataset, a real GPU exec config): a scalar `lance_vector_search` query runs on GPU with results identical to CPU; projecting the vector column falls back cleanly. A self-skipping integration scaffold (`test_lance_vector_search_transparent.cpp`, `SIRIUS_TEST_LANCE_*` env) is included for when the lance extension is available in CI.

### Note for e2e reviewers

Use a real GPU execution config. The planner-unit `minimal.yaml` is not set up for execution and segfaults in the `drain_after_error` path (pre-existing Sirius error-path robustness, unrelated to this change); the repo's `integration.yaml` requests a 32 GB GPU pool, so reduce it for smaller cards.
