### PR TITLE
Reduce `pread` calls in DuckDB metadata walk

### DIFF
--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -18,15 +18,18 @@
 
 #include "log/logging.hpp"
 
+#include <nvtx3/nvtx3.hpp>
+
 #include <duckdb/function/partition_stats.hpp>
 #include <duckdb/main/attached_database.hpp>
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/statistics/string_stats.hpp>
 #include <duckdb/storage/storage_manager.hpp>
+#include <duckdb/storage/table/column_data.hpp>
+#include <duckdb/storage/table/row_group.hpp>
+#include <duckdb/storage/table/row_group_collection.hpp>
 #include <duckdb/storage/table_storage_info.hpp>
-
-#include <nvtx3/nvtx3.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -335,7 +338,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
   // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
   // iteration order at v1.5.2 — relied on for indexing by row_group_index.
-  std::vector<duckdb::PartitionStatistics> partition_stats;
+  duckdb::vector<duckdb::PartitionStatistics> partition_stats;
   {
     nvtx3::scoped_range nvtx_ps{"sirius::native_metadata_partition_stats"};
     partition_stats = storage.GetPartitionStats(context);
@@ -362,10 +365,23 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   }
 
   duckdb::QueryContext qc{context};
-  std::vector<duckdb::ColumnSegmentInfo> column_segments;
+  duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
   {
     nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
-    column_segments = storage.GetColumnSegmentInfo(qc);
+    // Read segment metadata for projected columns only. DataTable::GetColumnSegmentInfo
+    // would lazily load every column's segment tree via synchronous BufferManager preads;
+    // per-column GetRawColumnData (GetColumn is private) touches just what we project.
+    auto& row_groups        = *storage.GetRowGroupCollection();
+    auto const n_row_groups = row_groups.GetRowGroupCount();
+    for (std::size_t rg = 0; rg < n_row_groups; ++rg) {
+      auto row_group = row_groups.GetRowGroup(rg);
+      if (!row_group) { continue; }
+      for (auto const& pc : projected_cols) {
+        if (pc.is_rowid) { continue; }
+        row_group->GetRawColumnData(pc.storage_idx)
+          .GetColumnSegmentInfo(qc, rg, {pc.storage_idx.GetPrimaryIndex()}, column_segments);
+      }
+    }
   }
 
   // Size to max_row_group_index + 1 so rowid-only and all-filtered row
@@ -376,7 +392,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     max_rg_idx = std::max(max_rg_idx, seg.row_group_index);
   }
   const std::size_t num_row_groups =
-    column_segments.empty() ? 0 : static_cast<std::size_t>(max_rg_idx) + 1;
+    column_segments.empty() ? handles.size() : static_cast<std::size_t>(max_rg_idx) + 1;
   md.row_groups.resize(num_row_groups);
   for (std::size_t rg = 0; rg < num_row_groups; ++rg) {
     md.row_groups[rg].row_group_index = rg;

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -26,6 +26,8 @@
 #include <duckdb/storage/storage_manager.hpp>
 #include <duckdb/storage/table_storage_info.hpp>
 
+#include <nvtx3/nvtx3.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <charconv>
@@ -302,6 +304,8 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   const std::vector<projected_column>& projected_cols,
   const std::vector<sirius::logical_type>& projected_types)
 {
+  nvtx3::scoped_range nvtx_walk{"sirius::native_metadata_walk"};
+
   duckdb_native_metadata md;
   md.viable = false;
 
@@ -331,7 +335,11 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
   // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
   // iteration order at v1.5.2 — relied on for indexing by row_group_index.
-  auto partition_stats = storage.GetPartitionStats(context);
+  std::vector<duckdb::PartitionStatistics> partition_stats;
+  {
+    nvtx3::scoped_range nvtx_ps{"sirius::native_metadata_partition_stats"};
+    partition_stats = storage.GetPartitionStats(context);
+  }
   row_group_handles handles;
   handles.reserve(partition_stats.size());
   for (std::size_t i = 0; i < partition_stats.size(); ++i) {
@@ -354,7 +362,11 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   }
 
   duckdb::QueryContext qc{context};
-  auto column_segments = storage.GetColumnSegmentInfo(qc);
+  std::vector<duckdb::ColumnSegmentInfo> column_segments;
+  {
+    nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
+    column_segments = storage.GetColumnSegmentInfo(qc);
+  }
 
   // Size to max_row_group_index + 1 so rowid-only and all-filtered row
   // groups still have an entry for rowid synthesis and trailing-empty

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -368,9 +368,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
   {
     nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
-    // Read segment metadata for projected columns only. DataTable::GetColumnSegmentInfo
-    // would lazily load every column's segment tree via synchronous BufferManager preads;
-    // per-column GetRawColumnData (GetColumn is private) touches just what we project.
+    // Read segment metadata for projected columns only.
     auto& row_groups        = *storage.GetRowGroupCollection();
     auto const n_row_groups = row_groups.GetRowGroupCount();
     for (std::size_t rg = 0; rg < n_row_groups; ++rg) {


### PR DESCRIPTION
`walk_duckdb_native_metadata` called `DataTable::GetcolumnSegmentInfo` which fetched segment-tree metadata for all columns, resulting in a large number of small `pread`s. Now it walks only projected columns via `RowGrouopCollection::GetRowGroup` -> `RowGroup::GetRawColumnData` -> `ColumnData::GetColumnSegmentInfo`. This PR also adds NVTX ranges around the walk.

**Results** (cold, SF10 TPC-H, RTX 4070 Ti, local NVMe):

| metric | before | after |
|---|---|---|
| metadata walk | 1405 ms | 681 ms (−52%) |
| metadata preads | 4581 | 1951 (−57%) |
| cold Q6 query | 1579 ms | 863 ms (−45%) |

Note that the metadata walk still dominates runtime at this small scale factor, so...
Follow-up: parallelize the per-row-group parse on the scan manager pool (prototype: ~3.5x faster).