### PR TITLE
fix(expr): block direct decimal-column arithmetic in cuDF-AST translator

### DIFF
--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -60,7 +60,8 @@ namespace {
 
 std::unique_ptr<node> translate_reference(duckdb::BoundReferenceExpression const& expr)
 {
-  return std::make_unique<node>(reference{static_cast<uint32_t>(expr.index)});
+  return std::make_unique<node>(
+    reference{static_cast<uint32_t>(expr.index), sirius::from_duckdb(expr.return_type)});
 }
 
 std::unique_ptr<node> translate_constant(duckdb::BoundConstantExpression const& expr)

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -85,10 +85,10 @@ std::unique_ptr<duckdb::Expression> from_duck_derived_ptr(duckdb::unique_ptr<T> 
 
 std::unique_ptr<duckdb::Expression> to_duckdb(reference const& alt)
 {
-  // Sirius reference carries only column_index. The downstream consumer
-  // (executor specialization) resolves the type from the input table_view,
-  // not from the reconstructed BoundReferenceExpression — so INTEGER is a
-  // safe placeholder.
+  // The downstream consumer (executor specialization) resolves the column type
+  // from the input table_view, not from the reconstructed
+  // BoundReferenceExpression — so INTEGER is a safe placeholder here regardless
+  // of reference::return_type.
   return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
     duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER},
     static_cast<duckdb::idx_t>(alt.column_index)));

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -327,18 +327,20 @@ namespace {
 
 /// @brief Recover the SQL type identifier of an AST node, where it is carried.
 ///
-/// Used by the function arm's decimal-propagation guard. Only the node kinds
-/// that carry a logical type return a meaningful id; alternatives without a
-/// logical type (e.g. reference) return INVALID, which is treated as a
-/// non-DECIMAL sentinel by the caller — matching the executor's return-type-only
-/// decimal skip (a reference to a decimal column is not the decimal-propagation
-/// case the cuDF intermediate-result bug targets).
+/// Used by the function arm's decimal-propagation guard. Node kinds that carry
+/// a logical type (reference, constant, cast, function_call) return its id;
+/// alternatives without one return INVALID, treated as a non-DECIMAL sentinel
+/// by the caller. References must be included so that direct decimal-column
+/// arithmetic (e.g. col + col) trips the guard, matching the pre-AST translator
+/// which checked every function child's return_type.
 sirius::type_id node_logical_type_id(sirius::ast::node const& expr)
 {
   return std::visit(
     [](auto const& alt) -> sirius::type_id {
       using T = std::decay_t<decltype(alt)>;
-      if constexpr (std::is_same_v<T, sirius::ast::constant>) {
+      if constexpr (std::is_same_v<T, sirius::ast::reference>) {
+        return alt.return_type.id();
+      } else if constexpr (std::is_same_v<T, sirius::ast::constant>) {
         return alt.return_type.id();
       } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
         return alt.target_type.id();

--- a/src/include/expression/ast/reference.hpp
+++ b/src/include/expression/ast/reference.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <cstdint>
 
@@ -24,11 +27,15 @@ namespace sirius::ast {
 /**
  * @brief Sirius-native mirror of duckdb::BoundReferenceExpression.
  *
- * Carries an index into the input data batch's column vector. The index is
- * populated by the translator.
+ * Carries an index into the input data batch's column vector and the SQL type
+ * of the referenced column (mirroring duckdb::BoundReferenceExpression's
+ * return_type). The executor resolves column types from the input table_view at
+ * runtime and ignores return_type; it exists so the cuDF-AST translator's
+ * decimal-propagation guard can see the type of a referenced decimal column.
  */
 struct reference {
   uint32_t column_index{0};
+  sirius::logical_type return_type{};
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/test/cpp/expression_executor/test_gpu_expression_translator.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_translator.cpp
@@ -1814,6 +1814,28 @@ TEST_CASE("translator: nested decimal arithmetic returns nullopt", "[expression_
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
+TEST_CASE("translator: direct decimal column arithmetic returns nullopt", "[expression_translator]")
+{
+  // Direct column-vs-column decimal arithmetic (col(0) + col(0)) must also be
+  // blocked (pending rapidsai/cudf#21996), not just arithmetic whose children
+  // are decimal constants or nested functions. The function's arguments are
+  // bare references here, so the guard depends on reference nodes carrying their
+  // DECIMAL return_type through from_duckdb.
+  auto const dec52 = LogicalType::DECIMAL(5, 2);
+
+  auto add =
+    duckdb::make_uniq<BoundFunctionExpression>(dec52,
+                                               ScalarFunction("+", {dec52, dec52}, dec52, nullptr),
+                                               duckdb::vector<duckdb::unique_ptr<Expression>>{},
+                                               nullptr);
+  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
+  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
+
+  auto translator = make_translator();
+  auto ast_tree   = translate(translator, *add);
+  REQUIRE_FALSE(ast_tree.has_value());
+}
+
 //===----------------------------------------------------------------------===//
 // Test: String column vs. string literal comparisons
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Need to be merged after #847 

## Summary

Restores the cuDF-AST translator's decimal-propagation guard for **direct** decimal column-vs-column arithmetic (e.g. `col + col`), which regressed when the translator was flipped to Sirius AST input.

`node_logical_type_id()` only recovered a type for `constant`/`cast`/`function_call` nodes and returned `INVALID` for `reference` nodes, because `sirius::ast::reference` dropped its type. The pre-AST translator checked every function child's `return_type` uniformly — including `BoundReferenceExpression` children — so `+`/`*` over decimal columns used to fall back to DuckDB. After the AST flip it could translate to a cuDF AST and hit the decimal intermediate-result bug (rapidsai/cudf#21996).

### Fix
- Carry the referenced column's SQL type on `sirius::ast::reference` (populated in `from_duckdb`, mirroring `duckdb::BoundReferenceExpression::return_type`).
- `node_logical_type_id()` reports it, restoring the original guard semantics.
- The executor still resolves column types from the input `table_view` at runtime and ignores this field.
- Adds a regression test for direct `col(0) + col(0)` over a DECIMAL column returning `nullopt`.

## Test Criteria

- Build: clean (release config).
- `[expression_translator]`, `[ast_scaffold]`, `[ast_to_duckdb]` suites: all green, including the new `direct decimal column arithmetic returns nullopt` test. Decimal column comparisons still translate (no over-blocking).
- Full `sirius_unittest`: 1555/1556 pass; the single failure is the pre-existing, environmental multi-GPU test (`test/cpp/pipeline/test_task_scheduler.cpp:161`) on a single-GPU host, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)