### PR TITLE
Improvements to sort operators #1

### DIFF
--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -18,6 +18,7 @@
 
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_order.hpp"
+#include "sirius_config.hpp"
 
 #include <cudf/table/table.hpp>
 
@@ -31,9 +32,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::SORT_SAMPLE;
 
   static constexpr std::size_t DEFAULT_NUM_SAMPLE_BATCHES = 5;
-
-  //! Maximum fraction of available GPU memory per partition (33%)
-  static constexpr double MAX_PARTITION_MEMORY_FRACTION = 0.33;
 
   sirius_physical_sort_sample(sirius_physical_order* order_by);
 
@@ -73,8 +71,14 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Whether boundaries have been computed
   bool boundaries_computed() const { return _boundary_state.load(std::memory_order_acquire) == 2; }
 
-  //! Override the maximum bytes per partition (0 = use default GPU memory-based calculation)
+  //! Override the maximum bytes per partition (0 = use GPU memory fraction below)
   void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
+
+  //! Fraction of available GPU memory per partition when max_partition_bytes override is 0
+  void set_max_partition_memory_fraction(double fraction)
+  {
+    _max_partition_memory_fraction = fraction;
+  }
 
   //! Release the partition boundaries table to free GPU memory
   void clear_partition_boundaries() { _partition_boundaries.reset(); }
@@ -91,8 +95,11 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! passthrough without blocking.
   std::atomic<int> _boundary_state{0};
 
-  //! Override for max partition bytes (0 = use default GPU memory-based calculation)
+  //! Override for max partition bytes (0 = use GPU memory fraction)
   size_t _max_partition_bytes_override = 0;
+
+  //! Fraction of available GPU memory per partition (from sirius_config operator_params)
+  double _max_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -33,12 +33,18 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
 
   static constexpr std::size_t DEFAULT_NUM_SAMPLE_BATCHES = 5;
 
-  sirius_physical_sort_sample(sirius_physical_order* order_by);
+  sirius_physical_sort_sample(
+    sirius_physical_order* order_by,
+    uint64_t max_partition_bytes         = 0,
+    double max_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION);
 
-  sirius_physical_sort_sample(duckdb::vector<sirius::logical_type> types,
-                              duckdb::vector<duckdb::BoundOrderByNode> orders,
-                              std::size_t estimated_cardinality,
-                              std::size_t num_sample_batches = DEFAULT_NUM_SAMPLE_BATCHES);
+  sirius_physical_sort_sample(
+    duckdb::vector<sirius::logical_type> types,
+    duckdb::vector<duckdb::BoundOrderByNode> orders,
+    std::size_t estimated_cardinality,
+    std::size_t num_sample_batches       = DEFAULT_NUM_SAMPLE_BATCHES,
+    uint64_t max_partition_bytes         = 0,
+    double max_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION);
 
   //! Order specification (copied from ORDER_BY) — determines which columns to sample
   duckdb::vector<duckdb::BoundOrderByNode> orders;
@@ -70,15 +76,6 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
 
   //! Whether boundaries have been computed
   bool boundaries_computed() const { return _boundary_state.load(std::memory_order_acquire) == 2; }
-
-  //! Override the maximum bytes per partition (0 = use GPU memory fraction below)
-  void set_max_partition_bytes(size_t bytes) { _max_partition_bytes_override = bytes; }
-
-  //! Fraction of available GPU memory per partition when max_partition_bytes override is 0
-  void set_max_partition_memory_fraction(double fraction)
-  {
-    _max_partition_memory_fraction = fraction;
-  }
 
   //! Release the partition boundaries table to free GPU memory
   void clear_partition_boundaries() { _partition_boundaries.reset(); }

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -38,6 +38,9 @@ constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES       = 512ULL * 1024 * 1024;  /
 constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES         = 512ULL * 1024 * 1024;  // 512 MB
 constexpr uint64_t DEFAULT_MAX_BUILD_HASH_TABLE_BYTES = 500ULL * 1024 * 1024;  // 500 MB
 
+/// Fraction of available GPU memory used per sort partition when max_sort_partition_bytes is 0.
+constexpr double DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION = 0.33;
+
 }  // namespace config
 
 /// Parameters controlling operator-level resource sizing.
@@ -50,8 +53,11 @@ struct operator_params {
   /// Default size estimate (bytes) for VARCHAR columns when computing rows per batch.
   uint64_t default_scan_task_varchar_size = config::DEFAULT_SCAN_TASK_VARCHAR_SIZE;
 
-  /// Maximum bytes per sort partition (0 = auto: 33% of available GPU memory).
+  /// Maximum bytes per sort partition (0 = auto based on max_sort_partition_memory_fraction).
   uint64_t max_sort_partition_bytes = 0;
+
+  /// Fraction of available GPU memory per sort partition when max_sort_partition_bytes is 0.
+  double max_sort_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION;
 
   /// Target size (bytes) per hash partition for joins and group-bys.
   uint64_t hash_partition_bytes = config::DEFAULT_HASH_PARTITION_BYTES;

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -189,7 +189,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
       size_t max_partition_bytes   = _max_partition_bytes_override > 0
                                        ? _max_partition_bytes_override
                                        : static_cast<size_t>(static_cast<double>(available_memory) *
-                                                           MAX_PARTITION_MEMORY_FRACTION);
+                                                           _max_partition_memory_fraction);
 
       if (max_partition_bytes > 0 && estimated_total_bytes > max_partition_bytes) {
         num_parts = (estimated_total_bytes + max_partition_bytes - 1) / max_partition_bytes;

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -96,7 +96,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   // Elect exactly one winner via CAS (0=not started → 1=computing).
   // The task_creator's while loop dispatches one task per batch, so multiple tasks
   // can be in-flight simultaneously. Losers passthrough without blocking — they don't
-  // need the boundaries themselves; sort_partition accesses them in a later pipeline.
+  // need the boundaries themselves; sort_partition runs next in the same pipeline task.
   int expected = 0;
   if (!_boundary_state.compare_exchange_strong(expected, 1, std::memory_order_acq_rel)) {
     SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
@@ -254,10 +254,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
       _num_partitions       = num_parts;
     }
 
-    // Pipeline framework calls stream.synchronize() after execute() returns, before
-    // publish_output(). Pipeline C only starts after all Pipeline B tasks complete,
-    // so _partition_boundaries is fully materialized on the GPU before sort_partition
-    // ever reads it. No explicit sync needed here.
+    // sort_partition runs in the same gpu_pipeline_task immediately after this
+    // execute() returns, so _partition_boundaries is visible before partition runs.
     _boundary_state.store(2, std::memory_order_release);
 
   } catch (...) {

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -33,9 +33,15 @@
 namespace sirius {
 namespace op {
 
-sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* order_by)
-  : sirius_physical_sort_sample(
-      order_by->types, copy_orders(order_by->orders), order_by->estimated_cardinality)
+sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* order_by,
+                                                         uint64_t max_partition_bytes,
+                                                         double max_partition_memory_fraction)
+  : sirius_physical_sort_sample(order_by->types,
+                                copy_orders(order_by->orders),
+                                order_by->estimated_cardinality,
+                                DEFAULT_NUM_SAMPLE_BATCHES,
+                                max_partition_bytes,
+                                max_partition_memory_fraction)
 {
 }
 
@@ -43,11 +49,15 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(
   duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   std::size_t estimated_cardinality,
-  std::size_t num_sample_batches)
+  std::size_t num_sample_batches,
+  uint64_t max_partition_bytes,
+  double max_partition_memory_fraction)
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::SORT_SAMPLE, std::move(types), estimated_cardinality),
     orders(std::move(orders)),
-    num_sample_batches(num_sample_batches)
+    num_sample_batches(num_sample_batches),
+    _max_partition_bytes_override(max_partition_bytes),
+    _max_partition_memory_fraction(max_partition_memory_fraction)
 {
 }
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -736,12 +736,9 @@ void sirius_pipeline_converter::split_order_by_sink(
   scheduled_.push_back(current_pipeline);
 
   // Create SORT_SAMPLE operator
-  auto sample_op   = duckdb::make_uniq<op::sirius_physical_sort_sample>(order_ptr);
+  auto sample_op = duckdb::make_uniq<op::sirius_physical_sort_sample>(
+    order_ptr, op_params_.max_sort_partition_bytes, op_params_.max_sort_partition_memory_fraction);
   auto* sample_ptr = sample_op.get();
-  if (op_params_.max_sort_partition_bytes > 0) {
-    sample_ptr->set_max_partition_bytes(op_params_.max_sort_partition_bytes);
-  }
-  sample_ptr->set_max_partition_memory_fraction(op_params_.max_sort_partition_memory_fraction);
 
   // Create SORT_PARTITION operator
   auto partition_op   = duckdb::make_uniq<op::sirius_physical_sort_partition>(order_ptr);

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -741,6 +741,7 @@ void sirius_pipeline_converter::split_order_by_sink(
   if (op_params_.max_sort_partition_bytes > 0) {
     sample_ptr->set_max_partition_bytes(op_params_.max_sort_partition_bytes);
   }
+  sample_ptr->set_max_partition_memory_fraction(op_params_.max_sort_partition_memory_fraction);
 
   // Create SORT_PARTITION operator
   auto partition_op   = duckdb::make_uniq<op::sirius_physical_sort_partition>(order_ptr);
@@ -755,7 +756,7 @@ void sirius_pipeline_converter::split_order_by_sink(
   auto sample_partition_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
   sample_partition_pipeline->source = order_op.get();
   sample_partition_pipeline->operators.push_back(*sample_ptr);
-  sample_partition_pipeline->sink   = partition_ptr;
+  sample_partition_pipeline->sink = partition_ptr;
   scheduled_.push_back(sample_partition_pipeline);
 
   // Create MERGE_SORT operator

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -742,12 +742,6 @@ void sirius_pipeline_converter::split_order_by_sink(
     sample_ptr->set_max_partition_bytes(op_params_.max_sort_partition_bytes);
   }
 
-  // Pipeline B: ORDER (source) -> SORT_SAMPLE (sink)
-  auto sample_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
-  sample_pipeline->source = order_op.get();
-  sample_pipeline->sink   = sample_ptr;
-  scheduled_.push_back(sample_pipeline);
-
   // Create SORT_PARTITION operator
   auto partition_op   = duckdb::make_uniq<op::sirius_physical_sort_partition>(order_ptr);
   auto* partition_ptr = partition_op.get();
@@ -755,11 +749,14 @@ void sirius_pipeline_converter::split_order_by_sink(
   // Wire sort_partition to read boundaries from sort_sample
   partition_ptr->set_sample_op(sample_ptr);
 
-  // Pipeline C: SORT_SAMPLE (source) -> SORT_PARTITION (sink)
-  auto partition_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
-  partition_pipeline->source = sample_ptr;
-  partition_pipeline->sink   = partition_ptr;
-  scheduled_.push_back(partition_pipeline);
+  // Pipeline B: ORDER (source) -> SORT_SAMPLE -> SORT_PARTITION (sink)
+  // Sample and partition run in one gpu_pipeline_task so partition sees sample
+  // boundaries immediately after sample completes on the same batch.
+  auto sample_partition_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
+  sample_partition_pipeline->source = order_op.get();
+  sample_partition_pipeline->operators.push_back(*sample_ptr);
+  sample_partition_pipeline->sink   = partition_ptr;
+  scheduled_.push_back(sample_partition_pipeline);
 
   // Create MERGE_SORT operator
   auto merge_op   = duckdb::make_uniq<op::sirius_physical_merge_sort>(order_ptr);
@@ -785,7 +782,7 @@ void sirius_pipeline_converter::split_order_by_sink(
     }
   }
 
-  // Pipeline D: SORT_PARTITION (source) -> MERGE_SORT (sink)
+  // Pipeline C: SORT_PARTITION (source) -> MERGE_SORT (sink)
   auto merge_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
   merge_pipeline->source = partition_ptr;
   merge_pipeline->sink   = merge_ptr;
@@ -1104,9 +1101,8 @@ void sirius_pipeline_converter::compute_repository_wiring()
              pipeline,
              dependent_pipeline);
       }
-    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY ||
-               pipeline->sink->type == op::SiriusPhysicalOperatorType::SORT_SAMPLE) {
-      // Pipeline barrier — sort operators process batches as they arrive
+    } else if (pipeline->sink->type == op::SiriusPhysicalOperatorType::ORDER_BY) {
+      // Pipeline barrier — downstream sample+partition pipeline processes batches as produced
       // (sort_sample overrides get_next_task_hint to wait for N batches)
       for (auto const& dependent_pipeline : source_to_pipelines[sink_op]) {
         emit("default", op::MemoryBarrierType::PIPELINE, sink_op, pipeline, dependent_pipeline);

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -119,6 +119,9 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("scan_task_batch_size", yaml::bytes(opt.scan_task_batch_size));
   r.optional("default_scan_task_varchar_size", yaml::bytes(opt.default_scan_task_varchar_size));
   r.optional("max_sort_partition_bytes", yaml::bytes(opt.max_sort_partition_bytes));
+  r.optional("max_sort_partition_memory_fraction",
+             opt.max_sort_partition_memory_fraction,
+             yaml::fraction<double>{});
   r.optional("hash_partition_bytes", yaml::bytes(opt.hash_partition_bytes));
   r.optional("concat_batch_bytes", yaml::bytes(opt.concat_batch_bytes));
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1389,6 +1389,22 @@ static void SetMaxSortPartitionBytes(ClientContext& context, SetScope scope, Val
                    params->max_sort_partition_bytes);
 }
 
+static void SetMaxSortPartitionMemoryFraction(ClientContext& context,
+                                              SetScope scope,
+                                              Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  const double fraction = parameter.GetValue<double>();
+  if (fraction < 0.0 || fraction > 1.0) {
+    throw InvalidInputException(
+      "max_sort_partition_memory_fraction must be between 0.0 and 1.0, got {}", fraction);
+  }
+  params->max_sort_partition_memory_fraction = fraction;
+  SIRIUS_LOG_DEBUG("Updated config MAX_SORT_PARTITION_MEMORY_FRACTION to {}",
+                   params->max_sort_partition_memory_fraction);
+}
+
 static void SetHashPartitionBytes(ClientContext& context, SetScope scope, Value& parameter)
 {
   auto* params = get_operator_params(context);
@@ -1557,10 +1573,17 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
 
   // Add in config option for sort partition size
   config.AddExtensionOption("max_sort_partition_bytes",
-                            "Maximum bytes per sort partition (0 = auto based on 33% GPU memory)",
+                            "Maximum bytes per sort partition (0 = auto based on "
+                            "max_sort_partition_memory_fraction of GPU memory)",
                             LogicalType::UBIGINT,
                             Value::UBIGINT(sirius::operator_params{}.max_sort_partition_bytes),
                             SetMaxSortPartitionBytes);
+  config.AddExtensionOption(
+    "max_sort_partition_memory_fraction",
+    "Fraction of available GPU memory per sort partition when max_sort_partition_bytes is 0",
+    LogicalType::DOUBLE,
+    Value::DOUBLE(sirius::operator_params{}.max_sort_partition_memory_fraction),
+    SetMaxSortPartitionMemoryFraction);
 
   // Logging configuration
   config.AddExtensionOption("sirius_log_level",


### PR DESCRIPTION
## Summary
Partial fix for [#424](https://github.com/sirius-db/sirius/issues/424). Addresses two items, the remaining will be done in another PR

1. Coalesce SORT_SAMPLE and SORT_PARTITION into one pipeline
   - Previously the 4-phase ORDER BY sort used four pipelines (ORDER → SORT_SAMPLE → SORT_PARTITION → MERGE_SORT). That added an unnecessary repository hop between operators that are tightly coupled—SORT_PARTITION reads boundaries directly from SORT_SAMPLE via _sample_op.

    - Now it is a 3-pipeline sort: ORDER → [SORT_SAMPLE → SORT_PARTITION] → MERGE_SORT. Sample and partition run in the same gpu_pipeline_task back-to-back on each batch.

2. Configurable sort partition memory fraction
     - Instead of hardcoding `MAX_PARTITION_MEMORY_FRACTION` (which is set to 33% and is used when the `max_sort_partition_bytes` is set to 0), this PR adds a sirius config called the `max_sort_partition_memory_fraction` which can be used to configure this percentage of available GPU memory)
