### PR TITLE
Add StarRocks CN thrift RPC skeleton

### DIFF
--- a/experimental/starrocks/src/lib.rs
+++ b/experimental/starrocks/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fmt,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream},
+    net::{
+        IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs,
+    },
     str::FromStr,
     sync::{
         Arc, Mutex,
@@ -13,10 +16,15 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use mysql_async::{OptsBuilder, Pool, Row, prelude::Queryable};
 use starrocks_thrift::{
+    agent_service, backend_service,
+    backend_service::{BackendServiceSyncHandler, BackendServiceSyncProcessor},
+    data,
+    frontend_service::{FrontendServiceSyncClient, TFrontendServiceSyncClient},
     heartbeat_service::{
         HeartbeatServiceSyncHandler, HeartbeatServiceSyncProcessor, TBackendInfo, THeartbeatResult,
         TMasterInfo,
     },
+    internal_service, master_service, starrocks_external_service,
     status::TStatus,
     status_code::TStatusCode,
     types,
@@ -24,20 +32,24 @@ use starrocks_thrift::{
 use thrift::{
     TransportErrorKind,
     protocol::{
-        TBinaryInputProtocolFactory, TBinaryOutputProtocolFactory, TInputProtocolFactory,
-        TOutputProtocolFactory,
+        TBinaryInputProtocol, TBinaryInputProtocolFactory, TBinaryOutputProtocol,
+        TBinaryOutputProtocolFactory, TInputProtocolFactory, TOutputProtocolFactory,
     },
     server::TProcessor,
     transport::{
-        TBufferedReadTransportFactory, TBufferedWriteTransportFactory, TIoChannel,
-        TReadTransportFactory, TTcpChannel, TWriteTransportFactory,
+        TBufferedReadTransport, TBufferedReadTransportFactory, TBufferedWriteTransport,
+        TBufferedWriteTransportFactory, TIoChannel, TReadTransportFactory, TTcpChannel,
+        TWriteTransportFactory,
     },
 };
 use tracing::{debug, info, warn};
 
-type HeartbeatProcessor = HeartbeatServiceSyncProcessor<ComputeNodeHeartbeatHandler>;
-
 const COMPUTE_NODE_PROC_PATH: &str = "/compute_nodes";
+
+// Bound the blocking FE report call so an unresponsive FE cannot wedge the report loop or
+// leak its blocking-pool thread for the process lifetime. Kept well under the report interval.
+const FE_REPORT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const FE_REPORT_RW_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Host(String);
@@ -183,31 +195,63 @@ impl Default for FeConfig {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Snapshot of FE-provided heartbeat identity and report sequencing state.
 pub struct HeartbeatStateSnapshot {
+    /// Sticky StarRocks cluster id learned from the first valid FE heartbeat.
     pub cluster_id: Option<types::TClusterId>,
+    /// Sticky FE auth token learned from the first valid FE heartbeat.
     pub token: Option<SecretString>,
+    /// Latest accepted FE epoch; older epochs are rejected as stale.
     pub epoch: Option<types::TEpoch>,
+    /// FE-assigned compute-node/backend id needed for follow-up reports.
     pub compute_node_id: Option<i64>,
+    /// FE thrift address used for `FrontendService.report` after heartbeat.
+    pub frontend_address: Option<types::TNetworkAddress>,
+    /// Local monotonic report version for empty CN inventory reports.
+    pub report_version: i64,
+    /// Wall-clock timestamp of the latest accepted heartbeat.
     pub last_heartbeat_ms: Option<u128>,
 }
 
 #[derive(Debug, Default)]
 struct HeartbeatState {
+    // Sticky cluster identity prevents a running CN from silently changing FE clusters.
     cluster_id: Option<types::TClusterId>,
+    // The FE token is stored redacted and must stay stable after first contact.
     token: Option<SecretString>,
+    // Epoch monotonicity lets the CN reject stale FE heartbeat state.
     epoch: Option<types::TEpoch>,
+    // FE-assigned id is required before the CN can send inventory reports.
     compute_node_id: Option<i64>,
+    // FE thrift endpoint is learned from heartbeat and used for reports.
+    frontend_address: Option<types::TNetworkAddress>,
+    // Report versions start at zero and increment only when a report is built.
+    report_version: i64,
+    // Used by the registration refresher to detect missing/stale heartbeats.
     last_heartbeat_ms: Option<u128>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// A prepared FE report plus the heartbeat identity it was built from.
+pub struct ComputeNodeReport {
+    /// FE-assigned backend id currently associated with this compute node.
+    pub backend_id: i64,
+    /// FE thrift address that should receive the report.
+    pub frontend_address: types::TNetworkAddress,
+    /// Empty-but-truthful report request for this storage-less CN.
+    pub request: master_service::TReportRequest,
 }
 
 #[derive(Clone, Debug)]
 pub struct SharedHeartbeatState(Arc<Mutex<HeartbeatState>>);
 
 impl SharedHeartbeatState {
+    /// Creates empty heartbeat state; reports are unavailable until heartbeat fills identity.
     pub fn new() -> Self {
         Self(Arc::new(Mutex::new(HeartbeatState::default())))
     }
 
+    /// Returns a copy of heartbeat state for tests and monitoring decisions.
     pub fn snapshot(&self) -> HeartbeatStateSnapshot {
         let state = self.0.lock().expect("heartbeat state mutex poisoned");
         HeartbeatStateSnapshot {
@@ -215,10 +259,28 @@ impl SharedHeartbeatState {
             token: state.token.clone(),
             epoch: state.epoch,
             compute_node_id: state.compute_node_id,
+            frontend_address: state.frontend_address.clone(),
+            report_version: state.report_version,
             last_heartbeat_ms: state.last_heartbeat_ms,
         }
     }
 
+    /// Builds the next FE report only after heartbeat supplies FE address and CN id.
+    pub fn next_report(&self, node: &ComputeNodeConfig) -> Option<ComputeNodeReport> {
+        let mut state = self.0.lock().expect("heartbeat state mutex poisoned");
+        let backend_id = state.compute_node_id?;
+        let frontend_address = state.frontend_address.clone()?;
+        // Saturating arithmetic avoids wrapping if a long-running process reaches i64::MAX.
+        state.report_version = state.report_version.saturating_add(1);
+
+        Some(ComputeNodeReport {
+            backend_id,
+            frontend_address,
+            request: build_report_request(node, state.report_version),
+        })
+    }
+
+    /// Returns how long ago the last accepted heartbeat arrived, if any.
     pub fn last_heartbeat_elapsed(&self) -> Option<Duration> {
         let state = self.0.lock().expect("heartbeat state mutex poisoned");
         let last_heartbeat_ms = state.last_heartbeat_ms?;
@@ -241,10 +303,19 @@ pub struct ComputeNodeHeartbeatHandler {
     state: SharedHeartbeatState,
     reboot_time_secs: i64,
     hardware_cores: i32,
+    // Operator-configured FE host used to validate the FE-advertised report target. The CN
+    // later opens an outbound connection to `frontend_address`; without this guard any peer
+    // that reaches the heartbeat port and wins trust-on-first-use could redirect that
+    // outbound connection to an arbitrary host. `None` keeps the legacy permissive behavior.
+    expected_frontend_host: Option<Host>,
 }
 
 impl ComputeNodeHeartbeatHandler {
-    pub fn new(config: ComputeNodeConfig, state: SharedHeartbeatState) -> Self {
+    pub fn new(
+        config: ComputeNodeConfig,
+        state: SharedHeartbeatState,
+        expected_frontend_host: Option<Host>,
+    ) -> Self {
         Self {
             config,
             state,
@@ -252,6 +323,7 @@ impl ComputeNodeHeartbeatHandler {
             hardware_cores: std::thread::available_parallelism()
                 .map(|parallelism| parallelism.get().min(i32::MAX as usize) as i32)
                 .unwrap_or(0),
+            expected_frontend_host,
         }
     }
 
@@ -259,6 +331,7 @@ impl ComputeNodeHeartbeatHandler {
         &self,
         master_info: &TMasterInfo,
     ) -> std::result::Result<(), HeartbeatError> {
+        // Sirius is advertising itself as a StarRocks compute node, so reject BE heartbeats.
         let received_node_type = master_info
             .node_type
             .ok_or(HeartbeatError::MissingNodeType)?;
@@ -274,6 +347,7 @@ impl ComputeNodeHeartbeatHandler {
             .lock()
             .map_err(|_| HeartbeatError::StatePoisoned)?;
 
+        // StarRocks FE epochs are monotonic; accepting an older epoch would roll state back.
         if let Some(epoch) = state.epoch
             && master_info.epoch < epoch
         {
@@ -283,6 +357,7 @@ impl ComputeNodeHeartbeatHandler {
             });
         }
 
+        // Cluster id is learned once and then treated as immutable for this process.
         if let Some(cluster_id) = master_info.cluster_id {
             if let Some(current_cluster_id) = state.cluster_id {
                 if cluster_id != current_cluster_id {
@@ -296,6 +371,7 @@ impl ComputeNodeHeartbeatHandler {
             }
         }
 
+        // Token changes are treated as suspicious because later RPCs depend on FE identity.
         if let Some(token) = &master_info.token {
             if let Some(current_token) = &state.token {
                 if token != current_token.expose_secret() {
@@ -310,24 +386,55 @@ impl ComputeNodeHeartbeatHandler {
         if let Some(compute_node_id) = master_info.backend_id {
             state.compute_node_id = Some(compute_node_id);
         }
+        // FE sends its thrift address in heartbeat; reports wait until this is known. Only
+        // accept the advertised report target when it matches the operator-configured FE host
+        // (when one is configured), so a hostile heartbeat cannot redirect the CN's outbound
+        // report connection. The heartbeat itself is still accepted for liveness. This assumes
+        // a single configured FE; multi-FE leader failover to a different host would need an
+        // allowlist here.
+        let advertised = &master_info.network_address;
+        let report_target_trusted = match &self.expected_frontend_host {
+            Some(expected) => frontend_host_trusted(expected.as_str(), &advertised.hostname),
+            None => true,
+        };
+        if report_target_trusted {
+            state.frontend_address = Some(advertised.clone());
+        } else {
+            warn!(
+                advertised_host = %advertised.hostname,
+                expected_host = %self.expected_frontend_host.as_ref().expect("checked above"),
+                "ignoring FE-advertised report address that does not match the configured FE host"
+            );
+        }
         state.last_heartbeat_ms = Some(unix_time_millis());
 
         Ok(())
     }
 
     fn compute_node_info(&self) -> TBackendInfo {
+        // Sentinels for capabilities a storage-less compute node does not expose. Named here
+        // because TBackendInfo::new takes many same-typed positional Option<TPort>/Option<i64>
+        // args (see HeartbeatService.thrift `struct TBackendInfo` for field order).
+        const BE_RPC_PORT_DISABLED: i32 = -1; // legacy thrift RPC port; unused by this CN
+        const PORT_DISABLED: i32 = -1; // arrow-flight port sentinel when not configured
+        const MEM_LIMIT_UNSET: i64 = 0; // no advertised memory limit for this skeleton
+        let arrow_flight_port = self
+            .config
+            .arrow_flight_port
+            .map(i32::from)
+            .unwrap_or(PORT_DISABLED);
         TBackendInfo::new(
-            i32::from(self.config.thrift_port),
-            i32::from(self.config.http_port),
-            Some(-1),
-            Some(i32::from(self.config.brpc_port)),
-            Some(self.config.version.clone()),
-            Some(self.hardware_cores),
-            None,
-            Some(self.reboot_time_secs),
-            Some(false),
-            Some(0),
-            Some(self.config.arrow_flight_port.map(i32::from).unwrap_or(-1)),
+            i32::from(self.config.thrift_port),     // be_port
+            i32::from(self.config.http_port),       // http_port
+            Some(BE_RPC_PORT_DISABLED),             // be_rpc_port
+            Some(i32::from(self.config.brpc_port)), // brpc_port
+            Some(self.config.version.clone()),      // version
+            Some(self.hardware_cores),              // num_hardware_cores
+            None,                                   // starlet_port
+            Some(self.reboot_time_secs),            // reboot_time
+            Some(false),                            // is_set_storage_path (CN has no storage)
+            Some(MEM_LIMIT_UNSET),                  // mem_limit_bytes
+            Some(arrow_flight_port),                // arrow_flight_port
         )
     }
 }
@@ -380,54 +487,302 @@ impl HeartbeatServiceSyncHandler for ComputeNodeHeartbeatHandler {
     }
 }
 
-pub struct HeartbeatServer {
-    join_handle: Option<JoinHandle<Result<()>>>,
-    shutdown: HeartbeatServerShutdown,
-    local_addr: SocketAddr,
+#[derive(Clone, Debug)]
+/// StarRocks `BackendService` skeleton for FE/coordinator requests sent to the CN.
+pub struct ComputeNodeBackendHandler;
+
+impl ComputeNodeBackendHandler {
+    /// Creates a stateless backend handler because no RPC has executable state yet.
+    pub fn new() -> Self {
+        Self
+    }
 }
 
-impl HeartbeatServer {
-    pub fn shutdown_handle(&self) -> HeartbeatServerShutdown {
+impl Default for ComputeNodeBackendHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BackendServiceSyncHandler for ComputeNodeBackendHandler {
+    // Plan execution is deferred until a real execution engine/brpc path is wired in.
+    fn handle_exec_plan_fragment(
+        &self,
+        _params: internal_service::TExecPlanFragmentParams,
+    ) -> thrift::Result<internal_service::TExecPlanFragmentResult> {
+        Ok(internal_service::TExecPlanFragmentResult::new(
+            Some(not_implemented_status("BackendService.execPlanFragment")),
+            None,
+        ))
+    }
+
+    // Cancellation is unsupported because this CN cannot start fragments yet.
+    fn handle_cancel_plan_fragment(
+        &self,
+        _params: internal_service::TCancelPlanFragmentParams,
+    ) -> thrift::Result<internal_service::TCancelPlanFragmentResult> {
+        Ok(internal_service::TCancelPlanFragmentResult::new(Some(
+            not_implemented_status("BackendService.cancelPlanFragment"),
+        )))
+    }
+
+    // Data exchange is unsupported until fragment execution and exchange tracking exist.
+    fn handle_transmit_data(
+        &self,
+        _params: internal_service::TTransmitDataParams,
+    ) -> thrift::Result<internal_service::TTransmitDataResult> {
+        Ok(internal_service::TTransmitDataResult::new(
+            Some(not_implemented_status("BackendService.transmitData")),
+            None,
+            None,
+            None,
+        ))
+    }
+
+    // Fetch returns an empty required batch plus NOT_IMPLEMENTED instead of panicking.
+    fn handle_fetch_data(
+        &self,
+        _params: internal_service::TFetchDataParams,
+    ) -> thrift::Result<internal_service::TFetchDataResult> {
+        Ok(internal_service::TFetchDataResult::new(
+            data::TResultBatch::new(Vec::new(), false, 0, None),
+            true,
+            0,
+            Some(not_implemented_status("BackendService.fetchData")),
+        ))
+    }
+
+    // Agent tasks mutate backend state/storage, so they are rejected explicitly.
+    fn handle_submit_tasks(
+        &self,
+        _tasks: Vec<agent_service::TAgentTaskRequest>,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.submitTasks"))
+    }
+
+    // Snapshot creation requires tablet storage, which this skeleton CN does not expose.
+    fn handle_make_snapshot(
+        &self,
+        _snapshot_request: agent_service::TSnapshotRequest,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.makeSnapshot"))
+    }
+
+    // Snapshot release is paired with snapshot creation and remains unsupported here.
+    fn handle_release_snapshot(
+        &self,
+        _snapshot_path: String,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.releaseSnapshot"))
+    }
+
+    // Cluster-state publishing is agent-task style coordination, not safe to fake.
+    fn handle_publish_cluster_state(
+        &self,
+        _request: agent_service::TAgentPublishRequest,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.publishClusterState"))
+    }
+
+    // Mini-load ETL work needs local execution/storage and is intentionally absent.
+    fn handle_submit_etl_task(
+        &self,
+        _request: agent_service::TMiniLoadEtlTaskRequest,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.submitEtlTask"))
+    }
+
+    // ETL status needs a required enum, so UNKNOWN accompanies NOT_IMPLEMENTED.
+    fn handle_get_etl_status(
+        &self,
+        _request: agent_service::TMiniLoadEtlStatusRequest,
+    ) -> thrift::Result<agent_service::TMiniLoadEtlStatusResult> {
+        Ok(agent_service::TMiniLoadEtlStatusResult::new(
+            not_implemented_status("BackendService.getEtlStatus"),
+            types::TEtlState::UNKNOWN,
+            None,
+            None,
+            None,
+        ))
+    }
+
+    // Deleting ETL files would affect storage paths this CN does not own.
+    fn handle_delete_etl_files(
+        &self,
+        _request: agent_service::TDeleteEtlFilesRequest,
+    ) -> thrift::Result<agent_service::TAgentResult> {
+        Ok(agent_result("BackendService.deleteEtlFiles"))
+    }
+
+    // Export execution is not present in this first thrift surface.
+    fn handle_submit_export_task(
+        &self,
+        _request: backend_service::TExportTaskRequest,
+    ) -> thrift::Result<TStatus> {
+        Ok(not_implemented_status("BackendService.submitExportTask"))
+    }
+
+    // Export status needs a required state, so UNKNOWN accompanies NOT_IMPLEMENTED.
+    fn handle_get_export_status(
+        &self,
+        _task_id: types::TUniqueId,
+    ) -> thrift::Result<internal_service::TExportStatusResult> {
+        Ok(internal_service::TExportStatusResult::new(
+            not_implemented_status("BackendService.getExportStatus"),
+            types::TExportState::UNKNOWN,
+            None,
+        ))
+    }
+
+    // Export task cleanup remains unsupported because no export task can be created.
+    fn handle_erase_export_task(&self, _task_id: types::TUniqueId) -> thrift::Result<TStatus> {
+        Ok(not_implemented_status("BackendService.eraseExportTask"))
+    }
+
+    // Empty tablet stats are truthful for a storage-less compute node.
+    fn handle_get_tablet_stat(&self) -> thrift::Result<backend_service::TTabletStatResult> {
+        Ok(backend_service::TTabletStatResult::new(BTreeMap::new()))
+    }
+
+    // Routine-load execution is deferred until load/execution support exists.
+    fn handle_submit_routine_load_task(
+        &self,
+        _tasks: Vec<backend_service::TRoutineLoadTask>,
+    ) -> thrift::Result<TStatus> {
+        Ok(not_implemented_status(
+            "BackendService.submitRoutineLoadTask",
+        ))
+    }
+
+    // Stream-load channels imply load state, so this skeleton reports unsupported.
+    fn handle_finish_stream_load_channel(
+        &self,
+        _stream_load_channel: backend_service::TStreamLoadChannel,
+    ) -> thrift::Result<TStatus> {
+        Ok(not_implemented_status(
+            "BackendService.finishStreamLoadChannel",
+        ))
+    }
+
+    // External scanner open is an execution path and remains unimplemented.
+    fn handle_open_scanner(
+        &self,
+        _params: starrocks_external_service::TScanOpenParams,
+    ) -> thrift::Result<starrocks_external_service::TScanOpenResult> {
+        Ok(starrocks_external_service::TScanOpenResult::new(
+            not_implemented_status("BackendService.openScanner"),
+            None,
+            None,
+        ))
+    }
+
+    // Scanner batches return EOS with NOT_IMPLEMENTED to satisfy required result fields.
+    fn handle_get_next(
+        &self,
+        _params: starrocks_external_service::TScanNextBatchParams,
+    ) -> thrift::Result<starrocks_external_service::TScanBatchResult> {
+        Ok(starrocks_external_service::TScanBatchResult::new(
+            not_implemented_status("BackendService.getNext"),
+            Some(true),
+            Some(Vec::new()),
+        ))
+    }
+
+    // Scanner close is unsupported because scanner contexts are never created.
+    fn handle_close_scanner(
+        &self,
+        _params: starrocks_external_service::TScanCloseParams,
+    ) -> thrift::Result<starrocks_external_service::TScanCloseResult> {
+        Ok(starrocks_external_service::TScanCloseResult::new(
+            not_implemented_status("BackendService.closeScanner"),
+        ))
+    }
+
+    // Tablet metadata is safe to report as empty because this CN has no tablet storage.
+    fn handle_get_tablets_info(
+        &self,
+        _request: backend_service::TGetTabletsInfoRequest,
+    ) -> thrift::Result<backend_service::TGetTabletsInfoResult> {
+        Ok(backend_service::TGetTabletsInfoResult::new(
+            ok_status(),
+            Some(0),
+            Some(BTreeMap::new()),
+        ))
+    }
+}
+
+/// Joinable handle for a blocking thrift server thread.
+pub struct ThriftServer {
+    // Owning the join handle lets shutdown wait for the accept loop to exit.
+    join_handle: Option<JoinHandle<Result<()>>>,
+    // Shared shutdown state used by signal handlers and Drop.
+    shutdown: ThriftServerShutdown,
+    // Bound address, useful for tests that bind port zero.
+    local_addr: SocketAddr,
+    // Static service label used in logs and join errors.
+    name: &'static str,
+}
+
+/// Heartbeat service server handle.
+pub type HeartbeatServer = ThriftServer;
+/// Backend service server handle.
+pub type BackendServer = ThriftServer;
+
+impl ThriftServer {
+    /// Clones the shutdown handle so async orchestration can stop the blocking thread.
+    pub fn shutdown_handle(&self) -> ThriftServerShutdown {
         self.shutdown.clone()
     }
 
+    /// Requests shutdown and wakes the blocking accept loop.
     pub fn shutdown(&self) {
         self.shutdown.shutdown();
     }
 
+    /// Returns the actual listen address, including the OS-selected port for port zero.
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
 
+    /// Waits for the server thread and reports any thread/server error.
     pub fn join(mut self) -> Result<()> {
         let join_handle = self
             .join_handle
             .take()
-            .context("heartbeat server join handle was already consumed")?;
-        join_heartbeat_thread(join_handle)
+            .with_context(|| format!("{} server join handle was already consumed", self.name))?;
+        join_thrift_thread(self.name, join_handle)
     }
 }
 
-impl Drop for HeartbeatServer {
+impl Drop for ThriftServer {
     fn drop(&mut self) {
         if self.join_handle.is_some() {
+            // Dropping an unjoined server should not leave the blocking accept loop alive.
             self.shutdown();
         }
     }
 }
 
 #[derive(Clone)]
-pub struct HeartbeatServerShutdown(Arc<HeartbeatServerShutdownState>);
+/// Shared shutdown state for a blocking thrift server.
+pub struct ThriftServerShutdown(Arc<ThriftServerShutdownState>);
 
-impl HeartbeatServerShutdown {
+/// Heartbeat service shutdown handle.
+pub type HeartbeatServerShutdown = ThriftServerShutdown;
+/// Backend service shutdown handle.
+pub type BackendServerShutdown = ThriftServerShutdown;
+
+impl ThriftServerShutdown {
+    /// Creates shutdown state and records the address used to wake `TcpListener::incoming`.
     fn new(wake_addr: SocketAddr) -> Self {
-        Self(Arc::new(HeartbeatServerShutdownState {
+        Self(Arc::new(ThriftServerShutdownState {
             requested: AtomicBool::new(false),
             active_connection: Arc::new(Mutex::new(None)),
             wake_addr,
         }))
     }
 
+    /// Marks shutdown requested, closes any in-flight client, and wakes the listener.
     pub fn shutdown(&self) {
         if self.0.requested.swap(true, Ordering::SeqCst) {
             return;
@@ -437,27 +792,43 @@ impl HeartbeatServerShutdown {
         let _ = TcpStream::connect(self.0.wake_addr);
     }
 
+    /// Returns whether shutdown has been requested.
     fn is_requested(&self) -> bool {
         self.0.requested.load(Ordering::SeqCst)
     }
 
+    /// Tracks the current connection so shutdown can interrupt a blocking thrift read.
     fn track_connection(&self, stream: &TcpStream) -> Result<ActiveConnectionGuard> {
         let shutdown_stream = stream
             .try_clone()
-            .context("failed to clone heartbeat client connection")?;
+            .context("failed to clone thrift client connection")?;
 
         let mut active_connection = self
             .0
             .active_connection
             .lock()
-            .map_err(|_| anyhow!("active heartbeat connection mutex poisoned"))?;
+            .map_err(|_| anyhow!("active thrift connection mutex poisoned"))?;
         *active_connection = Some(shutdown_stream);
+
+        // Close the race with shutdown(): if shutdown was requested in the window between the
+        // accept loop's is_requested() check and this store, close_active_connection() may have
+        // already run (and found an empty slot), and shutdown()'s one-shot body will not run
+        // again. Re-checking the flag under the same lock that close_active_connection() takes
+        // guarantees this connection is interrupted rather than blocking the processor — and the
+        // accept loop — forever. SeqCst + the mutex give the needed ordering: either this load
+        // observes the request, or close_active_connection() observes this stored stream.
+        if self.0.requested.load(Ordering::SeqCst)
+            && let Some(connection) = active_connection.as_ref()
+        {
+            let _ = connection.shutdown(Shutdown::Both);
+        }
 
         Ok(ActiveConnectionGuard {
             active_connection: self.0.active_connection.clone(),
         })
     }
 
+    /// Closes the active client connection if the processor is blocked waiting for input.
     fn close_active_connection(&self) {
         if let Ok(active_connection) = self.0.active_connection.lock()
             && let Some(connection) = active_connection.as_ref()
@@ -467,27 +838,34 @@ impl HeartbeatServerShutdown {
     }
 }
 
-struct HeartbeatServerShutdownState {
+struct ThriftServerShutdownState {
+    // Atomic flag lets the listener thread observe shutdown without locking.
     requested: AtomicBool,
+    // The current thrift connection is closed to unblock processor reads on shutdown.
     active_connection: Arc<Mutex<Option<TcpStream>>>,
+    // A loopback connection to this address wakes `TcpListener::incoming`.
     wake_addr: SocketAddr,
 }
 
 struct ActiveConnectionGuard {
+    // Dropping this guard clears the shutdown state's current active connection.
     active_connection: Arc<Mutex<Option<TcpStream>>>,
 }
 
 impl Drop for ActiveConnectionGuard {
     fn drop(&mut self) {
         if let Ok(mut active_connection) = self.active_connection.lock() {
+            // The processor finished or disconnected, so future shutdowns should not close it.
             *active_connection = None;
         }
     }
 }
 
+/// Starts the FE heartbeat thrift service on the configured heartbeat port.
 pub fn start_heartbeat_server(
     config: ComputeNodeConfig,
     state: SharedHeartbeatState,
+    expected_frontend_host: Option<Host>,
 ) -> Result<HeartbeatServer> {
     let listen_addr = format!("{}:{}", config.bind_host, config.heartbeat_port);
     let listener = TcpListener::bind(&listen_addr)
@@ -495,30 +873,66 @@ pub fn start_heartbeat_server(
     let local_addr = listener
         .local_addr()
         .context("failed to read heartbeat Thrift server address")?;
-    let shutdown = HeartbeatServerShutdown::new(listener_wake_addr(local_addr));
+    let shutdown = ThriftServerShutdown::new(listener_wake_addr(local_addr));
     let server_shutdown = shutdown.clone();
 
     info!(address = %local_addr, "starting heartbeat Thrift server");
+    // The generated processor owns the handler and is shared across sequential connections.
+    let processor = Arc::new(HeartbeatServiceSyncProcessor::new(
+        ComputeNodeHeartbeatHandler::new(config, state, expected_frontend_host),
+    ));
     let join_handle =
-        thread::spawn(move || run_heartbeat_server(listener, config, state, server_shutdown));
+        thread::spawn(move || run_thrift_server("heartbeat", listener, processor, server_shutdown));
 
-    Ok(HeartbeatServer {
+    Ok(ThriftServer {
         join_handle: Some(join_handle),
         shutdown,
         local_addr,
+        name: "heartbeat",
     })
 }
 
-fn run_heartbeat_server(
-    listener: TcpListener,
-    config: ComputeNodeConfig,
-    state: SharedHeartbeatState,
-    shutdown: HeartbeatServerShutdown,
-) -> Result<()> {
-    let processor = Arc::new(HeartbeatServiceSyncProcessor::new(
-        ComputeNodeHeartbeatHandler::new(config, state),
-    ));
+/// Starts the StarRocks `BackendService` thrift skeleton on `--thrift-port`.
+pub fn start_backend_server(config: &ComputeNodeConfig) -> Result<BackendServer> {
+    let listen_addr = format!("{}:{}", config.bind_host, config.thrift_port);
+    let listener = TcpListener::bind(&listen_addr)
+        .with_context(|| format!("failed to bind backend Thrift server at {listen_addr}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("failed to read backend Thrift server address")?;
+    let shutdown = ThriftServerShutdown::new(listener_wake_addr(local_addr));
+    let server_shutdown = shutdown.clone();
 
+    info!(
+        address = %local_addr,
+        brpc_port = config.brpc_port,
+        "starting backend Thrift server; brpc execution is not implemented yet"
+    );
+    // BackendService is stateless for now because every non-inventory RPC is unsupported.
+    let processor = Arc::new(BackendServiceSyncProcessor::new(
+        ComputeNodeBackendHandler::new(),
+    ));
+    let join_handle =
+        thread::spawn(move || run_thrift_server("backend", listener, processor, server_shutdown));
+
+    Ok(ThriftServer {
+        join_handle: Some(join_handle),
+        shutdown,
+        local_addr,
+        name: "backend",
+    })
+}
+
+/// Runs one generated thrift processor behind a blocking TCP listener.
+fn run_thrift_server<P>(
+    name: &'static str,
+    listener: TcpListener,
+    processor: Arc<P>,
+    shutdown: ThriftServerShutdown,
+) -> Result<()>
+where
+    P: TProcessor + Send + Sync + 'static,
+{
     for stream in listener.incoming() {
         if shutdown.is_requested() {
             break;
@@ -529,32 +943,52 @@ fn run_heartbeat_server(
                 if shutdown.is_requested() {
                     break;
                 }
-                let active_connection = shutdown.track_connection(&stream)?;
-                handle_heartbeat_connection(processor.clone(), stream, active_connection)?;
+                // StarRocks thrift clients use one connection for a sequence of calls.
+                // A transient per-connection error (e.g. fd exhaustion on try_clone/split, or a
+                // poisoned mutex) must not tear down the whole server — log and keep accepting,
+                // mirroring the accept-error and processor-error paths.
+                let active_connection = match shutdown.track_connection(&stream) {
+                    Ok(active_connection) => active_connection,
+                    Err(err) => {
+                        warn!(service = name, error = %err, "failed to track thrift connection; continuing");
+                        continue;
+                    }
+                };
+                if let Err(err) =
+                    handle_thrift_connection(name, processor.clone(), stream, active_connection)
+                {
+                    warn!(service = name, error = %err, "failed to handle thrift connection; continuing");
+                }
                 if shutdown.is_requested() {
                     break;
                 }
             }
             Err(_) if shutdown.is_requested() => break,
-            Err(err) => warn!(error = %err, "failed to accept heartbeat connection"),
+            Err(err) => warn!(service = name, error = %err, "failed to accept thrift connection"),
         }
     }
 
     shutdown.close_active_connection();
-    info!("heartbeat Thrift server stopped");
+    info!(service = name, "Thrift server stopped");
     Ok(())
 }
 
-fn handle_heartbeat_connection(
-    processor: Arc<HeartbeatProcessor>,
+/// Processes one client connection until EOF, thrift error, or server shutdown.
+fn handle_thrift_connection<P>(
+    name: &'static str,
+    processor: Arc<P>,
     stream: TcpStream,
     active_connection: ActiveConnectionGuard,
-) -> Result<()> {
+) -> Result<()>
+where
+    P: TProcessor + Send + Sync + 'static,
+{
+    // Keep the guard alive for the full processor loop so shutdown can close this stream.
     let _active_connection = active_connection;
     let channel = TTcpChannel::with_stream(stream);
     let (read_channel, write_channel) = channel
         .split()
-        .map_err(|err| anyhow!("failed to split heartbeat connection: {err}"))?;
+        .map_err(|err| anyhow!("failed to split {name} thrift connection: {err}"))?;
     let read_transport = TBufferedReadTransportFactory::new().create(Box::new(read_channel));
     let write_transport = TBufferedWriteTransportFactory::new().create(Box::new(write_channel));
     let mut input_protocol = TBinaryInputProtocolFactory::new().create(read_transport);
@@ -563,23 +997,27 @@ fn handle_heartbeat_connection(
     loop {
         match processor.process(&mut *input_protocol, &mut *output_protocol) {
             Ok(()) => {}
+            // EOF is a normal client disconnect; the server goes back to accepting.
             Err(thrift::Error::Transport(err)) if err.kind == TransportErrorKind::EndOfFile => {
                 return Ok(());
             }
             Err(err) => {
-                warn!(error = %err, "heartbeat processor completed with error");
+                // StarRocks may probe unsupported paths; keep the server alive after one error.
+                warn!(service = name, error = %err, "thrift processor completed with error");
                 return Ok(());
             }
         }
     }
 }
 
-fn join_heartbeat_thread(join_handle: JoinHandle<Result<()>>) -> Result<()> {
+/// Converts a blocking thread join into the crate's error type.
+fn join_thrift_thread(name: &'static str, join_handle: JoinHandle<Result<()>>) -> Result<()> {
     join_handle
         .join()
-        .map_err(|panic| anyhow!("heartbeat server thread panicked: {panic:?}"))?
+        .map_err(|panic| anyhow!("{name} server thread panicked: {panic:?}"))?
 }
 
+/// Maps an unspecified bind address to loopback so shutdown can wake the listener locally.
 fn listener_wake_addr(local_addr: SocketAddr) -> SocketAddr {
     match local_addr.ip() {
         IpAddr::V4(ip) if ip.is_unspecified() => {
@@ -590,6 +1028,130 @@ fn listener_wake_addr(local_addr: SocketAddr) -> SocketAddr {
         }
         _ => local_addr,
     }
+}
+
+/// Sends one empty inventory report to FE if heartbeat has provided FE address and CN id.
+pub fn report_to_frontend_once(
+    node: &ComputeNodeConfig,
+    state: &SharedHeartbeatState,
+) -> Result<Option<master_service::TMasterResult>> {
+    // Returning None lets the caller poll without error before the first heartbeat arrives.
+    let report = match state.next_report(node) {
+        Some(report) => report,
+        None => return Ok(None),
+    };
+
+    // FE thrift address comes from TMasterInfo.network_address in heartbeat.
+    let frontend = report.frontend_address.clone();
+    // Resolve and connect with bounded timeouts so an unreachable or accept-but-never-reply FE
+    // cannot wedge this blocking call — and therefore the whole report loop — indefinitely.
+    let socket_addrs: Vec<SocketAddr> = (frontend.hostname.as_str(), frontend.port as u16)
+        .to_socket_addrs()
+        .with_context(|| {
+            format!(
+                "failed to resolve FE thrift address {}:{}",
+                frontend.hostname, frontend.port
+            )
+        })?
+        .collect();
+    // Try every resolved address (e.g. an IPv4/IPv6 dual-stack or round-robin host) with a
+    // bounded connect, matching TcpStream::connect's multi-address behavior while still
+    // enforcing a timeout so an unresponsive FE cannot wedge the report loop.
+    let mut stream = None;
+    let mut last_err: Option<std::io::Error> = None;
+    for socket_addr in &socket_addrs {
+        match TcpStream::connect_timeout(socket_addr, FE_REPORT_CONNECT_TIMEOUT) {
+            Ok(connected) => {
+                stream = Some(connected);
+                break;
+            }
+            Err(err) => last_err = Some(err),
+        }
+    }
+    let stream = stream.ok_or_else(|| {
+        let detail = last_err
+            .map(|err| err.to_string())
+            .unwrap_or_else(|| "host resolved to no socket addresses".to_string());
+        anyhow!(
+            "failed to connect to FE thrift service at {}:{}: {detail}",
+            frontend.hostname,
+            frontend.port
+        )
+    })?;
+    stream
+        .set_read_timeout(Some(FE_REPORT_RW_TIMEOUT))
+        .context("failed to set FE thrift read timeout")?;
+    stream
+        .set_write_timeout(Some(FE_REPORT_RW_TIMEOUT))
+        .context("failed to set FE thrift write timeout")?;
+    let channel = TTcpChannel::with_stream(stream);
+
+    // Client and server both use strict binary thrift protocols in this crate.
+    let (read_channel, write_channel) = channel
+        .split()
+        .map_err(|err| anyhow!("failed to split FE thrift connection: {err}"))?;
+    let read_transport = TBufferedReadTransport::new(read_channel);
+    let write_transport = TBufferedWriteTransport::new(write_channel);
+    let input_protocol = TBinaryInputProtocol::new(read_transport, true);
+    let output_protocol = TBinaryOutputProtocol::new(write_transport, true);
+    let mut client = FrontendServiceSyncClient::new(input_protocol, output_protocol);
+
+    let result = client
+        .report(report.request)
+        .map_err(|err| anyhow!("failed to report compute node inventory to FE: {err}"))?;
+    // The Thrift round-trip succeeding does not mean the FE accepted the report; a non-OK
+    // status (e.g. unrecognized node or malformed payload) must surface as an error instead of
+    // being silently logged as success by the caller.
+    if result.status.status_code != TStatusCode::OK {
+        bail!(
+            "FE rejected compute node report (status {:?}): {}",
+            result.status.status_code,
+            result
+                .status
+                .error_msgs
+                .as_ref()
+                .map(|messages| messages.join("; "))
+                .unwrap_or_default()
+        );
+    }
+    Ok(Some(result))
+}
+
+/// Builds the truthful "empty CN" report payload expected by `FrontendService.report`.
+fn build_report_request(
+    node: &ComputeNodeConfig,
+    report_version: i64,
+) -> master_service::TReportRequest {
+    // A storage-less compute node sends an empty task report carrying its identity and
+    // report_version. The FE's ReportHandler picks the report type from WHICH optional fields
+    // are present and rejects a request that sets several types at once, and an empty-but-present
+    // tablet/disk map would falsely assert this node hosts zero tablets/disks (a Backend-style
+    // report). So tablets/disks/tablet_list/compaction-score/workgroups are LEFT UNSET; `tasks`
+    // is sent as an empty map because the FE only recognizes a compute node that reports at least
+    // one of tasks/resource_usage/datacache_metrics.
+    // NOTE: the exact shape the FE accepts is version-dependent; report_to_frontend_once now
+    // checks the returned status, so a rejection surfaces instead of being silently logged as
+    // success.
+    let tasks: BTreeMap<types::TTaskType, BTreeSet<i64>> = BTreeMap::new();
+
+    master_service::TReportRequest::new(
+        // StarRocks expects the backend identity to carry host plus thrift/http ports.
+        types::TBackend::new(
+            node.advertise_host.to_string(),
+            i32::from(node.thrift_port),
+            i32::from(node.http_port),
+        ),
+        Some(report_version), // report_version (required)
+        Some(tasks),          // tasks (empty: for compute-node recognition only)
+        None,                 // tablets (no tablet storage)
+        None,                 // disks (no local disks)
+        None,                 // force_recovery
+        None,                 // tablet_list
+        None,                 // tablet_max_compaction_score (only with a tablet report)
+        None,                 // active_workgroups
+        None,                 // resource_usage
+        None,                 // datacache_metrics
+    )
 }
 
 pub async fn register_node(fe: &FeConfig, node: &ComputeNodeConfig) -> Result<()> {
@@ -677,14 +1239,30 @@ async fn node_is_registered(
     Ok(false)
 }
 
+/// StarRocks success status helper.
 fn ok_status() -> TStatus {
     TStatus::new(TStatusCode::OK, None)
 }
 
+/// StarRocks unsupported status helper that names the RPC for operator diagnostics.
+fn not_implemented_status(rpc: &str) -> TStatus {
+    TStatus::new(
+        TStatusCode::NOT_IMPLEMENTED_ERROR,
+        Some(vec![format!("{rpc} is not implemented")]),
+    )
+}
+
+/// Heartbeat rejection status helper.
 fn error_status(message: String) -> TStatus {
     TStatus::new(TStatusCode::INTERNAL_ERROR, Some(vec![message]))
 }
 
+/// Agent-service unsupported result helper for methods returning `TAgentResult`.
+fn agent_result(rpc: &str) -> agent_service::TAgentResult {
+    agent_service::TAgentResult::new(not_implemented_status(rpc), None, None, None)
+}
+
+/// Current Unix time in seconds for heartbeat reboot metadata.
 fn unix_time_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -693,11 +1271,37 @@ fn unix_time_secs() -> i64 {
         .min(i64::MAX as u64) as i64
 }
 
+/// Current Unix time in milliseconds for heartbeat staleness tracking.
 fn unix_time_millis() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis()
+}
+
+/// Resolves a host (hostname or IP literal) to its IP addresses, ignoring the port. Returns an
+/// empty vec if resolution fails so callers can treat "unknown" distinctly from "no match".
+fn resolve_host_ips(host: &str) -> Vec<IpAddr> {
+    (host, 0u16)
+        .to_socket_addrs()
+        .map(|addrs| addrs.map(|addr| addr.ip()).collect())
+        .unwrap_or_default()
+}
+
+/// Decides whether an FE-advertised report host may be trusted against the configured FE host.
+/// An exact string match short-circuits without DNS. Otherwise both sides are resolved and a
+/// shared IP is required. Resolution failure on either side is treated as inconclusive and
+/// trusted, so a transient DNS hiccup never drops a legitimate FE address; only a confident
+/// mismatch (both resolve, no shared IP) is rejected.
+fn frontend_host_trusted(expected_host: &str, advertised_host: &str) -> bool {
+    if expected_host == advertised_host {
+        return true;
+    }
+    let expected_ips = resolve_host_ips(expected_host);
+    let advertised_ips = resolve_host_ips(advertised_host);
+    expected_ips.is_empty()
+        || advertised_ips.is_empty()
+        || expected_ips.iter().any(|ip| advertised_ips.contains(ip))
 }
 
 #[cfg(test)]
@@ -716,7 +1320,7 @@ mod tests {
     fn handler() -> (ComputeNodeHeartbeatHandler, SharedHeartbeatState) {
         let state = SharedHeartbeatState::new();
         (
-            ComputeNodeHeartbeatHandler::new(test_config(), state.clone()),
+            ComputeNodeHeartbeatHandler::new(test_config(), state.clone(), None),
             state,
         )
     }
@@ -763,6 +1367,10 @@ mod tests {
         );
         assert_eq!(snapshot.epoch, Some(7));
         assert_eq!(snapshot.compute_node_id, Some(10001));
+        assert_eq!(
+            snapshot.frontend_address,
+            Some(types::TNetworkAddress::new("127.0.0.1".to_string(), 9020))
+        );
         assert!(snapshot.last_heartbeat_ms.is_some());
     }
 
@@ -927,6 +1535,96 @@ mod tests {
         assert_eq!(COMPUTE_NODE_PROC_PATH, "/compute_nodes");
     }
 
+    /// Verifies tablet stat inventory is truthfully empty for a storage-less CN.
+    #[test]
+    fn backend_tablet_stat_returns_empty_inventory() {
+        let result = ComputeNodeBackendHandler::new()
+            .handle_get_tablet_stat()
+            .unwrap();
+
+        assert!(result.tablets_stats.is_empty());
+    }
+
+    /// Verifies tablet metadata reporting succeeds with version zero and no tablets.
+    #[test]
+    fn backend_tablets_info_returns_empty_ok_report() {
+        let result = ComputeNodeBackendHandler::new()
+            .handle_get_tablets_info(backend_service::TGetTabletsInfoRequest::new())
+            .unwrap();
+
+        assert_eq!(result.status.status_code, TStatusCode::OK);
+        assert_eq!(result.report_version, Some(0));
+        assert!(result.tablets.as_ref().is_some_and(BTreeMap::is_empty));
+    }
+
+    /// Verifies unsupported backend RPCs return explicit NOT_IMPLEMENTED statuses.
+    #[test]
+    fn backend_unsupported_calls_return_not_implemented_status() {
+        let handler = ComputeNodeBackendHandler::new();
+
+        let routine_load_status = handler.handle_submit_routine_load_task(Vec::new()).unwrap();
+        assert_not_implemented(&routine_load_status, "BackendService.submitRoutineLoadTask");
+
+        let agent_result = handler.handle_submit_tasks(Vec::new()).unwrap();
+        assert_not_implemented(&agent_result.status, "BackendService.submitTasks");
+
+        let export_status = handler
+            .handle_erase_export_task(types::TUniqueId::new(0, 0))
+            .unwrap();
+        assert_not_implemented(&export_status, "BackendService.eraseExportTask");
+    }
+
+    /// Verifies FE reporting waits until heartbeat supplies FE address and backend id.
+    #[test]
+    fn report_waits_for_heartbeat_identity() {
+        let state = SharedHeartbeatState::new();
+
+        assert!(state.next_report(&test_config()).is_none());
+        assert_eq!(state.snapshot().report_version, 0);
+    }
+
+    /// Verifies FE report payload identity, empty maps, and monotonic report version.
+    #[test]
+    fn report_payload_includes_identity_empty_state_and_monotonic_version() {
+        let (handler, state) = handler();
+        let mut config = test_config();
+        config.advertise_host = Host::new("cn.example.test").unwrap();
+        config.thrift_port = 19060;
+        config.http_port = 18040;
+
+        assert_eq!(
+            handler
+                .handle_heartbeat(master(7))
+                .unwrap()
+                .status
+                .status_code,
+            TStatusCode::OK
+        );
+
+        let first = state.next_report(&config).unwrap();
+        let second = state.next_report(&config).unwrap();
+
+        assert_eq!(first.backend_id, 10001);
+        assert_eq!(
+            first.frontend_address,
+            types::TNetworkAddress::new("127.0.0.1".to_string(), 9020)
+        );
+        assert_eq!(first.request.backend.host, "cn.example.test");
+        assert_eq!(first.request.backend.be_port, 19060);
+        assert_eq!(first.request.backend.http_port, 18040);
+        assert_eq!(first.request.report_version, Some(1));
+        assert_eq!(second.request.report_version, Some(2));
+        // tasks is an empty map (compute-node recognition); the Backend-only inventory fields
+        // are left unset so the FE does not interpret this as a tablet/disk report.
+        assert!(first.request.tasks.as_ref().is_some_and(BTreeMap::is_empty));
+        assert!(first.request.tablets.is_none());
+        assert!(first.request.disks.is_none());
+        assert!(first.request.tablet_list.is_none());
+        assert!(first.request.tablet_max_compaction_score.is_none());
+        assert!(first.request.active_workgroups.is_none());
+        assert_eq!(state.snapshot().report_version, 2);
+    }
+
     /// Verifies secrets stay redacted in debug output.
     #[test]
     fn secret_string_debug_redacts_value() {
@@ -942,7 +1640,7 @@ mod tests {
         let mut config = test_config();
         config.bind_host = Host::local();
         config.heartbeat_port = 0;
-        let server = match start_heartbeat_server(config, SharedHeartbeatState::new()) {
+        let server = match start_heartbeat_server(config, SharedHeartbeatState::new(), None) {
             Ok(server) => server,
             Err(err) if is_permission_denied(&err) => return,
             Err(err) => panic!("{err:?}"),
@@ -954,6 +1652,135 @@ mod tests {
         drop(stream);
     }
 
+    /// Regression for the shutdown TOCTOU race: a client that connects but never sends a
+    /// request leaves the server blocked in `processor.process()`; shutdown must still close
+    /// that tracked connection and let `join()` return promptly rather than hang forever.
+    #[test]
+    fn shutdown_interrupts_blocked_connection() {
+        let mut config = test_config();
+        config.bind_host = Host::local();
+        config.heartbeat_port = 0;
+        let server = match start_heartbeat_server(config, SharedHeartbeatState::new(), None) {
+            Ok(server) => server,
+            Err(err) if is_permission_denied(&err) => return,
+            Err(err) => panic!("{err:?}"),
+        };
+        let addr = server.local_addr();
+
+        // Connect without sending anything, then give the accept loop time to track it.
+        let stream = TcpStream::connect(addr).unwrap();
+        thread::sleep(Duration::from_millis(200));
+
+        let shutdown = server.shutdown_handle();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let joiner = thread::spawn(move || {
+            let _ = tx.send(server.join());
+        });
+        shutdown.shutdown();
+
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(join_result) => join_result.unwrap(),
+            Err(_) => panic!("server join did not complete after shutdown (blocked connection)"),
+        }
+        joiner.join().unwrap();
+        drop(stream);
+    }
+
+    /// Verifies a full request->process->reply round trip over the real Thrift transport stack
+    /// (not just a direct handler call), covering the machinery shared by the backend server.
+    #[test]
+    fn heartbeat_round_trip_over_thrift_transport() {
+        use starrocks_thrift::heartbeat_service::{
+            HeartbeatServiceSyncClient, THeartbeatServiceSyncClient,
+        };
+
+        let mut config = test_config();
+        config.bind_host = Host::local();
+        config.heartbeat_port = 0;
+        let state = SharedHeartbeatState::new();
+        let server = match start_heartbeat_server(config, state.clone(), None) {
+            Ok(server) => server,
+            Err(err) if is_permission_denied(&err) => return,
+            Err(err) => panic!("{err:?}"),
+        };
+        let addr = server.local_addr();
+
+        let stream = TcpStream::connect(addr).unwrap();
+        let channel = TTcpChannel::with_stream(stream);
+        let (read_channel, write_channel) = channel.split().unwrap();
+        let input_protocol =
+            TBinaryInputProtocol::new(TBufferedReadTransport::new(read_channel), true);
+        let output_protocol =
+            TBinaryOutputProtocol::new(TBufferedWriteTransport::new(write_channel), true);
+        let mut client = HeartbeatServiceSyncClient::new(input_protocol, output_protocol);
+
+        let result = client.heartbeat(master(7)).unwrap();
+        assert_eq!(result.status.status_code, TStatusCode::OK);
+        assert_eq!(result.backend_info.be_port, 9060);
+        // The state was mutated through the full transport path, not a direct handler call.
+        assert_eq!(state.snapshot().epoch, Some(7));
+        assert_eq!(state.snapshot().compute_node_id, Some(10001));
+
+        drop(client);
+        server.shutdown();
+        server.join().unwrap();
+    }
+
+    /// Verifies a heartbeat advertising a report address that does not match the configured FE
+    /// host is still accepted for liveness, but does not become the outbound report target.
+    #[test]
+    fn untrusted_frontend_address_is_not_used_as_report_target() {
+        let state = SharedHeartbeatState::new();
+        let handler = ComputeNodeHeartbeatHandler::new(
+            test_config(),
+            state.clone(),
+            Some(Host::new("127.0.0.1").unwrap()),
+        );
+        // master(7) advertises a network_address of 127.0.0.1:9020 (matches) — flip the host.
+        let mut hostile = master(7);
+        hostile.network_address = types::TNetworkAddress::new("10.0.0.9".to_string(), 9020);
+
+        let result = handler.handle_heartbeat(hostile).unwrap();
+
+        assert_eq!(result.status.status_code, TStatusCode::OK);
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.epoch, Some(7));
+        // The mismatched address was rejected, so no report target was learned.
+        assert!(snapshot.frontend_address.is_none());
+    }
+
+    /// Verifies a matching FE host is accepted as the report target.
+    #[test]
+    fn trusted_frontend_address_is_used_as_report_target() {
+        let state = SharedHeartbeatState::new();
+        let handler = ComputeNodeHeartbeatHandler::new(
+            test_config(),
+            state.clone(),
+            Some(Host::new("127.0.0.1").unwrap()),
+        );
+
+        let result = handler.handle_heartbeat(master(7)).unwrap();
+
+        assert_eq!(result.status.status_code, TStatusCode::OK);
+        assert_eq!(
+            state.snapshot().frontend_address,
+            Some(types::TNetworkAddress::new("127.0.0.1".to_string(), 9020))
+        );
+    }
+
+    /// Verifies the FE-host trust check matches exactly, intersects resolved IPs (so an alias
+    /// like `localhost` is accepted against `127.0.0.1`), and rejects only a confident mismatch.
+    #[test]
+    fn frontend_host_trust_normalizes_ip_aliases() {
+        // Exact string match short-circuits without resolution.
+        assert!(frontend_host_trusted("127.0.0.1", "127.0.0.1"));
+        // Two distinct IP literals always resolve to themselves and never intersect.
+        assert!(!frontend_host_trusted("127.0.0.1", "10.0.0.9"));
+        // `localhost` resolves to loopback and intersects the literal (or, if the environment
+        // cannot resolve it, is treated as inconclusive and trusted).
+        assert!(frontend_host_trusted("127.0.0.1", "localhost"));
+    }
+
     /// Detects sandboxed environments where binding a local listener is denied.
     fn is_permission_denied(err: &anyhow::Error) -> bool {
         err.chain().any(|cause| {
@@ -961,5 +1788,16 @@ mod tests {
                 .downcast_ref::<std::io::Error>()
                 .is_some_and(|err| err.kind() == std::io::ErrorKind::PermissionDenied)
         })
+    }
+
+    /// Verifies a status is NOT_IMPLEMENTED and includes the RPC name for diagnostics.
+    fn assert_not_implemented(status: &TStatus, rpc: &str) {
+        assert_eq!(status.status_code, TStatusCode::NOT_IMPLEMENTED_ERROR);
+        assert!(
+            status
+                .error_msgs
+                .as_ref()
+                .is_some_and(|messages| messages.iter().any(|message| message.contains(rpc)))
+        );
     }
 }

--- a/experimental/starrocks/src/main.rs
+++ b/experimental/starrocks/src/main.rs
@@ -3,16 +3,22 @@ use std::time::Duration;
 use anyhow::{Result, anyhow};
 use clap::Parser;
 use sirius_starrocks_cn::{
-    ComputeNodeConfig, FeConfig, HeartbeatServer, SharedHeartbeatState, register_node,
-    start_heartbeat_server,
+    BackendServer, BackendServerShutdown, ComputeNodeConfig, FeConfig, HeartbeatServer,
+    HeartbeatServerShutdown, SharedHeartbeatState, register_node, report_to_frontend_once,
+    start_backend_server, start_heartbeat_server,
 };
 use tracing::{debug, error, info, warn};
 
 const REGISTRATION_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+// The CN periodically refreshes registration when heartbeats stop arriving.
 const REGISTRATION_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+// If no heartbeat arrives within this window, registration is considered stale.
 const HEARTBEAT_STALE_AFTER: Duration = Duration::from_secs(30);
+// StarRocks BEs/CNs regularly report inventory; this skeleton reports empty state.
+const FRONTEND_REPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Parser)]
+/// Command-line arguments for the StarRocks compute-node shim.
 struct Args {
     #[command(flatten, next_help_heading = "FE")]
     fe: FeConfig,
@@ -25,12 +31,14 @@ struct Args {
 }
 
 #[derive(Clone, Debug, clap::Args)]
+/// Registration retry settings for initial FE registration.
 struct RegistrationConfig {
     #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u32).range(1..))]
     registration_max_attempts: u32,
 }
 
 #[tokio::main]
+/// Starts heartbeat/backend thrift services, registers with FE, and waits for shutdown.
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -42,19 +50,41 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let state = SharedHeartbeatState::new();
 
-    let server = start_heartbeat_server(args.compute_node.clone(), state.clone())?;
+    // HeartbeatService tells FE this process is alive and captures FE identity. The configured
+    // FE host pins the report target so a hostile heartbeat cannot redirect outbound reports.
+    let heartbeat_server = start_heartbeat_server(
+        args.compute_node.clone(),
+        state.clone(),
+        Some(args.fe.host.clone()),
+    )?;
+    // BackendService exposes the shallow CN RPC skeleton on the normal thrift port.
+    let backend_server = start_backend_server(&args.compute_node)?;
+    // Initial SQL registration is needed before FE starts heartbeating this CN.
     register_node_with_retries(&args.fe, &args.compute_node, &args.registration).await?;
 
+    // Registration stays active if FE heartbeats disappear after startup.
     let registration_task = tokio::spawn(maintain_registration(
         args.fe.clone(),
         args.compute_node.clone(),
         state.clone(),
     ));
+    // Reports start after heartbeat records FE thrift address and backend id.
+    let report_task = tokio::spawn(maintain_frontend_report(
+        args.compute_node.clone(),
+        state.clone(),
+    ));
 
     info!("compute node registered; waiting for FE heartbeats");
-    wait_until_shutdown(server, registration_task).await
+    wait_until_shutdown(
+        heartbeat_server,
+        backend_server,
+        registration_task,
+        report_task,
+    )
+    .await
 }
 
+/// Registers the CN with FE SQL, retrying during FE startup or transient failures.
 async fn register_node_with_retries(
     fe: &FeConfig,
     compute_node: &ComputeNodeConfig,
@@ -68,6 +98,7 @@ async fn register_node_with_retries(
         match register_node(fe, compute_node).await {
             Ok(()) => return Ok(()),
             Err(err) => {
+                // The last attempt returns the original registration error with context.
                 if attempt == registration.registration_max_attempts {
                     return Err(anyhow!(
                         "failed to register compute node with FE after {} attempts: {err}",
@@ -90,6 +121,7 @@ async fn register_node_with_retries(
     unreachable!("registration attempts loop always returns")
 }
 
+/// Periodically re-registers when heartbeat state indicates FE is no longer contacting us.
 async fn maintain_registration(
     fe: FeConfig,
     compute_node: ComputeNodeConfig,
@@ -98,6 +130,7 @@ async fn maintain_registration(
     loop {
         tokio::time::sleep(REGISTRATION_REFRESH_INTERVAL).await;
 
+        // Recent heartbeat means FE still knows this CN, so no SQL refresh is needed.
         if let Some(elapsed) = state.last_heartbeat_elapsed()
             && elapsed < HEARTBEAT_STALE_AFTER
         {
@@ -118,51 +151,137 @@ async fn maintain_registration(
     }
 }
 
+/// Periodically sends the FE a truthful empty inventory report after heartbeat identity exists.
+async fn maintain_frontend_report(compute_node: ComputeNodeConfig, state: SharedHeartbeatState) {
+    loop {
+        tokio::time::sleep(FRONTEND_REPORT_INTERVAL).await;
+
+        // Thrift clients are blocking, so run the single report call off the async runtime.
+        let compute_node = compute_node.clone();
+        let state = state.clone();
+        match tokio::task::spawn_blocking(move || report_to_frontend_once(&compute_node, &state))
+            .await
+        {
+            // FE accepted the empty inventory report.
+            Ok(Ok(Some(_result))) => {
+                debug!("reported compute node inventory to FE");
+            }
+            // Heartbeat has not yet supplied both FE address and backend id.
+            Ok(Ok(None)) => {
+                debug!("skipping FE report until heartbeat provides FE address and backend id");
+            }
+            // Network or FE thrift failures are retried by the next loop iteration.
+            Ok(Err(err)) => {
+                warn!(
+                    error = %err,
+                    retry_after_secs = FRONTEND_REPORT_INTERVAL.as_secs(),
+                    "failed to report compute node inventory to FE"
+                );
+            }
+            // A panic or cancellation in the blocking worker should not stop the CN process.
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    retry_after_secs = FRONTEND_REPORT_INTERVAL.as_secs(),
+                    "FE report worker failed"
+                );
+            }
+        }
+    }
+}
+
+/// Aborts the background maintenance tasks and asks both thrift servers to stop. Safe to call
+/// even when a component has already exited: `abort()` on a finished task and `shutdown()` on an
+/// already-stopped server are idempotent no-ops, so every shutdown path can stop everything.
+fn request_stop(
+    registration_task: &tokio::task::JoinHandle<()>,
+    report_task: &tokio::task::JoinHandle<()>,
+    heartbeat_shutdown: &HeartbeatServerShutdown,
+    backend_shutdown: &BackendServerShutdown,
+) {
+    registration_task.abort();
+    report_task.abort();
+    heartbeat_shutdown.shutdown();
+    backend_shutdown.shutdown();
+}
+
+/// Awaits a server's blocking-join task, flattening the join-task error and the server result.
+async fn join_server(join: tokio::task::JoinHandle<Result<()>>, label: &str) -> Result<()> {
+    join.await
+        .map_err(|err| anyhow!("{label} server join task failed: {err}"))?
+}
+
+/// Coordinates shutdown across thrift server threads and background maintenance loops.
 async fn wait_until_shutdown(
-    server: HeartbeatServer,
+    heartbeat_server: HeartbeatServer,
+    backend_server: BackendServer,
     mut registration_task: tokio::task::JoinHandle<()>,
+    mut report_task: tokio::task::JoinHandle<()>,
 ) -> Result<()> {
-    let shutdown = server.shutdown_handle();
-    let mut server_join = tokio::task::spawn_blocking(move || server.join());
+    let heartbeat_shutdown = heartbeat_server.shutdown_handle();
+    let backend_shutdown = backend_server.shutdown_handle();
+    let mut heartbeat_join = tokio::task::spawn_blocking(move || heartbeat_server.join());
+    let mut backend_join = tokio::task::spawn_blocking(move || backend_server.join());
     let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .map_err(|err| anyhow!("failed to install SIGTERM handler: {err}"))?;
 
     tokio::select! {
+        // Interactive shutdown path.
         signal = tokio::signal::ctrl_c() => {
             signal.map_err(|err| anyhow!("failed to wait for ctrl-c: {err}"))?;
             info!(signal = "ctrl-c", "shutdown signal received");
-            registration_task.abort();
-            shutdown.shutdown();
-            server_join
-                .await
-                .map_err(|err| anyhow!("heartbeat server join task failed: {err}"))??;
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
+            join_server(heartbeat_join, "heartbeat").await?;
+            join_server(backend_join, "backend").await?;
             info!("shutdown complete");
             Ok(())
         }
+        // Service-manager shutdown path.
         _ = terminate.recv() => {
-            let signal = "sigterm";
-            info!(signal, "shutdown signal received");
-            registration_task.abort();
-            shutdown.shutdown();
-            server_join
-                .await
-                .map_err(|err| anyhow!("heartbeat server join task failed: {err}"))??;
+            info!(signal = "sigterm", "shutdown signal received");
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
+            join_server(heartbeat_join, "heartbeat").await?;
+            join_server(backend_join, "backend").await?;
             info!("shutdown complete");
             Ok(())
         }
-        result = &mut server_join => {
-            registration_task.abort();
+        // If the heartbeat server exits first, stop everything else and surface its result.
+        result = &mut heartbeat_join => {
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
             let result = result
                 .map_err(|err| anyhow!("heartbeat server join task failed: {err}"))?;
             if let Err(err) = &result {
                 error!(error = %err, "heartbeat server exited");
             }
+            join_server(backend_join, "backend").await?;
             result
         }
+        // If the backend server exits first, stop everything else and surface its result.
+        result = &mut backend_join => {
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
+            let result = result
+                .map_err(|err| anyhow!("backend server join task failed: {err}"))?;
+            if let Err(err) = &result {
+                error!(error = %err, "backend server exited");
+            }
+            join_server(heartbeat_join, "heartbeat").await?;
+            result
+        }
+        // The registration loop is expected to run forever; an exit is treated as a failure.
         result = &mut registration_task => {
-            shutdown.shutdown();
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
+            join_server(heartbeat_join, "heartbeat").await?;
+            join_server(backend_join, "backend").await?;
             result.map_err(|err| anyhow!("registration monitor task failed: {err}"))?;
             Err(anyhow!("registration monitor exited unexpectedly"))
+        }
+        // The report loop is expected to run forever; an exit is treated as a failure.
+        result = &mut report_task => {
+            request_stop(&registration_task, &report_task, &heartbeat_shutdown, &backend_shutdown);
+            join_server(heartbeat_join, "heartbeat").await?;
+            join_server(backend_join, "backend").await?;
+            result.map_err(|err| anyhow!("FE report task failed: {err}"))?;
+            Err(anyhow!("FE report task exited unexpectedly"))
         }
     }
 }


### PR DESCRIPTION
## Summary

This adds an intentionally shallow StarRocks CN thrift RPC skeleton on top of the Substrait translator branch.

- Keeps heartbeat real and records FE identity from `TMasterInfo`.
- Starts a `BackendService` thrift server on `--thrift-port`.
- Returns truthful empty/default inventory for storage-less CN metadata calls.
- Returns explicit `NOT_IMPLEMENTED_ERROR` for execution, scan, load, snapshot, ETL, export, routine-load, and agent-task RPCs.
- Adds a minimal FE report loop after heartbeat provides FE thrift address and backend id.
- Leaves brpc/protobuf execution deferred.

## Runtime Shape

```mermaid
flowchart LR
  FE["FE / coordinator"]
  CN["CN thrift server"]
  CN2FE["CN FE thrift client"]

  FE -->|"HeartbeatService.heartbeat"| CN
  FE -->|"BackendService.*"| CN
  CN2FE -->|"FrontendService.report / status / txn"| FE
```

## CN Startup And Reporting

```mermaid
sequenceDiagram
  participant CN
  participant FE_SQL as FE MySQL/query port
  participant FE as FE thrift service
  participant CN_HB as CN HeartbeatService
  participant CN_BE as CN BackendService

  CN->>FE_SQL: ALTER SYSTEM ADD COMPUTE NODE "host:heartbeat_port"
  loop heartbeat
    FE->>CN_HB: heartbeat(TMasterInfo)
    CN_HB-->>FE: THeartbeatResult(TBackendInfo)
  end
  loop inventory report
    CN->>FE: FrontendService.report(TReportRequest)
    FE-->>CN: TMasterResult
  end
  FE->>CN_BE: get_tablet_stat / get_tablets_info
  CN_BE-->>FE: empty storage-less inventory
```

## Query Execution Surface

```mermaid
sequenceDiagram
  participant Client
  participant FE as FE planner/coordinator
  participant CN1 as CN BackendService
  participant CN2 as CN BackendService
  participant FE_CB as FE FrontendService

  Client->>FE: SQL query
  FE->>FE: parse / plan / fragment
  FE->>CN1: exec_plan_fragment(TExecPlanFragmentParams)
  FE->>CN2: exec_plan_fragment(TExecPlanFragmentParams)

  CN1->>CN2: transmit_data(TTransmitDataParams)
  CN2->>FE_CB: reportExecStatus(TReportExecStatusParams)

  FE->>CN1: fetch_data(TFetchDataParams)
  CN1-->>FE: TFetchDataResult(result_batch, eos)
  FE-->>Client: result rows

  alt cancel/error
    FE->>CN1: cancel_plan_fragment(TCancelPlanFragmentParams)
    CN1->>FE_CB: reportExecStatus(error/done)
  end
```

This PR does not implement that execution path yet. It only exposes the thrift shape and returns clear unsupported statuses for those calls.

## RPC Meaning

### HeartbeatService

`heartbeat(TMasterInfo) -> THeartbeatResult`

- FE sends identity and compatibility data: FE thrift address, epoch, token, backend id, run mode, node type, and optional disk/encryption flags.
- CN returns liveness metadata: thrift port, http port, brpc port, version, hardware cores, reboot time, storage-path flag, and arrow flight port.
- This PR records FE address/backend id so later CN-to-FE reports can be sent.

### BackendService

FE/coordinators call this into a CN.

- Query execution: `exec_plan_fragment`, `cancel_plan_fragment`, `transmit_data`, `fetch_data`.
- Inventory: `get_tablet_stat`, `get_tablets_info`.
- Storage/agent tasks: `submit_tasks`, `make_snapshot`, `release_snapshot`, `publish_cluster_state`.
- Load/export/ETL/routine-load: `submit_etl_task`, `get_etl_status`, `delete_etl_files`, `submit_export_task`, `get_export_status`, `erase_export_task`, `submit_routine_load_task`, `finish_stream_load_channel`.
- Scanner: `open_scanner`, `get_next`, `close_scanner`.

This PR supports only harmless inventory calls with empty results. Everything else returns `NOT_IMPLEMENTED_ERROR` with the RPC name.

### FrontendService

CNs use this as the callback surface into FE.

- Inventory/task reporting: `report(TReportRequest)`, `finishTask`.
- Execution status: `reportExecStatus`, `batchReportExecStatus`, `reportAuditStatistics`.
- Load/transaction: `loadTxnBegin`, `loadTxnPrepare`, `loadTxnCommit`, `loadTxnRollback`, `streamLoadPut`, `requestMergeCommit`, `updateExportTaskStatus`.
- Catalog/resource helpers: table metadata, resource usage, warehouse/query stats, auto-increment ids.

This PR implements only `report(TReportRequest)`, sending an empty task map plus `report_version` and backend identity; tablet/disk/tablet-list/compaction-score/workgroup fields are left unset so the FE does not interpret a storage-less CN as a tablet/disk report. The report response status is checked and a non-OK FE status is surfaced as an error rather than logged as success.

## Hardening

- FE report connection uses bounded connect/read/write timeouts so an unresponsive FE cannot stall the report loop or leak a blocking thread.
- The FE-advertised report address is validated (IP-normalized) against the configured FE host before it becomes the outbound report target, so a hostile or mismatched heartbeat cannot redirect the CN's outbound report.
- Transient per-connection errors no longer tear down the heartbeat/backend thrift server, and shutdown reliably interrupts an in-flight connection.

## Tests

- `pixi run -e cn cn-test`


