### PR TITLE
S3 SQL-surface cleanup, comments update

### DIFF
--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -78,11 +78,17 @@ namespace sirius::scan_manager {
 struct scan_manager_config {
   exec::thread_pool_config thread_pool{.num_threads = 8, .thread_name_prefix = "scan_manager"};
   bool use_sirius_datasource{false};
-  /// Number of @c uring_reactor instances in the ioctx pool.  Ignored when
-  /// @c use_sirius_datasource is false.
+  /// Reserved (not currently consumed). Intended size of the @c uring_reactor
+  /// pool, but the production @c uring_ioctx is built by @c SiriusContext, which
+  /// scales the reactor count with the number of GPUs the NUMA node serves
+  /// (@c clamp(4 * devices, 4, 16)) rather than reading this field. Parsed from
+  /// YAML and kept for forward compatibility / tests; setting it has no effect
+  /// on the engine today.
   std::size_t uring_n_reactors{4};
-  /// io_uring submission/completion queue depth per reactor.  Ignored when
-  /// @c use_sirius_datasource is false.
+  /// Reserved (not currently consumed). Intended io_uring submission/completion
+  /// queue depth per reactor; the production @c uring_ioctx hardcodes 64. Parsed
+  /// from YAML and kept for forward compatibility / tests; setting it has no
+  /// effect on the engine today.
   unsigned uring_ring_entries{64};
   /// Enable the prefetching cache.  Requires @c use_sirius_datasource=true;
   /// when true, SiriusContext (S6) allocates a pinned-host buffer_pool and

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -88,6 +88,10 @@ static void from_yaml(const YAML::Node& node, scan_manager::scan_manager_config&
   r.optional("thread_name_prefix", opt.thread_pool.thread_name_prefix);
   r.optional("cpu_affinity", opt.thread_pool.cpu_affinity_list);
   r.optional("use_sirius_datasource", opt.use_sirius_datasource);
+  // Reserved knobs: parsed and validated for forward compatibility, but not
+  // currently wired to the production uring_ioctx (SiriusContext scales the
+  // reactor pool with GPU count and hardcodes ring_entries=64). See
+  // scan_manager_config for details.
   r.optional("uring_n_reactors", opt.uring_n_reactors, yaml::greater_than<std::size_t>{0});
   r.optional("uring_ring_entries", opt.uring_ring_entries, yaml::greater_than<unsigned>{0});
   r.optional("enable_prefetch_cache", opt.enable_prefetch_cache);

--- a/src/sirius_sql_rewrite.cpp
+++ b/src/sirius_sql_rewrite.cpp
@@ -178,7 +178,13 @@ std::string rewrite_sirius_owned_remote_parquet_calls(std::string const& query)
     }
 
     auto const remaining = std::string_view(query).substr(i);
-    if ((i == 0 || !is_identifier_char(query[i - 1])) &&
+    // Left boundary: reject when the token continues an identifier (e.g.
+    // `xread_parquet`) *or* when it is schema/catalog-qualified (`main.read_parquet`,
+    // `cat.sch.read_parquet`). A qualifier dot binds tightly to the name that
+    // follows it and names a specific catalog object, which is not the
+    // Sirius-owned unqualified `read_parquet` — rewriting it would produce the
+    // unresolvable `main.sirius_read_parquet`.
+    if ((i == 0 || (!is_identifier_char(query[i - 1]) && query[i - 1] != '.')) &&
         iequals_prefix(remaining, NATIVE_READ_PARQUET_FN) &&
         (i + NATIVE_READ_PARQUET_FN.size() >= query.size() ||
          !is_identifier_char(query[i + NATIVE_READ_PARQUET_FN.size()])) &&

--- a/test/cpp/io/s3/test_s3_default_visibility_guard.cpp
+++ b/test/cpp/io/s3/test_s3_default_visibility_guard.cpp
@@ -7,6 +7,9 @@
 
 #include "catch.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
@@ -16,6 +19,8 @@
 #include <vector>
 
 namespace {
+
+constexpr std::string_view kGuardSourceFilename = "test_s3_default_visibility_guard.cpp";
 
 struct test_case_span {
   std::string header;
@@ -50,36 +55,151 @@ std::size_t line_number(std::string_view text, std::size_t offset)
   return line;
 }
 
+bool starts_with_at(std::string_view text, std::size_t pos, std::string_view token)
+{
+  return pos <= text.size() && token.size() <= text.size() - pos &&
+         text.substr(pos, token.size()) == token;
+}
+
+bool is_identifier_char(char c)
+{
+  return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_';
+}
+
+bool has_identifier_boundary_before(std::string_view text, std::size_t pos)
+{
+  return pos == 0 || !is_identifier_char(text[pos - 1]);
+}
+
+bool is_digit_separator(std::string_view text, std::size_t pos)
+{
+  return pos > 0 && pos + 1 < text.size() &&
+         std::isalnum(static_cast<unsigned char>(text[pos - 1])) != 0 &&
+         std::isalnum(static_cast<unsigned char>(text[pos + 1])) != 0;
+}
+
+std::size_t skip_line_comment(std::string_view text, std::size_t pos)
+{
+  auto const end = text.find('\n', pos + 2);
+  return end == std::string_view::npos ? text.size() : end + 1;
+}
+
+std::size_t skip_block_comment(std::string_view text, std::size_t pos)
+{
+  auto const end = text.find("*/", pos + 2);
+  return end == std::string_view::npos ? text.size() : end + 2;
+}
+
+std::size_t skip_quoted_literal(std::string_view text, std::size_t pos, char quote)
+{
+  bool escaped = false;
+  for (std::size_t i = pos + 1; i < text.size(); ++i) {
+    auto const c = text[i];
+    if (escaped) {
+      escaped = false;
+    } else if (c == '\\') {
+      escaped = true;
+    } else if (c == quote) {
+      return i + 1;
+    }
+  }
+  return text.size();
+}
+
+std::size_t skip_raw_string_literal(std::string_view text, std::size_t pos)
+{
+  if (!starts_with_at(text, pos, "R\"")) { return std::string_view::npos; }
+
+  auto const delimiter_start = pos + 2;
+  auto const open_paren      = text.find('(', delimiter_start);
+  if (open_paren == std::string_view::npos || open_paren - delimiter_start > 16) {
+    return std::string_view::npos;
+  }
+
+  auto const delimiter = text.substr(delimiter_start, open_paren - delimiter_start);
+  if (delimiter.find_first_of(" \t\n\r()\\") != std::string_view::npos) {
+    return std::string_view::npos;
+  }
+
+  auto const close = ")" + std::string{delimiter} + "\"";
+  auto const end   = text.find(close, open_paren + 1);
+  return end == std::string_view::npos ? text.size() : end + close.size();
+}
+
+std::size_t skip_ignored_region(std::string_view text, std::size_t pos)
+{
+  if (starts_with_at(text, pos, "//")) { return skip_line_comment(text, pos); }
+  if (starts_with_at(text, pos, "/*")) { return skip_block_comment(text, pos); }
+
+  auto const raw_end = skip_raw_string_literal(text, pos);
+  if (raw_end != std::string_view::npos) { return raw_end; }
+
+  if (pos < text.size() && text[pos] == '"') { return skip_quoted_literal(text, pos, '"'); }
+  if (pos < text.size() && text[pos] == '\'' && !is_digit_separator(text, pos)) {
+    return skip_quoted_literal(text, pos, '\'');
+  }
+
+  return std::string_view::npos;
+}
+
+std::size_t find_token_in_code(std::string_view text, std::string_view token, std::size_t pos = 0)
+{
+  for (std::size_t i = pos; i < text.size();) {
+    auto const skipped = skip_ignored_region(text, i);
+    if (skipped != std::string_view::npos) {
+      i = skipped;
+      continue;
+    }
+    if (starts_with_at(text, i, token) && has_identifier_boundary_before(text, i)) { return i; }
+    ++i;
+  }
+  return std::string_view::npos;
+}
+
+std::size_t find_test_case_macro_in_code(std::string_view text, std::size_t start)
+{
+  constexpr std::array<std::string_view, 2> kTestCaseMacros = {"TEST_CASE(", "TEMPLATE_TEST_CASE("};
+
+  std::size_t best = std::string_view::npos;
+  for (auto const token : kTestCaseMacros) {
+    auto const candidate = find_token_in_code(text, token, start);
+    if (candidate != std::string_view::npos &&
+        (best == std::string_view::npos || candidate < best)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+std::size_t find_char_in_code(std::string_view text, char token, std::size_t pos = 0)
+{
+  for (std::size_t i = pos; i < text.size();) {
+    auto const skipped = skip_ignored_region(text, i);
+    if (skipped != std::string_view::npos) {
+      i = skipped;
+      continue;
+    }
+    if (text[i] == token) { return i; }
+    ++i;
+  }
+  return std::string_view::npos;
+}
+
 std::size_t find_matching_brace(std::string_view text, std::size_t open_brace)
 {
   std::size_t depth = 0;
-  bool in_string    = false;
-  bool in_char      = false;
-  bool escaped      = false;
 
-  for (std::size_t i = open_brace; i < text.size(); ++i) {
-    char const c = text[i];
-    if (in_string || in_char) {
-      if (escaped) {
-        escaped = false;
-      } else if (c == '\\') {
-        escaped = true;
-      } else if ((in_string && c == '"') || (in_char && c == '\'')) {
-        in_string = false;
-        in_char   = false;
-      }
+  for (std::size_t i = open_brace; i < text.size();) {
+    auto const skipped = skip_ignored_region(text, i);
+    if (skipped != std::string_view::npos) {
+      i = skipped;
       continue;
     }
-    if (c == '"') {
-      in_string = true;
-      continue;
-    }
-    if (c == '\'') {
-      in_char = true;
-      continue;
-    }
+
+    auto const c = text[i];
     if (c == '{') {
       ++depth;
+      ++i;
       continue;
     }
     if (c == '}') {
@@ -87,6 +207,7 @@ std::size_t find_matching_brace(std::string_view text, std::size_t open_brace)
       --depth;
       if (depth == 0) { return i; }
     }
+    ++i;
   }
   return std::string_view::npos;
 }
@@ -96,9 +217,9 @@ std::vector<test_case_span> collect_test_cases(std::string const& source)
   std::vector<test_case_span> out;
   std::size_t pos = 0;
   while (true) {
-    auto const test_pos = source.find("TEST_CASE(", pos);
+    auto const test_pos = find_test_case_macro_in_code(source, pos);
     if (test_pos == std::string::npos) { break; }
-    auto const body_open = source.find('{', test_pos);
+    auto const body_open = find_char_in_code(source, '{', test_pos);
     REQUIRE(body_open != std::string::npos);
     auto const body_close = find_matching_brace(source, body_open);
     REQUIRE(body_close != std::string::npos);
@@ -124,8 +245,45 @@ bool hidden_by_default(std::string_view header)
 
 bool references_live_s3_guard(std::string_view body)
 {
-  return body.find("read_s3_test_env(") != std::string_view::npos ||
-         body.find("skip_if_no_s3_env(") != std::string_view::npos;
+  return find_token_in_code(body, "read_s3_test_env(") != std::string_view::npos ||
+         find_token_in_code(body, "skip_if_no_s3_env(") != std::string_view::npos;
+}
+
+bool should_scan_file(std::filesystem::path const& path)
+{
+  return path.filename() != kGuardSourceFilename;
+}
+
+std::vector<std::filesystem::path> discover_cpp_test_files(std::filesystem::path const& root)
+{
+  std::vector<std::filesystem::path> files;
+  auto const test_root = root / "test/cpp";
+  REQUIRE(std::filesystem::exists(test_root));
+
+  for (auto const& entry : std::filesystem::recursive_directory_iterator(test_root)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".cpp") { continue; }
+    auto const relative = std::filesystem::relative(entry.path(), root);
+    if (!should_scan_file(relative)) { continue; }
+    files.push_back(relative);
+  }
+
+  std::sort(files.begin(), files.end());
+  return files;
+}
+
+std::vector<std::string> collect_visibility_violations(std::filesystem::path const& relative,
+                                                       std::string const& source)
+{
+  INFO("Scanning " << relative.string());
+  if (!should_scan_file(relative)) { return {}; }
+
+  std::vector<std::string> violations;
+  for (auto const& test_case : collect_test_cases(source)) {
+    if (!has_tag(test_case.header, "s3") || hidden_by_default(test_case.header)) { continue; }
+    if (!references_live_s3_guard(test_case.body)) { continue; }
+    violations.push_back(relative.string() + ":" + std::to_string(test_case.line));
+  }
+  return violations;
 }
 
 std::string join_lines(std::vector<std::string> const& values)
@@ -141,23 +299,14 @@ std::string join_lines(std::vector<std::string> const& values)
 
 TEST_CASE("default-visible S3 tests do not silently skip live MinIO work", "[s3][test_hygiene]")
 {
-  auto const root = project_root();
-  std::vector<std::filesystem::path> const files{
-    "test/cpp/io/s3/test_s3_ioctx.cpp",
-    "test/cpp/io/s3/test_s3_blocking_ioctx.cpp",
-    "test/cpp/scan_manager/test_sirius_scan_manager_s3.cpp",
-    "test/cpp/scan_manager/test_describe_parquet_s3.cpp",
-    "test/cpp/integration/test_s3_sql_surface.cpp",
-  };
+  auto const root  = project_root();
+  auto const files = discover_cpp_test_files(root);
+  REQUIRE_FALSE(files.empty());
 
   std::vector<std::string> violations;
   for (auto const& relative : files) {
-    auto const source = read_text_file(root / relative);
-    for (auto const& test_case : collect_test_cases(source)) {
-      if (!has_tag(test_case.header, "s3") || hidden_by_default(test_case.header)) { continue; }
-      if (!references_live_s3_guard(test_case.body)) { continue; }
-      violations.push_back(relative.string() + ":" + std::to_string(test_case.line));
-    }
+    auto file_violations = collect_visibility_violations(relative, read_text_file(root / relative));
+    violations.insert(violations.end(), file_violations.begin(), file_violations.end());
   }
 
   INFO(
@@ -165,4 +314,130 @@ TEST_CASE("default-visible S3 tests do not silently skip live MinIO work", "[s3]
     "skip_if_no_s3_env; use [.][s3][integration] for live MinIO tests. Offenders:"
     << join_lines(violations));
   CHECK(violations.empty());
+}
+
+TEST_CASE("S3 default-visibility guard classifies synthetic test sources", "[s3][test_hygiene]")
+{
+  SECTION("excludes the guard source file itself from auto-discovery results")
+  {
+    auto const source = R"cpp(
+      TEST_CASE("self-referential guard", "[s3][test_hygiene]")
+      {
+        read_s3_test_env();
+      }
+    )cpp";
+
+    CHECK(
+      collect_visibility_violations("test/cpp/io/s3/test_s3_default_visibility_guard.cpp", source)
+        .empty());
+  }
+
+  SECTION("flags a newly discovered default-visible S3 test that calls the live guard")
+  {
+    auto const source = R"cpp(
+      TEST_CASE("new file with live S3 work", "[s3]")
+      {
+        auto env = read_s3_test_env();
+      }
+    )cpp";
+
+    auto const violations =
+      collect_visibility_violations("test/cpp/new_area/test_new_s3_file.cpp", source);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations.front() == "test/cpp/new_area/test_new_s3_file.cpp:2");
+  }
+
+  SECTION("handles Catch template test cases without matching TEST_CASE as a substring")
+  {
+    auto const source = R"cpp(
+      TEMPLATE_TEST_CASE("template S3 file with live work", "[s3]", int, long)
+      {
+        auto env = read_s3_test_env();
+      }
+
+      MY_TEST_CASE("not a Catch test", "[s3]") { auto env = read_s3_test_env(); }
+    )cpp";
+
+    auto const violations =
+      collect_visibility_violations("test/cpp/new_area/test_template_s3_file.cpp", source);
+    REQUIRE(violations.size() == 1);
+    CHECK(violations.front() == "test/cpp/new_area/test_template_s3_file.cpp:2");
+  }
+
+  SECTION("does not flag hidden S3 integration or benchmark tests")
+  {
+    auto const integration_source = R"cpp(
+      TEST_CASE("hidden live S3 test", "[.][s3][integration]")
+      {
+        read_s3_test_env();
+      }
+    )cpp";
+    auto const benchmark_source   = R"cpp(
+      TEST_CASE("hidden S3 benchmark", "[!benchmark][s3]")
+      {
+        skip_if_no_s3_env();
+      }
+    )cpp";
+
+    CHECK(
+      collect_visibility_violations("test/cpp/integration/test_hidden_s3.cpp", integration_source)
+        .empty());
+    CHECK(
+      collect_visibility_violations("test/cpp/integration/test_benchmark_s3.cpp", benchmark_source)
+        .empty());
+  }
+
+  SECTION("does not flag clean S3 tests or non-S3 tests that call the live guard")
+  {
+    auto const clean_s3_source = R"cpp(
+      TEST_CASE("pure S3 logic", "[s3]") { CHECK(true); }
+    )cpp";
+    auto const non_s3_source   = R"cpp(
+      TEST_CASE("helper with live guard", "[test_hygiene]")
+      {
+        read_s3_test_env();
+      }
+    )cpp";
+
+    CHECK(collect_visibility_violations("test/cpp/io/s3/test_clean.cpp", clean_s3_source).empty());
+    CHECK(collect_visibility_violations("test/cpp/helper/test_non_s3.cpp", non_s3_source).empty());
+  }
+
+  SECTION("ignores live-guard tokens inside comments and string literals")
+  {
+    auto const source = R"outer(
+TEST_CASE("comments and strings are inert", "[s3]")
+{
+  // read_s3_test_env();
+  /* skip_if_no_s3_env(); */
+  auto regular = "read_s3_test_env(";
+  auto raw = R"guard(skip_if_no_s3_env({}))guard";
+  CHECK(!regular.empty());
+}
+)outer";
+
+    CHECK(collect_visibility_violations("test/cpp/io/s3/test_comments.cpp", source).empty());
+  }
+
+  SECTION("matches braces while skipping comments and raw string literals")
+  {
+    auto const source = R"outer(
+TEST_CASE("brace tokenizer", "[s3]")
+{
+  // } read_s3_test_env();
+  /* { skip_if_no_s3_env(); } */
+  auto raw = R"guard({ read_s3_test_env( } )guard";
+  auto rows = 100'000;
+  int live = 42;
+}
+int outside = 7;
+)outer";
+
+    auto const cases = collect_test_cases(source);
+    REQUIRE(cases.size() == 1);
+    CHECK(cases.front().body.find("100'000") != std::string::npos);
+    CHECK(cases.front().body.find("int live = 42;") != std::string::npos);
+    CHECK(cases.front().body.find("int outside = 7;") == std::string::npos);
+    CHECK_FALSE(references_live_s3_guard(cases.front().body));
+  }
 }

--- a/test/cpp/sql/test_sirius_sql_rewrite.cpp
+++ b/test/cpp/sql/test_sirius_sql_rewrite.cpp
@@ -19,6 +19,36 @@ TEST_CASE("S3 SQL rewrite targets only Sirius-owned remote parquet calls", "[sql
     CHECK(output == "SELECT * FROM sirius_read_parquet('s3://x/y.parquet')");
   }
 
+  SECTION("leaves schema-qualified read_parquet calls untouched")
+  {
+    auto const input = std::string{"SELECT * FROM main.read_parquet('s3://b/k.parquet')"};
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(input) == input);
+  }
+
+  SECTION("leaves catalog and schema qualified read_parquet calls untouched")
+  {
+    auto const schema_qualified =
+      std::string{"SELECT * FROM myschema.read_parquet('s3://b/k.parquet')"};
+    auto const catalog_schema_qualified =
+      std::string{"SELECT * FROM cat.sch.read_parquet('s3://b/k.parquet')"};
+
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(schema_qualified) == schema_qualified);
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(catalog_schema_qualified) ==
+          catalog_schema_qualified);
+  }
+
+  SECTION("rewrites only the bare call in mixed qualified and bare queries")
+  {
+    auto const input = std::string{
+      "SELECT * FROM main.read_parquet('s3://a/file.parquet') "
+      "UNION ALL SELECT * FROM read_parquet('s3://b/file.parquet')"};
+    auto const expected = std::string{
+      "SELECT * FROM main.read_parquet('s3://a/file.parquet') "
+      "UNION ALL SELECT * FROM sirius_read_parquet('s3://b/file.parquet')"};
+
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(input) == expected);
+  }
+
   SECTION("R1b matches the function name case-insensitively")
   {
     CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(
@@ -58,6 +88,9 @@ TEST_CASE("S3 SQL rewrite targets only Sirius-owned remote parquet calls", "[sql
   SECTION("R1d does not rewrite adjacent parquet functions")
   {
     CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(
+            "SELECT * FROM xread_parquet('s3://x/y.parquet')") ==
+          "SELECT * FROM xread_parquet('s3://x/y.parquet')");
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(
             "SELECT * FROM parquet_scan('s3://x/y.parquet')") ==
           "SELECT * FROM parquet_scan('s3://x/y.parquet')");
     CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(
@@ -77,6 +110,23 @@ TEST_CASE("S3 SQL rewrite targets only Sirius-owned remote parquet calls", "[sql
             "SELECT * FROM read_parquet('file:///tmp/a.parquet')") ==
           "SELECT * FROM read_parquet('file:///tmp/a.parquet')");
   }
+
+  SECTION("rewrites s3 paths that contain dots inside the string literal")
+  {
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(
+            "SELECT * FROM read_parquet('s3://bucket.with.dots/k.parquet')") ==
+          "SELECT * FROM sirius_read_parquet('s3://bucket.with.dots/k.parquet')");
+  }
+
+  SECTION("rewrites when a stray dot is separated from the function by whitespace")
+  {
+    auto const input =
+      std::string{"SELECT * FROM t WHERE exists (SELECT 1) . read_parquet('s3://b/k.parquet')"};
+    auto const expected = std::string{
+      "SELECT * FROM t WHERE exists (SELECT 1) . "
+      "sirius_read_parquet('s3://b/k.parquet')"};
+    CHECK(sirius::rewrite_sirius_owned_remote_parquet_calls(input) == expected);
+  }
 }
 
 TEST_CASE("S3 SQL rewrite predicate detects Sirius-owned remote parquet calls",
@@ -92,6 +142,16 @@ TEST_CASE("S3 SQL rewrite predicate detects Sirius-owned remote parquet calls",
     CHECK(sirius::references_sirius_owned_s3_parquet(
       "SELECT * FROM read_parquet('/tmp/a.parquet') UNION ALL "
       "SELECT * FROM read_parquet('s3://b/k.parquet')"));
+  }
+
+  SECTION("does not treat qualified read_parquet calls as Sirius-owned")
+  {
+    CHECK_FALSE(sirius::references_sirius_owned_s3_parquet(
+      "SELECT * FROM main.read_parquet('s3://b/k.parquet')"));
+    CHECK_FALSE(sirius::references_sirius_owned_s3_parquet(
+      "SELECT * FROM cat.sch.read_parquet('s3://b/k.parquet')"));
+    CHECK(
+      sirius::references_sirius_owned_s3_parquet("SELECT * FROM read_parquet('s3://b/k.parquet')"));
   }
 
   SECTION("ignores local paths and unrelated queries")


### PR DESCRIPTION
The S3 SQL-surface rewrite that maps read_parquet('s3://...') to the Sirius-owned sirius_read_parquet treated a '.' as a valid left word boundary. A schema/catalog-qualified call such as
main.read_parquet('s3://b/k.parquet') was therefore rewritten to main.sirius_read_parquet(...), which does not resolve (sirius_read_parquet is registered unqualified) and corrupts an otherwise valid query.

Tighten the left-boundary check to also reject a name immediately preceded by '.', so qualified calls are left byte-for-byte unchanged while bare read_parquet('s3://...') calls are still rewritten. references_sirius_owned_s3_parquet follows automatically (it is defined as "the rewrite changed the query"), so a qualified call is no longer reported as Sirius-owned.

Harden the S3 default-visibility guard.** The hygiene meta-test that forbids default-visible `[s3]` tests from calling the live-MinIO helpers now auto-discovers source files via a recursive walk of `test/cpp/**/*.cpp` instead of a hardcoded list (so new S3 test files are policed automatically),

Also clarify the scan_manager_config uring_n_reactors / uring_ring_entries documentation: these are parsed and validated but not currently wired to the production uring_ioctx (SiriusContext scales the reactor pool with GPU count and hardcodes the ring depth). Mark them reserved so the knobs are not mistaken for live tuning controls.