### PR TITLE
feat: flip gpu_expression_translator to sirius::ast::node input

### DIFF
--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -26,6 +26,8 @@
 
 // standard library
 #include <algorithm>
+#include <iterator>
+#include <numeric>
 #include <type_traits>
 #include <variant>
 
@@ -571,32 +573,35 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
   // If there are no children, return
   if (alt.children.empty()) { return std::nullopt; }
 
-  // Add the children and combine with AND/OR operations as we go
-  auto result = add_expression(*alt.children[0], table_src);
-  if (!result) { return std::nullopt; }
-
-  for (size_t i = 1; i < alt.children.size(); ++i) {
-    // Add child expression
-    auto child_expr = add_expression(*alt.children[i], table_src);
-
-    // Check for failure in translating child
-    if (!child_expr) { return std::nullopt; }
-
-    // Combine with previous children using AND/OR
-    using enum sirius::ast::conjunction::kind;
-    if (alt.op == op_and) {
-      result = _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LOGICAL_AND, *result, *child_expr);
-    } else if (alt.op == op_or) {
-      result = _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LOGICAL_OR, *result, *child_expr);
-    } else {
+  // Resolve the cuDF operator once up front rather than re-checking per child.
+  cudf::ast::ast_operator cudf_op{};
+  using enum sirius::ast::conjunction::kind;
+  switch (alt.op) {
+    case op_and: cudf_op = cudf::ast::ast_operator::LOGICAL_AND; break;
+    case op_or: cudf_op = cudf::ast::ast_operator::LOGICAL_OR; break;
+    default:
       SIRIUS_LOG_DEBUG("[expression_translator] Unsupported conjunction type: {}",
                        static_cast<int>(alt.op));
       return std::nullopt;
-    }
   }
-  return result;
+
+  // Seed with the first child, then fold the rest, combining with AND/OR as we go.
+  auto seed = add_expression(*alt.children.front(), table_src);
+  if (!seed) { return std::nullopt; }
+
+  return std::accumulate(
+    std::next(alt.children.begin()), alt.children.end(), seed,
+    [&](std::optional<expr_ref> acc, std::unique_ptr<sirius::ast::node> const& child)
+      -> std::optional<expr_ref> {
+      // A previous child failed to translate; propagate the failure.
+      if (!acc) { return std::nullopt; }
+
+      // Add child expression and check for failure in translating it.
+      auto child_expr = add_expression(*child, table_src);
+      if (!child_expr) { return std::nullopt; }
+
+      return _ast_tree.emplace<cudf::ast::operation>(cudf_op, *acc, *child_expr);
+    });
 }
 
 //===----------BETWEEN----------===//

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -25,6 +25,7 @@
 #include <cudf/wrappers/timestamps.hpp>
 
 // standard library
+#include <algorithm>
 #include <type_traits>
 #include <variant>
 
@@ -255,22 +256,23 @@ std::optional<expr_ref> gpu_expression_translator::add_join_condition(
   if (!right_expr) { return std::nullopt; }
 
   switch (condition.comparison) {
-    case sirius::comparison_type::equal:
+    using enum sirius::comparison_type;
+    case equal:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::not_equal:
+    case not_equal:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::lt:
+    case lt:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
-    case sirius::comparison_type::gt:
+    case gt:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
-    case sirius::comparison_type::le:
+    case le:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::ge:
+    case ge:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
     default:
@@ -530,26 +532,27 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
 
   // Construct the comparison expression
   switch (alt.op) {
-    case sirius::comparison_type::equal:
+    using enum sirius::comparison_type;
+    case equal:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::not_equal:
+    case not_equal:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::lt:
+    case lt:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
-    case sirius::comparison_type::gt:
+    case gt:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
-    case sirius::comparison_type::le:
+    case le:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::ge:
+    case ge:
       return _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
-    case sirius::comparison_type::distinct_from:
-    case sirius::comparison_type::not_distinct_from: {
+    case distinct_from:
+    case not_distinct_from: {
       SIRIUS_LOG_DEBUG(
         "[expression_translator] DISTINCT comparisons not supported in expression translator");
       return std::nullopt;
@@ -580,10 +583,11 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     if (!child_expr) { return std::nullopt; }
 
     // Combine with previous children using AND/OR
-    if (alt.op == sirius::ast::conjunction::kind::op_and) {
+    using enum sirius::ast::conjunction::kind;
+    if (alt.op == op_and) {
       result = _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LOGICAL_AND, *result, *child_expr);
-    } else if (alt.op == sirius::ast::conjunction::kind::op_or) {
+    } else if (alt.op == op_or) {
       result = _ast_tree.emplace<cudf::ast::operation>(
         cudf::ast::ast_operator::LOGICAL_OR, *result, *child_expr);
     } else {
@@ -663,17 +667,18 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
   if (!child_expr) { return std::nullopt; }
 
   switch (alt.op) {
-    case sirius::ast::unary_op::kind::op_not:
+    using enum sirius::ast::unary_op::kind;
+    case op_not:
       return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, *child_expr);
-    case sirius::ast::unary_op::kind::op_is_null:
+    case op_is_null:
       return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::IS_NULL, *child_expr);
-    case sirius::ast::unary_op::kind::op_is_not_null: {
+    case op_is_not_null: {
       // Add IS_NULL followed by NOT to represent IS_NOT_NULL
       expr_ref is_null_op =
         _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::IS_NULL, *child_expr);
       return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, is_null_op);
     }
-    case sirius::ast::unary_op::kind::op_try:
+    case op_try:
     default:
       // cuDF AST cannot express TRY.
       SIRIUS_LOG_DEBUG(
@@ -728,37 +733,27 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
 std::optional<expr_ref> gpu_expression_translator::add_expression(
   sirius::ast::function_call const& alt, cudf::ast::table_reference const table_src)
 {
-  // cuDF AST only supports numeric binary functions
-  // We need to disable operations that propagate decimal types up the expression tree
-  // We are waiting on this bug fix: https://github.com/rapidsai/cudf/pull/21996
-  auto block_function_translation = [](sirius::ast::function_call const& alt) -> bool {
-    for (auto const& arg : alt.arguments()) {
-      if (node_logical_type_id(*arg) == sirius::type_id::DECIMAL) {
-        SIRIUS_LOG_DEBUG(
-          "[expression_translator] Blocking function because it propagates decimal types");
-        return true;
-      }
-    }
-    return false;
-  };
+  // cuDF AST only supports numeric binary functions. We must also disable any
+  // operation that propagates decimal types up the expression tree, pending the
+  // cuDF fix: https://github.com/rapidsai/cudf/pull/21996. Unsupported functions
+  // fall through to the default arm below, so checking decimal propagation once
+  // up front (rather than per supported case) is equivalent.
+  if (std::ranges::any_of(alt.arguments(), [](auto const& arg) {
+        return node_logical_type_id(*arg) == sirius::type_id::DECIMAL;
+      })) {
+    SIRIUS_LOG_DEBUG(
+      "[expression_translator] Blocking function because it propagates decimal types");
+    return std::nullopt;
+  }
 
   switch (alt.function()) {
-    case sirius::function_id::add:
-      if (block_function_translation(alt)) { return std::nullopt; }
-      return add_function_expression<cudf::ast::ast_operator::ADD>(alt, table_src);
-    case sirius::function_id::sub:
-      if (block_function_translation(alt)) { return std::nullopt; }
-      return add_function_expression<cudf::ast::ast_operator::SUB>(alt, table_src);
-    case sirius::function_id::mul:
-      if (block_function_translation(alt)) { return std::nullopt; }
-      return add_function_expression<cudf::ast::ast_operator::MUL>(alt, table_src);
-    case sirius::function_id::div:
-    case sirius::function_id::int_div:
-      if (block_function_translation(alt)) { return std::nullopt; }
-      return add_function_expression<cudf::ast::ast_operator::DIV>(alt, table_src);
-    case sirius::function_id::mod:
-      if (block_function_translation(alt)) { return std::nullopt; }
-      return add_function_expression<cudf::ast::ast_operator::MOD>(alt, table_src);
+    using enum sirius::function_id;
+    case add: return add_function_expression<cudf::ast::ast_operator::ADD>(alt, table_src);
+    case sub: return add_function_expression<cudf::ast::ast_operator::SUB>(alt, table_src);
+    case mul: return add_function_expression<cudf::ast::ast_operator::MUL>(alt, table_src);
+    case div:
+    case int_div: return add_function_expression<cudf::ast::ast_operator::DIV>(alt, table_src);
+    case mod: return add_function_expression<cudf::ast::ast_operator::MOD>(alt, table_src);
     default:
       SIRIUS_LOG_DEBUG("[expression_translator] Unsupported function: {}",
                        static_cast<int>(alt.function()));

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -590,9 +590,11 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
   if (!seed) { return std::nullopt; }
 
   return std::accumulate(
-    std::next(alt.children.begin()), alt.children.end(), seed,
-    [&](std::optional<expr_ref> acc, std::unique_ptr<sirius::ast::node> const& child)
-      -> std::optional<expr_ref> {
+    std::next(alt.children.begin()),
+    alt.children.end(),
+    seed,
+    [&](std::optional<expr_ref> acc,
+        std::unique_ptr<sirius::ast::node> const& child) -> std::optional<expr_ref> {
       // A previous child failed to translate; propagate the failure.
       if (!acc) { return std::nullopt; }
 

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -15,6 +15,7 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
 #include <expression/expression_internal.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
 #include <log/logging.hpp>
@@ -22,6 +23,10 @@
 // cudf
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <cudf/wrappers/timestamps.hpp>
+
+// standard library
+#include <type_traits>
+#include <variant>
 
 namespace sirius {
 
@@ -204,7 +209,7 @@ std::string gpu_expression_translator::translated_expression::to_string() const
 }
 
 std::optional<gpu_expression_translator::translated_expression>
-gpu_expression_translator::translate_expression(duckdb::Expression const& expr,
+gpu_expression_translator::translate_expression(sirius::ast::node const& expr,
                                                 cudf::ast::table_reference const table_src)
 {
   reset_tree();
@@ -218,7 +223,7 @@ gpu_expression_translator::translate_expression(duckdb::Expression const& expr,
 
 std::optional<gpu_expression_translator::translated_expression>
 gpu_expression_translator::translate_expression_with_names(
-  duckdb::Expression const& expr, column_name_resolver_fxn column_name_resolver)
+  sirius::ast::node const& expr, column_name_resolver_fxn column_name_resolver)
 {
   reset_tree();
   _column_name_resolver = std::move(column_name_resolver);
@@ -239,10 +244,14 @@ std::optional<expr_ref> gpu_expression_translator::add_join_condition(
   auto right_table_ref =
     swap_sides ? cudf::ast::table_reference::LEFT : cudf::ast::table_reference::RIGHT;
 
-  auto left_expr = add_expression(*sirius::unwrap(condition.left), left_table_ref);
+  auto left_node = sirius::ast::from_duckdb(*sirius::unwrap(condition.left));
+  if (!left_node) { return std::nullopt; }
+  auto left_expr = add_expression(*left_node, left_table_ref);
   if (!left_expr) { return std::nullopt; }
 
-  auto right_expr = add_expression(*sirius::unwrap(condition.right), right_table_ref);
+  auto right_node = sirius::ast::from_duckdb(*sirius::unwrap(condition.right));
+  if (!right_node) { return std::nullopt; }
+  auto right_expr = add_expression(*right_node, right_table_ref);
   if (!right_expr) { return std::nullopt; }
 
   switch (condition.comparison) {
@@ -310,52 +319,290 @@ gpu_expression_translator::translate_join_conditions(
   return result;
 }
 
-std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::Expression const& expr, cudf::ast::table_reference const table_src)
+namespace {
+
+/// @brief Recover the SQL type identifier of an AST node, where it is carried.
+///
+/// Used by the function arm's decimal-propagation guard. Only the node kinds
+/// that carry a logical type return a meaningful id; alternatives without a
+/// logical type (e.g. reference) return INVALID, which is treated as a
+/// non-DECIMAL sentinel by the caller — matching the executor's return-type-only
+/// decimal skip (a reference to a decimal column is not the decimal-propagation
+/// case the cuDF intermediate-result bug targets).
+sirius::type_id node_logical_type_id(sirius::ast::node const& expr)
 {
-  switch (expr.GetExpressionClass()) {
-    case duckdb::ExpressionClass::BOUND_BETWEEN:
-      return add_expression(expr.Cast<duckdb::BoundBetweenExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_CASE: {
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] CASE expressions cannot be translated to cuDF ASTs: {}",
-        expr.ToString());
-      return std::nullopt;
-    }
-    case duckdb::ExpressionClass::BOUND_CAST:
-      return add_expression(expr.Cast<duckdb::BoundCastExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_COMPARISON:
-      return add_expression(expr.Cast<duckdb::BoundComparisonExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_CONJUNCTION:
-      return add_expression(expr.Cast<duckdb::BoundConjunctionExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_CONSTANT:
-      return add_expression(expr.Cast<duckdb::BoundConstantExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_FUNCTION:
-      return add_expression(expr.Cast<duckdb::BoundFunctionExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_OPERATOR:
-      return add_expression(expr.Cast<duckdb::BoundOperatorExpression>(), table_src);
-    case duckdb::ExpressionClass::BOUND_PARAMETER: {
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] Cannot translate parameter expressions to cuDF ASTs: {}",
-        expr.ToString());
-      return std::nullopt;
-    }
-    case duckdb::ExpressionClass::BOUND_REF:
-      return add_expression(expr.Cast<duckdb::BoundReferenceExpression>(), table_src);
-    default:
-      throw duckdb::InternalException("[expression_translator] Unknown ExpressionClass: {}",
-                                      expr.GetExpressionClass());
+  return std::visit(
+    [](auto const& alt) -> sirius::type_id {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, sirius::ast::constant>) {
+        return alt.return_type.id();
+      } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
+        return alt.target_type.id();
+      } else if constexpr (std::is_same_v<T, sirius::ast::function_call>) {
+        return alt.return_type().id();
+      } else {
+        return sirius::type_id::INVALID;
+      }
+    },
+    expr.v);
+}
+
+}  // namespace
+
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::node const& expr, cudf::ast::table_reference const table_src)
+{
+  return std::visit(
+    [this, table_src](auto const& alt) -> std::optional<expr_ref> {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
+                    std::is_same_v<T, sirius::ast::constant> ||
+                    std::is_same_v<T, sirius::ast::comparison> ||
+                    std::is_same_v<T, sirius::ast::conjunction> ||
+                    std::is_same_v<T, sirius::ast::between> ||
+                    std::is_same_v<T, sirius::ast::case_expr> ||
+                    std::is_same_v<T, sirius::ast::cast> ||
+                    std::is_same_v<T, sirius::ast::unary_op> ||
+                    std::is_same_v<T, sirius::ast::coalesce> ||
+                    std::is_same_v<T, sirius::ast::in_list> ||
+                    std::is_same_v<T, sirius::ast::function_call>) {
+        return this->add_expression(alt, table_src);
+      } else {
+        static_assert(sizeof(T) == 0,
+                      "Unhandled sirius::ast alternative in add_expression dispatcher");
+      }
+    },
+    expr.v);
+}
+
+//===----------REFERENCE----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::reference const& alt, cudf::ast::table_reference const table_src)
+{
+  if (_column_name_resolver) {
+    return _ast_tree.emplace<cudf::ast::column_name_reference>(
+      _column_name_resolver(alt.column_index));
   }
+  return _ast_tree.emplace<cudf::ast::column_reference>(alt.column_index, table_src);
+}
+
+//===----------CONSTANT----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::constant const& alt, cudf::ast::table_reference const /*table_src*/)
+{
+  // A typed NULL constant has no cuDF AST literal representation; signal
+  // untranslatable so the caller falls back to DuckDB execution rather than
+  // unwrapping the empty payload below.
+  if (std::holds_alternative<sirius::null_value>(alt.payload)) {
+    SIRIUS_LOG_DEBUG("[expression_translator] NULL constants cannot be translated to cuDF ASTs");
+    return std::nullopt;
+  }
+
+  auto const cudf_type = sirius::get_cudf_type(alt.return_type);
+  // TODO: Expand type support as needed. See gpu_execute_constant.cpp.
+  switch (cudf_type.id()) {
+    case cudf::type_id::INT8: {
+      return add_literal_expression<cudf::numeric_scalar<int8_t>>(
+        std::get<int8_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::INT16: {
+      return add_literal_expression<cudf::numeric_scalar<int16_t>>(
+        std::get<int16_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::INT32: {
+      return add_literal_expression<cudf::numeric_scalar<int32_t>>(
+        std::get<int32_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::INT64: {
+      return add_literal_expression<cudf::numeric_scalar<int64_t>>(
+        std::get<int64_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::UINT8: {
+      return add_literal_expression<cudf::numeric_scalar<uint8_t>>(
+        std::get<uint8_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::UINT16: {
+      return add_literal_expression<cudf::numeric_scalar<uint16_t>>(
+        std::get<uint16_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::UINT32: {
+      return add_literal_expression<cudf::numeric_scalar<uint32_t>>(
+        std::get<uint32_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::UINT64: {
+      return add_literal_expression<cudf::numeric_scalar<uint64_t>>(
+        std::get<uint64_t>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::FLOAT32: {
+      return add_literal_expression<cudf::numeric_scalar<float>>(
+        std::get<float>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::FLOAT64: {
+      return add_literal_expression<cudf::numeric_scalar<double>>(
+        std::get<double>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::BOOL8: {
+      return add_literal_expression<cudf::numeric_scalar<bool>>(
+        std::get<bool>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::STRING: {
+      return add_literal_expression<cudf::string_scalar>(
+        std::get<std::string>(alt.payload), true, _stream, _resource_ref);
+    }
+    case cudf::type_id::TIMESTAMP_DAYS: {
+      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_D>>(
+        cudf::duration_D{std::get<sirius::date_value>(alt.payload).days},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::TIMESTAMP_SECONDS: {
+      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_s>>(
+        cudf::duration_s{std::get<sirius::timestamp_sec_value>(alt.payload).value},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::TIMESTAMP_MILLISECONDS: {
+      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_ms>>(
+        cudf::duration_ms{std::get<sirius::timestamp_ms_value>(alt.payload).value},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::TIMESTAMP_MICROSECONDS: {
+      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_us>>(
+        cudf::duration_us{std::get<sirius::timestamp_us_value>(alt.payload).value},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::TIMESTAMP_NANOSECONDS: {
+      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_ns>>(
+        cudf::duration_ns{std::get<sirius::timestamp_ns_value>(alt.payload).value},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    // cudf decimal type uses negative scale
+    case cudf::type_id::DECIMAL32: {
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal32>>(
+        std::get<sirius::decimal32>(alt.payload).value,
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::DECIMAL64: {
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal64>>(
+        std::get<sirius::decimal64>(alt.payload).value,
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    case cudf::type_id::DECIMAL128: {
+      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal128>>(
+        std::get<sirius::decimal128>(alt.payload).value,
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        true,
+        _stream,
+        _resource_ref);
+    }
+    default: {
+      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported constant type_id: {}",
+                       static_cast<int>(cudf_type.id()));
+      return std::nullopt;
+    }
+  }
+}
+
+//===----------COMPARISON----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::comparison const& alt, cudf::ast::table_reference const table_src)
+{
+  // Add the children
+  auto left_expr  = add_expression(*alt.left, table_src);
+  auto right_expr = add_expression(*alt.right, table_src);
+
+  // Check for failure in translating children
+  if (!left_expr || !right_expr) { return std::nullopt; }
+
+  // Construct the comparison expression
+  switch (alt.op) {
+    case sirius::comparison_type::equal:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
+    case sirius::comparison_type::not_equal:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
+    case sirius::comparison_type::lt:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
+    case sirius::comparison_type::gt:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
+    case sirius::comparison_type::le:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
+    case sirius::comparison_type::ge:
+      return _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
+    case sirius::comparison_type::distinct_from:
+    case sirius::comparison_type::not_distinct_from: {
+      SIRIUS_LOG_DEBUG(
+        "[expression_translator] DISTINCT comparisons not supported in expression translator");
+      return std::nullopt;
+    }
+    default:
+      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported comparison type: {}",
+                       static_cast<int>(alt.op));
+      return std::nullopt;
+  }
+}
+
+//===----------CONJUNCTION----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::conjunction const& alt, cudf::ast::table_reference const table_src)
+{
+  // If there are no children, return
+  if (alt.children.empty()) { return std::nullopt; }
+
+  // Add the children and combine with AND/OR operations as we go
+  auto result = add_expression(*alt.children[0], table_src);
+  if (!result) { return std::nullopt; }
+
+  for (size_t i = 1; i < alt.children.size(); ++i) {
+    // Add child expression
+    auto child_expr = add_expression(*alt.children[i], table_src);
+
+    // Check for failure in translating child
+    if (!child_expr) { return std::nullopt; }
+
+    // Combine with previous children using AND/OR
+    if (alt.op == sirius::ast::conjunction::kind::op_and) {
+      result = _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LOGICAL_AND, *result, *child_expr);
+    } else if (alt.op == sirius::ast::conjunction::kind::op_or) {
+      result = _ast_tree.emplace<cudf::ast::operation>(
+        cudf::ast::ast_operator::LOGICAL_OR, *result, *child_expr);
+    } else {
+      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported conjunction type: {}",
+                       static_cast<int>(alt.op));
+      return std::nullopt;
+    }
+  }
+  return result;
 }
 
 //===----------BETWEEN----------===//
 std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundBetweenExpression const& expr, cudf::ast::table_reference const table_src)
+  sirius::ast::between const& alt, cudf::ast::table_reference const table_src)
 {
   // Add the children.
-  auto input_expr = add_expression(*expr.input, table_src);
-  auto lower_expr = add_expression(*expr.lower, table_src);
-  auto upper_expr = add_expression(*expr.upper, table_src);
+  auto input_expr = add_expression(*alt.input, table_src);
+  auto lower_expr = add_expression(*alt.lower, table_src);
+  auto upper_expr = add_expression(*alt.upper, table_src);
 
   // Check for failure in translating children
   if (!input_expr || !lower_expr || !upper_expr) { return std::nullopt; }
@@ -369,19 +616,27 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     cudf::ast::ast_operator::LOGICAL_AND, lower_cmp_op, upper_cmp_op);
 }
 
+//===----------CASE----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::case_expr const& /*alt*/, cudf::ast::table_reference const /*table_src*/)
+{
+  SIRIUS_LOG_DEBUG("[expression_translator] CASE expressions cannot be translated to cuDF ASTs");
+  return std::nullopt;
+}
+
 //===----------CAST----------===//
 std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundCastExpression const& expr, cudf::ast::table_reference const table_src)
+  sirius::ast::cast const& alt, cudf::ast::table_reference const table_src)
 {
   // Add the child
-  auto child_expr = add_expression(*expr.child, table_src);
+  auto child_expr = add_expression(*alt.child, table_src);
 
   // Check for failure in translating child
   if (!child_expr) { return std::nullopt; }
 
   // Construct the CAST expression, if possible
   // CuDF AST only supports casts to INT64, UINT64, FLOAT64
-  auto const cudf_return_type = GetCudfType(expr.return_type);
+  auto const cudf_return_type = sirius::get_cudf_type(alt.target_type);
   switch (cudf_return_type.id()) {
     case cudf::type_id::INT64:
       return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::CAST_TO_INT64,
@@ -400,326 +655,115 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
   }
 }
 
-//===----------COMPARISON----------===//
+//===----------UNARY OPERATOR----------===//
 std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundComparisonExpression const& expr, cudf::ast::table_reference const table_src)
+  sirius::ast::unary_op const& alt, cudf::ast::table_reference const table_src)
 {
-  // Add the children
-  auto left_expr  = add_expression(*expr.left, table_src);
-  auto right_expr = add_expression(*expr.right, table_src);
+  auto child_expr = add_expression(*alt.child, table_src);
+  if (!child_expr) { return std::nullopt; }
 
-  // Check for failure in translating children
-  if (!left_expr || !right_expr) { return std::nullopt; }
-
-  // Construct the comparison expression
-  switch (expr.GetExpressionType()) {
-    case duckdb::ExpressionType::COMPARE_EQUAL:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::EQUAL, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_NOTEQUAL:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::NOT_EQUAL, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_LESSTHAN:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LESS, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_GREATERTHAN:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::GREATER, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LESS_EQUAL, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-      return _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::GREATER_EQUAL, *left_expr, *right_expr);
-    case duckdb::ExpressionType::COMPARE_DISTINCT_FROM:
-    case duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] DISTINCT comparisons not supported in expression translator");
-      return std::nullopt;
+  switch (alt.op) {
+    case sirius::ast::unary_op::kind::op_not:
+      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, *child_expr);
+    case sirius::ast::unary_op::kind::op_is_null:
+      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::IS_NULL, *child_expr);
+    case sirius::ast::unary_op::kind::op_is_not_null: {
+      // Add IS_NULL followed by NOT to represent IS_NOT_NULL
+      expr_ref is_null_op =
+        _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::IS_NULL, *child_expr);
+      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, is_null_op);
     }
+    case sirius::ast::unary_op::kind::op_try:
     default:
-      throw duckdb::InternalException("[expression_translator] Unknown comparison type: {}",
-                                      expr.GetExpressionType());
-  }
-}
-
-//===----------CONJUNCTION----------===//
-std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundConjunctionExpression const& expr, cudf::ast::table_reference const table_src)
-{
-  // If there are no children, return
-  if (expr.children.empty()) { return std::nullopt; }
-
-  // Add the children and combine with AND/OR operations as we go
-  auto result = add_expression(*expr.children[0], table_src);
-  if (!result) { return std::nullopt; }
-
-  for (size_t i = 1; i < expr.children.size(); ++i) {
-    // Add child expression
-    auto child_expr = add_expression(*expr.children[i], table_src);
-
-    // Check for failure in translating child
-    if (!child_expr) { return std::nullopt; }
-
-    // Combine with previous children using AND/OR
-    if (expr.GetExpressionType() == duckdb::ExpressionType::CONJUNCTION_AND) {
-      result = _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LOGICAL_AND, *result, *child_expr);
-    } else if (expr.GetExpressionType() == duckdb::ExpressionType::CONJUNCTION_OR) {
-      result = _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::LOGICAL_OR, *result, *child_expr);
-    } else {
-      throw duckdb::InternalException("[expression_translator] Unknown conjunction type: {}",
-                                      expr.GetExpressionType());
-    }
-  }
-  return result;
-}
-
-//===----------CONSTANT----------===//
-std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundConstantExpression const& expr, cudf::ast::table_reference const table_src)
-{
-  auto const cudf_type = GetCudfType(expr.return_type);
-  // TODO: Expand type support as needed. See gpu_execute_constant.cpp.
-  switch (cudf_type.id()) {
-    case cudf::type_id::INT8: {
-      return add_literal_expression<cudf::numeric_scalar<int8_t>>(
-        expr.value.GetValue<int8_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::INT16: {
-      return add_literal_expression<cudf::numeric_scalar<int16_t>>(
-        expr.value.GetValue<int16_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::INT32: {
-      return add_literal_expression<cudf::numeric_scalar<int32_t>>(
-        expr.value.GetValue<int32_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::INT64: {
-      return add_literal_expression<cudf::numeric_scalar<int64_t>>(
-        expr.value.GetValue<int64_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::UINT8: {
-      return add_literal_expression<cudf::numeric_scalar<uint8_t>>(
-        expr.value.GetValue<uint8_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::UINT16: {
-      return add_literal_expression<cudf::numeric_scalar<uint16_t>>(
-        expr.value.GetValue<uint16_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::UINT32: {
-      return add_literal_expression<cudf::numeric_scalar<uint32_t>>(
-        expr.value.GetValue<uint32_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::UINT64: {
-      return add_literal_expression<cudf::numeric_scalar<uint64_t>>(
-        expr.value.GetValue<uint64_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::FLOAT32: {
-      return add_literal_expression<cudf::numeric_scalar<float_t>>(
-        expr.value.GetValue<float_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::FLOAT64: {
-      return add_literal_expression<cudf::numeric_scalar<double_t>>(
-        expr.value.GetValue<double_t>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::BOOL8: {
-      return add_literal_expression<cudf::numeric_scalar<bool>>(
-        expr.value.GetValue<bool>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::STRING: {
-      return add_literal_expression<cudf::string_scalar>(
-        expr.value.GetValue<std::string>(), true, _stream, _resource_ref);
-    }
-    case cudf::type_id::TIMESTAMP_DAYS: {
-      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_D>>(
-        cudf::duration_D{expr.value.GetValue<duckdb::date_t>().days}, true, _stream, _resource_ref);
-    }
-    case cudf::type_id::TIMESTAMP_SECONDS: {
-      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_s>>(
-        cudf::duration_s{expr.value.GetValue<duckdb::timestamp_sec_t>().value},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    case cudf::type_id::TIMESTAMP_MILLISECONDS: {
-      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_ms>>(
-        cudf::duration_ms{expr.value.GetValue<duckdb::timestamp_ms_t>().value},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    case cudf::type_id::TIMESTAMP_MICROSECONDS: {
-      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_us>>(
-        cudf::duration_us{expr.value.GetValue<duckdb::timestamp_tz_t>().value},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    case cudf::type_id::TIMESTAMP_NANOSECONDS: {
-      return add_literal_expression<cudf::timestamp_scalar<cudf::timestamp_ns>>(
-        cudf::duration_ns{expr.value.GetValue<duckdb::timestamp_tz_t>().value},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    // cudf decimal type uses negative scale
-    case cudf::type_id::DECIMAL32: {
-      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal32>>(
-        expr.value.GetValueUnsafe<typename numeric::decimal32::rep>(),
-        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    case cudf::type_id::DECIMAL64: {
-      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal64>>(
-        expr.value.GetValueUnsafe<typename numeric::decimal64::rep>(),
-        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    case cudf::type_id::DECIMAL128: {
-      duckdb::hugeint_t const value = expr.value.GetValueUnsafe<duckdb::hugeint_t>();
-      __int128_t rep                = (static_cast<__int128_t>(value.upper) << 64) | value.lower;
-      return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal128>>(
-        rep,
-        numeric::scale_type{-duckdb::DecimalType::GetScale(expr.value.type())},
-        true,
-        _stream,
-        _resource_ref);
-    }
-    default: {
-      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported constant type_id: {}",
-                       static_cast<int>(cudf_type.id()));
+      // cuDF AST cannot express TRY.
+      SIRIUS_LOG_DEBUG(
+        "[expression_translator] TRY operator not supported in expression translator");
       return std::nullopt;
-    }
   }
+}
+
+//===----------COALESCE----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::coalesce const& /*alt*/, cudf::ast::table_reference const /*table_src*/)
+{
+  SIRIUS_LOG_DEBUG(
+    "[expression_translator] COALESCE operator not supported in expression translator");
+  return std::nullopt;
+}
+
+//===----------IN / NOT IN----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::in_list const& alt, cudf::ast::table_reference const table_src)
+{
+  // IN expressions must have at least one comparator value.
+  if (alt.values.empty()) { return std::nullopt; }
+
+  // Translate the first comparison expression
+  auto test_expr = add_expression(*alt.probe, table_src);
+  if (!test_expr) { return std::nullopt; }
+  auto comparator_expr = add_expression(*alt.values[0], table_src);
+  if (!comparator_expr) { return std::nullopt; }
+  expr_ref comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+    cudf::ast::ast_operator::EQUAL, *test_expr, *comparator_expr);
+
+  // Loop over values, building an OR tree of comparisons.
+  // Re-translate the probe expression each time to avoid shared AST subgraphs.
+  for (size_t i = 1; i < alt.values.size(); ++i) {
+    auto probe_expr = add_expression(*alt.probe, table_src);
+    if (!probe_expr) { return std::nullopt; }
+    auto value_expr = add_expression(*alt.values[i], table_src);
+    if (!value_expr) { return std::nullopt; }
+
+    expr_ref next_comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+      cudf::ast::ast_operator::EQUAL, *probe_expr, *value_expr);
+    comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
+      cudf::ast::ast_operator::LOGICAL_OR, comparison_expr, next_comparison_expr);
+  }
+
+  if (!alt.negated) { return comparison_expr; }
+  return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, comparison_expr);
 }
 
 //===----------FUNCTION----------===//
 std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundFunctionExpression const& expr, cudf::ast::table_reference const table_src)
+  sirius::ast::function_call const& alt, cudf::ast::table_reference const table_src)
 {
   // cuDF AST only supports numeric binary functions
   // We need to disable operations that propagate decimal types up the expression tree
   // We are waiting on this bug fix: https://github.com/rapidsai/cudf/pull/21996
-  auto block_function_translation = [](duckdb::BoundFunctionExpression const& expr) -> bool {
-    for (auto const& child : expr.children) {
-      auto const child_type = child->return_type;
-      if (child_type.id() == duckdb::LogicalTypeId::DECIMAL) {
+  auto block_function_translation = [](sirius::ast::function_call const& alt) -> bool {
+    for (auto const& arg : alt.arguments()) {
+      if (node_logical_type_id(*arg) == sirius::type_id::DECIMAL) {
         SIRIUS_LOG_DEBUG(
-          "[expression_translator] Blocking function '{}' because it propagates decimal types",
-          expr.function.name);
+          "[expression_translator] Blocking function because it propagates decimal types");
         return true;
       }
     }
     return false;
   };
 
-  auto const& func_str = expr.function.name;
-  if (func_str == "+") {
-    if (block_function_translation(expr)) { return std::nullopt; }
-    return add_function_expression<cudf::ast::ast_operator::ADD>(expr, table_src);
-  } else if (func_str == "-") {
-    if (block_function_translation(expr)) { return std::nullopt; }
-    return add_function_expression<cudf::ast::ast_operator::SUB>(expr, table_src);
-  } else if (func_str == "*") {
-    if (block_function_translation(expr)) { return std::nullopt; }
-    return add_function_expression<cudf::ast::ast_operator::MUL>(expr, table_src);
-  } else if (func_str == "/" || func_str == "//") {
-    if (block_function_translation(expr)) { return std::nullopt; }
-    return add_function_expression<cudf::ast::ast_operator::DIV>(expr, table_src);
-  } else if (func_str == "%") {
-    if (block_function_translation(expr)) { return std::nullopt; }
-    return add_function_expression<cudf::ast::ast_operator::MOD>(expr, table_src);
-  }
-  SIRIUS_LOG_DEBUG("[expression_translator] Unsupported function: {}", func_str);
-  return std::nullopt;
-}
-
-//===----------OPERATOR----------===//
-std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundOperatorExpression const& expr, cudf::ast::table_reference const table_src)
-{
-  switch (expr.type) {
-    case duckdb::ExpressionType::COMPARE_IN:  // Fallthrough
-    case duckdb::ExpressionType::COMPARE_NOT_IN: {
-      // [KEVIN]: It may be wise to limit the number of children for IN expressions that we
-      // attempt to translate, as a large number of children could lead to a very large/complex
-      // AST that could be very slow. For now, we will optimistically attempt to translate all
-      // IN expressions regardless of number of children, but we can revisit this if it becomes an
-      // issue.
-      assert(expr.children.size() > 1);  // IN expressions must have at least 2 children (test
-                                         // expression and at least 1 comparator expression)
-
-      // Translate the first comparison expression
-      auto test_expr = add_expression(*expr.children[0], table_src);
-      if (!test_expr) { return std::nullopt; }
-      auto comparator_expr = add_expression(*expr.children[1], table_src);
-      if (!comparator_expr) { return std::nullopt; }
-      expr_ref comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-        cudf::ast::ast_operator::EQUAL, *test_expr, *comparator_expr);
-
-      // Loop over children, building an OR tree of comparisons.
-      // Re-translate the test expression each time to avoid shared AST subgraphs.
-      for (size_t child = 2; child < expr.children.size(); ++child) {
-        auto test_expr = add_expression(*expr.children[0], table_src);
-        if (!test_expr) { return std::nullopt; }
-        auto comparator_expr = add_expression(*expr.children[child], table_src);
-        if (!comparator_expr) { return std::nullopt; }
-
-        expr_ref next_comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-          cudf::ast::ast_operator::EQUAL, *test_expr, *comparator_expr);
-        comparison_expr = _ast_tree.emplace<cudf::ast::operation>(
-          cudf::ast::ast_operator::LOGICAL_OR, comparison_expr, next_comparison_expr);
-      }
-
-      if (expr.type == duckdb::ExpressionType::COMPARE_IN) { return comparison_expr; }
-      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, comparison_expr);
-    }
-    case duckdb::ExpressionType::OPERATOR_COALESCE: {
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] COALESCE operator not supported in expression translator");
-      return std::nullopt;
-    }
-    case duckdb::ExpressionType::OPERATOR_TRY: {
-      SIRIUS_LOG_DEBUG(
-        "[expression_translator] TRY operator not supported in expression translator");
-      return std::nullopt;
-    }
-    case duckdb::ExpressionType::OPERATOR_NOT: {
-      auto child_expr = add_expression(*expr.children[0], table_src);
-      if (!child_expr) { return std::nullopt; }
-
-      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, *child_expr);
-    }
-    case duckdb::ExpressionType::OPERATOR_IS_NULL:  // Fallthrough
-    case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL: {
-      auto child_expr = add_expression(*expr.children[0], table_src);
-      if (!child_expr) { return std::nullopt; }
-
-      // Add IS_NULL followed by NOT to represent IS_NOT_NULL
-      expr_ref is_null_op =
-        _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::IS_NULL, *child_expr);
-      if (expr.type == duckdb::ExpressionType::OPERATOR_IS_NULL) { return is_null_op; }
-      return _ast_tree.emplace<cudf::ast::operation>(cudf::ast::ast_operator::NOT, is_null_op);
-    }
+  switch (alt.function()) {
+    case sirius::function_id::add:
+      if (block_function_translation(alt)) { return std::nullopt; }
+      return add_function_expression<cudf::ast::ast_operator::ADD>(alt, table_src);
+    case sirius::function_id::sub:
+      if (block_function_translation(alt)) { return std::nullopt; }
+      return add_function_expression<cudf::ast::ast_operator::SUB>(alt, table_src);
+    case sirius::function_id::mul:
+      if (block_function_translation(alt)) { return std::nullopt; }
+      return add_function_expression<cudf::ast::ast_operator::MUL>(alt, table_src);
+    case sirius::function_id::div:
+    case sirius::function_id::int_div:
+      if (block_function_translation(alt)) { return std::nullopt; }
+      return add_function_expression<cudf::ast::ast_operator::DIV>(alt, table_src);
+    case sirius::function_id::mod:
+      if (block_function_translation(alt)) { return std::nullopt; }
+      return add_function_expression<cudf::ast::ast_operator::MOD>(alt, table_src);
     default:
-      throw duckdb::InternalException("[expression_translator] Unknown operator type: {}",
-                                      expr.GetExpressionType());
+      SIRIUS_LOG_DEBUG("[expression_translator] Unsupported function: {}",
+                       static_cast<int>(alt.function()));
+      return std::nullopt;
   }
-}
-
-//===----------REFERENCE----------===//
-std::optional<expr_ref> gpu_expression_translator::add_expression(
-  duckdb::BoundReferenceExpression const& expr, cudf::ast::table_reference const table_src)
-{
-  if (_column_name_resolver) {
-    return _ast_tree.emplace<cudf::ast::column_name_reference>(_column_name_resolver(expr.index));
-  }
-  return _ast_tree.emplace<cudf::ast::column_reference>(expr.index, table_src);
 }
 
 }  // namespace sirius

--- a/src/include/expression_executor/gpu_expression_translator_internal.hpp
+++ b/src/include/expression_executor/gpu_expression_translator_internal.hpp
@@ -238,6 +238,12 @@ class gpu_expression_translator {
   std::optional<expr_ref> add_function_expression(sirius::ast::function_call const& alt,
                                                   cudf::ast::table_reference const table_src)
   {
+    // This helper builds a binary cuDF operation. DuckDB overloads some
+    // operators on arity (e.g. unary negation also binds as function "-"), so a
+    // function_call reaching here may carry a single argument; bail out rather
+    // than indexing arguments()[1] out of bounds.
+    if (alt.arguments().size() != 2) { return std::nullopt; }
+
     // Translate children
     auto left_expr  = add_expression(*alt.arguments()[0], table_src);
     auto right_expr = add_expression(*alt.arguments()[1], table_src);

--- a/src/include/expression_executor/gpu_expression_translator_internal.hpp
+++ b/src/include/expression_executor/gpu_expression_translator_internal.hpp
@@ -19,19 +19,11 @@
 // sirius
 #include <cudf/cudf_utils.hpp>
 
+#include <expression/ast/node.hpp>
 #include <expression/join_condition.hpp>
 
 // duckdb
 #include <duckdb/common/types.hpp>
-#include <duckdb/planner/expression/bound_between_expression.hpp>
-#include <duckdb/planner/expression/bound_case_expression.hpp>
-#include <duckdb/planner/expression/bound_cast_expression.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
-#include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/joinside.hpp>
 
 // cudf
@@ -123,9 +115,9 @@ class gpu_expression_translator {
   }
 
   /**
-   * @brief Try to translate a DuckDB expression into a cuDF AST.
+   * @brief Try to translate a Sirius AST expression into a cuDF AST.
    *
-   * @param expr The DuckDB expression to translate.
+   * @param expr The Sirius AST expression to translate.
    * @param table_src The table reference (LEFT, RIGHT, or NONE) to use for any column references in
    * the expression (DEFAULT is LEFT, and the argument is immaterial for single-table expressions,
    * i.e., not join conditions).
@@ -134,25 +126,25 @@ class gpu_expression_translator {
    * expression that could not be translated to cuDF AST.
    */
   std::optional<translated_expression> translate_expression(
-    duckdb::Expression const& expr,
+    sirius::ast::node const& expr,
     cudf::ast::table_reference const table_src = cudf::ast::table_reference::LEFT);
 
   /**
-   * @brief Try to translate a DuckDB expression into a cuDF AST, using column name references
+   * @brief Try to translate a Sirius AST expression into a cuDF AST, using column name references
    * instead of column index references.
    *
    * This is needed for cudf's parquet predicate pushdown (e.g. hybrid scan), which expects
    * filter expressions to use cudf::ast::column_name_reference (by name) rather than
    * cudf::ast::column_reference (by index).
    *
-   * @param expr The DuckDB expression to translate.
-   * @param column_name_resolver A function mapping BoundReferenceExpression::index to a column
+   * @param expr The Sirius AST expression to translate.
+   * @param column_name_resolver A function mapping a reference column index to a column
    * name string.
    * @return An optional containing the translated expression, or std::nullopt if translation
    * failed.
    */
   std::optional<translated_expression> translate_expression_with_names(
-    duckdb::Expression const& expr, column_name_resolver_fxn column_name_resolver);
+    sirius::ast::node const& expr, column_name_resolver_fxn column_name_resolver);
 
   /**
    * @brief Try to translate a sirius join condition into a cuDF AST.
@@ -198,31 +190,40 @@ class gpu_expression_translator {
 
   /// @brief Add the given expression to the AST, returning a reference to the added expression if
   /// translation was successful, or std::nullopt if translation failed.
-  std::optional<expr_ref> add_expression(duckdb::Expression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for BETWEEN expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundBetweenExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for CAST expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundCastExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for COMPARISON expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundComparisonExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for CONJUNCTION expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundConjunctionExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for CONSTANT expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundConstantExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for FUNCTION expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundFunctionExpression const& expr,
-                                         cudf::ast::table_reference const table_src);
-  /// @brief Specialized add_expression for OPERATOR expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundOperatorExpression const& expr,
+  std::optional<expr_ref> add_expression(sirius::ast::node const& expr,
                                          cudf::ast::table_reference const table_src);
   /// @brief Specialized add_expression for column REFERENCE expressions.
-  std::optional<expr_ref> add_expression(duckdb::BoundReferenceExpression const& expr,
+  std::optional<expr_ref> add_expression(sirius::ast::reference const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for CONSTANT expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::constant const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for COMPARISON expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::comparison const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for CONJUNCTION expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::conjunction const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for BETWEEN expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::between const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for CASE expressions (not translatable to cuDF AST).
+  std::optional<expr_ref> add_expression(sirius::ast::case_expr const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for CAST expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::cast const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for unary SQL operators (NOT, IS NULL, IS NOT NULL, TRY).
+  std::optional<expr_ref> add_expression(sirius::ast::unary_op const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for COALESCE expressions (not translatable to cuDF AST).
+  std::optional<expr_ref> add_expression(sirius::ast::coalesce const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for IN / NOT IN expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::in_list const& alt,
+                                         cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for FUNCTION expressions.
+  std::optional<expr_ref> add_expression(sirius::ast::function_call const& alt,
                                          cudf::ast::table_reference const table_src);
 
   /// @brief Add a single join condition to the current AST tree without resetting it.
@@ -234,12 +235,12 @@ class gpu_expression_translator {
   /// @brief Helper function for adding a binary function expression (e.g. addition) to the AST.
   /// OP is the cuDF AST operator corresponding to the function (e.g. cudf::ast::ast_operator::ADD).
   template <cudf::ast::ast_operator OP>
-  std::optional<expr_ref> add_function_expression(duckdb::BoundFunctionExpression const& expr,
+  std::optional<expr_ref> add_function_expression(sirius::ast::function_call const& alt,
                                                   cudf::ast::table_reference const table_src)
   {
     // Translate children
-    auto left_expr  = add_expression(*expr.children[0], table_src);
-    auto right_expr = add_expression(*expr.children[1], table_src);
+    auto left_expr  = add_expression(*alt.arguments()[0], table_src);
+    auto right_expr = add_expression(*alt.arguments()[1], table_src);
 
     // Check for failure in translating children
     if (!left_expr || !right_expr) { return std::nullopt; }

--- a/src/include/op/scan/scan_utils.hpp
+++ b/src/include/op/scan/scan_utils.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 // sirius
+#include <expression_executor/gpu_expression_translator_internal.hpp>
 #include <helper/logical_type.hpp>
 
 // duckdb
@@ -67,5 +68,27 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
   const duckdb::vector<sirius::logical_type>& returned_types,
   const std::vector<std::optional<std::size_t>>& batch_position_by_column_id,
   const std::unordered_set<std::size_t>& skip_primary_indices = {});
+
+/**
+ * @brief Bridge a DuckDB filter expression through sirius::ast::from_duckdb into the
+ * cuDF-AST translator's column-name pathway.
+ *
+ * Converts @p expr to a Sirius AST node (returning std::nullopt if the expression cannot be
+ * lowered), then forwards it to @p translator.translate_expression_with_names. The helper owns
+ * the intermediate Sirius AST node for the duration of the call.
+ *
+ * This is a free function (not a translator member) so the translator's public surface accepts
+ * only Sirius AST; the DuckDB-to-AST conversion lives at the scan boundary.
+ *
+ * @param translator The translator to lower the converted Sirius AST into a cuDF AST.
+ * @param expr The DuckDB filter expression to translate.
+ * @param resolver Function mapping a reference column index to a column name string.
+ * @return The translated expression, or std::nullopt if conversion or translation failed.
+ */
+std::optional<gpu_expression_translator::translated_expression>
+translate_duckdb_expression_with_names(
+  gpu_expression_translator& translator,
+  duckdb::Expression const& expr,
+  gpu_expression_translator::column_name_resolver_fxn resolver);
 
 }  // namespace sirius::op

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -17,6 +17,7 @@
 // sirius
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <expression/ast/from_duckdb.hpp>
 #include <helper/type_conversions.hpp>
 #include <log/logging.hpp>
 #include <op/scan/scan_utils.hpp>
@@ -24,6 +25,7 @@
 // standard library
 #include <format>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace sirius::op {
@@ -107,6 +109,16 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
     conjunction->children.push_back(std::move(expr));
   }
   return conjunction;
+}
+
+std::optional<gpu_expression_translator::translated_expression>
+translate_duckdb_expression_with_names(gpu_expression_translator& translator,
+                                       duckdb::Expression const& expr,
+                                       gpu_expression_translator::column_name_resolver_fxn resolver)
+{
+  auto node = sirius::ast::from_duckdb(expr);
+  if (!node) { return std::nullopt; }
+  return translator.translate_expression_with_names(*node, std::move(resolver));
 }
 
 }  // namespace sirius::op

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -21,6 +21,7 @@
 #include <op/scan/parquet_scan_operator_data.hpp>
 #include <op/scan/scan_info.hpp>
 #include <op/scan/scan_plan.hpp>
+#include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_parquet_scan_operator.hpp>
 #include <op/sirius_physical_operator.hpp>
 #include <pipeline/sirius_meta_pipeline.hpp>
@@ -211,7 +212,8 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
       return plan->batch_column_name(ref_index);
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
-    ast_expression = translator.translate_expression_with_names(*filter_expression, name_resolver);
+    ast_expression = sirius::op::translate_duckdb_expression_with_names(
+      translator, *filter_expression, name_resolver);
     if (ast_expression) {
       opts.set_filter(ast_expression->back());
       SIRIUS_LOG_DEBUG(

--- a/src/op/sirius_physical_parquet_scan.cpp
+++ b/src/op/sirius_physical_parquet_scan.cpp
@@ -147,8 +147,8 @@ sirius_physical_parquet_scan::sirius_physical_parquet_scan(
         gpu_expression_translator translator(
           translation_stream.view(),
           rmm::mr::get_per_device_resource_ref(rmm::cuda_device_id{device_id}));
-        auto translated =
-          translator.translate_expression_with_names(*duckdb_expression, name_resolver);
+        auto translated = sirius::op::translate_duckdb_expression_with_names(
+          translator, *duckdb_expression, name_resolver);
         // Synchronize BEFORE storing into translated_filter_by_device so any
         // future reader — on any stream, on any device after peer-access — is
         // guaranteed to observe the scalar allocations as already completed.

--- a/src/scan_manager/parquet_split_provider.cpp
+++ b/src/scan_manager/parquet_split_provider.cpp
@@ -272,8 +272,8 @@ void parquet_split_provider::run_batch(file_batch const& batch,
       return _plan->batch_column_name(ref_index);
     };
     gpu_expression_translator translator(stream, cudf::get_current_device_resource_ref());
-    ast_expression =
-      translator.translate_expression_with_names(*_duckdb_filter_expression, name_resolver);
+    ast_expression = sirius::op::translate_duckdb_expression_with_names(
+      translator, *_duckdb_filter_expression, name_resolver);
     if (ast_expression) {
       // Probe the first file's schema before committing to filter pushdown. The probe
       // result is reused below by the main file loop via the prefetch cache.

--- a/test/cpp/expression_executor/test_gpu_expression_translator.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_translator.cpp
@@ -18,10 +18,20 @@
 #include <catch.hpp>
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
 
 // duckdb
 #include <duckdb/common/helper.hpp>
+#include <duckdb/planner/expression/bound_between_expression.hpp>
+#include <duckdb/planner/expression/bound_case_expression.hpp>
+#include <duckdb/planner/expression/bound_cast_expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf
 #include <cudf/ast/expressions.hpp>
@@ -47,6 +57,20 @@ namespace {
 
 auto const stream = cudf::get_default_stream();
 auto const mr     = cudf::get_current_device_resource_ref();
+
+//===----------------------------------------------------------------------===//
+// DuckDB -> Sirius AST bridge
+//===----------------------------------------------------------------------===//
+
+// Builds a DuckDB expression as the fixtures do today, lowers it through
+// sirius::ast::from_duckdb, and translates the resulting Sirius AST node.
+// Returns std::nullopt when the expression cannot be lowered.
+std::optional<sirius::gpu_expression_translator::translated_expression> translate(
+  sirius::gpu_expression_translator& translator, duckdb::Expression const& e)
+{
+  auto node = sirius::ast::from_duckdb(e);
+  return node ? translator.translate_expression(*node) : std::nullopt;
+}
 
 //===----------------------------------------------------------------------===//
 // GPU <-> host copy helpers
@@ -265,7 +289,7 @@ TEST_CASE("translator: column reference produces identity", "[expression_transla
   auto expr = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -290,7 +314,7 @@ TEST_CASE("translator: comparison EQUAL", "[expression_translator]")
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -315,7 +339,7 @@ TEST_CASE("translator: comparison NOT EQUAL", "[expression_translator]")
     ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -340,7 +364,7 @@ TEST_CASE("translator: comparison LESS THAN", "[expression_translator]")
     ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -365,7 +389,7 @@ TEST_CASE("translator: comparison GREATER THAN", "[expression_translator]")
     ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -390,7 +414,7 @@ TEST_CASE("translator: comparison LESS THAN OR EQUAL", "[expression_translator]"
     ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -415,7 +439,7 @@ TEST_CASE("translator: comparison GREATER THAN OR EQUAL", "[expression_translato
     ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -442,7 +466,7 @@ TEST_CASE("translator: comparison between two columns", "[expression_translator]
     ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -463,7 +487,19 @@ TEST_CASE("translator: DISTINCT FROM returns nullopt", "[expression_translator]"
     ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
+  REQUIRE_FALSE(ast_tree.has_value());
+}
+
+TEST_CASE("translator: NULL constant returns nullopt", "[expression_translator]")
+{
+  // A typed NULL has no cuDF AST literal representation; the translator must
+  // report untranslatable rather than unwrapping the empty constant payload.
+  auto expr =
+    duckdb::make_uniq<BoundConstantExpression>(Value(LogicalType{LogicalTypeId::INTEGER}));
+
+  auto translator = make_translator();
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -548,7 +584,7 @@ TEST_CASE("translator: addition col(0) + 10", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -578,7 +614,7 @@ TEST_CASE("translator: subtraction col(0) - 3", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -608,7 +644,7 @@ TEST_CASE("translator: multiplication col(0) * 2", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -638,7 +674,7 @@ TEST_CASE("translator: division col(0) / 3", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -668,7 +704,7 @@ TEST_CASE("translator: integer division col(0) // 3", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -698,7 +734,7 @@ TEST_CASE("translator: modulo col(0) % 3", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -730,7 +766,7 @@ TEST_CASE("translator: col(0) + col(1)", "[expression_translator]")
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -754,7 +790,7 @@ TEST_CASE("translator: unsupported function returns nullopt", "[expression_trans
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -782,7 +818,7 @@ TEST_CASE("translator: conjunction with unsupported first child returns nullopt"
   conjunction->children.push_back(std::move(supported));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conjunction);
+  auto ast_tree   = translate(translator, *conjunction);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -808,7 +844,7 @@ TEST_CASE("translator: conjunction AND", "[expression_translator]")
   conj->children.push_back(std::move(cmp2));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -843,7 +879,7 @@ TEST_CASE("translator: conjunction OR", "[expression_translator]")
   conj->children.push_back(std::move(cmp2));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -884,7 +920,7 @@ TEST_CASE("translator: conjunction with three children", "[expression_translator
   conj->children.push_back(std::move(cmp3));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -903,7 +939,7 @@ TEST_CASE("translator: empty conjunction returns nullopt", "[expression_translat
   // No children
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -927,7 +963,7 @@ TEST_CASE("translator: BETWEEN expression", "[expression_translator]")
     std::move(input_expr), std::move(lower_expr), std::move(upper_expr), true, true);
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*between);
+  auto ast_tree   = translate(translator, *between);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -956,7 +992,7 @@ TEST_CASE("translator: BETWEEN with tight range", "[expression_translator]")
     std::move(input_expr), std::move(lower_expr), std::move(upper_expr), true, true);
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*between);
+  auto ast_tree   = translate(translator, *between);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -982,7 +1018,7 @@ TEST_CASE("translator: CAST to INT64", "[expression_translator]")
     BoundCastExpression::AddDefaultCastToType(std::move(child), LogicalType{LogicalTypeId::BIGINT});
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*cast_expr);
+  auto ast_tree   = translate(translator, *cast_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1006,7 +1042,7 @@ TEST_CASE("translator: CAST to FLOAT64", "[expression_translator]")
     BoundCastExpression::AddDefaultCastToType(std::move(child), LogicalType{LogicalTypeId::DOUBLE});
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*cast_expr);
+  auto ast_tree   = translate(translator, *cast_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1027,7 +1063,7 @@ TEST_CASE("translator: unsupported CAST returns nullopt", "[expression_translato
                                                              LogicalType{LogicalTypeId::VARCHAR});
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*cast_expr);
+  auto ast_tree   = translate(translator, *cast_expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -1051,7 +1087,7 @@ TEST_CASE("translator: IN operator", "[expression_translator]")
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(8)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*in_expr);
+  auto ast_tree   = translate(translator, *in_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1079,7 +1115,7 @@ TEST_CASE("translator: NOT IN operator", "[expression_translator]")
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(4)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*in_expr);
+  auto ast_tree   = translate(translator, *in_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1106,7 +1142,7 @@ TEST_CASE("translator: IN with single comparator", "[expression_translator]")
   in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*in_expr);
+  auto ast_tree   = translate(translator, *in_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1137,7 +1173,7 @@ TEST_CASE("translator: NOT operator", "[expression_translator]")
   not_expr->children.push_back(std::move(cmp));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*not_expr);
+  auto ast_tree   = translate(translator, *not_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1163,7 +1199,7 @@ TEST_CASE("translator: IS NULL operator", "[expression_translator]")
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*is_null_expr);
+  auto ast_tree   = translate(translator, *is_null_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1187,7 +1223,7 @@ TEST_CASE("translator: IS NOT NULL operator", "[expression_translator]")
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*is_not_null_expr);
+  auto ast_tree   = translate(translator, *is_not_null_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1221,7 +1257,7 @@ TEST_CASE("translator: CASE expression returns nullopt", "[expression_translator
   case_expr->case_checks.push_back(std::move(case_check));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*case_expr);
+  auto ast_tree   = translate(translator, *case_expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -1234,7 +1270,7 @@ TEST_CASE("translator: COALESCE operator returns nullopt", "[expression_translat
   coalesce_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*coalesce_expr);
+  auto ast_tree   = translate(translator, *coalesce_expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -1246,7 +1282,7 @@ TEST_CASE("translator: TRY operator returns nullopt", "[expression_translator]")
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*try_expr);
+  auto ast_tree   = translate(translator, *try_expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -1292,7 +1328,7 @@ TEST_CASE("translator: nested arithmetic (col(0) + 1) * (col(1) - 2)", "[express
   mul_expr->children.push_back(std::move(sub_expr));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*mul_expr);
+  auto ast_tree   = translate(translator, *mul_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1338,7 +1374,7 @@ TEST_CASE("translator: comparison with arithmetic col(0)*2 > col(1)+3", "[expres
     ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*cmp);
+  auto ast_tree   = translate(translator, *cmp);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1379,7 +1415,7 @@ TEST_CASE("translator: IN combined with AND/OR and comparison", "[expression_tra
   conj->children.push_back(std::move(cmp));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1413,7 +1449,7 @@ TEST_CASE("translator: deeply nested NOT(col(0) BETWEEN 3 AND 7)", "[expression_
   not_expr->children.push_back(std::move(between));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*not_expr);
+  auto ast_tree   = translate(translator, *not_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1446,7 +1482,7 @@ TEST_CASE("translator: float64 arithmetic col(0) + 0.5", "[expression_translator
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::DOUBLE(0.5)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1470,7 +1506,7 @@ TEST_CASE("translator: float64 comparison col(0) < 3.5", "[expression_translator
     ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1507,7 +1543,7 @@ TEST_CASE("translator: reuse translator for multiple expressions", "[expression_
       duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
     func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)));
 
-    auto ast_tree = translator.translate_expression(*func_expr);
+    auto ast_tree = translate(translator, *func_expr);
     REQUIRE(ast_tree.has_value());
 
     auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1532,7 +1568,7 @@ TEST_CASE("translator: reuse translator for multiple expressions", "[expression_
       duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
     func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
 
-    auto ast_tree = translator.translate_expression(*func_expr);
+    auto ast_tree = translate(translator, *func_expr);
     REQUIRE(ast_tree.has_value());
 
     auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1571,7 +1607,7 @@ TEST_CASE("translator: CAST(col(0) AS BIGINT) + 100", "[expression_translator]")
   func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::BIGINT(100)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*func_expr);
+  auto ast_tree   = translate(translator, *func_expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1600,7 +1636,7 @@ TEST_CASE("translator: single-row table", "[expression_translator]")
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1639,7 +1675,7 @@ TEST_CASE("translator: 100-row table with complex expression", "[expression_tran
     duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(100)));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*cmp);
+  auto ast_tree   = translate(translator, *cmp);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1677,7 +1713,7 @@ TEST_CASE("translator: decimal32 column EQUAL decimal literal", "[expression_tra
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1702,7 +1738,7 @@ TEST_CASE("translator: decimal64 column LESS decimal literal", "[expression_tran
     ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1738,7 +1774,7 @@ TEST_CASE("translator: nested decimal comparison col(0) >= 2.00 AND col(0) <= 4.
   conj->children.push_back(std::move(leq));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*conj);
+  auto ast_tree   = translate(translator, *conj);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1774,7 +1810,7 @@ TEST_CASE("translator: nested decimal arithmetic returns nullopt", "[expression_
     duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(200, uint8_t{5}, uint8_t{2})));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*mul);
+  auto ast_tree   = translate(translator, *mul);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -1794,7 +1830,7 @@ TEST_CASE("translator: string column EQUAL string literal", "[expression_transla
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -1814,7 +1850,7 @@ TEST_CASE("translator: string column NOT EQUAL string literal", "[expression_tra
     ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
 
   auto translator = make_translator();
-  auto ast_tree   = translator.translate_expression(*expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);


### PR DESCRIPTION
Closes #700, sub-issue of #666 

## Summary

Migrates the cuDF-AST lowering translator (`gpu_expression_translator`) from `duckdb::Expression`-typed input to Sirius-native `sirius::ast::node`. The cuDF AST output (`cudf::ast::tree`) is byte-identical — only the input type changes.

## Details

- Public `translate_expression*` entry points, the private `add_expression` dispatcher, and all per-alternative bodies now take Sirius AST; internal dispatch moves from `switch(GetExpressionClass())` to `std::visit` over `node.v`.
- Deletes all 8 `duckdb::Bound*Expression` `add_expression` overloads. The operator body splits into `unary_op` / `in_list` / `coalesce`; `case_expr` and `coalesce` resolve to explicit `std::nullopt` overloads, keeping the variant exhaustive (no default-throw).
- Function dispatch keys on `sirius::function_id`; constants read typed `sirius::value` payloads (distinct `timestamp_us` / `timestamp_ns`, fixing the old `timestamp_tz_t` conflation); cast switches on `sirius::get_cudf_type(target_type)`.
- `add_join_condition` bridges both sides through `sirius::ast::from_duckdb` inline (`join_condition.hpp` untouched).
- 3 production parquet call sites route through a shared free-function boundary helper `sirius::op::translate_duckdb_expression_with_names` in `scan_utils.{hpp,cpp}`; the hash-join path is unchanged.
- The test TU bridges its DuckDB-built fixtures through a single test-only `from_duckdb` helper.

## Test plan

- Build: clean (release config).
- `sirius_unittest`: 1554/1555 pass. The one failure is a pre-existing, environmental multi-GPU test (`test/cpp/pipeline/test_task_scheduler.cpp:161` — "Requested number of GPUs exceeds available GPUs") on a single-GPU host, unrelated to this change.
- Full `[expression_translator]` regression suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)