### PR TITLE
feat(skills): unify TPC-H runner on performance_test.py + nsys-profile mode

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -111,24 +111,15 @@ pixi run python test/tpch_performance/performance_test.py \
 **Required:**
 - `--input <path>` — Parquet directory containing TPC-H tables (one `.parquet` file or sub-directory per table).
 
-**Common options:**
-- `--engine {gpu, cpu, both}` — default `both`. `gpu`/`both` loads the Sirius extension; `cpu` does not.
-- `--iterations <N>` — default `1`.
-- `--queries <spec>` — comma list with ranges, e.g. `1,3,6-10` (default: all 22).
-- `--config <yaml>` — overrides `$SIRIUS_CONFIG_FILE` for the run; copied into `<benchmark_dir>/config.yml`.
-- `--output <dir>` — root directory for benchmark output (default: `test/tpch_performance/output/`). A timestamped subdir is always created underneath.
-- `--name <NAME>` — override the auto-generated benchmark subdirectory name. When set, output goes to `<output>/<NAME>/` instead of `<output>/tpch_<ts>_<mode>_<engine>_iter<N>/`. Useful for labeling runs (e.g. `--name baseline`, `--name with-fix`). Omit for the default timestamped name.
-- `--validation` — after timing, compare the saved `<engine>/q<N>/result.txt` files for CPU and GPU. Byte-exact match first, then `abs_tol=1e-10` on float columns (strict equality on Decimal/int/string/date). Requires `--engine both`; rejected otherwise. No query re-execution (so no second Sirius extension load and no risk of GPU pool re-init OOM).
+**Most-used flags** — the complete reference lives in `test/tpch_performance/CLAUDE.md` and `performance_test.py --help`; consult it rather than re-deriving flags here:
+- `--engine {gpu,cpu,both}` (default `both`) — `gpu`/`both` load the Sirius extension; `cpu` does not.
+- `--iterations <N>` (default `1`) and `--queries 1,3,6-10` (default: all 22).
+- `--mode {grouped,sequential,isolated,nsys-profile}` (default `grouped`) — `grouped` is hot-cache; `isolated` is true cold-start (needs the sudo setup below); `nsys-profile` is GPU-only and owned by the `profile-analyzer` skill.
+- `--pin {none,gpu,host}` (default `none`) — Sirius cache pre-load tier; rejected with `--engine cpu`.
+- `--validation` — byte-compare GPU vs CPU results after timing (`abs_tol=1e-10` on floats); requires `--engine both`.
+- `--name <NAME>` — label the output subdir instead of the default `tpch_<ts>_<mode>_<engine>_iter<N>`.
 
-**Iteration ordering (`--mode`):**
-- `grouped` (default) — per query: run all N iterations back-to-back; one connection per engine. Best for hot-cache measurement.
-- `sequential` — round-robin: iter 0 runs q1, q2, …; iter 1 runs q1, q2, … Single connection per engine.
-- `isolated` — renew the DuckDB connection per (query, iteration) and `drop_os_cache` before every run. True cold-start every execution. Requires the passwordless sudo setup below.
-
-**Pin-table (Sirius cache pre-load):**
-- `--pin {none, gpu, host}` — default `none`. `gpu` or `host` selects the Sirius cache tier; `none` disables pinning. Pin is per-query in `grouped`/`isolated` mode (pinned/unpinned around each query's iteration block) and a single union-pin (all referenced columns per table) at session start in `sequential` mode.
-- `--pin gpu`/`--pin host` is rejected when combined with `--engine cpu` (pin is Sirius-only).
-- Column lists per query live in `test/tpch_performance/tpch_pin_columns.py` (`QUERY_COLUMNS`). The runner imports `emit_pin` / `emit_unpin` / `emit_pin_all` / `emit_unpin_all` from that module.
+The CLAUDE.md is the source of truth for the rest of the surface (`--config`, `--output`, `--duckdb-profiling`, `--query-timeout`), the per-query pin column lists in `tpch_pin_columns.py`, and the shell-runner-only `--data-source` / `--pinning-mode` paths.
 
 **Examples:**
 ```bash
@@ -137,27 +128,10 @@ pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
     --iterations 2 --mode grouped --engine both
 
-# Per-query GPU-tier pinning, 3 iterations, queries 1/3/6 only
-pixi run python test/tpch_performance/performance_test.py \
-    --input ~/sirius/test_datasets/tpch_parquet_sf100 \
-    --queries 1,3,6 --iterations 3 --mode grouped --engine gpu \
-    --pin gpu
-
-# Sequential round-robin with a single host-tier union-pin
-pixi run python test/tpch_performance/performance_test.py \
-    --input ~/sirius/test_datasets/tpch_parquet_sf10 \
-    --iterations 2 --mode sequential --engine gpu \
-    --pin host
-
-# Cold-start measurement (renew connection + drop OS cache per run)
-pixi run python test/tpch_performance/performance_test.py \
-    --input ~/sirius/test_datasets/tpch_parquet_sf10 \
-    --iterations 2 --mode isolated --engine gpu
-
-# Validate GPU vs CPU after timing
+# Validate GPU vs CPU after timing (queries 1/3/6)
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
-    --iterations 1 --engine both --validation
+    --engine both --iterations 1 --validation --queries 1,3,6
 ```
 
 ### Cold-Run Benchmarking (`--mode isolated`)
@@ -170,14 +144,7 @@ echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches" | su
 
 ### Output Layout
 
-`<output_dir>/tpch_<YYYYMMDD_HHMMSS>_<mode>_<engine>_iter<N>/`
-
-- `config.yml` — copy of the Sirius config used (only when `--config` is provided).
-- `metadata.json` — fields: `commit`, `branch_name`, `date`, `mode`, `iterations`, `engine`, `queries`, `pin`, `runtime_file`.
-- `csv/runtimes.csv` — long-format header `engine, query, iteration, runtime_s`.
-- `log_dir/sirius_YYYY-MM-DD.log` — combined Sirius spdlog daily-sink output (`SIRIUS_LOG_DIR` target).
-- `<engine>/q<N>/result.txt` — fetched rows for that query, one `repr(row)` per line. Overwritten on each iteration (last iter wins).
-- `sirius/q<N>/sirius.log` — per-query Sirius log split, post-processed from the combined log after the run completes (Sirius engine runs only).
+A timestamped benchmark dir `<output>/tpch_<ts>_<mode>_<engine>_iter<N>/` (or `<output>/<NAME>/`) containing `metadata.json`, `csv/runtimes.csv` (`engine,query,iteration,runtime_s`), per-query `<engine>/q<N>/result.txt`, and per-query `sirius/q<N>/sirius.log`. See `test/tpch_performance/CLAUDE.md` for the full layout.
 
 ---
 

--- a/.claude/skills/optimization-advisor/SKILL.md
+++ b/.claude/skills/optimization-advisor/SKILL.md
@@ -17,8 +17,8 @@ You are identifying optimization targets in Sirius, a GPU-accelerated SQL query 
 
 **nsys profiling adds measurable overhead to query execution times.** When the user wants to validate that an optimization actually improved performance, always recommend running queries both WITH and WITHOUT profiling:
 
-1. **Profiled run** (`nsys_report.sh` / `profile_tpch_nsys.sh`) → Provides GPU analysis data (kernels, operators, occupancy, memory) to understand *why* performance changed
-2. **Non-profiled run** (`run_tpch_parquet.sh` or `benchmark_and_validate.sh`) → Provides accurate cold/hot timings to confirm the optimization actually helped
+1. **Profiled run** (`nsys_report.sh`, which delegates to `performance_test.py --nsys-profile`) → Provides GPU analysis data (kernels, operators, occupancy, memory) to understand *why* performance changed
+2. **Non-profiled run** (`performance_test.py`) → Provides accurate cold/hot timings to confirm the optimization actually helped
 
 Never claim an optimization improved or regressed performance based solely on profiled timings. The profiled data tells you what changed internally; the non-profiled timings tell you whether it actually got faster.
 
@@ -73,18 +73,21 @@ bash test/tpch_performance/nsys_hotspots.sh reports/<generated_dir>/profiles/
 
 ### Validating Optimizations (non-profiled timing run)
 
-After identifying and implementing an optimization, run queries WITHOUT profiling to get accurate timings:
+After identifying and implementing an optimization, run queries WITHOUT profiling to get accurate timings — use the same `performance_test.py` runner the `benchmark` skill uses:
 
 ```bash
-# Sirius-only timing (accurate cold/hot without nsys overhead)
 export SIRIUS_CONFIG_FILE=<path_to_config>
-bash test/tpch_performance/run_tpch_parquet.sh sirius <scale_factor> <iterations> <query_numbers...>
 
-# Full DuckDB vs Sirius benchmark with result validation
-bash test/tpch_performance/benchmark_and_validate.sh <scale_factor> <iterations>
+# Sirius-only timing (accurate cold/hot without nsys overhead)
+pixi run python test/tpch_performance/performance_test.py \
+    --input <parquet_dir> --engine gpu --iterations <N> [--queries 1,3,6-10]
+
+# Full DuckDB vs Sirius benchmark + result validation
+pixi run python test/tpch_performance/performance_test.py \
+    --input <parquet_dir> --engine both --iterations <N> --validation
 ```
 
-Compare these non-profiled timings against a previous non-profiled baseline to confirm the optimization actually improved wall-clock performance. Then run a new profiled analysis to understand what changed internally.
+Compare the resulting `<bench>/csv/runtimes.csv` against a previous non-profiled baseline to confirm the optimization actually improved wall-clock performance. Then run a new profiled analysis (`nsys_report.sh`) to understand what changed internally.
 
 ## Analysis Sections
 
@@ -172,4 +175,4 @@ Always present findings in a structured way:
 - For each target, explain what makes it slow and what to investigate
 - Link operators to source files so the developer can navigate directly
 - When comparing across queries, highlight operators that consistently dominate
-- When presenting optimization recommendations, remind the user to validate improvements with non-profiled timing runs (`run_tpch_parquet.sh` or `benchmark_and_validate.sh`) — profiled timings include nsys overhead and do not reflect actual query performance
+- When presenting optimization recommendations, remind the user to validate improvements with a non-profiled `performance_test.py` run — profiled timings include nsys overhead and do not reflect actual query performance

--- a/.claude/skills/optimization-advisor/SKILL.md
+++ b/.claude/skills/optimization-advisor/SKILL.md
@@ -17,7 +17,7 @@ You are identifying optimization targets in Sirius, a GPU-accelerated SQL query 
 
 **nsys profiling adds measurable overhead to query execution times.** When the user wants to validate that an optimization actually improved performance, always recommend running queries both WITH and WITHOUT profiling:
 
-1. **Profiled run** (`nsys_report.sh`, which delegates to `performance_test.py --nsys-profile`) → Provides GPU analysis data (kernels, operators, occupancy, memory) to understand *why* performance changed
+1. **Profiled run** (`nsys_report.sh`, which delegates to `performance_test.py --mode nsys-profile`) → Provides GPU analysis data (kernels, operators, occupancy, memory) to understand *why* performance changed
 2. **Non-profiled run** (`performance_test.py`) → Provides accurate cold/hot timings to confirm the optimization actually helped
 
 Never claim an optimization improved or regressed performance based solely on profiled timings. The profiled data tells you what changed internally; the non-profiled timings tell you whether it actually got faster.

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -146,6 +146,7 @@ All analysis is **scoped to the query execution window** — the time span from 
 | **Memory Transfer Breakdown** | H2D/D2H/D2D with Pageable vs Pinned src/dst, bandwidth in GB/s |
 | **CUDA Runtime API Hotspots** | Slowest CUDA API calls *during query execution only* |
 | **Host Memory Allocation During Query** | Only alloc calls during runtime (init allocs excluded) |
+| **Device Memory Allocation — cudaMalloc Counts** | Total `cudaMalloc` calls split init / during-query / cleanup — during-query calls bypass the RMM pool |
 | **Init/Cleanup Overhead** | What was excluded — cudaHostAlloc, cudaFreeHost, context creation, etc. |
 | **GPU Kernel Attribution** | Maps GPU kernel time back to Sirius operators via correlation chain |
 | **Top Kernels per Operator** | Which specific kernels each operator launches |
@@ -224,6 +225,12 @@ Domain numbers are not registered by Sirius — they're discovered from each nsy
 - If `cudaHostAlloc` appears in the "During Query Execution" section, that's a performance issue — synchronous allocation during active queries stalls the pipeline.
 - `cudaStreamSynchronize` is typically the dominant cost during query execution — it represents time the CPU waits for GPU work to complete.
 
+### Device Allocation (cudaMalloc)
+- The **Device Memory Allocation — cudaMalloc Counts** section reports the total number of `cudaMalloc` calls in the trace, split into `init` / `during_query` / `cleanup` (`cudaMallocHost` is excluded — it's a host pinned alloc, covered by the host section).
+- **`during_query > 0` is the red flag.** Sirius allocates GPU memory through the RMM pool; a raw `cudaMalloc` on the hot path means something bypassed the pool, and each one forces a device-wide sync that stalls the pipeline. This is a frequent source of unintended performance degradation when a new code path allocates outside the pool.
+- On a warm run, expect `during_query = 0`. A nonzero count points at the operator that introduced it — cross-reference the **GPU Kernel Attribution** section to find whose operator window the call falls in. `nsys_compare.sh` flags any per-query increase (0 → N included), so it catches an allocation newly introduced between two runs.
+- `init` allocations (one-time pool priming at startup) are normal and excluded from the query window.
+
 ### Register Spill
 - `local_bytes_per_thread > 0` means the kernel exceeded the register file and is spilling to local memory (which actually resides in global/L2 memory — much slower).
 - This is a red flag for performance-critical kernels. Solutions: reduce register usage, simplify kernel logic, or use `__launch_bounds__` to guide the compiler.
@@ -241,6 +248,7 @@ Domain numbers are not registered by Sirius — they're discovered from each nsy
 9. **Operator attribution**: Which operators consume the most GPU time? Focus optimization here.
 10. **OOM failures**: Queries failing with `std::bad_alloc` need memory optimization.
 11. **Profiling vs actual performance**: Always validate profiled timing changes with non-profiled runs. nsys overhead can mask or exaggerate real performance differences.
+12. **cudaMalloc during query**: the cudaMalloc count's `during_query` value should be 0 on warm runs. Any raw `cudaMalloc` inside the query window bypasses the RMM pool and forces a device-wide sync — a common source of unintended degradation. Use `nsys_compare.sh` to catch a count that newly appears (0 → N) between runs.
 
 ## Output Format
 

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -32,25 +32,26 @@ This is the complete workflow: profile for GPU analysis, then run without profil
 
 **Step 1: Profiled run** (for GPU analysis data)
 ```bash
-# Profile against parquet files
+# Profile TPC-H queries via nsys_report.sh (delegates to performance_test.py --nsys-profile)
 bash test/tpch_performance/nsys_report.sh --sf <scale_factor> [query_numbers...]
-
-# Profile against a DuckDB database file (native table scan path)
-bash test/tpch_performance/nsys_report.sh --db-path <path_to.duckdb> [query_numbers...]
 ```
+
+`nsys_report.sh` orchestrates the profiling under the hood: it calls `performance_test.py --nsys-profile` (the same runner the `benchmark` skill uses) to produce one `.nsys-rep` + `.sqlite` per query, then runs `nsys_analyze.sh` to emit `report.md` and `summary.json`.
 
 **Step 2: Non-profiled timing run** (for accurate cold/hot times)
 ```bash
-# Option A: Sirius-only timing
 export SIRIUS_CONFIG_FILE=<path_to_config>
-bash test/tpch_performance/run_tpch_parquet.sh sirius <scale_factor> <iterations> <query_numbers...>
 
-# Option B: Full DuckDB vs Sirius benchmark with validation
-export SIRIUS_CONFIG_FILE=<path_to_config>
-bash test/tpch_performance/benchmark_and_validate.sh <scale_factor> <iterations>
+# Sirius-only timing
+pixi run python test/tpch_performance/performance_test.py \
+    --input <parquet_dir> --engine gpu --iterations <N> [--queries 1,3,6-10]
+
+# DuckDB vs Sirius timing + result validation in one shot
+pixi run python test/tpch_performance/performance_test.py \
+    --input <parquet_dir> --engine both --iterations <N> --validation
 ```
 
-The non-profiled run produces per-query `timings.csv` files with accurate cold/hot timings. `benchmark_and_validate.sh` also validates GPU results against CPU and produces a comparison table with speedup ratios.
+The non-profiled run produces a long-format `<bench>/csv/runtimes.csv` (`engine,query,iteration,runtime_s`) and per-query `result.txt`. `--validation` additionally byte-compares the saved Sirius vs DuckDB results (with a small `abs_tol` on floats).
 
 **When comparing across runs:**
 - Use the non-profiled timings to determine if performance actually improved or regressed
@@ -59,19 +60,9 @@ The non-profiled run produces per-query `timings.csv` files with accurate cold/h
 
 **Full options for the profiled run:**
 ```bash
-# Parquet scan profiling
 bash test/tpch_performance/nsys_report.sh \
     --sf <scale_factor> \
-    --output-dir ./reports \
-    --label <custom_name> \
-    --iterations 4 \
-    --query-timeout 120 \
-    --compare <baseline_report_dir> \
-    [query_numbers...]
-
-# DuckDB native table scan profiling
-bash test/tpch_performance/nsys_report.sh \
-    --db-path <path_to.duckdb> \
+    --parquet-dir <path_to_parquet_dir> \
     --output-dir ./reports \
     --label <custom_name> \
     --iterations 4 \
@@ -80,7 +71,7 @@ bash test/tpch_performance/nsys_report.sh \
     [query_numbers...]
 ```
 
-The `--db-path` option uses `profile_tpch_nsys_duckdb_native.sh` to profile against native DuckDB tables instead of parquet views. This exercises the `duckdb_scan_task` scan path rather than the `parquet_scan_task` path.
+`--parquet-dir` defaults to `$PROJECT_DIR/test_datasets/tpch_parquet_sf<SF>`.
 
 **Output directory structure (profiled):**
 ```
@@ -89,23 +80,21 @@ reports/<label>_<YYYYMMDD_HHMMSS>/
   summary.json     - Machine-readable per-query metrics (profiled timings — use for analysis, not perf comparison)
   metadata.json    - Hardware, git commit, config, driver version
   comparison.md    - (if --compare used) Regression/improvement analysis
-  profiles/        - All raw artifacts
+  profiles/        - Flat raw artifacts (one set per query, flattened from the
+                     per-query subdirs produced by performance_test.py --nsys-profile)
     q1.sqlite, q1.nsys-rep, q1_timings.csv, q1_result.txt, ...
-    summary.txt
+  profiles_tree/   - Original per-query layout from performance_test.py:
+    sirius/q<N>/{nsys.nsys-rep, nsys.sqlite, nsys.sql, timings.csv, log_dir/}
 ```
 
-**Output from non-profiled run:**
+**Output from non-profiled run** (`performance_test.py` benchmark layout):
 ```
-# run_tpch_parquet.sh:
-timings_sirius_sf<SF>_q<N>.csv   - Per-query cold/hot timings (accurate, no profiling overhead)
-
-# benchmark_and_validate.sh:
-runs/<timestamp>_sf<SF>_<N>iter/
-  comparison.txt   - DuckDB vs Sirius timing table with speedup ratios
-  timings.csv      - Combined long-format timings (engine, query, iteration, runtime_s)
-  validation.csv   - Per-query result match status (success/validation/error)
-  sirius/q<N>/timings.csv  - Per-query Sirius timings
-  duckdb/q<N>/timings.csv  - Per-query DuckDB timings
+<benchmark_dir>/                      # default: test/tpch_performance/output/tpch_<ts>_<mode>_<engine>_iter<N>/
+  metadata.json                       # commit, branch, date, mode, iterations, engine, queries, pin
+  csv/runtimes.csv                    # long-format: engine,query,iteration,runtime_s
+  log_dir/sirius_<YYYY-MM-DD>.log     # combined Sirius spdlog daily sink
+  <engine>/q<N>/result.txt            # fetched rows, one repr(row) per line (last iter wins)
+  sirius/q<N>/sirius.log              # per-query Sirius log split (Sirius engine only)
 ```
 
 ### Workflow B: Generate Report from Existing Profiles
@@ -134,7 +123,7 @@ Default threshold is 10%. Values beyond the threshold are flagged:
 - **FIXED**: query failed in baseline but passes now
 - **BROKEN**: query passed in baseline but fails now
 
-**Important**: The timings in `summary.json` (used by `nsys_compare.sh`) are from profiled runs and include nsys overhead. These comparisons are useful for spotting large changes but should be validated with non-profiled timing runs before concluding a real regression or improvement exists. For definitive performance comparison, compare the non-profiled `timings.csv` files from `run_tpch_parquet.sh` or `benchmark_and_validate.sh`.
+**Important**: The timings in `summary.json` (used by `nsys_compare.sh`) are from profiled runs and include nsys overhead. These comparisons are useful for spotting large changes but should be validated with non-profiled timing runs before concluding a real regression or improvement exists. For definitive performance comparison, compare the `csv/runtimes.csv` files from a non-profiled `performance_test.py` run.
 
 ## Before Running
 
@@ -143,7 +132,7 @@ Default threshold is 10%. Values beyond the threshold are flagged:
   ```bash
   export SIRIUS_CONFIG_FILE=<path_to_config>
   ```
-- All paths in `profile_tpch_nsys.sh` are configurable via env vars (`DUCKDB`, `PARQUET_DIR`, `QUERY_DIR`, `OUTPUT_DIR`, `ITERATIONS`, `QUERY_TIMEOUT`).
+- For full options on the profiled run (parquet dir override, custom output dir, label, comparison baseline), see `bash test/tpch_performance/nsys_report.sh --help`.
 
 ## Analysis Sections
 
@@ -184,6 +173,9 @@ Sirius intercepts DuckDB query plans and offloads them to GPU via cuDF:
 5. **CUDA kernels** execute on the GPU
 
 ### NVTX Domain Hierarchy
+
+Domain numbers are not registered by Sirius — they're discovered from each nsys profile at analysis time (`nsys_analyze.sh` reads `NVTX_EVENTS` and groups by `domainId`). The mapping below is typical; what shows up depends on which libraries emitted NVTX ranges in your particular run.
+
 - **Domain 0 (Sirius)**: Physical operator execution (`sirius_physical_*::execute/sink`)
 - **Domain 1 (libkvikio)**: GPU-Direct Storage I/O operations (`posix_host_read`, `task`)
 - **Domain 2 (cuFile)**: cuFile handle management
@@ -193,7 +185,7 @@ Sirius intercepts DuckDB query plans and offloads them to GPU via cuDF:
 ### Key Relationships
 - **Operator -> Kernel attribution**: Correlates via `CUPTI_ACTIVITY_KIND_RUNTIME.correlationId` (links runtime API calls to kernels; runtime call timestamps fall within NVTX operator ranges)
 - **Cold vs Hot**: First iteration is "cold" (I/O, JIT). Subsequent iterations are "hot" (cached).
-- **Multi-stream**: Sirius uses 30-40 CUDA streams for parallelism
+- **Multi-stream**: Sirius uses a dynamic CUDA stream pool sized by the `pipeline.num_threads` setting in its YAML config (constructed in `src/pipeline/gpu_pipeline_executor.cpp`). The actual count depends on your config.
 
 ### Sirius Physical Operators
 | Operator | Purpose |
@@ -221,7 +213,7 @@ Sirius intercepts DuckDB query plans and offloads them to GPU via cuDF:
   - `registers`: Kernel uses too many registers per thread. Compiler flag `--maxrregcount` could help, or algorithmic changes to reduce register pressure.
   - `shared_mem`: Shared memory per block limits active blocks. The `shmem_b` column shows the *driver-allocated* amount (aligned to SM partition granularity, often 16KB/32KB/64KB/102KB). Reducing shared memory usage or using dynamic allocation may help.
   - `warps`: Block is too large relative to SM warp capacity.
-  - `hw_limit`: Hit the max blocks per SM limit (24 on Ada Lovelace).
+  - `hw_limit`: Hit the max blocks per SM limit (e.g. 24 on Ada Lovelace). `nsys_analyze.sh` reads `maxBlocksPerSm` from the profile, so the comparison auto-adapts per GPU.
 - **Note**: Low occupancy doesn't always mean poor performance — compute-bound kernels can achieve peak throughput at low occupancy if they have high ILP (instruction-level parallelism).
 
 ### Bandwidth

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -87,15 +87,7 @@ reports/<label>_<YYYYMMDD_HHMMSS>/
     sirius/q<N>/{nsys.nsys-rep, nsys.sqlite, nsys.sql, timings.csv, log_dir/}
 ```
 
-**Output from non-profiled run** (`performance_test.py` benchmark layout):
-```
-<benchmark_dir>/                      # default: test/tpch_performance/output/tpch_<ts>_<mode>_<engine>_iter<N>/
-  metadata.json                       # commit, branch, date, mode, iterations, engine, queries, pin
-  csv/runtimes.csv                    # long-format: engine,query,iteration,runtime_s
-  log_dir/sirius_<YYYY-MM-DD>.log     # combined Sirius spdlog daily sink
-  <engine>/q<N>/result.txt            # fetched rows, one repr(row) per line (last iter wins)
-  sirius/q<N>/sirius.log              # per-query Sirius log split (Sirius engine only)
-```
+**Output from non-profiled run** (`performance_test.py` benchmark layout): a timestamped `<benchmark_dir>/` with `metadata.json`, `csv/runtimes.csv` (`engine,query,iteration,runtime_s`), per-query `<engine>/q<N>/result.txt`, and per-query `sirius/q<N>/sirius.log`. See `test/tpch_performance/CLAUDE.md` for the full layout.
 
 ### Workflow B: Generate Report from Existing Profiles
 

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -32,11 +32,11 @@ This is the complete workflow: profile for GPU analysis, then run without profil
 
 **Step 1: Profiled run** (for GPU analysis data)
 ```bash
-# Profile TPC-H queries via nsys_report.sh (delegates to performance_test.py --nsys-profile)
+# Profile TPC-H queries via nsys_report.sh (delegates to performance_test.py --mode nsys-profile)
 bash test/tpch_performance/nsys_report.sh --sf <scale_factor> [query_numbers...]
 ```
 
-`nsys_report.sh` orchestrates the profiling under the hood: it calls `performance_test.py --nsys-profile` (the same runner the `benchmark` skill uses) to produce one `.nsys-rep` + `.sqlite` per query, then runs `nsys_analyze.sh` to emit `report.md` and `summary.json`.
+`nsys_report.sh` orchestrates the profiling under the hood: it calls `performance_test.py --mode nsys-profile` (the same runner the `benchmark` skill uses) to produce one `.nsys-rep` + `.sqlite` per query, then runs `nsys_analyze.sh` to emit `report.md` and `summary.json`.
 
 **Step 2: Non-profiled timing run** (for accurate cold/hot times)
 ```bash
@@ -81,7 +81,7 @@ reports/<label>_<YYYYMMDD_HHMMSS>/
   metadata.json    - Hardware, git commit, config, driver version
   comparison.md    - (if --compare used) Regression/improvement analysis
   profiles/        - Flat raw artifacts (one set per query, flattened from the
-                     per-query subdirs produced by performance_test.py --nsys-profile)
+                     per-query subdirs produced by performance_test.py --mode nsys-profile)
     q1.sqlite, q1.nsys-rep, q1_timings.csv, q1_result.txt, ...
   profiles_tree/   - Original per-query layout from performance_test.py:
     sirius/q<N>/{nsys.nsys-rep, nsys.sqlite, nsys.sql, timings.csv, log_dir/}

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -129,17 +129,17 @@ pixi run python test/tpch_performance/performance_test.py \
 # nsys-profile mode (one .nsys-rep + .sqlite per query under <bench>/sirius/q<N>/)
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
-    --engine gpu --iterations 2 --nsys-profile --queries 1,3,6
+    --engine gpu --iterations 2 --mode nsys-profile --queries 1,3,6
 ```
 
 Key flags:
 - `--engine gpu|cpu|both` — which engine to benchmark.
 - `--iterations N` — per-query iteration count.
-- `--mode grouped|sequential|isolated` — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (fresh connection + drop_os_cache per run; requires passwordless sudo).
+- `--mode grouped|sequential|isolated|nsys-profile` — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (fresh connection + drop_os_cache per run; requires passwordless sudo), `nsys-profile` (see below).
 - `--queries 1,3,6-10` — subset selection.
 - `--pin gpu|host|none` — Sirius cache pre-load tier. `gpu` is the only tier implemented today; `host` is allowed at the flag level but `CALL pin_table` throws `NotImplementedException` at bind time (`src/sirius_extension.cpp:681-683`) — queries then fall through to disk reads.
 - `--validation` — byte-compare GPU vs CPU `result.txt` after timing (with `abs_tol=1e-10` on float columns). Requires `--engine both`.
-- `--nsys-profile` — wrap each query in `nsys profile` (subprocess-per-query under DuckDB CLI). Requires `--engine gpu`; incompatible with `--validation`, `--duckdb-profiling`, `--mode != grouped`.
+- `--mode nsys-profile` — wrap each query in `nsys profile` (one DuckDB CLI subprocess per query; the cudaProfilerApi capture range covers the cold + hot iterations). Requires `--engine gpu`; incompatible with `--validation` and `--duckdb-profiling`.
 - `--query-timeout N` — per-query subprocess timeout in nsys-profile mode (default 90s).
 - `--name <NAME>` — override the auto-timestamped benchmark subdirectory name.
 - `--config <yaml>` — override `$SIRIUS_CONFIG_FILE` for this run.
@@ -247,17 +247,17 @@ A suite of scripts for GPU performance profiling and analysis using NVIDIA Nsigh
 
 ### Profiling queries
 
-The primary entry point is `performance_test.py --nsys-profile` (subprocess-per-query, one `.nsys-rep` + `.sqlite` per query under the standard `<bench>/sirius/q<N>/` layout):
+The primary entry point is `performance_test.py --mode nsys-profile` (subprocess-per-query, one `.nsys-rep` + `.sqlite` per query under the standard `<bench>/sirius/q<N>/` layout):
 
 ```bash
 export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
-    --engine gpu --iterations 2 --nsys-profile --queries 1,3,6
+    --engine gpu --iterations 2 --mode nsys-profile --queries 1,3,6
 ```
 
-For end-to-end profiling + analysis packaging, use `nsys_report.sh` (orchestrator below) — it delegates to `performance_test.py --nsys-profile` under the hood and flattens the per-query outputs into the report's `profiles/` directory for the analyze/compare tools.
+For end-to-end profiling + analysis packaging, use `nsys_report.sh` (orchestrator below) — it delegates to `performance_test.py --mode nsys-profile` under the hood and flattens the per-query outputs into the report's `profiles/` directory for the analyze/compare tools.
 
 ### Analyzing profiles
 

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -13,7 +13,7 @@ This directory contains benchmarking, profiling, and performance testing tools f
 
 ### Using generate_tpch_data.sh (recommended)
 
-Clones and builds `sirius-db/tpchgen-rs` from source with native CPU optimizations, then generates partitioned parquet files with optimized row groups. Called automatically by `run_tpch_parquet.sh` when data is missing.
+Clones and builds `sirius-db/tpchgen-rs` from source with native CPU optimizations, then generates partitioned parquet files with optimized row groups. Run this once per scale factor before invoking `performance_test.py`.
 
 ```bash
 cd test/tpch_performance
@@ -99,26 +99,50 @@ pixi run python generate_test_data_tpchgen-rs.py <SF> <partitions> <format>
 
 All commands run from the **project root** directory.
 
-### Full DuckDB vs Sirius benchmark with validation (recommended)
+### TPC-H benchmark with performance_test.py (primary runner)
 
-`benchmark_and_validate.sh` runs all 22 TPC-H queries for both Sirius and DuckDB, compares results for correctness, and produces a timestamped run directory with comprehensive output.
+`performance_test.py` is the canonical TPC-H runner shared by the `benchmark` and `profile-analyzer` skills. It registers TPC-H tables as parquet views over a single in-memory DuckDB connection per engine, runs each query for N iterations, and produces a structured per-query benchmark directory.
 
 ```bash
 export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 
-./test/tpch_performance/benchmark_and_validate.sh <scale_factor>
-# Example:
-./test/tpch_performance/benchmark_and_validate.sh 100
+# Both engines, 2 iterations, hot-cache (grouped) mode
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf100 \
+    --engine both --iterations 2
+
+# Sirius vs DuckDB result validation, queries 1/3/6 only
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf1 \
+    --engine both --iterations 1 --validation --queries 1,3,6
+
+# Per-query GPU-tier pinning
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf100 \
+    --engine gpu --iterations 3 --pin gpu
+
+# Cold-start measurement (drops OS cache between runs; requires passwordless sudo)
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf10 \
+    --engine gpu --iterations 2 --mode isolated
+
+# nsys-profile mode (one .nsys-rep + .sqlite per query under <bench>/sirius/q<N>/)
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf1 \
+    --engine gpu --iterations 2 --nsys-profile --queries 1,3,6
 ```
 
-Each run creates a directory under `runs/<timestamp>_sf<SF>_2iter/` containing:
-- `run_info.txt` — git branch/revision, tree clean/dirty, build freshness, hostname, memory, CPUs, GPUs, filesystem read benchmark, pinning_mode setting
-- `run_info.patch` — full git diff when tree is dirty
-- `sirius_config.yaml` — copy of the Sirius config used
-- `sirius/` and `duckdb/` — per-engine logs, per-query results and timings
-- `validation.csv` — per-query match/error status
-- `comparison.txt` — cold/warm timing table with speedup ratios
-- `timings.csv` — long-format iteration runtimes (engine,query,iteration,runtime_s)
+Key flags:
+- `--engine gpu|cpu|both` — which engine to benchmark.
+- `--iterations N` — per-query iteration count.
+- `--mode grouped|sequential|isolated` — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (fresh connection + drop_os_cache per run; requires passwordless sudo).
+- `--queries 1,3,6-10` — subset selection.
+- `--pin gpu|host|none` — Sirius cache pre-load tier. `gpu` is the only tier implemented today; `host` is allowed at the flag level but `CALL pin_table` throws `NotImplementedException` at bind time (`src/sirius_extension.cpp:681-683`) — queries then fall through to disk reads.
+- `--validation` — byte-compare GPU vs CPU `result.txt` after timing (with `abs_tol=1e-10` on float columns). Requires `--engine both`.
+- `--nsys-profile` — wrap each query in `nsys profile` (subprocess-per-query under DuckDB CLI). Requires `--engine gpu`; incompatible with `--validation`, `--duckdb-profiling`, `--mode != grouped`.
+- `--query-timeout N` — per-query subprocess timeout in nsys-profile mode (default 90s).
+- `--name <NAME>` — override the auto-timestamped benchmark subdirectory name.
+- `--config <yaml>` — override `$SIRIUS_CONFIG_FILE` for this run.
 
 #### `--data-source parquet | duckdb | duckdb-native` (scan path)
 
@@ -160,10 +184,10 @@ When passed `--pinning-mode per-query`, the Sirius engine wraps each query block
 The per-query column-set is sourced from `tpch_pin_columns.py` (must be a superset of every column the query references, otherwise the scan falls through to disk). The pin path is a glob whose `FileSystem::GlobFiles` expansion must equal the file list of the corresponding `CREATE VIEW … read_parquet([…])` — otherwise `sirius_scan_manager::create_provider_for` will not match and the cache is silently bypassed.
 
 ```bash
-./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query 100
+echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches" | sudo tee /etc/sudoers.d/drop_caches
 ```
 
-The DuckDB engine ignores the flag (pinning is Sirius-only) and runs as the unchanged baseline. Pinning time is **not** measured — markers (`__TPCH_PIN_BEGIN__`, `__TPCH_UNPIN_BEGIN__`, …) keep pin/unpin `Run Time` lines outside the iteration-time parser window. In single-session mode, every pinned table is unpinned at the end of its query block before the next query's pin calls run — no carry-over even when consecutive queries reference the same table. In multi-session mode the unpin still runs before each per-query process exits, defensively releasing GPU memory back to the allocator.
+Output layout (under `--output` root, default `test/tpch_performance/output/`):
 
 When passed `--pinning-mode pinned-hot`, the Sirius engine emits one union `CALL pin_table(...)` set before the timed query stream, using the union of referenced columns across all TPC-H queries, then emits one union `CALL unpin_table(...)` set after all queries finish. This keeps the pinned cache hot across query boundaries and excludes pin/unpin time from `timings.csv`. `pinned-hot` requires the default single-session mode; it is rejected with `--multi-session` because fresh DuckDB processes cannot preserve the cross-query cache.
 
@@ -191,22 +215,21 @@ export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 # Use custom parquet directory
 ./test/tpch_performance/run_tpch_parquet.sh --parquet-dir /data/tpch sirius 100 1 3 6
 ```
-
-Environment variables:
-- `SIRIUS_CONFIG_FILE` — path to Sirius config (required for sirius engine)
-- `TIMING_CSV` — path to write per-query timing CSV (optional)
-- `OUTPUT_DIR` — directory for structured output (set by `benchmark_and_validate.sh`)
-
-### DuckDB-only baseline
-
-```bash
-./test/tpch_performance/run_tpch_parquet_duckdb.sh <scale_factor> <query_numbers...>
-./test/tpch_performance/run_tpch_parquet_duckdb.sh --parquet-dir /data/tpch 100 1 3 6
+<bench>/                              # tpch_<ts>_<mode>_<engine>_iter<N>[_nsys] or --name override
+  metadata.json                       # commit, branch, date, mode, iterations, engine, queries, pin, nsys_profile
+  csv/runtimes.csv                    # engine,query,iteration,runtime_s
+  log_dir/sirius_<YYYY-MM-DD>.log     # combined Sirius spdlog (non-profile mode)
+  <engine>/q<N>/result.txt            # fetched rows, one repr(row) per line (last iter wins)
+  sirius/q<N>/sirius.log              # per-query log split (non-profile mode)
+  sirius/q<N>/{nsys.nsys-rep,         # nsys-profile mode only
+               nsys.sqlite,
+               nsys.sql, timings.csv,
+               log_dir/}
 ```
 
 ### Thread configuration sweep
 
-Runs Sirius-only across multiple thread configurations (pipeline, scan, task_creator threads) to find optimal settings. Modifies `integration.yaml` during the run and restores baseline when done.
+`sweep_threads.sh` runs Sirius-only across multiple thread configurations (pipeline, scan, task_creator threads) to find optimal settings. Modifies `integration.yaml` during the run and restores baseline when done.
 
 ```bash
 bash test/tpch_performance/sweep_threads.sh
@@ -214,13 +237,9 @@ bash test/tpch_performance/sweep_threads.sh
 
 Results are saved to `benchmark_results_thread_sweep/` as CSV files per configuration.
 
-### Python-based performance test (in-memory database)
+### Legacy shell runners
 
-Loads data into a DuckDB database, runs all 22 queries with both CPU and GPU, verifies results match:
-
-```bash
-pixi run python test/tpch_performance/performance_test.py <scale_factor>
-```
+The shell runners (`benchmark_and_validate.sh`, `run_tpch_parquet.sh`, `run_tpch_parquet_duckdb.sh`, `run_tpch_legacy.sh`, `profile_tpch_nsys.sh`) remain in the tree for backward compatibility with CI (`.github/workflows/test.yml`) and `.ai-helper/commands.yaml`, but are superseded by `performance_test.py`. New work — and the `benchmark` / `profile-analyzer` / `optimization-advisor` skills — should use the Python runner.
 
 ## Profiling with Nsight Systems
 
@@ -228,21 +247,17 @@ A suite of scripts for GPU performance profiling and analysis using NVIDIA Nsigh
 
 ### Profiling queries
 
-`profile_tpch_nsys.sh` runs each query in its own DuckDB process wrapped by nsys, producing per-query `.nsys-rep` and `.sqlite` files.
+The primary entry point is `performance_test.py --nsys-profile` (subprocess-per-query, one `.nsys-rep` + `.sqlite` per query under the standard `<bench>/sirius/q<N>/` layout):
 
 ```bash
 export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 
-# Profile all queries at SF300 with 2M row groups
-./test/tpch_performance/profile_tpch_nsys.sh 300_rg2m
-
-# Profile specific queries with custom timeout
-QUERY_TIMEOUT=120 ./test/tpch_performance/profile_tpch_nsys.sh 100 1 3 6 9
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_parquet_sf1 \
+    --engine gpu --iterations 2 --nsys-profile --queries 1,3,6
 ```
 
-Output is saved to `nsys_profiles/sf<SF>/` with per-query `.nsys-rep`, `.sqlite`, result, and timing files.
-
-Environment variables: `DUCKDB`, `PARQUET_DIR`, `QUERY_DIR`, `OUTPUT_DIR`, `QUERY_TIMEOUT`, `ITERATIONS`.
+For end-to-end profiling + analysis packaging, use `nsys_report.sh` (orchestrator below) — it delegates to `performance_test.py --nsys-profile` under the hood and flattens the per-query outputs into the report's `profiles/` directory for the analyze/compare tools.
 
 ### Analyzing profiles
 
@@ -299,6 +314,8 @@ Output: `reports/<label>_<YYYYMMDD_HHMMSS>/` containing `report.md`, `summary.js
 
 ## Key Files
 
+### Primary runner and supporting modules
+
 | File | Purpose |
 |------|---------|
 | `benchmark_and_validate.sh` | Full DuckDB vs Sirius benchmark with validation and timestamped runs |
@@ -327,10 +344,8 @@ The Sirius config file (`test/cpp/integration/integration.yaml`) controls:
 - **Host memory**: `capacity_bytes`, `initial_number_pools`, `pool_size`, `block_size`
   - Initial allocation = `initial_number_pools * pool_size * block_size`
 - **Thread pools**: `pipeline`, `duckdb_scan`, `task_creator`, `downgrade` thread counts
-- **Scan cache**: `duckdb_scan.cache` controls cache level (default: `none`, valid: `none`, `parquet`, `table_host`, `table_gpu`)
-  - In single-session benchmarks, the config YAML controls the cache level directly
-  - In multi-session benchmarks, per-query overrides can be set in `scan_cache_levels.yaml`
-- **Cold-run benchmarking**: Use `--multi-session --drop-os-cache` to drop OS filesystem cache between queries. Requires one-time passwordless sudo setup:
+- **Scan cache**: `duckdb_scan.cache` controls cache level (default: `none`, valid: `none`, `parquet`, `table_host`, `table_gpu`). Set it once in the YAML config that `performance_test.py` loads via `SIRIUS_CONFIG_FILE`.
+- **Cold-run benchmarking**: pass `--mode isolated` to `performance_test.py` to renew the DuckDB connection and drop OS filesystem cache before every run. Requires one-time passwordless sudo setup:
   ```bash
   echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches" | sudo tee /etc/sudoers.d/drop_caches
   ```

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -137,7 +137,7 @@ Key flags:
 - `--iterations N` — per-query iteration count.
 - `--mode grouped|sequential|isolated|nsys-profile` — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (fresh connection + drop_os_cache per run; requires passwordless sudo), `nsys-profile` (see below).
 - `--queries 1,3,6-10` — subset selection.
-- `--pin gpu|host|none` — Sirius cache pre-load tier. `gpu` is the only tier implemented today; `host` is allowed at the flag level but `CALL pin_table` throws `NotImplementedException` at bind time (`src/sirius_extension.cpp:681-683`) — queries then fall through to disk reads.
+- `--pin gpu|host|none` — Sirius cache pre-load tier. Both `gpu` and `host` are supported; `host` converts the pinned table into NUMA-local pinned host memory. Any other tier throws `NotImplementedException` at bind time (`src/sirius_extension.cpp:811-813`).
 - `--validation` — byte-compare GPU vs CPU `result.txt` after timing (with `abs_tol=1e-10` on float columns). Requires `--engine both`.
 - `--mode nsys-profile` — wrap each query in `nsys profile` (one DuckDB CLI subprocess per query; the cudaProfilerApi capture range covers the cold + hot iterations). Requires `--engine gpu`; incompatible with `--validation` and `--duckdb-profiling`.
 - `--query-timeout N` — per-query subprocess timeout in nsys-profile mode (default 90s).
@@ -197,7 +197,7 @@ When passed `--pinning-mode pinned-hot`, the Sirius engine emits one union `CALL
 
 To verify a query actually hit the cache, grep `runs/.../sirius/q<N>/sirius.log` for `using cached_split_provider`; the matching-fallback log line is `not all the columns are pinned for this query`.
 
-Tier override: the helper defaults to `tier='gpu'` — the only tier currently implemented in `src/sirius_extension.cpp`. **`tier='host'` is not supported right now and will be added later**: setting `SIRIUS_PIN_TIER=host` today makes the emitted `CALL pin_table` throw `NotImplementedException` at bind time (`src/sirius_extension.cpp:681-683`), and queries fall through to disk reads. Once host-tier support lands, flip via `SIRIUS_PIN_TIER=host`.
+Tier override: the helper defaults to `tier='gpu'`. Both `gpu` and `host` are supported in `src/sirius_extension.cpp`; set `SIRIUS_PIN_TIER=host` to pin into NUMA-local pinned host memory instead. Any other tier throws `NotImplementedException` at bind time (`src/sirius_extension.cpp:811-813`).
 
 ### Unified query runner
 

--- a/test/tpch_performance/nsys_analyze.sh
+++ b/test/tpch_performance/nsys_analyze.sh
@@ -321,6 +321,41 @@ GROUP BY s.value
 ORDER BY total_s DESC;
 
 .print
+.print #### Device Memory Allocation — cudaMalloc Counts
+.print (Raw cudaMalloc on the query hot path bypasses the RMM pool and forces a device
+.print  sync — a common source of unintended perf degradation. Expect 0 in the query
+.print  window on warm iterations; init-phase pool priming is normal. cudaMallocHost is
+.print  excluded here; host pinned allocs are in the section above.)
+SELECT
+    COUNT(*) AS cudamalloc_total,
+    COALESCE(SUM(CASE WHEN r.start >= (SELECT qstart FROM query_window)
+                       AND r.start <  (SELECT qend FROM query_window)
+                      THEN 1 ELSE 0 END), 0) AS during_query,
+    COALESCE(SUM(CASE WHEN r.start <  (SELECT qstart FROM query_window)
+                      THEN 1 ELSE 0 END), 0) AS init,
+    COALESCE(SUM(CASE WHEN r.start >= (SELECT qend FROM query_window)
+                      THEN 1 ELSE 0 END), 0) AS cleanup
+FROM CUPTI_ACTIVITY_KIND_RUNTIME r
+JOIN StringIds s ON r.nameId = s.id
+WHERE s.value LIKE 'cudaMalloc%' AND s.value NOT LIKE 'cudaMallocHost%';
+
+.print
+.print Breakdown by phase and function (during_query rows first):
+SELECT
+    CASE WHEN r.start <  (SELECT qstart FROM query_window) THEN 'init'
+         WHEN r.start >= (SELECT qend FROM query_window) THEN 'cleanup'
+         ELSE 'during_query' END AS phase,
+    s.value AS function,
+    COUNT(*) AS calls,
+    ROUND(SUM(r.end - r.start) / 1e6, 3) AS total_ms,
+    ROUND(MAX(r.end - r.start) / 1e6, 3) AS max_ms
+FROM CUPTI_ACTIVITY_KIND_RUNTIME r
+JOIN StringIds s ON r.nameId = s.id
+WHERE s.value LIKE 'cudaMalloc%' AND s.value NOT LIKE 'cudaMallocHost%'
+GROUP BY phase, s.value
+ORDER BY (phase = 'during_query') DESC, calls DESC;
+
+.print
 .print #### Init/Cleanup Overhead (excluded from query analysis)
 .print (Top CUDA API calls that occur before first operator or after last operator)
 SELECT

--- a/test/tpch_performance/nsys_compare.sh
+++ b/test/tpch_performance/nsys_compare.sh
@@ -137,6 +137,7 @@ jq -r --slurpfile curr "$CURRENT_JSON" --argjson threshold "$THRESHOLD" '
         [
             ["Passed Queries", $ba.passed, $ca.passed],
             ["Failed Queries", $ba.failed, $ca.failed],
+            ["cudaMalloc during query (count)", $ba.total_cuda_malloc_during_query, $ca.total_cuda_malloc_during_query],
             ["Total Hot Time (s)", $ba.total_hot_s, $ca.total_hot_s],
             ["Avg Hot Time (s)", $ba.avg_hot_s, $ca.avg_hot_s],
             ["Total GPU Time (s)", $ba.total_gpu_time_s, $ca.total_gpu_time_s],
@@ -147,12 +148,18 @@ jq -r --slurpfile curr "$CURRENT_JSON" --argjson threshold "$THRESHOLD" '
             ["Total Sync Time (s)", $ba.total_sync_time_s, $ca.total_sync_time_s]
         ][] |
         .[0] as $name | .[1] as $bv | .[2] as $cv |
-        if $bv != null and $cv != null and $bv != 0 then
+        # Count metrics compare directly: any increase is a REGRESSION, even 0 -> N.
+        (["Failed Queries", "cudaMalloc during query (count)"] | index($name)) as $is_count |
+        if $is_count != null then
+            (if $bv == null or $cv == null then "~"
+             elif $cv > $bv then "REGRESSION"
+             elif $cv < $bv then "IMPROVED"
+             else "~" end) as $status |
+            "| " + $name + " | " + ($bv // "-" | tostring) + " | " + ($cv // "-" | tostring) + " | " + ((($cv // 0) - ($bv // 0)) | tostring) + " | - | " + $status + " |"
+        elif $bv != null and $cv != null and $bv != 0 then
             (($cv - $bv) * 1000 | round / 1000) as $delta |
             (($cv - $bv) * 100 / $bv * 10 | round / 10) as $pct |
-            (if $name == "Failed Queries" then
-                (if $cv < $bv then "IMPROVED" elif $cv > $bv then "REGRESSION" else "~" end)
-             elif $pct > $threshold then "REGRESSION"
+            (if $pct > $threshold then "REGRESSION"
              elif $pct < (0 - $threshold) then "IMPROVED"
              else "~" end) as $status |
             "| " + $name + " | " + ($bv | tostring) + " | " + ($cv | tostring) + " | " + ($delta | tostring) + " | " + ($pct | tostring) + "% | " + $status + " |"
@@ -188,6 +195,33 @@ jq -r --slurpfile curr "$CURRENT_JSON" --argjson threshold "$THRESHOLD" '
         else
             "| " + $q + " | " + ($bg // "-" | tostring) + " | " + ($cg // "-" | tostring) + " | - | - |"
         end
+    )
+' "$BASELINE_JSON"
+
+echo ""
+
+# --- Per-query cudaMalloc on the hot path ---
+echo "## Per-Query cudaMalloc (during query execution)"
+echo ""
+echo "(Raw cudaMalloc inside the operator window bypasses the RMM pool. Any increase — especially 0 → N — flags an allocation newly introduced on the hot path.)"
+echo ""
+
+jq -r --slurpfile curr "$CURRENT_JSON" '
+    ([.queries[] | select(.status == "OK") | {(.query): (.memory.cuda_malloc_during_query // 0)}] | add // {}) as $base_cm |
+    ([$curr[0].queries[] | select(.status == "OK") | {(.query): (.memory.cuda_malloc_during_query // 0)}] | add // {}) as $curr_cm |
+
+    ([$base_cm, $curr_cm | keys[]] | unique | sort) as $queries |
+
+    "| Query | Base | Current | Delta | Status |",
+    "|-------|------|---------|-------|--------|",
+
+    ($queries[] |
+        . as $q |
+        ($base_cm[$q] // 0) as $bc |
+        ($curr_cm[$q] // 0) as $cc |
+        ($cc - $bc) as $delta |
+        (if $cc > $bc then "REGRESSION" elif $cc < $bc then "IMPROVED" else "~" end) as $status |
+        "| " + $q + " | " + ($bc | tostring) + " | " + ($cc | tostring) + " | " + ($delta | tostring) + " | " + $status + " |"
     )
 ' "$BASELINE_JSON"
 

--- a/test/tpch_performance/nsys_report.sh
+++ b/test/tpch_performance/nsys_report.sh
@@ -332,12 +332,19 @@ SELECT
     COALESCE((SELECT ROUND(SUM(end-start)/1e9, 4) FROM NVTX_EVENTS WHERE domainId=0 AND eventType=59 AND end>start), 0),
     COALESCE((SELECT ROUND(SUM(end-start)/1e9, 4) FROM CUPTI_ACTIVITY_KIND_SYNCHRONIZATION), 0),
     COALESCE((SELECT ROUND(SUM(bytes)/1048576.0, 2) FROM CUPTI_ACTIVITY_KIND_MEMSET), 0),
-    COALESCE((SELECT COUNT(DISTINCT deviceId) FROM CUPTI_ACTIVITY_KIND_KERNEL), 0)
+    COALESCE((SELECT COUNT(DISTINCT deviceId) FROM CUPTI_ACTIVITY_KIND_KERNEL), 0),
+    COALESCE((SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME r JOIN StringIds s ON r.nameId = s.id
+              WHERE s.value LIKE 'cudaMalloc%' AND s.value NOT LIKE 'cudaMallocHost%'), 0),
+    COALESCE((SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME r JOIN StringIds s ON r.nameId = s.id
+              WHERE s.value LIKE 'cudaMalloc%' AND s.value NOT LIKE 'cudaMallocHost%'
+                AND r.start >= (SELECT MIN(start) FROM NVTX_EVENTS WHERE domainId = 0 AND eventType = 59 AND end > start)
+                AND r.start <  (SELECT MAX(end)   FROM NVTX_EVENTS WHERE domainId = 0 AND eventType = 59 AND end > start)), 0)
 FROM ANALYSIS_DETAILS d;
 " 2>/dev/null)
 
     IFS='|' read -r trace_s kernels gpu_s streams h2d_gb d2h_gb d2d_gb \
-                    memcpy_s ops ops_s sync_s memset_mb gpus_used <<< "$metrics"
+                    memcpy_s ops ops_s sync_s memset_mb gpus_used \
+                    cuda_malloc_total cuda_malloc_during_query <<< "$metrics"
 
     # Parse timing CSV for cold/hot
     local timing_file="${db%.sqlite}_timings.csv"
@@ -376,6 +383,8 @@ FROM ANALYSIS_DETAILS d;
         --argjson ops "${ops:-0}" \
         --argjson ops_time "${ops_s:-0}" \
         --argjson sync_time "${sync_s:-0}" \
+        --argjson cuda_malloc_total "${cuda_malloc_total:-0}" \
+        --argjson cuda_malloc_during_query "${cuda_malloc_during_query:-0}" \
         --argjson cold "$cold_s" \
         --argjson hot "$hot_s" \
         --argjson all_hot "$all_hot_json" \
@@ -383,7 +392,7 @@ FROM ANALYSIS_DETAILS d;
             query: $q, status: "OK",
             timing: { cold_s: $cold, hot_s: $hot, all_hot_s: $all_hot, trace_duration_s: $trace },
             gpu: { total_kernels: $kernels, gpu_time_s: $gpu, streams_used: $streams, gpus_used: $gpus },
-            memory: { h2d_gb: $h2d, d2h_gb: $d2h, d2d_gb: $d2d, memcpy_time_s: $memcpy_time, memset_mb: $memset_mb },
+            memory: { h2d_gb: $h2d, d2h_gb: $d2h, d2d_gb: $d2d, memcpy_time_s: $memcpy_time, memset_mb: $memset_mb, cuda_malloc_total: $cuda_malloc_total, cuda_malloc_during_query: $cuda_malloc_during_query },
             operators: { count: $ops, total_time_s: $ops_time },
             sync_time_s: $sync_time
         }'
@@ -417,6 +426,7 @@ jq --slurpfile meta "$REPORT_DIR/metadata.json" \
            total_d2d_gb: ([.[] | select(.status == "OK") | .memory.d2d_gb] | add // 0),
            total_memcpy_time_s: ([.[] | select(.status == "OK") | .memory.memcpy_time_s] | add // 0),
            total_sync_time_s: ([.[] | select(.status == "OK") | .sync_time_s] | add // 0),
+           total_cuda_malloc_during_query: ([.[] | select(.status == "OK") | .memory.cuda_malloc_during_query] | add // 0),
            avg_hot_s: ([.[] | select(.status == "OK" and .timing.hot_s != null) | .timing.hot_s] | if length > 0 then add/length else null end),
            total_hot_s: ([.[] | select(.status == "OK" and .timing.hot_s != null) | .timing.hot_s] | add),
            total_cold_s: ([.[] | select(.status == "OK" and .timing.cold_s != null) | .timing.cold_s] | add)

--- a/test/tpch_performance/nsys_report.sh
+++ b/test/tpch_performance/nsys_report.sh
@@ -167,7 +167,7 @@ else
 
     PY_CMD=(
         pixi run python "$PROJECT_DIR/test/tpch_performance/performance_test.py"
-        --nsys-profile
+        --mode nsys-profile
         --input "$PARQUET_DIR"
         --engine gpu
         --iterations "$ITERATIONS"

--- a/test/tpch_performance/nsys_report.sh
+++ b/test/tpch_performance/nsys_report.sh
@@ -35,6 +35,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 OUTPUT_BASE="${OUTPUT_BASE:-$PROJECT_DIR/reports}"
 LABEL=""
 SF=""
+PARQUET_DIR=""
 PROFILE_DIR=""
 COMPARE_DIR=""
 ITERATIONS="${ITERATIONS:-2}"
@@ -50,34 +51,42 @@ usage() {
     echo ""
     echo "Options:"
     echo "  --sf SF              Scale factor for profiling (e.g., 300_rg2m, 100)"
+    echo "  --parquet-dir DIR    Override parquet directory (default: \$PROJECT_DIR/test_datasets/tpch_parquet_sf<SF>)"
     echo "  --profile-dir DIR    Use existing profiles (skip profiling)"
     echo "  --output-dir DIR     Base directory for reports (default: ./reports)"
     echo "  --label LABEL        Custom label (default: sirius_sf<SF>)"
     echo "  --compare DIR        Compare against a previous report directory"
     echo "  --iterations N       Iterations per query (default: 2)"
     echo "  --query-timeout N    Per-query timeout in seconds (default: 90)"
-    echo "  --cache-level LEVEL  Scan cache level: none, table_gpu, table_host, parquet (default: none)"
     echo "  -h, --help           Show this help"
     echo ""
     echo "Either --sf or --profile-dir is required."
+    echo ""
+    echo "To set scan_cache_level, configure it in your Sirius YAML config"
+    echo "(pointed at by \$SIRIUS_CONFIG_FILE)."
     exit 1
 }
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --sf)           SF="$2"; shift 2 ;;
+        --parquet-dir)  PARQUET_DIR="$2"; shift 2 ;;
         --profile-dir)  PROFILE_DIR="$2"; shift 2 ;;
         --output-dir)   OUTPUT_BASE="$2"; shift 2 ;;
         --label)        LABEL="$2"; shift 2 ;;
         --compare)      COMPARE_DIR="$2"; shift 2 ;;
         --iterations)   ITERATIONS="$2"; shift 2 ;;
         --query-timeout) QUERY_TIMEOUT="$2"; shift 2 ;;
-        --cache-level)  SCAN_CACHE_LEVEL="$2"; shift 2 ;;
         -h|--help)      usage ;;
         -*)             echo "ERROR: Unknown option: $1" >&2; usage ;;
         *)              QUERIES+=("$1"); shift ;;
     esac
 done
+
+# Default parquet dir based on SF (when neither --parquet-dir nor --profile-dir is set)
+if [ -z "$PARQUET_DIR" ] && [ -n "$SF" ]; then
+    PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+fi
 
 if [ -z "$SF" ] && [ -z "$PROFILE_DIR" ]; then
     echo "ERROR: Either --sf or --profile-dir is required" >&2
@@ -143,19 +152,56 @@ if [ -n "$PROFILE_DIR" ]; then
     echo "  Copied $(ls "$REPORT_DIR/profiles/"*.sqlite 2>/dev/null | wc -l) SQLite files"
     echo ""
 else
-    echo "[Phase 2] Running nsys profiling (sf=$SF, iterations=$ITERATIONS)..."
-    export OUTPUT_DIR="$REPORT_DIR/profiles"
-    export ITERATIONS
-    export QUERY_TIMEOUT
-    export SCAN_CACHE_LEVEL="${SCAN_CACHE_LEVEL:-}"
-    if bash "$PROJECT_DIR/test/tpch_performance/profile_tpch_nsys.sh" "$SF" "${QUERIES[@]+"${QUERIES[@]}"}"; then
-        echo ""
+    echo "[Phase 2] Running nsys profiling via performance_test.py"
+    echo "  sf=$SF, iterations=$ITERATIONS, parquet=$PARQUET_DIR"
+    if [ ! -d "$PARQUET_DIR" ]; then
+        echo "ERROR: Parquet directory not found: $PARQUET_DIR" >&2
+        echo "  Pass --parquet-dir or generate data with generate_tpch_data.sh" >&2
+        exit 1
+    fi
+
+    QUERIES_CSV=""
+    if [ ${#QUERIES[@]} -gt 0 ]; then
+        QUERIES_CSV=$(IFS=,; echo "${QUERIES[*]}")
+    fi
+
+    PY_CMD=(
+        pixi run python "$PROJECT_DIR/test/tpch_performance/performance_test.py"
+        --nsys-profile
+        --input "$PARQUET_DIR"
+        --engine gpu
+        --iterations "$ITERATIONS"
+        --output "$REPORT_DIR"
+        --name profiles_tree
+        --query-timeout "$QUERY_TIMEOUT"
+    )
+    if [ -n "$QUERIES_CSV" ]; then
+        PY_CMD+=(--queries "$QUERIES_CSV")
+    fi
+
+    if "${PY_CMD[@]}"; then
         echo "  Profiling complete."
     else
-        echo ""
         echo "  WARNING: Profiling finished with errors (some queries may have failed)"
     fi
     echo ""
+
+    # Flatten <REPORT_DIR>/profiles_tree/sirius/q<N>/ → <REPORT_DIR>/profiles/q<N>.<ext>
+    # so nsys_analyze.sh and Phase 4 metric extraction (which read flat
+    # profiles/q<N>.sqlite + q<N>_timings.csv) continue to work unchanged.
+    PROFILES_TREE="$REPORT_DIR/profiles_tree/sirius"
+    if [ -d "$PROFILES_TREE" ]; then
+        echo "[Phase 2] Flattening per-query outputs into $REPORT_DIR/profiles/"
+        for qdir in "$PROFILES_TREE"/q*/; do
+            [ -d "$qdir" ] || continue
+            q=$(basename "$qdir")  # q<N>
+            [ -f "$qdir/nsys.sqlite" ]     && cp "$qdir/nsys.sqlite"     "$REPORT_DIR/profiles/${q}.sqlite"
+            [ -f "$qdir/nsys.nsys-rep" ]   && cp "$qdir/nsys.nsys-rep"   "$REPORT_DIR/profiles/${q}.nsys-rep"
+            [ -f "$qdir/timings.csv" ]     && cp "$qdir/timings.csv"     "$REPORT_DIR/profiles/${q}_timings.csv"
+            [ -f "$qdir/nsys_stdout.txt" ] && cp "$qdir/nsys_stdout.txt" "$REPORT_DIR/profiles/${q}_result.txt"
+        done
+        echo ""
+    fi
 fi
 
 # Verify we have SQLite files

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -65,6 +65,8 @@ EXTENSION_PATH = os.path.join(
     "build/release/extension/sirius/sirius.duckdb_extension",
 )
 
+DUCKDB_BIN = os.path.join(REPO_ROOT, "build/release/duckdb")
+
 
 def _git_capture(args):
     try:
@@ -95,6 +97,7 @@ def setup_benchmark_dir(
     config_path,
     pin,
     name=None,
+    nsys_profile=False,
 ):
     """Create the benchmark output directory and return its paths.
 
@@ -115,7 +118,8 @@ def setup_benchmark_dir(
         benchmark_name = name
     else:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        benchmark_name = f"tpch_{ts}_{mode}_{engine}_iter{iterations}"
+        suffix = "_nsys" if nsys_profile else ""
+        benchmark_name = f"tpch_{ts}_{mode}_{engine}_iter{iterations}{suffix}"
     benchmark_dir = os.path.join(output_root, benchmark_name)
     csv_dir = os.path.join(benchmark_dir, "csv")
     log_dir = os.path.join(benchmark_dir, "log_dir")
@@ -137,6 +141,7 @@ def setup_benchmark_dir(
         "engine": engine,
         "queries": [f"q{q}" for q in queries],
         "pin": pin,
+        "nsys_profile": nsys_profile,
         "runtime_file": os.path.relpath(runtime_csv, benchmark_dir),
     }
     with open(os.path.join(benchmark_dir, "metadata.json"), "w") as f:
@@ -240,21 +245,36 @@ def _resolve_parquet_files(parquet_dir, table):
     return candidates
 
 
-def open_connection(parquet_dir, gpu_execution=False):
-    """Open an in-memory DuckDB, register TPC-H parquet views, optionally LOAD Sirius."""
-    log(f"Opening DuckDB connection over parquet dir {parquet_dir}")
-    con = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
+def _build_views_sql(parquet_dir):
+    """Return CREATE OR REPLACE VIEW SQL for the 8 TPC-H tables.
+
+    Each statement is terminated with `;\n`. Raises FileNotFoundError if any
+    table has no parquet files in `parquet_dir`.
+    """
+    parts = []
     for table in TPCH_TABLES:
         files = _resolve_parquet_files(parquet_dir, table)
         if not files:
             raise FileNotFoundError(
                 f"No parquet files found for table '{table}' in {parquet_dir}"
             )
-        log(f"  Registering view '{table}' over {len(files)} file(s)")
         file_list = ",".join(f"'{f}'" for f in files)
-        con.execute(
-            f"CREATE OR REPLACE VIEW {table} AS SELECT * FROM read_parquet([{file_list}])"
+        parts.append(
+            f"CREATE OR REPLACE VIEW {table} AS SELECT * FROM read_parquet([{file_list}]);"
         )
+    return "\n".join(parts) + "\n"
+
+
+def open_connection(parquet_dir, gpu_execution=False):
+    """Open an in-memory DuckDB, register TPC-H parquet views, optionally LOAD Sirius."""
+    log(f"Opening DuckDB connection over parquet dir {parquet_dir}")
+    con = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
+    log("Registering TPC-H parquet views")
+    for stmt in _build_views_sql(parquet_dir).split(";"):
+        stmt = stmt.strip()
+        if not stmt:
+            continue
+        con.execute(stmt)
     log("All TPC-H views registered")
     if gpu_execution:
         log(f"Loading Sirius extension from {EXTENSION_PATH}")
@@ -466,6 +486,204 @@ RUNNERS = {
     "sequential": run_sequential,
     "isolated": run_isolated,
 }
+
+
+def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
+    """Write the DuckDB SQL script for one nsys-profiled query.
+
+    Mirrors profile_tpch_nsys.sh:170-208 so that the resulting timings.csv
+    has rows (views, iter_1, iter_2, ...) and the cudaProfilerApi capture
+    range brackets iterations 2..N.
+    """
+    sql_path = os.path.join(qdir, "nsys.sql")
+    timing_path = os.path.join(qdir, "timings.csv")
+
+    parts = [
+        f"LOAD '{EXTENSION_PATH}';",
+        "SET gpu_execution = true;",
+        "CREATE TEMP TABLE _timings (seq INTEGER, step VARCHAR, ts TIMESTAMP);",
+        "INSERT INTO _timings VALUES (0, 'start', current_timestamp);",
+        _build_views_sql(parquet_dir).rstrip("\n"),
+        "INSERT INTO _timings VALUES (1, 'views', current_timestamp);",
+    ]
+
+    if pin != "none":
+        parts.append(emit_pin(qnum, parquet_dir))
+
+    query_sql = QUERIES[f"q{qnum}"].rstrip().rstrip(";") + ";"
+    for i in range(1, iterations + 1):
+        if i == 2:
+            parts.append("CALL profiler_start();")
+        parts.append(query_sql)
+        parts.append(
+            f"INSERT INTO _timings VALUES ({i + 1}, 'iter_{i}', current_timestamp);"
+        )
+
+    if iterations >= 2:
+        parts.append("CALL profiler_stop();")
+
+    if pin != "none":
+        parts.append(emit_unpin(qnum))
+
+    parts.append(
+        f"""COPY (
+    SELECT step, runtime_s FROM (
+        SELECT
+            seq,
+            step,
+            extract(epoch FROM (ts - LAG(ts) OVER (ORDER BY seq))) AS runtime_s
+        FROM _timings
+    )
+    WHERE seq > 0
+    ORDER BY seq
+) TO '{timing_path}' (FORMAT CSV, HEADER);"""
+    )
+
+    with open(sql_path, "w") as f:
+        f.write("\n".join(parts))
+        f.write("\n")
+    return sql_path
+
+
+def run_nsys_profile(
+    queries,
+    parquet_dir,
+    iterations,
+    writer,
+    *,
+    benchmark_dir,
+    pin,
+    config_path,
+    query_timeout,
+):
+    """Profile each query with NVIDIA Nsight Systems: one DuckDB subprocess per query.
+
+    Per query, builds a temp SQL file that registers views, optionally pins
+    tables, runs N iterations (cold + N-1 hot) bracketed by profiler_start /
+    profiler_stop for nsys's cudaProfilerApi capture range, and emits a
+    timings.csv via DuckDB's COPY. The subprocess is wrapped by
+    `nsys profile --capture-range=cudaProfilerApi`, producing one
+    .nsys-rep + .sqlite per query under <bench>/sirius/q<N>/.
+
+    Iteration runtimes from timings.csv are written into csv/runtimes.csv with
+    engine="sirius" and iteration=0..N-1.
+    """
+    if not os.path.isfile(DUCKDB_BIN):
+        raise SystemExit(
+            f"DuckDB binary not found at {DUCKDB_BIN}. "
+            "Build with `pixi run -e clang make release` first."
+        )
+    if not shutil.which("nsys"):
+        raise SystemExit("nsys (NVIDIA Nsight Systems) not found in PATH.")
+
+    log(
+        "Mode 'nsys-profile': one nsys-wrapped DuckDB subprocess per query "
+        f"(iterations={iterations}, query_timeout={query_timeout}s)"
+    )
+    pin_enabled = pin != "none"
+
+    for qnum in queries:
+        qdir = _query_dir(benchmark_dir, "sirius", qnum)
+        sub_log_dir = os.path.join(qdir, "log_dir")
+        os.makedirs(sub_log_dir, exist_ok=True)
+
+        sql_path = _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir)
+        nsys_output = os.path.join(qdir, "nsys")
+        stdout_path = os.path.join(qdir, "nsys_stdout.txt")
+
+        nsys_cmd = [
+            "nsys",
+            "profile",
+            "--trace=cuda,nvtx",
+            "--sample=none",
+            "--cudabacktrace=none",
+        ]
+        if iterations >= 2:
+            nsys_cmd.extend(
+                ["--capture-range=cudaProfilerApi", "--capture-range-end=stop"]
+            )
+        nsys_cmd.extend(
+            [
+                "--output",
+                nsys_output,
+                "--force-overwrite=true",
+                "--stats=false",
+                "--export=sqlite",
+                DUCKDB_BIN,
+                "-f",
+                sql_path,
+            ]
+        )
+
+        env = os.environ.copy()
+        if config_path:
+            env["SIRIUS_CONFIG_FILE"] = config_path
+        if pin_enabled:
+            env["SIRIUS_PIN_TIER"] = pin
+        env["SIRIUS_LOG_DIR"] = sub_log_dir
+
+        log(f"--- q{qnum} (nsys, iterations={iterations}) ---")
+        log(f"  output: {nsys_output}.nsys-rep / .sqlite")
+        start = time.perf_counter()
+        try:
+            with open(stdout_path, "w") as out:
+                proc = subprocess.run(
+                    nsys_cmd,
+                    timeout=query_timeout + 10,
+                    stdout=out,
+                    stderr=subprocess.STDOUT,
+                    env=env,
+                )
+        except subprocess.TimeoutExpired:
+            wall = time.perf_counter() - start
+            log(
+                f"  q{qnum} TIMED OUT after {wall:.1f}s "
+                f"(timeout={query_timeout + 10}s)"
+            )
+            for it in range(iterations):
+                _record(writer, "sirius", qnum, it, float("nan"))
+            continue
+        wall = time.perf_counter() - start
+        log(f"  q{qnum} subprocess returned in {wall:.2f}s (exit={proc.returncode})")
+
+        if proc.returncode != 0:
+            log(f"  q{qnum} FAILED — last lines of {stdout_path}:")
+            try:
+                with open(stdout_path) as f:
+                    tail = f.readlines()[-5:]
+                for line in tail:
+                    log(f"    > {line.rstrip()}")
+            except OSError:
+                pass
+            for it in range(iterations):
+                _record(writer, "sirius", qnum, it, float("nan"))
+            continue
+
+        # Parse the DuckDB-emitted timings.csv (rows: views, iter_1, iter_2, ...).
+        # The 'views' row is skipped; subsequent rows map to iter=0,1,...
+        timing_path = os.path.join(qdir, "timings.csv")
+        if not os.path.isfile(timing_path):
+            log(f"  q{qnum} WARNING: no timings.csv produced; recording NaN")
+            for it in range(iterations):
+                _record(writer, "sirius", qnum, it, float("nan"))
+            continue
+        with open(timing_path) as f:
+            reader = csv.reader(f)
+            next(reader, None)  # header: step,runtime_s
+            next(reader, None)  # 'views' row
+            it = 0
+            for row in reader:
+                if len(row) < 2:
+                    continue
+                try:
+                    rt = float(row[1])
+                except ValueError:
+                    rt = float("nan")
+                _record(writer, "sirius", qnum, it, rt)
+                it += 1
+            while it < iterations:
+                _record(writer, "sirius", qnum, it, float("nan"))
+                it += 1
 
 
 def split_sirius_log(log_dir, benchmark_dir, queries, iterations, mode):
@@ -688,6 +906,27 @@ def parse_args():
             "inflated vs an unprofiled baseline."
         ),
     )
+    p.add_argument(
+        "--nsys-profile",
+        action="store_true",
+        help=(
+            "Profile each query with NVIDIA Nsight Systems (nsys). Spawns one DuckDB "
+            "CLI subprocess per query wrapped in `nsys profile`; produces "
+            "<benchmark_dir>/sirius/q<N>/nsys.{nsys-rep,sqlite,sql} and a per-query "
+            "timings.csv. Requires --engine gpu and the DuckDB CLI at "
+            "build/release/duckdb plus `nsys` on PATH. Incompatible with "
+            "--validation, --duckdb-profiling, --mode sequential, --mode isolated."
+        ),
+    )
+    p.add_argument(
+        "--query-timeout",
+        type=int,
+        default=90,
+        help=(
+            "Per-query subprocess timeout in seconds for --nsys-profile mode "
+            "(default: 90). Ignored without --nsys-profile."
+        ),
+    )
     return p.parse_args()
 
 
@@ -712,6 +951,19 @@ def main():
             "--validation requires --engine both (needs both result sets to compare)"
         )
 
+    if args.nsys_profile:
+        if args.engine != "gpu":
+            raise SystemExit("--nsys-profile requires --engine gpu")
+        if args.validation:
+            raise SystemExit("--nsys-profile is incompatible with --validation")
+        if args.duckdb_profiling:
+            raise SystemExit("--nsys-profile is incompatible with --duckdb-profiling")
+        if args.mode != "grouped":
+            raise SystemExit(
+                "--nsys-profile only supports --mode grouped "
+                "(implicit per-query subprocess)"
+            )
+
     config_path = (args.config or "").strip()
     if config_path:
         os.environ["SIRIUS_CONFIG_FILE"] = config_path
@@ -733,6 +985,7 @@ def main():
         config_path,
         args.pin,
         name=args.name,
+        nsys_profile=args.nsys_profile,
     )
     os.environ["SIRIUS_LOG_DIR"] = log_dir
 
@@ -744,6 +997,7 @@ def main():
     log(f"Config:        {config_path or '(default)'}")
     log(f"Pin:           {args.pin}")
     log(f"DuckDB profiling: {args.duckdb_profiling}")
+    log(f"nsys-profile:  {args.nsys_profile}")
     log(f"Benchmark dir: {benchmark_dir}")
     log(f"Runtime CSV:   {runtime_csv}")
     log(f"Log dir:       {log_dir}")
@@ -752,21 +1006,37 @@ def main():
         writer = csv.writer(f)
         writer.writerow(["engine", "query", "iteration", "runtime_s"])
         f.flush()
-        RUNNERS[args.mode](
-            source,
-            queries,
-            engine_modes,
-            args.iterations,
-            writer,
-            benchmark_dir=benchmark_dir,
-            parquet_dir=parquet_dir,
-            pin=args.pin,
-            duckdb_profiling=args.duckdb_profiling,
-        )
+        if args.nsys_profile:
+            run_nsys_profile(
+                queries,
+                parquet_dir,
+                args.iterations,
+                writer,
+                benchmark_dir=benchmark_dir,
+                pin=args.pin,
+                config_path=config_path,
+                query_timeout=args.query_timeout,
+            )
+        else:
+            RUNNERS[args.mode](
+                source,
+                queries,
+                engine_modes,
+                args.iterations,
+                writer,
+                benchmark_dir=benchmark_dir,
+                parquet_dir=parquet_dir,
+                pin=args.pin,
+                duckdb_profiling=args.duckdb_profiling,
+            )
 
     log("Benchmark run complete")
 
-    if any(use_gpu for _, use_gpu in engine_modes):
+    # split_sirius_log post-processes the combined daily-sink log produced by
+    # the long-running Python connection. In --nsys-profile mode each query
+    # runs in its own subprocess with its own SIRIUS_LOG_DIR, so the per-query
+    # logs are already isolated under <bench>/sirius/q<N>/log_dir/.
+    if not args.nsys_profile and any(use_gpu for _, use_gpu in engine_modes):
         split_sirius_log(log_dir, benchmark_dir, queries, args.iterations, args.mode)
 
     if args.validation:

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -46,7 +46,7 @@ def log(msg):
     print(f"[{ts}] {msg}", flush=True)
 
 
-MODES = ("grouped", "sequential", "isolated")
+MODES = ("grouped", "sequential", "isolated", "nsys-profile")
 ENGINE_CHOICES = ("gpu", "cpu", "both")
 PIN_CHOICES = ("none", "gpu", "host")
 TPCH_TABLES = (
@@ -118,8 +118,7 @@ def setup_benchmark_dir(
         benchmark_name = name
     else:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        suffix = "_nsys" if nsys_profile else ""
-        benchmark_name = f"tpch_{ts}_{mode}_{engine}_iter{iterations}{suffix}"
+        benchmark_name = f"tpch_{ts}_{mode}_{engine}_iter{iterations}"
     benchmark_dir = os.path.join(output_root, benchmark_name)
     csv_dir = os.path.join(benchmark_dir, "csv")
     log_dir = os.path.join(benchmark_dir, "log_dir")
@@ -491,16 +490,22 @@ RUNNERS = {
 def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
     """Write the DuckDB SQL script for one nsys-profiled query.
 
-    Mirrors profile_tpch_nsys.sh:170-208 so that the resulting timings.csv
-    has rows (views, iter_1, iter_2, ...) and the cudaProfilerApi capture
-    range brackets iterations 2..N.
+    Produces a timings.csv with rows (views, iter_1, iter_2, ...). The
+    cudaProfilerApi capture range brackets iterations 1..N, so the cold run
+    (iter_1) is profiled along with every hot iteration; only the one-time
+    process-startup GPU-pool init is left outside the captured window.
     """
     sql_path = os.path.join(qdir, "nsys.sql")
     timing_path = os.path.join(qdir, "timings.csv")
 
+    # NOTE: the DuckDB CLI (build/release/duckdb) statically links the Sirius
+    # extension, so gpu_execution is already registered at startup. An explicit
+    # `LOAD '<ext>'` here throws "Table Function gpu_execution already exists".
+    # (Only the non-nsys path, which uses the vanilla Python duckdb module,
+    # needs LOAD.) The scaffolding (temp table, views, INSERTs, COPY) runs on
+    # plain DuckDB; gpu_execution is toggled on only around the query iterations
+    # so the LAG() window-function COPY is never routed through Sirius.
     parts = [
-        f"LOAD '{EXTENSION_PATH}';",
-        "SET gpu_execution = true;",
         "CREATE TEMP TABLE _timings (seq INTEGER, step VARCHAR, ts TIMESTAMP);",
         "INSERT INTO _timings VALUES (0, 'start', current_timestamp);",
         _build_views_sql(parquet_dir).rstrip("\n"),
@@ -510,17 +515,22 @@ def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
     if pin != "none":
         parts.append(emit_pin(qnum, parquet_dir))
 
+    parts.append("SET gpu_execution = true;")
+    # Open the nsys capture range BEFORE the first (cold) iteration so the cold
+    # run is profiled too. The one-time GPU memory-pool init happens at process
+    # startup (the statically-linked extension inits before any SQL runs), so it
+    # is still outside this range — only query execution (cold + every hot
+    # iteration) is captured.
+    parts.append("CALL profiler_start();")
     query_sql = QUERIES[f"q{qnum}"].rstrip().rstrip(";") + ";"
     for i in range(1, iterations + 1):
-        if i == 2:
-            parts.append("CALL profiler_start();")
         parts.append(query_sql)
         parts.append(
             f"INSERT INTO _timings VALUES ({i + 1}, 'iter_{i}', current_timestamp);"
         )
 
-    if iterations >= 2:
-        parts.append("CALL profiler_stop();")
+    parts.append("CALL profiler_stop();")
+    parts.append("SET gpu_execution = false;")
 
     if pin != "none":
         parts.append(emit_unpin(qnum))
@@ -559,9 +569,9 @@ def run_nsys_profile(
     """Profile each query with NVIDIA Nsight Systems: one DuckDB subprocess per query.
 
     Per query, builds a temp SQL file that registers views, optionally pins
-    tables, runs N iterations (cold + N-1 hot) bracketed by profiler_start /
-    profiler_stop for nsys's cudaProfilerApi capture range, and emits a
-    timings.csv via DuckDB's COPY. The subprocess is wrapped by
+    tables, then runs all N iterations (cold + hot) inside a single
+    profiler_start / profiler_stop range so the cold run is profiled too, and
+    emits a timings.csv via DuckDB's COPY. The subprocess is wrapped by
     `nsys profile --capture-range=cudaProfilerApi`, producing one
     .nsys-rep + .sqlite per query under <bench>/sirius/q<N>/.
 
@@ -597,11 +607,12 @@ def run_nsys_profile(
             "--trace=cuda,nvtx",
             "--sample=none",
             "--cudabacktrace=none",
+            # profiler_start/stop (in the temp SQL) bracket the cold + hot
+            # iterations; capture only that range so the process-startup
+            # GPU-pool init stays out of the trace.
+            "--capture-range=cudaProfilerApi",
+            "--capture-range-end=stop",
         ]
-        if iterations >= 2:
-            nsys_cmd.extend(
-                ["--capture-range=cudaProfilerApi", "--capture-range-end=stop"]
-            )
         nsys_cmd.extend(
             [
                 "--output",
@@ -829,7 +840,8 @@ def parse_args():
         default="grouped",
         help="Iteration ordering: grouped (per-query iterations back-to-back, hot "
         "cache), sequential (round-robin across queries), isolated (renew "
-        "connection + drop OS cache per run)",
+        "connection + drop OS cache per run), nsys-profile (one nsys-wrapped "
+        "DuckDB subprocess per query; --engine gpu only)",
     )
     p.add_argument(
         "--iterations",
@@ -911,24 +923,12 @@ def parse_args():
         ),
     )
     p.add_argument(
-        "--nsys-profile",
-        action="store_true",
-        help=(
-            "Profile each query with NVIDIA Nsight Systems (nsys). Spawns one DuckDB "
-            "CLI subprocess per query wrapped in `nsys profile`; produces "
-            "<benchmark_dir>/sirius/q<N>/nsys.{nsys-rep,sqlite,sql} and a per-query "
-            "timings.csv. Requires --engine gpu and the DuckDB CLI at "
-            "build/release/duckdb plus `nsys` on PATH. Incompatible with "
-            "--validation, --duckdb-profiling, --mode sequential, --mode isolated."
-        ),
-    )
-    p.add_argument(
         "--query-timeout",
         type=int,
         default=90,
         help=(
-            "Per-query subprocess timeout in seconds for --nsys-profile mode "
-            "(default: 90). Ignored without --nsys-profile."
+            "Per-query subprocess timeout in seconds for `--mode nsys-profile` "
+            "(default: 90). Ignored in the other modes."
         ),
     )
     return p.parse_args()
@@ -955,17 +955,15 @@ def main():
             "--validation requires --engine both (needs both result sets to compare)"
         )
 
-    if args.nsys_profile:
+    nsys_profile = args.mode == "nsys-profile"
+    if nsys_profile:
         if args.engine != "gpu":
-            raise SystemExit("--nsys-profile requires --engine gpu")
+            raise SystemExit("--mode nsys-profile requires --engine gpu")
         if args.validation:
-            raise SystemExit("--nsys-profile is incompatible with --validation")
+            raise SystemExit("--mode nsys-profile is incompatible with --validation")
         if args.duckdb_profiling:
-            raise SystemExit("--nsys-profile is incompatible with --duckdb-profiling")
-        if args.mode != "grouped":
             raise SystemExit(
-                "--nsys-profile only supports --mode grouped "
-                "(implicit per-query subprocess)"
+                "--mode nsys-profile is incompatible with --duckdb-profiling"
             )
 
     config_path = (args.config or "").strip()
@@ -989,7 +987,7 @@ def main():
         config_path,
         args.pin,
         name=args.name,
-        nsys_profile=args.nsys_profile,
+        nsys_profile=nsys_profile,
     )
     os.environ["SIRIUS_LOG_DIR"] = log_dir
 
@@ -1001,7 +999,7 @@ def main():
     log(f"Config:        {config_path or '(default)'}")
     log(f"Pin:           {args.pin}")
     log(f"DuckDB profiling: {args.duckdb_profiling}")
-    log(f"nsys-profile:  {args.nsys_profile}")
+    log(f"nsys-profile:  {nsys_profile}")
     log(f"Benchmark dir: {benchmark_dir}")
     log(f"Runtime CSV:   {runtime_csv}")
     log(f"Log dir:       {log_dir}")
@@ -1010,7 +1008,7 @@ def main():
         writer = csv.writer(f)
         writer.writerow(["engine", "query", "iteration", "runtime_s"])
         f.flush()
-        if args.nsys_profile:
+        if nsys_profile:
             run_nsys_profile(
                 queries,
                 parquet_dir,
@@ -1037,10 +1035,10 @@ def main():
     log("Benchmark run complete")
 
     # split_sirius_log post-processes the combined daily-sink log produced by
-    # the long-running Python connection. In --nsys-profile mode each query
+    # the long-running Python connection. In nsys-profile mode each query
     # runs in its own subprocess with its own SIRIUS_LOG_DIR, so the per-query
     # logs are already isolated under <bench>/sirius/q<N>/log_dir/.
-    if not args.nsys_profile and any(use_gpu for _, use_gpu in engine_modes):
+    if not nsys_profile and any(use_gpu for _, use_gpu in engine_modes):
         split_sirius_log(log_dir, benchmark_dir, queries, args.iterations, args.mode)
 
     if args.validation:

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -610,6 +610,10 @@ def run_nsys_profile(
                 "--stats=false",
                 "--export=sqlite",
                 DUCKDB_BIN,
+                # -unsigned mirrors the Python runner's allow_unsigned_extensions
+                # config (open_connection): without it, the DuckDB CLI rejects
+                # locally-built (unsigned) Sirius extensions.
+                "-unsigned",
                 "-f",
                 sql_path,
             ]

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -7,11 +7,10 @@ expansion must match the file list in the corresponding CREATE VIEW
 read_parquet([...]) call — otherwise the scan_manager path-equality check
 in src/scan_manager/sirius_scan_manager.cpp will fall through to disk.
 
-Pin tier: defaults to 'gpu' (the only tier currently implemented).
-tier='host' is not supported right now and will be added later — emitting
-CALL pin_table(..., tier='host', ...) today raises NotImplementedException
-in src/sirius_extension.cpp. Override the default via SIRIUS_PIN_TIER once
-host support lands.
+Pin tier: defaults to 'gpu'; both 'gpu' and 'host' are supported. Set
+SIRIUS_PIN_TIER=host to select the host tier, which converts the pinned
+table into NUMA-local pinned host memory. Any other tier raises
+NotImplementedException at bind time (src/sirius_extension.cpp).
 """
 from __future__ import annotations
 
@@ -230,12 +229,9 @@ def detect_pin_glob(parquet_dir: str, table: str) -> str:
 
 
 def emit_pin(query_num: int, parquet_dir: str) -> str:
-    # Tier defaults to 'gpu' — the only tier currently implemented in
-    # src/sirius_extension.cpp. tier='host' is NOT supported right now and
-    # will be added later; setting SIRIUS_PIN_TIER=host today will make the
-    # CALL pin_table statement throw NotImplementedException at bind time
-    # (src/sirius_extension.cpp:681-683). Once host-tier support lands,
-    # flip via SIRIUS_PIN_TIER=host.
+    # Tier defaults to 'gpu'; SIRIUS_PIN_TIER=host selects the host tier
+    # (both are supported — see src/sirius_extension.cpp). Any other tier
+    # throws NotImplementedException at bind time.
     tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
     cols_by_table = QUERY_COLUMNS[query_num]
     lines = []
@@ -296,9 +292,8 @@ def main(argv: list[str]) -> int:
             "       tpch_pin_columns.py pin-all <parquet_dir>\n"
             "       tpch_pin_columns.py unpin-all\n"
             "\n"
-            "Tier: defaults to 'gpu'; SIRIUS_PIN_TIER=host overrides once host-tier\n"
-            "support lands. tier='host' is NOT supported right now — use it today and\n"
-            "the CALL pin_table will throw NotImplementedException.",
+            "Tier: defaults to 'gpu'; set SIRIUS_PIN_TIER=host for the host tier\n"
+            "(both 'gpu' and 'host' are supported).",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Summary

Make `test/tpch_performance/performance_test.py` the single canonical TPC-H runner shared by the `benchmark`, `profile-analyzer`, and `optimization-advisor` skills — for both **non-profiled** timing runs and **nsys profiling** (now `--mode nsys-profile`). Previously `profile-analyzer` routed through separate shell runners and pointed at flags/scripts that didn't exist (`--db-path`, `profile_tpch_nsys_duckdb_native.sh`). This PR also consolidates the skill / `CLAUDE.md` docs so the runner's flag surface lives in exactly one place, and adds cudaMalloc-on-the-hot-path counting to the profiling tooling.

## What changed

- **`performance_test.py`**
  - nsys profiling is now a first-class **`--mode nsys-profile`** (replacing the earlier `--nsys-profile` flag): one `nsys profile`-wrapped DuckDB CLI subprocess per query → `<bench>/sirius/q<N>/nsys.{nsys-rep,sqlite}` + per-query `timings.csv`. Requires `--engine gpu`; rejects `--validation`/`--duckdb-profiling`.
  - **Drop the double `LOAD`.** The `build/release/duckdb` CLI statically links Sirius, so an explicit `LOAD '<…sirius.duckdb_extension>'` re-ran `sirius_duckdb_cpp_init` → registered `gpu_execution` twice and allocated a *second* memory pool. Only the non-nsys path (vanilla Python `duckdb` module) needs `LOAD`.
  - **Cold run is profiled.** The cudaProfilerApi capture range now opens *before* iteration 1, so cold + hot iterations are captured; the one-time process-startup pool init stays outside the range.
- **`nsys_report.sh`** — Phase 2 delegates to `performance_test.py --mode nsys-profile`, then flattens the per-query outputs into the report's flat `profiles/q<N>.*` layout so `nsys_analyze.sh` / metric extraction are unchanged. Adds `--parquet-dir`.
- **Docs / skill consolidation** — `benchmark`, `profile-analyzer`, and `optimization-advisor` `SKILL.md` plus `test/tpch_performance/CLAUDE.md` rewritten around the consolidated runner + `--mode nsys-profile`. **`CLAUDE.md` is now the single source of truth** for the runner's flag surface and output layout; the skills keep only skill-specific procedure and point to it. This removes duplicated flag tables that had already drifted — e.g. the `benchmark` skill was silently missing `--mode nsys-profile`, `--duckdb-profiling`, and `--query-timeout`. Also removed the broken `--db-path` / `profile_tpch_nsys_duckdb_native.sh` references and stale claims (hardcoded stream count, "24 on Ada Lovelace", NVTX-domain framing).
- **`--pin host` correction** — the host pin tier is now implemented (`sirius_extension.cpp` accepts both `gpu` and `host`; host converts the pinned table into NUMA-local pinned host memory), but `CLAUDE.md` and `tpch_pin_columns.py` still claimed `tier='host'` throws `NotImplementedException` and cited a dead line range. Corrected the module docstring, the `emit_pin` comment, the CLI help, and both `CLAUDE.md` references so `--pin host` / `SIRIUS_PIN_TIER=host` are documented as supported.
- **Profile-analyzer: count `cudaMalloc` on the query hot path** — a raw `cudaMalloc` inside the operator window bypasses the RMM pool and forces a device-wide sync, a common source of unintended perf degradation. `nsys_analyze.sh` gains a **"Device Memory Allocation — cudaMalloc Counts"** section (headline total + `init`/`during_query`/`cleanup` split + per-phase/function breakdown; `cudaMallocHost` excluded as host pinned). `nsys_report.sh` writes `memory.cuda_malloc_total` / `memory.cuda_malloc_during_query` per query (plus a `total_cuda_malloc_during_query` aggregate) to `summary.json`. `nsys_compare.sh` treats it as a count metric, flagging **any** per-query increase — `0 → N` included — as a REGRESSION, so an allocation newly introduced on the hot path is caught across runs.

## Root-cause notes (debugged on a GB10 / DGX Spark, unified memory)

- The OOM crashes were **not nsys** (verified: nsys cleanly profiles a trivial CUDA program) and **not the PR's C++** (this PR changes only docs + Python/shell; submodule pins are identical to dev). They were the **double `LOAD`** above, compounded on **unified memory**: on GB10 (ATS coherent memory) `cudaMemGetInfo.total` reports the *entire* ~119 GB system RAM, so a second eagerly-primed GPU pool (`usage_limit_fraction × 119 GB`) over-committed the shared pool → host OOM. With the `LOAD` removed (single init), it runs fine even at `usage_limit_fraction: 0.45`.
- **Unified-memory config note:** on GB10, `gpu.usage_limit_fraction` applies to *total system RAM* (GPU pool and host pinned pool draw from one pool), so keep it modest.

## Out of scope / follow-ups

- Legacy shell runners (`benchmark_and_validate.sh`, `run_tpch_parquet.sh`, `profile_tpch_nsys.sh`, …) stay in-tree for CI / `.ai-helper`; migrate callers and delete them in a follow-up.
- Latent cuCascade issue worth a separate tracker: the GPU pool capacity is wired as `cuda_async_memory_resource`'s `initial_pool_size` and sized from `cudaMemGetInfo.total`, which over-reserves on ATS/coherent-memory devices.

## Test plan

- [x] Rebased onto latest `upstream/dev` (`36633c12d`) — clean, submodules synced.
- [x] `pre-commit` clean on all changed files.
- [x] `--mode nsys-profile` argparse contract (requires `--engine gpu`; rejects `--validation`/`--duckdb-profiling`).
- [x] End-to-end on GB10 (SF1, q1/q3/q6): `nsys_report.sh` produces `report.md` + `summary.json` (3 passed / 0 failed) + per-query `.nsys-rep`/`.sqlite`; **cold run captured** (`total_cold_s` > 0); flat memory, no lingering processes.
- [x] cudaMalloc counting validated against a synthetic SQLite (total / `during_query` / `init` / `cleanup` split + during-query-first ordering) and `nsys_compare.sh` `0 → N` regression detection; `bash -n` clean on the three nsys scripts.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
