### PR TITLE
Add Codex AGENTS.md entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ compile_commands.json
 .zed
 
 # Local-only AI assistant + planning artifacts (per-machine, not for upstream)
-AGENTS.md
+AGENTS.override.md
 CLAUDE.local.md
 newplan.md
 telemetry_data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Read `CLAUDE.md` and follow its instructions.


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` file as the Codex-compatible repository instruction entrypoint.
- Delegate Codex guidance to the existing `CLAUDE.md` so the project does not maintain duplicate AI assistant instructions.
- Stop ignoring `AGENTS.md` and ignore `AGENTS.override.md` instead.

## Why
Codex discovers repository guidance from `AGENTS.md` by default. Committing this file makes Codex users load the same project instructions that are already maintained in `CLAUDE.md`, keeping shared expectations versioned and reducing drift between assistant-specific instruction files.

## Local overrides
Codex checks `AGENTS.override.md` before `AGENTS.md` in a directory and uses at most one instruction file per directory. Because `AGENTS.override.md` is ignored, contributors can create it for temporary or machine-local Codex guidance without accidentally committing those overrides.

If a local override should keep the shared repo guidance, include an explicit delegation such as:

```md
Read `CLAUDE.md` and follow its instructions.

Additional local instructions go here.
```

## Testing
- Verified `AGENTS.md` is no longer ignored by Git.
- Verified `AGENTS.override.md` is ignored by Git.