### PR TITLE
CI: Remove `pixi` self-hosted runner labels

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{ matrix.environment == 'vcpkg'
-        && fromJSON('["self-hosted", "ubuntu-24.04", "pixi", "cpu-xl"]')
+        && fromJSON('["self-hosted", "ubuntu-24.04", "cpu-xl"]')
         || format('ubuntu-24.04{0}', case(matrix.arch == 'arm64', '-arm', '')) }}
     timeout-minutes: ${{ case(matrix.environment == 'vcpkg', 240, 60) }}
     continue-on-error: ${{ matrix.cudf-channel == 'nightly' }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -47,7 +47,7 @@ jobs:
       cuda_archs: '75-real;80-real;86-real;89-real;90a-real;100f-real;120a-real;120'
       cuda_version: '13'
       artifact_postfix: '-cuda13'
-      runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "pixi", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "pixi", "arm-xl"]}'
+      runners: '{"linux_x64": ["self-hosted", "ubuntu-24.04", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-24.04", "arm-xl"]}'
 
   cuda-12:
     uses: sirius-db/extension-ci-tools/.github/workflows/_extension_distribution.yml@sirius
@@ -70,4 +70,4 @@ jobs:
       cuda_archs: '75-real;80-real;86-real;89-real;90a-real'
       cuda_version: '12'
       artifact_postfix: '-cuda12'
-      runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "pixi", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "pixi", "arm-xl"]}'
+      runners: '{"linux_x64": ["self-hosted", "ubuntu-22.04", "cpu-xl"], "linux_arm64": ["self-hosted", "ubuntu-22.04", "arm-xl"]}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   build-cuda-13:
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, ubuntu-24.04, pixi, cpu-xl]
+    runs-on: [self-hosted, ubuntu-24.04, cpu-xl]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,7 +72,7 @@ jobs:
   build-cuda-12:
     env:
       SCCACHE_GHA_ENABLED: true
-    runs-on: [self-hosted, ubuntu-22.04, pixi, cpu-xl]
+    runs-on: [self-hosted, ubuntu-22.04, cpu-xl]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -114,7 +114,7 @@ jobs:
           retention-days: 1
 
   test-cuda-13:
-    runs-on: [self-hosted, ubuntu-24.04, pixi, gpu-2xl4]
+    runs-on: [self-hosted, ubuntu-24.04, gpu-2xl4]
     needs: build-cuda-13
     if: needs.build-cuda-13.result == 'success'
     timeout-minutes: 60
@@ -190,7 +190,7 @@ jobs:
           retention-days: 14
 
   test-cuda-12:
-    runs-on: [self-hosted, ubuntu-22.04, pixi, gpu-2xl4]
+    runs-on: [self-hosted, ubuntu-22.04, gpu-2xl4]
     needs: build-cuda-12
     if: needs.build-cuda-12.result == 'success'
     timeout-minutes: 60


### PR DESCRIPTION
Follow up to #842 in order to close #845, this PR removes all `pixi` labels from our self-hosted runners. The `pixi` labels were used as testing and to ensure workflows ran on the v2 runners while the v1 legacy runners were still active. Now that the v1 runners have been removed, we can remove these labels as a final part of the switchover.