### PR TITLE
docs: trim CLAUDE.md to non-obvious, behavior-changing guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,248 +1,62 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Sirius is a GPU-native SQL engine that runs as a DuckDB extension, routing supported SQL
+operations to the GPU (via cuDF/RMM/cuCascade) and falling back to DuckDB's CPU execution
+otherwise. Once the extension is loaded it **transparently intercepts** normal SQL and runs it
+on the GPU — no special syntax needed.
 
-The main/default branch of this repository is `dev`.
+**The default/main branch is `dev`** (not `main`/`master`) — branch and open PRs against it.
 
-## Project Overview
+## Build & test
 
-Sirius is a GPU-native SQL engine that integrates with DuckDB as an extension. It leverages NVIDIA CUDA-X libraries (cuDF, RMM) to accelerate SQL query execution on GPUs. Sirius intercepts DuckDB's physical plan execution and routes supported operations to GPU execution while gracefully falling back to DuckDB's CPU execution for unsupported cases.
-
-**Key Integration Points:**
-- DuckDB extension architecture: Sirius loads as a DuckDB extension (`sirius.duckdb_extension`)
-- cuCascade: Third-party library for GPU memory management (tiered memory across GPU/host/disk)
-- RAPIDS cuDF: GPU DataFrame library for data manipulation
-- RMM: RAPIDS Memory Manager for GPU memory allocation
-
-## Build System
-
-### Environment Setup
-
-**Using Pixi (Recommended):**
-```bash
-pixi shell                    # Activate environment with all dependencies
-```
-
-### Git Worktrees
-
-When creating a new worktree, submodules are not automatically initialized. After creating the worktree, run:
-```bash
-git submodule update --init --recursive
-```
-
-### Building
+Run commands through `pixi run <cmd>` (don't drop into the interactive `pixi shell`) so each
+command runs in the activated environment:
 
 ```bash
-# Full build (uses all cores by default)
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+pixi run make                              # full build (uses all cores)
+CMAKE_BUILD_PARALLEL_LEVEL=8 pixi run make # if the build is OOM-killed, lower parallelism
+pixi run make clean                        # wipe the build dir (after a failed build, before rebuilding)
 
-# If build consumes too much memory, reduce parallelism
-CMAKE_BUILD_PARALLEL_LEVEL=8 make
+pixi run make test                         # build + run the C++ unit tests (Catch2, what CI runs); make test_debug for debug
 
-# After build errors, clean build directory
-rm -rf build
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+pixi run pre-commit run -a                 # all formatting/lint hooks
 ```
 
-Build outputs:
-- Static extension: `build/release/extension/sirius/sirius.duckdb_extension`
-- Loadable extension: `build/release/extension/sirius/sirius_loadable.duckdb_extension`
-- Unit test binary: `build/release/extension/sirius/test/cpp/sirius_unittest`
+Running tests directly (non-obvious invocations):
+```bash
+pixi run build/release/test/unittest --test-dir . test/sql/tpch-sirius.test    # one SQLLogic file
+pixi run build/release/extension/sirius/test/cpp/sirius_unittest "[cpu_cache]"  # by Catch2 tag/test name
+```
 
-### Building Python API
-
+**Python API** (links against the repo's `duckdb/` submodule via `DUCKDB_SOURCE_PATH`):
 ```bash
 pixi run -e duckdb-python build-duckdb-python
 ```
 
-This uses a dedicated pixi environment (`duckdb-python`) with pip, pybind11, and scikit-build-core. The task automatically points `DUCKDB_SOURCE_PATH` at the repo-level `duckdb/` submodule so the Python package links against the same DuckDB version as the C++ extension.
-
-**Usage from Python:**
-```python
-import duckdb
-
-con = duckdb.connect(config={"allow_unsigned_extensions": "true"})
-con.execute("LOAD 'build/release/extension/sirius/sirius.duckdb_extension'")
-result = con.execute("CALL gpu_execution('SELECT ...')").fetchall()
-```
-
-## Testing
-
-### SQL Logic Tests (End-to-End)
-```bash
-make test                                              # Run all SQLLogicTests
-make test_debug                                        # Debug build tests
-
-# Run specific test file
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
-build/release/test/unittest --test-dir . test/sql/tpch-sirius.test
-```
-
-### C++ Unit Tests
-```bash
-# Build and run all unit tests
-CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
-build/release/extension/sirius/test/cpp/sirius_unittest
-
-# Run tests with specific tag
-build/release/extension/sirius/test/cpp/sirius_unittest "[cpu_cache]"
-
-# Run specific test
-build/release/extension/sirius/test/cpp/sirius_unittest "test_cpu_cache_basic_string_single_col"
-```
-
-Test logs are saved to: `build/release/extension/sirius/test/cpp/log`
-
-Unit tests use Catch2 framework. Test files are in `test/cpp/` organized by component.
-
-### Performance Testing
-```bash
-# Requires duckdb-python to be built
-python3 test/tpch_performance/generate_test_data.py {SCALE_FACTOR}
-python3 test/tpch_performance/performance_test.py {SCALE_FACTOR}
-```
-
-## Code Formatting & Linting
-
-Sirius uses pre-commit hooks for code quality:
-
-```bash
-pre-commit run -a                    # Run all hooks on all files
-pre-commit install                   # Install git hooks (runs on every commit)
-```
-
-**Code style tools:**
-- C++/CUDA: clang-format (style defined in `.clang-format`)
-- Python: black
-- CMake: cmake-format
-- Spell check: codespell (custom words in `.codespell_words`)
-
-Configuration files:
-- `.clang-format`: C++/CUDA formatting rules
-- `.clang-tidy`: C++ linting rules
-- `.pre-commit-config.yaml`: All pre-commit hooks
+**Worktrees**: submodules are not auto-initialized — after creating one, run
+`git submodule update --init --recursive`.
 
 ## Architecture
 
-### Super Sirius (`gpu_execution`)
+**Super Sirius** is the live engine: namespace `sirius`, source under `src/op/` (operators),
+`src/planner/` (plan builders + `sirius_physical_plan_generator.cpp`), `src/pipeline/`,
+`src/cuda/` (GPU kernels). **Read `docs/super-sirius/` before modifying Super Sirius code** —
+see its [README](docs/super-sirius/README.md) for reading order.
 
-The active execution engine. Uses `namespace sirius`, entry point: `CALL gpu_execution('SELECT ...')`.
+**Everything under `src/legacy/` is the dead `gpu_processing` path — do not modify it.** All new
+work targets Super Sirius. Memory spilling / CPU fallback is handled by the downgrade executor
+(`src/downgrade/`, `src/creator/`); see `docs/super-sirius/memory-management.md`.
 
-- Physical plan generator: `sirius_physical_plan_generator` (`src/planner/sirius_physical_plan_generator.cpp`)
-- Operators: `sirius_physical_operator` subclasses in `src/op/` (e.g., `sirius_physical_hash_join.cpp`)
-- Plan builders: `src/planner/` (e.g., `sirius_plan_filter.cpp`, `sirius_plan_aggregate.cpp`)
-- Engine: `src/sirius_engine.cpp`, pipelines in `src/pipeline/`
-- Interface: `src/sirius_interface.cpp` (uses `sirius_interface` class)
-- Task-based execution: `src/creator/`, `src/downgrade/`, `src/op/scan/`
-- Extension entry point: `src/sirius_extension.cpp`
-- Expression evaluation: `src/expression_executor/`
-- Runtime configuration: `src/config.cpp` / `src/include/config.hpp`
-- CUDA kernels: `src/cuda/` (cuDF wrappers, expression dispatch)
+Before implementing operators / memory / expression / I/O work, run `/module-context <task>` to
+load accurate cudf/rmm/duckdb/cucascade API docs.
 
-> **Note:** A legacy code path (`gpu_processing`, `namespace duckdb`) still exists in `src/operator/`, `src/plan/`, `src/gpu_executor.cpp` etc. All new development targets Super Sirius.
+## Usage
 
-### Super Sirius Documentation
+Load the extension and run normal SQL — Sirius intercepts it transparently and runs supported
+queries on the GPU (controlled by the `gpu_execution` setting, on by default):
 
-Comprehensive documentation lives in `docs/super-sirius/` — see [README](docs/super-sirius/README.md) for index and reading order. **Read these docs before modifying Super Sirius code.**
-
-### Logging
-
-```bash
-export SIRIUS_LOG_DIR=/path/to/logs      # Default: ${CMAKE_BINARY_DIR}/log
-export SIRIUS_LOG_LEVEL=debug            # Levels: trace, debug, info, warn, error
-```
-
-## Development Guidelines
-
-### Loading Library Context for Implementation Tasks
-
-**Before implementing new features, operators, or significant bug fixes**, always run `/module-context <task description>` first. This loads the relevant API documentation for cudf, rmm, duckdb, cucascade, and libkvikio modules so you have accurate function signatures, parameter types, and existing usage patterns. The module docs live in `.claude/skills/module-discover/docs/` and contain detailed API references extracted from the actual library headers.
-
-This is especially important for tasks involving:
-- GPU operators (joins, aggregations, sorting, filters, projections)
-- Memory management (reservations, pools, streams, spilling)
-- Data I/O (parquet scanning, datasources)
-- Expression evaluation (AST, unary/binary ops, type casting)
-- Pipeline execution (tasks, executors, data batches)
-
-### Fallback Strategy
-
-Sirius gracefully falls back to DuckDB CPU execution when:
-- Data size exceeds GPU memory regions (caching or processing)
-- Unsupported data types (nested types, some temporal types)
-- Unsupported operators (window functions, ASOF JOIN, etc.)
-- libcudf row count limitations (~2B rows due to int32_t row IDs)
-
-The fallback mechanism is implemented in `src/fallback.cpp` and integrates with DuckDB's execution engine.
-
-### Supported Features
-
-**Data types:** INTEGER, BIGINT, FLOAT, DOUBLE, VARCHAR, DATE, TIMESTAMP, DECIMAL
-**Operators:** FILTER, PROJECTION, JOIN (Hash/Nested Loop/Delim), GROUP BY, ORDER BY, AGGREGATION, TOP-N, LIMIT, CTE, TABLE SCAN
-**Join types:** INNER, LEFT, RIGHT, OUTER (implemented via cudf::left_join, cudf::inner_join, etc.)
-
-### Code Organization
-
-- GPU kernels (`.cu` files) are in `src/cuda/` and subdirectories
-- CPU-side logic (`.cpp` files) coordinates GPU execution
-- Header files (`.hpp`) in `src/include/` mirror source structure
-- Each operator has both a DuckDB-facing interface (`operator/`) and cuDF implementation (`cuda/operator/`)
-
-### Adding New Operators
-
-1. Create header in `src/include/operator/gpu_physical_<operator>.hpp`
-2. Implement DuckDB integration in `src/operator/gpu_physical_<operator>.cpp`
-3. Add cuDF/CUDA implementation in `src/cuda/operator/<operator>.cu`
-4. Register in physical plan generator (`src/gpu_physical_plan_generator.cpp`)
-5. Add tests in `test/cpp/operator/` and `test/sql/`
-
-### CMake Notes
-
-- Uses CUDA 13+ (specified in `pixi.toml` features)
-- Requires C++20 and CUDA standard 20
-- Separable compilation enabled for CUDA (`CMAKE_CUDA_SEPARABLE_COMPILATION ON`)
-- GPU architectures: Turing through Blackwell (75, 80, 86, 90a, 100f, 120a, 120)
-- Links against: cudf::cudf, rmm::rmm, libnuma, yaml-cpp, absl::any_invocable, spdlog, cuCascade
-
-## Extension Development
-
-This is a DuckDB extension project using DuckDB's CMake extension infrastructure. Local builds are driven through the root `Makefile`, which configures the `duckdb/` submodule with the presets in `cmake/CMakePresets.json`.
-
-**Key files for extension integration:**
-- `Makefile`: Root build entry point for CMake preset builds
-- `extension_config.cmake`: Specifies which extensions to load (sirius, json, tpcds, tpch, parquet, icu)
-- `src/sirius_extension.cpp`: Extension registration (LoadInternal function)
-
-**Extension API Usage:**
-
-CLI:
 ```sql
 LOAD 'build/release/extension/sirius/sirius.duckdb_extension';
-CALL gpu_execution('SELECT ...');
--- Legacy mode (requires gpu_buffer_init first):
-CALL gpu_buffer_init('1 GB', '2 GB');
-CALL gpu_processing('SELECT ...');
+SELECT ...;                  -- transparently routed to the GPU
+-- SET gpu_execution = false;  -- to disable interception
 ```
-
-Python (requires `pixi run -e duckdb-python build-duckdb-python` first):
-```python
-con = duckdb.connect('db.duckdb', config={"allow_unsigned_extensions": "true"})
-con.execute("LOAD '/path/to/sirius.duckdb_extension'")
-con.execute("CALL gpu_execution('SELECT ...')").fetchall()
-```
-
-## Claude Code Skills
-
-Sirius includes Claude Code skills for performance analysis and dataset management. Invoke them via slash commands:
-
-| Skill | Command | Description |
-|-------|---------|-------------|
-| Profile Analyzer | `/profile-analyzer` | Analyzes GPU performance from nsys profiles — kernel occupancy, memory bandwidth, operator attribution, and regression detection. |
-| Dataset Manager | `/dataset-manager` | Generates benchmark datasets (TPC-H, TPC-DS, etc.) at any scale factor in parquet or duckdb format. |
-| Optimization Advisor | `/optimization-advisor` | Maps GPU hotspots from nsys profiles to source functions, detects efficiency bottlenecks, sync overhead, and parallelism opportunities. |
-| Benchmark | `/benchmark` | Runs TPC-H or TPC-DS benchmarks on Super Sirius or DuckDB CPU baseline — generate data, execute queries, validate results, and compare timings. |
-| Module Context | `/module-context` | **Auto-loaded before implementation tasks.** Identifies which dependency modules are relevant to a task and loads their API docs (signatures, descriptions, usage examples). |
-| Module Discover | `/module-discover` | Analyzes a dependency library, divides it into modules, and generates LLM-consumable API documentation. Run once per library to populate docs. |
-
-**Useful debugging tools:**
-- `tools/parse_pipeline_log.py`: Parses Sirius pipeline logs to show per-operator row counts for debugging incorrect query results.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ command runs in the activated environment:
 
 ```bash
 pixi run make                              # full build (uses all cores)
-CMAKE_BUILD_PARALLEL_LEVEL=8 pixi run make # if the build is OOM-killed, lower parallelism
 pixi run make clean                        # wipe the build dir (after a failed build, before rebuilding)
 
 pixi run make test                         # build + run the C++ unit tests (Catch2, what CI runs); make test_debug for debug


### PR DESCRIPTION
## Trim `CLAUDE.md` to non-obvious, behavior-changing guidance

`CLAUDE.md` has grown organically as the project has — which is natural, and it means it now covers a lot of ground. This PR is a focused tidy-up. The goal is to make it as useful as possible for Claude Code by keeping it tight and current.

The thing that makes `CLAUDE.md` different from a README: it's **injected into the context of every Claude Code session in this repo**. A human opens a README when they want it; the model reads `CLAUDE.md` on *every* task. That changes the cost/benefit. Each line is a small recurring cost, and — more importantly — the fewer lines there are, the more attention lands on the rules that really matter. So it's worth being deliberate about what earns a spot.

A useful bar for inclusion is: a line belongs if it's one of

1. **Behavior-changing** — a rule that makes the agent do something it otherwise wouldn't.
2. **A non-obvious gotcha** — something that would cost a wasted cycle to rediscover.
3. **An un-guessable name/command** — an exact task name, flag, or path the model can't reliably derive.

And the things that are better left out are the ones that tend to accumulate: content that's easily **discoverable** from the repo itself (`Makefile`, `pixi.toml`, `CMakeLists`, a `grep` of `src/`), content the harness **already surfaces** (Claude Code lists the available skills to the agent every session), **generic advice** the model already follows, **duplicated** info, and anything that can quietly drift **out of date**.

This PR applies that lens. The file goes from ~256 lines to 62. Here's the reasoning behind each change so reviewers can sanity-check the calls.

### Refreshed a few details that had drifted

The codebase has moved faster than the doc in a couple of places, so these are just catch-ups. They matter a bit more than the rest, because an always-loaded instruction that's out of date can nudge the agent in the wrong direction.

- **"Adding New Operators" referenced the older layout** (`src/include/operator/gpu_physical_*`, `src/operator/`, `src/gpu_physical_plan_generator.cpp`) rather than the current Super Sirius one (`src/op/`, `src/planner/sirius_physical_plan_generator.cpp`). Removed — see the "generic advice" note below for why it isn't replaced 1:1.
- **Fallback section pointed at `src/fallback.cpp`**, which now lives under `src/legacy/`; the current mechanism is the downgrade executor (`src/downgrade/`, `src/creator/`). Updated to point there and to `docs/super-sirius/memory-management.md`.
- **`make test` was described as running SQLLogicTests**; it actually builds and runs the C++ Catch2 unit tests (`test → test_release → release`, then `sirius_unittest`), which is also what CI runs. Corrected.
- **Logging default** said `SIRIUS_LOG_DIR` defaults to `${CMAKE_BINARY_DIR}/log`; the code default is `log` (relative to CWD). (Then removed — see below.)
- **The legacy-path note** listed `src/operator/`, `src/plan/`, `src/gpu_executor.cpp`; legacy now lives under `src/legacy/`. Corrected and kept — the "the live path is Super Sirius, leave `src/legacy/` alone" rule is one of the most valuable lines in the file.

### Removed things the repo itself already answers

These are quicker and more reliable for the model to read straight from the source, where they stay current automatically:

- **"Key Integration Points" and "CMake Notes"** — CUDA version, C++20, separable compilation, GPU arch list, link libraries — all live in `pixi.toml` / `CMakeLists`.
- **"Code Organization"** — a prose restatement of the directory layout, obtainable by listing `src/`.
- **"Supported Features"** — the data-type / operator / join-type inventory. This is both discoverable and the fastest-moving content in the file, so a copy here tends to lag behind.
- **Build-outputs list** — the two artifact paths that are actually used still appear inline in the test and usage snippets, so the standalone list was duplicative.
- **"Code Formatting & Linting"** — collapsed to `pre-commit run -a`; the tool and config-file list lives in `.pre-commit-config.yaml` / `.clang-format`.

### Removed what the harness already provides

- **The Claude Code skills table.** Claude Code lists the available skills (with descriptions) to the agent at the start of every session, so re-listing them here duplicates that and adds a second place to keep in sync. The one behavioral bit — "run `/module-context` before implementation work" — is kept as a one-line directive, since that's a workflow instruction rather than a skills listing.

### Trimmed advice the model already follows

- **The step-by-step "Adding New Operators" recipe.** Once refreshed it came down to "follow the existing operator pattern," which is the default behavior, and the paths overlapped the Architecture section. Pointing the model at the existing operators is more accurate and self-maintaining than a hand-written recipe.

### Moved niche reference toward the docs

- **Logging env vars** (`SIRIUS_LOG_DIR` / `SIRIUS_LOG_LEVEL`) — handy when you're changing log output, greppable in `src/config.cpp` at that moment.
- **`tools/parse_pipeline_log.py`** — useful when debugging wrong query results; discoverable in `tools/` when that comes up.

These two are the most debatable cuts — they're small and occasionally convenient. The reasoning is that per-session context is best spent on what helps *most* sessions, with occasional-use material living in `docs/`. Very happy to keep them if reviewers feel the convenience wins out.

### What stayed (and why it clears the bar)

- **Default branch is `dev`** — non-obvious, and it determines where branches/PRs go.
- **Build/test commands wrapped in `pixi run`** — the `pixi run <cmd>` form (vs. the interactive `pixi shell`) is the key thing for an agent, plus the OOM-parallelism and `make clean` notes.
- **The two non-obvious test invocations** — a SQLLogic file via the DuckDB `unittest` runner, and Catch2 tag/test selection on `sirius_unittest` (two different binaries).
- **Python API build** — the `build-duckdb-python` task name and the `DUCKDB_SOURCE_PATH` reason.
- **Worktree submodule gotcha** — submodules aren't auto-initialized.
- **Super Sirius vs. legacy** — live engine in `src/op/` + `src/planner/`; `src/legacy/` is the older path; read `docs/super-sirius/` before changing Super Sirius code.
- **Transparent execution** — loading the extension transparently intercepts SQL (`gpu_execution` setting, on by default), with a minimal LOAD + toggle example.

### Net effect

`CLAUDE.md`: **256 → 62 lines.** Everything retained is something hard for the model to derive on its own; everything removed is something the repo, the harness, or the docs already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
