### PR TITLE
feat(expr): add aggregate AST node + BOUND_AGGREGATE translation (#863)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(EXTENSION_SOURCES
     src/data/host_parquet_representation.cpp
     src/data/host_parquet_representation_converters.cpp
     src/downgrade/downgrade_executor.cpp
+    src/expression/aggregate_id.cpp
     src/expression/expression.cpp
     src/expression/from_duckdb.cpp
     src/expression/function_id.cpp
@@ -439,6 +440,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_bounded_thread_pool.cpp
     test/cpp/exec/test_inspectable_mpsc.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
+    test/cpp/expression/test_ast_aggregate.cpp
     test/cpp/expression/test_ast_from_duckdb.cpp
     test/cpp/expression/test_ast_scaffold.cpp
     test/cpp/expression/test_ast_to_duckdb.cpp

--- a/src/expression/aggregate_id.cpp
+++ b/src/expression/aggregate_id.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "expression/aggregate_id.hpp"
+
+// standard library
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+namespace sirius {
+
+namespace {
+
+// Forward table: DuckDB aggregate name -> Sirius aggregate id.
+// Linear scan; called once per BoundAggregateExpression at translator entry.
+constexpr std::array<std::pair<std::string_view, aggregate_id>, 8> kForwardTable = {{
+  {"sum", aggregate_id::sum},
+  {"sum_no_overflow", aggregate_id::sum_no_overflow},
+  {"count", aggregate_id::count},
+  {"count_star", aggregate_id::count_star},
+  {"min", aggregate_id::min},
+  {"max", aggregate_id::max},
+  {"avg", aggregate_id::avg},
+  {"first", aggregate_id::first},
+}};
+
+// Reverse table: Sirius aggregate id -> canonical DuckDB aggregate name.
+// Indexed directly by enum value; never searched.
+constexpr std::array<std::string_view, 8> kReverseTable = {
+  "sum",
+  "sum_no_overflow",
+  "count",
+  "count_star",
+  "min",
+  "max",
+  "avg",
+  "first",
+};
+
+static_assert(static_cast<std::size_t>(aggregate_id::first) + 1 == 8,
+              "aggregate_id::first must be the last entry; cardinality locked at 8.");
+static_assert(kReverseTable.size() == 8,
+              "kReverseTable must have one slot per aggregate_id value.");
+static_assert(kForwardTable.size() == 8,
+              "kForwardTable must have one entry per aggregate_id value.");
+
+// Walks both tables to ensure every enum value has exactly one canonical
+// forward entry whose name matches the reverse table at the same index.
+// Catches table drift (missing ids, duplicated canonicals, name mismatches)
+// at compile time.
+consteval bool aggregate_id_tables_are_consistent()
+{
+  std::array<int, kReverseTable.size()> canonical_counts{};
+  for (auto const& [name, id] : kForwardTable) {
+    auto const idx = static_cast<std::size_t>(id);
+    if (idx >= kReverseTable.size()) { return false; }
+    if (name == kReverseTable[idx]) { ++canonical_counts[idx]; }
+  }
+  for (auto const count : canonical_counts) {
+    if (count != 1) { return false; }
+  }
+  return true;
+}
+
+static_assert(aggregate_id_tables_are_consistent(),
+              "aggregate_id forward/reverse tables must agree on one canonical name per id.");
+
+}  // namespace
+
+std::optional<aggregate_id> from_duckdb_aggregate_name(std::string_view name)
+{
+  auto const it =
+    std::ranges::find(kForwardTable, name, &decltype(kForwardTable)::value_type::first);
+  if (it == kForwardTable.end()) { return std::nullopt; }
+  return it->second;
+}
+
+std::string_view to_duckdb_aggregate_name(aggregate_id id)
+{
+  return kReverseTable[static_cast<std::size_t>(id)];
+}
+
+}  // namespace sirius

--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -17,6 +17,8 @@
 #include "expression/ast/from_duckdb.hpp"
 
 // sirius
+#include "expression/aggregate_id.hpp"
+#include "expression/ast/aggregate.hpp"
 #include "expression/ast/between.hpp"
 #include "expression/ast/case_expr.hpp"
 #include "expression/ast/cast.hpp"
@@ -39,6 +41,7 @@
 #include <duckdb/common/enums/expression_type.hpp>
 #include <duckdb/common/exception.hpp>
 #include <duckdb/planner/expression.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
 #include <duckdb/planner/expression/bound_between_expression.hpp>
 #include <duckdb/planner/expression/bound_case_expression.hpp>
 #include <duckdb/planner/expression/bound_cast_expression.hpp>
@@ -173,6 +176,22 @@ std::unique_ptr<node> translate_function(duckdb::BoundFunctionExpression const& 
     function_call{*func_id_opt, std::move(arguments), std::move(return_type)});
 }
 
+std::unique_ptr<node> translate_aggregate(duckdb::BoundAggregateExpression const& aggr)
+{
+  auto agg_id_opt = sirius::from_duckdb_aggregate_name(aggr.function.name);
+  if (!agg_id_opt.has_value()) { return nullptr; }
+  std::vector<std::unique_ptr<node>> arguments;
+  arguments.reserve(aggr.children.size());
+  for (auto const& child : aggr.children) {
+    auto translated = from_duckdb(*child);
+    if (!translated) { return nullptr; }
+    arguments.push_back(std::move(translated));
+  }
+  auto return_type = sirius::from_duckdb(aggr.return_type);
+  return std::make_unique<node>(
+    aggregate{*agg_id_opt, std::move(arguments), std::move(return_type), aggr.IsDistinct()});
+}
+
 std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& expr)
 {
   auto const op_type = expr.GetExpressionType();
@@ -233,6 +252,8 @@ std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& 
 std::unique_ptr<node> from_duckdb(duckdb::Expression const& expr)
 {
   switch (expr.GetExpressionClass()) {
+    case duckdb::ExpressionClass::BOUND_AGGREGATE:
+      return translate_aggregate(expr.Cast<duckdb::BoundAggregateExpression>());
     case duckdb::ExpressionClass::BOUND_BETWEEN:
       return translate_between(expr.Cast<duckdb::BoundBetweenExpression>());
     case duckdb::ExpressionClass::BOUND_CASE:

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -17,6 +17,7 @@
 #include "expression/ast/to_duckdb.hpp"
 
 // sirius
+#include "expression/ast/aggregate.hpp"
 #include "expression/ast/between.hpp"
 #include "expression/ast/case_expr.hpp"
 #include "expression/ast/cast.hpp"
@@ -33,6 +34,8 @@
 #include "expression/join_condition.hpp"  // sirius::to_duckdb(comparison_type)
 #include "expression/value.hpp"           // sirius::to_duckdb(value, logical_type)
 #include "helper/type_conversions.hpp"    // sirius::to_duckdb(logical_type)
+
+#include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/enums/expression_type.hpp>
@@ -243,6 +246,13 @@ std::unique_ptr<duckdb::Expression> to_duckdb(function_call const& alt)
                                                        std::move(stub_fn),
                                                        std::move(children),
                                                        /*bind_info=*/nullptr));
+}
+
+std::unique_ptr<duckdb::Expression> to_duckdb(aggregate const& /*alt*/)
+{
+  throw not_implemented_exception(
+    "[sirius::ast::to_duckdb] aggregate reconstruction is not implemented; consumers read the "
+    "aggregate node natively (#863).");
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(node const& expr)

--- a/src/expression_executor/ast_op_counter.cpp
+++ b/src/expression_executor/ast_op_counter.cpp
@@ -15,6 +15,7 @@
  */
 
 // sirius
+#include <expression/ast/aggregate.hpp>
 #include <expression/ast/between.hpp>
 #include <expression/ast/case_expr.hpp>
 #include <expression/ast/cast.hpp>
@@ -140,6 +141,16 @@ std::size_t function_call::cudf_ast_op_count() const
     count += a->cudf_ast_op_count();
   }
   return count;
+}
+
+std::size_t aggregate::cudf_ast_op_count() const
+{
+  // Aggregate nodes never lower to cuDF AST ops — the method exists solely to
+  // keep the node variant exhaustive (node.hpp's has_cudf_ast_op_count concept).
+  // Dead at runtime: nothing constructs or visits an aggregate node in the
+  // expression-executor path. See https://github.com/sirius-db/sirius/issues/863.
+  throw not_implemented_exception(
+    "[ast::aggregate::cudf_ast_op_count] aggregate nodes are not lowered to cuDF AST ops (#863).");
 }
 
 std::size_t node::cudf_ast_op_count() const

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -17,12 +17,14 @@
 // sirius
 #include <cudf/cudf_utils.hpp>
 
-#include <expression/ast/node.hpp>  // sirius::ast::node + 11 alternatives
+#include <expression/ast/aggregate.hpp>  // sirius::ast::aggregate
+#include <expression/ast/node.hpp>       // sirius::ast::node alternatives
 #include <expression/ast/to_duckdb.hpp>  // sirius::ast::to_duckdb (per-alternative overloads + node dispatcher)
 #include <expression/expression_internal.hpp>
 #include <expression/function_id.hpp>
 #include <expression_executor/ast_supported_types.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <sirius/exception.hpp>
 
 // cucascade
 #include <cucascade/data/gpu_data_representation.hpp>
@@ -513,6 +515,14 @@ std::size_t gpu_expression_executor::count_ast_ops(duckdb::Expression const& exp
   }
 }
 
+execute_result gpu_expression_executor::execute(sirius::ast::aggregate const& /*expr*/,
+                                                execution_mode /*mode*/)
+{
+  throw not_implemented_exception(
+    "[gpu_expression_executor] aggregate nodes are not executed via the expression executor "
+    "(#863).");
+}
+
 execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, execution_mode mode)
 {
   return std::visit(
@@ -528,7 +538,8 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
                     std::is_same_v<T, sirius::ast::unary_op> ||
                     std::is_same_v<T, sirius::ast::coalesce> ||
                     std::is_same_v<T, sirius::ast::in_list> ||
-                    std::is_same_v<T, sirius::ast::function_call>) {
+                    std::is_same_v<T, sirius::ast::function_call> ||
+                    std::is_same_v<T, sirius::ast::aggregate>) {
         return this->execute(alt, mode);
       } else {
         static_assert(sizeof(T) == 0,

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -15,10 +15,12 @@
  */
 
 // sirius
+#include <expression/ast/aggregate.hpp>
 #include <expression/ast/from_duckdb.hpp>
 #include <expression/expression_internal.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
 #include <log/logging.hpp>
+#include <sirius/exception.hpp>
 
 // cudf
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -371,7 +373,8 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
                     std::is_same_v<T, sirius::ast::unary_op> ||
                     std::is_same_v<T, sirius::ast::coalesce> ||
                     std::is_same_v<T, sirius::ast::in_list> ||
-                    std::is_same_v<T, sirius::ast::function_call>) {
+                    std::is_same_v<T, sirius::ast::function_call> ||
+                    std::is_same_v<T, sirius::ast::aggregate>) {
         return this->add_expression(alt, table_src);
       } else {
         static_assert(sizeof(T) == 0,
@@ -768,6 +771,14 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
                        static_cast<int>(alt.function()));
       return std::nullopt;
   }
+}
+
+//===----------AGGREGATE----------===//
+std::optional<expr_ref> gpu_expression_translator::add_expression(
+  sirius::ast::aggregate const& /*alt*/, cudf::ast::table_reference const /*table_src*/)
+{
+  throw not_implemented_exception(
+    "[gpu_expression_translator] aggregate nodes cannot be lowered to a cuDF AST (#863).");
 }
 
 }  // namespace sirius

--- a/src/include/expression/aggregate_id.hpp
+++ b/src/include/expression/aggregate_id.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// standard library
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace sirius {
+
+/**
+ * @brief Closed identifier for every named aggregate function the Sirius GPU
+ *        executor recognises today.
+ *
+ * Backing type uint16_t pinned as ABI (locked at compile time in
+ * test_ast_aggregate.cpp). The integer values are part of the public ABI —
+ * new entries go at the end, never in the middle. Cardinality is exactly 8.
+ *
+ * Mirrors the closed sirius::function_id enum precedent. See
+ * https://github.com/sirius-db/sirius/issues/863.
+ */
+enum class aggregate_id : uint16_t {
+  sum = 0,
+  sum_no_overflow,
+  count,
+  count_star,
+  min,
+  max,
+  avg,
+  first,
+};
+
+/**
+ * @brief Resolve a DuckDB aggregate-function name to the matching aggregate_id.
+ *
+ * Returns std::nullopt when the name does not correspond to any aggregate the
+ * Sirius executor handles (a fallback signal). The DuckDB-side names equal the
+ * enum spellings.
+ */
+std::optional<aggregate_id> from_duckdb_aggregate_name(std::string_view name);
+
+/**
+ * @brief Recover the canonical DuckDB aggregate name for an aggregate_id.
+ *
+ * Returns the DuckDB-side spelling that round-trips back through
+ * from_duckdb_aggregate_name.
+ */
+std::string_view to_duckdb_aggregate_name(aggregate_id id);
+
+}  // namespace sirius

--- a/src/include/expression/ast/aggregate.hpp
+++ b/src/include/expression/ast/aggregate.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// sirius
+#include "expression/aggregate_id.hpp"  // sirius::aggregate_id
+#include "helper/logical_type.hpp"      // sirius::logical_type
+
+// standard library
+#include <memory>
+#include <vector>
+
+namespace sirius::ast {
+
+struct node;
+
+/**
+ * @brief Sirius-native mirror of duckdb::BoundAggregateExpression.
+ *
+ * Mirrors function_call (variadic arguments + return_type) and adds a
+ * `distinct` flag capturing duckdb::BoundAggregateExpression::IsDistinct().
+ * The filter and order-by clauses that DuckDB carries on the bound expression
+ * are hoisted away upstream by extract_aggregate_expressions and are NOT
+ * represented here.
+ *
+ * No default state: the only way to construct an `aggregate` is via the
+ * four-argument constructor. Move-only (the arguments vector holds
+ * `unique_ptr<node>`); private fields with const accessors prevent
+ * post-construction mutation. Moved-from instances are left in the standard
+ * valid-but-unspecified state and must not be read.
+ *
+ * See https://github.com/sirius-db/sirius/issues/863.
+ */
+class aggregate {
+ public:
+  aggregate(sirius::aggregate_id id,
+            std::vector<std::unique_ptr<node>> arguments,
+            sirius::logical_type return_type,
+            bool distinct)
+    : function_(id),
+      arguments_(std::move(arguments)),
+      return_type_(std::move(return_type)),
+      distinct_(distinct)
+  {
+  }
+
+  aggregate()                                = delete;
+  aggregate(aggregate const&)                = delete;
+  aggregate& operator=(aggregate const&)     = delete;
+  aggregate(aggregate&&) noexcept            = default;
+  aggregate& operator=(aggregate&&) noexcept = default;
+  ~aggregate()                               = default;
+
+  [[nodiscard]] sirius::aggregate_id function() const noexcept { return function_; }
+  [[nodiscard]] std::vector<std::unique_ptr<node>> const& arguments() const noexcept
+  {
+    return arguments_;
+  }
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
+  [[nodiscard]] bool distinct() const noexcept { return distinct_; }
+
+  [[nodiscard]] std::size_t cudf_ast_op_count() const;
+
+ private:
+  sirius::aggregate_id function_;
+  std::vector<std::unique_ptr<node>> arguments_;
+  sirius::logical_type return_type_;
+  bool distinct_;
+};
+
+}  // namespace sirius::ast

--- a/src/include/expression/ast/node.hpp
+++ b/src/include/expression/ast/node.hpp
@@ -38,6 +38,7 @@ struct node;
 // Per-node headers complete each alternative type below. Each header carries
 // its own `struct node;` forward declaration so it can hold
 // std::unique_ptr<node> children without depending on this file's ordering.
+#include "expression/ast/aggregate.hpp"
 #include "expression/ast/between.hpp"
 #include "expression/ast/case_expr.hpp"
 #include "expression/ast/cast.hpp"
@@ -103,7 +104,8 @@ struct node {
                                  unary_op,
                                  coalesce,
                                  in_list,
-                                 function_call>;
+                                 function_call,
+                                 aggregate>;
 
   static_assert(detail::all_have_cudf_ast_op_count<variant_t>::value,
                 "Every alternative in sirius::ast::node::variant_t must implement "

--- a/src/include/expression/ast/to_duckdb.hpp
+++ b/src/include/expression/ast/to_duckdb.hpp
@@ -48,6 +48,7 @@ std::unique_ptr<duckdb::Expression> to_duckdb(node const& expr);
 // Per-alternative overloads — called directly by gpu_expression_executor shims
 // to sidestep node's move-only constraint. The top-level to_duckdb(node) above
 // dispatches to these via std::visit.
+std::unique_ptr<duckdb::Expression> to_duckdb(aggregate const& alt);
 std::unique_ptr<duckdb::Expression> to_duckdb(between const& alt);
 std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt);
 std::unique_ptr<duckdb::Expression> to_duckdb(cast const& alt);

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -447,6 +447,7 @@ class gpu_expression_executor {
   execute_result execute(sirius::ast::unary_op const& expr, execution_mode mode);
   execute_result execute(sirius::ast::coalesce const& expr, execution_mode mode);
   execute_result execute(sirius::ast::in_list const& expr, execution_mode mode);
+  execute_result execute(sirius::ast::aggregate const& expr, execution_mode mode);
 
   // Counts the number of AST nodes that would be generated for the given expression if we
   // added it to the AST tree. This is used to determine whether we should execute in AST mode or

--- a/src/include/expression_executor/gpu_expression_translator_internal.hpp
+++ b/src/include/expression_executor/gpu_expression_translator_internal.hpp
@@ -225,6 +225,9 @@ class gpu_expression_translator {
   /// @brief Specialized add_expression for FUNCTION expressions.
   std::optional<expr_ref> add_expression(sirius::ast::function_call const& alt,
                                          cudf::ast::table_reference const table_src);
+  /// @brief Specialized add_expression for AGGREGATE expressions (not translatable to cuDF AST).
+  std::optional<expr_ref> add_expression(sirius::ast::aggregate const& alt,
+                                         cudf::ast::table_reference const table_src);
 
   /// @brief Add a single join condition to the current AST tree without resetting it.
   /// @param condition The join condition to translate.

--- a/test/cpp/expression/test_ast_aggregate.cpp
+++ b/test/cpp/expression/test_ast_aggregate.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for the sirius::ast::aggregate node, the sirius::aggregate_id name
+// mappers, and the BOUND_AGGREGATE arm of sirius::ast::from_duckdb.
+//
+// Covers the id mapper round-trips + unsupported-name nullopt, direct
+// aggregate-node construction, and translation of a directly-constructed
+// duckdb::BoundAggregateExpression (sum, count_star with no children,
+// COUNT(DISTINCT struct_pack(a, b)) recursion + distinct flag, and the
+// unsupported-name -> nullptr fallback).
+
+#include "catch.hpp"
+#include "expression/ast/from_duckdb.hpp"
+
+// sirius — node accessors and per-node struct types
+#include "expression/aggregate_id.hpp"
+#include "expression/ast/aggregate.hpp"
+#include "expression/ast/function_call.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
+#include "expression/function_id.hpp"
+#include "helper/logical_type.hpp"
+
+// duckdb — direct-ctor construction surface
+#include <duckdb/common/types.hpp>
+#include <duckdb/function/aggregate_function.hpp>
+#include <duckdb/function/scalar_function.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using duckdb::AggregateFunction;
+using duckdb::AggregateType;
+using duckdb::BoundAggregateExpression;
+using duckdb::BoundFunctionExpression;
+using duckdb::BoundReferenceExpression;
+using duckdb::LogicalType;
+using duckdb::LogicalTypeId;
+using duckdb::ScalarFunction;
+
+using sirius::aggregate_id;
+using sirius::from_duckdb_aggregate_name;
+using sirius::to_duckdb_aggregate_name;
+using sirius::ast::aggregate;
+using sirius::ast::function_call;
+using sirius::ast::node;
+using sirius::ast::reference;
+
+namespace {
+
+// Minimal AggregateFunction stub: only `.name` is read by from_duckdb; the
+// callback function pointers are never invoked during translation.
+AggregateFunction make_dummy_aggregate(std::string const& name,
+                                       duckdb::vector<LogicalType> const& args,
+                                       LogicalType const& ret_type)
+{
+  return AggregateFunction(
+    name, args, ret_type, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+}
+
+}  // namespace
+
+// ============================================================================
+// Compile-time invariants (locked ABI)
+// ============================================================================
+
+static_assert(std::is_enum_v<aggregate_id>, "sirius::aggregate_id must be an enum class.");
+static_assert(sizeof(aggregate_id) == 2, "sirius::aggregate_id is uint16_t-backed (locked ABI).");
+static_assert(static_cast<uint16_t>(aggregate_id::first) + 1 == 8,
+              "sirius::aggregate_id has exactly 8 entries (locked ABI).");
+
+// ============================================================================
+// aggregate_id name mapper round-trips
+// ============================================================================
+
+TEST_CASE("ast_aggregate - every supported aggregate name maps to its id", "[ast_aggregate]")
+{
+  struct entry {
+    std::string_view name;
+    aggregate_id id;
+  };
+  entry const cases[] = {
+    {"sum", aggregate_id::sum},
+    {"sum_no_overflow", aggregate_id::sum_no_overflow},
+    {"count", aggregate_id::count},
+    {"count_star", aggregate_id::count_star},
+    {"min", aggregate_id::min},
+    {"max", aggregate_id::max},
+    {"avg", aggregate_id::avg},
+    {"first", aggregate_id::first},
+  };
+  for (auto const& c : cases) {
+    auto const id = from_duckdb_aggregate_name(c.name);
+    REQUIRE(id.has_value());
+    REQUIRE(*id == c.id);
+    // Round-trip back to the canonical DuckDB name.
+    REQUIRE(to_duckdb_aggregate_name(*id) == c.name);
+  }
+}
+
+TEST_CASE("ast_aggregate - unsupported aggregate name returns std::nullopt", "[ast_aggregate]")
+{
+  REQUIRE_FALSE(from_duckdb_aggregate_name("stddev").has_value());
+  REQUIRE_FALSE(from_duckdb_aggregate_name("").has_value());
+}
+
+// ============================================================================
+// Direct aggregate-node construction
+// ============================================================================
+
+TEST_CASE("ast_aggregate - direct node construction reads back fields", "[ast_aggregate]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(std::make_unique<node>(reference{/*column_index=*/3}));
+
+  auto agg_node =
+    std::make_unique<node>(aggregate{aggregate_id::sum,
+                                     std::move(args),
+                                     sirius::logical_type::make(sirius::type_id::BIGINT),
+                                     /*distinct=*/true});
+
+  REQUIRE(agg_node->holds<aggregate>());
+  auto const& agg = agg_node->get<aggregate>();
+  REQUIRE(agg.function() == aggregate_id::sum);
+  REQUIRE(agg.arguments().size() == 1);
+  REQUIRE(agg.return_type().id() == sirius::type_id::BIGINT);
+  REQUIRE(agg.distinct() == true);
+}
+
+// ============================================================================
+// from_duckdb(BOUND_AGGREGATE)
+// ============================================================================
+
+TEST_CASE("ast_aggregate - sum over a single reference translates to aggregate node",
+          "[ast_aggregate]")
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.push_back(
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  auto fn = make_dummy_aggregate(
+    "sum", {LogicalType{LogicalTypeId::INTEGER}}, LogicalType{LogicalTypeId::BIGINT});
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
+    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+
+  auto out = sirius::ast::from_duckdb(*expr);
+  REQUIRE(out);
+  REQUIRE(out->holds<aggregate>());
+  auto const& agg = out->get<aggregate>();
+  REQUIRE(agg.function() == aggregate_id::sum);
+  REQUIRE(agg.arguments().size() == 1);
+  REQUIRE(agg.arguments()[0]->holds<reference>());
+  REQUIRE(agg.distinct() == false);
+}
+
+TEST_CASE("ast_aggregate - count_star with no children translates without throwing",
+          "[ast_aggregate]")
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;  // empty
+  auto fn   = make_dummy_aggregate("count_star", {}, LogicalType{LogicalTypeId::BIGINT});
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
+    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+
+  std::unique_ptr<node> out;
+  REQUIRE_NOTHROW(out = sirius::ast::from_duckdb(*expr));
+  REQUIRE(out);
+  REQUIRE(out->holds<aggregate>());
+  auto const& agg = out->get<aggregate>();
+  REQUIRE(agg.function() == aggregate_id::count_star);
+  REQUIRE(agg.arguments().empty());
+}
+
+TEST_CASE("ast_aggregate - COUNT(DISTINCT struct_pack(a, b)) recurses children and sets distinct",
+          "[ast_aggregate]")
+{
+  // Inner struct_pack(a, b): a BoundFunctionExpression over two references.
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> struct_children;
+  struct_children.push_back(
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  struct_children.push_back(
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
+  auto struct_return_type = LogicalType::STRUCT(
+    {{"a", LogicalType{LogicalTypeId::INTEGER}}, {"b", LogicalType{LogicalTypeId::INTEGER}}});
+  ScalarFunction struct_fn(
+    "struct_pack", duckdb::vector<LogicalType>{}, struct_return_type, /*function=*/nullptr);
+  auto struct_pack_expr = duckdb::make_uniq<BoundFunctionExpression>(
+    struct_return_type, struct_fn, std::move(struct_children), /*bind_info=*/nullptr);
+
+  // Outer count(DISTINCT struct_pack(a, b)).
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_children;
+  agg_children.push_back(std::move(struct_pack_expr));
+  auto fn = make_dummy_aggregate("count", {struct_return_type}, LogicalType{LogicalTypeId::BIGINT});
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
+    fn, std::move(agg_children), nullptr, nullptr, AggregateType::DISTINCT);
+
+  auto out = sirius::ast::from_duckdb(*expr);
+  REQUIRE(out);
+  REQUIRE(out->holds<aggregate>());
+  auto const& agg = out->get<aggregate>();
+  REQUIRE(agg.function() == aggregate_id::count);
+  REQUIRE(agg.distinct() == true);
+  REQUIRE(agg.arguments().size() == 1);
+  // The single argument recursed through from_duckdb into a struct_pack function_call.
+  REQUIRE(agg.arguments()[0]->holds<function_call>());
+  REQUIRE(agg.arguments()[0]->get<function_call>().function() == sirius::function_id::struct_pack);
+}
+
+TEST_CASE("ast_aggregate - unsupported aggregate name yields nullptr fallback (no throw)",
+          "[ast_aggregate]")
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.push_back(
+    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::DOUBLE}, 0));
+  auto fn = make_dummy_aggregate(
+    "stddev", {LogicalType{LogicalTypeId::DOUBLE}}, LogicalType{LogicalTypeId::DOUBLE});
+  auto expr = duckdb::make_uniq<BoundAggregateExpression>(
+    fn, std::move(children), nullptr, nullptr, AggregateType::NON_DISTINCT);
+
+  std::unique_ptr<node> out;
+  REQUIRE_NOTHROW(out = sirius::ast::from_duckdb(*expr));
+  REQUIRE(out == nullptr);
+}

--- a/test/cpp/expression/test_ast_scaffold.cpp
+++ b/test/cpp/expression/test_ast_scaffold.cpp
@@ -55,8 +55,8 @@ static_assert(!std::is_copy_constructible_v<node>,
 static_assert(!std::is_copy_assignable_v<node>, "sirius::ast::node must be move-only.");
 static_assert(std::is_move_constructible_v<node>, "sirius::ast::node must be move-constructible.");
 static_assert(std::is_move_assignable_v<node>, "sirius::ast::node must be move-assignable.");
-static_assert(std::variant_size_v<node::variant_t> == 11,
-              "sirius::ast::node has exactly 11 alternatives.");
+static_assert(std::variant_size_v<node::variant_t> == 12,
+              "sirius::ast::node has exactly 12 alternatives.");
 
 // ============================================================================
 // Per-node instantiation


### PR DESCRIPTION
## Summary

Extend the Sirius expression AST with a 12th `sirius::ast::aggregate` variant alternative so `duckdb::BoundAggregateExpression` becomes representable, and translate `BOUND_AGGREGATE` in `ast::from_duckdb` instead of falling into the `default:` throw arm. Purely additive — no runtime behavior change.

This is the prerequisite for the wrapper flip (#701): once `wrap()` calls `ast::from_duckdb` on every wrapped expression, aggregates (wrapped today by `sirius_plan_aggregate.cpp`) would otherwise hit the translator's `default:` throw. Doing this additively first keeps the wrapper flip a clean backing-type change.

Resolves #863 (sub-issue of #666).

## Changes

- **`sirius::aggregate_id`** — closed `uint16_t` enum (`sum`, `sum_no_overflow`, `count`, `count_star`, `min`, `max`, `avg`, `first`) with `from_duckdb_aggregate_name` / `to_duckdb_aggregate_name`, mirroring the `function_id` precedent. Forward/reverse tables guarded by a `consteval` consistency check.
- **`sirius::ast::aggregate`** — move-only node mirroring `function_call` (variadic children + return type) plus a `distinct` flag capturing `IsDistinct()`. Appended last in `node::variant_t` to preserve alternative-index ABI.
- **`from_duckdb`** — `translate_aggregate` maps name → id (returns `nullptr` on unsupported name for graceful fallback), recurses children through `from_duckdb`, captures `IsDistinct()`, copies `return_type`; `case BOUND_AGGREGATE` added. `filter`/`order_bys` are intentionally not read (hoisted away upstream by `extract_aggregate_expressions`).
- **Exhaustive visitors** — throwing `aggregate` arms added to every node visitor (`to_duckdb`, `gpu_expression_executor`, `gpu_expression_translator`, `cudf_ast_op_count`). These are dead at runtime this change (nothing constructs or visits an aggregate node until the wrapper flip); they exist solely to keep the variant exhaustive. `ast::to_duckdb` for aggregates is an intentional throwing stub.

## Tests

New Catch2 `[ast_aggregate]` coverage (7 cases / 51 assertions): the id mapper (all 8 names + unsupported → `nullopt`), direct node construction, and `from_duckdb` translation including `count_star` (no children) and `COUNT(DISTINCT struct_pack(a, b))` (struct-pack child recursion + distinct flag), plus the unsupported-name → `nullptr` fallback.

- `[ast_aggregate]` 51/51 assertions pass; expression-AST regression (`[ast_scaffold] [ast_from_duckdb] [ast_to_duckdb] [ast_function_id]`) 467/467 pass.
- Both build configs compile (default and `-DENABLE_LEGACY_SIRIUS=ON`); no `src/legacy/` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)