### PR TITLE
Improvements to sort operator #2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_gpu_partition_impl.cpp
     test/cpp/operator/test_host_table_chunk_reader.cpp
     test/cpp/operator/test_physical_concat.cpp
+    test/cpp/operator/test_physical_sort_sample.cpp
     test/cpp/operator/test_physical_filter.cpp
     test/cpp/operator/test_physical_limit.cpp
     test/cpp/operator/test_physical_mark_join.cpp

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -222,7 +222,7 @@ Reassembles partitioned data back into a linear stream. Behavior depends on join
 
 Samples N input batches to compute P-1 partition boundary rows for range partitioning.
 
-- On first execution: concatenate samples, sort, compute boundaries, set `_boundaries_computed`
+- On first execution: merge pre-sorted sample batches, compute boundaries, set `_boundaries_computed`
 - On subsequent executions: pass through data unchanged
 - Custom `get_next_task_hint()`: waits for N batches before returning READY
 

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -31,10 +31,9 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::SORT_SAMPLE;
 
-  static constexpr std::size_t DEFAULT_NUM_SAMPLE_BATCHES = 5;
-
   sirius_physical_sort_sample(
     sirius_physical_order* order_by,
+    uint64_t sort_sample_bytes           = config::DEFAULT_SORT_SAMPLE_BYTES,
     uint64_t max_partition_bytes         = 0,
     double max_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION);
 
@@ -42,15 +41,12 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
     duckdb::vector<sirius::logical_type> types,
     duckdb::vector<duckdb::BoundOrderByNode> orders,
     std::size_t estimated_cardinality,
-    std::size_t num_sample_batches       = DEFAULT_NUM_SAMPLE_BATCHES,
+    uint64_t sort_sample_bytes           = config::DEFAULT_SORT_SAMPLE_BYTES,
     uint64_t max_partition_bytes         = 0,
     double max_partition_memory_fraction = config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION);
 
   //! Order specification (copied from ORDER_BY) — determines which columns to sample
   duckdb::vector<duckdb::BoundOrderByNode> orders;
-
-  //! Number of batches to sample before computing partition boundaries
-  std::size_t num_sample_batches;
 
  public:
   bool is_source() const override { return true; }
@@ -65,8 +61,11 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
 
-  //! Override to wait for N batches before returning READY
+  //! Override to wait for enough sample bytes before returning READY
   std::optional<task_creation_hint> get_next_task_hint() override;
+
+  //! Override to pull sample bytes before boundary computation, then one batch at a time
+  std::unique_ptr<operator_data> get_next_task_input_data() override;
 
   //! Get the computed partition boundaries (P-1 rows, sort key columns only)
   const cudf::table& get_partition_boundaries() const { return *_partition_boundaries; }
@@ -91,6 +90,9 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! compare_exchange on this elects exactly one task as the winner; all others
   //! passthrough without blocking.
   std::atomic<int> _boundary_state{0};
+
+  //! Target bytes to accumulate for the boundary sample (from sirius_config operator_params)
+  uint64_t _sort_sample_bytes = config::DEFAULT_SORT_SAMPLE_BYTES;
 
   //! Override for max partition bytes (0 = use GPU memory fraction)
   size_t _max_partition_bytes_override = 0;

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -36,6 +36,7 @@ constexpr uint64_t DEFAULT_SCAN_TASK_BATCH_SIZE       = 512ULL * 1024 * 1024;  /
 constexpr uint64_t DEFAULT_SCAN_TASK_VARCHAR_SIZE     = 256LL;
 constexpr uint64_t DEFAULT_HASH_PARTITION_BYTES       = 512ULL * 1024 * 1024;  // 512 MB
 constexpr uint64_t DEFAULT_CONCAT_BATCH_BYTES         = 512ULL * 1024 * 1024;  // 512 MB
+constexpr uint64_t DEFAULT_SORT_SAMPLE_BYTES          = 512ULL * 1024 * 1024;  // 512 MB
 constexpr uint64_t DEFAULT_MAX_BUILD_HASH_TABLE_BYTES = 500ULL * 1024 * 1024;  // 500 MB
 
 /// Fraction of available GPU memory used per sort partition when max_sort_partition_bytes is 0.
@@ -64,6 +65,9 @@ struct operator_params {
 
   /// Target size (bytes) for the concat operator output batch.
   uint64_t concat_batch_bytes = config::DEFAULT_CONCAT_BATCH_BYTES;
+
+  /// Target size (bytes) of data to sample before computing sort partition boundaries.
+  uint64_t sort_sample_bytes = config::DEFAULT_SORT_SAMPLE_BYTES;
 
   /// Maximum build-side bytes for switching to BUILD_PROBE join mode.
   /// May be larger than concat_batch_bytes; build-side batches will be concatenated if needed.

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -46,8 +46,10 @@ bool repo_has_enough_sample_bytes(::cucascade::shared_data_repository* repo,
                                   uint64_t sort_sample_bytes,
                                   bool upstream_finished)
 {
-  if (!repo || repo->total_size() == 0) { return false; }
+  if (!repo) { return false; }
+  // Upstream done with no rows still needs a READY signal so the pipeline can drain.
   if (upstream_finished) { return true; }
+  if (repo->total_size() == 0) { return false; }
 
   uint64_t accumulated = 0;
   for (size_t part = 0; part < repo->num_partitions(); ++part) {

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -33,13 +33,45 @@
 namespace sirius {
 namespace op {
 
+namespace {
+
+uint64_t get_batch_bytes(const std::shared_ptr<::cucascade::data_batch>& batch)
+{
+  if (!batch) { return 0; }
+  auto ro = batch->to_read_only();
+  if (!ro.get_data()) { return 0; }
+  return ro.get_data()->get_size_in_bytes();
+}
+
+bool repo_has_enough_sample_bytes(::cucascade::shared_data_repository* repo,
+                                  uint64_t sort_sample_bytes,
+                                  bool upstream_finished)
+{
+  if (!repo || repo->total_size() == 0) { return false; }
+  if (upstream_finished) { return true; }
+
+  uint64_t accumulated = 0;
+  for (size_t part = 0; part < repo->num_partitions(); ++part) {
+    for (auto batch_id : repo->get_batch_ids(part)) {
+      auto batch = repo->get_data_batch_by_id(batch_id, part);
+      if (!batch) { continue; }
+      accumulated += get_batch_bytes(batch);
+      if (accumulated >= sort_sample_bytes) { return true; }
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 sirius_physical_sort_sample::sirius_physical_sort_sample(sirius_physical_order* order_by,
+                                                         uint64_t sort_sample_bytes,
                                                          uint64_t max_partition_bytes,
                                                          double max_partition_memory_fraction)
   : sirius_physical_sort_sample(order_by->types,
                                 copy_orders(order_by->orders),
                                 order_by->estimated_cardinality,
-                                DEFAULT_NUM_SAMPLE_BATCHES,
+                                sort_sample_bytes,
                                 max_partition_bytes,
                                 max_partition_memory_fraction)
 {
@@ -49,13 +81,13 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(
   duckdb::vector<sirius::logical_type> types,
   duckdb::vector<duckdb::BoundOrderByNode> orders,
   std::size_t estimated_cardinality,
-  std::size_t num_sample_batches,
+  uint64_t sort_sample_bytes,
   uint64_t max_partition_bytes,
   double max_partition_memory_fraction)
   : sirius_physical_operator(
       SiriusPhysicalOperatorType::SORT_SAMPLE, std::move(types), estimated_cardinality),
     orders(std::move(orders)),
-    num_sample_batches(num_sample_batches),
+    _sort_sample_bytes(sort_sample_bytes),
     _max_partition_bytes_override(max_partition_bytes),
     _max_partition_memory_fraction(max_partition_memory_fraction)
 {
@@ -68,17 +100,15 @@ std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hin
     return sirius_physical_operator::get_next_task_hint();
   }
 
-  // Need to wait for N batches before computing boundaries
+  // Need to wait for enough sample bytes before computing boundaries
   auto port_ids = get_port_ids();
   if (port_ids.empty()) { return std::nullopt; }
 
   auto* p = get_port(port_ids[0]);
-  if (!p) { return std::nullopt; }
+  if (!p || !p->repo) { return std::nullopt; }
 
   bool upstream_finished = p->src_pipeline && p->src_pipeline->is_pipeline_finished();
-  bool has_enough        = p->repo->size() >= static_cast<size_t>(num_sample_batches);
-
-  if (has_enough || (upstream_finished && p->repo->size() > 0)) {
+  if (repo_has_enough_sample_bytes(p->repo, _sort_sample_bytes, upstream_finished)) {
     return task_creation_hint{TaskCreationHint::READY, this};
   }
 
@@ -88,6 +118,36 @@ std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hin
   }
 
   return std::nullopt;
+}
+
+std::unique_ptr<operator_data> sirius_physical_sort_sample::get_next_task_input_data()
+{
+  // After boundaries are computed, process one batch at a time (passthrough mode).
+  if (_boundary_state.load(std::memory_order_acquire) == 2) {
+    return sirius_physical_operator::get_next_task_input_data();
+  }
+
+  // Before boundary computation: accumulate batches up to the sample byte threshold so
+  // execute() can concatenate, sort, and derive partition boundaries from a representative
+  // sample without pulling a fixed batch count that may be too large for big batches.
+  auto port_ids = get_port_ids();
+  if (port_ids.empty()) { return nullptr; }
+
+  auto* p = get_port(port_ids[0]);
+  if (!p || !p->repo) { return nullptr; }
+
+  std::vector<std::shared_ptr<::cucascade::data_batch>> input_batch;
+  uint64_t accumulated_bytes = 0;
+  while (true) {
+    auto batch = p->repo->pop_next_data_batch();
+    if (!batch) { break; }
+    accumulated_bytes += get_batch_bytes(batch);
+    input_batch.push_back(std::move(batch));
+    if (accumulated_bytes >= _sort_sample_bytes) { break; }
+  }
+
+  if (input_batch.empty()) { return nullptr; }
+  return std::make_unique<pipelineable_operator_data>(std::move(input_batch));
 }
 
 std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operator_data& input_data,
@@ -113,8 +173,9 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
-  SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches",
-                   input_batches.size());
+  SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches ({} bytes target)",
+                   input_batches.size(),
+                   _sort_sample_bytes);
   auto start = std::chrono::high_resolution_clock::now();
 
   // 1. Collect valid batches and find memory space

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -21,10 +21,9 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "log/logging.hpp"
 #include "op/cudf_sort_order.hpp"
+#include "op/merge/gpu_merge_impl.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "sirius/exception.hpp"
-
-#include <cudf/concatenate.hpp>
 
 #include <nvtx3/nvtx3.hpp>
 
@@ -128,7 +127,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::get_next_task_input_
   }
 
   // Before boundary computation: accumulate batches up to the sample byte threshold so
-  // execute() can concatenate, sort, and derive partition boundaries from a representative
+  // execute() can merge pre-sorted runs and derive partition boundaries from a representative
   // sample without pulling a fixed batch count that may be too large for big batches.
   auto port_ids = get_port_ids();
   if (port_ids.empty()) { return nullptr; }
@@ -194,19 +193,12 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory),
   // reset state to NOT_STARTED so the rescheduled task can win the CAS and retry.
   try {
-    // 2. Concatenate all sample batches into one table
-    std::vector<cudf::table_view> sample_views;
     size_t total_sample_bytes = 0;
-    sample_views.reserve(valid_batches.size());
     for (auto const& batch : valid_batches) {
-      auto view = get_cudf_table_view(batch);
-      sample_views.push_back(view);
       total_sample_bytes += batch.get_data()->get_size_in_bytes();
     }
 
-    auto concat_table = cudf::concatenate(sample_views, stream, space->get_default_allocator());
-
-    // 3. Build cudf order vectors from BoundOrderByNode
+    // 2. Build cudf order vectors from BoundOrderByNode
     std::vector<int> order_key_idx;
     std::vector<cudf::order> column_order;
     std::vector<cudf::null_order> null_precedence;
@@ -224,25 +216,19 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
       null_precedence.push_back(to_cudf_null_order(ord.type, ord.null_order));
     }
 
-    // 4. Sort the concatenated sample by sort keys
-    std::vector<cudf::column_view> sort_cols;
-    for (int idx : order_key_idx) {
-      sort_cols.push_back(concat_table->view().column(idx));
+    // 3. Merge pre-sorted sample batches (ORDER_BY sorts each batch locally).
+    cudf::table_view merged_sample_view;
+    std::shared_ptr<::cucascade::data_batch> merged_sample_batch;
+    if (valid_batches.size() == 1) {
+      merged_sample_view = get_cudf_table_view(valid_batches[0]);
+    } else {
+      merged_sample_batch = gpu_merge_impl::merge_order_by(
+        valid_batches, order_key_idx, column_order, null_precedence, stream, *space);
+      merged_sample_view = get_cudf_table_view(merged_sample_batch->to_read_only());
     }
-    auto sorted_indices = cudf::sorted_order(cudf::table_view(sort_cols),
-                                             column_order,
-                                             null_precedence,
-                                             stream,
-                                             space->get_default_allocator());
 
-    auto sorted_table = cudf::gather(concat_table->view(),
-                                     sorted_indices->view(),
-                                     cudf::out_of_bounds_policy::DONT_CHECK,
-                                     stream,
-                                     space->get_default_allocator());
-
-    // 5. Compute number of partitions
-    size_t total_rows      = static_cast<size_t>(sorted_table->num_rows());
+    // 4. Compute number of partitions
+    size_t total_rows      = static_cast<size_t>(merged_sample_view.num_rows());
     size_t avg_batch_bytes = valid_batches.empty() ? 0 : total_sample_bytes / valid_batches.size();
     size_t avg_rows_per_batch = valid_batches.empty() ? 0 : total_rows / valid_batches.size();
     size_t num_parts          = 1;
@@ -281,7 +267,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
         num_parts);
     }
 
-    // 6. Pick P-1 evenly-spaced boundary rows from the sorted sample (sort key columns only)
+    // 5. Pick P-1 evenly-spaced boundary rows from the merged sample (sort key columns only)
     if (num_parts <= 1 || total_rows == 0) {
       // Single partition — no boundaries needed
       _num_partitions = 1;
@@ -309,10 +295,10 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                                     cudaMemcpyHostToDevice,
                                     stream.value()));
 
-      // Extract only the sort key columns from sorted table for the boundaries
+      // Extract only the sort key columns from merged sample for the boundaries
       std::vector<cudf::column_view> sort_key_cols;
       for (int idx : order_key_idx) {
-        sort_key_cols.push_back(sorted_table->view().column(idx));
+        sort_key_cols.push_back(merged_sample_view.column(idx));
       }
       cudf::table_view sort_keys_view(sort_key_cols);
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -737,7 +737,10 @@ void sirius_pipeline_converter::split_order_by_sink(
 
   // Create SORT_SAMPLE operator
   auto sample_op = duckdb::make_uniq<op::sirius_physical_sort_sample>(
-    order_ptr, op_params_.max_sort_partition_bytes, op_params_.max_sort_partition_memory_fraction);
+    order_ptr,
+    op_params_.sort_sample_bytes,
+    op_params_.max_sort_partition_bytes,
+    op_params_.max_sort_partition_memory_fraction);
   auto* sample_ptr = sample_op.get();
 
   // Create SORT_PARTITION operator

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -124,6 +124,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
              yaml::fraction<double>{});
   r.optional("hash_partition_bytes", yaml::bytes(opt.hash_partition_bytes));
   r.optional("concat_batch_bytes", yaml::bytes(opt.concat_batch_bytes));
+  r.optional("sort_sample_bytes", yaml::bytes(opt.sort_sample_bytes));
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));
   r.optional("enable_gpu_duckdb_native_scan", opt.enable_gpu_duckdb_native_scan);
   r.reject_unknown();

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1421,6 +1421,14 @@ static void SetConcatBatchBytes(ClientContext& context, SetScope scope, Value& p
   SIRIUS_LOG_DEBUG("Updated config CONCAT_BATCH_BYTES to {}", params->concat_batch_bytes);
 }
 
+static void SetSortSampleBytes(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  params->sort_sample_bytes = UBigIntValue::Get(parameter);
+  SIRIUS_LOG_DEBUG("Updated config SORT_SAMPLE_BYTES to {}", params->sort_sample_bytes);
+}
+
 static void SetLogLevel(ClientContext& context, SetScope scope, Value& parameter)
 {
   Config::LOG_LEVEL = StringValue::Get(parameter);
@@ -1613,6 +1621,12 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::UBIGINT,
                             Value::UBIGINT(sirius::operator_params{}.concat_batch_bytes),
                             SetConcatBatchBytes);
+
+  config.AddExtensionOption("sort_sample_bytes",
+                            "Target bytes to sample before computing sort partition boundaries",
+                            LogicalType::UBIGINT,
+                            Value::UBIGINT(sirius::operator_params{}.sort_sample_bytes),
+                            SetSortSampleBytes);
 
   config.AddExtensionOption("scan_cache_level",
                             "Scan result caching level: none, table_gpu, table_host, parquet",

--- a/test/cpp/operator/test_physical_sort_sample.cpp
+++ b/test/cpp/operator/test_physical_sort_sample.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "helper/type_conversions.hpp"
+#include "operator_test_utils.hpp"
+
+#include <catch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <op/sirius_physical_sort_sample.hpp>
+#include <pipeline/sirius_pipeline.hpp>
+
+#include <numeric>
+#include <vector>
+
+using namespace duckdb;
+using namespace sirius::op;
+using namespace cucascade;
+using namespace cucascade::memory;
+using namespace sirius::test::operator_utils;
+using sirius::op::pipelineable_operator_data;
+
+namespace {
+
+duckdb::BoundOrderByNode make_order(
+  duckdb::idx_t col_idx,
+  duckdb::LogicalType type,
+  duckdb::OrderType dir         = duckdb::OrderType::ASCENDING,
+  duckdb::OrderByNullType nulls = duckdb::OrderByNullType::NULLS_LAST)
+{
+  return duckdb::BoundOrderByNode(
+    dir, nulls, duckdb::make_uniq<duckdb::BoundReferenceExpression>(std::move(type), col_idx));
+}
+
+class mock_gpu_pipeline : public sirius::pipeline::sirius_pipeline {
+ public:
+  explicit mock_gpu_pipeline(const sirius::pipeline::pipeline_build_context& ctx)
+    : sirius_pipeline(ctx), _finished(false)
+  {
+  }
+
+  void set_finished(bool finished) { _finished = finished; }
+
+  bool is_pipeline_finished() const override { return _finished; }
+
+ private:
+  bool _finished;
+};
+
+sirius_physical_sort_sample make_sort_sample(uint64_t sort_sample_bytes)
+{
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, duckdb::LogicalType::INTEGER));
+
+  return sirius_physical_sort_sample(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    std::move(orders),
+    1000,
+    sort_sample_bytes);
+}
+
+void add_int_batches(cucascade::shared_data_repository& repo,
+                     memory_space& space,
+                     int num_batches,
+                     std::size_t rows_per_batch)
+{
+  for (int b = 0; b < num_batches; ++b) {
+    std::vector<int32_t> values(rows_per_batch);
+    std::iota(values.begin(), values.end(), static_cast<int32_t>(b * rows_per_batch));
+    repo.add_data_batch(make_numeric_batch<int32_t>(space, values, cudf::type_id::INT32), 0);
+  }
+}
+
+void attach_port(sirius_physical_sort_sample& sample_op,
+                 cucascade::shared_data_repository& repo,
+                 duckdb::shared_ptr<mock_gpu_pipeline> src_pipeline = nullptr)
+{
+  auto port           = std::make_unique<sirius_physical_operator::port>();
+  port->type          = MemoryBarrierType::PIPELINE;
+  port->repo          = &repo;
+  port->src_pipeline  = std::move(src_pipeline);
+  port->dest_pipeline = nullptr;
+  sample_op.add_port("input", std::move(port));
+}
+
+std::size_t batch_count(const operator_data& data)
+{
+  return dynamic_cast<const pipelineable_operator_data&>(data).get_data_batches().size();
+}
+
+}  // namespace
+
+TEST_CASE("sirius_physical_sort_sample stops sampling at sort_sample_bytes threshold",
+          "[physical_sort_sample]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold         = 6144;
+  constexpr int num_batches            = 5;
+  constexpr std::size_t rows_per_batch = 1000;
+
+  auto sample_op = make_sort_sample(threshold);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  add_int_batches(*repo, *space, num_batches, rows_per_batch);
+  attach_port(sample_op, *repo);
+
+  auto result = sample_op.get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  REQUIRE(batch_count(*result) < static_cast<std::size_t>(num_batches));
+  REQUIRE(batch_count(*result) >= 1);
+
+  std::size_t total_batches_returned = batch_count(*result);
+  while (true) {
+    auto next = sample_op.get_next_task_input_data();
+    if (!next) { break; }
+    total_batches_returned += batch_count(*next);
+  }
+
+  REQUIRE(total_batches_returned == static_cast<std::size_t>(num_batches));
+}
+
+TEST_CASE("sirius_physical_sort_sample get_next_task_hint waits for sample bytes",
+          "[physical_sort_sample]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold         = 6144;
+  constexpr std::size_t rows_per_batch = 1000;
+
+  auto sample_op = make_sort_sample(threshold);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+
+  const sirius::pipeline::pipeline_build_context build_ctx{true};
+  auto src_pipeline = duckdb::make_shared_ptr<mock_gpu_pipeline>(build_ctx);
+  src_pipeline->set_finished(false);
+
+  // get_next_task_hint() reports the upstream pipeline's first operator as the producer.
+  auto upstream_producer = duckdb::make_uniq<sirius_physical_operator>(
+    SiriusPhysicalOperatorType::ORDER_BY,
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    1000);
+  sirius::pipeline::sirius_pipeline_build_state build_state;
+  build_state.add_pipeline_operator(*src_pipeline, *upstream_producer);
+
+  attach_port(sample_op, *repo, src_pipeline);
+
+  add_int_batches(*repo, *space, 1, rows_per_batch);
+  auto waiting_hint = sample_op.get_next_task_hint();
+  REQUIRE(waiting_hint.has_value());
+  REQUIRE(waiting_hint->hint == TaskCreationHint::WAITING_FOR_INPUT_DATA);
+  REQUIRE(waiting_hint->producer == upstream_producer.get());
+
+  add_int_batches(*repo, *space, 1, rows_per_batch);
+  auto ready_hint = sample_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+  REQUIRE(ready_hint->producer == &sample_op);
+}
+
+TEST_CASE(
+  "sirius_physical_sort_sample pulls all remaining data when upstream finished below threshold",
+  "[physical_sort_sample]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold         = 100000;
+  constexpr int num_batches            = 3;
+  constexpr std::size_t rows_per_batch = 1000;
+
+  auto sample_op = make_sort_sample(threshold);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  add_int_batches(*repo, *space, num_batches, rows_per_batch);
+
+  const sirius::pipeline::pipeline_build_context build_ctx{true};
+  auto src_pipeline = duckdb::make_shared_ptr<mock_gpu_pipeline>(build_ctx);
+  src_pipeline->set_finished(true);
+  attach_port(sample_op, *repo, src_pipeline);
+
+  auto ready_hint = sample_op.get_next_task_hint();
+  REQUIRE(ready_hint.has_value());
+  REQUIRE(ready_hint->hint == TaskCreationHint::READY);
+
+  auto result = sample_op.get_next_task_input_data();
+  REQUIRE(result != nullptr);
+  REQUIRE(batch_count(*result) == static_cast<std::size_t>(num_batches));
+  REQUIRE(sample_op.get_next_task_input_data() == nullptr);
+}

--- a/test/cpp/operator/test_physical_sort_sample.cpp
+++ b/test/cpp/operator/test_physical_sort_sample.cpp
@@ -17,11 +17,16 @@
 #include "helper/type_conversions.hpp"
 #include "operator_test_utils.hpp"
 
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime.h>
+
 #include <catch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <op/sirius_physical_sort_sample.hpp>
 #include <pipeline/sirius_pipeline.hpp>
+#include <sirius_config.hpp>
 
 #include <numeric>
 #include <vector>
@@ -99,6 +104,16 @@ void attach_port(sirius_physical_sort_sample& sample_op,
 std::size_t batch_count(const operator_data& data)
 {
   return dynamic_cast<const pipelineable_operator_data&>(data).get_data_batches().size();
+}
+
+int32_t read_int32_column(const cudf::column_view& col, cudf::size_type row)
+{
+  std::vector<int32_t> host(col.size());
+  REQUIRE(cudaMemcpy(host.data(),
+                     col.data<int32_t>(),
+                     host.size() * sizeof(int32_t),
+                     cudaMemcpyDeviceToHost) == cudaSuccess);
+  return host[row];
 }
 
 }  // namespace
@@ -200,4 +215,43 @@ TEST_CASE(
   REQUIRE(result != nullptr);
   REQUIRE(batch_count(*result) == static_cast<std::size_t>(num_batches));
   REQUIRE(sample_op.get_next_task_input_data() == nullptr);
+}
+
+TEST_CASE("sirius_physical_sort_sample merges pre-sorted batches for partition boundaries",
+          "[physical_sort_sample]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  constexpr std::size_t rows_per_batch = 50;
+  std::vector<int32_t> high_keys(rows_per_batch);
+  std::iota(high_keys.begin(), high_keys.end(), 50);
+  std::vector<int32_t> low_keys(rows_per_batch);
+  std::iota(low_keys.begin(), low_keys.end(), 0);
+
+  auto batch_high = make_numeric_batch<int32_t>(*space, high_keys, cudf::type_id::INT32);
+  auto batch_low  = make_numeric_batch<int32_t>(*space, low_keys, cudf::type_id::INT32);
+
+  duckdb::vector<duckdb::BoundOrderByNode> orders;
+  orders.push_back(make_order(0, duckdb::LogicalType::INTEGER));
+
+  // Force two partitions from estimated total size vs max_partition_bytes.
+  sirius_physical_sort_sample sample_op(
+    sirius::from_duckdb_vec(duckdb::vector<duckdb::LogicalType>{duckdb::LogicalType::INTEGER}),
+    std::move(orders),
+    1000,
+    1'000'000,
+    2500,
+    sirius::config::DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION);
+
+  auto output = sample_op.execute(pipelineable_operator_data({batch_high, batch_low}),
+                                  cudf::get_default_stream());
+  REQUIRE(output != nullptr);
+  REQUIRE(sample_op.boundaries_computed());
+  REQUIRE(sample_op.get_num_partitions() == 2);
+  REQUIRE(sample_op.get_partition_boundaries().num_rows() == 1);
+
+  const auto boundary_key =
+    read_int32_column(sample_op.get_partition_boundaries().view().column(0), 0);
+  REQUIRE(boundary_key == 50);
 }

--- a/test/cpp/operator/test_physical_sort_sample.cpp
+++ b/test/cpp/operator/test_physical_sort_sample.cpp
@@ -187,6 +187,27 @@ TEST_CASE("sirius_physical_sort_sample get_next_task_hint waits for sample bytes
   REQUIRE(ready_hint->producer == &sample_op);
 }
 
+TEST_CASE("sirius_physical_sort_sample is ready when upstream finished with empty repo",
+          "[physical_sort_sample]")
+{
+  auto sample_op = make_sort_sample(100000);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+
+  const sirius::pipeline::pipeline_build_context build_ctx{true};
+  auto src_pipeline = duckdb::make_shared_ptr<mock_gpu_pipeline>(build_ctx);
+  src_pipeline->set_finished(true);
+  attach_port(sample_op, *repo, src_pipeline);
+
+  // Upstream finished but produced no batches — must not block waiting for sample bytes.
+  auto hint = sample_op.get_next_task_hint();
+  REQUIRE(hint.has_value());
+  REQUIRE(hint->hint == TaskCreationHint::READY);
+  REQUIRE(hint->producer == &sample_op);
+
+  // No batches to pull; execute() should still be able to mark boundaries done.
+  REQUIRE(sample_op.get_next_task_input_data() == nullptr);
+}
+
 TEST_CASE(
   "sirius_physical_sort_sample pulls all remaining data when upstream finished below threshold",
   "[physical_sort_sample]")


### PR DESCRIPTION
## Summary
Second PR for https://github.com/sirius-db/sirius/issues/424. After this there is one more issue left that will be addressed in the third PR.

This PR improves `SORT_SAMPLE` (partition boundary sampling for multi-partition sorts) in three related changes.

### 1. Override `get_next_task_input_data()`
**Problem:** There was a mismatch between `get_next_task_hint()` and `get_next_task_input_data()`. `get_next_task_hint()` waited until enough batches were available in the input repo before signaling READY, but `get_next_task_input_data()` still only pulled a single batch per task. So even when the hint said the operator was ready to compute boundaries, `execute()` would only ever see one batch at a time — not the multi-batch sample the rest of the logic assumed.
**Change:**
- Add an overridden `get_next_task_input_data()` on `sirius_physical_sort_sample` so it aligns with what `get_next_task_hint()` is waiting for.
- Before boundary computation: pull batches from the input repo until the sampling target is reached, then hand them to `execute()` as a single multi-batch input.
- After boundaries are computed: fall back to the default behavior and process one batch at a time (passthrough mode).
### 2. Byte-based sampling via `sort_sample_bytes ` (replaces fixed batch count)
**Problem:** The old fixed batch count (`DEFAULT_NUM_SAMPLE_BATCHES = 5`) doesn't scale with variable batch sizes. With very large batches, pulling 5 can be overwhelming; with small batches, 5 may not be enough.
**Change:**
- Replace `num_sample_batches` with `sort_sample_bytes` in `operator_params` (default **512 MB**, similar to how the concat operator sizes its output).
- Expose `sort_sample_bytes` as a DuckDB extension option and YAML config.
- Update `get_next_task_hint()` to wait until enough sample bytes are available (or upstream finishes with remaining data).
- Wire the config through `sirius_pipeline_converter` when building `SORT_SAMPLE`.
- Add unit tests for byte threshold, hint behavior, and upstream-finished below threshold.
### 3. Merge pre-sorted batches (replaces concatenate + full sort)
**Problem:** Upstream `ORDER_BY` already produces locally sorted batches, but `SORT_SAMPLE` was concatenating the sample, running a full GPU sort, and only then computing partition boundaries — redundant work.
**Change:**
- Use `gpu_merge_impl::merge_order_by` to merge pre-sorted sample batches, then compute boundaries from the merged result.
- Remove the `cudf::concatenate` + full-sort path for multi-batch samples.
- Add a unit test verifying correct partition boundaries from merged pre-sorted runs.
- Update `operators.md` to describe merge-based sampling.
