### PR TITLE
docs: refresh Super Sirius docs for AST migration, DuckDB-native scan, S3, and sort pipeline

### DIFF
--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -31,15 +31,16 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Execution Flow](execution-flow.md) | End-to-end query trace with file:line references |
 | [Physical Plan Generation](physical-plan-generation.md) | Logical-to-physical mapping, pipeline construction, splitting rules |
 | [Operators](operators.md) | All physical operators: interface, GPU implementation, cuDF APIs |
-| [Expression Executor](expression-executor.md) | gpu_expression_executor, GPU expression translator, cuDF AST |
+| [Expression Executor](expression-executor.md) | gpu_expression_executor, Sirius AST hierarchy, GPU expression translator, cuDF AST |
 | [Pipeline Execution](pipeline-execution.md) | GPU executor, task scheduling, completion, OOM handling, per-task-device contract under SCHED-RR |
 | [Task Creator](task-creator.md) | Task creation: hint chain, per-operator scheduling behavior |
-| [Scan](scan.md) | Scan subsystem: parquet scan, DuckDB scan, caching, prefetched data source |
+| [Scan](scan.md) | Scan subsystem: parquet scan, DuckDB scan, DuckDB-native GPU scan, S3, caching, prefetched data source |
 | [Memory Management](memory-management.md) | cuCascade tiers, reservations, downgrade executor |
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
 | [Optimizations](optimizations.md) | Performance optimizations with PRs, code paths, configs |
 | [Multi-GPU Architecture](multi-gpu-architecture.md) | How Sirius executes SQL across every GPU on a node — tiers, pin tables, SCHED-RR, cross-GPU transfers, downgrade, concurrency invariants |
+| [Dynamic Filters](dynamic-filters.md) | Framework for runtime-computed filter predicates: zone maps, bloom filters, SIP, adaptive pushdown |
 
 ## Suggested Reading Order
 
@@ -56,4 +57,4 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 11. **Configuration** — tuning knobs and runtime settings
 12. **Optimizations** — performance improvements and their mechanisms
 
-<!-- last-updated-commit: d6baaedc0d2bb07b27a00c65135513f3c23f0b37 -->
+<!-- last-updated-commit: 46e7cb063196f7f59c9877ee497325ec5fc0d22a -->

--- a/docs/super-sirius/expression-executor.md
+++ b/docs/super-sirius/expression-executor.md
@@ -6,9 +6,9 @@ This document covers the GPU expression execution subsystem used by FILTER and P
 
 **File:** `src/include/expression_executor/gpu_expression_executor.hpp`
 
-`gpu_expression_executor` evaluates DuckDB expressions on the GPU. It provides two execution modes:
+`gpu_expression_executor` evaluates expressions on the GPU using the Sirius AST type hierarchy (see [Sirius AST Type Hierarchy](#sirius-ast-type-hierarchy)). It provides two execution modes:
 
-> **API boundary:** Operator headers and the executor's public header take expressions as `sirius::expression` / `sirius::join_condition` — opaque PIMPL wrappers around `duckdb::Expression` / `duckdb::JoinCondition` defined in `src/include/expression/`. Plan builders wrap at the DuckDB boundary (`sirius::wrap`); operator `.cpp` files unwrap internally via `expression/expression_internal.hpp` to access the raw DuckDB type. This keeps `duckdb/planner/expression/...` includes out of the operator surface.
+> **API boundary:** Operator headers and the executor's public header take expressions as `sirius::expression` / `sirius::join_condition` — opaque PIMPL wrappers around a `sirius::ast::node` / DuckDB `JoinCondition` defined in `src/include/expression/`. Plan builders translate at the DuckDB boundary (`sirius::wrap`, which calls `sirius::ast::from_duckdb` internally); operator `.cpp` files unwrap to a `sirius::ast::node const*` via `expression/expression_internal.hpp`. This keeps both `duckdb/planner/expression/...` and `expression/ast/node.hpp` out of the operator surface.
 
 | Method | Purpose | Used By |
 |--------|---------|---------|
@@ -16,6 +16,61 @@ This document covers the GPU expression execution subsystem used by FILTER and P
 | `select(batch)` | Filters: evaluates a boolean expression and returns only rows that pass | FILTER |
 
 Both methods accept a `data_batch` and return a new `data_batch` with the result. The `rmm::cuda_stream_view` and memory resource are passed to the constructor and stored as members — they are not per-call arguments.
+
+## Sirius AST Type Hierarchy
+
+**Files:** `src/include/expression/ast/node.hpp`, `src/include/expression/ast/*.hpp`
+
+`sirius::ast::node` is a `std::variant`-based sum type over all Sirius expression node kinds. It is the internal representation stored inside `sirius::expression`'s PIMPL, and the type the executor dispatches on via `std::visit`.
+
+```cpp
+struct node {
+  using variant_t = std::variant<reference,
+                                 constant,
+                                 comparison,
+                                 conjunction,
+                                 between,
+                                 case_expr,
+                                 cast,
+                                 unary_op,
+                                 coalesce,
+                                 in_list,
+                                 function_call,
+                                 aggregate>;
+  variant_t v;
+};
+```
+
+`node` is move-only. Children are stored as `std::unique_ptr<node>` inside each alternative struct, making the tree recursive without incomplete-type issues.
+
+| Alternative | Sirius type | Typical source |
+|-------------|-------------|----------------|
+| `reference` | `sirius::ast::reference` | Column reference (`BoundReferenceExpression`) |
+| `constant` | `sirius::ast::constant` | Literal value (`BoundConstantExpression`) — payload stored as `sirius::value` |
+| `comparison` | `sirius::ast::comparison` | `=`, `!=`, `<`, `>`, `<=`, `>=`, `IS NOT DISTINCT FROM` |
+| `conjunction` | `sirius::ast::conjunction` | `AND`, `OR` |
+| `between` | `sirius::ast::between` | `BETWEEN … AND …` |
+| `case_expr` | `sirius::ast::case_expr` | `CASE WHEN … THEN … ELSE … END` |
+| `cast` | `sirius::ast::cast` | `CAST(x AS T)` |
+| `unary_op` | `sirius::ast::unary_op` | `NOT x`, `-x`, arithmetic binary ops (`+`, `-`, `*`, `/`) |
+| `coalesce` | `sirius::ast::coalesce` | `COALESCE(a, b, 0)` |
+| `in_list` | `sirius::ast::in_list` | `x IN (1, 2, 3)` |
+| `function_call` | `sirius::ast::function_call` | Named function (`YEAR`, `UPPER`, etc.) — `sirius::function_id` enum |
+| `aggregate` | `sirius::ast::aggregate` | Aggregate function (`SUM`, `COUNT`, etc.) — `sirius::aggregate_id` enum |
+
+**Translation boundary:** `sirius::wrap(expr)` calls `sirius::ast::from_duckdb(expr)` to produce a `sirius::ast::node` from a `duckdb::Expression`. This happens once at plan time in the plan builders. The resulting node is stored in the `sirius::expression` PIMPL and never re-translated.
+
+**Key files:**
+
+| File | Purpose |
+|------|---------|
+| `src/include/expression/ast/node.hpp` | `sirius::ast::node` variant definition |
+| `src/include/expression/ast/from_duckdb.hpp` | `sirius::ast::from_duckdb` — DuckDB → Sirius AST translator |
+| `src/include/expression/value.hpp` | `sirius::value` — typed constant payload (INT8–DECIMAL128, VARCHAR, TIMESTAMP, …) |
+| `src/include/expression/function_id.hpp` | `sirius::function_id` closed enum of supported functions |
+| `src/include/expression/aggregate_id.hpp` | `sirius::aggregate_id` closed enum of supported aggregates |
+| `src/include/expression/expression.hpp` | `sirius::expression` — the public PIMPL type |
+| `src/include/expression/expression_internal.hpp` | `sirius::expression::impl` completion; `unwrap()` / `release()` helpers |
 
 ## Execution Strategies
 
@@ -55,23 +110,26 @@ SET expression_executor_strategy = 'ast_jit';   -- or 'ast_interpret', 'material
 
 ## Supported Expression Types
 
-| Expression Type | Class | Example |
-|----------------|-------|---------|
-| Column reference | `BoundReferenceExpression` | `column #3` |
-| Constant | `BoundConstantExpression` | `42`, `'hello'` |
-| Comparison | `BoundComparisonExpression` | `a > b`, `x = 10`, `a IS NOT DISTINCT FROM b` |
-| Conjunction | `BoundConjunctionExpression` | `a AND b`, `x OR y` |
-| Arithmetic/logical | `BoundOperatorExpression` | `a + b`, `NOT x`, `COALESCE(a, b, 0)`, `x IN (1, 2, 3)` |
-| Function call | `BoundFunctionExpression` | `UPPER(name)`, `YEAR(date)` |
-| Type cast | `BoundCastExpression` | `CAST(x AS DOUBLE)` |
-| CASE/WHEN | `BoundCaseExpression` | `CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END` |
-| BETWEEN | `BoundBetweenExpression` | `x BETWEEN 10 AND 20` |
+| Expression Type | Sirius AST alternative | Example |
+|----------------|------------------------|---------|
+| Column reference | `sirius::ast::reference` | `column #3` |
+| Constant | `sirius::ast::constant` | `42`, `'hello'` |
+| Comparison | `sirius::ast::comparison` | `a > b`, `x = 10`, `a IS NOT DISTINCT FROM b` |
+| Conjunction | `sirius::ast::conjunction` | `a AND b`, `x OR y` |
+| Arithmetic / unary | `sirius::ast::unary_op` | `a + b`, `NOT x`, `-x` |
+| COALESCE | `sirius::ast::coalesce` | `COALESCE(a, b, 0)` |
+| IN-list | `sirius::ast::in_list` | `x IN (1, 2, 3)` |
+| Function call | `sirius::ast::function_call` | `UPPER(name)`, `YEAR(date)` |
+| Type cast | `sirius::ast::cast` | `CAST(x AS DOUBLE)` |
+| CASE/WHEN | `sirius::ast::case_expr` | `CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END` |
+| BETWEEN | `sirius::ast::between` | `x BETWEEN 10 AND 20` |
+| Aggregate | `sirius::ast::aggregate` | `SUM(x)`, `COUNT(*)` |
 
-`COALESCE` is materialized via `cudf::replace_nulls` iteratively across children: the first child is materialized (scalars are lifted to a column); each subsequent child replaces the residual nulls in the running result. Children are only evaluated when the running result still has nulls. The result is wrapped via `materialize_as_ast_column` so COALESCE composes inside AST-capable parents. `count_ast_ops` returns 0 — COALESCE always takes the materialize-only path.
+`coalesce` is materialized via `cudf::replace_nulls` iteratively across children: the first child is materialized (scalars are lifted to a column); each subsequent child replaces the residual nulls in the running result. Children are only evaluated when the running result still has nulls. The result is wrapped via `materialize_as_ast_column` so COALESCE composes inside AST-capable parents. `cudf_ast_op_count` returns 0 — `coalesce` always takes the materialize-only path.
 
-`COMPARE_IN` covers the full numeric set (INT8–INT64, UINT8–UINT64, BOOL8, FLOAT, DOUBLE, DECIMAL32/64/128, all TIMESTAMP precisions, DATE) plus VARCHAR. BOOL8 dispatches via `uint8_t` because `std::vector<bool>::data()` is deleted.
+`in_list` covers the full numeric set (INT8–INT64, UINT8–UINT64, BOOL8, FLOAT, DOUBLE, DECIMAL32/64/128, all TIMESTAMP precisions, DATE) plus VARCHAR. BOOL8 dispatches via `uint8_t` because `std::vector<bool>::data()` is deleted.
 
-Per-expression-type dispatch lives in `src/expression_executor/specializations/` (one file per expression class: `gpu_execute_comparison.cpp`, `gpu_execute_case.cpp`, etc.). Each specialization decides how to emit AST nodes, materialize, or fall back based on the effective execution mode.
+Per-expression-type dispatch lives in `src/expression_executor/specializations/` (one file per Sirius AST alternative: `gpu_execute_comparison.cpp`, `gpu_execute_case.cpp`, etc.). Each specialization decides how to emit cuDF AST nodes, materialize, or fall back based on the effective execution mode.
 
 ### AST-Eligible Operations
 
@@ -89,25 +147,35 @@ Anything outside this set is an AST breaker and forces materialization at that n
 
 ## GPU Expression Translator
 
-**File:** `src/include/expression_executor/gpu_expression_translator.hpp`
+**File:** `src/include/expression_executor/gpu_expression_translator_internal.hpp`
 
-`gpu_expression_translator` is a **separate** utility that converts DuckDB expressions into standalone cuDF AST trees for operators that need compiled expression evaluation outside the executor — primarily mixed joins.
+`gpu_expression_translator` is a **separate** utility that converts Sirius AST expressions into standalone cuDF AST trees for operators that need compiled expression evaluation outside the executor — primarily mixed joins and parquet filter pushdown.
 
 ```cpp
 struct translated_expression {
     cudf::ast::tree tree;
+    std::optional<rmm::cuda_stream> owned_stream;
     std::vector<std::unique_ptr<cudf::scalar>> owned_literals;
 };
 ```
 
+The primary entry point takes a `sirius::ast::node const&`:
+
+```cpp
+std::optional<translated_expression> translate_expression(
+    sirius::ast::node const& expr,
+    cudf::ast::table_reference table_src = cudf::ast::table_reference::LEFT);
+```
+
+A second overload, `translate_expression_with_names`, produces `cudf::ast::column_name_reference` nodes instead of index-based references — used for cuDF parquet predicate pushdown.
+
 ### Unsupported Translations
 
 These return `nullopt`, causing the caller to fall back to row-by-row evaluation:
-- CASE expressions
-- COALESCE, TRY
-- CAST with non-fixed-width types (e.g., VARCHAR)
-- Parameter expressions
-- DISTINCT operators (IS DISTINCT FROM throws `NotImplementedException`)
+- `case_expr` nodes
+- `coalesce` nodes and `TRY`
+- `cast` with non-fixed-width target types (e.g., VARCHAR)
+- `IS DISTINCT FROM` (throws `NotImplementedException`)
 
 ### Join Condition Translation
 
@@ -124,7 +192,11 @@ This is used by `sirius_physical_hash_join` in MIXED_JOIN mode to pass inequalit
 |------|---------|
 | `src/include/expression_executor/gpu_expression_executor.hpp` | Main executor class |
 | `src/expression_executor/gpu_expression_executor.cpp` | Driver: strategy dispatch, AST tree management, temp lifetimes |
-| `src/expression_executor/specializations/gpu_execute_*.cpp` | Per-expression-class dispatch (comparison, case, function, …) |
+| `src/expression_executor/specializations/gpu_execute_*.cpp` | Per-Sirius-AST-alternative dispatch (comparison, case, function, …) |
 | `src/include/expression_executor/expression_executor_strategy.hpp` | `expression_executor_strategy` enum + string conversions |
-| `src/include/expression_executor/gpu_expression_translator.hpp` | Standalone DuckDB → cuDF AST translator (for mixed joins) |
+| `src/include/expression_executor/gpu_expression_translator_internal.hpp` | Sirius AST → cuDF AST translator (mixed joins, parquet pushdown) |
 | `src/expression_executor/gpu_expression_translator.cpp` | Translator implementation |
+| `src/include/expression/ast/node.hpp` | `sirius::ast::node` variant; per-alternative headers included from here |
+| `src/include/expression/ast/from_duckdb.hpp` | `sirius::ast::from_duckdb` — DuckDB → Sirius AST translation |
+| `src/include/expression/expression.hpp` | `sirius::expression` PIMPL type |
+| `src/include/expression/expression_internal.hpp` | PIMPL completion; `unwrap()` / `release()` helpers |

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -66,7 +66,12 @@ See [Scan — Iceberg Scan](scan.md#iceberg-scan) for details.
 ### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
 **File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
 
-Source operator for parquet scans. Carries a `parquet_scan_info` populated by the pipeline converter and pulls splits from a `split_connector` populated by `sirius_scan_manager` on its own thread pool. Each `parquet_scan_data` split drives a `cudf::io::read_parquet` call followed by `scan_plan`-driven output assembly (data columns, hive-partition synthesis, output ordering). See [Scan — Scan Manager](scan.md#scan-manager).
+Source operator for parquet scans (local or S3). Carries a `scan_info` (concrete subclass: `parquet_scan_info`) populated by the pipeline converter and pulls splits from a `split_connector` populated by `sirius_scan_manager` on its own thread pool. Each `parquet_scan_data` split drives a `cudf::io::read_parquet` call followed by `scan_plan`-driven output assembly (data columns, hive-partition synthesis, output ordering). See [Scan — Scan Manager](scan.md#scan-manager).
+
+### `sirius_gpu_duckdb_native_scan_operator` — `GPU_DUCKDB_NATIVE_SCAN`
+**File:** `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp`
+
+Source operator for GPU-native reading of DuckDB `.duckdb` format tables. Carries a `duckdb_native_scan_info` and pulls splits from a `split_connector` fed by a `duckdb_native_split_provider`. Each split carries a slice of per-row-group segment metadata; `execute()` decodes the segments into a `cudf::table` using the native DuckDB format decode kernels. See [Scan — GPU DuckDB-Native Scan](scan.md#sirius_gpu_duckdb_native_scan_operator----gpu_duckdb_native_scan).
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
@@ -299,7 +304,8 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | DUCKDB_SCAN | Scan | DuckDB table function |
 | PARQUET_SCAN | Scan | Direct Parquet reading |
 | ICEBERG_SCAN | Scan | Parquet reading with Iceberg delete filters |
-| GPU_PARQUET_SCAN | Scan | Source operator served by `sirius_scan_manager` |
+| GPU_PARQUET_SCAN | Scan | Source operator served by `sirius_scan_manager` (local or S3) |
+| GPU_DUCKDB_NATIVE_SCAN | Scan | GPU-native DuckDB format scan via `duckdb_native_split_provider` |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `gpu_expression_executor::select()` |

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -26,18 +26,17 @@ num_partitions = max(1, total_bytes / hash_partition_bytes)
 
 **Code path:** `src/creator/task_creator.cpp` — `drain_pending_tasks()`
 
-### 4-Phase Sort Pipeline (Architectural)
+### 3-Phase Sort Pipeline (PR #866)
 
-**Motivation:** Sorting datasets larger than GPU memory requires distributed sorting with dynamic partition boundaries.
+**Motivation:** Sorting datasets larger than GPU memory requires distributed sorting with dynamic partition boundaries. SORT_SAMPLE and SORT_PARTITION are tightly coupled (the partition operator reads boundaries directly from the sample operator via `_sample_op`), so colocating them in one pipeline eliminates an unnecessary repository hop and scheduling overhead.
 
-**Mechanism:** ORDER_BY is split into 4 pipeline phases:
+**Mechanism:** ORDER_BY is split into 3 pipeline phases:
 1. **ORDER_BY**: Local sort of each batch
-2. **SORT_SAMPLE**: Sample N batches, compute P-1 partition boundary rows
-3. **SORT_PARTITION**: Range-partition data using boundaries
-4. **MERGE_SORT**: Multi-way merge of pre-sorted partitions via `cudf::merge_order_by()`
+2. **SORT_SAMPLE + SORT_PARTITION**: Sample N batches to compute boundaries, then range-partition — both run back-to-back in the same `gpu_pipeline_task`
+3. **MERGE_SORT**: Multi-way merge of pre-sorted partitions via `cudf::merge_order_by()`
 
 **Code path:**
-- `src/sirius_engine.cpp` — `initialize_internal()` (pipeline splitting)
+- `src/pipeline/sirius_pipeline_converter.cpp` — `split_order_by_sink()` (pipeline splitting)
 - `src/op/sirius_physical_sort_sample.cpp` — boundary computation
 - `src/op/sirius_physical_sort_partition.cpp` — range partitioning
 - `src/op/sirius_physical_merge_sort.cpp` — multi-way merge

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -208,7 +208,9 @@ In the diagrams below, `[A, B, C]` denotes a pipeline where A is `operators[0]` 
 
 TABLE_SCAN splits along two paths depending on the table function:
 
-**Parquet (`parquet_scan` / `read_parquet`):** TABLE_SCAN is replaced with `GPU_PARQUET_SCAN` at `operators[0]` of the same pipeline — no separate scan pipeline is created. The DuckDB bind data is captured into a `parquet_scan_info` and parked on the operator. During `prepare_for_query`, `sirius_scan_manager` reads the info, builds a `split_provider` (parquet or cached), and binds a `split_connector` to the operator. The operator pulls splits from the connector inside `get_next_task_input_data()` (see [Scan — Scan Manager](scan.md#scan-manager)).
+**Parquet (`parquet_scan` / `read_parquet`, including `s3://` paths):** TABLE_SCAN is replaced with `GPU_PARQUET_SCAN` at `operators[0]` of the same pipeline — no separate scan pipeline is created. The DuckDB bind data is captured into a `parquet_scan_info` (a concrete `scan_info` subclass) and parked on the operator. During `prepare_for_query`, `sirius_scan_manager` reads the info, builds a `split_provider` via `scan_info::make_provider()` (parquet or cached), and binds a `split_connector` to the operator. The operator pulls splits from the connector inside `get_next_task_input_data()` (see [Scan — Scan Manager](scan.md#scan-manager)).
+
+**DuckDB-native (`seq_scan` against an attached `.duckdb` file):** TABLE_SCAN is replaced with `GPU_DUCKDB_NATIVE_SCAN` at `operators[0]` when the bound table entry is a native DuckDB format table. A `duckdb_native_scan_info` is parked on the operator and consumed by a `duckdb_native_split_provider` during `prepare_for_query`.
 
 **DuckDB-managed (`seq_scan`, `iceberg_scan`):** A separate scan pipeline is created, and the original TABLE_SCAN is kept as the first operator of the main pipeline:
 
@@ -275,20 +277,18 @@ graph LR
 - Build-side CONCAT pushes to the HASH_JOIN's `"build"` port with `FULL` barrier (default)
 - The probe and build PARTITION operators are linked as siblings for partition count coordination
 
-### ORDER_BY → 4-Phase Sort
+### ORDER_BY → 3-Phase Sort
 
 ```mermaid
 graph LR
-    P1["Pipeline 1<br/>[scan, ..., ORDER_BY]"] -->|"PIPELINE"| P2["Pipeline 2<br/>[SORT_SAMPLE]"]
-    P2 -->|"PIPELINE"| P3["Pipeline 3<br/>[SORT_PARTITION]"]
-    P3 -->|"FULL"| P4["Pipeline 4<br/>[MERGE_SORT]"]
-    P4 -->|"FULL"| DS["downstream"]
+    P1["Pipeline 1<br/>[scan, ..., ORDER_BY]"] -->|"PIPELINE"| P2["Pipeline 2<br/>[SORT_SAMPLE, SORT_PARTITION]"]
+    P2 -->|"FULL"| P3["Pipeline 3<br/>[MERGE_SORT]"]
+    P3 -->|"FULL"| DS["downstream"]
 ```
 
 1. **Pipeline 1**: Current pipeline keeps ORDER_BY as sink (local sort per batch)
-2. **Pipeline 2**: SORT_SAMPLE. `PIPELINE` barrier — batches arrive as produced; sort_sample overrides `get_next_task_hint()` to wait for N samples before computing boundaries
-3. **Pipeline 3**: SORT_PARTITION. `PIPELINE` barrier — range-partitions data using computed boundaries
-4. **Pipeline 4**: MERGE_SORT. `FULL` barrier — must wait for all partitions. Downstream pipelines that previously used ORDER_BY as source are updated to use MERGE_SORT
+2. **Pipeline 2**: SORT_SAMPLE and SORT_PARTITION run back-to-back in the same `gpu_pipeline_task`. `PIPELINE` barrier from Pipeline 1 — batches arrive as produced; SORT_SAMPLE overrides `get_next_task_hint()` to wait for N samples before computing boundaries; SORT_PARTITION reads boundaries directly from SORT_SAMPLE via `_sample_op`
+3. **Pipeline 3**: MERGE_SORT. `FULL` barrier — must wait for all partitions. Downstream pipelines that previously used ORDER_BY as source are updated to use MERGE_SORT
 
 ### HASH_GROUP_BY
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -4,13 +4,14 @@ This document covers the scan subsystem end-to-end: how data enters Super Sirius
 
 ## Overview
 
-Super Sirius supports four scan paths:
+Super Sirius supports five scan paths:
 
 | Path | Operator | Use Case | Data Flow |
 |------|----------|----------|-----------|
 | **DuckDB Scan** | `DUCKDB_SCAN` | General DuckDB-managed tables | DuckDB table function → column builders → `host_data_representation` |
 | **Parquet Scan** | `PARQUET_SCAN` | Legacy direct Parquet reading | Parquet byte ranges → `host_parquet_representation` |
-| **GPU Parquet Scan** | `GPU_PARQUET_SCAN` | Parquet file reading via the scan manager | `sirius_scan_manager` produces `parquet_scan_data` splits → GPU read |
+| **GPU Parquet Scan** | `GPU_PARQUET_SCAN` | Parquet file reading via the scan manager (local or S3) | `sirius_scan_manager` produces `parquet_scan_data` splits → GPU read |
+| **GPU DuckDB-Native Scan** | `GPU_DUCKDB_NATIVE_SCAN` | GPU-native `.duckdb` file reading | `sirius_scan_manager` walks per-row-group segment metadata → GPU decode |
 | **Iceberg Scan** | `ICEBERG_SCAN` | Apache Iceberg V1/V2/V3 tables | Parquet scan + GPU-accelerated delete filters |
 
 The DuckDB and legacy parquet paths funnel through `duckdb_scan_executor` and the data-repository infrastructure. The GPU parquet path is driven by `sirius_scan_manager` and a dedicated `split_provider` per scan operator (see [Scan Manager](#scan-manager)).
@@ -51,15 +52,22 @@ Iceberg table scan. Inherits from `sirius_physical_parquet_scan`. Holds delete f
 ### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
 **File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
 
-Source operator for parquet scans. Carries a `parquet_scan_info` populated by the pipeline converter from the DuckDB bind data (file paths, projected column ids, table filters, hive partition indices, target batch size). The operator owns a bound `split_connector`; `get_next_task_input_data()` blocks inside `split_connector::get_next_split()` until either a `parquet_scan_data` is available or the connector is closed and drained.
+Source operator for parquet scans. Carries a `scan_info` (concrete subclass: `parquet_scan_info`) populated by the pipeline converter from the DuckDB bind data (file paths, projected column ids, table filters, hive partition indices, target batch size). The operator owns a bound `split_connector`; `get_next_task_input_data()` blocks inside `split_connector::get_next_split()` until either a `parquet_scan_data` is available or the connector is closed and drained.
 
-`execute(input_data)` runs per task: it calls `cudf::io::read_parquet` over the row-group slices in the split, optionally applies a fallback DuckDB expression filter when AST translation failed, prunes pure-filter columns, and assembles the output table according to the `scan_plan` (data columns, hive-partition synthesis, output ordering).
+`execute(input_data)` runs per task: it calls `cudf::io::read_parquet` over the row-group slices in the split, optionally applies a fallback expression filter when AST translation failed, prunes pure-filter columns, and assembles the output table according to the `scan_plan` (data columns, hive-partition synthesis, output ordering).
+
+Parquet files on S3 (`s3://…` paths) are routed through the `s3_ioctx` backend automatically — the pipeline converter detects the scheme from the bind data paths and the scan manager selects the appropriate `sirius_ioctx` per GPU device at provider-construction time.
+
+### `sirius_gpu_duckdb_native_scan_operator` — `GPU_DUCKDB_NATIVE_SCAN`
+**File:** `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp`
+
+Source operator for GPU-native reading of DuckDB `.duckdb` format table entries. Carries a `duckdb_native_scan_info` populated by the pipeline converter. The scan manager walks per-row-group segment metadata once at `prepare_for_query` and emits one split per row-group batch via a `duckdb_native_split_provider`. Each split carries a slice of the row-group metadata vector plus a shared `duckdb_native_scan_info` handle. `execute()` decodes the segments described by the split into a `cudf::table` using the native DuckDB format decode kernels (`duckdb_native_decoder`).
 
 ## Scan Manager
 
 **Files:** `src/include/scan_manager/sirius_scan_manager.hpp`, `src/scan_manager/sirius_scan_manager.cpp`, `src/include/scan_manager/split_provider.hpp`, `src/include/scan_manager/split_connector.hpp`
 
-`sirius_scan_manager` owns a configurable thread pool and is responsible for producing the input splits consumed by every `GPU_PARQUET_SCAN` source operator. It runs alongside the GPU pipeline executors and is independent from the data repository / port machinery used between intermediate operators.
+`sirius_scan_manager` owns a configurable thread pool and is responsible for producing the input splits consumed by every `GPU_PARQUET_SCAN` and `GPU_DUCKDB_NATIVE_SCAN` source operator. It runs alongside the GPU pipeline executors and is independent from the data repository / port machinery used between intermediate operators.
 
 ### Components
 
@@ -67,14 +75,18 @@ Source operator for parquet scans. Carries a `parquet_scan_info` populated by th
 |-----------|------|------|
 | `sirius_scan_manager` | `scan_manager/sirius_scan_manager.{hpp,cpp}` | Owns thread pool, holds providers and pinned-table entries, drives provider execution |
 | `split_provider` | `scan_manager/split_provider.hpp` | Abstract producer of `operator_data` splits |
+| `scan_info` | `op/scan/scan_info.hpp` | Polymorphic base for per-format scan bind data; subclasses implement `make_provider()` |
+| `parquet_scan_info` | `op/scan/parquet_scan_info.hpp` | Parquet-specific bind data; `make_provider()` returns a `parquet_split_provider` |
+| `duckdb_native_scan_info` | `op/scan/duckdb_native_scan_info.hpp` | DuckDB-format-specific bind data; `make_provider()` returns a `duckdb_native_split_provider` |
 | `parquet_split_provider` | `scan_manager/parquet_split_provider.{hpp,cpp}` | Provider that parses parquet metadata and emits `parquet_scan_data` per row-group partition |
+| `duckdb_native_split_provider` | `scan_manager/duckdb_native_split_provider.{hpp,cpp}` | Provider that walks DuckDB row-group segment metadata and emits splits for native GPU decode |
 | `cached_split_provider` | `scan_manager/cached_split_provider.{hpp,cpp}` | Provider that emits zero-copy splits over pinned columns (see [Pinned Tables](#pinned-tables)) |
 | `split_connector` | `scan_manager/split_connector.hpp` | Lock-protected blocking queue between the provider and the operator |
 
 ### Lifecycle
 
-1. **Plan stage:** during pipeline conversion, `split_parquet_scan_source` packages the DuckDB bind data into a `parquet_scan_info` and constructs a `sirius_gpu_parquet_scan_operator` carrying that info. The operator is inserted at `operators[0]` of the pipeline; no separate metadata pipeline is created.
-2. **Per-query preparation:** `sirius_scan_manager::prepare_for_query(query)` walks the plan, picks each parquet scan source, and calls `create_provider_for(op)`. The factory returns either a `cached_split_provider` (when a pinned entry matches the operator's file paths) or a `parquet_split_provider`. A fresh `split_connector` is bound to the operator and the provider is stored in the manager's map.
+1. **Plan stage:** during pipeline conversion, `split_parquet_scan_source` packages the DuckDB bind data into a `scan_info` concrete subclass (`parquet_scan_info` for parquet / S3 paths, `duckdb_native_scan_info` for DuckDB-format tables) and constructs the corresponding source operator carrying that info. The operator is inserted at `operators[0]` of the pipeline; no separate metadata pipeline is created.
+2. **Per-query preparation:** `sirius_scan_manager::prepare_for_query(query)` walks the plan, picks each scan source, and calls `create_provider_for(op)`. For parquet scans the factory checks for a pinned-table cache hit first and returns a `cached_split_provider` on match; otherwise it calls `scan_info::make_provider()` to build the format-specific provider. A fresh `split_connector` is bound to the operator and the provider is stored in the manager's map.
 3. **Execution:** a driver thread runs providers **sequentially** in registration order. Each provider's `start(pool, connector)` schedules work onto the manager's thread pool and returns a future; the driver waits on it before starting the next provider. Inside the operator, `get_next_task_input_data()` blocks on `split_connector::get_next_split()` and returns each split as it arrives, so consumer-side scheduling is decoupled from production order.
 4. **Teardown:** the provider closes the connector on every termination path (success, exception); on synchronous failure the manager closes it as a safety net. Once closed and drained, the operator's `all_ports_empty()` returns true and `get_next_task_hint()` returns `nullopt`.
 
@@ -144,7 +156,7 @@ SELECT SUM(l_extendedprice * l_quantity)
 CALL unpin_table('lineitem');
 ```
 
-`tier` accepts `gpu` or `host`; only `gpu` is supported today (a `host` argument throws `NotImplementedException` and will be added later).
+`tier` accepts `gpu` (columns pinned to GPU device memory) or `host` (columns pinned to host memory). In both cases subsequent scans of the same paths are served from the pinned columns without file I/O.
 
 A `pinned_entry` stores the column projection, resolved file paths, per-column chunk vectors, and the memory space the columns reside in. When `prepare_for_query` runs, the scan manager matches the operator's `parquet_scan_info::file_paths` against pinned entries; on a hit, it constructs a `cached_split_provider` (zero-copy view-backed `data_batch` per chunk) instead of a `parquet_split_provider`. The cached provider forwards the same `scan_plan` and filter expression as the parquet path, so the operator's `execute()` is unchanged. When `needs_output_assembly(*plan)` is false (identity layout), the cached batch is forwarded straight through with no permute or prune.
 
@@ -376,6 +388,33 @@ Two C++20 concepts define the plug-in contract:
 
 A new backend is: a custom `io_object` + reactor + `templated_ioctx<your_reactor>`. `uring_ioctx = templated_ioctx<uring_reactor>` is the first instantiation.
 
+### S3 Backend
+
+**Files:** `src/include/io/s3/s3_ioctx.hpp`, `src/io/s3/s3_ioctx.cpp`, `src/include/io/s3/s3_request_authorizer.hpp`, `src/include/io/s3/s3_io_object.hpp`
+
+`sirius::io::s3::s3_ioctx` implements the `sirius_ioctx` interface for reading parquet files from S3 using libcurl HTTP Range GETs. Unlike the io_uring backend, S3 has no native device-read path — device reads bounce through a host staging buffer followed by `cudaMemcpyAsync`.
+
+Authentication is delegated to a `s3_request_authorizer` implementation passed via `s3_ioctx_config`:
+
+| Authorizer | Mechanism |
+|------------|-----------|
+| `sirius_sigv4_presigned_authorizer` | Generates AWS SigV4-signed presigned URLs for each request |
+| `sirius_sigv4_header_authorizer` | Adds `Authorization` + `x-amz-*` headers; supports STS session tokens and dual-signing modes (AWS standard + custom endpoints) |
+
+The path from SQL to S3 reads:
+
+```sql
+SELECT * FROM read_parquet('s3://bucket/key.parquet')
+```
+
+1. Pipeline converter detects `s3://` prefix in bind data paths; sets scan_info to a `parquet_scan_info` with the S3 paths.
+2. `sirius_scan_manager::prepare_for_query` calls `scan_info::make_provider()` which builds a `parquet_split_provider` backed by an `s3_ioctx`.
+3. The scan manager selects the per-GPU `s3_ioctx` via `gpu_ioctxs` map (injected at initialization from `SiriusContext`).
+4. `parquet_split_provider` fetches parquet footers via the `s3_ioctx`, then produces `parquet_scan_data` splits served from S3 range GETs.
+5. Each split's `cudf::io::read_parquet` call uses a `sirius_datasource` backed by `s3_ioctx`, routing every read through libcurl.
+
+`s3_ioctx_config` controls authentication, connection limits, per-call timeout, retry count and backoff, and optional host-memory staging (FSMR-backed bounded staging buffer for device reads).
+
 ### Cache Seam
 
 `sirius_ioctx::device_read{,_async}` is non-virtual: it consults `_cache` and falls through to pure-virtual `device_read_io{,_async}`. Backends never see the cache; the cache never sees the backend. `supports_device_read()` stays `true` even when the cache serves the read because the final copy is still `cudaMemcpyAsync` from pinned host memory to device.
@@ -499,15 +538,24 @@ graph TD
 | `src/include/op/scan/cached_ranges.hpp` | Cache range structure |
 | `src/include/op/scan/config.hpp` | Scan config, cache_level enum |
 | `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp` | GPU parquet scan source operator |
-| `src/include/op/scan/parquet_scan_info.hpp` | Bind data parked on the scan operator for the scan manager |
+| `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp` | GPU DuckDB-native scan source operator |
+| `src/include/op/scan/scan_info.hpp` | Polymorphic base for per-format scan bind data |
+| `src/include/op/scan/parquet_scan_info.hpp` | Parquet-specific scan bind data (concrete `scan_info`) |
+| `src/include/op/scan/duckdb_native_scan_info.hpp` | DuckDB-format-specific scan bind data (concrete `scan_info`) |
+| `src/include/op/scan/duckdb_native_metadata.hpp` | DuckDB row-group segment metadata walker |
+| `src/include/op/scan/duckdb_native_decoder.hpp` | DuckDB format GPU decode kernels |
 | `src/include/op/scan/parquet_scan_operator_data.hpp` | `parquet_scan_data` split type emitted by providers |
 | `src/include/op/scan/scan_plan.hpp` | Index-space mapping (P/C/D), output layout, partition injection |
 | `src/include/op/scan/parquet_schema_mapping.hpp` | Name-based DuckDB→parquet column resolution |
 | `src/include/scan_manager/sirius_scan_manager.hpp` | Scan manager: thread pool, providers, pinned-table registry |
 | `src/include/scan_manager/split_provider.hpp` | Abstract split producer |
 | `src/include/scan_manager/parquet_split_provider.hpp` | Parquet metadata-driven split provider |
+| `src/include/scan_manager/duckdb_native_split_provider.hpp` | DuckDB-native metadata-driven split provider |
 | `src/include/scan_manager/cached_split_provider.hpp` | Pinned-column split provider |
 | `src/include/scan_manager/split_connector.hpp` | Blocking queue between provider and operator |
+| `src/include/io/s3/s3_ioctx.hpp` | S3 ioctx: libcurl HTTP Range GET backend |
+| `src/include/io/s3/s3_request_authorizer.hpp` | Authentication abstraction (SigV4 presigned / header-signing) |
+| `src/include/io/s3/s3_io_object.hpp` | S3 io_object with bucket/key/size metadata |
 | `src/include/pin_table.hpp` / `src/pin_table.cpp` | `pin_table` / `unpin_table` table-function bindings |
 | `src/include/op/sirius_physical_iceberg_scan.hpp` | Iceberg scan operator |
 | `src/include/op/scan/iceberg_scan_task.hpp` | Iceberg scan task with delete filters |


### PR DESCRIPTION
## Summary

- **expression-executor.md**: Update the API boundary note to reflect `sirius::expression` PIMPL now holds a `sirius::ast::node` (not a raw DuckDB type). Add a new "Sirius AST Type Hierarchy" section documenting the 12-alternative `sirius::ast::node` variant, the `sirius::value` / `sirius::function_id` / `sirius::aggregate_id` payload types, and the `from_duckdb` translation boundary. Update expression type table and GPU Expression Translator section to show `sirius::ast::node` inputs.
- **scan.md**: Add `GPU_DUCKDB_NATIVE_SCAN` as a fifth scan path. Document the polymorphic `scan_info` base class with `make_provider()` and the `duckdb_native_scan_info` / `duckdb_native_split_provider` concrete implementations. Add an S3 Backend section covering `s3_ioctx`, `s3_request_authorizer`, SigV4 presigned/header-signing modes, and the end-to-end SQL→S3 read flow. Update `pin_table` to note `tier='host'` is now supported.
- **operators.md**: Add `GPU_DUCKDB_NATIVE_SCAN` operator entry in scan operators section and summary table.
- **physical-plan-generation.md**: Update TABLE_SCAN splitting description to cover polymorphic `scan_info` dispatch and the new `GPU_DUCKDB_NATIVE_SCAN` path. Update ORDER_BY from 4-phase to 3-phase sort (SORT_SAMPLE and SORT_PARTITION coalesced into a single pipeline per PR #866).
- **optimizations.md**: Update "4-Phase Sort Pipeline" entry to "3-Phase Sort Pipeline (PR #866)" with the coalescing motivation and updated code path.
- **README.md**: Add Dynamic Filters doc link; update descriptions for Scan and Expression Executor entries; advance commit marker to `46e7cb063`.

## PRs covered

AST migration (#707, #715, #716, #796, #807, #828, #847, #848, #865, #870, #873), DuckDB GPU-native scan (#736–#792), S3 datasource (#746, #758, #784, #805, #843), scan_info polymorphism (#749), sort 3-pipeline (#866), pin_table host tier (#774), dynamic filters scaffold (#664).

## Test plan

- [ ] Verify all 6 modified `.md` files render correctly (no broken links, tables, or mermaid diagrams)
- [ ] Confirm `dynamic-filters.md` link in README resolves to the existing file
- [ ] Spot-check code path references against current source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)