### PR TITLE
Unify scan_plan across parquet and DuckDB-native scans

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_repository_wiring_materializer.cpp
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
+    test/cpp/scan/test_build_scan_plan.cpp
     test/cpp/scan/test_column_builder.cpp
     test/cpp/scan/test_duckdb_block_layout.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp

--- a/src/include/op/scan/duckdb_native_decoder.hpp
+++ b/src/include/op/scan/duckdb_native_decoder.hpp
@@ -52,8 +52,7 @@ class duckdb_native_ingestible_table_info;
 struct duckdb_native_split_payload {
   std::vector<duckdb_row_group_metadata> row_groups;
   /// Stable alias into the ingestible's owned bind data. Carries
-  /// @c storage / @c context / @c projected_cols / @c projected_types that
-  /// the decoder reads.
+  /// @c storage / @c context / @c plan that the decoder reads.
   duckdb_native_ingestible_table_info const* table_info = nullptr;
   /// Sirius IO substrate handles. Set by the regular (non-cached) split
   /// path so the decoder can read .db blocks via @c sirius_ioctx::host_read

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -63,16 +63,14 @@ class duckdb_native_ingestible_table_info : public io::ingestible_table_info {
  public:
   duckdb::vector<sirius::logical_type> returned_types;
   duckdb::vector<duckdb::ColumnIndex> column_ids;
-  duckdb::vector<duckdb::idx_t> projection_ids;
-  duckdb::vector<std::string> names;
   duckdb::unique_ptr<duckdb::TableFilterSet> table_filters;
   std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE;
 
   duckdb::DataTable* storage     = nullptr;
   duckdb::ClientContext* context = nullptr;
-  std::vector<projected_column> projected_cols;
-  std::vector<sirius::logical_type> projected_types;
-  duckdb::vector<sirius::logical_type> output_types;
+  /// Canonical scan plan, built by the pipeline converter. Single source of truth
+  /// for the walker, decoder, filter building, and output assembly.
+  std::shared_ptr<scan_plan const> plan;
   std::string db_path;
 
   duckdb_native_ingestible_table_info() = default;
@@ -120,19 +118,16 @@ class duckdb_native_split_info : public io::scan_info {
 // duckdb_native_post_filter_and_projection_info
 //===----------------------------------------------------------------------===//
 /**
- * @brief Per-split post-decode filter + projection description.
+ * @brief Per-split post-decode filter + assembly description.
  *
- * Emitted by @c duckdb_native_gpu_ingestible whenever the @c table_filters
- * survived translation OR the scan emitted more columns than
- * @c output_types requested (trailing filter-only columns).
- * @c apply_filter triggers the @c gpu_expression_executor pass against the
- * ingestible's shared filter expression; @c output_arity drives the
- * projection-down step.
+ * Emitted when a filter survived translation or the plan needs output assembly.
+ * @c apply_filter runs the filter expression; @c needs_assembly runs
+ * @c assemble_scan_output to reshape the decoded batch to the plan's layout.
  */
 class duckdb_native_post_filter_and_projection_info : public io::post_filter_and_projection_info {
  public:
-  bool apply_filter        = false;
-  std::size_t output_arity = 0;
+  bool apply_filter   = false;
+  bool needs_assembly = false;
 };
 
 //===----------------------------------------------------------------------===//
@@ -169,11 +164,15 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   duckdb_native_metadata _metadata;
   std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
   std::shared_ptr<sirius::io::sirius_io_object> _db_io_object;
+  /// Canonical scan plan, shared from the bind data. Drives filter building
+  /// and post-decode output assembly.
+  std::shared_ptr<scan_plan const> _plan;
   /// Pre-built coalesced filter expression. Empty when no translatable
   /// filters survived. Reused across every emitted split.
   std::shared_ptr<duckdb::Expression> _filter_expression;
-  bool _projection_required = false;
-  std::size_t _output_arity = 0;
+  /// Mirrors needs_output_assembly(*_plan): reshape the decoded batch to the
+  /// plan's output layout post-decode.
+  bool _needs_assembly = false;
 
   std::vector<row_group_batch> _batches;
   std::atomic<std::size_t> _next_batch_idx{0};

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -38,11 +38,7 @@
 
 namespace sirius::op::scan {
 
-/// Synthetic rowid columns carry no `storage_idx`.
-struct projected_column {
-  duckdb::StorageIndex storage_idx;
-  bool is_rowid = false;
-};
+struct scan_plan;  // op/scan/scan_plan.hpp — walker takes it by const ref
 
 /// Mirrors `duckdb::ColumnSegmentInfo` with the compression string resolved
 /// to the enum.
@@ -80,7 +76,7 @@ struct duckdb_row_group_metadata {
   /// Absolute row index of the row group's first row.
   duckdb::idx_t row_group_start;
   duckdb::idx_t row_count;
-  /// Parallel to the walker's `projected_cols` argument.
+  /// Parallel to the plan's `data_columns`.
   std::vector<duckdb_column_metadata> columns;
   std::size_t decoded_bytes_budget = 0;
   /// Parallel to `columns`. For varchar columns: Σ(seg.segment_count ×
@@ -127,8 +123,7 @@ struct duckdb_native_metadata {
 duckdb_native_metadata walk_duckdb_native_metadata(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
-  const std::vector<projected_column>& projected_cols,
-  const std::vector<sirius::logical_type>& projected_types,
+  scan_plan const& plan,
   const duckdb::TableFilterSet* table_filters           = nullptr,
   const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr);
 

--- a/src/include/op/scan/scan_plan.hpp
+++ b/src/include/op/scan/scan_plan.hpp
@@ -61,14 +61,25 @@ namespace sirius::op::scan {
 struct scan_plan {
   /// A column produced by the reader, in batch order.
   struct data_column {
-    std::size_t primary_idx;  ///< P — index into the DuckDB schema. Holds DuckDB's rowid
-                              ///<     sentinel when @c is_rowid.
+    /// Decode info the reader-typed (duckdb-native) path needs per column. Set as
+    /// a unit or not at all: parquet/pinned leave it empty and let the reader
+    /// resolve types from the file itself.
+    struct reader_decode_info {
+      sirius::logical_type type;  ///< Logical type the decoder and walker read.
+      bool is_rowid = false;      ///< true for a synthesized rowid column.
+    };
+
+    std::size_t primary_idx;  ///< P — index into the DuckDB schema. Holds DuckDB's
+                              ///<     rowid sentinel when @c reader_info->is_rowid.
     std::string name;         ///< reader column name. Empty for rowid and the plain-read case.
-    bool is_rowid = false;    ///< true for a synthesized rowid column (duckdb-native only).
-    std::optional<sirius::logical_type>
-      type;  ///< Logical type, set via @c build_scan_plan_options::type_for.
-             ///< @c nullopt when the reader resolves types itself.
+    std::optional<reader_decode_info> reader_info;  ///< Set only on the reader-typed path.
   };
+
+  // FUTURE: duckdb-native is the only reader that needs per-column decode info
+  // today, so data_column::reader_info is a plain optional. When a second reader
+  // needs its own (e.g. ORC/Arrow codec or dictionary state), promote reader_info
+  // to a std::variant. Define each format's arm as its own type beside that
+  // format's reader — not nested in scan_plan — so the formats stay decoupled.
 
   /// A column synthesized from the file path, injected after read.
   struct partition_column {
@@ -177,13 +188,14 @@ struct scan_plan {
 
 /// Optional knobs for @ref build_scan_plan; the duckdb-native scan opts in.
 struct build_scan_plan_options {
-  /// When true, rowid columns are kept in @c data_columns (flagged @c is_rowid)
-  /// and @c output_layout for the reader to synthesize, instead of dropped.
+  /// When true, rowid columns are kept in @c data_columns (flagged via
+  /// @c reader_info->is_rowid) and @c output_layout for the reader to
+  /// synthesize, instead of dropped.
   bool decode_rowid_columns = false;
 
-  /// Resolves each column's logical type into @c data_column::type; empty leaves
-  /// types @c nullopt. Receives the @c ColumnIndex so the caller can special-case
-  /// rowid, which has no @c returned_types slot.
+  /// Resolves each column's logical type into its @c reader_decode_info; empty
+  /// leaves @c reader_info unset. Receives the @c ColumnIndex so the caller can
+  /// special-case rowid, which has no @c returned_types slot.
   std::function<std::optional<sirius::logical_type>(duckdb::ColumnIndex const&)> type_for = {};
 };
 

--- a/src/include/op/scan/scan_plan.hpp
+++ b/src/include/op/scan/scan_plan.hpp
@@ -31,6 +31,7 @@
 // standard library
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -39,28 +40,34 @@
 namespace sirius::op::scan {
 
 /**
- * @brief Canonical plan for a parquet-style scan.
+ * @brief Canonical plan for a file-format scan.
  *
- * Built once by the scan operator from DuckDB planner inputs (column_ids,
- * projection_ids, names, returned_types, partition_indices). All downstream
- * consumers — reader column projection, filter-expression building, hive
- * injection, post-filter output assembly — read from this single structure
- * instead of maintaining parallel vectors.
+ * Format-agnostic: the same structure drives the parquet scan and the
+ * DuckDB-native scan. Built once by the scan operator from DuckDB planner inputs
+ * (column_ids, projection_ids, names, returned_types, partition_indices). All
+ * downstream consumers — reader column projection, filter-expression building,
+ * partition injection, post-filter output assembly — read from this single
+ * structure instead of maintaining parallel vectors.
  *
  * Three index spaces appear throughout the scan pipeline:
  *   P = primary index       (position in DuckDB's full schema @c names / @c returned_types)
  *   C = column_ids position (position in the operator's @c column_ids list)
- *   D = batch position      (position in the reader's output table, after hive removal)
+ *   D = batch position      (position in the reader's output table, after partition removal)
  *
- * Hive-partition columns live in P-space but are not in the parquet file, so
+ * Hive-partition columns live in P-space but are not stored in the data file, so
  * they never appear in D-space. They are injected post-read into the final
  * output in the order column_ids expects.
  */
 struct scan_plan {
-  /// A column produced by the parquet reader, in batch order.
+  /// A column produced by the reader, in batch order.
   struct data_column {
-    std::size_t primary_idx;  ///< P — index into the DuckDB schema
-    std::string name;         ///< parquet column name
+    std::size_t primary_idx;  ///< P — index into the DuckDB schema. Holds DuckDB's rowid
+                              ///<     sentinel when @c is_rowid.
+    std::string name;         ///< reader column name. Empty for rowid and the plain-read case.
+    bool is_rowid = false;    ///< true for a synthesized rowid column (duckdb-native only).
+    std::optional<sirius::logical_type>
+      type;  ///< Logical type, set via @c build_scan_plan_options::type_for.
+             ///< @c nullopt when the reader resolves types itself.
   };
 
   /// A column synthesized from the file path, injected after read.
@@ -78,7 +85,7 @@ struct scan_plan {
       idx;  ///< index into @c data_columns (if DATA) or @c partition_columns (if PARTITION)
   };
 
-  /// Columns read from parquet, in D order.
+  /// Columns produced by the reader, in D order.
   std::vector<data_column> data_columns;
 
   /// Partition columns injected post-read.
@@ -93,7 +100,7 @@ struct scan_plan {
 
   /// Primary indices of hive-partition columns. Supplied to
   /// @c convert_table_filters_to_expression so those filters are dropped
-  /// from pushdown (they aren't in the parquet file).
+  /// from pushdown (they aren't stored in the data file).
   std::unordered_set<std::size_t> partition_primary_indices;
 
   /// True iff the reader needs explicit column projection — set when the planner
@@ -118,7 +125,7 @@ struct scan_plan {
   /// and as the D-indexed resolver for AST filter translation.
   [[nodiscard]] std::vector<std::string> data_column_names() const;
 
-  /// Resolve a D-space index to a parquet column name, for use as the AST
+  /// Resolve a D-space index to a reader column name, for use as the AST
   /// translator's name resolver.
   [[nodiscard]] std::string batch_column_name(duckdb::idx_t batch_position) const;
 
@@ -168,6 +175,18 @@ struct scan_plan {
   std::vector<std::string> const& partition_values,
   rmm::cuda_stream_view stream);
 
+/// Optional knobs for @ref build_scan_plan; the duckdb-native scan opts in.
+struct build_scan_plan_options {
+  /// When true, rowid columns are kept in @c data_columns (flagged @c is_rowid)
+  /// and @c output_layout for the reader to synthesize, instead of dropped.
+  bool decode_rowid_columns = false;
+
+  /// Resolves each column's logical type into @c data_column::type; empty leaves
+  /// types @c nullopt. Receives the @c ColumnIndex so the caller can special-case
+  /// rowid, which has no @c returned_types slot.
+  std::function<std::optional<sirius::logical_type>(duckdb::ColumnIndex const&)> type_for = {};
+};
+
 /// Build a scan_plan from DuckDB planner inputs. See @c scan_plan for semantics.
 ///
 /// @param column_ids          Column ids exposed by the table function.
@@ -183,11 +202,13 @@ struct scan_plan {
 /// @param partition_indices   Hive partition indices advertised by the bind data.
 ///                            TODO: other partition indices may need to be supported for other
 ///                            formats.
+/// @param options             Optional knobs (rowid routing, type resolution).
 scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
                           duckdb::vector<duckdb::idx_t> const& projection_ids,
                           duckdb::vector<std::string> const& names,
                           duckdb::vector<sirius::logical_type> const& returned_types,
                           std::size_t output_types_size,
-                          duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices);
+                          duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices,
+                          build_scan_plan_options const& options = {});
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -849,13 +849,13 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
 
   for (std::size_t ci = 0; ci < num_cols; ++ci) {
     auto const& dc = plan.data_columns[ci];
-    if (dc.is_rowid) {
+    if (dc.reader_info->is_rowid) {
       is_rowid_col[ci] = true;
       staged_cols.emplace_back();
       staged_cols.back().total_rows = total_rows;
       continue;
     }
-    if (dc.type->is_varchar()) {
+    if (dc.reader_info->type.is_varchar()) {
       staged_cols.push_back(
         stage_one_varchar_column(staging, db, block_manager, *sf_bm, split.row_groups, ci));
     } else {
@@ -867,7 +867,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
                                                          owned_stats_cache,
                                                          split.row_groups,
                                                          ci,
-                                                         *dc.type));
+                                                         dc.reader_info->type));
     }
   }
 
@@ -923,7 +923,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
       vc_to_final_idx.push_back(ci);
     } else {
       gpu_column_decode_input input;
-      input.out_type   = sirius_to_cudf_type(*plan.data_columns[ci].type);
+      input.out_type   = sirius_to_cudf_type(plan.data_columns[ci].reader_info->type);
       input.total_rows = static_cast<uint32_t>(staged.total_rows);
       input.has_nulls  = staged.has_nulls;
       fill_fixed_width_runs(staged.data, device_buf, input.data);

--- a/src/op/scan/duckdb_native_decoder.cpp
+++ b/src/op/scan/duckdb_native_decoder.cpp
@@ -24,6 +24,7 @@
 #include "io/types.hpp"
 #include "op/scan/duckdb_block_layout.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
+#include "op/scan/scan_plan.hpp"
 #include "sirius_context.hpp"
 
 #include <cudf/column/column.hpp>
@@ -829,7 +830,8 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
 
   auto mr_ref = mem_space.get_default_allocator();
 
-  std::size_t const num_cols = scan_info.projected_cols.size();
+  auto const& plan           = *scan_info.plan;
+  std::size_t const num_cols = plan.data_columns.size();
 
   std::size_t total_rows = 0;
   for (auto const& rg : split.row_groups) {
@@ -846,14 +848,14 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
   std::vector<bool> is_rowid_col(num_cols, false);
 
   for (std::size_t ci = 0; ci < num_cols; ++ci) {
-    auto const& pcol = scan_info.projected_cols[ci];
-    if (pcol.is_rowid) {
+    auto const& dc = plan.data_columns[ci];
+    if (dc.is_rowid) {
       is_rowid_col[ci] = true;
       staged_cols.emplace_back();
       staged_cols.back().total_rows = total_rows;
       continue;
     }
-    if (scan_info.projected_types[ci].is_varchar()) {
+    if (dc.type->is_varchar()) {
       staged_cols.push_back(
         stage_one_varchar_column(staging, db, block_manager, *sf_bm, split.row_groups, ci));
     } else {
@@ -865,7 +867,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
                                                          owned_stats_cache,
                                                          split.row_groups,
                                                          ci,
-                                                         scan_info.projected_types[ci]));
+                                                         *dc.type));
     }
   }
 
@@ -921,7 +923,7 @@ std::unique_ptr<cudf::table> decode_duckdb_native_split(duckdb_native_split_payl
       vc_to_final_idx.push_back(ci);
     } else {
       gpu_column_decode_input input;
-      input.out_type   = sirius_to_cudf_type(scan_info.projected_types[ci]);
+      input.out_type   = sirius_to_cudf_type(*plan.data_columns[ci].type);
       input.total_rows = static_cast<uint32_t>(staged.total_rows);
       input.has_nulls  = staged.has_nulls;
       fill_fixed_width_runs(staged.data, device_buf, input.data);

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -62,7 +62,7 @@ std::vector<row_group_batch_local> partition_row_groups_into_batches(
   std::vector<bool> is_varchar(num_cols, false);
   bool any_varchar = false;
   for (std::size_t c = 0; c < num_cols; ++c) {
-    is_varchar[c] = plan.data_columns[c].type->is_varchar();
+    is_varchar[c] = plan.data_columns[c].reader_info->type.is_varchar();
     any_varchar   = any_varchar || is_varchar[c];
   }
 

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -21,6 +21,7 @@
 #include <log/logging.hpp>
 #include <op/scan/duckdb_native_decoder.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/scan_plan.hpp>
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
@@ -52,16 +53,16 @@ struct row_group_batch_local {
 std::vector<row_group_batch_local> partition_row_groups_into_batches(
   const std::vector<duckdb_row_group_metadata>& row_groups,
   std::size_t approximate_batch_size,
-  const std::vector<sirius::logical_type>& projected_types)
+  scan_plan const& plan)
 {
   std::vector<row_group_batch_local> batches;
   if (row_groups.empty()) return batches;
 
-  const std::size_t num_cols = projected_types.size();
+  const std::size_t num_cols = plan.data_columns.size();
   std::vector<bool> is_varchar(num_cols, false);
   bool any_varchar = false;
   for (std::size_t c = 0; c < num_cols; ++c) {
-    is_varchar[c] = projected_types[c].is_varchar();
+    is_varchar[c] = plan.data_columns[c].type->is_varchar();
     any_varchar   = any_varchar || is_varchar[c];
   }
 
@@ -144,19 +145,15 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
     throw std::invalid_argument(
       "[duckdb_native_gpu_ingestible] table_info.context must be non-null");
   }
-  if (bind.projected_cols.size() != bind.projected_types.size()) {
-    throw std::invalid_argument(
-      "[duckdb_native_gpu_ingestible] projected_cols and projected_types must be parallel");
+  if (!bind.plan) {
+    throw std::invalid_argument("[duckdb_native_gpu_ingestible] table_info.plan must be non-null");
   }
+  _plan = bind.plan;
 
   // Walk metadata once. Pushed-down filters drive row-group pruning in the walk;
   // column_ids maps each filter to its storage index.
-  _metadata = walk_duckdb_native_metadata(*bind.storage,
-                                          *bind.context,
-                                          bind.projected_cols,
-                                          bind.projected_types,
-                                          bind.table_filters.get(),
-                                          &bind.column_ids);
+  _metadata = walk_duckdb_native_metadata(
+    *bind.storage, *bind.context, *_plan, bind.table_filters.get(), &bind.column_ids);
   if (!_metadata.viable) {
     SPDLOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}",
                  _metadata.viability_failure_reason);
@@ -165,43 +162,27 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
   }
 
   // Mint the .db io_object once per query when the manager exposes a
-  // backend for db_path (matches duckdb_native_split_provider).
+  // backend for db_path.
   _io_ctx = !bind.db_path.empty() ? mgr.io_ctx_shared_for(bind.db_path) : nullptr;
   if (_io_ctx && !bind.db_path.empty()) { _db_io_object = _io_ctx->create_io_object(bind.db_path); }
 
-  // Pre-build the coalesced filter expression once.
+  // Pre-build the coalesced filter expression once. The plan's C → D map resolves
+  // each filter column to its batch position (rowid included).
   if (bind.table_filters && !bind.table_filters->filters.empty()) {
-    duckdb::vector<duckdb::idx_t> source_ids_fallback;
-    if (bind.projection_ids.empty()) {
-      source_ids_fallback.reserve(bind.column_ids.size());
-      for (duckdb::idx_t i = 0; i < bind.column_ids.size(); ++i) {
-        source_ids_fallback.push_back(i);
-      }
-    }
-    auto const& source_ids =
-      bind.projection_ids.empty() ? source_ids_fallback : bind.projection_ids;
-
-    std::vector<std::optional<std::size_t>> emission_order_map(bind.column_ids.size());
-    for (std::size_t k = 0; k < source_ids.size(); ++k) {
-      emission_order_map[source_ids[k]] = k;
-    }
-
-    auto filter_expr_duckdb = sirius::op::convert_table_filters_to_expression(
-      *bind.table_filters, bind.column_ids, bind.returned_types, emission_order_map);
+    auto filter_expr_duckdb =
+      sirius::op::convert_table_filters_to_expression(*bind.table_filters,
+                                                      bind.column_ids,
+                                                      bind.returned_types,
+                                                      _plan->batch_position_by_column_id);
     if (filter_expr_duckdb) {
       _filter_expression = std::shared_ptr<duckdb::Expression>(filter_expr_duckdb.release());
     }
   }
 
-  // Decoder emits one column per source_id; projection-down is needed when
-  // the planner injected pure-filter trailing columns beyond output_types.
-  std::size_t const decoded_cols =
-    bind.projection_ids.empty() ? bind.column_ids.size() : bind.projection_ids.size();
-  _output_arity        = bind.output_types.size();
-  _projection_required = (_output_arity > 0) && (decoded_cols > _output_arity);
+  _needs_assembly = needs_output_assembly(*_plan);
 
-  auto batches = partition_row_groups_into_batches(
-    _metadata.row_groups, bind.approximate_batch_size, bind.projected_types);
+  auto batches =
+    partition_row_groups_into_batches(_metadata.row_groups, bind.approximate_batch_size, *_plan);
   _batches.reserve(batches.size());
   for (auto const& b : batches) {
     _batches.push_back({b.first_idx, b.count});
@@ -226,11 +207,10 @@ duckdb_native_gpu_ingestible::next_split_provider()
   row_group_batch claimed = _batches[idx];
 
   bool const apply_filter        = static_cast<bool>(_filter_expression);
-  bool const has_post_processing = apply_filter || _projection_required;
-  std::size_t const output_arity = _output_arity;
-  bool const projection_required = _projection_required;
+  bool const needs_assembly      = _needs_assembly;
+  bool const has_post_processing = apply_filter || needs_assembly;
 
-  return [this, claimed, apply_filter, projection_required, output_arity, has_post_processing]()
+  return [this, claimed, apply_filter, needs_assembly, has_post_processing]()
            -> std::vector<std::unique_ptr<op::operator_data>> {
     auto split_info = std::make_unique<duckdb_native_split_info>();
     split_info->payload.table_info =
@@ -244,10 +224,10 @@ duckdb_native_gpu_ingestible::next_split_provider()
 
     std::unique_ptr<io::post_filter_and_projection_info> filter_info;
     if (has_post_processing) {
-      auto pf          = std::make_unique<duckdb_native_post_filter_and_projection_info>();
-      pf->apply_filter = apply_filter;
-      pf->output_arity = projection_required ? output_arity : 0;
-      filter_info      = std::move(pf);
+      auto pf            = std::make_unique<duckdb_native_post_filter_and_projection_info>();
+      pf->apply_filter   = apply_filter;
+      pf->needs_assembly = needs_assembly;
+      filter_info        = std::move(pf);
     }
 
     auto metadata =
@@ -304,14 +284,10 @@ std::unique_ptr<cudf::table> duckdb_native_gpu_ingestible::post_filter_and_proje
     input    = exec.select(src->view());
   }
 
-  if (pf.output_arity > 0 && static_cast<std::size_t>(input->num_columns()) > pf.output_arity) {
-    auto cols = input->release();
-    std::vector<std::unique_ptr<cudf::column>> selected;
-    selected.reserve(pf.output_arity);
-    for (std::size_t i = 0; i < pf.output_arity; ++i) {
-      selected.push_back(std::move(cols[i]));
-    }
-    input = std::make_unique<cudf::table>(std::move(selected));
+  // Reshape the decoder's D-order batch to the plan's output layout: drop
+  // pure-filter columns and reorder to the operator's expected output.
+  if (pf.needs_assembly) {
+    input = assemble_scan_output(*_plan, std::move(input), /*partition_values=*/{}, stream);
   }
 
   return input;

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -17,6 +17,7 @@
 #include "op/scan/duckdb_native_metadata.hpp"
 
 #include "log/logging.hpp"
+#include "op/scan/scan_plan.hpp"
 
 #include <nvtx3/nvtx3.hpp>
 
@@ -199,8 +200,7 @@ void compute_row_counts(duckdb_native_metadata& md,
 
 // Per-segment exact: chars + offsets. Walker refuse-on-absent guarantees
 // every VARCHAR data segment carries Some here.
-void compute_decoded_byte_budgets(duckdb_native_metadata& md,
-                                  const std::vector<sirius::logical_type>& projected_types)
+void compute_decoded_byte_budgets(duckdb_native_metadata& md, scan_plan const& plan)
 {
   for (auto& rg_md : md.row_groups) {
     std::size_t budget = 0;
@@ -210,7 +210,8 @@ void compute_decoded_byte_budgets(duckdb_native_metadata& md,
         budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
         continue;
       }
-      if (projected_types[ci].is_varchar()) {
+      auto const& type = *plan.data_columns[ci].type;
+      if (type.is_varchar()) {
         std::size_t chars_total = 0;
         for (const auto& seg : col_md.data_segments) {
           chars_total += static_cast<std::size_t>(seg.segment_count) *
@@ -218,8 +219,7 @@ void compute_decoded_byte_budgets(duckdb_native_metadata& md,
         }
         budget += chars_total + static_cast<std::size_t>(rg_md.row_count) * sizeof(std::uint32_t);
       } else {
-        budget +=
-          static_cast<std::size_t>(rg_md.row_count) * projected_types[ci].fixed_width_byte_size();
+        budget += static_cast<std::size_t>(rg_md.row_count) * type.fixed_width_byte_size();
       }
     }
     rg_md.decoded_bytes_budget = budget;
@@ -360,8 +360,7 @@ bool is_supported_validity_compression(duckdb::CompressionType c)
 duckdb_native_metadata walk_duckdb_native_metadata(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
-  const std::vector<projected_column>& projected_cols,
-  const std::vector<sirius::logical_type>& projected_types,
+  scan_plan const& plan,
   const duckdb::TableFilterSet* table_filters,
   const duckdb::vector<duckdb::ColumnIndex>* column_ids)
 {
@@ -375,21 +374,16 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused: {}", md.viability_failure_reason);
   };
 
-  if (projected_cols.empty()) {
+  if (plan.data_columns.empty()) {
     refuse("no projected columns");
     return md;
   }
-  if (projected_cols.size() != projected_types.size()) {
-    refuse("projected_cols and projected_types size mismatch");
-    return md;
-  }
 
-  for (std::size_t ci = 0; ci < projected_types.size(); ++ci) {
-    if (projected_cols[ci].is_rowid) { continue; }
+  for (auto const& dc : plan.data_columns) {
+    if (dc.is_rowid) { continue; }
     std::string reason;
-    if (!is_supported_logical_type(projected_types[ci], reason)) {
-      refuse("column " + std::to_string(projected_cols[ci].storage_idx.GetPrimaryIndex()) + ": " +
-             reason);
+    if (!is_supported_logical_type(*dc.type, reason)) {
+      refuse("column " + std::to_string(dc.primary_idx) + ": " + reason);
       return md;
     }
   }
@@ -416,10 +410,10 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
   // O(1) skip for non-projected columns in the GetColumnSegmentInfo loop.
   std::unordered_map<duckdb::idx_t, std::size_t> projected_lookup;
-  projected_lookup.reserve(projected_cols.size());
-  for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-    if (projected_cols[ci].is_rowid) { continue; }
-    projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
+  projected_lookup.reserve(plan.data_columns.size());
+  for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
+    if (plan.data_columns[ci].is_rowid) { continue; }
+    projected_lookup.emplace(plan.data_columns[ci].primary_idx, ci);
   }
 
   duckdb::QueryContext qc{context};
@@ -432,10 +426,11 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     for (std::size_t rg = 0; rg < n_row_groups; ++rg) {
       auto row_group = row_groups.GetRowGroup(rg);
       if (!row_group) { continue; }
-      for (auto const& pc : projected_cols) {
-        if (pc.is_rowid) { continue; }
-        row_group->GetRawColumnData(pc.storage_idx)
-          .GetColumnSegmentInfo(qc, rg, {pc.storage_idx.GetPrimaryIndex()}, column_segments);
+      for (auto const& dc : plan.data_columns) {
+        if (dc.is_rowid) { continue; }
+        duckdb::StorageIndex const storage_idx(dc.primary_idx);
+        row_group->GetRawColumnData(storage_idx)
+          .GetColumnSegmentInfo(qc, rg, {dc.primary_idx}, column_segments);
       }
     }
   }
@@ -452,12 +447,12 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   md.row_groups.resize(num_row_groups);
   for (std::size_t rg = 0; rg < num_row_groups; ++rg) {
     md.row_groups[rg].row_group_index = rg;
-    md.row_groups[rg].columns.resize(projected_cols.size());
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
+    md.row_groups[rg].columns.resize(plan.data_columns.size());
+    for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
+      auto const& dc = plan.data_columns[ci];
       md.row_groups[rg].columns[ci].column_id =
-        projected_cols[ci].is_rowid ? std::numeric_limits<duckdb::idx_t>::max()
-                                    : projected_cols[ci].storage_idx.GetPrimaryIndex();
-      md.row_groups[rg].columns[ci].is_rowid = projected_cols[ci].is_rowid;
+        dc.is_rowid ? std::numeric_limits<duckdb::idx_t>::max() : dc.primary_idx;
+      md.row_groups[rg].columns[ci].is_rowid = dc.is_rowid;
     }
     if (rg < handles.size()) { md.row_groups[rg].row_group_start = handles[rg].first; }
   }
@@ -481,7 +476,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
     auto desc = build_segment_descriptor(seg, compression);
 
-    if (!validity_seg && projected_types[ci].is_varchar()) {
+    if (!validity_seg && plan.data_columns[ci].type->is_varchar()) {
       // Refuse on absent stat so downstream consumers can deref unchecked.
       // Some(0) is legal data (all-empty row group); decode produces 0 chars.
       desc.max_string_length = parse_segment_max_string_length(seg.segment_stats);
@@ -506,9 +501,10 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   for (std::size_t rg_idx = 0; rg_idx < handles.size(); ++rg_idx) {
     auto& prg = handles[rg_idx].second;
     if (!prg) { continue; }
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
-      auto stats = prg->GetColumnStatistics(projected_cols[ci].storage_idx);
+    for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
+      auto const& dc = plan.data_columns[ci];
+      if (dc.is_rowid || !dc.type->is_varchar()) { continue; }
+      auto stats = prg->GetColumnStatistics(duckdb::StorageIndex(dc.primary_idx));
       if (!stats || !duckdb::StringStats::HasMaxStringLength(*stats)) { continue; }
       const auto rg_typed_max   = duckdb::StringStats::MaxStringLength(*stats);
       const auto& data_segs     = md.row_groups[rg_idx].columns[ci].data_segments;
@@ -541,7 +537,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     md, storage.GetAttached().GetStorageManager().GetBlockManager().GetBlockSize());
 
   compute_row_counts(md, partition_stats);
-  compute_decoded_byte_budgets(md, projected_types);
+  compute_decoded_byte_budgets(md, plan);
 
   // Row-group pruning
   if (table_filters != nullptr && !table_filters->filters.empty() && column_ids != nullptr &&
@@ -557,9 +553,9 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   // per-column upper bound hits the cudf int32 chars threshold (cudf
   // throws there in default-mode make_offsets_child_column).
   for (auto& rg : md.row_groups) {
-    rg.varchar_bytes_per_col.assign(projected_cols.size(), 0);
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
+    rg.varchar_bytes_per_col.assign(plan.data_columns.size(), 0);
+    for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
+      if (plan.data_columns[ci].is_rowid || !plan.data_columns[ci].type->is_varchar()) { continue; }
       std::size_t total = 0;
       for (const auto& seg : rg.columns[ci].data_segments) {
         total += static_cast<std::size_t>(seg.segment_count) *
@@ -587,7 +583,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     "[duckdb_native_metadata] walked {} row groups across {} projected columns; "
     "stats-pruned {} row groups (~{} decoded bytes); viable=true",
     md.row_groups.size(),
-    projected_cols.size(),
+    plan.data_columns.size(),
     md.pruned_row_groups,
     md.pruned_decoded_bytes);
   return md;

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -210,7 +210,7 @@ void compute_decoded_byte_budgets(duckdb_native_metadata& md, scan_plan const& p
         budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
         continue;
       }
-      auto const& type = *plan.data_columns[ci].type;
+      auto const& type = plan.data_columns[ci].reader_info->type;
       if (type.is_varchar()) {
         std::size_t chars_total = 0;
         for (const auto& seg : col_md.data_segments) {
@@ -380,9 +380,9 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   }
 
   for (auto const& dc : plan.data_columns) {
-    if (dc.is_rowid) { continue; }
+    if (dc.reader_info->is_rowid) { continue; }
     std::string reason;
-    if (!is_supported_logical_type(*dc.type, reason)) {
+    if (!is_supported_logical_type(dc.reader_info->type, reason)) {
       refuse("column " + std::to_string(dc.primary_idx) + ": " + reason);
       return md;
     }
@@ -412,7 +412,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   std::unordered_map<duckdb::idx_t, std::size_t> projected_lookup;
   projected_lookup.reserve(plan.data_columns.size());
   for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
-    if (plan.data_columns[ci].is_rowid) { continue; }
+    if (plan.data_columns[ci].reader_info->is_rowid) { continue; }
     projected_lookup.emplace(plan.data_columns[ci].primary_idx, ci);
   }
 
@@ -427,7 +427,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
       auto row_group = row_groups.GetRowGroup(rg);
       if (!row_group) { continue; }
       for (auto const& dc : plan.data_columns) {
-        if (dc.is_rowid) { continue; }
+        if (dc.reader_info->is_rowid) { continue; }
         duckdb::StorageIndex const storage_idx(dc.primary_idx);
         row_group->GetRawColumnData(storage_idx)
           .GetColumnSegmentInfo(qc, rg, {dc.primary_idx}, column_segments);
@@ -451,8 +451,8 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
       auto const& dc = plan.data_columns[ci];
       md.row_groups[rg].columns[ci].column_id =
-        dc.is_rowid ? std::numeric_limits<duckdb::idx_t>::max() : dc.primary_idx;
-      md.row_groups[rg].columns[ci].is_rowid = dc.is_rowid;
+        dc.reader_info->is_rowid ? std::numeric_limits<duckdb::idx_t>::max() : dc.primary_idx;
+      md.row_groups[rg].columns[ci].is_rowid = dc.reader_info->is_rowid;
     }
     if (rg < handles.size()) { md.row_groups[rg].row_group_start = handles[rg].first; }
   }
@@ -476,7 +476,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
     auto desc = build_segment_descriptor(seg, compression);
 
-    if (!validity_seg && plan.data_columns[ci].type->is_varchar()) {
+    if (!validity_seg && plan.data_columns[ci].reader_info->type.is_varchar()) {
       // Refuse on absent stat so downstream consumers can deref unchecked.
       // Some(0) is legal data (all-empty row group); decode produces 0 chars.
       desc.max_string_length = parse_segment_max_string_length(seg.segment_stats);
@@ -503,7 +503,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     if (!prg) { continue; }
     for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
       auto const& dc = plan.data_columns[ci];
-      if (dc.is_rowid || !dc.type->is_varchar()) { continue; }
+      if (dc.reader_info->is_rowid || !dc.reader_info->type.is_varchar()) { continue; }
       auto stats = prg->GetColumnStatistics(duckdb::StorageIndex(dc.primary_idx));
       if (!stats || !duckdb::StringStats::HasMaxStringLength(*stats)) { continue; }
       const auto rg_typed_max   = duckdb::StringStats::MaxStringLength(*stats);
@@ -555,7 +555,10 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   for (auto& rg : md.row_groups) {
     rg.varchar_bytes_per_col.assign(plan.data_columns.size(), 0);
     for (std::size_t ci = 0; ci < plan.data_columns.size(); ++ci) {
-      if (plan.data_columns[ci].is_rowid || !plan.data_columns[ci].type->is_varchar()) { continue; }
+      if (plan.data_columns[ci].reader_info->is_rowid ||
+          !plan.data_columns[ci].reader_info->type.is_varchar()) {
+        continue;
+      }
       std::size_t total = 0;
       for (const auto& seg : rg.columns[ci].data_segments) {
         total += static_cast<std::size_t>(seg.segment_count) *

--- a/src/op/scan/scan_plan.cpp
+++ b/src/op/scan/scan_plan.cpp
@@ -227,8 +227,13 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
       scan_plan::data_column dc;
       dc.primary_idx = primary_idx;
       dc.name        = (is_rowid || names.empty()) ? std::string{} : names.at(primary_idx);
-      dc.is_rowid    = is_rowid;
-      if (options.type_for) { dc.type = options.type_for(col_idx); }
+      // Reader-typed path: carry the per-column type and rowid flag as a unit.
+      // type_for must resolve a type for every such column (checked below).
+      if (options.type_for) {
+        if (auto type = options.type_for(col_idx)) {
+          dc.reader_info = scan_plan::data_column::reader_decode_info{std::move(*type), is_rowid};
+        }
+      }
       plan.data_columns.push_back(std::move(dc));
       primary_to_batch[primary_idx] = batch_idx;
       if (is_output) {
@@ -267,14 +272,14 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
     plan.batch_position_by_column_id[c] = it->second;
   }
 
-  // On the reader-typed path every data column must carry a type (the
+  // On the reader-typed path every data column must carry reader_decode_info (the
   // decoder/walker dereference it); fail here rather than deref nullopt later.
   if (options.decode_rowid_columns || options.type_for) {
     for (auto const& dc : plan.data_columns) {
-      if (!dc.type.has_value()) {
+      if (!dc.reader_info.has_value()) {
         throw sirius::internal_exception(
-          "[build_scan_plan] data column (primary_idx {}) has no logical type; the reader-typed "
-          "scan_plan path requires options.type_for to resolve every column.",
+          "[build_scan_plan] data column (primary_idx {}) has no reader_decode_info; the "
+          "reader-typed scan_plan path requires options.type_for to resolve every column.",
           dc.primary_idx);
       }
     }

--- a/src/op/scan/scan_plan.cpp
+++ b/src/op/scan/scan_plan.cpp
@@ -159,7 +159,8 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
                           duckdb::vector<std::string> const& names,
                           duckdb::vector<sirius::logical_type> const& returned_types,
                           std::size_t output_types_size,
-                          duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices)
+                          duckdb::vector<duckdb::HivePartitioningIndex> const& partition_indices,
+                          build_scan_plan_options const& options)
 {
   scan_plan plan;
 
@@ -190,11 +191,23 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
   std::unordered_map<std::size_t, std::size_t> primary_to_batch;  // P → D
 
   auto handle_position = [&](std::size_t column_ids_pos, bool is_output) {
-    auto const primary_idx = column_ids.at(column_ids_pos).GetPrimaryIndex();
-    if (duckdb::IsVirtualColumn(primary_idx)) { return; }
+    auto const& col_idx    = column_ids.at(column_ids_pos);
+    auto const primary_idx = col_idx.GetPrimaryIndex();
+
+    // Rowid becomes a data column only when the reader can synthesize it
+    // (decode_rowid_columns). Other virtual columns are never decodable and are
+    // always dropped.
+    bool const is_rowid = col_idx.IsRowIdColumn();
+    if (is_rowid) {
+      if (!options.decode_rowid_columns) { return; }
+    } else if (duckdb::IsVirtualColumn(primary_idx)) {
+      return;
+    }
+    // Rowid carries DuckDB's sentinel primary index, so two rowid references
+    // collapse to one batch column (both output_layout entries point at it).
     if (!seen_primary_indices.insert(primary_idx).second) { return; }
 
-    bool const is_partition = plan.partition_primary_indices.count(primary_idx) > 0;
+    bool const is_partition = !is_rowid && plan.partition_primary_indices.count(primary_idx) > 0;
 
     if (is_partition) {
       // Filter-only partition columns are dropped: DuckDB prunes at the file
@@ -207,14 +220,16 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
       plan.output_layout.push_back(
         scan_plan::output_entry{scan_plan::output_entry::PARTITION, partition_cols_idx});
     } else {
-      // Data column — always added to the batch (even if filter-only, we need
-      // it for filter evaluation). Store an empty name when @c names is empty:
-      // the caller's guard only forces non-empty names for name-dependent paths
-      // (projection, filter, partitions), and the plain-read case populates
-      // data_columns without ever consuming the name downstream.
+      // Data column — always added to the batch (filter-only columns are read for
+      // filter evaluation). Empty name for rowid (no schema slot) or when @c names
+      // is empty (the plain-read case never consumes it).
       auto const batch_idx = plan.data_columns.size();
-      std::string col_name = names.empty() ? std::string{} : names.at(primary_idx);
-      plan.data_columns.push_back(scan_plan::data_column{primary_idx, std::move(col_name)});
+      scan_plan::data_column dc;
+      dc.primary_idx = primary_idx;
+      dc.name        = (is_rowid || names.empty()) ? std::string{} : names.at(primary_idx);
+      dc.is_rowid    = is_rowid;
+      if (options.type_for) { dc.type = options.type_for(col_idx); }
+      plan.data_columns.push_back(std::move(dc));
       primary_to_batch[primary_idx] = batch_idx;
       if (is_output) {
         plan.output_layout.push_back(
@@ -235,14 +250,34 @@ scan_plan build_scan_plan(duckdb::vector<duckdb::ColumnIndex> const& column_ids,
   }
 
   // Build the C → D map. An entry is nullopt when the column is a hive
-  // partition, virtual, or simply not referenced by projection_ids.
+  // partition, a non-rowid virtual column, or simply not referenced by
+  // projection_ids. Rowid resolves to its data column when decoded so a filter
+  // that references rowid still maps.
   plan.batch_position_by_column_id.assign(column_ids.size(), std::nullopt);
   for (std::size_t c = 0; c < column_ids.size(); ++c) {
-    auto const primary_idx = column_ids[c].GetPrimaryIndex();
-    if (duckdb::IsVirtualColumn(primary_idx)) { continue; }
+    auto const& col_idx    = column_ids[c];
+    auto const primary_idx = col_idx.GetPrimaryIndex();
+    if (col_idx.IsRowIdColumn()) {
+      if (!options.decode_rowid_columns) { continue; }
+    } else if (duckdb::IsVirtualColumn(primary_idx)) {
+      continue;
+    }
     auto it = primary_to_batch.find(primary_idx);
     if (it == primary_to_batch.end()) { continue; }
     plan.batch_position_by_column_id[c] = it->second;
+  }
+
+  // On the reader-typed path every data column must carry a type (the
+  // decoder/walker dereference it); fail here rather than deref nullopt later.
+  if (options.decode_rowid_columns || options.type_for) {
+    for (auto const& dc : plan.data_columns) {
+      if (!dc.type.has_value()) {
+        throw sirius::internal_exception(
+          "[build_scan_plan] data column (primary_idx {}) has no logical type; the reader-typed "
+          "scan_plan path requires options.type_for to resolve every column.",
+          dc.primary_idx);
+      }
+    }
   }
 
   SIRIUS_LOG_DEBUG("[scan_plan] built plan: {} data col(s), {} partition col(s), {} output entries",

--- a/src/op/scan/scan_utils.cpp
+++ b/src/op/scan/scan_utils.cpp
@@ -70,14 +70,19 @@ duckdb::unique_ptr<duckdb::Expression> convert_table_filters_to_expression(
       continue;
     }
 
-    auto primary_idx = column_ids.at(column_index).GetPrimaryIndex();
+    auto const& col_idx = column_ids.at(column_index);
+    auto primary_idx    = col_idx.GetPrimaryIndex();
     if (skip_primary_indices.count(primary_idx)) {
       SIRIUS_LOG_DEBUG(
         "TABLE_SCAN filter: skipping filter on primary_idx={} (hive partition or equivalent)",
         primary_idx);
       continue;
     }
-    auto const col_type = returned_types.at(primary_idx);
+    // Rowid has no slot in returned_types (its primary index is DuckDB's
+    // sentinel), so resolve its type directly. Rowid is synthesized as BIGINT.
+    auto const col_type = col_idx.IsRowIdColumn()
+                            ? sirius::logical_type::make(sirius::type_id::BIGINT)
+                            : returned_types.at(primary_idx);
 
     SIRIUS_LOG_DEBUG("TABLE_SCAN filter: column_index={}, primary_idx={}, type={}, filter_type={}",
                      column_index,

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -25,6 +25,7 @@
 #include "log/logging.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
 #include "op/scan/parquet_gpu_ingestible.hpp"
+#include "op/scan/scan_plan.hpp"
 #include "op/scan/sirius_gpu_scan_operator.hpp"
 #include "op/sirius_physical_column_data_scan.hpp"
 #include "op/sirius_physical_concat.hpp"
@@ -310,6 +311,8 @@ void sirius_pipeline_converter::insert_duckdb_native_scan_operator(
   table_info->db_path = table.GetStorage().GetAttached().GetStorageManager().GetDBPath();
   table_info->approximate_batch_size = op_params_.scan_task_batch_size;
 
+  // Output-first read order: the first scan_op.types.size() entries are emitted
+  // columns; the rest are filter-only columns read for a predicate but not emitted.
   std::vector<std::size_t> source_ids_fallback;
   if (scan_op.projection_ids.empty()) {
     source_ids_fallback.resize(scan_op.column_ids.size());
@@ -318,24 +321,37 @@ void sirius_pipeline_converter::insert_duckdb_native_scan_operator(
   auto const& source_ids =
     scan_op.projection_ids.empty() ? source_ids_fallback : scan_op.projection_ids;
 
-  table_info->projected_cols.reserve(source_ids.size());
-  table_info->projected_types.reserve(source_ids.size());
-  for (std::size_t k = 0; k < source_ids.size(); ++k) {
-    auto pid            = source_ids[k];
-    auto const& col_idx = scan_op.column_ids[pid];
-    op::scan::projected_column pc;
-    pc.is_rowid = col_idx.IsRowIdColumn();
-    if (!pc.is_rowid) { pc.storage_idx = duckdb::StorageIndex(col_idx.GetPrimaryIndex()); }
-    table_info->projected_cols.push_back(pc);
-
-    sirius::logical_type t;
-    if (k < scan_op.types.size()) {
-      t = scan_op.types[k];
-    } else {
-      t = scan_op.returned_types.at(col_idx.GetPrimaryIndex());
+  // Resolve the rowid output type. Rowid's primary index is DuckDB's virtual-column
+  // sentinel, so returned_types cannot supply it; the planner records it in
+  // scan_op.types at the rowid output position. Default BIGINT when rowid is filter-only.
+  std::size_t const output_arity = scan_op.types.size();
+  auto rowid_type                = sirius::logical_type::make(sirius::type_id::BIGINT);
+  for (std::size_t k = 0; k < source_ids.size() && k < output_arity; ++k) {
+    if (scan_op.column_ids[source_ids[k]].IsRowIdColumn()) {
+      rowid_type = scan_op.types[k];
+      break;
     }
-    table_info->projected_types.push_back(t);
   }
+
+  // Build the canonical scan plan once. decode_rowid_columns keeps synthesized
+  // rowid columns in the plan; type_for supplies the per-column types the walker
+  // and decoder need. No hive partitioning on a base-table seq_scan.
+  op::scan::build_scan_plan_options plan_opts;
+  plan_opts.decode_rowid_columns = true;
+  plan_opts.type_for =
+    [&](duckdb::ColumnIndex const& col_idx) -> std::optional<sirius::logical_type> {
+    if (col_idx.IsRowIdColumn()) { return rowid_type; }
+    return scan_op.returned_types.at(col_idx.GetPrimaryIndex());
+  };
+  duckdb::vector<duckdb::HivePartitioningIndex> const no_partition_indices;
+  table_info->plan =
+    std::make_shared<op::scan::scan_plan const>(op::scan::build_scan_plan(scan_op.column_ids,
+                                                                          scan_op.projection_ids,
+                                                                          scan_op.names,
+                                                                          scan_op.returned_types,
+                                                                          output_arity,
+                                                                          no_partition_indices,
+                                                                          std::move(plan_opts)));
 
   // Filters drive row-group pruning in the metadata walk and post-decode filtering.
   if (scan_op.table_filters) {
@@ -345,9 +361,7 @@ void sirius_pipeline_converter::insert_duckdb_native_scan_operator(
     }
   }
   table_info->column_ids     = scan_op.column_ids;
-  table_info->projection_ids = scan_op.projection_ids;
   table_info->returned_types = scan_op.returned_types;
-  table_info->output_types   = scan_op.types;
 
   auto gpu_scan_op = duckdb::make_uniq<op::scan::sirius_gpu_scan_operator>(
     scan_op.types, scan_op.estimated_cardinality, std::move(table_info));

--- a/test/cpp/scan/test_build_scan_plan.cpp
+++ b/test/cpp/scan/test_build_scan_plan.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for build_scan_plan's options surface, focused on the
+// duckdb-native extras (rowid routing + per-column types) added on top of the
+// parquet behavior. The parquet defaults must keep dropping rowid and leaving
+// types unset.
+
+#include <catch.hpp>
+#include <duckdb/common/column_index.hpp>
+#include <duckdb/common/constants.hpp>
+#include <duckdb/common/types.hpp>
+#include <duckdb/common/vector.hpp>
+#include <helper/logical_type.hpp>
+#include <op/scan/scan_plan.hpp>
+#include <sirius/exception.hpp>
+
+#include <optional>
+#include <string>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+
+namespace {
+
+duckdb::ColumnIndex rowid_index() { return duckdb::ColumnIndex(duckdb::COLUMN_IDENTIFIER_ROW_ID); }
+
+logical_type integer() { return logical_type::make(type_id::INTEGER); }
+logical_type bigint() { return logical_type::make(type_id::BIGINT); }
+
+// Resolves a column's type the way the pipeline converter does for the native
+// path: rowid → BIGINT, everything else from the schema's returned_types.
+build_scan_plan_options native_options(duckdb::vector<logical_type> const& returned_types)
+{
+  build_scan_plan_options opts;
+  opts.decode_rowid_columns = true;
+  opts.type_for = [&returned_types](duckdb::ColumnIndex const& ci) -> std::optional<logical_type> {
+    if (ci.IsRowIdColumn()) { return bigint(); }
+    return returned_types[ci.GetPrimaryIndex()];
+  };
+  return opts;
+}
+
+}  // namespace
+
+TEST_CASE("build_scan_plan native routes rowid into data_columns with a type",
+          "[scan][build_scan_plan]")
+{
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), rowid_index()};
+  duckdb::vector<duckdb::idx_t> projection_ids;  // read all, both emitted
+  duckdb::vector<std::string> names{"a"};
+  duckdb::vector<logical_type> returned_types{integer()};
+  duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
+
+  auto plan = build_scan_plan(column_ids,
+                              projection_ids,
+                              names,
+                              returned_types,
+                              /*output_types_size=*/2,
+                              no_partitions,
+                              native_options(returned_types));
+
+  REQUIRE(plan.data_columns.size() == 2);
+  REQUIRE_FALSE(plan.data_columns[0].is_rowid);
+  REQUIRE(plan.data_columns[0].primary_idx == 0);
+  REQUIRE(plan.data_columns[0].type.has_value());
+  REQUIRE(plan.data_columns[0].type->id() == type_id::INTEGER);
+
+  REQUIRE(plan.data_columns[1].is_rowid);
+  REQUIRE(plan.data_columns[1].type.has_value());
+  REQUIRE(plan.data_columns[1].type->id() == type_id::BIGINT);
+
+  REQUIRE(plan.output_layout.size() == 2);
+  REQUIRE(plan.output_layout[0].source == scan_plan::output_entry::DATA);
+  REQUIRE(plan.output_layout[0].idx == 0);
+  REQUIRE(plan.output_layout[1].source == scan_plan::output_entry::DATA);
+  REQUIRE(plan.output_layout[1].idx == 1);
+}
+
+TEST_CASE("build_scan_plan parquet defaults drop rowid and leave types unset",
+          "[scan][build_scan_plan]")
+{
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), rowid_index()};
+  duckdb::vector<duckdb::idx_t> projection_ids;
+  duckdb::vector<std::string> names{"a"};
+  duckdb::vector<logical_type> returned_types{integer()};
+  duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
+
+  // Default options: decode_rowid_columns == false, type_for empty.
+  auto plan = build_scan_plan(
+    column_ids, projection_ids, names, returned_types, /*output_types_size=*/2, no_partitions);
+
+  REQUIRE(plan.data_columns.size() == 1);  // rowid dropped
+  REQUIRE_FALSE(plan.data_columns[0].is_rowid);
+  REQUIRE(plan.data_columns[0].primary_idx == 0);
+  REQUIRE_FALSE(plan.data_columns[0].type.has_value());  // parquet derives types from the footer
+
+  REQUIRE(plan.output_layout.size() == 1);
+  REQUIRE(plan.output_layout[0].source == scan_plan::output_entry::DATA);
+  REQUIRE(plan.output_layout[0].idx == 0);
+}
+
+TEST_CASE("build_scan_plan native throws when type_for is missing", "[scan][build_scan_plan]")
+{
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0)};
+  duckdb::vector<duckdb::idx_t> projection_ids;
+  duckdb::vector<std::string> names{"a"};
+  duckdb::vector<logical_type> returned_types{integer()};
+  duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
+
+  // decode_rowid_columns opts into the reader-typed path but no type_for is
+  // supplied, so every data column ends up with a null type — build_scan_plan
+  // must reject this at build time rather than defer a null deref to the decoder.
+  build_scan_plan_options opts;
+  opts.decode_rowid_columns = true;
+
+  REQUIRE_THROWS_AS(build_scan_plan(column_ids,
+                                    projection_ids,
+                                    names,
+                                    returned_types,
+                                    /*output_types_size=*/1,
+                                    no_partitions,
+                                    opts),
+                    sirius::internal_exception);
+}
+
+TEST_CASE("build_scan_plan keeps a pure-filter column out of the output layout",
+          "[scan][build_scan_plan]")
+{
+  // projection_ids = {0, 1} with output_types_size = 1: column 0 is emitted,
+  // column 1 is read for a filter only. Both land in data_columns; only column 0
+  // is in output_layout.
+  duckdb::vector<duckdb::ColumnIndex> column_ids{duckdb::ColumnIndex(0), duckdb::ColumnIndex(1)};
+  duckdb::vector<duckdb::idx_t> projection_ids{0, 1};
+  duckdb::vector<std::string> names{"a", "b"};
+  duckdb::vector<logical_type> returned_types{integer(), integer()};
+  duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
+
+  auto plan = build_scan_plan(column_ids,
+                              projection_ids,
+                              names,
+                              returned_types,
+                              /*output_types_size=*/1,
+                              no_partitions,
+                              native_options(returned_types));
+
+  REQUIRE(plan.data_columns.size() == 2);
+  REQUIRE(plan.output_layout.size() == 1);
+  REQUIRE(plan.output_layout[0].source == scan_plan::output_entry::DATA);
+  REQUIRE(plan.output_layout[0].idx == 0);
+
+  auto const pure_filter = plan.pure_filter_batch_positions();
+  REQUIRE(pure_filter.size() == 1);
+  REQUIRE(pure_filter.count(1) == 1);  // batch position 1 (column b) is filter-only
+}
+
+TEST_CASE("build_scan_plan reorders data_columns and output to match projection order",
+          "[scan][build_scan_plan]")
+{
+  // projection_ids = {2, 0, 1} reorders the output. data_columns end up in
+  // projection order (D space); output_layout is the identity over that order;
+  // batch_position_by_column_id maps each column_ids slot to its D position.
+  duckdb::vector<duckdb::ColumnIndex> column_ids{
+    duckdb::ColumnIndex(0), duckdb::ColumnIndex(1), duckdb::ColumnIndex(2)};
+  duckdb::vector<duckdb::idx_t> projection_ids{2, 0, 1};
+  duckdb::vector<std::string> names{"a", "b", "c"};
+  duckdb::vector<logical_type> returned_types{integer(), integer(), integer()};
+  duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
+
+  auto plan = build_scan_plan(column_ids,
+                              projection_ids,
+                              names,
+                              returned_types,
+                              /*output_types_size=*/3,
+                              no_partitions,
+                              native_options(returned_types));
+
+  REQUIRE(plan.data_columns.size() == 3);
+  REQUIRE(plan.data_columns[0].primary_idx == 2);
+  REQUIRE(plan.data_columns[1].primary_idx == 0);
+  REQUIRE(plan.data_columns[2].primary_idx == 1);
+
+  REQUIRE(plan.output_layout.size() == 3);
+  for (std::size_t i = 0; i < 3; ++i) {
+    REQUIRE(plan.output_layout[i].source == scan_plan::output_entry::DATA);
+    REQUIRE(plan.output_layout[i].idx == i);
+  }
+
+  REQUIRE(plan.batch_position_by_column_id.size() == 3);
+  REQUIRE(plan.batch_position_by_column_id[0] == std::optional<std::size_t>{1});
+  REQUIRE(plan.batch_position_by_column_id[1] == std::optional<std::size_t>{2});
+  REQUIRE(plan.batch_position_by_column_id[2] == std::optional<std::size_t>{0});
+}

--- a/test/cpp/scan/test_build_scan_plan.cpp
+++ b/test/cpp/scan/test_build_scan_plan.cpp
@@ -74,14 +74,14 @@ TEST_CASE("build_scan_plan native routes rowid into data_columns with a type",
                               native_options(returned_types));
 
   REQUIRE(plan.data_columns.size() == 2);
-  REQUIRE_FALSE(plan.data_columns[0].is_rowid);
+  REQUIRE(plan.data_columns[0].reader_info.has_value());
+  REQUIRE_FALSE(plan.data_columns[0].reader_info->is_rowid);
   REQUIRE(plan.data_columns[0].primary_idx == 0);
-  REQUIRE(plan.data_columns[0].type.has_value());
-  REQUIRE(plan.data_columns[0].type->id() == type_id::INTEGER);
+  REQUIRE(plan.data_columns[0].reader_info->type.id() == type_id::INTEGER);
 
-  REQUIRE(plan.data_columns[1].is_rowid);
-  REQUIRE(plan.data_columns[1].type.has_value());
-  REQUIRE(plan.data_columns[1].type->id() == type_id::BIGINT);
+  REQUIRE(plan.data_columns[1].reader_info.has_value());
+  REQUIRE(plan.data_columns[1].reader_info->is_rowid);
+  REQUIRE(plan.data_columns[1].reader_info->type.id() == type_id::BIGINT);
 
   REQUIRE(plan.output_layout.size() == 2);
   REQUIRE(plan.output_layout[0].source == scan_plan::output_entry::DATA);
@@ -104,9 +104,9 @@ TEST_CASE("build_scan_plan parquet defaults drop rowid and leave types unset",
     column_ids, projection_ids, names, returned_types, /*output_types_size=*/2, no_partitions);
 
   REQUIRE(plan.data_columns.size() == 1);  // rowid dropped
-  REQUIRE_FALSE(plan.data_columns[0].is_rowid);
   REQUIRE(plan.data_columns[0].primary_idx == 0);
-  REQUIRE_FALSE(plan.data_columns[0].type.has_value());  // parquet derives types from the footer
+  // parquet leaves reader_info unset and derives types from the footer.
+  REQUIRE_FALSE(plan.data_columns[0].reader_info.has_value());
 
   REQUIRE(plan.output_layout.size() == 1);
   REQUIRE(plan.output_layout[0].source == scan_plan::output_entry::DATA);
@@ -122,8 +122,9 @@ TEST_CASE("build_scan_plan native throws when type_for is missing", "[scan][buil
   duckdb::vector<duckdb::HivePartitioningIndex> no_partitions;
 
   // decode_rowid_columns opts into the reader-typed path but no type_for is
-  // supplied, so every data column ends up with a null type — build_scan_plan
-  // must reject this at build time rather than defer a null deref to the decoder.
+  // supplied, so every data column ends up with no reader_decode_info —
+  // build_scan_plan must reject this at build time rather than defer a null
+  // deref to the decoder.
   build_scan_plan_options opts;
   opts.decode_rowid_columns = true;
 

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -84,8 +84,9 @@ scan_plan make_plan(std::vector<col_spec> const& cols,
   for (std::size_t i = 0; i < cols.size(); ++i) {
     scan_plan::data_column dc;
     dc.primary_idx = cols[i].primary_idx;
-    dc.is_rowid    = cols[i].is_rowid;
-    if (i < types.size()) { dc.type = types[i]; }
+    if (i < types.size()) {
+      dc.reader_info = scan_plan::data_column::reader_decode_info{types[i], cols[i].is_rowid};
+    }
     plan.data_columns.push_back(std::move(dc));
   }
   return plan;

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -27,10 +27,12 @@
 #include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <op/scan/duckdb_native_metadata.hpp>
+#include <op/scan/scan_plan.hpp>
 #include <utils/utils.hpp>
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 using namespace sirius;
 using namespace sirius::op::scan;
@@ -63,19 +65,30 @@ duckdb::DataTable& get_storage(duckdb::Connection& con, const std::string& table
   return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
 }
 
-projected_column real_col(duckdb::idx_t col_id)
-{
-  projected_column pc;
-  pc.storage_idx = duckdb::StorageIndex(col_id);
-  pc.is_rowid    = false;
-  return pc;
-}
+// A projected-column spec for the walker tests: a storage primary index plus
+// the rowid flag. make_plan() zips these with their logical types into the
+// scan_plan the walker consumes (mirroring build_scan_plan's data_columns).
+struct col_spec {
+  duckdb::idx_t primary_idx = 0;
+  bool is_rowid             = false;
+};
 
-projected_column rowid_col()
+col_spec real_col(duckdb::idx_t col_id) { return {col_id, false}; }
+col_spec rowid_col() { return {0, true}; }
+
+scan_plan make_plan(std::vector<col_spec> const& cols,
+                    std::vector<sirius::logical_type> const& types)
 {
-  projected_column pc;
-  pc.is_rowid = true;
-  return pc;
+  scan_plan plan;
+  plan.data_columns.reserve(cols.size());
+  for (std::size_t i = 0; i < cols.size(); ++i) {
+    scan_plan::data_column dc;
+    dc.primary_idx = cols[i].primary_idx;
+    dc.is_rowid    = cols[i].is_rowid;
+    if (i < types.size()) { dc.type = types[i]; }
+    plan.data_columns.push_back(std::move(dc));
+  }
+  return plan;
 }
 
 // A one-column TableFilterSet keyed by the relative scan-column index `col_key`
@@ -109,22 +122,9 @@ TEST_CASE("walker refuses empty projection", "[scan][duckdb_native_walker]")
   exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 100)");
   auto& storage = get_storage(con, "t");
 
-  auto md = walk_duckdb_native_metadata(storage, *con.context, {}, {});
+  auto md = walk_duckdb_native_metadata(storage, *con.context, scan_plan{});
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("no projected columns") != std::string::npos);
-}
-
-TEST_CASE("walker refuses parallel-vector mismatch", "[scan][duckdb_native_walker]")
-{
-  auto [db_owner, con] = sirius::make_test_db_and_connection();
-  exec_ok(con, "CREATE TABLE t(a INTEGER)");
-  auto& storage = get_storage(con, "t");
-
-  std::vector<projected_column> cols   = {real_col(0)};
-  std::vector<sirius::logical_type> ts = {};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
-  REQUIRE_FALSE(md.viable);
-  REQUIRE(md.viability_failure_reason.find("size mismatch") != std::string::npos);
 }
 
 TEST_CASE("walker refuses HUGEINT type", "[scan][duckdb_native_walker]")
@@ -134,9 +134,9 @@ TEST_CASE("walker refuses HUGEINT type", "[scan][duckdb_native_walker]")
   exec_ok(con, "INSERT INTO t VALUES (1), (2), (3)");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::HUGEINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("HUGEINT") != std::string::npos);
 }
@@ -150,9 +150,9 @@ TEST_CASE("walker emits descriptors for INTEGER table", "[scan][duckdb_native_wa
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE(md.viability_failure_reason.empty());
   REQUIRE_FALSE(md.row_groups.empty());
@@ -179,12 +179,12 @@ TEST_CASE("walker emits rowid sentinels with no segments", "[scan][duckdb_native
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0), rowid_col()};
+  std::vector<col_spec> cols           = {real_col(0), rowid_col()};
   std::vector<sirius::logical_type> ts = {
     sirius::logical_type::make(sirius::type_id::INTEGER),
     sirius::logical_type::make(sirius::type_id::BIGINT),
   };
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -211,9 +211,9 @@ TEST_CASE("walker rowid-only projection gets row_count from PartitionStats",
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {rowid_col()};
+  std::vector<col_spec> cols           = {rowid_col()};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::BIGINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -241,9 +241,9 @@ TEST_CASE("walker separates data and validity segments by column_path",
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -267,9 +267,9 @@ TEST_CASE("walker populates per-segment max_string_length for VARCHAR",
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
   for (const auto& rg : md.row_groups) {
@@ -292,9 +292,9 @@ TEST_CASE("walker accepts all-empty varchar row group (Some(0))", "[scan][duckdb
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
 
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
@@ -324,9 +324,9 @@ TEST_CASE("walker per-segment max_string_length reflects long strings",
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -345,9 +345,9 @@ TEST_CASE("walker refuses DECIMAL128 (precision > 18)", "[scan][duckdb_native_wa
   exec_ok(con, "INSERT INTO t VALUES (1), (2), (3)");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(38, 0)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("DECIMAL128") != std::string::npos);
 }
@@ -360,9 +360,9 @@ TEST_CASE("walker accepts DECIMAL64 (precision <= 18)", "[scan][duckdb_native_wa
   exec_ok(con, "CHECKPOINT");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(18, 2)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 }
@@ -376,9 +376,9 @@ TEST_CASE("walker refuses STRUCT projected type", "[scan][duckdb_native_walker]"
   exec_ok(con, "INSERT INTO t VALUES (1)");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::STRUCT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("STRUCT") != std::string::npos);
 }
@@ -390,9 +390,9 @@ TEST_CASE("walker refuses LIST projected type", "[scan][duckdb_native_walker]")
   exec_ok(con, "INSERT INTO t VALUES (1)");
   auto& storage = get_storage(con, "t");
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::LIST)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("LIST") != std::string::npos);
 }
@@ -496,11 +496,11 @@ TEST_CASE("statistics pruning drops row groups below a lower-bound filter",
   auto [db_owner, con] = sirius::make_test_db_and_connection();
   auto& storage        = make_monotonic_int_table(con);
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
   // Baseline: no filter → nothing pruned.
-  auto base = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto base = walk_duckdb_native_metadata(storage, *con.context, make_plan(cols, ts));
   REQUIRE(base.viable);
   REQUIRE(base.pruned_row_groups == 0);
   REQUIRE(base.row_groups.size() >= 2);  // 300k rows > one 122880-row group
@@ -508,8 +508,8 @@ TEST_CASE("statistics pruning drops row groups below a lower-bound filter",
   // a >= 250000 → row groups entirely below 250000 are FILTER_ALWAYS_FALSE.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000));
-  auto pruned =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto pruned = walk_duckdb_native_metadata(
+    storage, *con.context, make_plan(cols, ts), &ctx.filters, &ctx.column_ids);
 
   REQUIRE(pruned.viable);
   REQUIRE(pruned.pruned_row_groups >= 1);
@@ -534,14 +534,14 @@ TEST_CASE("statistics pruning keeps every row group when the filter matches all"
   auto [db_owner, con] = sirius::make_test_db_and_connection();
   auto& storage        = make_monotonic_int_table(con);
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
   // a >= 0 is always true for this data → no row group can be pruned.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(0));
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_duckdb_native_metadata(
+    storage, *con.context, make_plan(cols, ts), &ctx.filters, &ctx.column_ids);
 
   REQUIRE(md.viable);
   REQUIRE(md.pruned_row_groups == 0);
@@ -554,7 +554,7 @@ TEST_CASE("statistics pruning refuses (CPU fallback) when every row group is pru
   auto [db_owner, con] = sirius::make_test_db_and_connection();
   auto& storage        = make_monotonic_int_table(con);
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
   // a >= 1_000_000 exceeds every value → all row groups FILTER_ALWAYS_FALSE.
@@ -562,8 +562,8 @@ TEST_CASE("statistics pruning refuses (CPU fallback) when every row group is pru
   // (which correctly returns the empty result).
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(1000000));
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_duckdb_native_metadata(
+    storage, *con.context, make_plan(cols, ts), &ctx.filters, &ctx.column_ids);
 
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("pruned") != std::string::npos);
@@ -579,7 +579,7 @@ TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
   auto [db_owner, con] = sirius::make_test_db_and_connection();
   auto& storage        = make_monotonic_int_table(con);
 
-  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<col_spec> cols           = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
   filter_ctx ctx;
@@ -588,8 +588,8 @@ TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
       duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000)));
   ctx.column_ids.push_back(duckdb::ColumnIndex(0));
 
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_duckdb_native_metadata(
+    storage, *con.context, make_plan(cols, ts), &ctx.filters, &ctx.column_ids);
 
   REQUIRE(md.viable);
   REQUIRE(md.pruned_row_groups >= 1);


### PR DESCRIPTION
Routes the DuckDB-native GPU scan through the same `scan_plan` abstraction the parquet scan already uses. The native bind data now carries a shared `scan_plan` instead of parallel `projected_cols`/`projected_types` vectors: the walker and decoder read `plan.data_columns`, filters resolve through `plan.batch_position_by_column_id`, and output is reshaped via `assemble_scan_output` instead of a hand-rolled projection. `scan_plan` gains optional `is_rowid` + per-column type fields (behind `build_scan_plan_options`) so the native decoder can synthesize rowid and resolve types up front; the parquet path is unchanged. Also fixes a latent crash when a filter references the `rowid` column.
