### PR TITLE
Improvements to pinned data caches

### DIFF
--- a/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_parquet_scan_operator.cpp
@@ -336,17 +336,7 @@ std::unique_ptr<operator_data> sirius_gpu_parquet_scan_operator::execute(
           "[sirius_gpu_parquet_scan_operator] Cached filter expression could not be lowered to a "
           "Sirius AST node; materializing the cached batch unfiltered.");
       }
-      // No filter but assembly is needed (the plan permutes / drops columns relative to
-      // data_columns). Materialize the cached view into an owning table so
-      // assemble_scan_output can release the columns by D-position and reassemble them
-      // in output_layout order.
-      std::vector<std::unique_ptr<cudf::column>> owned_cols;
-      owned_cols.reserve(cached_view.num_columns());
-      for (cudf::size_type i = 0; i < cached_view.num_columns(); ++i) {
-        owned_cols.push_back(std::make_unique<cudf::column>(
-          cached_view.column(i), stream, cudf::get_current_device_resource_ref()));
-      }
-      table = std::make_unique<cudf::table>(std::move(owned_cols));
+      table = gpu_rep.release_table(stream);
     }
 
     if (needs_assembly) {

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -386,6 +386,9 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
 
   try {
     local_state._input_data->prepare_for_processing(requested_memory_space, stream);
+    // synchronizing here to ensure the timing collected by Quent and logging for preparing the task
+    // is accurate.
+    stream.synchronize();
   } catch (const rmm::out_of_memory& oom) {
     auto peak_bytes  = allocator->get_peak_allocated_bytes(stream);
     auto input_basis = local_state.get_reservation_size_info()->input_basis;

--- a/src/scan_manager/cached_split_provider.cpp
+++ b/src/scan_manager/cached_split_provider.cpp
@@ -138,40 +138,13 @@ std::vector<std::unique_ptr<op::operator_data>> cached_split_provider::produce_s
         return std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(),
                                                        std::move(gpu_repr));
       } else if constexpr (std::is_same_v<T, host_chunk>) {
-        // Slice the host_data_representation down to only the columns the scan
-        // requests, then materialize on the executing GPU. The conversion is
-        // eager (vs returning a HOST batch and letting the scan operator
-        // convert) so downstream consumers — sirius_gpu_parquet_scan_operator,
-        // assemble_scan_output, expression executor — only ever see GPU
-        // batches and can stay tier-agnostic.
+        // HOST tier: each chunk holds the full pinned table; slice down to the
+        // columns the scan actually wants. Conversion back to GPU happens later
+        // in scan_cached_operator_data::prepare_for_processing.
         auto sliced = chunk->slice(std::span<const std::size_t>(_column_indices));
 
-        int current_device = -1;
-        auto cuda_err      = cudaGetDevice(&current_device);
-        if (cuda_err != cudaSuccess) {
-          throw std::runtime_error(
-            std::string("[cached_split_provider] cudaGetDevice failed during host->gpu "
-                        "conversion: ") +
-            cudaGetErrorString(cuda_err));
-        }
-        auto gpu_it = _gpu_memory_spaces.find(current_device);
-        if (gpu_it == _gpu_memory_spaces.end() || gpu_it->second == nullptr) {
-          throw std::runtime_error(
-            "[cached_split_provider] no GPU memory_space registered for device " +
-            std::to_string(current_device) +
-            " — pin_table(tier='host') cached scan cannot materialize chunk on this GPU");
-        }
-        auto* target_gpu_space = gpu_it->second;
-        auto stream            = target_gpu_space->acquire_stream();
-        auto& registry         = ::sirius::converter_registry::get();
-        auto gpu_repr =
-          registry.convert<cucascade::gpu_table_representation>(*sliced, target_gpu_space, stream);
-        // Sync before sliced/source goes out of scope so the H->D copies
-        // captured on the converter's stream complete before any host pages
-        // (still referenced by sliced) potentially move.
-        stream.synchronize();
         return std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(),
-                                                       std::move(gpu_repr));
+                                                       std::move(sliced));
       }
     },
     _batches[batch_idx]);


### PR DESCRIPTION
1. Added synchronization after preparing for processing to capture proper timings for logs and quent. 
2. Made changes to make host pinned data mode to gpu on prepare for processing instead of task creation
3. Made changes to avoid copying data from cached tables. 

Changes 1 and 2 do not really change performance, but make things more proper and it makes preparing data for processing properly show up in Quent
Change 3 shows a 4% performance improvement on SF100 with data pinned on host, benchmarked sequential (all tables are pinned up front)