### PR TITLE
feat(expr): flip sirius::expression PIMPL to hold a Sirius AST node (#701)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(EXTENSION_SOURCES
     src/downgrade/downgrade_executor.cpp
     src/expression/aggregate_id.cpp
     src/expression/ast/clone.cpp
+    src/expression/ast/node.cpp
     src/expression/expression.cpp
     src/expression/from_duckdb.cpp
     src/expression/function_id.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(EXTENSION_SOURCES
     src/data/host_parquet_representation_converters.cpp
     src/downgrade/downgrade_executor.cpp
     src/expression/aggregate_id.cpp
+    src/expression/ast/clone.cpp
     src/expression/expression.cpp
     src/expression/from_duckdb.cpp
     src/expression/function_id.cpp
@@ -441,6 +442,7 @@ set(TEST_SOURCES
     test/cpp/exec/test_inspectable_mpsc.cpp
     test/cpp/exec/test_interruptible_mpmc.cpp
     test/cpp/expression/test_ast_aggregate.cpp
+    test/cpp/expression/test_ast_clone.cpp
     test/cpp/expression/test_ast_from_duckdb.cpp
     test/cpp/expression/test_ast_scaffold.cpp
     test/cpp/expression/test_ast_to_duckdb.cpp

--- a/src/expression/ast/clone.cpp
+++ b/src/expression/ast/clone.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "expression/ast/clone.hpp"
+
+// sirius
+#include "expression/ast/node.hpp"  // complete node: needed to construct/destroy child unique_ptr vectors
+
+// standard library
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace sirius::ast {
+
+namespace {
+
+// Deep-clone a single optional child node owner.
+std::unique_ptr<node> clone_child(std::unique_ptr<node> const& child)
+{
+  return child ? clone(*child) : nullptr;
+}
+
+// Deep-clone a vector of child node owners.
+std::vector<std::unique_ptr<node>> clone_children(
+  std::vector<std::unique_ptr<node>> const& children)
+{
+  std::vector<std::unique_ptr<node>> out;
+  out.reserve(children.size());
+  std::ranges::transform(children, std::back_inserter(out), clone_child);
+  return out;
+}
+
+}  // namespace
+
+std::unique_ptr<node> clone(node const& src)
+{
+  return std::visit(
+    [](auto const& alt) -> std::unique_ptr<node> {
+      using T = std::decay_t<decltype(alt)>;
+
+      if constexpr (std::is_same_v<T, reference>) {
+        return std::make_unique<node>(reference{alt.column_index, alt.return_type});
+      } else if constexpr (std::is_same_v<T, constant>) {
+        return std::make_unique<node>(constant{alt.payload, alt.return_type});
+      } else if constexpr (std::is_same_v<T, comparison>) {
+        return std::make_unique<node>(
+          comparison{alt.op, clone_child(alt.left), clone_child(alt.right)});
+      } else if constexpr (std::is_same_v<T, conjunction>) {
+        return std::make_unique<node>(conjunction{alt.op, clone_children(alt.children)});
+      } else if constexpr (std::is_same_v<T, between>) {
+        return std::make_unique<node>(between{clone_child(alt.input),
+                                              clone_child(alt.lower),
+                                              clone_child(alt.upper),
+                                              alt.lower_inclusive,
+                                              alt.upper_inclusive});
+      } else if constexpr (std::is_same_v<T, case_expr>) {
+        std::vector<case_expr::when_then> cases;
+        cases.reserve(alt.cases.size());
+        for (auto const& wt : alt.cases) {
+          cases.push_back(case_expr::when_then{clone_child(wt.when_), clone_child(wt.then_)});
+        }
+        return std::make_unique<node>(
+          case_expr{std::move(cases), clone_child(alt.else_), alt.return_type()});
+      } else if constexpr (std::is_same_v<T, cast>) {
+        return std::make_unique<node>(cast{clone_child(alt.child), alt.target_type, alt.try_cast});
+      } else if constexpr (std::is_same_v<T, unary_op>) {
+        return std::make_unique<node>(unary_op{alt.op, clone_child(alt.child)});
+      } else if constexpr (std::is_same_v<T, coalesce>) {
+        return std::make_unique<node>(coalesce{clone_children(alt.children), alt.return_type()});
+      } else if constexpr (std::is_same_v<T, in_list>) {
+        return std::make_unique<node>(
+          in_list{clone_child(alt.probe), clone_children(alt.values), alt.negated});
+      } else if constexpr (std::is_same_v<T, function_call>) {
+        return std::make_unique<node>(
+          function_call{alt.function(), clone_children(alt.arguments()), alt.return_type()});
+      } else if constexpr (std::is_same_v<T, aggregate>) {
+        return std::make_unique<node>(aggregate{
+          alt.function(), clone_children(alt.arguments()), alt.return_type(), alt.distinct()});
+      } else {
+        static_assert(sizeof(T) == 0,
+                      "Unhandled sirius::ast alternative in clone(node) — add a clone arm "
+                      "for the new variant member");
+      }
+    },
+    src.v);
+}
+
+}  // namespace sirius::ast

--- a/src/expression/ast/node.cpp
+++ b/src/expression/ast/node.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Single translation unit for sirius::ast::node member definitions. Keep every
+// node:: method here so they do not spread across per-feature .cpp files. The
+// per-alternative method bodies (e.g. reference::cudf_ast_op_count) live with
+// their own concerns; only node:: members belong in this file.
+
+#include "expression/ast/node.hpp"
+
+#include "sirius/exception.hpp"
+
+#include <cstddef>
+#include <string_view>
+#include <variant>
+
+namespace sirius::ast {
+
+namespace {
+
+[[noreturn]] void throw_wrong_node_type(std::string_view context, std::string_view expected)
+{
+  throw not_implemented_exception("{}: expected {}", context, expected);
+}
+
+}  // namespace
+
+bool node::is_reference() const noexcept { return holds<reference>(); }
+
+bool node::is_aggregate() const noexcept { return holds<aggregate>(); }
+
+bool node::is_function_call() const noexcept { return holds<function_call>(); }
+
+reference const& node::as_reference() const
+{
+  if (!is_reference()) { throw std::bad_variant_access(); }
+  return get<reference>();
+}
+
+aggregate const& node::as_aggregate() const
+{
+  if (!is_aggregate()) { throw std::bad_variant_access(); }
+  return get<aggregate>();
+}
+
+function_call const& node::as_function_call() const
+{
+  if (!is_function_call()) { throw std::bad_variant_access(); }
+  return get<function_call>();
+}
+
+std::size_t node::cudf_ast_op_count() const
+{
+  return std::visit([](auto const& alt) { return alt.cudf_ast_op_count(); }, v);
+}
+
+reference const& require_reference(node const* n, std::string_view context)
+{
+  if (n == nullptr) { throw_wrong_node_type(context, "non-null reference node"); }
+  try {
+    return n->as_reference();
+  } catch (std::bad_variant_access const&) {
+    throw_wrong_node_type(context, "reference node");
+  }
+}
+
+aggregate const& require_aggregate(node const* n, std::string_view context)
+{
+  if (n == nullptr) { throw_wrong_node_type(context, "non-null aggregate node"); }
+  try {
+    return n->as_aggregate();
+  } catch (std::bad_variant_access const&) {
+    throw_wrong_node_type(context, "aggregate node");
+  }
+}
+
+}  // namespace sirius::ast

--- a/src/expression/ast/node.cpp
+++ b/src/expression/ast/node.cpp
@@ -31,6 +31,12 @@ namespace sirius::ast {
 
 namespace {
 
+// Boundary helper for the require_* accessors below, which run during GPU operator
+// construction (under create_plan). A null or wrong-type node means the GPU path cannot
+// handle this expression shape — e.g. wrap() returned null for an unsupported aggregate, or
+// a group key that is not a bound reference. not_implemented_exception is deliberate: it is
+// caught by OnFinalizePrepare's `catch (std::exception&)` and triggers graceful CPU fallback
+// rather than signalling an internal Sirius invariant violation.
 [[noreturn]] void throw_wrong_node_type(std::string_view context, std::string_view expected)
 {
   throw not_implemented_exception("{}: expected {}", context, expected);

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -15,7 +15,12 @@
  */
 
 // sirius
+#include <expression/ast/from_duckdb.hpp>
 #include <expression/expression_internal.hpp>
+
+// duckdb — wrap()/wrap_many() own duckdb::Expression unique_ptrs by value, so the
+// complete type is needed for their destructors (the internal header no longer pulls it in).
+#include <duckdb/planner/expression.hpp>
 
 // standard library
 #include <memory>
@@ -36,7 +41,12 @@ expression& expression::operator=(expression&&) noexcept = default;
 expression wrap(std::unique_ptr<duckdb::Expression> expr)
 {
   if (!expr) { return expression{}; }
-  return expression{std::make_unique<expression::impl>(expression::impl{std::move(expr)})};
+  // wrap() is the DuckDB->Sirius translation boundary. from_duckdb returns nullptr
+  // for an unsupported shape (a fallback signal) -> yield a null expression; its
+  // own exceptions on a genuinely-unseen ExpressionClass propagate unchanged.
+  auto node = sirius::ast::from_duckdb(*expr);
+  if (!node) { return expression{}; }
+  return expression{std::make_unique<expression::impl>(expression::impl{std::move(node)})};
 }
 
 std::vector<expression> wrap_many(std::vector<std::unique_ptr<duckdb::Expression>> exprs)

--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -145,7 +145,8 @@ std::unique_ptr<node> translate_case(duckdb::BoundCaseExpression const& expr)
   }
   auto else_node = from_duckdb(*expr.else_expr);
   if (!else_node) { return nullptr; }
-  return std::make_unique<node>(case_expr{std::move(cases), std::move(else_node)});
+  return std::make_unique<node>(
+    case_expr{std::move(cases), std::move(else_node), sirius::from_duckdb(expr.return_type)});
 }
 
 std::unique_ptr<node> translate_cast(duckdb::BoundCastExpression const& expr)
@@ -222,7 +223,8 @@ std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& 
       if (!translated) { return nullptr; }
       children.push_back(std::move(translated));
     }
-    return std::make_unique<node>(coalesce{std::move(children)});
+    return std::make_unique<node>(
+      coalesce{std::move(children), sirius::from_duckdb(expr.return_type)});
   }
 
   if (op_type == duckdb::ExpressionType::COMPARE_IN ||

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -88,13 +88,17 @@ std::unique_ptr<duckdb::Expression> from_duck_derived_ptr(duckdb::unique_ptr<T> 
 
 std::unique_ptr<duckdb::Expression> to_duckdb(reference const& alt)
 {
-  // The downstream consumer (executor specialization) resolves the column type
-  // from the input table_view, not from the reconstructed
-  // BoundReferenceExpression — so INTEGER is a safe placeholder here regardless
-  // of reference::return_type.
+  // Reconstruct the reference with its recorded return_type. Executor
+  // specializations resolve the column type from the input table_view and
+  // ignore this field, but join-key resolution (nested-loop / hash join) reads
+  // BoundReferenceExpression::return_type directly to decide whether a cast is
+  // needed, so the real type must be preserved. Fall back to INTEGER only when
+  // the node carries no type (default-constructed SQLNULL sentinel).
+  auto return_type = alt.return_type.id() == sirius::type_id::SQLNULL
+                       ? duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER}
+                       : sirius::to_duckdb(alt.return_type);
   return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
-    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER},
-    static_cast<duckdb::idx_t>(alt.column_index)));
+    std::move(return_type), static_cast<duckdb::idx_t>(alt.column_index)));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(constant const& alt)
@@ -143,11 +147,12 @@ std::unique_ptr<duckdb::Expression> to_duckdb(between const& alt)
 
 std::unique_ptr<duckdb::Expression> to_duckdb(case_expr const& alt)
 {
-  // case_expr carries no top-level return_type; INTEGER placeholder is safe —
-  // the executor's BoundCaseExpression specialization derives the type from
-  // the THEN branches at evaluation time, not from this stub.
-  auto out = duckdb::make_uniq<duckdb::BoundCaseExpression>(
-    duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
+  // Reconstruct the case expression with its recorded return_type. Executor
+  // specializations derive the result type from the THEN branches at evaluation
+  // time and ignore this field, but the AST-path post_process recovers each
+  // expression's return_type via to_duckdb, so the real type must be preserved
+  // here to avoid spurious down-casts of the materialized result.
+  auto out = duckdb::make_uniq<duckdb::BoundCaseExpression>(sirius::to_duckdb(alt.return_type()));
   out->case_checks.reserve(alt.cases.size());
   for (auto const& wt : alt.cases) {
     duckdb::BoundCaseCheck check;
@@ -202,9 +207,11 @@ std::unique_ptr<duckdb::Expression> to_duckdb(coalesce const& alt)
 {
   // COALESCE result type is the common type of its children. The downstream
   // executor specialization re-derives this from the children at evaluation
-  // time; INTEGER is a safe placeholder for this stub.
+  // time and ignores this field, but the AST-path post_process recovers each
+  // expression's return_type via to_duckdb, so the real type must be preserved
+  // here to avoid spurious down-casts of the materialized result.
   auto out = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
-    duckdb::ExpressionType::OPERATOR_COALESCE, duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER});
+    duckdb::ExpressionType::OPERATOR_COALESCE, sirius::to_duckdb(alt.return_type()));
   for (auto const& child : alt.children) {
     out->children.push_back(to_duck_ptr(to_duckdb(*child)));
   }

--- a/src/expression_executor/ast_op_counter.cpp
+++ b/src/expression_executor/ast_op_counter.cpp
@@ -153,9 +153,4 @@ std::size_t aggregate::cudf_ast_op_count() const
     "[ast::aggregate::cudf_ast_op_count] aggregate nodes are not lowered to cuDF AST ops (#863).");
 }
 
-std::size_t node::cudf_ast_op_count() const
-{
-  return std::visit([](auto const& alt) { return alt.cudf_ast_op_count(); }, v);
-}
-
 }  // namespace sirius::ast

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -178,9 +178,9 @@ gpu_expression_executor::gpu_expression_executor(
   std::size_t min_ast_size)
   : _strategy(strategy), _mr(resource_ref), _stream(stream), _min_ast_size(min_ast_size)
 {
-  _expressions.reserve(expressions.size());
+  _ast_expressions.reserve(expressions.size());
   for (auto const& expr : expressions) {
-    _expressions.push_back(sirius::unwrap(expr));
+    _ast_expressions.push_back(sirius::unwrap(expr));
   }
 }
 
@@ -191,7 +191,7 @@ gpu_expression_executor::gpu_expression_executor(sirius::expression const& expre
                                                  std::size_t min_ast_size)
   : _strategy(strategy), _mr(resource_ref), _stream(stream), _min_ast_size(min_ast_size)
 {
-  _expressions.push_back(sirius::unwrap(expression));
+  _ast_expressions.push_back(sirius::unwrap(expression));
 }
 
 gpu_expression_executor::gpu_expression_executor(duckdb::Expression const* expression,

--- a/src/expression_executor/gpu_expression_translator.cpp
+++ b/src/expression_executor/gpu_expression_translator.cpp
@@ -16,7 +16,6 @@
 
 // sirius
 #include <expression/ast/aggregate.hpp>
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/expression_internal.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
 #include <log/logging.hpp>
@@ -249,12 +248,12 @@ std::optional<expr_ref> gpu_expression_translator::add_join_condition(
   auto right_table_ref =
     swap_sides ? cudf::ast::table_reference::LEFT : cudf::ast::table_reference::RIGHT;
 
-  auto left_node = sirius::ast::from_duckdb(*sirius::unwrap(condition.left));
+  auto const* left_node = sirius::unwrap(condition.left);
   if (!left_node) { return std::nullopt; }
   auto left_expr = add_expression(*left_node, left_table_ref);
   if (!left_expr) { return std::nullopt; }
 
-  auto right_node = sirius::ast::from_duckdb(*sirius::unwrap(condition.right));
+  auto const* right_node = sirius::unwrap(condition.right);
   if (!right_node) { return std::nullopt; }
   auto right_expr = add_expression(*right_node, right_table_ref);
   if (!right_expr) { return std::nullopt; }

--- a/src/include/expression/ast/case_expr.hpp
+++ b/src/include/expression/ast/case_expr.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <memory>
 #include <vector>
@@ -30,17 +33,42 @@ struct node;
  * Named case_expr (not `case`) because `case` is a C++ keyword. Inner member
  * names that alias keywords (when/then/else) keep a trailing underscore since
  * those are stuck with the keyword-collision constraint.
+ *
+ * `return_type` is set by the translator at construction time so the executor
+ * does not need to re-derive it. Move-only (the when/then/else members hold
+ * `unique_ptr<node>`); the return type accessor exposes the recorded type.
+ * Moved-from instances are left in the standard valid-but-unspecified state.
  */
-struct case_expr {
+class case_expr {
+ public:
   struct when_then {
     std::unique_ptr<node> when_;
     std::unique_ptr<node> then_;
   };
 
+  case_expr(std::vector<when_then> cases,
+            std::unique_ptr<node> else_clause,
+            sirius::logical_type return_type)
+    : cases(std::move(cases)), else_(std::move(else_clause)), return_type_(std::move(return_type))
+  {
+  }
+
+  case_expr()                                = delete;
+  case_expr(case_expr const&)                = delete;
+  case_expr& operator=(case_expr const&)     = delete;
+  case_expr(case_expr&&) noexcept            = default;
+  case_expr& operator=(case_expr&&) noexcept = default;
+  ~case_expr()                               = default;
+
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
+
   std::vector<when_then> cases;
   std::unique_ptr<node> else_;
 
   std::size_t cudf_ast_op_count() const;
+
+ private:
+  sirius::logical_type return_type_;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/clone.hpp
+++ b/src/include/expression/ast/clone.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// sirius
+#include "expression/ast/node.hpp"  // sirius::ast::node
+
+// standard library
+#include <memory>
+
+namespace sirius::ast {
+
+/**
+ * @brief Deep-clone a Sirius AST node tree.
+ *
+ * `node` is move-only (children are owned via std::unique_ptr<node>), so it has
+ * no copy constructor. clone walks @p src via std::visit, reconstructs each
+ * alternative from its public fields/accessors, and recursively deep-clones
+ * every child unique_ptr. The returned tree is an independent allocation that
+ * shares no ownership with @p src.
+ *
+ * Used by the aggregate copy path (sirius_physical_ungrouped_aggregate's
+ * copy_expressions), where an aggregate node must be duplicated and a
+ * to_duckdb round-trip is impossible (to_duckdb(aggregate) throws by design).
+ * See https://github.com/sirius-db/sirius/issues/701.
+ */
+std::unique_ptr<node> clone(node const& src);
+
+}  // namespace sirius::ast

--- a/src/include/expression/ast/coalesce.hpp
+++ b/src/include/expression/ast/coalesce.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <memory>
 #include <vector>
@@ -31,11 +34,34 @@ struct node;
  * OPERATOR_COALESCE kind of duckdb::BoundOperatorExpression. Split out of
  * the broader `unary_op` node because coalesce is the only non-unary member
  * of that family.
+ *
+ * `return_type` is set by the translator at construction time so the executor
+ * does not need to re-derive it. Move-only (children hold `unique_ptr<node>`);
+ * the return type accessor exposes the recorded type. Moved-from instances are
+ * left in the standard valid-but-unspecified state.
  */
-struct coalesce {
+class coalesce {
+ public:
+  coalesce(std::vector<std::unique_ptr<node>> children, sirius::logical_type return_type)
+    : children(std::move(children)), return_type_(std::move(return_type))
+  {
+  }
+
+  coalesce()                               = delete;
+  coalesce(coalesce const&)                = delete;
+  coalesce& operator=(coalesce const&)     = delete;
+  coalesce(coalesce&&) noexcept            = default;
+  coalesce& operator=(coalesce&&) noexcept = default;
+  ~coalesce()                              = default;
+
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
+
   std::vector<std::unique_ptr<node>> children;
 
   std::size_t cudf_ast_op_count() const;
+
+ private:
+  sirius::logical_type return_type_;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/node.hpp
+++ b/src/include/expression/ast/node.hpp
@@ -20,6 +20,7 @@
 #include <concepts>
 #include <cstddef>
 #include <memory>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -154,7 +155,21 @@ struct node {
     return std::get<T>(v);
   }
 
+  [[nodiscard]] bool is_reference() const noexcept;
+  [[nodiscard]] bool is_aggregate() const noexcept;
+  [[nodiscard]] bool is_function_call() const noexcept;
+
+  /// Returns the held alternative; throws std::bad_variant_access if the type does not match.
+  [[nodiscard]] reference const& as_reference() const;
+  [[nodiscard]] aggregate const& as_aggregate() const;
+  [[nodiscard]] function_call const& as_function_call() const;
+
   [[nodiscard]] std::size_t cudf_ast_op_count() const;
 };
+
+/// Strict accessors for operator boundaries: return the held alternative or throw
+/// not_implemented_exception (with `context`) when `n` is null or holds a different type.
+[[nodiscard]] reference const& require_reference(node const* n, std::string_view context);
+[[nodiscard]] aggregate const& require_aggregate(node const* n, std::string_view context);
 
 }  // namespace sirius::ast

--- a/src/include/expression/expression.hpp
+++ b/src/include/expression/expression.hpp
@@ -29,17 +29,18 @@ class Expression;
 namespace sirius {
 
 /**
- * @brief Opaque, move-only wrapper around a duckdb::Expression*.
+ * @brief Opaque, move-only wrapper around a Sirius AST node.
  *
  * Lets Super Sirius operator headers, the expression-executor public header, and the
  * physical-plan-generator header avoid including any duckdb/planner/expression/... header.
  *
  * Internally stores a std::unique_ptr<impl>, where `impl` is forward-declared here and
- * defined in expression_internal.hpp. Code that needs to reach the underlying
- * duckdb::Expression includes expression_internal.hpp and uses the free `unwrap` / `release`
- * helpers; no friend declarations are required.
+ * defined in expression_internal.hpp. wrap() translates an incoming duckdb::Expression
+ * into a sirius::ast::node at the boundary; code that needs to reach the underlying node
+ * includes expression_internal.hpp and uses the free `unwrap` / `release` helpers; no
+ * friend declarations are required. See https://github.com/sirius-db/sirius/issues/701.
  *
- * Semantics mirror std::unique_ptr<duckdb::Expression>: unique ownership, move-only.
+ * Semantics mirror std::unique_ptr<sirius::ast::node>: unique ownership, move-only.
  */
 class expression {
  public:
@@ -60,10 +61,10 @@ class expression {
   expression(const expression&)            = delete;
   expression& operator=(const expression&) = delete;
 
-  /// Returns true if this wrapper does not hold a duckdb::Expression.
+  /// Returns true if this wrapper does not hold a Sirius AST node.
   [[nodiscard]] bool is_null() const noexcept { return !_impl; }
 
-  /// Returns true if this wrapper holds a duckdb::Expression.
+  /// Returns true if this wrapper holds a Sirius AST node.
   explicit operator bool() const noexcept { return static_cast<bool>(_impl); }
 
   /**
@@ -85,9 +86,13 @@ class expression {
 //===----------------------------------------------------------------------===//
 
 /**
- * @brief Wraps a duckdb::Expression unique_ptr in a sirius::expression.
+ * @brief Translates a duckdb::Expression unique_ptr into a sirius::expression.
  *
- * @param expr  The DuckDB expression to wrap. May be null; a null input produces a null
+ * This is the DuckDB->Sirius translation boundary: the incoming expression is lowered
+ * to a sirius::ast::node via sirius::ast::from_duckdb and the resulting node is stored.
+ *
+ * @param expr  The DuckDB expression to translate. May be null; a null input — or an
+ *              unsupported shape that from_duckdb declines to translate — produces a null
  *              sirius::expression.
  * @return The wrapped sirius::expression.
  */

--- a/src/include/expression/expression_internal.hpp
+++ b/src/include/expression/expression_internal.hpp
@@ -17,10 +17,8 @@
 #pragma once
 
 // sirius
+#include <expression/ast/node.hpp>
 #include <expression/expression.hpp>
-
-// duckdb
-#include <duckdb/planner/expression.hpp>
 
 // standard library
 #include <memory>
@@ -32,38 +30,40 @@ namespace sirius {
  * @brief Concrete layout of the sirius::expression PIMPL.
  *
  * Completed only in translation units that include this header. Everywhere else
- * `expression::impl` is an incomplete forward-declared type.
+ * `expression::impl` is an incomplete forward-declared type. The wrapper holds a
+ * Sirius-native AST node; the DuckDB->Sirius translation happens at the wrap()
+ * boundary (see expression.cpp). See https://github.com/sirius-db/sirius/issues/701.
  */
 struct expression::impl {
-  std::unique_ptr<duckdb::Expression> expr;
+  std::unique_ptr<sirius::ast::node> node;
 };
 
 //===----------------------------------------------------------------------===//
 // Read-only unwrap helpers
 //===----------------------------------------------------------------------===//
 
-inline duckdb::Expression const* unwrap(expression const& e) noexcept
+inline sirius::ast::node const* unwrap(expression const& e) noexcept
 {
   auto const* p = e.get_impl();
-  return p ? p->expr.get() : nullptr;
+  return p ? p->node.get() : nullptr;
 }
 
-inline duckdb::Expression* unwrap(expression& e) noexcept
+inline sirius::ast::node* unwrap(expression& e) noexcept
 {
   auto* p = e.get_impl();
-  return p ? p->expr.get() : nullptr;
+  return p ? p->node.get() : nullptr;
 }
 
 /**
- * @brief Transfers the underlying duckdb::Expression out of the wrapper.
+ * @brief Transfers the underlying Sirius AST node out of the wrapper.
  *
  * After this call, the sirius::expression is null.
  */
-inline std::unique_ptr<duckdb::Expression> release(expression& e) noexcept
+inline std::unique_ptr<sirius::ast::node> release(expression& e) noexcept
 {
   auto* p = e.get_impl();
   if (p == nullptr) { return nullptr; }
-  auto out = std::move(p->expr);
+  auto out = std::move(p->node);
   e        = expression{};  // drop the impl so is_null() returns true
   return out;
 }

--- a/src/include/op/aggregate/aggregate_op_util.hpp
+++ b/src/include/op/aggregate/aggregate_op_util.hpp
@@ -31,8 +31,13 @@ namespace op {
 /**
  * @brief Map a simple Sirius aggregate_id to a single cuDF aggregation kind.
  *
- * Returns std::nullopt for aggregates that decompose into multiple cuDF kinds (avg) or use a
- * different merge path (first, count distinct).
+ * Pure aggregate_id -> Kind mapping over the closed aggregate_id enum. DISTINCT is NOT an
+ * aggregate_id: COUNT(DISTINCT ...) is the `count` id with the distinct() modifier set, and is
+ * intercepted by the caller (COLLECT_SET path) before this helper runs — so there is no
+ * count_distinct case to add here.
+ *
+ * Returns std::nullopt for ids that do not map to a single merge-able cuDF kind: `avg`
+ * (decomposes into SUM + COUNT_VALID) and `first` (NTH_ELEMENT, handled by the caller).
  */
 std::optional<cudf::aggregation::Kind> to_cudf_aggregation_kind(sirius::aggregate_id id);
 

--- a/src/include/op/aggregate/aggregate_op_util.hpp
+++ b/src/include/op/aggregate/aggregate_op_util.hpp
@@ -17,14 +17,24 @@
 #pragma once
 
 #include "duckdb/common/vector.hpp"
+#include "expression/aggregate_id.hpp"
 #include "expression/expression.hpp"
 
 #include <cudf/aggregation.hpp>
 
+#include <optional>
 #include <vector>
 
 namespace sirius {
 namespace op {
+
+/**
+ * @brief Map a simple Sirius aggregate_id to a single cuDF aggregation kind.
+ *
+ * Returns std::nullopt for aggregates that decompose into multiple cuDF kinds (avg) or use a
+ * different merge path (first, count distinct).
+ */
+std::optional<cudf::aggregation::Kind> to_cudf_aggregation_kind(sirius::aggregate_id id);
 
 /**
  * @brief Mapping from one original DuckDB aggregate expression to its position(s) in the expanded

--- a/src/op/aggregate/aggregate_op_util.cpp
+++ b/src/op/aggregate/aggregate_op_util.cpp
@@ -19,10 +19,7 @@
 #include "cudf/cudf_utils.hpp"
 #include "duckdb/common/assert.hpp"
 #include "expression/aggregate_id.hpp"
-#include "expression/ast/aggregate.hpp"
-#include "expression/ast/function_call.hpp"
 #include "expression/ast/node.hpp"
-#include "expression/ast/reference.hpp"
 #include "expression/expression_internal.hpp"
 #include "sirius/exception.hpp"
 
@@ -32,6 +29,21 @@
 namespace sirius {
 namespace op {
 
+std::optional<cudf::aggregation::Kind> to_cudf_aggregation_kind(sirius::aggregate_id id)
+{
+  switch (id) {
+    case sirius::aggregate_id::sum:
+    case sirius::aggregate_id::sum_no_overflow: return cudf::aggregation::Kind::SUM;
+    case sirius::aggregate_id::count: return cudf::aggregation::Kind::COUNT_VALID;
+    case sirius::aggregate_id::count_star: return cudf::aggregation::Kind::COUNT_ALL;
+    case sirius::aggregate_id::min: return cudf::aggregation::Kind::MIN;
+    case sirius::aggregate_id::max: return cudf::aggregation::Kind::MAX;
+    case sirius::aggregate_id::avg:
+    case sirius::aggregate_id::first: return std::nullopt;
+  }
+  return std::nullopt;
+}
+
 CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
   const duckdb::vector<sirius::expression>& groups_p,
   const duckdb::vector<sirius::expression>& expressions)
@@ -40,31 +52,23 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
 
   // 1. Extract group_idx from groups_p
   for (const auto& group : groups_p) {
-    auto const* group_expr = sirius::unwrap(group);
-    if (group_expr == nullptr || !group_expr->holds<sirius::ast::reference>()) {
-      throw not_implemented_exception(
-        "[convert_duckdb_aggregates_to_cudf] group expression is not a bound reference");
-    }
-    result.group_idx.push_back(
-      static_cast<int>(group_expr->get<sirius::ast::reference>().column_index));
+    auto const& ref = sirius::ast::require_reference(sirius::unwrap(group),
+                                                     "convert_duckdb_aggregates_to_cudf group");
+    result.group_idx.push_back(static_cast<int>(ref.column_index));
   }
 
   // 2. Extract aggregates (cudf::aggregation::Kind) from expressions
   for (const auto& aggregate : expressions) {
-    auto const* anode = sirius::unwrap(aggregate);
-    if (anode == nullptr || !anode->holds<sirius::ast::aggregate>()) {
-      throw not_implemented_exception(
-        "[convert_duckdb_aggregates_to_cudf] expression is not an aggregate node");
-    }
-    auto const& aggr = anode->get<sirius::ast::aggregate>();
-    std::string const fname{sirius::to_duckdb_aggregate_name(aggr.function())};
+    auto const& aggr = sirius::ast::require_aggregate(
+      sirius::unwrap(aggregate), "convert_duckdb_aggregates_to_cudf aggregate");
+    auto const fid       = aggr.function();
     auto const& children = aggr.arguments();
 
     // Handle AVG specially: it expands into SUM + COUNT_VALID
-    if (fname == "avg") {
+    if (fid == sirius::aggregate_id::avg) {
       D_ASSERT(children.size() == 1);
-      D_ASSERT(children[0]->holds<sirius::ast::reference>());
-      auto col_idx = static_cast<int>(children[0]->get<sirius::ast::reference>().column_index);
+      D_ASSERT(children[0]->is_reference());
+      auto col_idx = static_cast<int>(children[0]->as_reference().column_index);
 
       size_t sum_position = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::SUM);
@@ -82,26 +86,24 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
     // Handle COUNT(DISTINCT col) and COUNT(DISTINCT (col1, col2, ...)):
     // Use COLLECT_SET locally; merge via MERGE_SETS; then count list elements.
     // For multi-column, a struct column is synthesized from the component columns.
-    if (aggr.distinct() && fname == "count") {
+    if (aggr.distinct() && fid == sirius::aggregate_id::count) {
       D_ASSERT(children.size() == 1);
       auto const& child = *children[0];
       size_t position   = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::COLLECT_SET);
 
-      if (child.holds<sirius::ast::reference>()) {
+      if (child.is_reference()) {
         // Single-column case: COUNT(DISTINCT col)
-        result.cudf_aggregate_idx.push_back(
-          static_cast<int>(child.get<sirius::ast::reference>().column_index));
+        result.cudf_aggregate_idx.push_back(static_cast<int>(child.as_reference().column_index));
         result.cudf_aggregate_struct_col_indices.push_back({});
       } else {
         // Multi-column case: COUNT(DISTINCT (col1, col2, ...)) — child is a struct_pack expression
-        D_ASSERT(child.holds<sirius::ast::function_call>());
-        auto const& func_expr = child.get<sirius::ast::function_call>();
+        D_ASSERT(child.is_function_call());
+        auto const& func_expr = child.as_function_call();
         std::vector<int> struct_indices;
         for (auto const& arg : func_expr.arguments()) {
-          D_ASSERT(arg->holds<sirius::ast::reference>());
-          struct_indices.push_back(
-            static_cast<int>(arg->get<sirius::ast::reference>().column_index));
+          D_ASSERT(arg->is_reference());
+          struct_indices.push_back(static_cast<int>(arg->as_reference().column_index));
         }
         D_ASSERT(!struct_indices.empty());
         result.cudf_aggregate_idx.push_back(-1);  // sentinel: struct column, see gpu_aggregate_impl
@@ -113,40 +115,33 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       continue;
     }
 
-    // Convert the aggregate function to a cudf::aggregation::Kind
-    cudf::aggregation::Kind agg_kind;
-    if (fname == "sum" || fname == "sum_no_overflow") {
-      agg_kind = cudf::aggregation::Kind::SUM;
-    } else if (fname == "count") {
-      agg_kind = cudf::aggregation::Kind::COUNT_VALID;
-    } else if (fname == "count_star") {
-      agg_kind = cudf::aggregation::Kind::COUNT_ALL;
-    } else if (fname == "min") {
-      agg_kind = cudf::aggregation::Kind::MIN;
-    } else if (fname == "max") {
-      agg_kind = cudf::aggregation::Kind::MAX;
-    } else {
-      throw std::runtime_error("Unsupported aggregate function: " + fname);
+    auto const agg_kind = to_cudf_aggregation_kind(fid);
+    if (!agg_kind) {
+      throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
+                               std::string{sirius::to_duckdb_aggregate_name(fid)});
     }
     size_t current_position = result.cudf_aggregates.size();
-    result.cudf_aggregates.push_back(agg_kind);
+    result.cudf_aggregates.push_back(*agg_kind);
 
     // 3. Extract aggregate_idx from the children of the aggregate expression
     if (children.empty()) {
       // COUNT(*) has no children - use 0 as a placeholder (will be handled by COUNT_ALL)
-      if (fname == "count_star") {
+      if (fid == sirius::aggregate_id::count_star) {
         result.cudf_aggregate_idx.push_back(0);
       } else {
-        throw std::runtime_error("Unsupported aggregate function: " + fname + " with no children");
+        throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
+                                 std::string{sirius::to_duckdb_aggregate_name(fid)} +
+                                 " with no children");
       }
     } else {
       if (children.size() == 1) {
         // Extract the column index from the first child (most aggregates have one child)
-        D_ASSERT(children[0]->holds<sirius::ast::reference>());
+        D_ASSERT(children[0]->is_reference());
         result.cudf_aggregate_idx.push_back(
-          static_cast<int>(children[0]->get<sirius::ast::reference>().column_index));
+          static_cast<int>(children[0]->as_reference().column_index));
       } else {
-        throw std::runtime_error("Unsupported aggregate function: " + fname + " with " +
+        throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
+                                 std::string{sirius::to_duckdb_aggregate_name(fid)} + " with " +
                                  std::to_string(children.size()) + " children");
       }
     }

--- a/src/op/aggregate/aggregate_op_util.cpp
+++ b/src/op/aggregate/aggregate_op_util.cpp
@@ -23,11 +23,28 @@
 #include "expression/expression_internal.hpp"
 #include "sirius/exception.hpp"
 
+#include <format>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace sirius {
 namespace op {
+
+namespace {
+
+// Single place that builds the "Unsupported aggregate function: <name>" diagnostic so the
+// message (and the aggregate_id -> name lookup) is not repeated at every rejection site.
+[[noreturn]] void throw_unsupported_aggregate(sirius::aggregate_id fid,
+                                              std::string_view detail = {})
+{
+  auto const name = sirius::to_duckdb_aggregate_name(fid);
+  throw std::runtime_error(detail.empty()
+                             ? std::format("Unsupported aggregate function: {}", name)
+                             : std::format("Unsupported aggregate function: {} {}", name, detail));
+}
+
+}  // namespace
 
 std::optional<cudf::aggregation::Kind> to_cudf_aggregation_kind(sirius::aggregate_id id)
 {
@@ -116,10 +133,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
     }
 
     auto const agg_kind = to_cudf_aggregation_kind(fid);
-    if (!agg_kind) {
-      throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
-                               std::string{sirius::to_duckdb_aggregate_name(fid)});
-    }
+    if (!agg_kind) { throw_unsupported_aggregate(fid); }
     size_t current_position = result.cudf_aggregates.size();
     result.cudf_aggregates.push_back(*agg_kind);
 
@@ -129,9 +143,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       if (fid == sirius::aggregate_id::count_star) {
         result.cudf_aggregate_idx.push_back(0);
       } else {
-        throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
-                                 std::string{sirius::to_duckdb_aggregate_name(fid)} +
-                                 " with no children");
+        throw_unsupported_aggregate(fid, "with no children");
       }
     } else {
       if (children.size() == 1) {
@@ -140,9 +152,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
         result.cudf_aggregate_idx.push_back(
           static_cast<int>(children[0]->as_reference().column_index));
       } else {
-        throw std::runtime_error(std::string{"Unsupported aggregate function: "} +
-                                 std::string{sirius::to_duckdb_aggregate_name(fid)} + " with " +
-                                 std::to_string(children.size()) + " children");
+        throw_unsupported_aggregate(fid, "with " + std::to_string(children.size()) + " children");
       }
     }
     result.cudf_aggregate_struct_col_indices.push_back({});

--- a/src/op/aggregate/aggregate_op_util.cpp
+++ b/src/op/aggregate/aggregate_op_util.cpp
@@ -18,10 +18,13 @@
 
 #include "cudf/cudf_utils.hpp"
 #include "duckdb/common/assert.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression/aggregate_id.hpp"
+#include "expression/ast/aggregate.hpp"
+#include "expression/ast/function_call.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
 #include "expression/expression_internal.hpp"
+#include "sirius/exception.hpp"
 
 #include <stdexcept>
 #include <string>
@@ -38,21 +41,30 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
   // 1. Extract group_idx from groups_p
   for (const auto& group : groups_p) {
     auto const* group_expr = sirius::unwrap(group);
-    D_ASSERT(group_expr->type == duckdb::ExpressionType::BOUND_REF);
-    auto& bound_ref = group_expr->Cast<duckdb::BoundReferenceExpression>();
-    result.group_idx.push_back(static_cast<int>(bound_ref.index));
+    if (group_expr == nullptr || !group_expr->holds<sirius::ast::reference>()) {
+      throw not_implemented_exception(
+        "[convert_duckdb_aggregates_to_cudf] group expression is not a bound reference");
+    }
+    result.group_idx.push_back(
+      static_cast<int>(group_expr->get<sirius::ast::reference>().column_index));
   }
 
   // 2. Extract aggregates (cudf::aggregation::Kind) from expressions
   for (const auto& aggregate : expressions) {
-    auto& aggr = sirius::unwrap(aggregate)->Cast<duckdb::BoundAggregateExpression>();
+    auto const* anode = sirius::unwrap(aggregate);
+    if (anode == nullptr || !anode->holds<sirius::ast::aggregate>()) {
+      throw not_implemented_exception(
+        "[convert_duckdb_aggregates_to_cudf] expression is not an aggregate node");
+    }
+    auto const& aggr = anode->get<sirius::ast::aggregate>();
+    std::string const fname{sirius::to_duckdb_aggregate_name(aggr.function())};
+    auto const& children = aggr.arguments();
 
     // Handle AVG specially: it expands into SUM + COUNT_VALID
-    if (aggr.function.name == "avg") {
-      D_ASSERT(aggr.children.size() == 1);
-      D_ASSERT(aggr.children[0]->type == duckdb::ExpressionType::BOUND_REF);
-      auto& bound_ref = aggr.children[0]->Cast<duckdb::BoundReferenceExpression>();
-      auto col_idx    = static_cast<int>(bound_ref.index);
+    if (fname == "avg") {
+      D_ASSERT(children.size() == 1);
+      D_ASSERT(children[0]->holds<sirius::ast::reference>());
+      auto col_idx = static_cast<int>(children[0]->get<sirius::ast::reference>().column_index);
 
       size_t sum_position = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::SUM);
@@ -62,7 +74,7 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       result.cudf_aggregate_idx.push_back(col_idx);
       result.cudf_aggregate_struct_col_indices.push_back({});
       result.aggregate_slots.push_back(
-        AggregateSlot{true, false, sum_position, duckdb::GetCudfType(aggr.return_type)});
+        AggregateSlot{true, false, sum_position, sirius::get_cudf_type(aggr.return_type())});
       result.has_avg = true;
       continue;
     }
@@ -70,26 +82,26 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
     // Handle COUNT(DISTINCT col) and COUNT(DISTINCT (col1, col2, ...)):
     // Use COLLECT_SET locally; merge via MERGE_SETS; then count list elements.
     // For multi-column, a struct column is synthesized from the component columns.
-    if (aggr.IsDistinct() && aggr.function.name == "count") {
-      D_ASSERT(aggr.children.size() == 1);
-      auto& child     = *aggr.children[0];
-      size_t position = result.cudf_aggregates.size();
+    if (aggr.distinct() && fname == "count") {
+      D_ASSERT(children.size() == 1);
+      auto const& child = *children[0];
+      size_t position   = result.cudf_aggregates.size();
       result.cudf_aggregates.push_back(cudf::aggregation::Kind::COLLECT_SET);
 
-      if (child.type == duckdb::ExpressionType::BOUND_REF) {
+      if (child.holds<sirius::ast::reference>()) {
         // Single-column case: COUNT(DISTINCT col)
-        auto& bound_ref = child.Cast<duckdb::BoundReferenceExpression>();
-        result.cudf_aggregate_idx.push_back(static_cast<int>(bound_ref.index));
+        result.cudf_aggregate_idx.push_back(
+          static_cast<int>(child.get<sirius::ast::reference>().column_index));
         result.cudf_aggregate_struct_col_indices.push_back({});
       } else {
         // Multi-column case: COUNT(DISTINCT (col1, col2, ...)) — child is a struct_pack expression
-        D_ASSERT(child.type == duckdb::ExpressionType::BOUND_FUNCTION);
-        auto& func_expr = child.Cast<duckdb::BoundFunctionExpression>();
+        D_ASSERT(child.holds<sirius::ast::function_call>());
+        auto const& func_expr = child.get<sirius::ast::function_call>();
         std::vector<int> struct_indices;
-        for (auto& arg : func_expr.children) {
-          D_ASSERT(arg->type == duckdb::ExpressionType::BOUND_REF);
-          auto& br = arg->Cast<duckdb::BoundReferenceExpression>();
-          struct_indices.push_back(static_cast<int>(br.index));
+        for (auto const& arg : func_expr.arguments()) {
+          D_ASSERT(arg->holds<sirius::ast::reference>());
+          struct_indices.push_back(
+            static_cast<int>(arg->get<sirius::ast::reference>().column_index));
         }
         D_ASSERT(!struct_indices.empty());
         result.cudf_aggregate_idx.push_back(-1);  // sentinel: struct column, see gpu_aggregate_impl
@@ -101,42 +113,41 @@ CudfAggregateDefinitions convert_duckdb_aggregates_to_cudf(
       continue;
     }
 
-    // Convert DuckDB aggregate function name to cudf::aggregation::Kind
+    // Convert the aggregate function to a cudf::aggregation::Kind
     cudf::aggregation::Kind agg_kind;
-    if (aggr.function.name == "sum" || aggr.function.name == "sum_no_overflow") {
+    if (fname == "sum" || fname == "sum_no_overflow") {
       agg_kind = cudf::aggregation::Kind::SUM;
-    } else if (aggr.function.name == "count") {
+    } else if (fname == "count") {
       agg_kind = cudf::aggregation::Kind::COUNT_VALID;
-    } else if (aggr.function.name == "count_star") {
+    } else if (fname == "count_star") {
       agg_kind = cudf::aggregation::Kind::COUNT_ALL;
-    } else if (aggr.function.name == "min") {
+    } else if (fname == "min") {
       agg_kind = cudf::aggregation::Kind::MIN;
-    } else if (aggr.function.name == "max") {
+    } else if (fname == "max") {
       agg_kind = cudf::aggregation::Kind::MAX;
     } else {
-      throw std::runtime_error("Unsupported aggregate function: " + aggr.function.name);
+      throw std::runtime_error("Unsupported aggregate function: " + fname);
     }
     size_t current_position = result.cudf_aggregates.size();
     result.cudf_aggregates.push_back(agg_kind);
 
     // 3. Extract aggregate_idx from the children of the aggregate expression
-    if (aggr.children.empty()) {
+    if (children.empty()) {
       // COUNT(*) has no children - use 0 as a placeholder (will be handled by COUNT_ALL)
-      if (aggr.function.name == "count_star") {
+      if (fname == "count_star") {
         result.cudf_aggregate_idx.push_back(0);
       } else {
-        throw std::runtime_error("Unsupported aggregate function: " + aggr.function.name +
-                                 " with no children");
+        throw std::runtime_error("Unsupported aggregate function: " + fname + " with no children");
       }
     } else {
-      if (aggr.children.size() == 1) {
+      if (children.size() == 1) {
         // Extract the column index from the first child (most aggregates have one child)
-        D_ASSERT(aggr.children[0]->type == duckdb::ExpressionType::BOUND_REF);
-        auto& bound_ref = aggr.children[0]->Cast<duckdb::BoundReferenceExpression>();
-        result.cudf_aggregate_idx.push_back(static_cast<int>(bound_ref.index));
+        D_ASSERT(children[0]->holds<sirius::ast::reference>());
+        result.cudf_aggregate_idx.push_back(
+          static_cast<int>(children[0]->get<sirius::ast::reference>().column_index));
       } else {
-        throw std::runtime_error("Unsupported aggregate function: " + aggr.function.name +
-                                 " with " + std::to_string(aggr.children.size()) + " children");
+        throw std::runtime_error("Unsupported aggregate function: " + fname + " with " +
+                                 std::to_string(children.size()) + " children");
       }
     }
     result.cudf_aggregate_struct_col_indices.push_back({});

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/joinside.hpp"
+#include "expression/ast/to_duckdb.hpp"
 #include "expression/expression_internal.hpp"
 #include "expression_executor/gpu_expression_translator_internal.hpp"
 #include "helper/type_conversions.hpp"
@@ -102,8 +103,10 @@ bool sirius_physical_hash_join::are_conditions_supported(
   std::unordered_set<std::size_t> equality_left_cols, equality_right_cols;
   for (auto const& cond : conditions) {
     if (!is_equality(cond.comparison)) { continue; }
-    collect_bound_ref_indices(*sirius::unwrap(cond.left), equality_left_cols);
-    collect_bound_ref_indices(*sirius::unwrap(cond.right), equality_right_cols);
+    auto left_owned  = sirius::ast::to_duckdb(*sirius::unwrap(cond.left));
+    auto right_owned = sirius::ast::to_duckdb(*sirius::unwrap(cond.right));
+    collect_bound_ref_indices(*left_owned, equality_left_cols);
+    collect_bound_ref_indices(*right_owned, equality_right_cols);
   }
 
   // For each inequality condition, verify that its left/right column references don't overlap
@@ -112,8 +115,10 @@ bool sirius_physical_hash_join::are_conditions_supported(
   for (auto const& cond : conditions) {
     if (is_equality(cond.comparison)) { continue; }
     std::unordered_set<std::size_t> ineq_left_cols, ineq_right_cols;
-    collect_bound_ref_indices(*sirius::unwrap(cond.left), ineq_left_cols);
-    collect_bound_ref_indices(*sirius::unwrap(cond.right), ineq_right_cols);
+    auto left_owned  = sirius::ast::to_duckdb(*sirius::unwrap(cond.left));
+    auto right_owned = sirius::ast::to_duckdb(*sirius::unwrap(cond.right));
+    collect_bound_ref_indices(*left_owned, ineq_left_cols);
+    collect_bound_ref_indices(*right_owned, ineq_right_cols);
     for (auto const idx : ineq_left_cols) {
       if (equality_left_cols.count(idx) > 0) { return false; }
     }
@@ -233,8 +238,10 @@ sirius_physical_hash_join::sirius_physical_hash_join(
 
   for (std::size_t cond_idx = 0; cond_idx < conditions.size(); cond_idx++) {
     auto& condition        = conditions[cond_idx];
-    auto const* left_expr  = sirius::unwrap(condition.left);
-    auto const* right_expr = sirius::unwrap(condition.right);
+    auto left_owned        = sirius::ast::to_duckdb(*sirius::unwrap(condition.left));
+    auto right_owned       = sirius::ast::to_duckdb(*sirius::unwrap(condition.right));
+    auto const* left_expr  = left_owned.get();
+    auto const* right_expr = right_owned.get();
 
     if (!is_equality(condition.comparison)) {
       // Inequality conditions are handled at execute time via the cuDF mixed_join binary predicate.

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression/ast/to_duckdb.hpp"
 #include "expression/expression_internal.hpp"
 #include "expression_executor/gpu_expression_executor.hpp"
 #include "expression_executor/gpu_expression_translator_internal.hpp"
@@ -189,7 +190,7 @@ bool sirius_physical_nested_loop_join::is_supported(
 {
   if (join_type == duckdb::JoinType::MARK) { return true; }
   for (auto& cond : conditions) {
-    auto const* left_expr = sirius::unwrap(cond.left);
+    auto left_expr = sirius::ast::to_duckdb(*sirius::unwrap(cond.left));
     if (left_expr->return_type.InternalType() == duckdb::PhysicalType::STRUCT ||
         left_expr->return_type.InternalType() == duckdb::PhysicalType::LIST ||
         left_expr->return_type.InternalType() == duckdb::PhysicalType::ARRAY) {
@@ -206,7 +207,8 @@ duckdb::vector<sirius::logical_type> sirius_physical_nested_loop_join::get_join_
 {
   duckdb::vector<sirius::logical_type> result;
   for (auto& op : conditions) {
-    result.push_back(sirius::from_duckdb(sirius::unwrap(op.right)->return_type));
+    auto right_expr = sirius::ast::to_duckdb(*sirius::unwrap(op.right));
+    result.push_back(sirius::from_duckdb(right_expr->return_type));
   }
   return result;
 }
@@ -533,18 +535,12 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     };
 
     for (const auto& cond : conditions) {
-      cudf::size_type left_join_input_index  = resolve_join_col(*sirius::unwrap(cond.left),
-                                                               left_expressions_to_idx,
-                                                               left_batch,
-                                                               left,
-                                                               left_col_views,
-                                                               "left");
-      cudf::size_type right_join_input_index = resolve_join_col(*sirius::unwrap(cond.right),
-                                                                right_expressions_to_idx,
-                                                                right_batch,
-                                                                right,
-                                                                right_col_views,
-                                                                "right");
+      auto left_owned                       = sirius::ast::to_duckdb(*sirius::unwrap(cond.left));
+      auto right_owned                      = sirius::ast::to_duckdb(*sirius::unwrap(cond.right));
+      cudf::size_type left_join_input_index = resolve_join_col(
+        *left_owned, left_expressions_to_idx, left_batch, left, left_col_views, "left");
+      cudf::size_type right_join_input_index = resolve_join_col(
+        *right_owned, right_expressions_to_idx, right_batch, right, right_col_views, "right");
 
       left_refs.emplace_back(left_join_input_index, cudf::ast::table_reference::LEFT);
       right_refs.emplace_back(right_join_input_index, cudf::ast::table_reference::RIGHT);

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -19,6 +19,7 @@
 #include "data/data_batch_utils.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression/ast/to_duckdb.hpp"
 #include "expression/expression_internal.hpp"
 #include "log/logging.hpp"
 #include "op/partition/gpu_partition_impl.hpp"
@@ -85,10 +86,12 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
           condition.comparison != sirius::comparison_type::not_distinct_from) {
         continue;
       }
-      std::optional<std::size_t> left_index =
-        extract_bound_ref_index(*sirius::unwrap(hash_join_op.conditions[cond_idx].left));
-      std::optional<std::size_t> right_index =
-        extract_bound_ref_index(*sirius::unwrap(hash_join_op.conditions[cond_idx].right));
+      auto left_owned =
+        sirius::ast::to_duckdb(*sirius::unwrap(hash_join_op.conditions[cond_idx].left));
+      auto right_owned =
+        sirius::ast::to_duckdb(*sirius::unwrap(hash_join_op.conditions[cond_idx].right));
+      std::optional<std::size_t> left_index  = extract_bound_ref_index(*left_owned);
+      std::optional<std::size_t> right_index = extract_bound_ref_index(*right_owned);
       if (left_index.has_value() && right_index.has_value()) {
         // Determine if a type cast is needed for hash alignment.
         // When the join condition has a BOUND_CAST on one side, the two sides have different
@@ -96,8 +99,7 @@ void sirius_physical_partition::get_partition_keys_and_type(sirius_physical_oper
         // values for the same integer in different representations, so without a cast, matching
         // keys would land in different partitions. We apply the same cast used by the join
         // condition so both sides hash identically.
-        const auto& key_expr = is_build ? *sirius::unwrap(hash_join_op.conditions[cond_idx].right)
-                                        : *sirius::unwrap(hash_join_op.conditions[cond_idx].left);
+        const auto& key_expr = is_build ? *right_owned : *left_owned;
         if (is_build) {
           _partition_keys.push_back(right_index.value());
         } else {

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -120,11 +120,8 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
   layout.aggregates.reserve(aggregates.size());
 
   for (size_t i = 0; i < aggregates.size(); ++i) {
-    auto const* agg_node = sirius::unwrap(aggregates[i]);
-    if (agg_node == nullptr || !agg_node->holds<sirius::ast::aggregate>()) {
-      throw not_implemented_exception("ungrouped aggregate: expression is not an aggregate node");
-    }
-    auto const& agg = agg_node->get<sirius::ast::aggregate>();
+    auto const& agg =
+      sirius::ast::require_aggregate(sirius::unwrap(aggregates[i]), "ungrouped aggregate");
     if (agg.distinct()) {
       throw not_implemented_exception("Distinct aggregates not supported in GPU path yet");
     }
@@ -134,9 +131,7 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
     }
 
     auto agg_return_type = sirius::to_duckdb(agg.return_type());
-    auto child_ref_index = [&]() {
-      return children[0]->get<sirius::ast::reference>().column_index;
-    };
+    auto child_ref_index = [&]() { return children[0]->as_reference().column_index; };
 
     aggregate_spec spec;
     spec.input_idx       = -1;
@@ -144,79 +139,89 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
     spec.local_sum_idx   = std::numeric_limits<size_t>::max();
     spec.local_count_idx = std::numeric_limits<size_t>::max();
 
-    std::string const fname{sirius::to_duckdb_aggregate_name(agg.function())};
-    if (fname == "count_star") {
-      spec.kind          = aggregate_kind::COUNT_STAR;
-      spec.return_type   = duckdb::LogicalType::BIGINT;
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
-      layout.merge_nth_index.push_back(std::nullopt);
-    } else if (fname == "count") {
-      if (children.empty()) {
-        throw not_implemented_exception("count() without arguments not supported");
-      }
-      spec.kind          = aggregate_kind::COUNT;
-      spec.return_type   = duckdb::LogicalType::BIGINT;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
-      layout.merge_nth_index.push_back(std::nullopt);
-    } else if (fname == "sum" || fname == "sum_no_overflow") {
-      if (children.empty()) {
-        throw not_implemented_exception("sum() without arguments not supported");
-      }
-      spec.kind          = aggregate_kind::SUM;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg_return_type);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
-      layout.merge_nth_index.push_back(std::nullopt);
-    } else if (fname == "min") {
-      if (children.empty()) {
-        throw not_implemented_exception("min() without arguments not supported");
-      }
-      spec.kind          = aggregate_kind::MIN;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg_return_type);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::MIN);
-      layout.merge_nth_index.push_back(std::nullopt);
-    } else if (fname == "max") {
-      if (children.empty()) {
-        throw not_implemented_exception("max() without arguments not supported");
-      }
-      spec.kind          = aggregate_kind::MAX;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg_return_type);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::MAX);
-      layout.merge_nth_index.push_back(std::nullopt);
-    } else if (fname == "avg") {
-      if (children.empty()) {
-        throw not_implemented_exception("avg() without arguments not supported");
-      }
-      spec.kind          = aggregate_kind::AVG;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg_return_type);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
-      layout.merge_nth_index.push_back(std::nullopt);
-      spec.local_count_idx = local_idx++;
-      layout.local_types.push_back(duckdb::LogicalType::BIGINT);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
-      layout.merge_nth_index.push_back(std::nullopt);
-      layout.has_avg = true;
-    } else if (fname == "first") {
-      spec.kind          = aggregate_kind::FIRST;
-      spec.input_idx     = child_ref_index();
-      spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg_return_type);
-      layout.merge_kinds.push_back(cudf::aggregation::Kind::NTH_ELEMENT);
-      layout.merge_nth_index.push_back(0);  // first element
-    } else {
-      throw not_implemented_exception("Aggregate not supported: " + fname);
+    switch (agg.function()) {
+      case sirius::aggregate_id::count_star:
+        spec.kind          = aggregate_kind::COUNT_STAR;
+        spec.return_type   = duckdb::LogicalType::BIGINT;
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+        layout.merge_nth_index.push_back(std::nullopt);
+        break;
+      case sirius::aggregate_id::count:
+        if (children.empty()) {
+          throw not_implemented_exception("count() without arguments not supported");
+        }
+        spec.kind          = aggregate_kind::COUNT;
+        spec.return_type   = duckdb::LogicalType::BIGINT;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+        layout.merge_nth_index.push_back(std::nullopt);
+        break;
+      case sirius::aggregate_id::sum:
+      case sirius::aggregate_id::sum_no_overflow:
+        if (children.empty()) {
+          throw not_implemented_exception("sum() without arguments not supported");
+        }
+        spec.kind          = aggregate_kind::SUM;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(agg_return_type);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+        layout.merge_nth_index.push_back(std::nullopt);
+        break;
+      case sirius::aggregate_id::min:
+        if (children.empty()) {
+          throw not_implemented_exception("min() without arguments not supported");
+        }
+        spec.kind          = aggregate_kind::MIN;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(agg_return_type);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::MIN);
+        layout.merge_nth_index.push_back(std::nullopt);
+        break;
+      case sirius::aggregate_id::max:
+        if (children.empty()) {
+          throw not_implemented_exception("max() without arguments not supported");
+        }
+        spec.kind          = aggregate_kind::MAX;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(agg_return_type);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::MAX);
+        layout.merge_nth_index.push_back(std::nullopt);
+        break;
+      case sirius::aggregate_id::avg:
+        if (children.empty()) {
+          throw not_implemented_exception("avg() without arguments not supported");
+        }
+        spec.kind          = aggregate_kind::AVG;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(agg_return_type);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+        layout.merge_nth_index.push_back(std::nullopt);
+        spec.local_count_idx = local_idx++;
+        layout.local_types.push_back(duckdb::LogicalType::BIGINT);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
+        layout.merge_nth_index.push_back(std::nullopt);
+        layout.has_avg = true;
+        break;
+      case sirius::aggregate_id::first:
+        spec.kind          = aggregate_kind::FIRST;
+        spec.input_idx     = child_ref_index();
+        spec.local_sum_idx = local_idx++;
+        layout.local_types.push_back(agg_return_type);
+        layout.merge_kinds.push_back(cudf::aggregation::Kind::NTH_ELEMENT);
+        layout.merge_nth_index.push_back(0);  // first element
+        break;
+      default:
+        throw not_implemented_exception(
+          "Aggregate not supported: {}",
+          std::string{sirius::to_duckdb_aggregate_name(agg.function())});
     }
 
     layout.aggregates.push_back(std::move(spec));

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -19,9 +19,13 @@
 #include "cudf/cudf_utils.hpp"
 #include "data/data_batch_utils.hpp"
 #include "duckdb/common/types/decimal.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "expression/aggregate_id.hpp"
+#include "expression/ast/aggregate.hpp"
+#include "expression/ast/clone.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
 #include "expression/expression_internal.hpp"
+#include "helper/type_conversions.hpp"
 #include "op/merge/gpu_merge_impl.hpp"
 #include "op/sirius_physical_ungrouped_aggregate_merge.hpp"
 #include "sirius/exception.hpp"
@@ -116,21 +120,31 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
   layout.aggregates.reserve(aggregates.size());
 
   for (size_t i = 0; i < aggregates.size(); ++i) {
-    auto& agg = sirius::unwrap(aggregates[i])->Cast<duckdb::BoundAggregateExpression>();
-    if (agg.IsDistinct()) {
+    auto const* agg_node = sirius::unwrap(aggregates[i]);
+    if (agg_node == nullptr || !agg_node->holds<sirius::ast::aggregate>()) {
+      throw not_implemented_exception("ungrouped aggregate: expression is not an aggregate node");
+    }
+    auto const& agg = agg_node->get<sirius::ast::aggregate>();
+    if (agg.distinct()) {
       throw not_implemented_exception("Distinct aggregates not supported in GPU path yet");
     }
-    if (agg.children.size() > 1) {
+    auto const& children = agg.arguments();
+    if (children.size() > 1) {
       throw not_implemented_exception("Aggregates with multiple children not supported yet");
     }
 
+    auto agg_return_type = sirius::to_duckdb(agg.return_type());
+    auto child_ref_index = [&]() {
+      return children[0]->get<sirius::ast::reference>().column_index;
+    };
+
     aggregate_spec spec;
     spec.input_idx       = -1;
-    spec.return_type     = agg.return_type;
+    spec.return_type     = agg_return_type;
     spec.local_sum_idx   = std::numeric_limits<size_t>::max();
     spec.local_count_idx = std::numeric_limits<size_t>::max();
 
-    const auto& fname = agg.function.name;
+    std::string const fname{sirius::to_duckdb_aggregate_name(agg.function())};
     if (fname == "count_star") {
       spec.kind          = aggregate_kind::COUNT_STAR;
       spec.return_type   = duckdb::LogicalType::BIGINT;
@@ -139,54 +153,54 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
       layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
       layout.merge_nth_index.push_back(std::nullopt);
     } else if (fname == "count") {
-      if (agg.children.empty()) {
+      if (children.empty()) {
         throw not_implemented_exception("count() without arguments not supported");
       }
       spec.kind          = aggregate_kind::COUNT;
       spec.return_type   = duckdb::LogicalType::BIGINT;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
       layout.local_types.push_back(duckdb::LogicalType::BIGINT);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
       layout.merge_nth_index.push_back(std::nullopt);
     } else if (fname == "sum" || fname == "sum_no_overflow") {
-      if (agg.children.empty()) {
+      if (children.empty()) {
         throw not_implemented_exception("sum() without arguments not supported");
       }
       spec.kind          = aggregate_kind::SUM;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg.return_type);
+      layout.local_types.push_back(agg_return_type);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
       layout.merge_nth_index.push_back(std::nullopt);
     } else if (fname == "min") {
-      if (agg.children.empty()) {
+      if (children.empty()) {
         throw not_implemented_exception("min() without arguments not supported");
       }
       spec.kind          = aggregate_kind::MIN;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg.return_type);
+      layout.local_types.push_back(agg_return_type);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::MIN);
       layout.merge_nth_index.push_back(std::nullopt);
     } else if (fname == "max") {
-      if (agg.children.empty()) {
+      if (children.empty()) {
         throw not_implemented_exception("max() without arguments not supported");
       }
       spec.kind          = aggregate_kind::MAX;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg.return_type);
+      layout.local_types.push_back(agg_return_type);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::MAX);
       layout.merge_nth_index.push_back(std::nullopt);
     } else if (fname == "avg") {
-      if (agg.children.empty()) {
+      if (children.empty()) {
         throw not_implemented_exception("avg() without arguments not supported");
       }
       spec.kind          = aggregate_kind::AVG;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg.return_type);
+      layout.local_types.push_back(agg_return_type);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::SUM);
       layout.merge_nth_index.push_back(std::nullopt);
       spec.local_count_idx = local_idx++;
@@ -196,9 +210,9 @@ aggregate_layout build_aggregate_layout(const duckdb::vector<sirius::expression>
       layout.has_avg = true;
     } else if (fname == "first") {
       spec.kind          = aggregate_kind::FIRST;
-      spec.input_idx     = agg.children[0]->Cast<duckdb::BoundReferenceExpression>().index;
+      spec.input_idx     = child_ref_index();
       spec.local_sum_idx = local_idx++;
-      layout.local_types.push_back(agg.return_type);
+      layout.local_types.push_back(agg_return_type);
       layout.merge_kinds.push_back(cudf::aggregation::Kind::NTH_ELEMENT);
       layout.merge_nth_index.push_back(0);  // first element
     } else {
@@ -452,7 +466,14 @@ static duckdb::vector<sirius::expression> copy_expressions(
   duckdb::vector<sirius::expression> result;
   result.reserve(src.size());
   for (const auto& expr : src) {
-    result.push_back(sirius::wrap(sirius::unwrap(expr)->Copy()));
+    // node is move-only and aggregate nodes cannot round-trip through to_duckdb,
+    // so deep-clone the AST node and re-wrap it directly (bypassing wrap/from_duckdb).
+    auto const* src_node = sirius::unwrap(expr);
+    if (src_node == nullptr) {
+      throw not_implemented_exception("copy_expressions: cannot clone a null aggregate expression");
+    }
+    result.push_back(sirius::expression{std::make_unique<sirius::expression::impl>(
+      sirius::expression::impl{sirius::ast::clone(*src_node)})});
   }
   return result;
 }

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -23,6 +23,8 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
 #include "expression/expression.hpp"
 #include "expression/expression_internal.hpp"
 #include "helper/type_conversions.hpp"
@@ -137,9 +139,8 @@ static bool can_use_partitioned_aggregate(duckdb::ClientContext& context,
         for (auto& partition_col : partition_columns) {
           // we only support bound reference here
           auto const* expr = sirius::unwrap(projection.select_list[partition_col]);
-          if (expr->GetExpressionType() != duckdb::ExpressionType::BOUND_REF) { return false; }
-          auto& ref = expr->Cast<duckdb::BoundReferenceExpression>();
-          new_columns.push_back(ref.index);
+          if (!expr->holds<sirius::ast::reference>()) { return false; }
+          new_columns.push_back(expr->get<sirius::ast::reference>().column_index);
         }
         // continue into child node with new columns
         partition_columns = std::move(new_columns);

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "expression/ast/to_duckdb.hpp"
 #include "expression/expression_internal.hpp"
 #include "expression/join_condition.hpp"
 #include "helper/type_conversions.hpp"
@@ -348,7 +349,7 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       bool keys_extractable = true;
       for (const auto& c : hj.conditions) {
         if (c.comparison != sirius::comparison_type::equal) { continue; }
-        auto const* right_expr = sirius::unwrap(c.right);
+        auto right_expr = sirius::ast::to_duckdb(*sirius::unwrap(c.right));
         if (right_expr->GetExpressionClass() != duckdb::ExpressionClass::BOUND_REF) {
           keys_extractable = false;
           break;

--- a/test/cpp/expression/test_ast_clone.cpp
+++ b/test/cpp/expression/test_ast_clone.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for sirius::ast::clone — the deep-clone helper used by the aggregate
+// copy path. node is move-only, so clone must reconstruct each alternative and
+// recursively duplicate every child unique_ptr into an independent allocation.
+
+#include "catch.hpp"
+#include "expression/ast/clone.hpp"
+
+// sirius — node accessors and per-node struct types
+#include "expression/aggregate_id.hpp"
+#include "expression/ast/aggregate.hpp"
+#include "expression/ast/function_call.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
+#include "expression/function_id.hpp"
+#include "helper/logical_type.hpp"
+
+// standard library
+#include <memory>
+#include <utility>
+#include <vector>
+
+using sirius::ast::aggregate;
+using sirius::ast::clone;
+using sirius::ast::function_call;
+using sirius::ast::node;
+using sirius::ast::reference;
+
+// ============================================================================
+// Test 1: reference
+// ============================================================================
+
+TEST_CASE("ast_clone - cloning a reference yields an independent node with equal fields",
+          "[ast_clone]")
+{
+  auto src = std::make_unique<node>(
+    reference{/*column_index=*/7, sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto cloned = clone(*src);
+
+  REQUIRE(cloned != nullptr);
+  REQUIRE(cloned.get() != src.get());  // independent allocation
+  REQUIRE(cloned->holds<reference>());
+  auto const& ref = cloned->get<reference>();
+  REQUIRE(ref.column_index == 7);
+  REQUIRE(ref.return_type.id() == sirius::type_id::INTEGER);
+}
+
+// ============================================================================
+// Test 2: aggregate with one reference child
+// ============================================================================
+
+TEST_CASE("ast_clone - cloning an aggregate deep-clones its reference child", "[ast_clone]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(std::make_unique<node>(
+    reference{/*column_index=*/3, sirius::logical_type::make(sirius::type_id::BIGINT)}));
+
+  auto src = std::make_unique<node>(aggregate{sirius::aggregate_id::sum,
+                                              std::move(args),
+                                              sirius::logical_type::make(sirius::type_id::BIGINT),
+                                              /*distinct=*/true});
+
+  auto cloned = clone(*src);
+
+  REQUIRE(cloned != nullptr);
+  REQUIRE(cloned.get() != src.get());
+  REQUIRE(cloned->holds<aggregate>());
+  auto const& agg = cloned->get<aggregate>();
+  REQUIRE(agg.function() == sirius::aggregate_id::sum);
+  REQUIRE(agg.distinct() == true);
+  REQUIRE(agg.return_type().id() == sirius::type_id::BIGINT);
+  REQUIRE(agg.arguments().size() == 1);
+
+  // The child is an independent allocation holding an equal reference.
+  auto const& src_child = src->get<aggregate>().arguments()[0];
+  REQUIRE(agg.arguments()[0].get() != src_child.get());
+  REQUIRE(agg.arguments()[0]->holds<reference>());
+  REQUIRE(agg.arguments()[0]->get<reference>().column_index == 3);
+}
+
+// ============================================================================
+// Test 3: function_call (struct_pack shape) with two reference children
+// ============================================================================
+
+TEST_CASE("ast_clone - cloning a struct_pack function_call deep-clones every child", "[ast_clone]")
+{
+  std::vector<std::unique_ptr<node>> args;
+  args.push_back(std::make_unique<node>(
+    reference{/*column_index=*/1, sirius::logical_type::make(sirius::type_id::INTEGER)}));
+  args.push_back(std::make_unique<node>(
+    reference{/*column_index=*/2, sirius::logical_type::make(sirius::type_id::INTEGER)}));
+
+  auto src =
+    std::make_unique<node>(function_call{sirius::function_id::struct_pack,
+                                         std::move(args),
+                                         sirius::logical_type::make(sirius::type_id::INTEGER)});
+
+  auto cloned = clone(*src);
+
+  REQUIRE(cloned != nullptr);
+  REQUIRE(cloned->holds<function_call>());
+  auto const& fc = cloned->get<function_call>();
+  REQUIRE(fc.function() == sirius::function_id::struct_pack);
+  REQUIRE(fc.arguments().size() == 2);
+
+  auto const& src_args = src->get<function_call>().arguments();
+  for (std::size_t i = 0; i < 2; ++i) {
+    REQUIRE(fc.arguments()[i].get() != src_args[i].get());
+    REQUIRE(fc.arguments()[i]->holds<reference>());
+    REQUIRE(fc.arguments()[i]->get<reference>().column_index ==
+            src_args[i]->get<reference>().column_index);
+  }
+}

--- a/test/cpp/expression/test_ast_scaffold.cpp
+++ b/test/cpp/expression/test_ast_scaffold.cpp
@@ -128,16 +128,17 @@ TEST_CASE("ast_scaffold - between holds three children and inclusivity flags", "
 
 TEST_CASE("ast_scaffold - case_expr holds when/then pairs and an else clause", "[ast_scaffold]")
 {
-  case_expr c;
-  case_expr::when_then wt;
-  wt.when_ = std::make_unique<node>(reference{0});
-  wt.then_ = std::make_unique<node>(reference{1});
-  c.cases.push_back(std::move(wt));
-  c.else_ = std::make_unique<node>(reference{2});
+  std::vector<case_expr::when_then> cases;
+  cases.push_back(case_expr::when_then{std::make_unique<node>(reference{0}),
+                                       std::make_unique<node>(reference{1})});
+  case_expr c{std::move(cases),
+              std::make_unique<node>(reference{2}),
+              sirius::logical_type::make(sirius::type_id::INTEGER)};
   REQUIRE(c.cases.size() == 1);
   REQUIRE(c.cases[0].when_);
   REQUIRE(c.cases[0].then_);
   REQUIRE(c.else_);
+  REQUIRE(c.return_type().id() == sirius::type_id::INTEGER);
   node n{std::move(c)};
   REQUIRE(n.holds<case_expr>());
 }
@@ -182,11 +183,13 @@ TEST_CASE("ast_scaffold - unary_op op defaults to invalid sentinel", "[ast_scaff
 
 TEST_CASE("ast_scaffold - coalesce holds N-ary children", "[ast_scaffold]")
 {
-  coalesce co;
-  co.children.push_back(std::make_unique<node>(reference{0}));
-  co.children.push_back(std::make_unique<node>(reference{1}));
-  co.children.push_back(std::make_unique<node>(reference{2}));
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(std::make_unique<node>(reference{0}));
+  children.push_back(std::make_unique<node>(reference{1}));
+  children.push_back(std::make_unique<node>(reference{2}));
+  coalesce co{std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)};
   REQUIRE(co.children.size() == 3);
+  REQUIRE(co.return_type().id() == sirius::type_id::INTEGER);
   node n{std::move(co)};
   REQUIRE(n.holds<coalesce>());
 }

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -510,11 +510,14 @@ TEST_CASE("ast_to_duckdb - case_expr (single WHEN/THEN + ELSE) translates to Bou
       comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}),
     /*then_=*/make_int_const(10),
   });
-  node orig{case_expr{std::move(cases), /*else_=*/make_int_const(0)}};
+  node orig{case_expr{std::move(cases),
+                      /*else_=*/make_int_const(0),
+                      sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
   auto const& ce = out->Cast<BoundCaseExpression>();
+  REQUIRE(ce.return_type.id() == LogicalTypeId::INTEGER);
   REQUIRE(ce.case_checks.size() == 1);
   REQUIRE(ce.case_checks[0].when_expr);
   REQUIRE(ce.case_checks[0].then_expr);
@@ -535,7 +538,8 @@ TEST_CASE("ast_to_duckdb - case_expr (two WHEN/THEN + ELSE) translates to BoundC
       comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(2)}),
     make_int_const(20),
   });
-  node orig{case_expr{std::move(cases), make_int_const(0)}};
+  node orig{case_expr{
+    std::move(cases), make_int_const(0), sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
@@ -627,10 +631,11 @@ TEST_CASE("ast_to_duckdb - coalesce (3 args) translates to OPERATOR_COALESCE", "
   children.push_back(make_ref(0));
   children.push_back(make_ref(1));
   children.push_back(make_int_const(0));
-  node orig{coalesce{std::move(children)}};
+  node orig{coalesce{std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto out = sirius::ast::to_duckdb(orig);
   REQUIRE(out);
   REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_COALESCE);
+  REQUIRE(out->Cast<BoundOperatorExpression>().return_type.id() == LogicalTypeId::INTEGER);
   REQUIRE(out->Cast<BoundOperatorExpression>().children.size() == 3);
 }
 
@@ -763,6 +768,50 @@ TEST_CASE("ast_to_duckdb - function_call year translates to BoundFunctionExpress
 }
 
 // ============================================================================
+// case_expr / coalesce return_type fidelity — regression guard (#701)
+//
+// The AST-path executor recovers each expression's return_type by round-tripping
+// the node through to_duckdb, so case_expr and coalesce MUST emit their recorded
+// return_type rather than a placeholder. The earlier INTEGER-typed cases above
+// cannot catch a placeholder regression (the placeholder itself was INTEGER), so
+// these assert a non-INTEGER (DECIMAL) return type survives the Sirius->DuckDB
+// translation. A DECIMAL silently narrowed to INTEGER corrupts the materialized
+// result and trips a downstream join type-mismatch.
+// ============================================================================
+
+TEST_CASE("ast_to_duckdb - case_expr preserves non-INTEGER (DECIMAL) return_type",
+          "[ast_to_duckdb]")
+{
+  std::vector<case_expr::when_then> cases;
+  cases.push_back(case_expr::when_then{
+    std::make_unique<node>(comparison{sirius::comparison_type::gt, make_ref(0), make_int_const(1)}),
+    make_int_const(10),
+  });
+  node orig{case_expr{std::move(cases),
+                      /*else_=*/make_int_const(0),
+                      sirius::logical_type::make_decimal(/*precision=*/38, /*scale=*/12)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionClass() == ExpressionClass::BOUND_CASE);
+  // Must be the recorded DECIMAL type, NOT an INTEGER placeholder.
+  REQUIRE(out->Cast<BoundCaseExpression>().return_type.id() == LogicalTypeId::DECIMAL);
+}
+
+TEST_CASE("ast_to_duckdb - coalesce preserves non-INTEGER (DECIMAL) return_type", "[ast_to_duckdb]")
+{
+  std::vector<std::unique_ptr<node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_ref(1));
+  node orig{coalesce{std::move(children),
+                     sirius::logical_type::make_decimal(/*precision=*/38, /*scale=*/12)}};
+  auto out = sirius::ast::to_duckdb(orig);
+  REQUIRE(out);
+  REQUIRE(out->GetExpressionType() == ExpressionType::OPERATOR_COALESCE);
+  // Must be the recorded DECIMAL type, NOT an INTEGER placeholder.
+  REQUIRE(out->Cast<BoundOperatorExpression>().return_type.id() == LogicalTypeId::DECIMAL);
+}
+
+// ============================================================================
 // Self-equivalence sweep — for every alternative, round-trip through
 // from_duckdb(*to_duckdb(node)) and check structural equivalence with the
 // original node tree.
@@ -840,7 +889,8 @@ TEST_CASE("ast_to_duckdb - case_expr self-equivalence via from_duckdb", "[ast_to
       comparison{sirius::comparison_type::equal, make_ref(0), make_int_const(1)}),
     make_int_const(10),
   });
-  node orig{case_expr{std::move(cases), make_int_const(0)}};
+  node orig{case_expr{
+    std::move(cases), make_int_const(0), sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto duck_expr = sirius::ast::to_duckdb(orig);
   REQUIRE(duck_expr);
   auto round = sirius::ast::from_duckdb(*duck_expr);
@@ -878,7 +928,7 @@ TEST_CASE("ast_to_duckdb - coalesce self-equivalence via from_duckdb", "[ast_to_
   children.push_back(make_ref(0));
   children.push_back(make_ref(1));
   children.push_back(make_int_const(0));
-  node orig{coalesce{std::move(children)}};
+  node orig{coalesce{std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)}};
   auto duck_expr = sirius::ast::to_duckdb(orig);
   REQUIRE(duck_expr);
   auto round = sirius::ast::from_duckdb(*duck_expr);

--- a/test/cpp/expression/test_expression.cpp
+++ b/test/cpp/expression/test_expression.cpp
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-// Tests for sirius::expression — the opaque wrapper around duckdb::Expression
-// that lets Super Sirius operator headers stay free of duckdb/planner/expression/ includes.
+// Tests for sirius::expression — the opaque wrapper that now holds a Sirius AST
+// node. wrap() is the DuckDB->Sirius translation boundary (via ast::from_duckdb),
+// so these tests assert AST node structure/values rather than duckdb pointer
+// identity (which the backing-type flip intentionally destroys). See
+// https://github.com/sirius-db/sirius/issues/701.
 
 #include "catch.hpp"
+#include "expression/ast/constant.hpp"
+#include "expression/ast/node.hpp"
 #include "expression/expression.hpp"
 #include "expression/expression_internal.hpp"
 
@@ -27,6 +32,7 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using sirius::expression;
@@ -51,6 +57,16 @@ namespace {
 std::unique_ptr<duckdb::Expression> make_const(int32_t v)
 {
   return std::make_unique<duckdb::BoundConstantExpression>(duckdb::Value::INTEGER(v));
+}
+
+// Assert the wrapped node is an INTEGER constant equal to `expected`.
+void require_int_constant(sirius::ast::node const* n, int32_t expected)
+{
+  REQUIRE(n != nullptr);
+  REQUIRE(n->holds<sirius::ast::constant>());
+  auto const& c = n->get<sirius::ast::constant>();
+  REQUIRE(std::holds_alternative<int32_t>(c.payload));
+  REQUIRE(std::get<int32_t>(c.payload) == expected);
 }
 
 }  // namespace
@@ -78,36 +94,27 @@ TEST_CASE("expression - wrap(nullptr) yields a null expression", "[expression]")
 // wrap / unwrap round-trip
 // ============================================================================
 
-TEST_CASE("expression - wrap preserves pointer identity via unwrap", "[expression]")
-{
-  auto raw      = make_const(42);
-  auto* raw_ptr = raw.get();
-
-  expression e = sirius::wrap(std::move(raw));
-  REQUIRE_FALSE(e.is_null());
-  REQUIRE(static_cast<bool>(e));
-  REQUIRE(sirius::unwrap(e) == raw_ptr);
-}
-
-TEST_CASE("expression - wrap preserves underlying expression state", "[expression]")
+TEST_CASE("expression - wrap translates to a Sirius AST node", "[expression]")
 {
   expression e = sirius::wrap(make_const(42));
+  REQUIRE_FALSE(e.is_null());
+  REQUIRE(static_cast<bool>(e));
+  require_int_constant(sirius::unwrap(e), 42);
+}
 
-  auto const* casted = dynamic_cast<duckdb::BoundConstantExpression const*>(sirius::unwrap(e));
-  REQUIRE(casted != nullptr);
-  REQUIRE(casted->value == duckdb::Value::INTEGER(42));
+TEST_CASE("expression - wrap preserves the underlying constant value", "[expression]")
+{
+  expression e = sirius::wrap(make_const(42));
+  require_int_constant(sirius::unwrap(e), 42);
 }
 
 TEST_CASE("expression - const unwrap overload returns pointer-to-const", "[expression]")
 {
-  auto raw      = make_const(5);
-  auto* raw_ptr = raw.get();
-
-  expression mutable_e = sirius::wrap(std::move(raw));
+  expression mutable_e = sirius::wrap(make_const(5));
   expression const& ce = mutable_e;
 
-  duckdb::Expression const* p = sirius::unwrap(ce);  // picks const overload
-  REQUIRE(p == raw_ptr);
+  sirius::ast::node const* p = sirius::unwrap(ce);  // picks const overload
+  require_int_constant(p, 5);
 }
 
 // ============================================================================
@@ -116,29 +123,23 @@ TEST_CASE("expression - const unwrap overload returns pointer-to-const", "[expre
 
 TEST_CASE("expression - move-construction nulls the source", "[expression]")
 {
-  auto raw      = make_const(7);
-  auto* raw_ptr = raw.get();
-
-  expression a = sirius::wrap(std::move(raw));
+  expression a = sirius::wrap(make_const(7));
   expression b{std::move(a)};
 
   REQUIRE(a.is_null());
   REQUIRE_FALSE(b.is_null());
-  REQUIRE(sirius::unwrap(b) == raw_ptr);
+  require_int_constant(sirius::unwrap(b), 7);
 }
 
 TEST_CASE("expression - move-assignment nulls the source", "[expression]")
 {
-  auto raw      = make_const(11);
-  auto* raw_ptr = raw.get();
-
-  expression a = sirius::wrap(std::move(raw));
+  expression a = sirius::wrap(make_const(11));
   expression b;
   b = std::move(a);
 
   REQUIRE(a.is_null());
   REQUIRE_FALSE(b.is_null());
-  REQUIRE(sirius::unwrap(b) == raw_ptr);
+  require_int_constant(sirius::unwrap(b), 11);
 }
 
 // ============================================================================
@@ -147,14 +148,11 @@ TEST_CASE("expression - move-assignment nulls the source", "[expression]")
 
 TEST_CASE("expression - release transfers ownership and nulls the source", "[expression]")
 {
-  auto raw      = make_const(99);
-  auto* raw_ptr = raw.get();
-
-  expression e                             = sirius::wrap(std::move(raw));
-  std::unique_ptr<duckdb::Expression> back = sirius::release(e);
+  expression e                            = sirius::wrap(make_const(99));
+  std::unique_ptr<sirius::ast::node> back = sirius::release(e);
 
   REQUIRE(e.is_null());
-  REQUIRE(back.get() == raw_ptr);
+  require_int_constant(back.get(), 99);
 }
 
 TEST_CASE("expression - release on a null expression returns nullptr", "[expression]")
@@ -181,21 +179,18 @@ TEST_CASE("expression - double release is safe", "[expression]")
 // wrap_many
 // ============================================================================
 
-TEST_CASE("expression - wrap_many preserves size, order, and per-element identity", "[expression]")
+TEST_CASE("expression - wrap_many preserves size and order", "[expression]")
 {
   std::vector<std::unique_ptr<duckdb::Expression>> input;
-  std::vector<duckdb::Expression const*> originals;
   for (int32_t i = 0; i < 4; ++i) {
-    auto e = make_const(i);
-    originals.push_back(e.get());
-    input.push_back(std::move(e));
+    input.push_back(make_const(i));
   }
 
   auto wrapped = sirius::wrap_many(std::move(input));
 
-  REQUIRE(wrapped.size() == originals.size());
-  for (std::size_t i = 0; i < wrapped.size(); ++i) {
-    REQUIRE(sirius::unwrap(wrapped[i]) == originals[i]);
+  REQUIRE(wrapped.size() == 4);
+  for (int32_t i = 0; i < 4; ++i) {
+    require_int_constant(sirius::unwrap(wrapped[static_cast<std::size_t>(i)]), i);
   }
 }
 
@@ -207,20 +202,15 @@ TEST_CASE("expression - wrap_many on empty input returns empty vector", "[expres
 
 TEST_CASE("expression - wrap_many handles mixed null and non-null slots", "[expression]")
 {
-  auto a      = make_const(1);
-  auto c      = make_const(3);
-  auto* a_ptr = a.get();
-  auto* c_ptr = c.get();
-
   std::vector<std::unique_ptr<duckdb::Expression>> input;
-  input.push_back(std::move(a));
+  input.push_back(make_const(1));
   input.push_back(nullptr);
-  input.push_back(std::move(c));
+  input.push_back(make_const(3));
 
   auto wrapped = sirius::wrap_many(std::move(input));
 
   REQUIRE(wrapped.size() == 3);
-  REQUIRE(sirius::unwrap(wrapped[0]) == a_ptr);
+  require_int_constant(sirius::unwrap(wrapped[0]), 1);
   REQUIRE(wrapped[1].is_null());
-  REQUIRE(sirius::unwrap(wrapped[2]) == c_ptr);
+  require_int_constant(sirius::unwrap(wrapped[2]), 3);
 }

--- a/test/cpp/expression/test_join_condition.cpp
+++ b/test/cpp/expression/test_join_condition.cpp
@@ -18,6 +18,8 @@
 // mapping helpers.
 
 #include "catch.hpp"
+#include "expression/ast/constant.hpp"
+#include "expression/ast/node.hpp"
 #include "expression/expression_internal.hpp"
 #include "expression/join_condition.hpp"
 
@@ -28,6 +30,7 @@
 
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using sirius::comparison_type;
@@ -66,6 +69,16 @@ duckdb::JoinCondition make_cond(duckdb::unique_ptr<duckdb::Expression> left,
   return c;
 }
 
+// Assert the wrapped node is an INTEGER constant equal to `expected`.
+void require_int_constant(sirius::ast::node const* n, int32_t expected)
+{
+  REQUIRE(n != nullptr);
+  REQUIRE(n->holds<sirius::ast::constant>());
+  auto const& c = n->get<sirius::ast::constant>();
+  REQUIRE(std::holds_alternative<int32_t>(c.payload));
+  REQUIRE(std::get<int32_t>(c.payload) == expected);
+}
+
 }  // namespace
 
 // ============================================================================
@@ -94,8 +107,6 @@ TEST_CASE("join_condition - wrap_join_conditions transfers expressions and maps 
           "[join_condition]")
 {
   std::vector<duckdb::JoinCondition> input;
-  std::vector<duckdb::Expression const*> left_ptrs;
-  std::vector<duckdb::Expression const*> right_ptrs;
 
   struct entry {
     duckdb::ExpressionType in;
@@ -108,19 +119,15 @@ TEST_CASE("join_condition - wrap_join_conditions transfers expressions and maps 
   };
 
   for (auto const& [duckdb_type, _] : entries) {
-    auto l = make_const(10);
-    auto r = make_const(20);
-    left_ptrs.push_back(l.get());
-    right_ptrs.push_back(r.get());
-    input.push_back(make_cond(std::move(l), std::move(r), duckdb_type));
+    input.push_back(make_cond(make_const(10), make_const(20), duckdb_type));
   }
 
   auto wrapped = sirius::wrap_join_conditions(std::move(input));
 
   REQUIRE(wrapped.size() == std::size(entries));
   for (std::size_t i = 0; i < wrapped.size(); ++i) {
-    REQUIRE(sirius::unwrap(wrapped[i].left) == left_ptrs[i]);
-    REQUIRE(sirius::unwrap(wrapped[i].right) == right_ptrs[i]);
+    require_int_constant(sirius::unwrap(wrapped[i].left), 10);
+    require_int_constant(sirius::unwrap(wrapped[i].right), 20);
     REQUIRE(wrapped[i].comparison == entries[i].expected_out);
   }
 }

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -2348,7 +2348,8 @@ TEST_CASE("native_ast - coalesce (MATERIALIZE)", "[expression_executor_ast_nativ
   std::vector<std::unique_ptr<sirius::ast::node>> children;
   children.push_back(ref_node_native(0));
   children.push_back(int_const_node_native(99));
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{
+    std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto out = run_native_ast(*space, hand_ast.get(), tv, MAT);
   REQUIRE(out);
@@ -2459,7 +2460,9 @@ TEST_CASE("native_ast - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
     sirius::comparison_type::equal, ref_node_native(0), int_const_node_native(5)});
   cases.back().then_ = int_const_node_native(100);
   auto hand_ast      = std::make_unique<sirius::ast::node>(
-    sirius::ast::case_expr{std::move(cases), int_const_node_native(0)});
+    sirius::ast::case_expr{std::move(cases),
+                           int_const_node_native(0),
+                           sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto out = run_native_ast(*space, hand_ast.get(), in.view, MAT);
   REQUIRE(out);

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -571,8 +571,8 @@ TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
       sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)}),
     int_const_node(10),
   });
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::case_expr{std::move(cases), int_const_node(0)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::case_expr{
+    std::move(cases), int_const_node(0), sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
@@ -757,7 +757,8 @@ TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[gpu_expression_executor_
   std::vector<std::unique_ptr<sirius::ast::node>> children;
   children.push_back(ref_node(0));
   children.push_back(int_const_node(0));
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{std::move(children)});
+  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{
+    std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)});
 
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);


### PR DESCRIPTION
## Summary

Flips `sirius::expression`'s PIMPL backing from `std::unique_ptr<duckdb::Expression>` to `std::unique_ptr<sirius::ast::node>`, keeping the public surface (`wrap`/`wrap_many`/`unwrap`/`release`/`join_condition`) intact. `wrap()` becomes the `ast::from_duckdb` translation boundary, the Phase-7 `add_join_condition` double-translation collapses to direct node use, and every `unwrap()`/`release()` consumer moves to the AST-typed accessors.

Resolves #701.

## Changes

- `expression::impl` now holds `unique_ptr<sirius::ast::node>`. `unwrap()` returns a borrowed `sirius::ast::node const*`/`*`; `release()` returns the owned `unique_ptr<sirius::ast::node>` and nulls the source.
- `wrap()` returns a null expression on null/unsupported input instead of throwing at the boundary.
- Aggregate consumers (`ungrouped_aggregate`, `aggregate_op_util`) read the native `sirius::ast::aggregate` node. `copy_expressions` deep-copies via a new `sirius::ast::clone(node const&)` helper, whose visitor has a terminal `static_assert` guarding future variant additions.
- Non-aggregate join sites recover a `duckdb::Expression` via `ast::to_duckdb` on the stored node (each binds the owned pointer to a local — no dangling temporaries).
- `case_expr`/`coalesce`/`reference` emit their recorded `return_type` instead of an INTEGER placeholder, preventing a DECIMAL→INT32 down-cast in the executor AST path's `post_process`.
- Null guards on `unwrap()` derefs in the aggregate operators (controlled fallback rather than a release-mode crash).
- Wrapper unit tests migrated from DuckDB pointer-identity assertions to AST-node-structure assertions.

## Testing

- Builds in both configs (`ENABLE_LEGACY_SIRIUS=OFF` and `ON`); no `src/legacy/` edits.
- Expression AST + wrapper suites pass (`[ast_clone] [ast_to_duckdb] [ast_aggregate] [ast_scaffold] [ast_from_duckdb] [ast_function_id]`, `[expression] [join_condition]`), plus aggregate operator suites (`[physical_grouped_aggregate]`, `[physical_grouped_aggregate_count_distinct]`, `[physical_grouped_aggregate_merge]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
