### PR TITLE
feat(expr): remove DuckDB-typed executor overloads; migrate tests to Sirius AST (#702)

### DIFF
--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -21,8 +21,6 @@
 #include <expression/ast/node.hpp>       // sirius::ast::node alternatives
 #include <expression/ast/to_duckdb.hpp>  // sirius::ast::to_duckdb (per-alternative overloads + node dispatcher)
 #include <expression/expression_internal.hpp>
-#include <expression/function_id.hpp>
-#include <expression_executor/ast_supported_types.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
 
@@ -34,15 +32,6 @@
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/planner/expression.hpp>
-#include <duckdb/planner/expression/bound_between_expression.hpp>
-#include <duckdb/planner/expression/bound_case_expression.hpp>
-#include <duckdb/planner/expression/bound_cast_expression.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
-#include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf
 #include <cudf/column/column_factories.hpp>
@@ -194,16 +183,6 @@ gpu_expression_executor::gpu_expression_executor(sirius::expression const& expre
   _ast_expressions.push_back(sirius::unwrap(expression));
 }
 
-gpu_expression_executor::gpu_expression_executor(duckdb::Expression const* expression,
-                                                 rmm::device_async_resource_ref resource_ref,
-                                                 rmm::cuda_stream_view stream,
-                                                 expression_executor_strategy strategy,
-                                                 std::size_t min_ast_size)
-  : _strategy(strategy), _mr(resource_ref), _stream(stream), _min_ast_size(min_ast_size)
-{
-  _expressions.push_back(expression);
-}
-
 gpu_expression_executor::gpu_expression_executor(sirius::ast::node const* expression,
                                                  rmm::device_async_resource_ref resource_ref,
                                                  rmm::cuda_stream_view stream,
@@ -281,9 +260,8 @@ void gpu_expression_executor::release_temporaries(
 
 std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view input)
 {
-  D_ASSERT(_expressions.empty() != _ast_expressions.empty());
   _output_columns.clear();
-  _output_columns.reserve(std::max(_expressions.size(), _ast_expressions.size()));
+  _output_columns.reserve(_ast_expressions.size());
 
   // Reset AST state from any previous invocation so that the tree, temp scalars, and temp columns
   // do not accumulate stale nodes across calls.
@@ -294,10 +272,9 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
   // Get the table_view from the input_batch
   _input_table = std::move(input);
 
-  // Per-result column post-processing — shared between the DuckDB and the
-  // AST branches below. The DuckDB-typed expression is the parity reference;
-  // the AST branch round-trips through sirius::ast::to_duckdb to recover the
-  // expression_class + return_type fields for the same post-processing path.
+  // Per-result column post-processing. The AST node is round-tripped through
+  // sirius::ast::to_duckdb to recover the expression_class + return_type fields
+  // that drive the post-processing path.
   auto post_process = [this](duckdb::Expression const& expr, execute_result result) {
     if (expr.expression_class == duckdb::ExpressionClass::BOUND_REF) {
       // BOUND_REF: pass column through without type check
@@ -333,23 +310,13 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
     }
   };
 
-  if (!_ast_expressions.empty()) {
-    // AST path: iterate _ast_expressions and route through the std::visit dispatcher.
-    // The per-result post-processing recovers expression_class + return_type by
-    // round-tripping through sirius::ast::to_duckdb so the column post-processing
-    // matches the DuckDB branch exactly.
-    for (auto const* ast_expr : _ast_expressions) {
-      auto result    = execute(*ast_expr, execution_mode::MATERIALIZE);
-      auto duck_expr = sirius::ast::to_duckdb(*ast_expr);
-      post_process(*duck_expr, std::move(result));
-    }
-  } else {
-    // DuckDB path: existing call sites unchanged.
-    for (auto& _expression : _expressions) {
-      auto const& expr = *_expression;
-      auto result      = execute(expr, execution_mode::MATERIALIZE);
-      post_process(expr, std::move(result));
-    }
+  // Iterate _ast_expressions and route through the std::visit dispatcher.
+  // The per-result post-processing recovers expression_class + return_type by
+  // round-tripping through sirius::ast::to_duckdb.
+  for (auto const* ast_expr : _ast_expressions) {
+    auto result    = execute(*ast_expr, execution_mode::MATERIALIZE);
+    auto duck_expr = sirius::ast::to_duckdb(*ast_expr);
+    post_process(*duck_expr, std::move(result));
   }
 
   return std::make_unique<cudf::table>(std::move(_output_columns), _stream, _mr);
@@ -357,17 +324,14 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
 
 std::unique_ptr<cudf::table> gpu_expression_executor::select(cudf::table_view input)
 {
-  D_ASSERT(_expressions.empty() != _ast_expressions.empty());
-  D_ASSERT(_expressions.size() + _ast_expressions.size() == 1);
-  if (!_ast_expressions.empty()) {
-    // AST branch: round-trip the single node through sirius::ast::to_duckdb so the
-    // BOOLEAN return-type assertion matches the DuckDB branch exactly (debug-only).
-    auto duck_expr = sirius::ast::to_duckdb(*_ast_expressions[0]);
-    D_ASSERT(duck_expr->return_type == duckdb::LogicalType::BOOLEAN);
-  } else {
-    auto const& expr = *_expressions[0];
-    D_ASSERT(expr.return_type == duckdb::LogicalType::BOOLEAN);
-  }
+  D_ASSERT(_ast_expressions.size() == 1);
+#ifdef D_ASSERT_IS_ENABLED
+  // Round-trip the single node through sirius::ast::to_duckdb so the BOOLEAN
+  // return-type assertion holds. Guarded so release builds skip the wasted
+  // DuckDB tree allocation (D_ASSERT is a no-op under NDEBUG).
+  auto duck_expr = sirius::ast::to_duckdb(*_ast_expressions[0]);
+  D_ASSERT(duck_expr->return_type == duckdb::LogicalType::BOOLEAN);
+#endif
 
   // Call execute(input_batch) to set _input_table and produce the boolean mask as a single column
   auto mask_batch = execute(input);
@@ -375,144 +339,6 @@ std::unique_ptr<cudf::table> gpu_expression_executor::select(cudf::table_view in
 
   // Apply the boolean mask to filter the input batch
   return cudf::apply_boolean_mask(input, mask_view, _stream, _mr);
-}
-
-execute_result gpu_expression_executor::execute(duckdb::Expression const& expr, execution_mode mode)
-{
-  switch (expr.GetExpressionClass()) {
-    case duckdb::ExpressionClass::BOUND_BETWEEN:
-      return execute(expr.Cast<duckdb::BoundBetweenExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_CASE:
-      return execute(expr.Cast<duckdb::BoundCaseExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_CAST:
-      return execute(expr.Cast<duckdb::BoundCastExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_CONSTANT:
-      return execute(expr.Cast<duckdb::BoundConstantExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_COMPARISON:
-      return execute(expr.Cast<duckdb::BoundComparisonExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_CONJUNCTION:
-      return execute(expr.Cast<duckdb::BoundConjunctionExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_FUNCTION:
-      return execute(expr.Cast<duckdb::BoundFunctionExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_OPERATOR:
-      return execute(expr.Cast<duckdb::BoundOperatorExpression>(), mode);
-    case duckdb::ExpressionClass::BOUND_REF:
-      return execute(expr.Cast<duckdb::BoundReferenceExpression>(), mode);
-    default:
-      throw duckdb::InternalException(
-        "[gpu_expression_executor] execute called on an expression [{}] with unsupported "
-        "expression class: {}",
-        expr.ToString(),
-        static_cast<int>(expr.GetExpressionClass()));
-  }
-}
-
-std::size_t gpu_expression_executor::count_ast_ops(duckdb::Expression const& expr) const
-{
-  switch (expr.GetExpressionClass()) {
-    case duckdb::ExpressionClass::BOUND_BETWEEN: {
-      auto const& between_expr = expr.Cast<duckdb::BoundBetweenExpression>();
-      // 2 comparison ops + 1 AND op + the ops in the children
-      return 3 + count_ast_ops(*between_expr.input) + count_ast_ops(*between_expr.lower) +
-             count_ast_ops(*between_expr.upper);
-    }
-    case duckdb::ExpressionClass::BOUND_CASE: {
-      // No AST support
-      return 0;
-    }
-    case duckdb::ExpressionClass::BOUND_CAST: {
-      auto const& cast_expr = expr.Cast<duckdb::BoundCastExpression>();
-      if (std::find(supported_ast_cast_types.begin(),
-                    supported_ast_cast_types.end(),
-                    expr.return_type.id()) != supported_ast_cast_types.end()) {
-        return 1 + count_ast_ops(*cast_expr.child);
-      }
-      return 0;
-    }
-    case duckdb::ExpressionClass::BOUND_COMPARISON: {
-      auto const& comp_expr = expr.Cast<duckdb::BoundComparisonExpression>();
-      return 1 + count_ast_ops(*comp_expr.left) + count_ast_ops(*comp_expr.right);
-    }
-    case duckdb::ExpressionClass::BOUND_CONJUNCTION: {
-      auto const& conj_expr = expr.Cast<duckdb::BoundConjunctionExpression>();
-      auto count =
-        conj_expr.children.size() - 1;  // Number of AND/OR ops is one less than number of children
-      for (const auto& child : conj_expr.children) {
-        count += count_ast_ops(*child);
-      }
-      return count;
-    }
-    case duckdb::ExpressionClass::BOUND_CONSTANT: {
-      // Base case
-      return 0;
-    }
-    case duckdb::ExpressionClass::BOUND_FUNCTION: {
-      auto const& func_expr = expr.Cast<duckdb::BoundFunctionExpression>();
-
-      /// First we check if the output type is decimal, since cuDF ASTs choke on intermediate
-      /// decimal results currently.
-      /// TODO: Fix when the following bug fix is in:
-      /// https://github.com/rapidsai/cudf/pull/21996
-      if (func_expr.return_type.id() == duckdb::LogicalTypeId::DECIMAL) { return 0; }
-
-      // Check the set of supported AST functions. If the function is supported, count 1 for the
-      // function itself plus the ops in the children.
-      auto const resolved_id_opt = sirius::from_duckdb_function_name(func_expr.function.name);
-      if (resolved_id_opt.has_value() &&
-          std::find(supported_ast_functions.begin(),
-                    supported_ast_functions.end(),
-                    *resolved_id_opt) != supported_ast_functions.end()) {
-        std::size_t count = 1;
-        for (const auto& child : func_expr.children) {
-          count += count_ast_ops(*child);
-        }
-        return count;
-      }
-      return 0;
-    }
-    case duckdb::ExpressionClass::BOUND_OPERATOR: {
-      auto const& op_expr = expr.Cast<duckdb::BoundOperatorExpression>();
-      switch (op_expr.type) {
-        case duckdb::ExpressionType::COMPARE_IN:  // Fallthrough
-        case duckdb::ExpressionType::COMPARE_NOT_IN: {
-          auto const num_ors = op_expr.children.size() - 2;
-          auto const num_eqs = op_expr.children.size() - 1;
-          auto count =
-            num_ors + num_eqs + (op_expr.type == duckdb::ExpressionType::COMPARE_NOT_IN ? 1 : 0);
-          for (const auto& child : op_expr.children) {
-            count += count_ast_ops(*child);
-          }
-          return count;
-        }
-        case duckdb::ExpressionType::OPERATOR_COALESCE: return 0;
-        case duckdb::ExpressionType::OPERATOR_TRY:
-          throw duckdb::NotImplementedException(
-            "[gpu_expression_executor] count_ast_ops called on an unsupported TRY operator "
-            "expression.");
-        case duckdb::ExpressionType::OPERATOR_NOT: return 1 + count_ast_ops(*op_expr.children[0]);
-        case duckdb::ExpressionType::OPERATOR_IS_NULL:
-          return 1 + count_ast_ops(*op_expr.children[0]);
-        case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL:
-          return 2 + count_ast_ops(*op_expr.children[0]);
-        default:
-          throw duckdb::InternalException(
-            "[gpu_expression_executor] count_ast_ops called on an operator expression [{}] with "
-            "unsupported operator type: {}",
-            op_expr.ToString(),
-            static_cast<int>(op_expr.type));
-      }
-    }
-    case duckdb::ExpressionClass::BOUND_REF: {
-      // Base case
-      return 0;
-    }
-    default:
-      throw duckdb::InternalException(
-        "[gpu_expression_executor] count_ast_ops called on an expression [{}] with unsupported "
-        "expression class: {}",
-        expr.ToString(),
-        static_cast<int>(expr.GetExpressionClass()));
-  }
 }
 
 execute_result gpu_expression_executor::execute(sirius::ast::aggregate const& /*expr*/,
@@ -547,13 +373,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, e
       }
     },
     expr.v);
-}
-
-std::size_t gpu_expression_executor::count_ast_ops(sirius::ast::node const& expr) const
-{
-  // Delegates to the single-source-of-truth implementation living next to the
-  // AST struct definitions; see src/expression_executor/ast_op_counter.cpp.
-  return expr.cudf_ast_op_count();
 }
 
 }  // namespace sirius

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -351,28 +351,11 @@ execute_result gpu_expression_executor::execute(sirius::ast::aggregate const& /*
 
 execute_result gpu_expression_executor::execute(sirius::ast::node const& expr, execution_mode mode)
 {
+  // Every sirius::ast alternative has a matching private execute(alt, mode)
+  // overload, so overload resolution enforces dispatch completeness at compile
+  // time (a new alternative without an overload fails to compile here).
   return std::visit(
-    [this, mode](auto const& alt) -> execute_result {
-      using T = std::decay_t<decltype(alt)>;
-      if constexpr (std::is_same_v<T, sirius::ast::reference> ||
-                    std::is_same_v<T, sirius::ast::constant> ||
-                    std::is_same_v<T, sirius::ast::comparison> ||
-                    std::is_same_v<T, sirius::ast::conjunction> ||
-                    std::is_same_v<T, sirius::ast::between> ||
-                    std::is_same_v<T, sirius::ast::case_expr> ||
-                    std::is_same_v<T, sirius::ast::cast> ||
-                    std::is_same_v<T, sirius::ast::unary_op> ||
-                    std::is_same_v<T, sirius::ast::coalesce> ||
-                    std::is_same_v<T, sirius::ast::in_list> ||
-                    std::is_same_v<T, sirius::ast::function_call> ||
-                    std::is_same_v<T, sirius::ast::aggregate>) {
-        return this->execute(alt, mode);
-      } else {
-        static_assert(sizeof(T) == 0,
-                      "Unhandled sirius::ast alternative in execute(sirius::ast::node) dispatcher");
-      }
-    },
-    expr.v);
+    [this, mode](auto const& alt) -> execute_result { return this->execute(alt, mode); }, expr.v);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_between.cpp
+++ b/src/expression_executor/specializations/gpu_execute_between.cpp
@@ -15,13 +15,9 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
-
-// duckdb
-#include <duckdb/planner/expression/bound_between_expression.hpp>
 
 // cudf
 #include <cudf/binaryop.hpp>
@@ -112,23 +108,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::between const& alt,
                                               _stream,
                                               _mr);
   return execute_result(std::move(result_column));
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundBetweenExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:between] BoundBetweenExpression could not be lowered to a "
-      "Sirius AST node (an embedded subexpression is unsupported).");
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_case.cpp
+++ b/src/expression_executor/specializations/gpu_execute_case.cpp
@@ -15,14 +15,10 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/function_id.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
-
-// duckdb
-#include <duckdb/planner/expression/bound_case_expression.hpp>
 
 // cudf
 #include <cudf/ast/expressions.hpp>
@@ -126,23 +122,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::case_expr const& al
     return materialize_as_ast_column(std::move(current_result.release_column()));
   }
   return current_result;
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundCaseExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:case] BoundCaseExpression could not be lowered to a Sirius AST "
-      "node (a WHEN, THEN, or ELSE subexpression is unsupported).");
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_cast.cpp
+++ b/src/expression_executor/specializations/gpu_execute_cast.cpp
@@ -15,15 +15,11 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/ast_supported_types.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <helper/logical_type.hpp>
 #include <sirius/exception.hpp>
-
-// duckdb
-#include <duckdb/planner/expression/bound_cast_expression.hpp>
 
 // cudf
 #include <cudf/cudf_utils.hpp>
@@ -90,23 +86,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::cast const& alt, ex
     return materialize_as_ast_column(std::move(result_column));
   }
   return execute_result(std::move(result_column));
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundCastExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:cast] BoundCastExpression could not be lowered to a Sirius AST "
-      "node (the cast child is unsupported).");
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_comparison.cpp
+++ b/src/expression_executor/specializations/gpu_execute_comparison.cpp
@@ -15,7 +15,6 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/join_condition.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
@@ -23,7 +22,6 @@
 
 // duckdb
 #include <duckdb/common/exception.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
 
 // cudf
 #include <cudf/ast/ast_operator.hpp>
@@ -132,23 +130,5 @@ execute_result gpu_expression_executor::execute(sirius::ast::comparison const& a
       left.get_column_view(), right.get_column_view(), binary_op, output_type, _stream, _mr);
   }
   return execute_result(std::move(result_column));
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundComparisonExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:comparison] BoundComparisonExpression with comparison type {} "
-      "could not be lowered to a Sirius AST node.",
-      static_cast<int>(expr.GetExpressionType()));
-  }
-  return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_conjunction.cpp
+++ b/src/expression_executor/specializations/gpu_execute_conjunction.cpp
@@ -15,14 +15,12 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
 
 // duckdb
 #include <duckdb/common/exception.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 
 // cudf
 #include <cudf/binaryop.hpp>
@@ -112,24 +110,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::conjunction const& 
     output = execute_result(std::move(output_column));
   }
   return output;
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundConjunctionExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:conjunction] BoundConjunctionExpression with conjunction type {} "
-      "could not be lowered to a Sirius AST node.",
-      static_cast<int>(expr.GetExpressionType()));
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_constant.cpp
+++ b/src/expression_executor/specializations/gpu_execute_constant.cpp
@@ -15,7 +15,6 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
@@ -24,7 +23,6 @@
 
 // duckdb
 #include <duckdb/common/exception.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
 
 // cudf
 #include <cudf/ast/expressions.hpp>
@@ -204,23 +202,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::constant const& alt
       throw not_implemented_exception("[gpu_expression_executor] Unsupported scalar type: %s",
                                       alt.return_type.to_string());
   }
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundConstantExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:constant] BoundConstantExpression could not be lowered to a "
-      "Sirius AST node (sirius::ast::from_duckdb returned nullptr).");
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -15,7 +15,6 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/function_id.hpp>
 #include <expression/value.hpp>
@@ -27,7 +26,6 @@
 
 // duckdb
 #include <duckdb/common/assert.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
 
 // cudf
 #include <cudf/binaryop.hpp>
@@ -389,25 +387,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::function_call const
   throw internal_exception(
     "[gpu_expression_executor:function]: registered function_id has no GPU dispatch arm: id={}",
     static_cast<int>(resolved_id));
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundFunctionExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:function] BoundFunctionExpression could not be lowered to a "
-      "Sirius AST node (function '{}' has no Sirius function_id mapping, or an argument is "
-      "unsupported).",
-      expr.function.name);
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_operator.cpp
+++ b/src/expression_executor/specializations/gpu_execute_operator.cpp
@@ -15,7 +15,6 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
@@ -25,7 +24,6 @@
 
 // duckdb
 #include <duckdb/common/assert.hpp>
-#include <duckdb/planner/expression/bound_operator_expression.hpp>
 
 // cudf
 #include <cudf/binaryop.hpp>
@@ -574,29 +572,6 @@ execute_result gpu_expression_executor::execute(sirius::ast::coalesce const& alt
     return materialize_as_ast_column(current_result.release_column());
   }
   return current_result;
-}
-
-//===----------------------------------------------------------------------===//
-// DuckDB-typed entry — routes to one of the three native bodies via the
-// public node dispatcher's std::visit over from_duckdb(expr).
-//===----------------------------------------------------------------------===//
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundOperatorExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:operator] BoundOperatorExpression with operator type {} could "
-      "not be lowered to a Sirius AST node.",
-      static_cast<int>(expr.GetExpressionType()));
-  }
-  return execute(*node, mode);
 }
 
 }  // namespace sirius

--- a/src/expression_executor/specializations/gpu_execute_reference.cpp
+++ b/src/expression_executor/specializations/gpu_execute_reference.cpp
@@ -15,13 +15,9 @@
  */
 
 // sirius
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/node.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <sirius/exception.hpp>
-
-// duckdb
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 namespace sirius {
 using ast_result     = gpu_expression_executor::ast_result;
@@ -35,22 +31,5 @@ execute_result gpu_expression_executor::execute(sirius::ast::reference const& al
     return execute_result(ast_result(col_expr));
   }
   return execute_result(_input_table.column(alt.column_index));
-}
-
-// DuckDB-typed entrypoint. Bridges callers that still pass duckdb::Expression
-// directly into the executor; the eventual home for this from_duckdb step is
-// the planning stage so the executor sees only native sirius::ast types, but
-// until upstream call sites are migrated this overload (and the duckdb
-// includes it requires) must stay.
-execute_result gpu_expression_executor::execute(duckdb::BoundReferenceExpression const& expr,
-                                                execution_mode mode)
-{
-  auto node = sirius::ast::from_duckdb(expr);
-  if (!node) {
-    throw not_implemented_exception(
-      "[gpu_expression_executor:reference] BoundReferenceExpression could not be lowered to a "
-      "Sirius AST node (sirius::ast::from_duckdb returned nullptr).");
-  }
-  return execute(*node, mode);
 }
 }  // namespace sirius

--- a/src/include/expression_executor/gpu_expression_executor.hpp
+++ b/src/include/expression_executor/gpu_expression_executor.hpp
@@ -42,15 +42,6 @@
 
 namespace duckdb {
 class Expression;
-class BoundBetweenExpression;
-class BoundCaseExpression;
-class BoundCastExpression;
-class BoundComparisonExpression;
-class BoundConjunctionExpression;
-class BoundConstantExpression;
-class BoundFunctionExpression;
-class BoundOperatorExpression;
-class BoundReferenceExpression;
 }  // namespace duckdb
 
 namespace sirius {
@@ -309,24 +300,10 @@ class gpu_expression_executor {
     std::size_t min_ast_size                    = 2);
 
   /**
-   * @brief Non-owning ctor for internal call sites that already hold a raw duckdb::Expression
-   * pointer (e.g., NLJ lambda over cuDF expressions, parquet scan filter pushdown). The caller
-   * retains ownership; the executor only reads from the expression.
-   */
-  gpu_expression_executor(
-    duckdb::Expression const* expression,
-    rmm::device_async_resource_ref resource_ref = cudf::get_current_device_resource_ref(),
-    rmm::cuda_stream_view stream                = cudf::get_default_stream(),
-    expression_executor_strategy strategy       = strategy_from_config(),
-    std::size_t min_ast_size                    = 2);
-
-  /**
-   * @brief Non-owning ctor for call sites that hold a raw sirius::ast::node pointer.
+   * @brief Non-owning ctor for call sites that hold a raw sirius::ast::node pointer
+   * (e.g., NLJ lambda over cuDF expressions, parquet scan filter pushdown).
    *
    * The caller retains ownership; the executor only reads from the node tree.
-   * Parallel to the duckdb::Expression const* ctor above. The class invariant
-   * after construction is that exactly one of _expressions / _ast_expressions
-   * is non-empty.
    */
   gpu_expression_executor(
     sirius::ast::node const* expression,
@@ -371,10 +348,7 @@ class gpu_expression_executor {
   execute_result execute(sirius::ast::node const& expr, execution_mode mode = execution_mode::AST);
 
  private:
-  std::vector<duckdb::Expression const*> _expressions;  ///< The expressions to execute
-  std::vector<sirius::ast::node const*>
-    _ast_expressions;  ///< AST expressions (additive dual-path surface). Mutually exclusive with
-                       ///< _expressions per the class invariant.
+  std::vector<sirius::ast::node const*> _ast_expressions;  ///< The AST expressions to execute
   expression_executor_strategy _strategy;  ///< The strategy to use for expression evaluation
   rmm::device_async_resource_ref _mr;  ///< The allocator to pass to cudf APIs for any allocations
   rmm::cuda_stream_view _stream;       ///< The stream in which to execute any cuDF operations
@@ -414,22 +388,6 @@ class gpu_expression_executor {
   void release_temporaries(std::vector<std::vector<std::size_t>> const& scalar_indices,
                            std::vector<std::vector<std::size_t>> const& column_indices);
 
-  // Generic execute method
-  execute_result execute(duckdb::Expression const& expr, execution_mode mode = execution_mode::AST);
-
-  // Leaf expression nodes
-  execute_result execute(duckdb::BoundReferenceExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundConstantExpression const& expr, execution_mode mode);
-
-  // Interior expression nodes
-  execute_result execute(duckdb::BoundBetweenExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundCaseExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundCastExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundComparisonExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundConjunctionExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundFunctionExpression const& expr, execution_mode mode);
-  execute_result execute(duckdb::BoundOperatorExpression const& expr, execution_mode mode);
-
   // Leaf Sirius-AST nodes — dispatch targets for the std::visit-based
   // execute(sirius::ast::node, mode) above.
   execute_result execute(sirius::ast::reference const& expr, execution_mode mode);
@@ -448,12 +406,6 @@ class gpu_expression_executor {
   execute_result execute(sirius::ast::coalesce const& expr, execution_mode mode);
   execute_result execute(sirius::ast::in_list const& expr, execution_mode mode);
   execute_result execute(sirius::ast::aggregate const& expr, execution_mode mode);
-
-  // Counts the number of AST nodes that would be generated for the given expression if we
-  // added it to the AST tree. This is used to determine whether we should execute in AST mode or
-  // MATERIALIZE mode for the expression (by comparing the count to `min_ast_size`).
-  [[nodiscard]] std::size_t count_ast_ops(duckdb::Expression const& expr) const;
-  [[nodiscard]] std::size_t count_ast_ops(sirius::ast::node const& expr) const;
 };
 
 }  // namespace sirius

--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -16,6 +16,7 @@
 
 // sirius
 #include <data/data_batch_utils.hpp>
+#include <expression/ast/from_duckdb.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <log/logging.hpp>
 #include <op/scan/parquet_scan_operator_data.hpp>
@@ -243,16 +244,25 @@ std::unique_ptr<cudf::table> sirius_gpu_parquet_scan_operator::read_table_from_m
 
   // Apply the filter if it was not pushed down into the parquet scan.
   if (filter_expression && !ast_expression) {
-    sirius::gpu_expression_executor gpu_expression_executor(
-      filter_expression.get(), cudf::get_current_device_resource_ref(), stream);
-    // Hold the source table in a separate variable so its destruction (and the
-    // stream-ordered dealloc of its buffers) is sequenced after select()'s kernels
-    // have been queued. Assigning select()'s result directly back to `table` would
-    // destruct the source synchronously before the queued kernels read from it.
-    auto input_table = std::move(table);
-    table            = gpu_expression_executor.select(input_table->view());
-    SIRIUS_LOG_DEBUG(
-      "[sirius_gpu_parquet_scan_operator] Applied duckdb filter expression post parquet scan.");
+    // Translate the DuckDB filter expression to a native Sirius AST node at the boundary.
+    // `filter_node` is held in a local that outlives select()'s queued kernels.
+    auto filter_node = sirius::ast::from_duckdb(*filter_expression);
+    if (!filter_node) {
+      SIRIUS_LOG_DEBUG(
+        "[sirius_gpu_parquet_scan_operator] Filter expression could not be lowered to a Sirius "
+        "AST node; forwarding the unfiltered table.");
+    } else {
+      sirius::gpu_expression_executor gpu_expression_executor(
+        filter_node.get(), cudf::get_current_device_resource_ref(), stream);
+      // Hold the source table in a separate variable so its destruction (and the
+      // stream-ordered dealloc of its buffers) is sequenced after select()'s kernels
+      // have been queued. Assigning select()'s result directly back to `table` would
+      // destruct the source synchronously before the queued kernels read from it.
+      auto input_table = std::move(table);
+      table            = gpu_expression_executor.select(input_table->view());
+      SIRIUS_LOG_DEBUG(
+        "[sirius_gpu_parquet_scan_operator] Applied filter expression post parquet scan.");
+    }
   }
 
   // Reshape the reader's output to the scan_plan's D-order layout: reorder data
@@ -307,15 +317,25 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
       return std::make_unique<pipelineable_operator_data>(std::move(batches));
     }
 
-    if (has_filter) {
+    // Translate the cached DuckDB filter to a native Sirius AST node at the boundary, if any.
+    // `filter_node` outlives select()'s queued kernels.
+    std::unique_ptr<sirius::ast::node> filter_node;
+    if (has_filter) { filter_node = sirius::ast::from_duckdb(*cached->filter_expression); }
+
+    if (has_filter && filter_node) {
       // select() consumes the view and produces an owning table containing every D-column
       // (filter columns included) restricted to the rows that pass the predicate.
       sirius::gpu_expression_executor gpu_expression_executor(
-        cached->filter_expression.get(), cudf::get_current_device_resource_ref(), stream);
+        filter_node.get(), cudf::get_current_device_resource_ref(), stream);
       table = gpu_expression_executor.select(cached_view);
       SIRIUS_LOG_DEBUG(
-        "[sirius_gpu_parquet_scan_operator] Applied duckdb filter expression on cached batch.");
+        "[sirius_gpu_parquet_scan_operator] Applied filter expression on cached batch.");
     } else {
+      if (has_filter) {
+        SIRIUS_LOG_DEBUG(
+          "[sirius_gpu_parquet_scan_operator] Cached filter expression could not be lowered to a "
+          "Sirius AST node; materializing the cached batch unfiltered.");
+      }
       // No filter but assembly is needed (the plan permutes / drops columns relative to
       // data_columns). Materialize the cached view into an owning table so
       // assemble_scan_output can release the columns by D-position and reassemble them

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -485,6 +485,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     // Resolves one side of a join condition to a column index in col_views, evaluating or casting
     // as needed. Returns the index to use as the cudf::ast::column_reference offset.
     auto resolve_join_col = [&](const duckdb::Expression& expr,
+                                const sirius::ast::node& ast_expr,
                                 std::map<uint64_t, cudf::size_type>& expr_to_idx,
                                 const ::cucascade::read_only_data_batch& batch,
                                 const cudf::table_view& table,
@@ -497,7 +498,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
       expr_to_idx[cond_hash]           = join_input_index;
       cudf::size_type source_idx       = 0;
       if (!get_column_index(expr, source_idx)) {
-        sirius::gpu_expression_executor executor(&expr, mr, stream);
+        sirius::gpu_expression_executor executor(&ast_expr, mr, stream);
         auto expr_result_table = executor.execute(table);
         auto expr_view         = expr_result_table->view();
         if (expr_view.num_columns() != 1) {
@@ -535,12 +536,19 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
     };
 
     for (const auto& cond : conditions) {
-      auto left_owned                       = sirius::ast::to_duckdb(*sirius::unwrap(cond.left));
-      auto right_owned                      = sirius::ast::to_duckdb(*sirius::unwrap(cond.right));
+      auto const* left_node                 = sirius::unwrap(cond.left);
+      auto const* right_node                = sirius::unwrap(cond.right);
+      auto left_owned                       = sirius::ast::to_duckdb(*left_node);
+      auto right_owned                      = sirius::ast::to_duckdb(*right_node);
       cudf::size_type left_join_input_index = resolve_join_col(
-        *left_owned, left_expressions_to_idx, left_batch, left, left_col_views, "left");
-      cudf::size_type right_join_input_index = resolve_join_col(
-        *right_owned, right_expressions_to_idx, right_batch, right, right_col_views, "right");
+        *left_owned, *left_node, left_expressions_to_idx, left_batch, left, left_col_views, "left");
+      cudf::size_type right_join_input_index = resolve_join_col(*right_owned,
+                                                                *right_node,
+                                                                right_expressions_to_idx,
+                                                                right_batch,
+                                                                right,
+                                                                right_col_views,
+                                                                "right");
 
       left_refs.emplace_back(left_join_input_index, cudf::ast::table_reference::LEFT);
       right_refs.emplace_back(right_join_input_index, cudf::ast::table_reference::RIGHT);

--- a/test/cpp/expression_executor/ast_test_support.hpp
+++ b/test/cpp/expression_executor/ast_test_support.hpp
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Shared test helpers for the expression_executor unit tests.
+//
+// Two families of helpers were previously copy-pasted across
+// test_gpu_expression_executor.cpp, test_gpu_expression_translator.cpp, and
+// test_gpu_expression_executor_ast_equivalence.cpp:
+//   1. sirius::ast::node construction shortcuts (make_ref, make_int_const, ...)
+//   2. GPU->host column copy helpers (copy_column_to_host, ...)
+// They are gathered here so the three suites share one definition. All entities
+// are `inline`/templates so the header can be included into multiple translation
+// units that are linked into the same sirius_unittest binary.
+
+// sirius — AST node construction surface
+#include <expression/ast/between.hpp>
+#include <expression/ast/case_expr.hpp>
+#include <expression/ast/cast.hpp>
+#include <expression/ast/coalesce.hpp>
+#include <expression/ast/comparison.hpp>
+#include <expression/ast/conjunction.hpp>
+#include <expression/ast/constant.hpp>
+#include <expression/ast/function_call.hpp>
+#include <expression/ast/in_list.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/ast/reference.hpp>
+#include <expression/ast/unary_op.hpp>
+#include <expression/expression_internal.hpp>
+#include <expression/function_id.hpp>
+#include <expression/value.hpp>
+#include <helper/logical_type.hpp>
+
+// cudf
+#include <cudf/column/column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime_api.h>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sirius::expr_test {
+
+using ast_node = sirius::ast::node;
+
+//===----------------------------------------------------------------------===//
+// sirius::ast::node construction helpers
+//===----------------------------------------------------------------------===//
+
+inline std::unique_ptr<ast_node> make_ref(uint32_t idx)
+{
+  return std::make_unique<ast_node>(sirius::ast::reference{idx});
+}
+
+inline std::unique_ptr<ast_node> make_ref_typed(uint32_t idx, sirius::logical_type type)
+{
+  return std::make_unique<ast_node>(sirius::ast::reference{idx, type});
+}
+
+inline std::unique_ptr<ast_node> make_int_const(int32_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, sirius::logical_type::make(sirius::type_id::INTEGER)});
+}
+
+inline std::unique_ptr<ast_node> make_bigint_const(int64_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, sirius::logical_type::make(sirius::type_id::BIGINT)});
+}
+
+inline std::unique_ptr<ast_node> make_double_const(double v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, sirius::logical_type::make(sirius::type_id::DOUBLE)});
+}
+
+inline std::unique_ptr<ast_node> make_str_const(std::string s)
+{
+  return std::make_unique<ast_node>(sirius::ast::constant{
+    sirius::value{std::move(s)}, sirius::logical_type::make(sirius::type_id::VARCHAR)});
+}
+
+// A typed NULL constant (no cuDF AST literal representation).
+inline std::unique_ptr<ast_node> make_null_const(sirius::logical_type type)
+{
+  return std::make_unique<ast_node>(sirius::ast::constant{sirius::value{}, type});
+}
+
+inline std::unique_ptr<ast_node> make_dec32_const(int32_t unscaled,
+                                                  uint8_t precision,
+                                                  uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal32{unscaled, scale}},
+                          sirius::logical_type::make_decimal(precision, scale)});
+}
+
+inline std::unique_ptr<ast_node> make_dec64_const(int64_t unscaled,
+                                                  uint8_t precision,
+                                                  uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal64{unscaled, scale}},
+                          sirius::logical_type::make_decimal(precision, scale)});
+}
+
+inline std::unique_ptr<ast_node> make_dec128_const(__int128_t unscaled,
+                                                   uint8_t precision,
+                                                   uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal128{unscaled, scale}},
+                          sirius::logical_type::make_decimal(precision, scale)});
+}
+
+inline std::unique_ptr<ast_node> make_cmp(sirius::comparison_type op,
+                                          std::unique_ptr<ast_node> left,
+                                          std::unique_ptr<ast_node> right)
+{
+  return std::make_unique<ast_node>(sirius::ast::comparison{op, std::move(left), std::move(right)});
+}
+
+inline std::unique_ptr<ast_node> make_func(sirius::function_id id,
+                                           std::vector<std::unique_ptr<ast_node>> args,
+                                           sirius::logical_type return_type)
+{
+  return std::make_unique<ast_node>(sirius::ast::function_call{id, std::move(args), return_type});
+}
+
+inline std::unique_ptr<ast_node> make_conj(sirius::ast::conjunction::kind kind,
+                                           std::vector<std::unique_ptr<ast_node>> children)
+{
+  return std::make_unique<ast_node>(sirius::ast::conjunction{kind, std::move(children)});
+}
+
+inline std::unique_ptr<ast_node> make_between(std::unique_ptr<ast_node> input,
+                                              std::unique_ptr<ast_node> lower,
+                                              std::unique_ptr<ast_node> upper,
+                                              bool lower_inclusive,
+                                              bool upper_inclusive)
+{
+  return std::make_unique<ast_node>(sirius::ast::between{
+    std::move(input), std::move(lower), std::move(upper), lower_inclusive, upper_inclusive});
+}
+
+inline std::unique_ptr<ast_node> make_cast(std::unique_ptr<ast_node> child,
+                                           sirius::logical_type target_type,
+                                           bool try_cast)
+{
+  return std::make_unique<ast_node>(sirius::ast::cast{std::move(child), target_type, try_cast});
+}
+
+inline std::unique_ptr<ast_node> make_coalesce(std::vector<std::unique_ptr<ast_node>> children,
+                                               sirius::logical_type return_type)
+{
+  return std::make_unique<ast_node>(sirius::ast::coalesce{std::move(children), return_type});
+}
+
+inline std::unique_ptr<ast_node> make_in(std::unique_ptr<ast_node> probe,
+                                         std::vector<std::unique_ptr<ast_node>> values,
+                                         bool negated)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::in_list{std::move(probe), std::move(values), negated});
+}
+
+inline std::unique_ptr<ast_node> make_unary(sirius::ast::unary_op::kind kind,
+                                            std::unique_ptr<ast_node> child)
+{
+  return std::make_unique<ast_node>(sirius::ast::unary_op{kind, std::move(child)});
+}
+
+// Wrap an owned Sirius AST node into a sirius::expression for the owning ctors /
+// join_condition.
+inline sirius::expression wrap_node(std::unique_ptr<ast_node> n)
+{
+  return sirius::expression{
+    std::make_unique<sirius::expression::impl>(sirius::expression::impl{std::move(n)})};
+}
+
+//===----------------------------------------------------------------------===//
+// GPU -> host column copy helpers
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+std::vector<T> copy_column_to_host(cudf::column_view const& col)
+{
+  std::vector<T> host(col.size());
+  if (col.size() > 0) {
+    cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+inline std::vector<uint8_t> copy_bool_column_to_host(cudf::column_view const& col)
+{
+  std::vector<uint8_t> host(col.size());
+  if (col.size() > 0) {
+    cudaMemcpy(host.data(), col.head(), sizeof(uint8_t) * col.size(), cudaMemcpyDeviceToHost);
+  }
+  return host;
+}
+
+inline std::vector<std::string> copy_string_column_to_host(cudf::column_view const& col)
+{
+  std::vector<std::string> host;
+  if (col.size() == 0) { return host; }
+
+  cudf::strings_column_view str_col(col);
+  std::vector<cudf::size_type> offsets(col.size() + 1);
+  cudaMemcpy(offsets.data(),
+             str_col.offsets().data<cudf::size_type>(),
+             (col.size() + 1) * sizeof(cudf::size_type),
+             cudaMemcpyDeviceToHost);
+
+  std::vector<char> chars(offsets.back());
+  if (!chars.empty()) {
+    cudaMemcpy(chars.data(),
+               str_col.chars_begin(cudf::get_default_stream()),
+               offsets.back(),
+               cudaMemcpyDeviceToHost);
+  }
+
+  host.reserve(col.size());
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    auto start = offsets[i];
+    auto end   = offsets[i + 1];
+    if (chars.empty()) {
+      host.emplace_back();
+    } else {
+      host.emplace_back(chars.data() + start, chars.data() + end);
+    }
+  }
+  return host;
+}
+
+inline std::vector<bool> copy_valids_to_host(cudf::column_view const& col)
+{
+  std::vector<bool> valids(col.size(), true);
+  if (!col.nullable() || col.null_count() == 0) { return valids; }
+  auto const num_words = cudf::num_bitmask_words(col.size());
+  std::vector<cudf::bitmask_type> host_mask(num_words);
+  cudaMemcpy(host_mask.data(),
+             col.null_mask(),
+             num_words * sizeof(cudf::bitmask_type),
+             cudaMemcpyDeviceToHost);
+  constexpr auto bits_per_word = sizeof(cudf::bitmask_type) * 8;
+  for (cudf::size_type i = 0; i < col.size(); ++i) {
+    auto word = host_mask[i / bits_per_word];
+    auto bit  = i % bits_per_word;
+    valids[i] = ((word >> bit) & 1U) != 0U;
+  }
+  return valids;
+}
+
+}  // namespace sirius::expr_test

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -30,29 +30,18 @@
 #include <expression/ast/comparison.hpp>
 #include <expression/ast/conjunction.hpp>
 #include <expression/ast/constant.hpp>
-#include <expression/ast/from_duckdb.hpp>
 #include <expression/ast/function_call.hpp>
 #include <expression/ast/in_list.hpp>
 #include <expression/ast/node.hpp>
 #include <expression/ast/reference.hpp>
 #include <expression/ast/unary_op.hpp>
+#include <expression/expression_internal.hpp>
 #include <expression/function_id.hpp>
 #include <expression/join_condition.hpp>
 #include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <helper/logical_type.hpp>
 #include <memory/sirius_memory_reservation_manager.hpp>
-
-// duckdb
-#include <duckdb/common/helper.hpp>
-#include <duckdb/planner/expression/bound_between_expression.hpp>
-#include <duckdb/planner/expression/bound_case_expression.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
-#include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf, etc.
 #include <cudf/column/column_factories.hpp>
@@ -66,7 +55,6 @@
 #include <memory>
 #include <numeric>
 
-using namespace duckdb;
 using namespace cucascade;
 using namespace cucascade::memory;
 using memory_mgr = ::sirius::memory::sirius_memory_reservation_manager;
@@ -397,6 +385,117 @@ struct ast_jit_strategy {
   static constexpr auto value = exp_strategy_enum::AST_JIT;
 };
 
+// ---------------------------------------------------------------------------
+// Native sirius::ast::node construction helpers — every test expression is
+// built directly as a Sirius AST node (no DuckDB Bound*Expression involved).
+// Mirrors the make_ref / make_int_const style used by test_ast_to_duckdb.cpp.
+// ---------------------------------------------------------------------------
+
+using ast_node = sirius::ast::node;
+using sirius::logical_type;
+using sirius::type_id;
+
+std::unique_ptr<ast_node> make_ref(uint32_t idx)
+{
+  return std::make_unique<ast_node>(sirius::ast::reference{idx});
+}
+
+std::unique_ptr<ast_node> make_int_const(int32_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::INTEGER)});
+}
+
+std::unique_ptr<ast_node> make_bigint_const(int64_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::BIGINT)});
+}
+
+std::unique_ptr<ast_node> make_str_const(std::string s)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{std::move(s)}, logical_type::make(type_id::VARCHAR)});
+}
+
+std::unique_ptr<ast_node> make_dec32_const(int32_t unscaled, uint8_t precision, uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal32{unscaled, scale}},
+                          logical_type::make_decimal(precision, scale)});
+}
+
+std::unique_ptr<ast_node> make_dec64_const(int64_t unscaled, uint8_t precision, uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal64{unscaled, scale}},
+                          logical_type::make_decimal(precision, scale)});
+}
+
+std::unique_ptr<ast_node> make_dec128_const(__int128_t unscaled, uint8_t precision, uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal128{unscaled, scale}},
+                          logical_type::make_decimal(precision, scale)});
+}
+
+std::unique_ptr<ast_node> make_cmp(sirius::comparison_type op,
+                                   std::unique_ptr<ast_node> left,
+                                   std::unique_ptr<ast_node> right)
+{
+  return std::make_unique<ast_node>(sirius::ast::comparison{op, std::move(left), std::move(right)});
+}
+
+std::unique_ptr<ast_node> make_func(sirius::function_id id,
+                                    std::vector<std::unique_ptr<ast_node>> args,
+                                    logical_type return_type)
+{
+  return std::make_unique<ast_node>(sirius::ast::function_call{id, std::move(args), return_type});
+}
+
+std::unique_ptr<ast_node> make_conj(sirius::ast::conjunction::kind kind,
+                                    std::vector<std::unique_ptr<ast_node>> children)
+{
+  return std::make_unique<ast_node>(sirius::ast::conjunction{kind, std::move(children)});
+}
+
+std::unique_ptr<ast_node> make_between(std::unique_ptr<ast_node> input,
+                                       std::unique_ptr<ast_node> lower,
+                                       std::unique_ptr<ast_node> upper,
+                                       bool lower_inclusive,
+                                       bool upper_inclusive)
+{
+  return std::make_unique<ast_node>(sirius::ast::between{
+    std::move(input), std::move(lower), std::move(upper), lower_inclusive, upper_inclusive});
+}
+
+std::unique_ptr<ast_node> make_coalesce(std::vector<std::unique_ptr<ast_node>> children,
+                                        logical_type return_type)
+{
+  return std::make_unique<ast_node>(sirius::ast::coalesce{std::move(children), return_type});
+}
+
+std::unique_ptr<ast_node> make_in(std::unique_ptr<ast_node> probe,
+                                  std::vector<std::unique_ptr<ast_node>> values,
+                                  bool negated)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::in_list{std::move(probe), std::move(values), negated});
+}
+
+std::unique_ptr<ast_node> make_unary(sirius::ast::unary_op::kind kind,
+                                     std::unique_ptr<ast_node> child)
+{
+  return std::make_unique<ast_node>(sirius::ast::unary_op{kind, std::move(child)});
+}
+
+// Wrap an owned Sirius AST node into a sirius::expression for the owning ctors.
+sirius::expression wrap_node(std::unique_ptr<ast_node> n)
+{
+  return sirius::expression{
+    std::make_unique<sirius::expression::impl>(sirius::expression::impl{std::move(n)})};
+}
+
 // Shorthand: build executor, run execute(), return output table view and input table view.
 struct exec_result {
   std::shared_ptr<data_batch> input;
@@ -407,10 +506,13 @@ struct exec_result {
 
 exec_result run_execute(memory_space& space,
                         std::shared_ptr<data_batch> const& input_batch,
-                        duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs,
+                        std::vector<std::unique_ptr<ast_node>> nodes,
                         exp_strategy_enum strategy = MAT)
 {
-  auto wrapped = sirius::wrap_many(std::move(exprs));
+  duckdb::vector<sirius::expression> wrapped;
+  for (auto& n : nodes) {
+    wrapped.push_back(wrap_node(std::move(n)));
+  }
   exp_executor executor(wrapped, get_resource_ref(space), cudf::get_default_stream(), strategy);
   auto input_ro     = input_batch->to_read_only();
   auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
@@ -425,10 +527,10 @@ exec_result run_execute(memory_space& space,
 
 exec_result run_select(memory_space& space,
                        std::shared_ptr<data_batch> const& input_batch,
-                       duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs,
+                       std::unique_ptr<ast_node> node,
                        exp_strategy_enum strategy = MAT)
 {
-  auto wrapped = sirius::wrap_many(std::move(exprs));
+  auto wrapped = wrap_node(std::move(node));
   exp_executor executor(wrapped, get_resource_ref(space), cudf::get_default_stream(), strategy);
   auto input_ro     = input_batch->to_read_only();
   auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
@@ -441,22 +543,12 @@ exec_result run_select(memory_space& space,
   return {input_batch, output_batch, in_repr.get_table_view(), out_repr.get_table_view()};
 }
 
-// Helper: make a BoundFunctionExpression with the given name, arg types, return type, and children.
-duckdb::unique_ptr<BoundFunctionExpression> make_func_expr(
-  const std::string& name,
-  LogicalType const& return_type,
-  std::vector<LogicalType> arg_types,
-  duckdb::vector<duckdb::unique_ptr<Expression>> children)
+// Convenience: pack a single node into the projection driver's vector.
+std::vector<std::unique_ptr<ast_node>> one(std::unique_ptr<ast_node> n)
 {
-  auto expr = duckdb::make_uniq<BoundFunctionExpression>(
-    return_type,
-    ScalarFunction(name, std::move(arg_types), return_type, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  for (auto& child : children) {
-    expr->children.push_back(std::move(child));
-  }
-  return expr;
+  std::vector<std::unique_ptr<ast_node>> v;
+  v.push_back(std::move(n));
+  return v;
 }
 }  // namespace
 
@@ -479,14 +571,10 @@ TEMPLATE_TEST_CASE("execute projects references, constants, and comparisons",
     auto input = make_input_batch(
       *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    exprs.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42)));
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(50));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs)));
+    std::vector<std::unique_ptr<ast_node>> exprs;
+    exprs.push_back(make_ref(0));
+    exprs.push_back(make_int_const(42));
+    exprs.push_back(make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(50)));
 
     auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
     REQUIRE(ov.num_columns() == 3);
@@ -513,15 +601,11 @@ TEMPLATE_TEST_CASE("execute projects references, constants, and comparisons",
     std::iota(raw.begin(), raw.end(), 0);
     auto input = make_decimal64_batch(*space, static_cast<int8_t>(scale), raw);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
+    std::vector<std::unique_ptr<ast_node>> exprs;
+    exprs.push_back(make_ref(0));
+    exprs.push_back(make_dec64_const(42, 18, scale));
     exprs.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(18, scale), 0));
-    exprs.push_back(
-      duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{42}, 18, scale)));
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(18, scale), 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{64}, 18, scale));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_LESSTHAN, std::move(lhs), std::move(rhs)));
+      make_cmp(sirius::comparison_type::lt, make_ref(0), make_dec64_const(64, 18, scale)));
 
     auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
     REQUIRE(ov.num_columns() == 3);
@@ -545,14 +629,10 @@ TEMPLATE_TEST_CASE("execute projects references, constants, and comparisons",
     auto input = make_input_batch(
       *space, {cudf::data_type{cudf::type_id::STRING}}, {std::pair<int, int>{1, 5}});
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-    exprs.push_back(duckdb::make_uniq<BoundConstantExpression>(Value("hello")));
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value("str_3"));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_EQUAL, std::move(lhs), std::move(rhs)));
+    std::vector<std::unique_ptr<ast_node>> exprs;
+    exprs.push_back(make_ref(0));
+    exprs.push_back(make_str_const("hello"));
+    exprs.push_back(make_cmp(sirius::comparison_type::equal, make_ref(0), make_str_const("str_3")));
 
     auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
     REQUIRE(ov.num_columns() == 3);
@@ -591,13 +671,9 @@ TEMPLATE_TEST_CASE("select filters rows and handles edge cases",
     auto input = make_input_batch(
       *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 9}});
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs)));
+    auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(5));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
     std::vector<int32_t> expected;
     for (auto v : in_vals) {
@@ -611,13 +687,9 @@ TEMPLATE_TEST_CASE("select filters rows and handles edge cases",
     auto input = make_input_batch(
       *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 9}});
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1000));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs)));
+    auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(1000));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     REQUIRE(ov.num_rows() == 0);
     REQUIRE(ov.num_columns() == iv.num_columns());
   }
@@ -629,13 +701,9 @@ TEMPLATE_TEST_CASE("select filters rows and handles edge cases",
     std::iota(raw.begin(), raw.end(), 0);
     auto input = make_decimal64_batch(*space, static_cast<int8_t>(scale), raw);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::DECIMAL(18, scale), 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{64}, 18, scale));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs)));
+    auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_dec64_const(64, 18, scale));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_vals                       = copy_column_to_host<int64_t>(iv.column(0));
     std::vector<int64_t> expected;
     for (auto v : in_vals) {
@@ -649,13 +717,9 @@ TEMPLATE_TEST_CASE("select filters rows and handles edge cases",
     auto input = make_input_batch(
       *space, {cudf::data_type{cudf::type_id::STRING}}, {std::pair<int, int>{1, 3}});
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    auto lhs = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0);
-    auto rhs = duckdb::make_uniq<BoundConstantExpression>(Value("str_2"));
-    exprs.push_back(duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_EQUAL, std::move(lhs), std::move(rhs)));
+    auto expr = make_cmp(sirius::comparison_type::equal, make_ref(0), make_str_const("str_2"));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_strs                       = copy_string_column_to_host(iv.column(0));
     std::vector<std::string> expected;
     for (auto const& v : in_strs) {
@@ -686,18 +750,13 @@ TEMPLATE_TEST_CASE("execute arithmetic functions",
 
   SECTION("col0 + 10")
   {
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("+",
-                     LogicalType{LogicalTypeId::INTEGER},
-                     {LogicalType{LogicalTypeId::INTEGER}, LogicalType{LogicalTypeId::INTEGER}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_int_const(10));
+    auto expr = make_func(
+      sirius::function_id::add, std::move(children), logical_type::make(type_id::INTEGER));
 
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.num_columns() == 1);
     auto in0  = copy_column_to_host<int32_t>(iv.column(0));
     auto out0 = copy_column_to_host<int32_t>(ov.column(0));
@@ -708,19 +767,13 @@ TEMPLATE_TEST_CASE("execute arithmetic functions",
 
   SECTION("col0 * col1")
   {
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("*",
-                     LogicalType{LogicalTypeId::INTEGER},
-                     {LogicalType{LogicalTypeId::INTEGER}, LogicalType{LogicalTypeId::INTEGER}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
+    auto expr = make_func(
+      sirius::function_id::mul, std::move(children), logical_type::make(type_id::INTEGER));
 
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     auto in0                           = copy_column_to_host<int32_t>(iv.column(0));
     auto in1                           = copy_column_to_host<int32_t>(iv.column(1));
     auto out0                          = copy_column_to_host<int32_t>(ov.column(0));
@@ -731,18 +784,13 @@ TEMPLATE_TEST_CASE("execute arithmetic functions",
 
   SECTION("col0 % 3")
   {
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("%",
-                     LogicalType{LogicalTypeId::INTEGER},
-                     {LogicalType{LogicalTypeId::INTEGER}, LogicalType{LogicalTypeId::INTEGER}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_int_const(3));
+    auto expr = make_func(
+      sirius::function_id::mod, std::move(children), logical_type::make(type_id::INTEGER));
 
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     auto in0                           = copy_column_to_host<int32_t>(iv.column(0));
     auto out0                          = copy_column_to_host<int32_t>(ov.column(0));
     for (size_t i = 0; i < in0.size(); ++i) {
@@ -769,7 +817,7 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL64)",
 
   uint8_t const width = 18;
   uint8_t const scale = 2;
-  auto const dec_type = LogicalType::DECIMAL(width, scale);
+  auto const dec_type = logical_type::make_decimal(width, scale);
 
   // Values: 0.00, 0.01, ... 0.09 (stored as 0, 1, ... 9 at scale 2)
   std::vector<int64_t> raw_a = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -780,15 +828,12 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL64)",
     auto input = make_decimal64_batch(*space, static_cast<int8_t>(scale), raw_a);
 
     // 1.25 at scale 2 → raw value 125
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-    children.push_back(
-      duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{125}, width, scale)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_dec64_const(125, width, scale));
+    auto expr = make_func(sirius::function_id::add, std::move(children), dec_type);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(make_func_expr("+", dec_type, {dec_type, dec_type}, std::move(children)));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.num_columns() == 1);
     REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
     REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
@@ -806,14 +851,12 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL64)",
   {
     auto input = make_decimal64_two_col_batch(*space, static_cast<int8_t>(scale), raw_b, raw_a);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-    children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 1));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
+    auto expr = make_func(sirius::function_id::sub, std::move(children), dec_type);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(make_func_expr("-", dec_type, {dec_type, dec_type}, std::move(children)));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
     REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
 
@@ -832,17 +875,12 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL64)",
 
     // 2 as DECIMAL(18, 0) → same cudf type_id (DECIMAL64), scale 0.
     // cudf MUL: output scale = lhs_scale + rhs_scale = -2 + 0 = -2.
-    auto const dec_int_type = LogicalType::DECIMAL(width, 0);
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_dec64_const(2, width, /*scale=*/0));
+    auto expr = make_func(sirius::function_id::mul, std::move(children), dec_type);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-    children.push_back(
-      duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{2}, width, uint8_t{0})));
-
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(make_func_expr("*", dec_type, {dec_type, dec_int_type}, std::move(children)));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
     REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
 
@@ -870,22 +908,19 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL32)",
   // DECIMAL32 branches in gpu_execute_constant.cpp and GetCudfType.
   uint8_t const width = 8;
   uint8_t const scale = 2;
-  auto const dec_type = LogicalType::DECIMAL(width, scale);
+  auto const dec_type = logical_type::make_decimal(width, scale);
 
   // 1.00, 2.00, 3.00 ... 10.00 (raw: 100, 200, ... 1000 at scale 2)
   std::vector<int32_t> raw = {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000};
   auto input               = make_decimal32_batch(*space, static_cast<int8_t>(scale), raw);
 
   // col0 + 0.50 → raw add 50
-  duckdb::vector<duckdb::unique_ptr<Expression>> children;
-  children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-  children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int32_t{50}, width, scale)));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_dec32_const(50, width, scale));
+  auto expr = make_func(sirius::function_id::add, std::move(children), dec_type);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(make_func_expr("+", dec_type, {dec_type, dec_type}, std::move(children)));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL32);
   REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
@@ -916,30 +951,25 @@ TEMPLATE_TEST_CASE("execute nested decimal arithmetic (col + 1.00) * 2",
 
   uint8_t const width = 18;
   uint8_t const scale = 2;
-  auto const dec_type = LogicalType::DECIMAL(width, scale);
-  auto const dec_int  = LogicalType::DECIMAL(width, 0);
+  auto const dec_type = logical_type::make_decimal(width, scale);
 
   // 0.00, 0.01 ... 0.09
   std::vector<int64_t> raw = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto input               = make_decimal64_batch(*space, static_cast<int8_t>(scale), raw);
 
   // Inner: col + 1.00 (both scale 2) → result scale 2
-  duckdb::vector<duckdb::unique_ptr<Expression>> add_children;
-  add_children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-  add_children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{100}, width, scale)));
-  auto add_expr = make_func_expr("+", dec_type, {dec_type, dec_type}, std::move(add_children));
+  std::vector<std::unique_ptr<ast_node>> add_children;
+  add_children.push_back(make_ref(0));
+  add_children.push_back(make_dec64_const(100, width, scale));
+  auto add_expr = make_func(sirius::function_id::add, std::move(add_children), dec_type);
 
   // Outer: (col + 1.00) * 2 where 2 is DECIMAL(18, 0) so MUL output scale = -2 + 0 = -2
-  duckdb::vector<duckdb::unique_ptr<Expression>> mul_children;
+  std::vector<std::unique_ptr<ast_node>> mul_children;
   mul_children.push_back(std::move(add_expr));
-  mul_children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{2}, width, uint8_t{0})));
+  mul_children.push_back(make_dec64_const(2, width, /*scale=*/0));
+  auto expr = make_func(sirius::function_id::mul, std::move(mul_children), dec_type);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(make_func_expr("*", dec_type, {dec_type, dec_int}, std::move(mul_children)));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
   REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
@@ -968,22 +998,19 @@ TEMPLATE_TEST_CASE("execute decimal arithmetic (DECIMAL128)",
 
   uint8_t const width = 38;
   uint8_t const scale = 2;
-  auto const dec_type = LogicalType::DECIMAL(width, scale);
+  auto const dec_type = logical_type::make_decimal(width, scale);
 
   // 1.00, 2.00, 3.00 (raw: 100, 200, 300 at scale 2)
   std::vector<__int128_t> raw = {100, 200, 300};
   auto input                  = make_decimal128_batch(*space, static_cast<int8_t>(scale), raw);
 
   // col + 1.25 → raw add 125
-  duckdb::vector<duckdb::unique_ptr<Expression>> children;
-  children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-  children.push_back(duckdb::make_uniq<BoundConstantExpression>(
-    Value::DECIMAL(duckdb::hugeint_t{125}, width, scale)));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_dec128_const(__int128_t{125}, width, scale));
+  auto expr = make_func(sirius::function_id::add, std::move(children), dec_type);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(make_func_expr("+", dec_type, {dec_type, dec_type}, std::move(children)));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL128);
   REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
@@ -1011,8 +1038,7 @@ TEMPLATE_TEST_CASE("execute decimal DIV (DECIMAL64)",
 
   uint8_t const width = 18;
   uint8_t const scale = 2;
-  auto const dec_type = LogicalType::DECIMAL(width, scale);
-  auto const dec_int  = LogicalType::DECIMAL(width, 0);
+  auto const dec_type = logical_type::make_decimal(width, scale);
 
   // 4.00, 5.00, 6.00, 7.00 (raw 400, 500, 600, 700 at scale 2)
   std::vector<int64_t> raw = {400, 500, 600, 700};
@@ -1020,15 +1046,12 @@ TEMPLATE_TEST_CASE("execute decimal DIV (DECIMAL64)",
 
   // col / 2 (2 as DECIMAL(18, 0)) → fixed_point div truncates toward zero in
   // the output scale; 500/2 = 250, 700/2 = 350.
-  duckdb::vector<duckdb::unique_ptr<Expression>> children;
-  children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec_type, 0));
-  children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{2}, width, uint8_t{0})));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_dec64_const(2, width, /*scale=*/0));
+  auto expr = make_func(sirius::function_id::div, std::move(children), dec_type);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(make_func_expr("/", dec_type, {dec_type, dec_int}, std::move(children)));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
   REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale));
@@ -1061,9 +1084,9 @@ TEMPLATE_TEST_CASE("execute decimal TPC-H Q1 shape price * (1 - discount)",
   uint8_t const width     = 18;
   uint8_t const scale2    = 2;
   uint8_t const scale4    = 4;
-  auto const price_type   = LogicalType::DECIMAL(width, scale2);  // DECIMAL(18,2)
-  auto const discount_t   = LogicalType::DECIMAL(width, scale2);  // DECIMAL(18,2)
-  auto const mul_ret_type = LogicalType::DECIMAL(width, scale4);  // DECIMAL(18,4)
+  auto const price_type   = logical_type::make_decimal(width, scale2);  // DECIMAL(18,2)
+  auto const discount_t   = logical_type::make_decimal(width, scale2);  // DECIMAL(18,2)
+  auto const mul_ret_type = logical_type::make_decimal(width, scale4);  // DECIMAL(18,4)
 
   // price: 1000.00, 2000.00, 3000.00
   std::vector<int64_t> raw_price = {100000, 200000, 300000};
@@ -1073,23 +1096,18 @@ TEMPLATE_TEST_CASE("execute decimal TPC-H Q1 shape price * (1 - discount)",
     make_decimal64_two_col_batch(*space, static_cast<int8_t>(scale2), raw_price, raw_discount);
 
   // Inner: 1.00 - discount (scalar on left, column on right)
-  duckdb::vector<duckdb::unique_ptr<Expression>> sub_children;
-  sub_children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(int64_t{100}, width, scale2)));
-  sub_children.push_back(duckdb::make_uniq<BoundReferenceExpression>(discount_t, 1));
-  auto sub_expr =
-    make_func_expr("-", discount_t, {discount_t, discount_t}, std::move(sub_children));
+  std::vector<std::unique_ptr<ast_node>> sub_children;
+  sub_children.push_back(make_dec64_const(100, width, scale2));
+  sub_children.push_back(make_ref(1));
+  auto sub_expr = make_func(sirius::function_id::sub, std::move(sub_children), discount_t);
 
   // Outer: price * (1.00 - discount) → return type DECIMAL(18, 4)
-  duckdb::vector<duckdb::unique_ptr<Expression>> mul_children;
-  mul_children.push_back(duckdb::make_uniq<BoundReferenceExpression>(price_type, 0));
+  std::vector<std::unique_ptr<ast_node>> mul_children;
+  mul_children.push_back(make_ref(0));
   mul_children.push_back(std::move(sub_expr));
+  auto expr = make_func(sirius::function_id::mul, std::move(mul_children), mul_ret_type);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(
-    make_func_expr("*", mul_ret_type, {price_type, discount_t}, std::move(mul_children)));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.column(0).type().id() == cudf::type_id::DECIMAL64);
   REQUIRE(ov.column(0).type().scale() == -static_cast<int32_t>(scale4));
@@ -1128,18 +1146,13 @@ TEMPLATE_TEST_CASE("select LIKE and NOT LIKE",
   SECTION("LIKE 'str_2'")
   {
     // col0 LIKE 'str_2' — exact match via LIKE
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-    children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value("str_2")));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("~~",
-                     LogicalType{LogicalTypeId::BOOLEAN},
-                     {LogicalType{LogicalTypeId::VARCHAR}, LogicalType{LogicalTypeId::VARCHAR}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_str_const("str_2"));
+    auto expr = make_func(
+      sirius::function_id::like, std::move(children), logical_type::make(type_id::BOOLEAN));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_strs                       = copy_string_column_to_host(iv.column(0));
     std::vector<std::string> expected;
     for (auto const& s : in_strs) {
@@ -1151,36 +1164,26 @@ TEMPLATE_TEST_CASE("select LIKE and NOT LIKE",
   SECTION("LIKE 'str_%' — wildcard")
   {
     // col0 LIKE 'str_%' — should match all rows
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-    children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value("str_%")));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("~~",
-                     LogicalType{LogicalTypeId::BOOLEAN},
-                     {LogicalType{LogicalTypeId::VARCHAR}, LogicalType{LogicalTypeId::VARCHAR}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_str_const("str_%"));
+    auto expr = make_func(
+      sirius::function_id::like, std::move(children), logical_type::make(type_id::BOOLEAN));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     REQUIRE(ov.num_rows() == iv.num_rows());
   }
 
   SECTION("NOT LIKE 'str_1'")
   {
     // col0 NOT LIKE 'str_1' — should exclude 'str_1' rows
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-    children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value("str_1")));
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(
-      make_func_expr("!~~",
-                     LogicalType{LogicalTypeId::BOOLEAN},
-                     {LogicalType{LogicalTypeId::VARCHAR}, LogicalType{LogicalTypeId::VARCHAR}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_str_const("str_1"));
+    auto expr = make_func(
+      sirius::function_id::not_like, std::move(children), logical_type::make(type_id::BOOLEAN));
 
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_strs                       = copy_string_column_to_host(iv.column(0));
     std::vector<std::string> expected;
     for (auto const& s : in_strs) {
@@ -1208,24 +1211,13 @@ TEMPLATE_TEST_CASE("execute CASE expression",
   auto input = make_input_batch(
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
 
-  auto when_expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(50)));
-  auto then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1));
-  auto else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.push_back(sirius::ast::case_expr::when_then{
+    make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(50)), make_int_const(1)});
+  auto expr = std::make_unique<ast_node>(sirius::ast::case_expr{
+    std::move(cases), make_int_const(0), logical_type::make(type_id::INTEGER)});
 
-  auto case_expr = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  BoundCaseCheck check;
-  check.when_expr = std::move(when_expr);
-  check.then_expr = std::move(then_expr);
-  case_expr->case_checks.push_back(std::move(check));
-  case_expr->else_expr = std::move(else_expr);
-
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(case_expr));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   REQUIRE(ov.num_columns() == 1);
   REQUIRE(ov.num_rows() == iv.num_rows());
 
@@ -1250,30 +1242,15 @@ TEMPLATE_TEST_CASE("execute CASE with multiple WHEN branches",
   auto input = make_input_batch(
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
 
-  auto case_expr = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.push_back(sirius::ast::case_expr::when_then{
+    make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(30)), make_int_const(-1)});
+  cases.push_back(sirius::ast::case_expr::when_then{
+    make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(70)), make_int_const(1)});
+  auto expr = std::make_unique<ast_node>(sirius::ast::case_expr{
+    std::move(cases), make_int_const(0), logical_type::make(type_id::INTEGER)});
 
-  BoundCaseCheck check1;
-  check1.when_expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(30)));
-  check1.then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(-1));
-  case_expr->case_checks.push_back(std::move(check1));
-
-  BoundCaseCheck check2;
-  check2.when_expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(70)));
-  check2.then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1));
-  case_expr->case_checks.push_back(std::move(check2));
-
-  case_expr->else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
-
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(case_expr));
-
-  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
   auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
   auto out_vals                      = copy_column_to_host<int32_t>(ov.column(0));
   for (size_t i = 0; i < in_vals.size(); ++i) {
@@ -1297,17 +1274,13 @@ TEMPLATE_TEST_CASE(
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
 
   // col0 BETWEEN 20 AND 50 (inclusive)
-  auto between = duckdb::make_uniq<BoundBetweenExpression>(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(20)),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(50)),
-    true,   // lower_inclusive
-    true);  // upper_inclusive
+  auto expr = make_between(make_ref(0),
+                           make_int_const(20),
+                           make_int_const(50),
+                           /*lower_inclusive=*/true,
+                           /*upper_inclusive=*/true);
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(between));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
   std::vector<int32_t> expected;
   for (auto v : in_vals) {
@@ -1335,18 +1308,13 @@ TEMPLATE_TEST_CASE("select IN and NOT IN",
 
   SECTION("IN (2, 4, 6)")
   {
-    auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                              LogicalType{LogicalTypeId::BOOLEAN});
-    in_expr->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-    in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(4)));
-    in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(6)));
+    std::vector<std::unique_ptr<ast_node>> values;
+    values.push_back(make_int_const(2));
+    values.push_back(make_int_const(4));
+    values.push_back(make_int_const(6));
+    auto expr = make_in(make_ref(0), std::move(values), /*negated=*/false);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(in_expr));
-
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
     std::vector<int32_t> expected;
     for (auto v : in_vals) {
@@ -1357,19 +1325,14 @@ TEMPLATE_TEST_CASE("select IN and NOT IN",
 
   SECTION("NOT IN (0, 1, 2, 3)")
   {
-    auto not_in_expr = duckdb::make_uniq<BoundOperatorExpression>(
-      ExpressionType::COMPARE_NOT_IN, LogicalType{LogicalTypeId::BOOLEAN});
-    not_in_expr->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    not_in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
-    not_in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-    not_in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-    not_in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+    std::vector<std::unique_ptr<ast_node>> values;
+    values.push_back(make_int_const(0));
+    values.push_back(make_int_const(1));
+    values.push_back(make_int_const(2));
+    values.push_back(make_int_const(3));
+    auto expr = make_in(make_ref(0), std::move(values), /*negated=*/true);
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(not_in_expr));
-
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
     std::vector<int32_t> expected;
     for (auto v : in_vals) {
@@ -1399,30 +1362,18 @@ TEMPLATE_TEST_CASE("select IS NULL and IS NOT NULL",
 
   SECTION("IS NULL")
   {
-    auto is_null = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
-                                                              LogicalType{LogicalTypeId::BOOLEAN});
-    is_null->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+    auto expr = make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(0));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(is_null));
-
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     // Null rows should pass the IS NULL filter
     REQUIRE(ov.num_rows() == 2);
   }
 
   SECTION("IS NOT NULL")
   {
-    auto is_not_null = duckdb::make_uniq<BoundOperatorExpression>(
-      ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-    is_not_null->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+    auto expr = make_unary(sirius::ast::unary_op::kind::op_is_not_null, make_ref(0));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(is_not_null));
-
-    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
     // Non-null rows should pass
     REQUIRE(ov.num_rows() == 3);
     auto out_vals = copy_column_to_host<int32_t>(ov.column(0));
@@ -1450,16 +1401,12 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids    = {true, false, true, false, true};
     auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    coalesce->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(-1)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_int_const(-1));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.num_columns() == 1);
     REQUIRE(ov.num_rows() == iv.num_rows());
     REQUIRE(ov.column(0).null_count() == 0);
@@ -1484,17 +1431,12 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids_b    = {false, true, false, true, false};
     auto input = make_two_int32_batch_with_nulls(*space, values_a, valids_a, values_b, valids_b);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.num_columns() == 1);
     REQUIRE(ov.num_rows() == iv.num_rows());
     REQUIRE(ov.column(0).null_count() == 1);
@@ -1517,18 +1459,13 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids_b    = {false, true, false, false};
     auto input = make_two_int32_batch_with_nulls(*space, values_a, valids_a, values_b, valids_b);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-    coalesce->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(-7)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
+    children.push_back(make_int_const(-7));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.column(0).null_count() == 0);
     std::vector<int32_t> expected = {10, 200, -7, -7};
     REQUIRE(copy_column_to_host<int32_t>(ov.column(0)) == expected);
@@ -1543,21 +1480,15 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids_b    = {false, true, false, false};
     auto input = make_two_int32_batch_with_nulls(*space, values_a, valids_a, values_b, valids_b);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
     // Third child is col_a again (same column still has the same nulls) — drives the
     // column-replacement branch a second time with residual nulls surviving.
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+    children.push_back(make_ref(0));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.column(0).null_count() == 2);
 
     auto out_vals                     = copy_column_to_host<int32_t>(ov.column(0));
@@ -1577,18 +1508,13 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids_all_true     = {true, true, true, true, true};
     auto input = make_int32_batch_with_nulls(*space, values_all_valid, valids_all_true);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
     // Poison: out-of-range reference. Only safe if short-circuit skips it.
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 999));
+    children.push_back(make_ref(999));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
+    auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, one(std::move(expr)), strategy);
     REQUIRE(ov.num_columns() == 1);
     REQUIRE(ov.column(0).null_count() == 0);
     REQUIRE(copy_column_to_host<int32_t>(ov.column(0)) == values_all_valid);
@@ -1603,17 +1529,12 @@ TEMPLATE_TEST_CASE("execute COALESCE",
     std::vector<bool> valids    = {true, false, true};
     auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-    auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                               LogicalType{LogicalTypeId::INTEGER});
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    coalesce->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 999));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(999));
+    auto expr = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-    duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-    exprs.push_back(std::move(coalesce));
-
-    REQUIRE_THROWS(run_execute(*space, input, std::move(exprs), strategy));
+    REQUIRE_THROWS(run_execute(*space, input, one(std::move(expr)), strategy));
   }
 }
 
@@ -1634,21 +1555,14 @@ TEMPLATE_TEST_CASE("select COALESCE nested in predicate",
   std::vector<bool> valids    = {true, false, true, false, true};
   auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-  auto coalesce = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
-                                                             LogicalType{LogicalTypeId::INTEGER});
-  coalesce->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  coalesce->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_int_const(0));
+  auto coalesce = make_coalesce(std::move(children), logical_type::make(type_id::INTEGER));
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    std::move(coalesce),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(20)));
+  auto expr = make_cmp(sirius::comparison_type::gt, std::move(coalesce), make_int_const(20));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(cmp));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   REQUIRE(ov.num_rows() == 2);
   REQUIRE(copy_column_to_host<int32_t>(ov.column(0)) == std::vector<int32_t>{30, 50});
 }
@@ -1667,15 +1581,9 @@ TEMPLATE_TEST_CASE("select respects null mask under plain comparison",
   std::vector<bool> valids    = {true, false, true, false, true};
   auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(2));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(cmp));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
 
   std::vector<int32_t> expected;
   for (size_t i = 0; i < values.size(); ++i) {
@@ -1701,15 +1609,9 @@ TEMPLATE_TEST_CASE("select COMPARE_NOT_DISTINCT_FROM",
   std::vector<bool> valids    = {true, false, true, false, true};
   auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_NOT_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(30)));
+  auto expr = make_cmp(sirius::comparison_type::not_distinct_from, make_ref(0), make_int_const(30));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(cmp));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   REQUIRE(ov.num_rows() == 1);
   REQUIRE(ov.column(0).null_count() == 0);
   REQUIRE(copy_column_to_host<int32_t>(ov.column(0)) == std::vector<int32_t>{30});
@@ -1730,15 +1632,9 @@ TEMPLATE_TEST_CASE("select COMPARE_DISTINCT_FROM",
   std::vector<bool> valids    = {true, false, true, false, true};
   auto input                  = make_int32_batch_with_nulls(*space, values, valids);
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(30)));
+  auto expr = make_cmp(sirius::comparison_type::distinct_from, make_ref(0), make_int_const(30));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(cmp));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   REQUIRE(ov.num_rows() == 4);
   REQUIRE(ov.column(0).null_count() == 2);
 }
@@ -1757,19 +1653,10 @@ TEMPLATE_TEST_CASE("select NOT operator",
     make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 9}});
 
   // NOT (col0 > 5) — should keep rows where col0 <= 5
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
+  auto cmp  = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(5));
+  auto expr = make_unary(sirius::ast::unary_op::kind::op_not, std::move(cmp));
 
-  auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(std::move(cmp));
-
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(not_expr));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
   std::vector<int32_t> expected;
   for (auto v : in_vals) {
@@ -1800,29 +1687,20 @@ TEMPLATE_TEST_CASE("select conjunction with AST breaker",
 
   // WHERE col0 > 3 AND col1 LIKE 'str_%'
   // col0 > 3 is AST-capable, LIKE is not — forces mixed materialization
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  auto cmp = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(3));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> like_children;
-  like_children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 1));
-  like_children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value("str_%")));
-  auto like =
-    make_func_expr("~~",
-                   LogicalType{LogicalTypeId::BOOLEAN},
-                   {LogicalType{LogicalTypeId::VARCHAR}, LogicalType{LogicalTypeId::VARCHAR}},
-                   std::move(like_children));
+  std::vector<std::unique_ptr<ast_node>> like_children;
+  like_children.push_back(make_ref(1));
+  like_children.push_back(make_str_const("str_%"));
+  auto like = make_func(
+    sirius::function_id::like, std::move(like_children), logical_type::make(type_id::BOOLEAN));
 
-  auto conjunction = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conjunction->children.push_back(std::move(cmp));
-  conjunction->children.push_back(std::move(like));
+  std::vector<std::unique_ptr<ast_node>> conj_children;
+  conj_children.push_back(std::move(cmp));
+  conj_children.push_back(std::move(like));
+  auto expr = make_conj(sirius::ast::conjunction::kind::op_and, std::move(conj_children));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(conjunction));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_col0                       = copy_column_to_host<int32_t>(iv.column(0));
   auto in_col1                       = copy_string_column_to_host(iv.column(1));
 
@@ -1848,23 +1726,15 @@ TEMPLATE_TEST_CASE("select OR conjunction",
     make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 20}});
 
   // col0 < 3 OR col0 > 17
-  auto lt = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
-  auto gt = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(17)));
+  auto lt = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(3));
+  auto gt = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(17));
 
-  auto disjunction = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-  disjunction->children.push_back(std::move(lt));
-  disjunction->children.push_back(std::move(gt));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(lt));
+  children.push_back(std::move(gt));
+  auto expr = make_conj(sirius::ast::conjunction::kind::op_or, std::move(children));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(disjunction));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
   std::vector<int32_t> expected;
   for (auto v : in_vals) {
@@ -1892,26 +1762,15 @@ TEMPLATE_TEST_CASE("select with nested CASE in predicate",
     *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
 
   // WHERE (CASE WHEN col0 > 50 THEN col0 ELSE 0 END) > 75
-  auto case_expr = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  BoundCaseCheck check;
-  check.when_expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(50)));
-  check.then_expr =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  case_expr->case_checks.push_back(std::move(check));
-  case_expr->else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.push_back(sirius::ast::case_expr::when_then{
+    make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(50)), make_ref(0)});
+  auto case_node = std::make_unique<ast_node>(sirius::ast::case_expr{
+    std::move(cases), make_int_const(0), logical_type::make(type_id::INTEGER)});
 
-  auto outer_cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    std::move(case_expr),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(75)));
+  auto expr = make_cmp(sirius::comparison_type::gt, std::move(case_node), make_int_const(75));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(outer_cmp));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_vals                       = copy_column_to_host<int32_t>(iv.column(0));
   std::vector<int32_t> expected;
   for (auto v : in_vals) {
@@ -1941,28 +1800,21 @@ TEMPLATE_TEST_CASE("select IN with conjunction multi-column",
                      {std::pair<int, int>{0, 9}, std::pair<int, int>{0, 50}});
 
   // WHERE col0 IN (1, 3, 5, 7) AND col1 >= 20
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7)));
+  std::vector<std::unique_ptr<ast_node>> in_values;
+  in_values.push_back(make_int_const(1));
+  in_values.push_back(make_int_const(3));
+  in_values.push_back(make_int_const(5));
+  in_values.push_back(make_int_const(7));
+  auto in_expr = make_in(make_ref(0), std::move(in_values), /*negated=*/false);
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHANOREQUALTO,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BIGINT}, 1),
-    duckdb::make_uniq<BoundConstantExpression>(Value::BIGINT(20)));
+  auto cmp = make_cmp(sirius::comparison_type::ge, make_ref(1), make_bigint_const(20));
 
-  auto conjunction = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conjunction->children.push_back(std::move(in_expr));
-  conjunction->children.push_back(std::move(cmp));
+  std::vector<std::unique_ptr<ast_node>> conj_children;
+  conj_children.push_back(std::move(in_expr));
+  conj_children.push_back(std::move(cmp));
+  auto expr = make_conj(sirius::ast::conjunction::kind::op_and, std::move(conj_children));
 
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
-  exprs.push_back(std::move(conjunction));
-
-  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(exprs), strategy);
+  auto [in_batch, out_batch, iv, ov] = run_select(*space, input, std::move(expr), strategy);
   auto in_col0                       = copy_column_to_host<int32_t>(iv.column(0));
   auto in_col1                       = copy_column_to_host<int64_t>(iv.column(1));
   std::vector<int32_t> expected_col0;
@@ -1998,45 +1850,31 @@ TEMPLATE_TEST_CASE("execute mixed arithmetic and CASE projection",
                      {std::pair<int, int>{1, 50}, std::pair<int, int>{1, 10}});
 
   // Output: [col0 + col1, CASE WHEN col0 > 25 THEN col1 * 2 ELSE col1 END]
-  duckdb::vector<duckdb::unique_ptr<Expression>> exprs;
+  std::vector<std::unique_ptr<ast_node>> exprs;
 
   // Expression 0: col0 + col1
   {
-    duckdb::vector<duckdb::unique_ptr<Expression>> children;
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-    exprs.push_back(
-      make_func_expr("+",
-                     LogicalType{LogicalTypeId::INTEGER},
-                     {LogicalType{LogicalTypeId::INTEGER}, LogicalType{LogicalTypeId::INTEGER}},
-                     std::move(children)));
+    std::vector<std::unique_ptr<ast_node>> children;
+    children.push_back(make_ref(0));
+    children.push_back(make_ref(1));
+    exprs.push_back(make_func(
+      sirius::function_id::add, std::move(children), logical_type::make(type_id::INTEGER)));
   }
 
   // Expression 1: CASE WHEN col0 > 25 THEN col1 * 2 ELSE col1 END
   {
-    duckdb::vector<duckdb::unique_ptr<Expression>> mul_children;
-    mul_children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-    mul_children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-    auto then_expr =
-      make_func_expr("*",
-                     LogicalType{LogicalTypeId::INTEGER},
-                     {LogicalType{LogicalTypeId::INTEGER}, LogicalType{LogicalTypeId::INTEGER}},
-                     std::move(mul_children));
+    std::vector<std::unique_ptr<ast_node>> mul_children;
+    mul_children.push_back(make_ref(1));
+    mul_children.push_back(make_int_const(2));
+    auto then_expr = make_func(
+      sirius::function_id::mul, std::move(mul_children), logical_type::make(type_id::INTEGER));
 
-    auto case_expr = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-    BoundCaseCheck check;
-    check.when_expr = duckdb::make_uniq<BoundComparisonExpression>(
-      ExpressionType::COMPARE_GREATERTHAN,
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-      duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(25)));
-    check.then_expr = std::move(then_expr);
-    case_expr->case_checks.push_back(std::move(check));
-    case_expr->else_expr =
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1);
-    exprs.push_back(std::move(case_expr));
+    std::vector<sirius::ast::case_expr::when_then> cases;
+    cases.push_back(sirius::ast::case_expr::when_then{
+      make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(25)),
+      std::move(then_expr)});
+    exprs.push_back(std::make_unique<ast_node>(
+      sirius::ast::case_expr{std::move(cases), make_ref(1), logical_type::make(type_id::INTEGER)}));
   }
 
   auto [in_batch, out_batch, iv, ov] = run_execute(*space, input, std::move(exprs), strategy);
@@ -2075,16 +1913,9 @@ int32_batch make_int32_input(memory_space& space)
   return {batch, in_repr.get_table_view()};
 }
 
-std::unique_ptr<sirius::ast::node> ref_node_native(uint32_t idx)
-{
-  return std::make_unique<sirius::ast::node>(sirius::ast::reference{idx});
-}
+std::unique_ptr<sirius::ast::node> ref_node_native(uint32_t idx) { return make_ref(idx); }
 
-std::unique_ptr<sirius::ast::node> int_const_node_native(int32_t v)
-{
-  return std::make_unique<sirius::ast::node>(
-    sirius::ast::constant{sirius::value{v}, sirius::logical_type::make(sirius::type_id::INTEGER)});
-}
+std::unique_ptr<sirius::ast::node> int_const_node_native(int32_t v) { return make_int_const(v); }
 
 std::unique_ptr<cudf::table> run_native_ast(memory_space& space,
                                             sirius::ast::node const* expr_ptr,
@@ -2474,33 +2305,60 @@ TEST_CASE("native_ast - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
   }
 }
 
-// Translator-only TEST_CASE: verifies that the BoundComparisonExpression shim
-// path now produces a non-null sirius::ast::node for COMPARE_DISTINCT_FROM and
-// COMPARE_NOT_DISTINCT_FROM. The executor's downstream behaviour on these
-// comparison kinds is GPU-bound and asserted by the existing
-// [expression_executor_ast_native][comparison] cases — this case only proves
-// that the lowering pipeline no longer drops these comparison kinds at the
-// from_duckdb step (sirius-db/sirius#699).
-TEST_CASE("native_ast - BoundComparisonExpression DISTINCT_FROM translates without nullptr",
-          "[expression_executor_ast_native_translate][comparison]")
+// Native-AST executor coverage for the null-safe comparison kinds
+// (COMPARE_DISTINCT_FROM / COMPARE_NOT_DISTINCT_FROM) built directly as
+// sirius::ast::comparison nodes — the comparison-kind enum is preserved end to
+// end through the executor without any DuckDB Bound*Expression round-trip
+// (sirius-db/sirius#699). DuckDB->Sirius lowering of these kinds is covered by
+// the dedicated [ast_from_duckdb] suite.
+TEST_CASE("native_ast - comparison DISTINCT_FROM / NOT_DISTINCT_FROM executes",
+          "[expression_executor_ast_native][comparison]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  // Input: {10, NULL, 30, NULL, 50}.
+  std::vector<int32_t> values = {10, 99, 30, 99, 50};
+  std::vector<bool> valids    = {true, false, true, false, true};
 
-  auto node = sirius::ast::from_duckdb(*expr);
-  REQUIRE(node);
-  REQUIRE(node->holds<sirius::ast::comparison>());
-  REQUIRE(node->get<sirius::ast::comparison>().op == sirius::comparison_type::distinct_from);
+  {
+    auto batch    = make_int32_batch_with_nulls(*space, values, valids);
+    auto ro       = batch->to_read_only();
+    auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+    auto tv       = in_repr.get_table_view();
 
-  auto left2  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right2 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7));
-  auto expr2  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left2), std::move(right2));
+    auto node = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+      sirius::comparison_type::not_distinct_from, ref_node_native(0), int_const_node_native(30)});
+    REQUIRE(node->holds<sirius::ast::comparison>());
+    REQUIRE(node->get<sirius::ast::comparison>().op == sirius::comparison_type::not_distinct_from);
 
-  auto node2 = sirius::ast::from_duckdb(*expr2);
-  REQUIRE(node2);
-  REQUIRE(node2->holds<sirius::ast::comparison>());
-  REQUIRE(node2->get<sirius::ast::comparison>().op == sirius::comparison_type::not_distinct_from);
+    // Only the real 30 is null-safe-equal to 30; the two NULLs are not.
+    auto out = run_native_ast(*space, node.get(), tv, MAT);
+    REQUIRE(out);
+    auto out_host = copy_bool_column_to_host(out->view().column(0));
+    REQUIRE(out_host.size() == values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      REQUIRE(out_host[i] == ((valids[i] && values[i] == 30) ? 1U : 0U));
+    }
+  }
+
+  {
+    auto batch    = make_int32_batch_with_nulls(*space, values, valids);
+    auto ro       = batch->to_read_only();
+    auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+    auto tv       = in_repr.get_table_view();
+
+    auto node = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
+      sirius::comparison_type::distinct_from, ref_node_native(0), int_const_node_native(30)});
+    REQUIRE(node->holds<sirius::ast::comparison>());
+    REQUIRE(node->get<sirius::ast::comparison>().op == sirius::comparison_type::distinct_from);
+
+    // Everything except the real 30 is null-safe-distinct from 30 (both NULLs included).
+    auto out = run_native_ast(*space, node.get(), tv, MAT);
+    REQUIRE(out);
+    auto out_host = copy_bool_column_to_host(out->view().column(0));
+    REQUIRE(out_host.size() == values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      REQUIRE(out_host[i] == ((valids[i] && values[i] == 30) ? 0U : 1U));
+    }
+  }
 }

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -15,6 +15,8 @@
  */
 
 // test
+#include "ast_test_support.hpp"
+
 #include <catch.hpp>
 #include <utils/utils.hpp>
 
@@ -57,6 +59,7 @@
 
 using namespace cucascade;
 using namespace cucascade::memory;
+using namespace sirius::expr_test;
 using memory_mgr = ::sirius::memory::sirius_memory_reservation_manager;
 
 namespace {
@@ -89,77 +92,6 @@ memory_space* get_default_gpu_space()
 rmm::device_async_resource_ref get_resource_ref(memory_space& space)
 {
   return space.get_default_allocator();
-}
-
-template <typename T>
-std::vector<T> copy_column_to_host(const cudf::column_view& col)
-{
-  std::vector<T> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
-}
-
-std::vector<uint8_t> copy_bool_column_to_host(const cudf::column_view& col)
-{
-  std::vector<uint8_t> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.head(), sizeof(uint8_t) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
-}
-
-std::vector<std::string> copy_string_column_to_host(const cudf::column_view& col)
-{
-  std::vector<std::string> host;
-  if (col.size() == 0) { return host; }
-
-  cudf::strings_column_view str_col(col);
-  std::vector<cudf::size_type> offsets(col.size() + 1);
-  cudaMemcpy(offsets.data(),
-             str_col.offsets().data<cudf::size_type>(),
-             (col.size() + 1) * sizeof(cudf::size_type),
-             cudaMemcpyDeviceToHost);
-
-  std::vector<char> chars(offsets.back());
-  if (!chars.empty()) {
-    cudaMemcpy(chars.data(),
-               str_col.chars_begin(cudf::get_default_stream()),
-               offsets.back(),
-               cudaMemcpyDeviceToHost);
-  }
-
-  host.reserve(col.size());
-  for (cudf::size_type i = 0; i < col.size(); ++i) {
-    auto start = offsets[i];
-    auto end   = offsets[i + 1];
-    if (chars.empty()) {
-      host.emplace_back();
-    } else {
-      host.emplace_back(chars.data() + start, chars.data() + end);
-    }
-  }
-  return host;
-}
-
-std::vector<bool> copy_valids_to_host(const cudf::column_view& col)
-{
-  std::vector<bool> valids(col.size(), true);
-  if (!col.nullable() || col.null_count() == 0) { return valids; }
-  auto const num_words = cudf::num_bitmask_words(col.size());
-  std::vector<cudf::bitmask_type> host_mask(num_words);
-  cudaMemcpy(host_mask.data(),
-             col.null_mask(),
-             num_words * sizeof(cudf::bitmask_type),
-             cudaMemcpyDeviceToHost);
-  constexpr auto bits_per_word = sizeof(cudf::bitmask_type) * 8;
-  for (cudf::size_type i = 0; i < col.size(); ++i) {
-    auto word = host_mask[i / bits_per_word];
-    auto bit  = i % bits_per_word;
-    valids[i] = ((word >> bit) & 1U) != 0U;
-  }
-  return valids;
 }
 
 std::shared_ptr<data_batch> make_input_batch(
@@ -385,116 +317,12 @@ struct ast_jit_strategy {
   static constexpr auto value = exp_strategy_enum::AST_JIT;
 };
 
-// ---------------------------------------------------------------------------
-// Native sirius::ast::node construction helpers — every test expression is
-// built directly as a Sirius AST node (no DuckDB Bound*Expression involved).
-// Mirrors the make_ref / make_int_const style used by test_ast_to_duckdb.cpp.
-// ---------------------------------------------------------------------------
+// Native sirius::ast::node construction helpers (make_ref / make_int_const / ...)
+// and GPU->host copy helpers live in ast_test_support.hpp, shared across the
+// expression_executor test suites.
 
-using ast_node = sirius::ast::node;
 using sirius::logical_type;
 using sirius::type_id;
-
-std::unique_ptr<ast_node> make_ref(uint32_t idx)
-{
-  return std::make_unique<ast_node>(sirius::ast::reference{idx});
-}
-
-std::unique_ptr<ast_node> make_int_const(int32_t v)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::INTEGER)});
-}
-
-std::unique_ptr<ast_node> make_bigint_const(int64_t v)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::BIGINT)});
-}
-
-std::unique_ptr<ast_node> make_str_const(std::string s)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{std::move(s)}, logical_type::make(type_id::VARCHAR)});
-}
-
-std::unique_ptr<ast_node> make_dec32_const(int32_t unscaled, uint8_t precision, uint8_t scale)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{sirius::decimal32{unscaled, scale}},
-                          logical_type::make_decimal(precision, scale)});
-}
-
-std::unique_ptr<ast_node> make_dec64_const(int64_t unscaled, uint8_t precision, uint8_t scale)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{sirius::decimal64{unscaled, scale}},
-                          logical_type::make_decimal(precision, scale)});
-}
-
-std::unique_ptr<ast_node> make_dec128_const(__int128_t unscaled, uint8_t precision, uint8_t scale)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{sirius::decimal128{unscaled, scale}},
-                          logical_type::make_decimal(precision, scale)});
-}
-
-std::unique_ptr<ast_node> make_cmp(sirius::comparison_type op,
-                                   std::unique_ptr<ast_node> left,
-                                   std::unique_ptr<ast_node> right)
-{
-  return std::make_unique<ast_node>(sirius::ast::comparison{op, std::move(left), std::move(right)});
-}
-
-std::unique_ptr<ast_node> make_func(sirius::function_id id,
-                                    std::vector<std::unique_ptr<ast_node>> args,
-                                    logical_type return_type)
-{
-  return std::make_unique<ast_node>(sirius::ast::function_call{id, std::move(args), return_type});
-}
-
-std::unique_ptr<ast_node> make_conj(sirius::ast::conjunction::kind kind,
-                                    std::vector<std::unique_ptr<ast_node>> children)
-{
-  return std::make_unique<ast_node>(sirius::ast::conjunction{kind, std::move(children)});
-}
-
-std::unique_ptr<ast_node> make_between(std::unique_ptr<ast_node> input,
-                                       std::unique_ptr<ast_node> lower,
-                                       std::unique_ptr<ast_node> upper,
-                                       bool lower_inclusive,
-                                       bool upper_inclusive)
-{
-  return std::make_unique<ast_node>(sirius::ast::between{
-    std::move(input), std::move(lower), std::move(upper), lower_inclusive, upper_inclusive});
-}
-
-std::unique_ptr<ast_node> make_coalesce(std::vector<std::unique_ptr<ast_node>> children,
-                                        logical_type return_type)
-{
-  return std::make_unique<ast_node>(sirius::ast::coalesce{std::move(children), return_type});
-}
-
-std::unique_ptr<ast_node> make_in(std::unique_ptr<ast_node> probe,
-                                  std::vector<std::unique_ptr<ast_node>> values,
-                                  bool negated)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::in_list{std::move(probe), std::move(values), negated});
-}
-
-std::unique_ptr<ast_node> make_unary(sirius::ast::unary_op::kind kind,
-                                     std::unique_ptr<ast_node> child)
-{
-  return std::make_unique<ast_node>(sirius::ast::unary_op{kind, std::move(child)});
-}
-
-// Wrap an owned Sirius AST node into a sirius::expression for the owning ctors.
-sirius::expression wrap_node(std::unique_ptr<ast_node> n)
-{
-  return sirius::expression{
-    std::make_unique<sirius::expression::impl>(sirius::expression::impl{std::move(n)})};
-}
 
 // Shorthand: build executor, run execute(), return output table view and input table view.
 struct exec_result {

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-// Three-leg byte-equivalence tests for the dual-path gpu_expression_executor.
+// Byte-equivalence tests for the (now single-path) gpu_expression_executor.
 //
-// For each Sirius AST alternative, the test constructs the same expression
-// three ways:
-//   1. directly as a duckdb::BoundXxxExpression (DuckDB-direct leg)
-//   2. as a hand-built sirius::ast::node{<alt>{...}}            (hand-AST leg)
-//   3. via sirius::ast::from_duckdb(*duck_expr)                 (translator leg)
+// For each Sirius AST alternative, the test constructs the same expression two
+// ways:
+//   1. as a hand-built sirius::ast::node{<alt>{...}}            (hand-AST leg)
+//   2. via sirius::ast::from_duckdb(*duck_expr)                 (translator leg)
 //
-// All three are executed against the same input table and the output columns
-// are asserted byte-equivalent pairwise on host. Confirms the new
-// sirius::ast::node-typed executor surface produces identical output to the
-// existing duckdb::Expression-typed surface for every alternative.
+// Both are executed against the same input table through the surviving
+// sirius::ast::node-typed executor surface and the output columns are asserted
+// byte-equivalent on host. This confirms sirius::ast::from_duckdb lowers a
+// DuckDB expression into a node the executor evaluates identically to the
+// hand-built node. The DuckDB-typed executor entry that this file originally
+// exercised as a third leg was removed in Phase 9 (#702); the duckdb::BoundXxx
+// expression here now serves only as the input to from_duckdb.
 
 // test
 #include <catch.hpp>
@@ -280,17 +282,13 @@ TEST_CASE("ast_equivalence - reference identity round-trip", "[gpu_expression_ex
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-  REQUIRE(duck_out);
   REQUIRE(hand_out);
   REQUIRE(translated_out);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -312,14 +310,11 @@ TEST_CASE("ast_equivalence - constant INTEGER", "[gpu_expression_executor_ast]")
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -337,14 +332,11 @@ TEST_CASE("ast_equivalence - constant VARCHAR", "[gpu_expression_executor_ast]")
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_string_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_string_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_string_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -368,14 +360,11 @@ TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[gpu_expression_e
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -394,14 +383,11 @@ TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[gpu_expression
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
   auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -420,14 +406,11 @@ TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[gpu_expressio
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -462,14 +445,11 @@ TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_ex
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -500,14 +480,11 @@ TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[gpu_expression_
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
   auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -530,14 +507,11 @@ TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[gpu_expression_executor_a
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -577,14 +551,11 @@ TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -607,14 +578,11 @@ TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[gpu_expressi
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_column_to_host<int64_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int64_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int64_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -646,14 +614,11 @@ TEST_CASE("ast_equivalence - unary_op NOT (MATERIALIZE)", "[gpu_expression_execu
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -675,14 +640,11 @@ TEST_CASE("ast_equivalence - unary_op IS_NULL (MATERIALIZE)", "[gpu_expression_e
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -704,14 +666,11 @@ TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[gpu_expressi
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -720,9 +679,9 @@ TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)", "[gpu_expressi
   // OPERATOR_TRY is recognized by the AST surface but not executable by the
   // current gpu_expression_executor (it throws on dispatch through
   // gpu_execute_operator.cpp). Verify only the translation half of the contract
-  // for this kind: the three legs translate to AST shapes with matching unary_op
-  // kinds. Execution coverage is intentionally omitted until the underlying
-  // OPERATOR_TRY specialization lands.
+  // for this kind: the translated node has the expected unary_op kind and round-
+  // trips back to OPERATOR_TRY. Execution coverage is intentionally omitted until
+  // the underlying OPERATOR_TRY specialization lands.
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
                                                               LogicalType{LogicalTypeId::INTEGER});
   duck_expr->children.push_back(duck_int_ref(0));
@@ -763,14 +722,11 @@ TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[gpu_expression_executor_
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -803,14 +759,11 @@ TEST_CASE("ast_equivalence - in_list IN (MATERIALIZE)", "[gpu_expression_executo
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -839,14 +792,11 @@ TEST_CASE("ast_equivalence - in_list IN (AST_INTERPRET)", "[gpu_expression_execu
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
   auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
 
-  auto duck_host       = copy_bool_column_to_host(duck_out->view().column(0));
   auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
   auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -882,14 +832,11 @@ TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, MAT);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
   auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }
 
@@ -921,13 +868,10 @@ TEST_CASE("ast_equivalence - function_call add (AST_INTERPRET)", "[gpu_expressio
   auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
   REQUIRE(translated_ast);
 
-  auto duck_out       = run_one(*space, duck_expr.get(), tv, AST_I);
   auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
   auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
 
-  auto duck_host       = copy_column_to_host<int32_t>(duck_out->view().column(0));
   auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
   auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(duck_host == hand_host);
   REQUIRE(hand_host == translated_host);
 }

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -28,8 +28,14 @@
 // hand-built node. The DuckDB-typed executor entry that this file originally
 // exercised as a third leg was removed in Phase 9 (#702); the duckdb::BoundXxx
 // expression here now serves only as the input to from_duckdb.
+//
+// The per-case scaffolding (build input, run both legs, copy to host, assert
+// equal) is factored into expect_hand_eq_translated(); each TEST_CASE only
+// builds the DuckDB expression and the matching hand AST.
 
 // test
+#include "ast_test_support.hpp"
+
 #include <catch.hpp>
 #include <utils/utils.hpp>
 
@@ -38,22 +44,9 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
-#include <expression/ast/between.hpp>
-#include <expression/ast/case_expr.hpp>
-#include <expression/ast/cast.hpp>
-#include <expression/ast/coalesce.hpp>
-#include <expression/ast/comparison.hpp>
-#include <expression/ast/conjunction.hpp>
-#include <expression/ast/constant.hpp>
 #include <expression/ast/from_duckdb.hpp>
-#include <expression/ast/function_call.hpp>
-#include <expression/ast/in_list.hpp>
 #include <expression/ast/node.hpp>
-#include <expression/ast/reference.hpp>
 #include <expression/ast/to_duckdb.hpp>
-#include <expression/ast/unary_op.hpp>
-#include <expression/function_id.hpp>
-#include <expression/join_condition.hpp>
 #include <expression/value.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <helper/logical_type.hpp>
@@ -72,24 +65,21 @@
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // cudf
-#include <cudf/column/column_factories.hpp>
-#include <cudf/null_mask.hpp>
-#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
 
 #include <cuda_runtime_api.h>
 
 // standard library
 #include <cstdint>
 #include <memory>
-#include <numeric>
 #include <optional>
-#include <string>
 #include <utility>
 #include <vector>
 
 using namespace duckdb;
 using namespace cucascade;
 using namespace cucascade::memory;
+using namespace sirius::expr_test;
 
 namespace {
 
@@ -123,77 +113,6 @@ memory_space* get_default_gpu_space()
 rmm::device_async_resource_ref get_resource_ref(memory_space& space)
 {
   return space.get_default_allocator();
-}
-
-template <typename T>
-std::vector<T> copy_column_to_host(const cudf::column_view& col)
-{
-  std::vector<T> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
-}
-
-std::vector<uint8_t> copy_bool_column_to_host(const cudf::column_view& col)
-{
-  std::vector<uint8_t> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.head(), sizeof(uint8_t) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
-}
-
-std::vector<std::string> copy_string_column_to_host(const cudf::column_view& col)
-{
-  std::vector<std::string> host;
-  if (col.size() == 0) { return host; }
-
-  cudf::strings_column_view str_col(col);
-  std::vector<cudf::size_type> offsets(col.size() + 1);
-  cudaMemcpy(offsets.data(),
-             str_col.offsets().data<cudf::size_type>(),
-             (col.size() + 1) * sizeof(cudf::size_type),
-             cudaMemcpyDeviceToHost);
-
-  std::vector<char> chars(offsets.back());
-  if (!chars.empty()) {
-    cudaMemcpy(chars.data(),
-               str_col.chars_begin(cudf::get_default_stream()),
-               offsets.back(),
-               cudaMemcpyDeviceToHost);
-  }
-
-  host.reserve(col.size());
-  for (cudf::size_type i = 0; i < col.size(); ++i) {
-    auto start = offsets[i];
-    auto end   = offsets[i + 1];
-    if (chars.empty()) {
-      host.emplace_back();
-    } else {
-      host.emplace_back(chars.data() + start, chars.data() + end);
-    }
-  }
-  return host;
-}
-
-std::vector<bool> copy_valids_to_host(const cudf::column_view& col)
-{
-  std::vector<bool> valids(col.size(), true);
-  if (!col.nullable() || col.null_count() == 0) { return valids; }
-  auto const num_words = cudf::num_bitmask_words(col.size());
-  std::vector<cudf::bitmask_type> host_mask(num_words);
-  cudaMemcpy(host_mask.data(),
-             col.null_mask(),
-             num_words * sizeof(cudf::bitmask_type),
-             cudaMemcpyDeviceToHost);
-  constexpr auto bits_per_word = sizeof(cudf::bitmask_type) * 8;
-  for (cudf::size_type i = 0; i < col.size(); ++i) {
-    auto word = host_mask[i / bits_per_word];
-    auto bit  = i % bits_per_word;
-    valids[i] = ((word >> bit) & 1U) != 0U;
-  }
-  return valids;
 }
 
 std::shared_ptr<data_batch> make_input_batch(
@@ -234,20 +153,6 @@ std::unique_ptr<cudf::table> run_one(memory_space& space,
   return executor.execute(tv);
 }
 
-// Small-node construction shortcuts.
-std::unique_ptr<sirius::ast::node> ref_node(uint32_t idx)
-{
-  return std::make_unique<sirius::ast::node>(sirius::ast::reference{idx});
-}
-
-std::unique_ptr<sirius::ast::node> int_const_node(int32_t v)
-{
-  return std::make_unique<sirius::ast::node>(sirius::ast::constant{
-    /*payload=*/sirius::value{v},
-    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
-  });
-}
-
 // DuckDB-side BoundReferenceExpression with INTEGER placeholder.
 duckdb::unique_ptr<Expression> duck_int_ref(uint32_t idx)
 {
@@ -262,6 +167,43 @@ duckdb::unique_ptr<Expression> duck_int_const(int32_t v)
     duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(v)).release());
 }
 
+// Shared scaffolding: build an input table, run the hand-built and the
+// translated AST through the executor, and assert their output columns are
+// byte-equal on host. `copy` extracts the comparable host representation of the
+// single output column (e.g. copy_column_to_host<int32_t>, copy_bool_column_to_host).
+template <class HostCopy>
+void expect_hand_eq_translated(duckdb::Expression& duck_expr,
+                               sirius::ast::node& hand_ast,
+                               std::vector<cudf::data_type> column_types,
+                               std::vector<std::optional<std::pair<int, int>>> ranges,
+                               exp_strategy_enum strategy,
+                               HostCopy copy)
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto input = make_input_batch(*space, std::move(column_types), std::move(ranges));
+  auto tv    = get_table_view(input);
+
+  auto translated_ast = sirius::ast::from_duckdb(duck_expr);
+  REQUIRE(translated_ast);
+
+  auto hand_out       = run_one(*space, &hand_ast, tv, strategy);
+  auto translated_out = run_one(*space, translated_ast.get(), tv, strategy);
+  REQUIRE(hand_out);
+  REQUIRE(translated_out);
+
+  auto hand_host       = copy(hand_out->view().column(0));
+  auto translated_host = copy(translated_out->view().column(0));
+  REQUIRE(hand_host == translated_host);
+}
+
+// Convenience: single-INT32-column input with the given value range.
+std::vector<cudf::data_type> int32_col() { return {cudf::data_type{cudf::type_id::INT32}}; }
+std::vector<std::optional<std::pair<int, int>>> range(int lo, int hi)
+{
+  return {std::pair<int, int>{lo, hi}};
+}
+
 }  // namespace
 
 // ============================================================================
@@ -270,26 +212,11 @@ duckdb::unique_ptr<Expression> duck_int_const(int32_t v)
 
 TEST_CASE("ast_equivalence - reference identity round-trip", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
-  auto tv = get_table_view(input);
-
   auto duck_expr =
     duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::reference{0});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-  REQUIRE(hand_out);
-  REQUIRE(translated_out);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast = make_ref(0);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 100), MAT, copy_column_to_host<int32_t>);
 }
 
 // ============================================================================
@@ -298,46 +225,18 @@ TEST_CASE("ast_equivalence - reference identity round-trip", "[gpu_expression_ex
 
 TEST_CASE("ast_equivalence - constant INTEGER", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
-  auto tv = get_table_view(input);
-
-  auto duck_expr      = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
-  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::constant{
-    sirius::value{int32_t{42}}, sirius::logical_type::make(sirius::type_id::INTEGER)});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
+  auto hand_ast  = make_int_const(42);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 100), MAT, copy_column_to_host<int32_t>);
 }
 
 TEST_CASE("ast_equivalence - constant VARCHAR", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input = make_input_batch(
-    *space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
-  auto tv = get_table_view(input);
-
-  auto duck_expr      = duckdb::make_uniq<BoundConstantExpression>(Value("hello"));
-  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::constant{
-    sirius::value{std::string{"hello"}}, sirius::logical_type::make(sirius::type_id::VARCHAR)});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_string_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_string_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto duck_expr = duckdb::make_uniq<BoundConstantExpression>(Value("hello"));
+  auto hand_ast  = make_str_const("hello");
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 100), MAT, copy_string_column_to_host);
 }
 
 // ============================================================================
@@ -347,85 +246,38 @@ TEST_CASE("ast_equivalence - constant VARCHAR", "[gpu_expression_executor_ast]")
 
 TEST_CASE("ast_equivalence - comparison EQUAL (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5));
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - comparison EQUAL (AST_INTERPRET)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5));
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), AST_I, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - comparison LESSTHAN (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(5));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(5)});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(5));
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_bool_column_to_host);
 }
 
 // ============================================================================
 // conjunction — AND (MATERIALIZE + AST_INTERPRET).
 // ============================================================================
 
-TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_executor_ast]")
+namespace {
+duckdb::unique_ptr<Expression> duck_and_1_9()
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
   auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
@@ -433,59 +285,32 @@ TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_ex
   auto duck_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
   duck_expr->children.push_back(std::move(duck_lhs));
   duck_expr->children.push_back(std::move(duck_rhs));
+  return duckdb::unique_ptr<Expression>(duck_expr.release());
+}
 
+std::unique_ptr<sirius::ast::node> hand_and_1_9()
+{
   std::vector<std::unique_ptr<sirius::ast::node>> children;
-  children.push_back(std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::gt, ref_node(0), int_const_node(1)}));
-  children.push_back(std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(9)}));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::conjunction{sirius::ast::conjunction::kind::op_and, std::move(children)});
+  children.push_back(make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(1)));
+  children.push_back(make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(9)));
+  return make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
+}
+}  // namespace
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+TEST_CASE("ast_equivalence - conjunction AND (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto duck_expr = duck_and_1_9();
+  auto hand_ast  = hand_and_1_9();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
-  auto duck_lhs = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN, duck_int_ref(0), duck_int_const(1));
-  auto duck_rhs = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN, duck_int_ref(0), duck_int_const(9));
-  auto duck_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  duck_expr->children.push_back(std::move(duck_lhs));
-  duck_expr->children.push_back(std::move(duck_rhs));
-
-  std::vector<std::unique_ptr<sirius::ast::node>> children;
-  children.push_back(std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::gt, ref_node(0), int_const_node(1)}));
-  children.push_back(std::make_unique<sirius::ast::node>(
-    sirius::ast::comparison{sirius::comparison_type::lt, ref_node(0), int_const_node(9)}));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::conjunction{sirius::ast::conjunction::kind::op_and, std::move(children)});
-
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto duck_expr = duck_and_1_9();
+  auto hand_ast  = hand_and_1_9();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), AST_I, copy_bool_column_to_host);
 }
 
 // ============================================================================
@@ -494,25 +319,11 @@ TEST_CASE("ast_equivalence - conjunction AND (AST_INTERPRET)", "[gpu_expression_
 
 TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 20}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundBetweenExpression>(
     duck_int_ref(0), duck_int_const(5), duck_int_const(15), /*lo=*/true, /*hi=*/true);
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::between{ref_node(0), int_const_node(5), int_const_node(15), true, true});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast = make_between(make_ref(0), make_int_const(5), make_int_const(15), true, true);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 20), MAT, copy_bool_column_to_host);
 }
 
 // ============================================================================
@@ -522,41 +333,25 @@ TEST_CASE("ast_equivalence - between (MATERIALIZE)", "[gpu_expression_executor_a
 TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
           "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_when = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
-  auto duck_then = duck_int_const(10);
-  auto duck_else = duck_int_const(0);
   BoundCaseCheck check;
   check.when_expr = std::move(duck_when);
-  check.then_expr = std::move(duck_then);
+  check.then_expr = duck_int_const(10);
   auto duck_expr  = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
   duck_expr->case_checks.push_back(std::move(check));
-  duck_expr->else_expr = std::move(duck_else);
+  duck_expr->else_expr = duck_int_const(0);
 
   std::vector<sirius::ast::case_expr::when_then> cases;
   cases.push_back(sirius::ast::case_expr::when_then{
-    std::make_unique<sirius::ast::node>(
-      sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)}),
-    int_const_node(10),
+    make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5)),
+    make_int_const(10),
   });
   auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::case_expr{
-    std::move(cases), int_const_node(0), sirius::logical_type::make(sirius::type_id::INTEGER)});
+    std::move(cases), make_int_const(0), sirius::logical_type::make(sirius::type_id::INTEGER)});
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_column_to_host<int32_t>);
 }
 
 // ============================================================================
@@ -565,25 +360,12 @@ TEST_CASE("ast_equivalence - case_expr WHEN/THEN/ELSE (MATERIALIZE)",
 
 TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
   auto duck_expr =
     BoundCastExpression::AddDefaultCastToType(duck_int_ref(0), LogicalType{LogicalTypeId::BIGINT});
-  auto hand_ast       = std::make_unique<sirius::ast::node>(sirius::ast::cast{
-    ref_node(0), sirius::logical_type::make(sirius::type_id::BIGINT), /*try_cast=*/false});
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_column_to_host<int64_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int64_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto hand_ast =
+    make_cast(make_ref(0), sirius::logical_type::make(sirius::type_id::BIGINT), /*try_cast=*/false);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), MAT, copy_column_to_host<int64_t>);
 }
 
 // ============================================================================
@@ -592,86 +374,43 @@ TEST_CASE("ast_equivalence - cast INTEGER->BIGINT (MATERIALIZE)", "[gpu_expressi
 
 TEST_CASE("ast_equivalence - unary_op NOT (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
   // Need a BOOLEAN-producing child; use a comparison.
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_inner = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_EQUAL, duck_int_ref(0), duck_int_const(5));
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
   duck_expr->children.push_back(std::move(duck_inner));
 
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::unary_op{
-    sirius::ast::unary_op::kind::op_not,
-    std::make_unique<sirius::ast::node>(
-      sirius::ast::comparison{sirius::comparison_type::equal, ref_node(0), int_const_node(5)}),
-  });
+  auto hand_ast =
+    make_unary(sirius::ast::unary_op::kind::op_not,
+               make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(5)));
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - unary_op IS_NULL (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
   duck_expr->children.push_back(duck_int_ref(0));
 
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_null, ref_node(0)});
+  auto hand_ast = make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(0));
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - unary_op IS_NOT_NULL (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
   duck_expr->children.push_back(duck_int_ref(0));
 
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::unary_op{sirius::ast::unary_op::kind::op_is_not_null, ref_node(0)});
+  auto hand_ast = make_unary(sirius::ast::unary_op::kind::op_is_not_null, make_ref(0));
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)", "[gpu_expression_executor_ast]")
@@ -697,121 +436,75 @@ TEST_CASE("ast_equivalence - unary_op TRY translation (no exec)", "[gpu_expressi
 }
 
 // ============================================================================
-// coalesce — 3-arg INTEGER (MATERIALIZE — AST breaker).
+// coalesce — 2-arg INTEGER (MATERIALIZE — AST breaker).
 // ============================================================================
 
 TEST_CASE("ast_equivalence - coalesce (MATERIALIZE)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_COALESCE,
                                                               LogicalType{LogicalTypeId::INTEGER});
   duck_expr->children.push_back(duck_int_ref(0));
   duck_expr->children.push_back(duck_int_const(0));
 
   std::vector<std::unique_ptr<sirius::ast::node>> children;
-  children.push_back(ref_node(0));
-  children.push_back(int_const_node(0));
-  auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::coalesce{
-    std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER)});
+  children.push_back(make_ref(0));
+  children.push_back(make_int_const(0));
+  auto hand_ast =
+    make_coalesce(std::move(children), sirius::logical_type::make(sirius::type_id::INTEGER));
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), MAT, copy_column_to_host<int32_t>);
 }
 
 // ============================================================================
-// in_list — IN + NOT IN (MATERIALIZE + AST_INTERPRET).
+// in_list — IN (MATERIALIZE + AST_INTERPRET).
 // ============================================================================
 
-TEST_CASE("ast_equivalence - in_list IN (MATERIALIZE)", "[gpu_expression_executor_ast]")
+namespace {
+duckdb::unique_ptr<Expression> duck_in_2_5_8()
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                               LogicalType{LogicalTypeId::BOOLEAN});
   duck_expr->children.push_back(duck_int_ref(0));
   duck_expr->children.push_back(duck_int_const(2));
   duck_expr->children.push_back(duck_int_const(5));
   duck_expr->children.push_back(duck_int_const(8));
+  return duckdb::unique_ptr<Expression>(duck_expr.release());
+}
 
+std::unique_ptr<sirius::ast::node> hand_in_2_5_8()
+{
   std::vector<std::unique_ptr<sirius::ast::node>> values;
-  values.push_back(int_const_node(2));
-  values.push_back(int_const_node(5));
-  values.push_back(int_const_node(8));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::in_list{ref_node(0), std::move(values), /*negated=*/false});
+  values.push_back(make_int_const(2));
+  values.push_back(make_int_const(5));
+  values.push_back(make_int_const(8));
+  return make_in(make_ref(0), std::move(values), /*negated=*/false);
+}
+}  // namespace
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+TEST_CASE("ast_equivalence - in_list IN (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto duck_expr = duck_in_2_5_8();
+  auto hand_ast  = hand_in_2_5_8();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), MAT, copy_bool_column_to_host);
 }
 
 TEST_CASE("ast_equivalence - in_list IN (AST_INTERPRET)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 10}});
-  auto tv = get_table_view(input);
-
-  auto duck_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                              LogicalType{LogicalTypeId::BOOLEAN});
-  duck_expr->children.push_back(duck_int_ref(0));
-  duck_expr->children.push_back(duck_int_const(2));
-  duck_expr->children.push_back(duck_int_const(5));
-  duck_expr->children.push_back(duck_int_const(8));
-
-  std::vector<std::unique_ptr<sirius::ast::node>> values;
-  values.push_back(int_const_node(2));
-  values.push_back(int_const_node(5));
-  values.push_back(int_const_node(8));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::in_list{ref_node(0), std::move(values), /*negated=*/false});
-
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
-
-  auto hand_host       = copy_bool_column_to_host(hand_out->view().column(0));
-  auto translated_host = copy_bool_column_to_host(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto duck_expr = duck_in_2_5_8();
+  auto hand_ast  = hand_in_2_5_8();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 10), AST_I, copy_bool_column_to_host);
 }
 
 // ============================================================================
 // function_call — add (MATERIALIZE + AST_INTERPRET).
 // ============================================================================
 
-TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_executor_ast]")
+namespace {
+duckdb::unique_ptr<Expression> duck_add_3()
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
   auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
     LogicalType{LogicalTypeId::INTEGER},
     ScalarFunction(
@@ -820,58 +513,32 @@ TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_
     nullptr);
   duck_expr->children.push_back(duck_int_ref(0));
   duck_expr->children.push_back(duck_int_const(3));
+  return duckdb::unique_ptr<Expression>(duck_expr.release());
+}
 
+std::unique_ptr<sirius::ast::node> hand_add_3()
+{
   std::vector<std::unique_ptr<sirius::ast::node>> args;
-  args.push_back(ref_node(0));
-  args.push_back(int_const_node(3));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::function_call{sirius::function_id::add,
-                               std::move(args),
-                               sirius::logical_type::make(sirius::type_id::INTEGER)});
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  return make_func(sirius::function_id::add,
+                   std::move(args),
+                   sirius::logical_type::make(sirius::type_id::INTEGER));
+}
+}  // namespace
 
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, MAT);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, MAT);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+TEST_CASE("ast_equivalence - function_call add (MATERIALIZE)", "[gpu_expression_executor_ast]")
+{
+  auto duck_expr = duck_add_3();
+  auto hand_ast  = hand_add_3();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), MAT, copy_column_to_host<int32_t>);
 }
 
 TEST_CASE("ast_equivalence - function_call add (AST_INTERPRET)", "[gpu_expression_executor_ast]")
 {
-  auto* space = get_default_gpu_space();
-  REQUIRE(space != nullptr);
-  auto input =
-    make_input_batch(*space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 50}});
-  auto tv = get_table_view(input);
-
-  auto duck_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  duck_expr->children.push_back(duck_int_ref(0));
-  duck_expr->children.push_back(duck_int_const(3));
-
-  std::vector<std::unique_ptr<sirius::ast::node>> args;
-  args.push_back(ref_node(0));
-  args.push_back(int_const_node(3));
-  auto hand_ast = std::make_unique<sirius::ast::node>(
-    sirius::ast::function_call{sirius::function_id::add,
-                               std::move(args),
-                               sirius::logical_type::make(sirius::type_id::INTEGER)});
-
-  auto translated_ast = sirius::ast::from_duckdb(*duck_expr);
-  REQUIRE(translated_ast);
-
-  auto hand_out       = run_one(*space, hand_ast.get(), tv, AST_I);
-  auto translated_out = run_one(*space, translated_ast.get(), tv, AST_I);
-
-  auto hand_host       = copy_column_to_host<int32_t>(hand_out->view().column(0));
-  auto translated_host = copy_column_to_host<int32_t>(translated_out->view().column(0));
-  REQUIRE(hand_host == translated_host);
+  auto duck_expr = duck_add_3();
+  auto hand_ast  = hand_add_3();
+  expect_hand_eq_translated(
+    *duck_expr, *hand_ast, int32_col(), range(0, 50), AST_I, copy_column_to_host<int32_t>);
 }

--- a/test/cpp/expression_executor/test_gpu_expression_translator.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_translator.cpp
@@ -15,6 +15,8 @@
  */
 
 // test
+#include "ast_test_support.hpp"
+
 #include <catch.hpp>
 
 // sirius — node-construction surface (build every test expression as a
@@ -59,130 +61,15 @@
 #include <string>
 #include <vector>
 
+using namespace sirius::expr_test;
+
 namespace {
 
 auto const stream = cudf::get_default_stream();
 auto const mr     = cudf::get_current_device_resource_ref();
 
-using ast_node = sirius::ast::node;
 using sirius::logical_type;
 using sirius::type_id;
-
-//===----------------------------------------------------------------------===//
-// Native sirius::ast::node construction helpers
-//===----------------------------------------------------------------------===//
-
-std::unique_ptr<ast_node> make_ref(uint32_t idx)
-{
-  return std::make_unique<ast_node>(sirius::ast::reference{idx});
-}
-
-std::unique_ptr<ast_node> make_ref_typed(uint32_t idx, logical_type type)
-{
-  return std::make_unique<ast_node>(sirius::ast::reference{idx, type});
-}
-
-std::unique_ptr<ast_node> make_int_const(int32_t v)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::INTEGER)});
-}
-
-std::unique_ptr<ast_node> make_bigint_const(int64_t v)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::BIGINT)});
-}
-
-std::unique_ptr<ast_node> make_double_const(double v)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::DOUBLE)});
-}
-
-std::unique_ptr<ast_node> make_str_const(std::string s)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{std::move(s)}, logical_type::make(type_id::VARCHAR)});
-}
-
-std::unique_ptr<ast_node> make_dec32_const(int32_t unscaled, uint8_t precision, uint8_t scale)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{sirius::decimal32{unscaled, scale}},
-                          logical_type::make_decimal(precision, scale)});
-}
-
-std::unique_ptr<ast_node> make_dec64_const(int64_t unscaled, uint8_t precision, uint8_t scale)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::constant{sirius::value{sirius::decimal64{unscaled, scale}},
-                          logical_type::make_decimal(precision, scale)});
-}
-
-// A typed NULL constant (no cuDF AST literal representation).
-std::unique_ptr<ast_node> make_null_const(logical_type type)
-{
-  return std::make_unique<ast_node>(sirius::ast::constant{sirius::value{}, type});
-}
-
-std::unique_ptr<ast_node> make_cmp(sirius::comparison_type op,
-                                   std::unique_ptr<ast_node> left,
-                                   std::unique_ptr<ast_node> right)
-{
-  return std::make_unique<ast_node>(sirius::ast::comparison{op, std::move(left), std::move(right)});
-}
-
-std::unique_ptr<ast_node> make_func(sirius::function_id id,
-                                    std::vector<std::unique_ptr<ast_node>> args,
-                                    logical_type return_type)
-{
-  return std::make_unique<ast_node>(sirius::ast::function_call{id, std::move(args), return_type});
-}
-
-std::unique_ptr<ast_node> make_conj(sirius::ast::conjunction::kind kind,
-                                    std::vector<std::unique_ptr<ast_node>> children)
-{
-  return std::make_unique<ast_node>(sirius::ast::conjunction{kind, std::move(children)});
-}
-
-std::unique_ptr<ast_node> make_between(std::unique_ptr<ast_node> input,
-                                       std::unique_ptr<ast_node> lower,
-                                       std::unique_ptr<ast_node> upper,
-                                       bool lower_inclusive,
-                                       bool upper_inclusive)
-{
-  return std::make_unique<ast_node>(sirius::ast::between{
-    std::move(input), std::move(lower), std::move(upper), lower_inclusive, upper_inclusive});
-}
-
-std::unique_ptr<ast_node> make_cast(std::unique_ptr<ast_node> child,
-                                    logical_type target_type,
-                                    bool try_cast)
-{
-  return std::make_unique<ast_node>(sirius::ast::cast{std::move(child), target_type, try_cast});
-}
-
-std::unique_ptr<ast_node> make_in(std::unique_ptr<ast_node> probe,
-                                  std::vector<std::unique_ptr<ast_node>> values,
-                                  bool negated)
-{
-  return std::make_unique<ast_node>(
-    sirius::ast::in_list{std::move(probe), std::move(values), negated});
-}
-
-std::unique_ptr<ast_node> make_unary(sirius::ast::unary_op::kind kind,
-                                     std::unique_ptr<ast_node> child)
-{
-  return std::make_unique<ast_node>(sirius::ast::unary_op{kind, std::move(child)});
-}
-
-// Wrap an owned Sirius AST node into a sirius::expression (for join_condition).
-sirius::expression wrap_node(std::unique_ptr<ast_node> n)
-{
-  return sirius::expression{
-    std::make_unique<sirius::expression::impl>(sirius::expression::impl{std::move(n)})};
-}
 
 //===----------------------------------------------------------------------===//
 // Translator bridge — translate a hand-built Sirius AST node directly.
@@ -192,29 +79,6 @@ std::optional<sirius::gpu_expression_translator::translated_expression> translat
   sirius::gpu_expression_translator& translator, ast_node const& node)
 {
   return translator.translate_expression(node);
-}
-
-//===----------------------------------------------------------------------===//
-// GPU <-> host copy helpers
-//===----------------------------------------------------------------------===//
-
-template <typename T>
-std::vector<T> copy_column_to_host(cudf::column_view const& col)
-{
-  std::vector<T> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.data<T>(), sizeof(T) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
-}
-
-std::vector<uint8_t> copy_bool_column_to_host(cudf::column_view const& col)
-{
-  std::vector<uint8_t> host(col.size());
-  if (col.size() > 0) {
-    cudaMemcpy(host.data(), col.head(), sizeof(uint8_t) * col.size(), cudaMemcpyDeviceToHost);
-  }
-  return host;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/expression_executor/test_gpu_expression_translator.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_translator.cpp
@@ -17,21 +17,29 @@
 // test
 #include <catch.hpp>
 
-// sirius
-#include <expression/ast/from_duckdb.hpp>
+// sirius — node-construction surface (build every test expression as a
+// sirius::ast::node directly; no DuckDB Bound*Expression in the test body).
+#include <expression/ast/between.hpp>
+#include <expression/ast/case_expr.hpp>
+#include <expression/ast/cast.hpp>
+#include <expression/ast/coalesce.hpp>
+#include <expression/ast/comparison.hpp>
+#include <expression/ast/conjunction.hpp>
+#include <expression/ast/constant.hpp>
+#include <expression/ast/function_call.hpp>
+#include <expression/ast/in_list.hpp>
+#include <expression/ast/node.hpp>
+#include <expression/ast/reference.hpp>
+#include <expression/ast/unary_op.hpp>
+#include <expression/expression_internal.hpp>
+#include <expression/function_id.hpp>
+#include <expression/join_condition.hpp>  // sirius::comparison_type, sirius::from_duckdb (enum mapper)
+#include <expression/value.hpp>
 #include <expression_executor/gpu_expression_translator_internal.hpp>
+#include <helper/logical_type.hpp>
 
-// duckdb
-#include <duckdb/common/helper.hpp>
-#include <duckdb/planner/expression/bound_between_expression.hpp>
-#include <duckdb/planner/expression/bound_case_expression.hpp>
-#include <duckdb/planner/expression/bound_cast_expression.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
-#include <duckdb/planner/expression/bound_constant_expression.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
-#include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <duckdb/planner/expression/bound_reference_expression.hpp>
+// duckdb — only the comparison-type enum the join-condition test parameterizes over.
+#include <duckdb/common/enums/expression_type.hpp>
 
 // cudf
 #include <cudf/ast/expressions.hpp>
@@ -51,25 +59,139 @@
 #include <string>
 #include <vector>
 
-using namespace duckdb;
-
 namespace {
 
 auto const stream = cudf::get_default_stream();
 auto const mr     = cudf::get_current_device_resource_ref();
 
+using ast_node = sirius::ast::node;
+using sirius::logical_type;
+using sirius::type_id;
+
 //===----------------------------------------------------------------------===//
-// DuckDB -> Sirius AST bridge
+// Native sirius::ast::node construction helpers
 //===----------------------------------------------------------------------===//
 
-// Builds a DuckDB expression as the fixtures do today, lowers it through
-// sirius::ast::from_duckdb, and translates the resulting Sirius AST node.
-// Returns std::nullopt when the expression cannot be lowered.
-std::optional<sirius::gpu_expression_translator::translated_expression> translate(
-  sirius::gpu_expression_translator& translator, duckdb::Expression const& e)
+std::unique_ptr<ast_node> make_ref(uint32_t idx)
 {
-  auto node = sirius::ast::from_duckdb(e);
-  return node ? translator.translate_expression(*node) : std::nullopt;
+  return std::make_unique<ast_node>(sirius::ast::reference{idx});
+}
+
+std::unique_ptr<ast_node> make_ref_typed(uint32_t idx, logical_type type)
+{
+  return std::make_unique<ast_node>(sirius::ast::reference{idx, type});
+}
+
+std::unique_ptr<ast_node> make_int_const(int32_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::INTEGER)});
+}
+
+std::unique_ptr<ast_node> make_bigint_const(int64_t v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::BIGINT)});
+}
+
+std::unique_ptr<ast_node> make_double_const(double v)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{v}, logical_type::make(type_id::DOUBLE)});
+}
+
+std::unique_ptr<ast_node> make_str_const(std::string s)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{std::move(s)}, logical_type::make(type_id::VARCHAR)});
+}
+
+std::unique_ptr<ast_node> make_dec32_const(int32_t unscaled, uint8_t precision, uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal32{unscaled, scale}},
+                          logical_type::make_decimal(precision, scale)});
+}
+
+std::unique_ptr<ast_node> make_dec64_const(int64_t unscaled, uint8_t precision, uint8_t scale)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::constant{sirius::value{sirius::decimal64{unscaled, scale}},
+                          logical_type::make_decimal(precision, scale)});
+}
+
+// A typed NULL constant (no cuDF AST literal representation).
+std::unique_ptr<ast_node> make_null_const(logical_type type)
+{
+  return std::make_unique<ast_node>(sirius::ast::constant{sirius::value{}, type});
+}
+
+std::unique_ptr<ast_node> make_cmp(sirius::comparison_type op,
+                                   std::unique_ptr<ast_node> left,
+                                   std::unique_ptr<ast_node> right)
+{
+  return std::make_unique<ast_node>(sirius::ast::comparison{op, std::move(left), std::move(right)});
+}
+
+std::unique_ptr<ast_node> make_func(sirius::function_id id,
+                                    std::vector<std::unique_ptr<ast_node>> args,
+                                    logical_type return_type)
+{
+  return std::make_unique<ast_node>(sirius::ast::function_call{id, std::move(args), return_type});
+}
+
+std::unique_ptr<ast_node> make_conj(sirius::ast::conjunction::kind kind,
+                                    std::vector<std::unique_ptr<ast_node>> children)
+{
+  return std::make_unique<ast_node>(sirius::ast::conjunction{kind, std::move(children)});
+}
+
+std::unique_ptr<ast_node> make_between(std::unique_ptr<ast_node> input,
+                                       std::unique_ptr<ast_node> lower,
+                                       std::unique_ptr<ast_node> upper,
+                                       bool lower_inclusive,
+                                       bool upper_inclusive)
+{
+  return std::make_unique<ast_node>(sirius::ast::between{
+    std::move(input), std::move(lower), std::move(upper), lower_inclusive, upper_inclusive});
+}
+
+std::unique_ptr<ast_node> make_cast(std::unique_ptr<ast_node> child,
+                                    logical_type target_type,
+                                    bool try_cast)
+{
+  return std::make_unique<ast_node>(sirius::ast::cast{std::move(child), target_type, try_cast});
+}
+
+std::unique_ptr<ast_node> make_in(std::unique_ptr<ast_node> probe,
+                                  std::vector<std::unique_ptr<ast_node>> values,
+                                  bool negated)
+{
+  return std::make_unique<ast_node>(
+    sirius::ast::in_list{std::move(probe), std::move(values), negated});
+}
+
+std::unique_ptr<ast_node> make_unary(sirius::ast::unary_op::kind kind,
+                                     std::unique_ptr<ast_node> child)
+{
+  return std::make_unique<ast_node>(sirius::ast::unary_op{kind, std::move(child)});
+}
+
+// Wrap an owned Sirius AST node into a sirius::expression (for join_condition).
+sirius::expression wrap_node(std::unique_ptr<ast_node> n)
+{
+  return sirius::expression{
+    std::make_unique<sirius::expression::impl>(sirius::expression::impl{std::move(n)})};
+}
+
+//===----------------------------------------------------------------------===//
+// Translator bridge — translate a hand-built Sirius AST node directly.
+//===----------------------------------------------------------------------===//
+
+std::optional<sirius::gpu_expression_translator::translated_expression> translate(
+  sirius::gpu_expression_translator& translator, ast_node const& node)
+{
+  return translator.translate_expression(node);
 }
 
 //===----------------------------------------------------------------------===//
@@ -262,15 +384,11 @@ std::unique_ptr<cudf::table> make_string_table(std::vector<std::string> const& v
 
 sirius::join_condition make_reference_join_condition(duckdb::ExpressionType comparison)
 {
-  duckdb::JoinCondition condition;
-  condition.left =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  condition.right =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  condition.comparison = comparison;
-  return sirius::join_condition{sirius::wrap(std::move(condition.left)),
-                                sirius::wrap(std::move(condition.right)),
-                                sirius::from_duckdb(condition.comparison)};
+  // The join_condition's operands are hand-built Sirius AST reference nodes; the
+  // comparison-enum mapping still goes through sirius::from_duckdb(ExpressionType),
+  // which is the join_condition comparison mapper (NOT the expression from_duckdb).
+  return sirius::join_condition{
+    wrap_node(make_ref(0)), wrap_node(make_ref(0)), sirius::from_duckdb(comparison)};
 }
 
 }  // namespace
@@ -286,7 +404,7 @@ TEST_CASE("translator: column reference produces identity", "[expression_transla
   auto tv                     = table->view();
 
   // Build: col_ref(0)
-  auto expr = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto expr = make_ref(0);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -308,10 +426,7 @@ TEST_CASE("translator: comparison EQUAL", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) == 3
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -333,10 +448,7 @@ TEST_CASE("translator: comparison NOT EQUAL", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::not_equal, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -358,10 +470,7 @@ TEST_CASE("translator: comparison LESS THAN", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -383,10 +492,7 @@ TEST_CASE("translator: comparison GREATER THAN", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -408,10 +514,7 @@ TEST_CASE("translator: comparison LESS THAN OR EQUAL", "[expression_translator]"
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::le, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -433,10 +536,7 @@ TEST_CASE("translator: comparison GREATER THAN OR EQUAL", "[expression_translato
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::ge, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -460,10 +560,7 @@ TEST_CASE("translator: comparison between two columns", "[expression_translator]
   auto tv                   = table->view();
 
   // Build: col(0) > col(1)
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1);
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::gt, make_ref(0), make_ref(1));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -481,10 +578,7 @@ TEST_CASE("translator: comparison between two columns", "[expression_translator]
 
 TEST_CASE("translator: DISTINCT FROM returns nullopt", "[expression_translator]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::distinct_from, make_ref(0), make_int_const(3));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -495,8 +589,7 @@ TEST_CASE("translator: NULL constant returns nullopt", "[expression_translator]"
 {
   // A typed NULL has no cuDF AST literal representation; the translator must
   // report untranslatable rather than unwrapping the empty constant payload.
-  auto expr =
-    duckdb::make_uniq<BoundConstantExpression>(Value(LogicalType{LogicalTypeId::INTEGER}));
+  auto expr = make_null_const(logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -572,19 +665,15 @@ TEST_CASE("translator: addition col(0) + 10", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  // Build: col(0) + 10  via BoundFunctionExpression with name "+"
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)));
+  // Build: col(0) + 10
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(10));
+  auto expr =
+    make_func(sirius::function_id::add, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -603,18 +692,14 @@ TEST_CASE("translator: subtraction col(0) - 3", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "-", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  auto expr =
+    make_func(sirius::function_id::sub, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -633,18 +718,14 @@ TEST_CASE("translator: multiplication col(0) * 2", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "*", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(2));
+  auto expr =
+    make_func(sirius::function_id::mul, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -663,18 +744,14 @@ TEST_CASE("translator: division col(0) / 3", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "/", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  auto expr =
+    make_func(sirius::function_id::div, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -693,18 +770,14 @@ TEST_CASE("translator: integer division col(0) // 3", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "//", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  auto expr =
+    make_func(sirius::function_id::int_div, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -723,18 +796,14 @@ TEST_CASE("translator: modulo col(0) % 3", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "%", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_int_const(3));
+  auto expr =
+    make_func(sirius::function_id::mod, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -754,19 +823,14 @@ TEST_CASE("translator: col(0) + col(1)", "[expression_translator]")
   auto table                = make_int32x2_table(col0, col1);
   auto tv                   = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_ref(1));
+  auto expr =
+    make_func(sirius::function_id::add, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE(ast_tree.has_value());
 
   auto result    = cudf::compute_column(tv, ast_tree->back(), stream, mr);
@@ -781,16 +845,15 @@ TEST_CASE("translator: col(0) + col(1)", "[expression_translator]")
 
 TEST_CASE("translator: unsupported function returns nullopt", "[expression_translator]")
 {
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction("abs", {LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  // A non-arithmetic function (substring) has no cuDF-AST binary-op lowering;
+  // the translator must report untranslatable.
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  auto expr = make_func(
+    sirius::function_id::substring, std::move(args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
-  auto ast_tree   = translate(translator, *func_expr);
+  auto ast_tree   = translate(translator, *expr);
   REQUIRE_FALSE(ast_tree.has_value());
 }
 
@@ -800,22 +863,18 @@ TEST_CASE("translator: unsupported function returns nullopt", "[expression_trans
 TEST_CASE("translator: conjunction with unsupported first child returns nullopt",
           "[expression_translator]")
 {
-  auto unsupported = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction("abs", {LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  unsupported->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  std::vector<std::unique_ptr<ast_node>> unsupported_args;
+  unsupported_args.push_back(make_ref(0));
+  auto unsupported = make_func(sirius::function_id::substring,
+                               std::move(unsupported_args),
+                               logical_type::make(type_id::INTEGER));
 
-  auto supported = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
+  auto supported = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(0));
 
-  auto conjunction = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conjunction->children.push_back(std::move(unsupported));
-  conjunction->children.push_back(std::move(supported));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(unsupported));
+  children.push_back(std::move(supported));
+  auto conjunction = make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conjunction);
@@ -829,19 +888,13 @@ TEST_CASE("translator: conjunction AND", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) > 3 AND col(0) < 8
-  auto left1  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right1 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto cmp1   = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN, std::move(left1), std::move(right1));
+  auto cmp1 = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(3));
+  auto cmp2 = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(8));
 
-  auto left2  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right2 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(8));
-  auto cmp2   = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN, std::move(left2), std::move(right2));
-
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conj->children.push_back(std::move(cmp1));
-  conj->children.push_back(std::move(cmp2));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(cmp1));
+  children.push_back(std::move(cmp2));
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -864,19 +917,13 @@ TEST_CASE("translator: conjunction OR", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) <= 2 OR col(0) >= 9
-  auto left1  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right1 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2));
-  auto cmp1   = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left1), std::move(right1));
+  auto cmp1 = make_cmp(sirius::comparison_type::le, make_ref(0), make_int_const(2));
+  auto cmp2 = make_cmp(sirius::comparison_type::ge, make_ref(0), make_int_const(9));
 
-  auto left2  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right2 = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(9));
-  auto cmp2   = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(left2), std::move(right2));
-
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-  conj->children.push_back(std::move(cmp1));
-  conj->children.push_back(std::move(cmp2));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(cmp1));
+  children.push_back(std::move(cmp2));
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_or, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -899,25 +946,15 @@ TEST_CASE("translator: conjunction with three children", "[expression_translator
   auto tv                     = table->view();
 
   // Build: col(0) > 2 AND col(0) < 9 AND col(0) != 5
-  auto cmp1 = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  auto cmp1 = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(2));
+  auto cmp2 = make_cmp(sirius::comparison_type::lt, make_ref(0), make_int_const(9));
+  auto cmp3 = make_cmp(sirius::comparison_type::not_equal, make_ref(0), make_int_const(5));
 
-  auto cmp2 = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(9)));
-
-  auto cmp3 = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_NOTEQUAL,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
-
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conj->children.push_back(std::move(cmp1));
-  conj->children.push_back(std::move(cmp2));
-  conj->children.push_back(std::move(cmp3));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(cmp1));
+  children.push_back(std::move(cmp2));
+  children.push_back(std::move(cmp3));
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -935,8 +972,8 @@ TEST_CASE("translator: conjunction with three children", "[expression_translator
 
 TEST_CASE("translator: empty conjunction returns nullopt", "[expression_translator]")
 {
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
   // No children
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_and, {});
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -954,13 +991,7 @@ TEST_CASE("translator: BETWEEN expression", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) BETWEEN 3 AND 7  ->  col(0) >= 3 AND col(0) <= 7
-  auto input_expr =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto lower_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto upper_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7));
-
-  auto between = duckdb::make_uniq<BoundBetweenExpression>(
-    std::move(input_expr), std::move(lower_expr), std::move(upper_expr), true, true);
+  auto between = make_between(make_ref(0), make_int_const(3), make_int_const(7), true, true);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *between);
@@ -983,13 +1014,7 @@ TEST_CASE("translator: BETWEEN with tight range", "[expression_translator]")
   auto tv                     = table->view();
 
   // BETWEEN 3 AND 3 -> only 3 matches
-  auto input_expr =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto lower_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-  auto upper_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
-
-  auto between = duckdb::make_uniq<BoundBetweenExpression>(
-    std::move(input_expr), std::move(lower_expr), std::move(upper_expr), true, true);
+  auto between = make_between(make_ref(0), make_int_const(3), make_int_const(3), true, true);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *between);
@@ -1013,9 +1038,7 @@ TEST_CASE("translator: CAST to INT64", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: CAST(col(0) AS BIGINT)
-  auto child = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto cast_expr =
-    BoundCastExpression::AddDefaultCastToType(std::move(child), LogicalType{LogicalTypeId::BIGINT});
+  auto cast_expr = make_cast(make_ref(0), logical_type::make(type_id::BIGINT), /*try_cast=*/false);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *cast_expr);
@@ -1037,9 +1060,7 @@ TEST_CASE("translator: CAST to FLOAT64", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto child = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto cast_expr =
-    BoundCastExpression::AddDefaultCastToType(std::move(child), LogicalType{LogicalTypeId::DOUBLE});
+  auto cast_expr = make_cast(make_ref(0), logical_type::make(type_id::DOUBLE), /*try_cast=*/false);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *cast_expr);
@@ -1058,9 +1079,7 @@ TEST_CASE("translator: CAST to FLOAT64", "[expression_translator]")
 TEST_CASE("translator: unsupported CAST returns nullopt", "[expression_translator]")
 {
   // CAST to VARCHAR is not supported
-  auto child = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto cast_expr = BoundCastExpression::AddDefaultCastToType(std::move(child),
-                                                             LogicalType{LogicalTypeId::VARCHAR});
+  auto cast_expr = make_cast(make_ref(0), logical_type::make(type_id::VARCHAR), /*try_cast=*/false);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *cast_expr);
@@ -1078,13 +1097,11 @@ TEST_CASE("translator: IN operator", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) IN (2, 5, 8)
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(8)));
+  std::vector<std::unique_ptr<ast_node>> in_values;
+  in_values.push_back(make_int_const(2));
+  in_values.push_back(make_int_const(5));
+  in_values.push_back(make_int_const(8));
+  auto in_expr = make_in(make_ref(0), std::move(in_values), /*negated=*/false);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *in_expr);
@@ -1107,12 +1124,10 @@ TEST_CASE("translator: NOT IN operator", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) NOT IN (2, 4)
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_NOT_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(4)));
+  std::vector<std::unique_ptr<ast_node>> in_values;
+  in_values.push_back(make_int_const(2));
+  in_values.push_back(make_int_const(4));
+  auto in_expr = make_in(make_ref(0), std::move(in_values), /*negated=*/true);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *in_expr);
@@ -1135,11 +1150,9 @@ TEST_CASE("translator: IN with single comparator", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: col(0) IN (2) -- single-element IN list
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  std::vector<std::unique_ptr<ast_node>> in_values;
+  in_values.push_back(make_int_const(2));
+  auto in_expr = make_in(make_ref(0), std::move(in_values), /*negated=*/false);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *in_expr);
@@ -1163,14 +1176,8 @@ TEST_CASE("translator: NOT operator", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: NOT (col(0) > 3)
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
-
-  auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(std::move(cmp));
+  auto cmp      = make_cmp(sirius::comparison_type::gt, make_ref(0), make_int_const(3));
+  auto not_expr = make_unary(sirius::ast::unary_op::kind::op_not, std::move(cmp));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *not_expr);
@@ -1193,10 +1200,7 @@ TEST_CASE("translator: IS NULL operator", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto is_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
-    ExpressionType::OPERATOR_IS_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_null_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  auto is_null_expr = make_unary(sirius::ast::unary_op::kind::op_is_null, make_ref(0));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *is_null_expr);
@@ -1217,10 +1221,7 @@ TEST_CASE("translator: IS NOT NULL operator", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto is_not_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
-    ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_not_null_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  auto is_not_null_expr = make_unary(sirius::ast::unary_op::kind::op_is_not_null, make_ref(0));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *is_not_null_expr);
@@ -1240,21 +1241,12 @@ TEST_CASE("translator: IS NOT NULL operator", "[expression_translator]")
 
 TEST_CASE("translator: CASE expression returns nullopt", "[expression_translator]")
 {
-  // BoundCaseExpression: CASE WHEN col(0)=1 THEN 10 ELSE 0 END
-  auto check = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  auto result_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10));
-
-  duckdb::BoundCaseCheck case_check;
-  case_check.when_expr = std::move(check);
-  case_check.then_expr = std::move(result_expr);
-
-  auto else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
-  auto case_expr = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
-  case_expr->else_expr = std::move(else_expr);
-  case_expr->case_checks.push_back(std::move(case_check));
+  // CASE WHEN col(0)=1 THEN 10 ELSE 0 END
+  std::vector<sirius::ast::case_expr::when_then> cases;
+  cases.push_back(sirius::ast::case_expr::when_then{
+    make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(1)), make_int_const(10)});
+  auto case_expr = std::make_unique<ast_node>(sirius::ast::case_expr{
+    std::move(cases), make_int_const(0), logical_type::make(type_id::INTEGER)});
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *case_expr);
@@ -1263,11 +1255,11 @@ TEST_CASE("translator: CASE expression returns nullopt", "[expression_translator
 
 TEST_CASE("translator: COALESCE operator returns nullopt", "[expression_translator]")
 {
-  auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
-    ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
-  coalesce_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  coalesce_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(make_ref(0));
+  children.push_back(make_int_const(0));
+  auto coalesce_expr = std::make_unique<ast_node>(
+    sirius::ast::coalesce{std::move(children), logical_type::make(type_id::INTEGER)});
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *coalesce_expr);
@@ -1276,10 +1268,7 @@ TEST_CASE("translator: COALESCE operator returns nullopt", "[expression_translat
 
 TEST_CASE("translator: TRY operator returns nullopt", "[expression_translator]")
 {
-  auto try_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
-                                                             LogicalType{LogicalTypeId::INTEGER});
-  try_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  auto try_expr = make_unary(sirius::ast::unary_op::kind::op_try, make_ref(0));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *try_expr);
@@ -1298,34 +1287,23 @@ TEST_CASE("translator: nested arithmetic (col(0) + 1) * (col(1) - 2)", "[express
   auto tv                   = table->view();
 
   // Build: (col(0) + 1) * (col(1) - 2)
-  auto add_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  add_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  add_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
+  std::vector<std::unique_ptr<ast_node>> add_args;
+  add_args.push_back(make_ref(0));
+  add_args.push_back(make_int_const(1));
+  auto add_expr =
+    make_func(sirius::function_id::add, std::move(add_args), logical_type::make(type_id::INTEGER));
 
-  auto sub_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "-", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  sub_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-  sub_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  std::vector<std::unique_ptr<ast_node>> sub_args;
+  sub_args.push_back(make_ref(1));
+  sub_args.push_back(make_int_const(2));
+  auto sub_expr =
+    make_func(sirius::function_id::sub, std::move(sub_args), logical_type::make(type_id::INTEGER));
 
-  auto mul_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "*", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  mul_expr->children.push_back(std::move(add_expr));
-  mul_expr->children.push_back(std::move(sub_expr));
+  std::vector<std::unique_ptr<ast_node>> mul_args;
+  mul_args.push_back(std::move(add_expr));
+  mul_args.push_back(std::move(sub_expr));
+  auto mul_expr =
+    make_func(sirius::function_id::mul, std::move(mul_args), logical_type::make(type_id::INTEGER));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *mul_expr);
@@ -1349,29 +1327,20 @@ TEST_CASE("translator: comparison with arithmetic col(0)*2 > col(1)+3", "[expres
   auto tv                   = table->view();
 
   // Build LHS: col(0) * 2
-  auto lhs = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "*", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  lhs->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  lhs->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
+  std::vector<std::unique_ptr<ast_node>> lhs_args;
+  lhs_args.push_back(make_ref(0));
+  lhs_args.push_back(make_int_const(2));
+  auto lhs =
+    make_func(sirius::function_id::mul, std::move(lhs_args), logical_type::make(type_id::INTEGER));
 
   // Build RHS: col(1) + 3
-  auto rhs = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  rhs->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-  rhs->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  std::vector<std::unique_ptr<ast_node>> rhs_args;
+  rhs_args.push_back(make_ref(1));
+  rhs_args.push_back(make_int_const(3));
+  auto rhs =
+    make_func(sirius::function_id::add, std::move(rhs_args), logical_type::make(type_id::INTEGER));
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHAN, std::move(lhs), std::move(rhs));
+  auto cmp = make_cmp(sirius::comparison_type::gt, std::move(lhs), std::move(rhs));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *cmp);
@@ -1395,24 +1364,20 @@ TEST_CASE("translator: IN combined with AND/OR and comparison", "[expression_tra
   auto tv                        = table->view();
 
   // Build: col(0) IN (1, 3, 5, 7, 9) AND col(1) >= 50
-  auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
-                                                            LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(9)));
+  std::vector<std::unique_ptr<ast_node>> in_values;
+  in_values.push_back(make_int_const(1));
+  in_values.push_back(make_int_const(3));
+  in_values.push_back(make_int_const(5));
+  in_values.push_back(make_int_const(7));
+  in_values.push_back(make_int_const(9));
+  auto in_expr = make_in(make_ref(0), std::move(in_values), /*negated=*/false);
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHANOREQUALTO,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BIGINT}, 1),
-    duckdb::make_uniq<BoundConstantExpression>(Value::BIGINT(50)));
+  auto cmp = make_cmp(sirius::comparison_type::ge, make_ref(1), make_bigint_const(50));
 
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conj->children.push_back(std::move(in_expr));
-  conj->children.push_back(std::move(cmp));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(in_expr));
+  children.push_back(std::move(cmp));
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -1437,16 +1402,8 @@ TEST_CASE("translator: deeply nested NOT(col(0) BETWEEN 3 AND 7)", "[expression_
   auto tv                     = table->view();
 
   // Build: NOT (col(0) BETWEEN 3 AND 7)
-  auto between = duckdb::make_uniq<BoundBetweenExpression>(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7)),
-    true,
-    true);
-
-  auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(std::move(between));
+  auto between  = make_between(make_ref(0), make_int_const(3), make_int_const(7), true, true);
+  auto not_expr = make_unary(sirius::ast::unary_op::kind::op_not, std::move(between));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *not_expr);
@@ -1472,14 +1429,11 @@ TEST_CASE("translator: float64 arithmetic col(0) + 0.5", "[expression_translator
   auto table                 = make_float64_table(values);
   auto tv                    = table->view();
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::DOUBLE},
-    ScalarFunction("+", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::DOUBLE}, 0));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::DOUBLE(0.5)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(make_ref(0));
+  args.push_back(make_double_const(0.5));
+  auto func_expr =
+    make_func(sirius::function_id::add, std::move(args), logical_type::make(type_id::DOUBLE));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *func_expr);
@@ -1500,10 +1454,7 @@ TEST_CASE("translator: float64 comparison col(0) < 3.5", "[expression_translator
   auto table                 = make_float64_table(values);
   auto tv                    = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::DOUBLE}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::DOUBLE(3.5));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::lt, make_ref(0), make_double_const(3.5));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -1533,15 +1484,11 @@ TEST_CASE("translator: reuse translator for multiple expressions", "[expression_
 
   // First translation: col(0) + 10
   {
-    auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-      LogicalType{LogicalTypeId::INTEGER},
-      ScalarFunction(
-        "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-      duckdb::vector<duckdb::unique_ptr<Expression>>{},
-      nullptr);
-    func_expr->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)));
+    std::vector<std::unique_ptr<ast_node>> args;
+    args.push_back(make_ref(0));
+    args.push_back(make_int_const(10));
+    auto func_expr =
+      make_func(sirius::function_id::add, std::move(args), logical_type::make(type_id::INTEGER));
 
     auto ast_tree = translate(translator, *func_expr);
     REQUIRE(ast_tree.has_value());
@@ -1558,15 +1505,11 @@ TEST_CASE("translator: reuse translator for multiple expressions", "[expression_
 
   // Second translation with same translator: col(0) * 3
   {
-    auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-      LogicalType{LogicalTypeId::INTEGER},
-      ScalarFunction(
-        "*", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-      duckdb::vector<duckdb::unique_ptr<Expression>>{},
-      nullptr);
-    func_expr->children.push_back(
-      duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-    func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+    std::vector<std::unique_ptr<ast_node>> args;
+    args.push_back(make_ref(0));
+    args.push_back(make_int_const(3));
+    auto func_expr =
+      make_func(sirius::function_id::mul, std::move(args), logical_type::make(type_id::INTEGER));
 
     auto ast_tree = translate(translator, *func_expr);
     REQUIRE(ast_tree.has_value());
@@ -1593,18 +1536,13 @@ TEST_CASE("translator: CAST(col(0) AS BIGINT) + 100", "[expression_translator]")
   auto tv                     = table->view();
 
   // Build: CAST(col(0) AS BIGINT) + 100
-  auto cast_child =
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto cast_expr = BoundCastExpression::AddDefaultCastToType(std::move(cast_child),
-                                                             LogicalType{LogicalTypeId::BIGINT});
+  auto cast_expr = make_cast(make_ref(0), logical_type::make(type_id::BIGINT), /*try_cast=*/false);
 
-  auto func_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::BIGINT},
-    ScalarFunction("+", {LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::BIGINT, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  func_expr->children.push_back(std::move(cast_expr));
-  func_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::BIGINT(100)));
+  std::vector<std::unique_ptr<ast_node>> args;
+  args.push_back(std::move(cast_expr));
+  args.push_back(make_bigint_const(100));
+  auto func_expr =
+    make_func(sirius::function_id::add, std::move(args), logical_type::make(type_id::BIGINT));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *func_expr);
@@ -1630,10 +1568,7 @@ TEST_CASE("translator: single-row table", "[expression_translator]")
   auto table                  = make_int32_table(values);
   auto tv                     = table->view();
 
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::equal, make_ref(0), make_int_const(42));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -1658,21 +1593,13 @@ TEST_CASE("translator: 100-row table with complex expression", "[expression_tran
   auto tv    = table->view();
 
   // Build: (col(0) + col(1)) == 100
-  auto add_expr = duckdb::make_uniq<BoundFunctionExpression>(
-    LogicalType{LogicalTypeId::INTEGER},
-    ScalarFunction(
-      "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
-    duckdb::vector<duckdb::unique_ptr<Expression>>{},
-    nullptr);
-  add_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  add_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
+  std::vector<std::unique_ptr<ast_node>> add_args;
+  add_args.push_back(make_ref(0));
+  add_args.push_back(make_ref(1));
+  auto add_expr =
+    make_func(sirius::function_id::add, std::move(add_args), logical_type::make(type_id::INTEGER));
 
-  auto cmp = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL,
-    std::move(add_expr),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(100)));
+  auto cmp = make_cmp(sirius::comparison_type::equal, std::move(add_expr), make_int_const(100));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *cmp);
@@ -1690,10 +1617,10 @@ TEST_CASE("translator: 100-row table with complex expression", "[expression_tran
 // Test: Decimal column vs. decimal literal comparisons
 //
 // NOTE: decimal column-vs-literal comparisons work once rapidsai/cudf#21447 is
-// included. Decimal arithmetic (BoundFunctionExpression children returning
-// DECIMAL) is currently blocked by the translator pending rapidsai/cudf#21996,
-// so the positive tests here stay inside the comparison pattern and a negative
-// test below pins the blocking behavior.
+// included. Decimal arithmetic (function_call children returning DECIMAL) is
+// currently blocked by the translator pending rapidsai/cudf#21996, so the
+// positive tests here stay inside the comparison pattern and a negative test
+// below pins the blocking behavior.
 //===----------------------------------------------------------------------===//
 
 TEST_CASE("translator: decimal32 column EQUAL decimal literal", "[expression_translator]")
@@ -1703,14 +1630,11 @@ TEST_CASE("translator: decimal32 column EQUAL decimal literal", "[expression_tra
   auto table                    = make_decimal32_table(col_reps, -2);
   auto tv                       = table->view();
 
-  auto const dec52 = LogicalType::DECIMAL(5, 2);
+  auto const dec52 = logical_type::make_decimal(5, 2);
 
   // col(0) == 2.50
-  auto left = duckdb::make_uniq<BoundReferenceExpression>(dec52, 0);
-  auto right =
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(250, uint8_t{5}, uint8_t{2}));
-  auto expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
+  auto expr =
+    make_cmp(sirius::comparison_type::equal, make_ref_typed(0, dec52), make_dec32_const(250, 5, 2));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -1728,14 +1652,11 @@ TEST_CASE("translator: decimal64 column LESS decimal literal", "[expression_tran
   auto table                    = make_decimal64_table(col_reps, -4);
   auto tv                       = table->view();
 
-  auto const dec124 = LogicalType::DECIMAL(12, 4);
+  auto const dec124 = logical_type::make_decimal(12, 4);
 
   // col(0) < 2.5000
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(dec124, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(
-    Value::DECIMAL(int64_t{25000}, uint8_t{12}, uint8_t{4}));
-  auto expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
+  auto expr = make_cmp(
+    sirius::comparison_type::lt, make_ref_typed(0, dec124), make_dec64_const(25000, 12, 4));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -1754,24 +1675,21 @@ TEST_CASE("translator: nested decimal comparison col(0) >= 2.00 AND col(0) <= 4.
   auto table                    = make_decimal32_table(col_reps, -2);
   auto tv                       = table->view();
 
-  auto const dec52 = LogicalType::DECIMAL(5, 2);
+  auto const dec52 = logical_type::make_decimal(5, 2);
 
   // col(0) >= 2.00
-  auto geq = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_GREATERTHANOREQUALTO,
-    duckdb::make_uniq<BoundReferenceExpression>(dec52, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(200, uint8_t{5}, uint8_t{2})));
+  auto geq =
+    make_cmp(sirius::comparison_type::ge, make_ref_typed(0, dec52), make_dec32_const(200, 5, 2));
 
   // col(0) <= 4.00
-  auto leq = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_LESSTHANOREQUALTO,
-    duckdb::make_uniq<BoundReferenceExpression>(dec52, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(400, uint8_t{5}, uint8_t{2})));
+  auto leq =
+    make_cmp(sirius::comparison_type::le, make_ref_typed(0, dec52), make_dec32_const(400, 5, 2));
 
   // (col(0) >= 2.00) AND (col(0) <= 4.00)
-  auto conj = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  conj->children.push_back(std::move(geq));
-  conj->children.push_back(std::move(leq));
+  std::vector<std::unique_ptr<ast_node>> children;
+  children.push_back(std::move(geq));
+  children.push_back(std::move(leq));
+  auto conj = make_conj(sirius::ast::conjunction::kind::op_and, std::move(children));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *conj);
@@ -1784,30 +1702,23 @@ TEST_CASE("translator: nested decimal comparison col(0) >= 2.00 AND col(0) <= 4.
 
 TEST_CASE("translator: nested decimal arithmetic returns nullopt", "[expression_translator]")
 {
-  // Any BoundFunctionExpression whose children have DECIMAL return_type must be
-  // blocked by the translator (pending rapidsai/cudf#21996). Build a nested
-  // expression (col(0) + col(0)) * 2.00 over a DECIMAL(5,2) column and confirm
-  // the translator refuses both the inner and outer functions.
-  auto const dec52 = LogicalType::DECIMAL(5, 2);
+  // Any function_call whose children have DECIMAL return_type must be blocked by
+  // the translator (pending rapidsai/cudf#21996). Build a nested expression
+  // (col(0) + col(0)) * 2.00 over a DECIMAL(5,2) column and confirm the
+  // translator refuses both the inner and outer functions.
+  auto const dec52 = logical_type::make_decimal(5, 2);
 
   // col(0) + col(0)
-  auto add =
-    duckdb::make_uniq<BoundFunctionExpression>(dec52,
-                                               ScalarFunction("+", {dec52, dec52}, dec52, nullptr),
-                                               duckdb::vector<duckdb::unique_ptr<Expression>>{},
-                                               nullptr);
-  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
-  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
+  std::vector<std::unique_ptr<ast_node>> add_args;
+  add_args.push_back(make_ref_typed(0, dec52));
+  add_args.push_back(make_ref_typed(0, dec52));
+  auto add = make_func(sirius::function_id::add, std::move(add_args), dec52);
 
   // (col(0) + col(0)) * 2.00
-  auto mul =
-    duckdb::make_uniq<BoundFunctionExpression>(dec52,
-                                               ScalarFunction("*", {dec52, dec52}, dec52, nullptr),
-                                               duckdb::vector<duckdb::unique_ptr<Expression>>{},
-                                               nullptr);
-  mul->children.push_back(std::move(add));
-  mul->children.push_back(
-    duckdb::make_uniq<BoundConstantExpression>(Value::DECIMAL(200, uint8_t{5}, uint8_t{2})));
+  std::vector<std::unique_ptr<ast_node>> mul_args;
+  mul_args.push_back(std::move(add));
+  mul_args.push_back(make_dec32_const(200, 5, 2));
+  auto mul = make_func(sirius::function_id::mul, std::move(mul_args), dec52);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *mul);
@@ -1820,16 +1731,13 @@ TEST_CASE("translator: direct decimal column arithmetic returns nullopt", "[expr
   // blocked (pending rapidsai/cudf#21996), not just arithmetic whose children
   // are decimal constants or nested functions. The function's arguments are
   // bare references here, so the guard depends on reference nodes carrying their
-  // DECIMAL return_type through from_duckdb.
-  auto const dec52 = LogicalType::DECIMAL(5, 2);
+  // DECIMAL return_type.
+  auto const dec52 = logical_type::make_decimal(5, 2);
 
-  auto add =
-    duckdb::make_uniq<BoundFunctionExpression>(dec52,
-                                               ScalarFunction("+", {dec52, dec52}, dec52, nullptr),
-                                               duckdb::vector<duckdb::unique_ptr<Expression>>{},
-                                               nullptr);
-  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
-  add->children.push_back(duckdb::make_uniq<BoundReferenceExpression>(dec52, 0));
+  std::vector<std::unique_ptr<ast_node>> add_args;
+  add_args.push_back(make_ref_typed(0, dec52));
+  add_args.push_back(make_ref_typed(0, dec52));
+  auto add = make_func(sirius::function_id::add, std::move(add_args), dec52);
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *add);
@@ -1846,10 +1754,7 @@ TEST_CASE("translator: string column EQUAL string literal", "[expression_transla
   auto tv    = table->view();
 
   // col(0) == 'bravo'
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::VARCHAR, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value("bravo"));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::equal, make_ref(0), make_str_const("bravo"));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);
@@ -1866,10 +1771,7 @@ TEST_CASE("translator: string column NOT EQUAL string literal", "[expression_tra
   auto tv    = table->view();
 
   // col(0) != 'foo'
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType::VARCHAR, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value("foo"));
-  auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
+  auto expr = make_cmp(sirius::comparison_type::not_equal, make_ref(0), make_str_const("foo"));
 
   auto translator = make_translator();
   auto ast_tree   = translate(translator, *expr);


### PR DESCRIPTION
## Summary

Deletes the legacy DuckDB-typed executor surface now that the wrapper holds a Sirius AST node (Phase 8), and migrates the executor/translator test suites to construct `sirius::ast::node` directly. After this, `gpu_expression_executor` accepts only native `sirius::ast` input.

Resolves #702.

## Changes

- `gpu_expression_executor`: remove the `duckdb::Expression const*` ctor, the dead `_expressions` member, the duckdb-typed `execute()`/`count_ast_ops()` overloads, and the `BoundXxx` forward decls. The AST-native `execute` overloads remain.
- Guard `select()`'s `to_duckdb` round-trip (consumed only by a `D_ASSERT` on the BOOLEAN return type) behind `D_ASSERT_IS_ENABLED`, so release builds skip the debug-only allocation on the filter hot path.
- Strip the duckdb-typed `from_duckdb` shim from all 9 `gpu_execute_*` specializations.
- Migrate the 3 remaining callers to the `sirius::ast::node const*` ctor: NLJ `resolve_join_col` and the two parquet-scan filter sites (each holds the translated node in a local that outlives `select()`'s queued kernels).
- Migrate the executor/translator test suites to build `sirius::ast::node` directly (coverage parity 43/56); the ast-equivalence suite drops its redundant `duck_out` leg (a duplicate of the translated leg).

## Follow-up cleanup

Post-review tidy-up of the migrated code; no behavior change:

- Add shared `test/cpp/expression_executor/ast_test_support.hpp` consolidating the AST node builders (`make_*`, `wrap_node`) and GPU->host copy helpers that were duplicated across all three expression_executor test suites; remove the per-file copies.
- Collapse the repetitive ast-equivalence `TEST_CASE`s behind an `expect_hand_eq_translated` helper, so each case only builds the DuckDB and hand-AST expressions.
- Simplify the `execute(sirius::ast::node)` `std::visit` dispatcher to a direct `execute(alt, mode)` call (overload resolution already enforces dispatch completeness).

## Testing

- Both build configs compile (`ENABLE_LEGACY_SIRIUS=OFF` and `ON`).
- Full `sirius_unittest` green (sole skip: the pre-existing 2-GPU-only `test_task_scheduler` case).
- The `[gpu_expression_executor_ast]` equivalence suite passes.
