### PR TITLE
Move expensive CI checks to merge queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,67 +42,85 @@ jobs:
       SCCACHE_GHA_ENABLED: true
     strategy:
       matrix:
-        arch:
-          - x64
-          - arm64
-        compiler:
-          - gcc
-          - clang
-        build-type:
-          - release
-          - debug
-        environment: [default]
-        cudf-channel:
-          - stable
-        variant: [super]
-        exclude:
-          - compiler: gcc
-            build-type: debug
-          - compiler: clang
+        build:
+          - arch: x64
+            compiler: gcc
             build-type: release
-        include:
+            environment: default
+            cudf-channel: stable
+            variant: super
+            run-on-pr: true
+          - arch: x64
+            compiler: clang
+            build-type: debug
+            environment: default
+            cudf-channel: stable
+            variant: super
+            run-on-pr: true
+          - arch: arm64
+            compiler: gcc
+            build-type: release
+            environment: default
+            cudf-channel: stable
+            variant: super
+            run-on-pr: false
+          - arch: arm64
+            compiler: clang
+            build-type: debug
+            environment: default
+            cudf-channel: stable
+            variant: super
+            run-on-pr: false
           - arch: x64
             compiler: gcc
             build-type: release
             environment: vcpkg
             cudf-channel: stable
             variant: super
+            run-on-pr: false
           - arch: arm64
             compiler: gcc
             build-type: release
             environment: default
             cudf-channel: nightly
             variant: super
+            run-on-pr: false
           - arch: x64
             compiler: gcc
             build-type: release
             environment: default
             cudf-channel: stable
             variant: legacy
+            run-on-pr: false
+        exclude:
+          # On PRs, drop rows marked merge/dev-only; on merge_group/dev, match nothing.
+          - build:
+              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
       fail-fast: false
+    name: build (${{ matrix.build.arch }}, ${{ matrix.build.compiler }}, ${{ matrix.build.build-type }}, ${{ matrix.build.environment }}, ${{ matrix.build.cudf-channel }}, ${{ matrix.build.variant }})
     runs-on: >-
-      ${{ matrix.environment == 'vcpkg'
+      ${{ matrix.build.environment == 'vcpkg'
         && fromJSON('["self-hosted", "ubuntu-24.04", "cpu-xl"]')
-        || format('ubuntu-24.04{0}', case(matrix.arch == 'arm64', '-arm', '')) }}
-    timeout-minutes: ${{ case(matrix.environment == 'vcpkg', 240, 60) }}
-    continue-on-error: ${{ matrix.cudf-channel == 'nightly' }}
+        || format('ubuntu-24.04{0}', case(matrix.build.arch == 'arm64', '-arm', '')) }}
+    timeout-minutes: ${{ case(matrix.build.environment == 'vcpkg', 240, 60) }}
+    continue-on-error: ${{ matrix.build.cudf-channel == 'nightly' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
       - name: Unshallow vcpkg for version overrides
-        if: matrix.environment == 'vcpkg'
+        if: matrix.build.environment == 'vcpkg'
         run: git -C vcpkg rev-parse --is-shallow-repository | grep -q true && git -C vcpkg fetch --unshallow || true
 
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           cache: false
           pixi-version: v0.69.0
-          activate-environment: ${{ matrix.environment != 'vcpkg' && matrix.cudf-channel != 'nightly' }}
+          activate-environment: ${{ matrix.build.environment != 'vcpkg' && matrix.build.cudf-channel != 'nightly' }}
           environments: >-
-            ${{ matrix.cudf-channel == 'nightly' && 'nightly-runner'
-              || matrix.environment }}
+            ${{ matrix.build.cudf-channel == 'nightly' && 'nightly-runner'
+              || matrix.build.environment }}
 
       - name: Configure cache backends
         run: |
@@ -119,20 +137,20 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
-      - run: ${{ case(matrix.cudf-channel == 'nightly', 'pixi run -e nightly-runner nightly-run', '') }} make ${{ matrix.variant == 'legacy' && format('legacy-{0}', matrix.build-type) || case(matrix.compiler == 'gcc', matrix.build-type, format('clang-{0}', matrix.build-type)) }} -j$(nproc)
-        if: matrix.environment != 'vcpkg'
+      - run: ${{ case(matrix.build.cudf-channel == 'nightly', 'pixi run -e nightly-runner nightly-run', '') }} make ${{ matrix.build.variant == 'legacy' && format('legacy-{0}', matrix.build.build-type) || case(matrix.build.compiler == 'gcc', matrix.build.build-type, format('clang-{0}', matrix.build.build-type)) }} -j$(nproc)
+        if: matrix.build.environment != 'vcpkg'
         env:
           CUDAARCHS: "100"
 
       - name: Build (vcpkg)
-        if: matrix.environment == 'vcpkg'
+        if: matrix.build.environment == 'vcpkg'
         run: |
           set -o pipefail
           pixi run -e vcpkg cmake -S duckdb --preset vcpkg-release 2>&1 | tee /tmp/vcpkg.log
           pixi run -e vcpkg cmake --build build/vcpkg-release --target duckdb duckdb_local_extension_repo sirius_unittest 2>&1 | tee -a /tmp/vcpkg.log
 
       - name: vcpkg cache summary
-        if: matrix.environment == 'vcpkg' && always()
+        if: matrix.build.environment == 'vcpkg' && always()
         run: |
           [ -f /tmp/vcpkg.log ] || exit 0
           RESTORED=$(grep -oP 'Restored \K\d+(?= package)' /tmp/vcpkg.log | head -1)
@@ -160,8 +178,8 @@ jobs:
     if: always()
     steps:
       - name: All checks ok
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ needs.lint.result == 'success' && needs.build.result == 'success' }}
         run: exit 0
       - name: Some checks failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ !(needs.lint.result == 'success' && needs.build.result == 'success') }}
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
   build-cuda-12:
     env:
       SCCACHE_GHA_ENABLED: true
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, ubuntu-22.04, cpu-xl]
     timeout-minutes: 60
     steps:
@@ -192,7 +193,7 @@ jobs:
   test-cuda-12:
     runs-on: [self-hosted, ubuntu-22.04, gpu-2xl4]
     needs: build-cuda-12
-    if: needs.build-cuda-12.result == 'success'
+    if: github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success'
     timeout-minutes: 60
     env:
       CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
@@ -271,10 +272,10 @@ jobs:
     if: always()
     steps:
       - name: All builds ok
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ needs.build-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.build-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success')) }}
         run: exit 0
       - name: Some builds failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ !(needs.build-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.build-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success'))) }}
         run: exit 1
 
   test:
@@ -283,8 +284,8 @@ jobs:
     if: always()
     steps:
       - name: All tests ok
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ needs.test-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.test-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.test-cuda-12.result == 'success')) }}
         run: exit 0
       - name: Some tests failed
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ !(needs.test-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.test-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.test-cuda-12.result == 'success'))) }}
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel existing runs on PRs but run on all `dev` and merge queue commits
 
 jobs:
-  build-cuda:
+  build:
     env:
       SCCACHE_GHA_ENABLED: true
       CARGO_INCREMENTAL: "0"
@@ -46,7 +46,6 @@ jobs:
           - cuda:
               run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
       fail-fast: false
-    name: build-cuda-${{ matrix.cuda.version }}
     runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "cpu-xl"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
     steps:
@@ -88,9 +87,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  test-cuda:
-    needs: build-cuda
-    if: needs.build-cuda.result == 'success'
+  test-run:
+    needs: build
     strategy:
       matrix:
         cuda:
@@ -107,7 +105,6 @@ jobs:
           - cuda:
               run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
       fail-fast: false
-    name: test-cuda-${{ matrix.cuda.version }}
     runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "gpu-2xl4"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
     env:
@@ -181,26 +178,14 @@ jobs:
           path: ${{ steps.tpch.outputs.run_dir }}
           retention-days: 14
 
-  build:
-    runs-on: ubuntu-slim
-    needs: build-cuda
-    if: always()
-    steps:
-      - name: All builds ok
-        if: ${{ needs.build-cuda.result == 'success' }}
-        run: exit 0
-      - name: Some builds failed
-        if: ${{ needs.build-cuda.result != 'success' }}
-        run: exit 1
-
   test:
     runs-on: ubuntu-slim
-    needs: test-cuda
+    needs: test-run
     if: always()
     steps:
-      - name: All tests ok
-        if: ${{ needs.test-cuda.result == 'success' }}
+      - name: Test workflow ok
+        if: ${{ needs['test-run'].result == 'success' }}
         run: exit 0
-      - name: Some tests failed
-        if: ${{ needs.test-cuda.result != 'success' }}
+      - name: Test workflow failed
+        if: ${{ needs['test-run'].result != 'success' }}
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel existing runs on PRs but run on all `dev` and merge queue commits
 
 jobs:
-  build-cuda-13:
+  build-cuda:
     env:
       SCCACHE_GHA_ENABLED: true
       CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
-    runs-on: [self-hosted, ubuntu-24.04, cpu-xl]
+    strategy:
+      matrix:
+        cuda:
+          - version: "13"
+            pixi-environment: default
+            runner: ubuntu-24.04
+            run-on-pr: true
+          - version: "12"
+            pixi-environment: cuda12
+            runner: ubuntu-22.04
+            run-on-pr: false
+        exclude:
+          # On PRs, drop CUDA variants marked merge/dev-only; on merge_group/dev, match nothing.
+          - cuda:
+              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
+      fail-fast: false
+    name: build-cuda-${{ matrix.cuda.version }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "cpu-xl"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -41,7 +58,7 @@ jobs:
         with:
           cache: false
           pixi-version: v0.69.0
-          activate-environment: default
+          activate-environment: ${{ matrix.cuda.pixi-environment }}
 
       - name: Configure sccache backend
         run: |
@@ -66,62 +83,32 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: build-cuda-13
+          name: build-cuda-${{ matrix.cuda.version }}
           path: build.tar
           if-no-files-found: error
           retention-days: 1
 
-  build-cuda-12:
-    env:
-      SCCACHE_GHA_ENABLED: true
-      CARGO_INCREMENTAL: "0"
-      RUSTC_WRAPPER: sccache
-    if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, ubuntu-22.04, cpu-xl]
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          submodules: recursive
-
-      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
-        with:
-          cache: false
-          pixi-version: v0.69.0
-          activate-environment: cuda12
-
-      - name: Configure sccache backend
-        run: |
-          if [[ -n "${SCCACHE_BUCKET}" ]]; then
-            echo "SCCACHE_BUCKET DEFINED -> Self Hosted Runner, Disable GHA sccache"
-            echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
-          else
-            echo "SCCACHE_BUCKET UNDEFINED -> GitHub Runner, Enable GHA sccache"
-            echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          fi
-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-
-      - name: Build
-        env:
-          CUDAARCHS: "89" # 75 for T4 capability; 89 for L4 capability
-        run: make -j$(nproc)
-
-      - name: Package build artifacts
-        run: tar -cf build.tar build/release/
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: build-cuda-12
-          path: build.tar
-          if-no-files-found: error
-          retention-days: 1
-
-  test-cuda-13:
-    runs-on: [self-hosted, ubuntu-24.04, gpu-2xl4]
-    needs: build-cuda-13
-    if: needs.build-cuda-13.result == 'success'
+  test-cuda:
+    needs: build-cuda
+    if: needs.build-cuda.result == 'success'
+    strategy:
+      matrix:
+        cuda:
+          - version: "13"
+            pixi-environment: default
+            runner: ubuntu-24.04
+            run-on-pr: true
+          - version: "12"
+            pixi-environment: cuda12
+            runner: ubuntu-22.04
+            run-on-pr: false
+        exclude:
+          # On PRs, drop CUDA variants marked merge/dev-only; on merge_group/dev, match nothing.
+          - cuda:
+              run-on-pr: ${{ fromJSON(github.event_name == 'pull_request' && 'false' || 'null') }}
+      fail-fast: false
+    name: test-cuda-${{ matrix.cuda.version }}
+    runs-on: ${{ fromJSON(format('["self-hosted", "{0}", "gpu-2xl4"]', matrix.cuda.runner)) }}
     timeout-minutes: 60
     env:
       CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
@@ -133,11 +120,11 @@ jobs:
         with:
           cache: false
           pixi-version: v0.69.0
-          activate-environment: default
+          activate-environment: ${{ matrix.cuda.pixi-environment }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: build-cuda-13
+          name: build-cuda-${{ matrix.cuda.version }}
 
       - name: Extract build artifacts
         run: tar -xf build.tar
@@ -151,7 +138,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: unittest-logs-cuda13-${{ github.run_id }}
+          name: unittest-logs-cuda${{ matrix.cuda.version }}-${{ github.run_id }}
           path: build/release/extension/sirius/test/cpp/log/
           if-no-files-found: ignore
           retention-days: 14
@@ -190,106 +177,30 @@ jobs:
         if: always() && steps.tpch.outputs.run_dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tpch-run-${{ github.run_id }}-cuda-13
-          path: ${{ steps.tpch.outputs.run_dir }}
-          retention-days: 14
-
-  test-cuda-12:
-    runs-on: [self-hosted, ubuntu-22.04, gpu-2xl4]
-    needs: build-cuda-12
-    if: github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success'
-    timeout-minutes: 60
-    env:
-      CUDA_CACHE_PATH: /home/runner/actions-runner/_work/.cuda-cache
-      SIRIUS_LOG_LEVEL: trace
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
-        with:
-          cache: false
-          pixi-version: v0.69.0
-          activate-environment: cuda12
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-cuda-12
-
-      - name: Extract build artifacts
-        run: tar -xf build.tar
-
-      - name: Run C++ unit tests
-        run: |
-            nvidia-smi
-            timeout 45m ./build/release/extension/sirius/test/cpp/sirius_unittest --abort
-
-      - name: Upload unit test logs
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unittest-logs-cuda12-${{ github.run_id }}
-          path: build/release/extension/sirius/test/cpp/log/
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Prepare SQL test datasets
-        run: |
-          ./setup_test_datasets.sh
-          chmod -R a+r test_datasets/
-          mkdir -p test_datasets/tpch_parquet_sf1
-          ./build/release/duckdb -f scripts/tpch_to_parquet.sql
-
-      - name: TPC-H performance snapshot
-        id: tpch
-        env:
-          SIRIUS_CONFIG_FILE: ${{ github.workspace }}/test/cpp/integration/integration.yaml
-          PARQUET_DIR: ${{ github.workspace }}/test_datasets/tpch_parquet_sf1
-        run: |
-          ./test/tpch_performance/benchmark_and_validate.sh 1
-          RUN_DIR=$(ls -td runs/*/ | head -1)
-          echo "run_dir=$RUN_DIR" >> "$GITHUB_OUTPUT"
-          {
-            echo "## TPC-H Performance (SF1)"
-            echo '```'
-            cat "$RUN_DIR/comparison.txt"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          ERRORS=$(tail -n +2 "$RUN_DIR/validation.csv" | grep -cE ',error$' || true)
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::TPC-H snapshot: $ERRORS queries errored"
-            if [ "${{ github.event_name }}" = "merge_group" ]; then
-              exit 1
-            fi
-          fi
-
-      - name: Upload TPC-H run artifacts
-        if: always() && steps.tpch.outputs.run_dir != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: tpch-run-${{ github.run_id }}-cuda-12
+          name: tpch-run-${{ github.run_id }}-cuda-${{ matrix.cuda.version }}
           path: ${{ steps.tpch.outputs.run_dir }}
           retention-days: 14
 
   build:
     runs-on: ubuntu-slim
-    needs: [build-cuda-13, build-cuda-12]
+    needs: build-cuda
     if: always()
     steps:
       - name: All builds ok
-        if: ${{ needs.build-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.build-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success')) }}
+        if: ${{ needs.build-cuda.result == 'success' }}
         run: exit 0
       - name: Some builds failed
-        if: ${{ !(needs.build-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.build-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.build-cuda-12.result == 'success'))) }}
+        if: ${{ needs.build-cuda.result != 'success' }}
         run: exit 1
 
   test:
     runs-on: ubuntu-slim
-    needs: [test-cuda-13, test-cuda-12]
+    needs: test-cuda
     if: always()
     steps:
       - name: All tests ok
-        if: ${{ needs.test-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.test-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.test-cuda-12.result == 'success')) }}
+        if: ${{ needs.test-cuda.result == 'success' }}
         run: exit 0
       - name: Some tests failed
-        if: ${{ !(needs.test-cuda-13.result == 'success' && ((github.event_name == 'pull_request' && needs.test-cuda-12.result == 'skipped') || (github.event_name != 'pull_request' && needs.test-cuda-12.result == 'success'))) }}
+        if: ${{ needs.test-cuda.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
## Summary

Move expensive CI coverage from pull request runs to the merge queue while keeping PR CI focused on common failures.

The Test workflow now uses CPU build matrix jobs to produce CUDA-specific artifacts, GPU test matrix jobs to consume those artifacts, and a single `test` gate for the workflow.

## Pull request CI

| Workflow | Jobs / rows |
|---|---|
| Check | `lint` |
| Check | `build` matrix: `x64`, `gcc`, `release`, `default`, stable cuDF, `super` |
| Check | `build` matrix: `x64`, `clang`, `debug`, `default`, stable cuDF, `super` |
| Check | `check` aggregate |
| Test | `build` matrix: CUDA 13 on `ubuntu-24.04` CPU runner |
| Test | `test-run` matrix: CUDA 13 on `ubuntu-24.04` GPU runner |
| Test | `test` aggregate gate |
| Distribution | Only when `.github/workflows/distribution.yml` changes |

## Merge group / dev CI

Everything from PR CI, plus:

| Workflow | Additional jobs / rows |
|---|---|
| Check | `build` matrix: `arm64`, `gcc`, `release`, `default`, stable cuDF, `super` |
| Check | `build` matrix: `arm64`, `clang`, `debug`, `default`, stable cuDF, `super` |
| Check | `build` matrix: `x64`, `gcc`, `release`, `vcpkg`, stable cuDF, `super` |
| Check | `build` matrix: `arm64`, `gcc`, `release`, `default`, nightly cuDF, `super` |
| Check | `build` matrix: `x64`, `gcc`, `release`, `default`, stable cuDF, `legacy` |
| Test | `build` matrix: CUDA 12 on `ubuntu-22.04` CPU runner |
| Test | `test-run` matrix: CUDA 12 on `ubuntu-22.04` GPU runner |
| Distribution | `cuda-13` distribution build |
| Distribution | `cuda-12` distribution build |

## Required checks

The intended gate for the Test workflow is `test`. The `build` jobs in that workflow are CPU-only artifact producers; test jobs start after the build matrix completes, and the final `test` job fails if the GPU test matrix does not succeed.

## Validation

- `pixi run pre-commit run --files .github/workflows/check.yml .github/workflows/test.yml .github/workflows/distribution.yml`
- `git diff --check`
