### PR TITLE
Improvements to sort operator #3

### DIFF
--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -503,6 +503,7 @@ class sirius_physical_operator {
 
   //! Get the input batch
   virtual std::unique_ptr<operator_data> get_next_task_input_data();
+
   //! Check if all ports are empty
   [[nodiscard]] virtual bool all_ports_empty();
   //! Check if the pipeline is finished

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -29,6 +29,8 @@ namespace op {
 
 class sirius_physical_sort_sample : public sirius_physical_operator {
  public:
+  enum class BoundaryState : uint8_t { NOT_DONE, SCHEDULED, DONE };
+
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::SORT_SAMPLE;
 
   sirius_physical_sort_sample(
@@ -74,7 +76,10 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   size_t get_num_partitions() const { return _num_partitions; }
 
   //! Whether boundaries have been computed
-  bool boundaries_computed() const { return _boundary_state.load(std::memory_order_acquire) == 2; }
+  bool boundaries_computed() const
+  {
+    return _boundary_state.load(std::memory_order_acquire) == BoundaryState::DONE;
+  }
 
   //! Release the partition boundaries table to free GPU memory
   void clear_partition_boundaries() { _partition_boundaries.reset(); }
@@ -86,10 +91,10 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
   //! Number of partitions computed from the sample
   size_t _num_partitions = 1;
 
-  //! Boundary computation state: 0 = not started, 1 = computing, 2 = done.
-  //! compare_exchange on this elects exactly one task as the winner; all others
-  //! passthrough without blocking.
-  std::atomic<int> _boundary_state{0};
+  //! Boundary computation lifecycle: NOT_DONE → SCHEDULED (input claimed) → DONE.
+  //! get_next_task_input_data() transitions to SCHEDULED under the task-creation lock;
+  //! execute() completes the transition to DONE.
+  std::atomic<BoundaryState> _boundary_state{BoundaryState::NOT_DONE};
 
   //! Target bytes to accumulate for the boundary sample (from sirius_config operator_params)
   uint64_t _sort_sample_bytes = config::DEFAULT_SORT_SAMPLE_BYTES;

--- a/src/include/op/sirius_physical_sort_sample.hpp
+++ b/src/include/op/sirius_physical_sort_sample.hpp
@@ -93,7 +93,8 @@ class sirius_physical_sort_sample : public sirius_physical_operator {
 
   //! Boundary computation lifecycle: NOT_DONE → SCHEDULED (input claimed) → DONE.
   //! get_next_task_input_data() transitions to SCHEDULED under the task-creation lock;
-  //! execute() completes the transition to DONE.
+  //! execute() completes the transition to DONE. On OOM the state stays SCHEDULED so the
+  //! rescheduled task retries while task_creator does not spawn a duplicate boundary task.
   std::atomic<BoundaryState> _boundary_state{BoundaryState::NOT_DONE};
 
   //! Target bytes to accumulate for the boundary sample (from sirius_config operator_params)

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -96,12 +96,15 @@ sirius_physical_sort_sample::sirius_physical_sort_sample(
 
 std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hint()
 {
-  // If boundaries already computed, use default behavior (process batches as they arrive)
-  if (_boundary_state.load(std::memory_order_acquire) == 2) {
-    return sirius_physical_operator::get_next_task_hint();
-  }
+  const auto state = _boundary_state.load(std::memory_order_acquire);
 
-  // Need to wait for enough sample bytes before computing boundaries
+  // Boundaries already computed — process batches one at a time.
+  if (state == BoundaryState::DONE) { return sirius_physical_operator::get_next_task_hint(); }
+
+  // Boundary task already scheduled; wait for it to finish before creating more tasks.
+  if (state == BoundaryState::SCHEDULED) { return std::nullopt; }
+
+  // NOT_DONE: wait for enough sample bytes before scheduling the boundary task.
   auto port_ids = get_port_ids();
   if (port_ids.empty()) { return std::nullopt; }
 
@@ -123,14 +126,16 @@ std::optional<task_creation_hint> sirius_physical_sort_sample::get_next_task_hin
 
 std::unique_ptr<operator_data> sirius_physical_sort_sample::get_next_task_input_data()
 {
-  // After boundaries are computed, process one batch at a time (passthrough mode).
-  if (_boundary_state.load(std::memory_order_acquire) == 2) {
-    return sirius_physical_operator::get_next_task_input_data();
-  }
+  const auto state = _boundary_state.load(std::memory_order_acquire);
 
-  // Before boundary computation: accumulate batches up to the sample byte threshold so
-  // execute() can merge pre-sorted runs and derive partition boundaries from a representative
-  // sample without pulling a fixed batch count that may be too large for big batches.
+  // After boundaries are computed, process one batch at a time (passthrough mode).
+  if (state == BoundaryState::DONE) { return sirius_physical_operator::get_next_task_input_data(); }
+
+  // Boundary input already claimed by the in-flight boundary task.
+  if (state == BoundaryState::SCHEDULED) { return nullptr; }
+
+  // NOT_DONE: accumulate batches up to the sample byte threshold so execute() can merge
+  // pre-sorted runs and derive partition boundaries from a representative sample.
   auto port_ids = get_port_ids();
   if (port_ids.empty()) { return nullptr; }
 
@@ -148,6 +153,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::get_next_task_input_
   }
 
   if (input_batch.empty()) { return nullptr; }
+
+  _boundary_state.store(BoundaryState::SCHEDULED, std::memory_order_release);
   return std::make_unique<pipelineable_operator_data>(std::move(input_batch));
 }
 
@@ -159,17 +166,23 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   const auto& input_batches = input.get_read_only_batches();
 
   // Fast path: boundaries already computed — just pass through.
-  if (_boundary_state.load(std::memory_order_acquire) == 2) {
+  if (_boundary_state.load(std::memory_order_acquire) == BoundaryState::DONE) {
     SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
-  // Elect exactly one winner via CAS (0=not started → 1=computing).
-  // The task_creator's while loop dispatches one task per batch, so multiple tasks
-  // can be in-flight simultaneously. Losers passthrough without blocking — they don't
-  // need the boundaries themselves; sort_partition runs next in the same pipeline task.
-  int expected = 0;
-  if (!_boundary_state.compare_exchange_strong(expected, 1, std::memory_order_acq_rel)) {
+  const auto state = _boundary_state.load(std::memory_order_acquire);
+  if (state == BoundaryState::SCHEDULED) {
+    // Normal path: input was claimed by get_next_task_input_data().
+  } else if (state == BoundaryState::NOT_DONE) {
+    // OOM retry or direct unit-test invoke — claim boundary computation.
+    auto expected = BoundaryState::NOT_DONE;
+    if (!_boundary_state.compare_exchange_strong(
+          expected, BoundaryState::SCHEDULED, std::memory_order_acq_rel)) {
+      SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
+      return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
+    }
+  } else {
     SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
@@ -188,12 +201,12 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   }
 
   if (valid_batches.empty() || !space) {
-    _boundary_state.store(2, std::memory_order_release);
+    _boundary_state.store(BoundaryState::DONE, std::memory_order_release);
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
   // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory),
-  // reset state to NOT_STARTED so the rescheduled task can win the CAS and retry.
+  // reset to NOT_DONE so the rescheduled task can retry boundary computation.
   try {
     size_t total_sample_bytes = 0;
     for (auto const& batch : valid_batches) {
@@ -315,12 +328,11 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
 
     // sort_partition runs in the same gpu_pipeline_task immediately after this
     // execute() returns, so _partition_boundaries is visible before partition runs.
-    _boundary_state.store(2, std::memory_order_release);
+    _boundary_state.store(BoundaryState::DONE, std::memory_order_release);
 
   } catch (...) {
-    // Reset to NOT_STARTED so the rescheduled task (or another in-flight task) can
-    // win the CAS election and retry boundary computation.
-    _boundary_state.store(0, std::memory_order_release);
+    // Reset to NOT_DONE so the rescheduled task can retry boundary computation.
+    _boundary_state.store(BoundaryState::NOT_DONE, std::memory_order_release);
     throw;
   }
 

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -171,21 +171,12 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
-  const auto state = _boundary_state.load(std::memory_order_acquire);
-  if (state == BoundaryState::SCHEDULED) {
-    // Normal path: input was claimed by get_next_task_input_data().
-  } else if (state == BoundaryState::NOT_DONE) {
-    // OOM retry or direct unit-test invoke — claim boundary computation.
-    auto expected = BoundaryState::NOT_DONE;
-    if (!_boundary_state.compare_exchange_strong(
-          expected, BoundaryState::SCHEDULED, std::memory_order_acq_rel)) {
-      SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
-      return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
-    }
-  } else {
-    SIRIUS_LOG_DEBUG("Sort sample: passthrough ({} batches)", input_batches.size());
-    return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
-  }
+  // Otherwise this is the boundary-computation task. get_next_task_input_data() already moved the
+  // state to SCHEDULED, and the SCHEDULED guard in get_next_task_hint()/get_next_task_input_data()
+  // ensures only this single task is ever created — so no concurrent or duplicate boundary task can
+  // race here. On OOM below we leave the state at SCHEDULED (rather than resetting to NOT_DONE) so
+  // the rescheduled task, which carries the same input, resumes this computation while
+  // task_creator continues to see the operator as scheduled.
 
   SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches ({} bytes target)",
                    input_batches.size(),
@@ -205,8 +196,9 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
-  // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory),
-  // reset to NOT_DONE so the rescheduled task can retry boundary computation.
+  // Wrap GPU work in try/catch: if any allocation throws (e.g. rmm::out_of_memory), leave the state
+  // at SCHEDULED and rethrow. The rescheduled task carries the same input and re-enters here to
+  // retry, and keeping SCHEDULED prevents task_creator from spawning a duplicate boundary task.
   try {
     size_t total_sample_bytes = 0;
     for (auto const& batch : valid_batches) {
@@ -331,8 +323,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     _boundary_state.store(BoundaryState::DONE, std::memory_order_release);
 
   } catch (...) {
-    // Reset to NOT_DONE so the rescheduled task can retry boundary computation.
-    _boundary_state.store(BoundaryState::NOT_DONE, std::memory_order_release);
+    // Leave the state at SCHEDULED so the rescheduled task retries boundary computation without
+    // task_creator treating the operator as unscheduled and creating its own duplicate task.
     throw;
   }
 

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -171,13 +171,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
-  // Otherwise this is the boundary-computation task. get_next_task_input_data() already moved the
-  // state to SCHEDULED, and the SCHEDULED guard in get_next_task_hint()/get_next_task_input_data()
-  // ensures only this single task is ever created — so no concurrent or duplicate boundary task can
-  // race here. On OOM below we leave the state at SCHEDULED (rather than resetting to NOT_DONE) so
-  // the rescheduled task, which carries the same input, resumes this computation while
-  // task_creator continues to see the operator as scheduled.
-
+  // do boundary computation
   SIRIUS_LOG_DEBUG("Sort sample: computing partition boundaries from {} batches ({} bytes target)",
                    input_batches.size(),
                    _sort_sample_bytes);

--- a/test/cpp/operator/test_physical_sort_sample.cpp
+++ b/test/cpp/operator/test_physical_sort_sample.cpp
@@ -137,6 +137,10 @@ TEST_CASE("sirius_physical_sort_sample stops sampling at sort_sample_bytes thres
   REQUIRE(result != nullptr);
   REQUIRE(batch_count(*result) < static_cast<std::size_t>(num_batches));
   REQUIRE(batch_count(*result) >= 1);
+  REQUIRE(sample_op.get_next_task_input_data() == nullptr);
+
+  (void)sample_op.execute(*result, cudf::get_default_stream());
+  REQUIRE(sample_op.boundaries_computed());
 
   std::size_t total_batches_returned = batch_count(*result);
   while (true) {
@@ -208,6 +212,25 @@ TEST_CASE("sirius_physical_sort_sample is ready when upstream finished with empt
   REQUIRE(sample_op.get_next_task_input_data() == nullptr);
 }
 
+TEST_CASE("sirius_physical_sort_sample get_next_task_hint returns nullopt while scheduled",
+          "[physical_sort_sample]")
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+
+  constexpr uint64_t threshold         = 6144;
+  constexpr std::size_t rows_per_batch = 1000;
+
+  auto sample_op = make_sort_sample(threshold);
+  auto repo      = std::make_unique<cucascade::shared_data_repository>();
+  add_int_batches(*repo, *space, 2, rows_per_batch);
+  attach_port(sample_op, *repo);
+
+  REQUIRE(sample_op.get_next_task_hint()->hint == TaskCreationHint::READY);
+  REQUIRE(sample_op.get_next_task_input_data() != nullptr);
+  REQUIRE_FALSE(sample_op.get_next_task_hint().has_value());
+}
+
 TEST_CASE(
   "sirius_physical_sort_sample pulls all remaining data when upstream finished below threshold",
   "[physical_sort_sample]")
@@ -235,6 +258,10 @@ TEST_CASE(
   auto result = sample_op.get_next_task_input_data();
   REQUIRE(result != nullptr);
   REQUIRE(batch_count(*result) == static_cast<std::size_t>(num_batches));
+  REQUIRE(sample_op.get_next_task_input_data() == nullptr);
+
+  (void)sample_op.execute(*result, cudf::get_default_stream());
+  REQUIRE(sample_op.boundaries_computed());
   REQUIRE(sample_op.get_next_task_input_data() == nullptr);
 }
 


### PR DESCRIPTION
## Summary

Refactors `sort_sample` boundary scheduling to use an explicit state machine instead of a magic `atomic<int>` and a CAS election in `execute()`.

**Before:** The task creator could schedule multiple boundary tasks in parallel. `execute()` used a CAS (`0 → 1`) to elect one winner; losers passthrough'd, wasting GPU work when boundaries weren't ready yet.

**After:** Boundary lifecycle is `NOT_DONE → SCHEDULED → DONE`:
- `get_next_task_input_data()` claims the sample input and moves to `SCHEDULED` (at most one boundary task)
- `get_next_task_hint()` returns `nullopt` while `SCHEDULED`, blocking duplicate boundary tasks
- `execute()` computes boundaries and moves to `DONE`; OOM resets to `NOT_DONE` for retry

Remaining passthrough batches after boundary computation rely on existing scheduling: when merge is scheduled downstream, its FULL barrier on pipeline B is unfinished, so `get_operator_for_next_task()` walks back to `sort_sample` — no follow-up hook needed.