### PR TITLE
test(task_scheduler): skip device-preference test on single-GPU hosts

### DIFF
--- a/test/cpp/pipeline/test_task_scheduler.cpp
+++ b/test/cpp/pipeline/test_task_scheduler.cpp
@@ -22,6 +22,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -160,6 +162,16 @@ TEST_CASE("Task queue handles empty queue gracefully", "[pipeline_queue]")
 
 TEST_CASE("Task scheduler dispatches tasks with device preference", "[task_scheduler]")
 {
+  // Multi-GPU device-preference dispatch needs a real 2-GPU host; skip on
+  // single-GPU machines (mirrors the require_two_gpus() convention used by the
+  // MGPU operator tests in mgpu_test_utils.hpp).
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+  if (device_count < 2) {
+    WARN("Task scheduler device-preference test requires >=2 GPUs; single-GPU host — skipping");
+    return;
+  }
+
   auto manager = initialize_memory_manager(2);
   sirius::exec::thread_pool_config gpu_config{2};
   sirius::exec::thread_pool_config scan_config{2};


### PR DESCRIPTION
## Summary

`TEST_CASE("Task scheduler dispatches tasks with device preference", "[task_scheduler]")` requires a real 2-GPU host — it calls `initialize_memory_manager(2)` and asserts a 2-GPU scheduler dispatches all tasks. On single-GPU machines it fails consistently (`test_task_scheduler.cpp:161`), which is a persistent red herring in local `sirius_unittest` runs.

This adds a guard that `WARN`s and returns early when fewer than 2 GPUs are visible, mirroring the `require_two_gpus()` convention already used by the MGPU operator tests (`test/cpp/operator/mgpu_test_utils.hpp`). The check is inlined rather than reusing `require_two_gpus()` directly, since that helper lives in an operator-test header that pulls in heavier shared-env/config machinery not appropriate for a pipeline test.

## Behavior

- **>=2 GPUs:** unchanged — the test runs as before.
- **<2 GPUs:** the case is skipped with a `WARN`, instead of failing.

## Testing

On a single-GPU host:

```
$ sirius_unittest "[task_scheduler]"
...
test_task_scheduler.cpp:171: warning:
  Task scheduler device-preference test requires >=2 GPUs; single-GPU host — skipping
All tests passed (3 assertions in 3 test cases)
```