### PR TITLE
Parallelize the duckdb-native scan metadata walk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ set(TEST_SOURCES
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_column_builder.cpp
     test/cpp/scan/test_duckdb_block_layout.cpp
+    test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
     test/cpp/scan/test_duckdb_native_split_provider.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp
     test/cpp/scan/test_gpu_decode_alp.cpp

--- a/src/include/op/scan/duckdb_native_batch_coalescer.hpp
+++ b/src/include/op/scan/duckdb_native_batch_coalescer.hpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "helper/logical_type.hpp"
+#include "op/scan/duckdb_native_metadata.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <utility>
+#include <vector>
+
+namespace sirius::op::scan {
+
+//===----------------------------------------------------------------------===//
+// Streaming, order-independent row-group -> batch coalescer.
+//
+// The parallel metadata walk parses row groups on many worker threads, out of
+// order. The scan operator (a single consumer) feeds each parsed row group here
+// via push(); the coalescer packs them into batches that respect the same two
+// caps the serial `partition_row_groups_into_batches` enforced:
+//   - total decoded bytes per batch  <= approximate_batch_size (0 disables), and
+//   - per-varchar-column chars per batch < kCudfInt32StringsThreshold.
+// Completed batches surface through has_ready()/pop_ready() as soon as the next
+// row group would breach a cap. Centralizing batching on the one consumer —
+// rather than partitioning each worker slice independently — yields exactly ONE
+// undersized tail batch per scan: the accumulator remainder returned by flush()
+// after the producer has closed. Rowids are absolute per row group
+// (row_group_start), so packing order does not affect correctness.
+//===----------------------------------------------------------------------===//
+class batch_coalescer {
+ public:
+  batch_coalescer(std::size_t approximate_batch_size,
+                  const std::vector<sirius::logical_type>& projected_types)
+    : _cap_bytes(approximate_batch_size)
+  {
+    _is_varchar.reserve(projected_types.size());
+    for (auto const& t : projected_types) {
+      auto const is_v = t.is_varchar();
+      _is_varchar.push_back(is_v);
+      _any_varchar = _any_varchar || is_v;
+    }
+    _current_varchar.assign(projected_types.size(), 0);
+  }
+
+  /// Add one parsed row group. Empty row groups (row_count == 0) are dropped:
+  /// they decode to nothing and their absolute rowid range is empty. An
+  /// over-cap row group lands as the sole member of its own batch (it is added
+  /// to an empty accumulator, then closed when the next row group arrives).
+  void push(duckdb_row_group_metadata rg)
+  {
+    if (rg.row_count == 0) { return; }
+
+    auto const this_bytes = rg.decoded_bytes_budget;
+    if (!_current.empty() && would_close(this_bytes, rg)) { close_current(); }
+
+    _current_bytes += this_bytes;
+    if (_any_varchar) {
+      for (std::size_t c = 0; c < _is_varchar.size(); ++c) {
+        if (_is_varchar[c]) { _current_varchar[c] += rg.varchar_bytes_per_col[c]; }
+      }
+    }
+    _current.push_back(std::move(rg));
+  }
+
+  /// True iff a completed (cap-closed) batch is queued for the consumer.
+  [[nodiscard]] bool has_ready() const { return !_ready.empty(); }
+
+  /// Pop the oldest completed batch. Precondition: has_ready().
+  std::vector<duckdb_row_group_metadata> pop_ready()
+  {
+    auto batch = std::move(_ready.front());
+    _ready.pop_front();
+    return batch;
+  }
+
+  /// Flush the in-progress accumulator as the single tail batch. Call once the
+  /// producer has closed and all row groups have been pushed. May be empty.
+  std::vector<duckdb_row_group_metadata> flush()
+  {
+    auto tail = std::move(_current);
+    reset_current();
+    return tail;
+  }
+
+ private:
+  [[nodiscard]] bool would_close(std::size_t this_bytes, const duckdb_row_group_metadata& rg) const
+  {
+    if (_cap_bytes > 0 && _current_bytes + this_bytes > _cap_bytes) { return true; }
+    if (_any_varchar) {
+      for (std::size_t c = 0; c < _is_varchar.size(); ++c) {
+        if (_is_varchar[c] &&
+            _current_varchar[c] + rg.varchar_bytes_per_col[c] >= kCudfInt32StringsThreshold) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void close_current()
+  {
+    _ready.push_back(std::move(_current));
+    reset_current();
+  }
+
+  void reset_current()
+  {
+    _current.clear();
+    _current_bytes = 0;
+    std::fill(_current_varchar.begin(), _current_varchar.end(), std::size_t{0});
+  }
+
+  std::size_t _cap_bytes;
+  std::vector<bool> _is_varchar;
+  bool _any_varchar = false;
+
+  std::vector<duckdb_row_group_metadata> _current;
+  std::size_t _current_bytes = 0;
+  std::vector<std::size_t> _current_varchar;
+  std::deque<std::vector<duckdb_row_group_metadata>> _ready;
+};
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -31,6 +31,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace sirius::op::scan {
@@ -82,8 +83,7 @@ struct duckdb_row_group_metadata {
   std::size_t decoded_bytes_budget = 0;
   /// Parallel to `columns`. For varchar columns: Σ(seg.segment_count ×
   /// *seg.max_string_length) — the upper bound used against the cudf int32
-  /// chars threshold. 0 for non-varchar columns. Populated by the walker so
-  /// downstream partitioning never re-walks segments.
+  /// chars threshold. 0 for non-varchar columns.
   std::vector<std::size_t> varchar_bytes_per_col;
 };
 
@@ -98,33 +98,75 @@ struct duckdb_row_group_metadata {
 constexpr std::size_t kCudfInt32StringsThreshold =
   static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max());
 
-/// When `viable` is false the walker bailed at the first unsupported
-/// segment or type; `row_groups` is partial and must not be consumed.
-struct duckdb_native_metadata {
-  std::vector<duckdb_row_group_metadata> row_groups;
-  bool viable = false;
-  std::string viability_failure_reason;
-};
-
-/// Metadata-only walk of `storage` via `DataTable::GetColumnSegmentInfo`
-/// and `GetPartitionStats`. Pins no blocks and reads no bytes.
-///
-/// Returns `viable = false` with a populated `viability_failure_reason`
-/// on the first unsupported segment or type.
-///
-/// Caller is responsible for the operator-level escape gates
-/// (`dynamic_filters`, sample options, virtual columns, type pushdown)
-/// on the originating `LogicalGet`.
-duckdb_native_metadata walk_duckdb_native_metadata(
-  duckdb::DataTable& storage,
-  duckdb::ClientContext& context,
-  const std::vector<projected_column>& projected_cols,
-  const std::vector<sirius::logical_type>& projected_types);
-
 /// Exposed for direct unit-testing of the codec-rejection logic without
 /// going through DuckDB's codec selection (which is hard to drive into
 /// unsupported codecs in a test).
 bool is_supported_data_compression(duckdb::CompressionType c);
 bool is_supported_validity_compression(duckdb::CompressionType c);
+
+//===----------------------------------------------------------------------===//
+// 2 phase metadata walk:
+//  - 1) serial prepare_duckdb_native_walk(), invoked in duckdb_native_split_provider ctor
+//  - 2) parallel walk_duckdb_native_row_group_range(), dispatched to scan_manager worker threads
+//===----------------------------------------------------------------------===//
+
+/// @brief Serial prepare: read PartitionStatistics, validate projected types and
+/// partition `row_start`, and capture the row-group count, block size, and a
+/// storage primary index -> projected column index map. No per-segment IO.
+/// PartitionStatistics touches ClientContext / LocalStorage, which are not thread-safe
+struct duckdb_native_walk_plan {
+  duckdb::DataTable* storage     = nullptr;
+  duckdb::ClientContext* context = nullptr;
+
+  const std::vector<projected_column>* projected_cols      = nullptr;
+  const std::vector<sirius::logical_type>* projected_types = nullptr;
+  std::unordered_map<duckdb::idx_t, std::size_t>
+    projected_lookup;  /// Map storage primary index -> projected column index (rowid cols
+                       /// excluded).
+
+  //===----------RowGroupCollection data----------===//
+  std::size_t n_row_groups = 0;
+  std::size_t block_size   = 0;
+
+  //===----------PartitionStatistics data: vector across row groups----------===//
+  std::vector<duckdb::idx_t> row_group_start;  ///< Absolute first-row index per row group
+                                               ///< (PartitionStatistics::row_start).
+  std::vector<duckdb::idx_t>
+    row_count;  ///< Rows per row group (PartitionStatistics::count); 0 where unavailable.
+
+  //===----------Error Handling----------===//
+  // `viable == false` (with reason) for:
+  //  - unsupported projected types,
+  //  - an invalid partition `row_start`, or
+  //  - an empty table.
+  bool viable = false;
+  std::string viability_failure_reason;
+};
+duckdb_native_walk_plan prepare_duckdb_native_walk(
+  duckdb::DataTable& storage,
+  duckdb::ClientContext& context,
+  const std::vector<projected_column>& projected_cols,
+  const std::vector<sirius::logical_type>& projected_types);
+
+/// @brief Walk the projected-column segment metadata for row groups [rg_begin, rg_end)
+/// of `plan`, filling per-row-group
+///  - `decoded_bytes_budget`,
+///  - `varchar_bytes_per_col`, and
+///  - segment `bytes_size`.
+struct duckdb_native_row_group_range {
+  //===----------ColumnSegmentInfo data----------===//
+  std::vector<duckdb_row_group_metadata>
+    row_groups;  ///< rg metadata ranging over [rg_begin, rg_end)
+
+  //===----------Error Handling----------===//
+  //`viable == false` (with reason) on the first
+  //  - unsupported segment compression, or
+  //  - absent/over-threshold varchar stat.
+  // `row_groups` is then partial and must not be consumed.
+  bool viable = true;
+  std::string viability_failure_reason;
+};
+duckdb_native_row_group_range walk_duckdb_native_row_group_range(
+  const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp
@@ -28,7 +28,14 @@ class split_connector;
 class sirius_scan_manager;
 }  // namespace sirius::scan_manager
 
+namespace sirius::io {
+class sirius_ioctx;
+class sirius_io_object;
+}  // namespace sirius::io
+
 namespace sirius::op::scan {
+
+class batch_coalescer;
 
 //===----------------------------------------------------------------------===//
 // GPU-native DuckDB scan operator.
@@ -72,6 +79,18 @@ class sirius_gpu_duckdb_native_scan_operator : public sirius_physical_operator {
 
   std::unique_ptr<scan_manager::split_connector> _split_connector;
   std::unique_ptr<duckdb_native_scan_info> _scan_info;
+
+  // Consumer-side coalescing of the parallel walk's per-range row groups into
+  // cap-sized batches (exactly one tail batch per scan). Lazily created on the
+  // first pulled split — by then scan_info has been moved to the split provider,
+  // so the batch caps and projected types are read off the pulled payloads, and
+  // the shared scan_info / io handles are captured to rebuild coalesced payloads.
+  // Reset per query in set_split_connector. The task creator drives a single
+  // self-perpetuating worker per scan operator, so this state needs no lock.
+  std::unique_ptr<batch_coalescer> _coalescer;
+  std::shared_ptr<duckdb_native_scan_info const> _batch_scan_info;
+  std::shared_ptr<sirius::io::sirius_ioctx> _batch_io_ctx;
+  std::shared_ptr<sirius::io::sirius_io_object> _batch_db_io_object;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/scan_manager/duckdb_native_split_provider.hpp
+++ b/src/include/scan_manager/duckdb_native_split_provider.hpp
@@ -39,21 +39,16 @@ class duckdb_native_split_provider : public split_provider {
   struct split_payload : public op::operator_data {
     std::vector<op::scan::duckdb_row_group_metadata> row_groups;
     std::shared_ptr<op::scan::duckdb_native_scan_info const> scan_info;
-    /// sirius_io substrate handles. Set by the regular (non-cached) split path so
-    /// the scan task can read .db blocks via sirius_ioctx::host_read instead of
-    /// going through DuckDB's BufferManager. Both null when the scan_manager
-    /// was configured with use_sirius_datasource=false (falls back to BufferManager).
+    /// sirius_io substrate handles for reading .db blocks via
+    /// sirius_ioctx. Always non-null (the provider requires a
+    /// non-null io_ctx); the scan task threads them onto every
+    // decode.
     std::shared_ptr<sirius::io::sirius_ioctx> io_ctx;
     std::shared_ptr<sirius::io::sirius_io_object> db_io_object;
   };
 
-  struct row_group_batch {
-    std::size_t first_idx;
-    std::size_t count;
-  };
-
   explicit duckdb_native_split_provider(op::scan::duckdb_native_scan_info info,
-                                        std::shared_ptr<sirius::io::sirius_ioctx> io_ctx = nullptr);
+                                        std::shared_ptr<sirius::io::sirius_ioctx> io_ctx);
 
   ~duckdb_native_split_provider() override;
 
@@ -64,16 +59,22 @@ class duckdb_native_split_provider : public split_provider {
 
   [[nodiscard]] bool has_more_splits() const override;
 
+  // Each claimed split is a *row-group range*, not a finished batch. The
+  // thunk emits one raw split_payload carrying the range's parsed row groups;
+  // the scan operator's batch_coalescer packs those into cap-sized batches
+  // (with a single tail batch). next_split_provider() itself only does the
+  // cheap atomic claim.
   std::function<std::vector<std::unique_ptr<op::operator_data>>()> next_split_provider() override;
 
  private:
   std::shared_ptr<op::scan::duckdb_native_scan_info const> _scan_info;
-  op::scan::duckdb_native_metadata _metadata;
-  std::vector<row_group_batch> _batches;
-  std::atomic<std::size_t> _next_batch_idx{0};
-  /// Parked for the downstream scan task to read .db blocks via
-  /// sirius_ioctx::host_read. Null when the scan_manager runs without
-  /// sirius_datasource.
+  op::scan::duckdb_native_walk_plan _plan;
+  std::size_t _chunk_row_groups = 1;  ///< The number of row groups claimed per range (tunable via
+                                      ///< config SIRIUS_METADATA_PARSE_CHUNK)
+  std::size_t _num_ranges = 0;
+  std::atomic<std::size_t> _next_range_idx{0};
+  /// sirius_io handles threaded onto every split so the scan task reads .db
+  /// blocks via sirius_ioctx. Both non-null (validated in the ctor).
   std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
   std::shared_ptr<sirius::io::sirius_io_object> _db_io_object;
 };

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -165,73 +165,16 @@ duckdb_segment_descriptor build_segment_descriptor(const duckdb::ColumnSegmentIn
   return desc;
 }
 
-using row_group_handles =
-  std::vector<std::pair<duckdb::idx_t, duckdb::shared_ptr<duckdb::PartitionRowGroup>>>;
-
-// Use PartitionStatistics::count as the source of truth so rowid-only
-// projections (no data segments to sum) still get a real row_count.
-void compute_row_counts(duckdb_native_metadata& md,
-                        const std::vector<duckdb::PartitionStatistics>& partition_stats)
-{
-  for (auto& rg_md : md.row_groups) {
-    if (rg_md.row_group_index < partition_stats.size()) {
-      rg_md.row_count = partition_stats[rg_md.row_group_index].count;
-      continue;
-    }
-    duckdb::idx_t row_count = 0;
-    for (const auto& col_md : rg_md.columns) {
-      if (col_md.is_rowid) { continue; }
-      duckdb::idx_t col_count = 0;
-      for (const auto& d : col_md.data_segments) {
-        col_count += d.segment_count;
-      }
-      if (col_count > 0) {
-        row_count = col_count;
-        break;
-      }
-    }
-    rg_md.row_count = row_count;
-  }
-}
-
-// Per-segment exact: chars + offsets. Walker refuse-on-absent guarantees
-// every VARCHAR data segment carries Some here.
-void compute_decoded_byte_budgets(duckdb_native_metadata& md,
-                                  const std::vector<sirius::logical_type>& projected_types)
-{
-  for (auto& rg_md : md.row_groups) {
-    std::size_t budget = 0;
-    for (std::size_t ci = 0; ci < rg_md.columns.size(); ++ci) {
-      const auto& col_md = rg_md.columns[ci];
-      if (col_md.is_rowid) {
-        budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
-        continue;
-      }
-      if (projected_types[ci].is_varchar()) {
-        std::size_t chars_total = 0;
-        for (const auto& seg : col_md.data_segments) {
-          chars_total += static_cast<std::size_t>(seg.segment_count) *
-                         static_cast<std::size_t>(*seg.max_string_length);
-        }
-        budget += chars_total + static_cast<std::size_t>(rg_md.row_count) * sizeof(std::uint32_t);
-      } else {
-        budget +=
-          static_cast<std::size_t>(rg_md.row_count) * projected_types[ci].fixed_width_byte_size();
-      }
-    }
-    rg_md.decoded_bytes_budget = budget;
-  }
-}
-
 // ColumnSegmentInfo lacks segment_size. Derive via sorted-by-(block_id,
 // block_offset) delta to the next walked segment; last-in-block falls back
 // to `block_size - block_offset`. Upper bound only: trailing free space and
 // cross-table partial-block neighbors inflate it. Codec headers self-bound
 // reads, so correctness-safe; only H2D and staging bytes pay the overshoot.
-void compute_segment_bytes_size(duckdb_native_metadata& md, std::size_t block_size)
+void compute_segment_bytes_size(std::vector<duckdb_row_group_metadata>& row_groups,
+                                std::size_t block_size)
 {
   std::vector<duckdb_segment_descriptor*> refs;
-  for (auto& rg : md.row_groups) {
+  for (auto& rg : row_groups) {
     for (auto& col : rg.columns) {
       for (auto& s : col.data_segments)
         if (s.block_id >= 0) refs.push_back(&s);
@@ -245,28 +188,10 @@ void compute_segment_bytes_size(duckdb_native_metadata& md, std::size_t block_si
   });
   for (std::size_t i = 0; i < refs.size(); ++i) {
     auto& seg                = *refs[i];
-    const bool last_in_block = i + 1 == refs.size() || refs[i + 1]->block_id != seg.block_id;
-    const std::size_t end =
+    auto const last_in_block = i + 1 == refs.size() || refs[i + 1]->block_id != seg.block_id;
+    auto const end =
       last_in_block ? block_size : static_cast<std::size_t>(refs[i + 1]->block_offset);
     seg.bytes_size = end - static_cast<std::size_t>(seg.block_offset);
-  }
-}
-
-// The walker over-allocates to `max_row_group_index + 1`; row groups
-// whose every projected segment was filtered out arrive here with
-// row_count == 0. Rowid-only entries are kept.
-void drop_empty_trailing_row_groups(duckdb_native_metadata& md)
-{
-  while (!md.row_groups.empty() && md.row_groups.back().row_count == 0) {
-    bool has_rowid = false;
-    for (const auto& col_md : md.row_groups.back().columns) {
-      if (col_md.is_rowid) {
-        has_rowid = true;
-        break;
-      }
-    }
-    if (has_rowid) { break; }
-    md.row_groups.pop_back();
   }
 }
 
@@ -301,78 +226,116 @@ bool is_supported_validity_compression(duckdb::CompressionType c)
   }
 }
 
-duckdb_native_metadata walk_duckdb_native_metadata(
+//===----------prepare_duckdb_native_walk----------===//
+duckdb_native_walk_plan prepare_duckdb_native_walk(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
   const std::vector<projected_column>& projected_cols,
   const std::vector<sirius::logical_type>& projected_types)
 {
-  nvtx3::scoped_range nvtx_walk{"sirius::native_metadata_walk"};
+  nvtx3::scoped_range nvtx_prep{"sirius::native_metadata_prepare"};
 
-  duckdb_native_metadata md;
-  md.viable = false;
+  duckdb_native_walk_plan plan;
+  plan.viable          = false;
+  plan.storage         = &storage;
+  plan.context         = &context;
+  plan.projected_cols  = &projected_cols;
+  plan.projected_types = &projected_types;
 
-  auto refuse = [&md](std::string reason) {
-    md.viability_failure_reason = std::move(reason);
-    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused: {}", md.viability_failure_reason);
+  auto refuse = [&plan](std::string reason) {
+    plan.viability_failure_reason = std::move(reason);
+    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused (prepare): {}",
+                     plan.viability_failure_reason);
   };
 
   if (projected_cols.empty()) {
     refuse("no projected columns");
-    return md;
+    return plan;
   }
   if (projected_cols.size() != projected_types.size()) {
     refuse("projected_cols and projected_types size mismatch");
-    return md;
+    return plan;
   }
 
+  // Type gate
   for (std::size_t ci = 0; ci < projected_types.size(); ++ci) {
     if (projected_cols[ci].is_rowid) { continue; }
     std::string reason;
     if (!is_supported_logical_type(projected_types[ci], reason)) {
       refuse("column " + std::to_string(projected_cols[ci].storage_idx.GetPrimaryIndex()) + ": " +
              reason);
-      return md;
+      return plan;
     }
   }
 
-  // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
-  // iteration order at v1.5.2 — relied on for indexing by row_group_index.
+  // GetPartitionStats touches LocalStorage/ClientContext, so it must run here,
+  // serially, before the row-group ranges are walked concurrently.
   duckdb::vector<duckdb::PartitionStatistics> partition_stats;
   {
+    /// @note Synchronous pread()s happen here when cold
     nvtx3::scoped_range nvtx_ps{"sirius::native_metadata_partition_stats"};
     partition_stats = storage.GetPartitionStats(context);
   }
-  row_group_handles handles;
-  handles.reserve(partition_stats.size());
+
+  auto const& row_groups = *storage.GetRowGroupCollection();
+  plan.n_row_groups      = row_groups.GetRowGroupCount();
+  plan.block_size = storage.GetAttached().GetStorageManager().GetBlockManager().GetBlockSize();
+
+  plan.row_group_start.assign(plan.n_row_groups, 0);
+  plan.row_count.assign(plan.n_row_groups, 0);
   for (std::size_t i = 0; i < partition_stats.size(); ++i) {
-    auto& ps = partition_stats[i];
+    auto const& ps = partition_stats[i];
     if (!ps.row_start.IsValid()) {
-      // Defaulting to 0 would emit wrong rowids; route to CPU instead.
       refuse("partition_stats[" + std::to_string(i) +
              "].row_start is not valid; cannot synthesize rowids");
-      return md;
+      return plan;
     }
-    handles.emplace_back(ps.row_start.GetIndex(), ps.partition_row_group);
+    // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
+    // iteration order at v1.5.2.
+    if (i < plan.n_row_groups) {
+      plan.row_group_start[i] = ps.row_start.GetIndex();
+      plan.row_count[i]       = ps.count;
+    }
   }
 
-  // O(1) skip for non-projected columns in the GetColumnSegmentInfo loop.
-  std::unordered_map<duckdb::idx_t, std::size_t> projected_lookup;
-  projected_lookup.reserve(projected_cols.size());
+  // Prepare skipping non-projected columns in the GetColumnSegmentInfo loop.
+  plan.projected_lookup.reserve(projected_cols.size());
   for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
     if (projected_cols[ci].is_rowid) { continue; }
-    projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
+    plan.projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
   }
 
-  duckdb::QueryContext qc{context};
+  plan.viable = true;
+  return plan;
+}
+
+//===----------walk_duckdb_native_row_group_range----------===//
+duckdb_native_row_group_range walk_duckdb_native_row_group_range(
+  const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end)
+{
+  duckdb_native_row_group_range result;
+
+  auto const& projected_cols  = *plan.projected_cols;
+  auto const& projected_types = *plan.projected_types;
+
+  rg_end = std::min(rg_end, plan.n_row_groups);
+  if (rg_begin >= rg_end) { return result; }  // viable=true, empty range
+
+  auto refuse = [&result](std::string reason) {
+    result.viable                   = false;
+    result.viability_failure_reason = std::move(reason);
+    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused (range): {}",
+                     result.viability_failure_reason);
+  };
+
+  // Get column segment metadata
+  duckdb::QueryContext qc{*plan.context};
   duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
   {
     nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
-    // Read segment metadata for projected columns only.
-    auto& row_groups        = *storage.GetRowGroupCollection();
-    auto const n_row_groups = row_groups.GetRowGroupCount();
-    for (std::size_t rg = 0; rg < n_row_groups; ++rg) {
-      auto row_group = row_groups.GetRowGroup(rg);
+    auto& row_groups = *plan.storage->GetRowGroupCollection();
+    for (std::size_t rg = rg_begin; rg < rg_end; ++rg) {
+      auto row_group = row_groups.GetRowGroup(static_cast<duckdb::idx_t>(rg));
       if (!row_group) { continue; }
       for (auto const& pc : projected_cols) {
         if (pc.is_rowid) { continue; }
@@ -382,59 +345,55 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-  // Size to max_row_group_index + 1 so rowid-only and all-filtered row
-  // groups still have an entry for rowid synthesis and trailing-empty
-  // pruning to inspect.
-  duckdb::idx_t max_rg_idx = 0;
-  for (const auto& seg : column_segments) {
-    max_rg_idx = std::max(max_rg_idx, seg.row_group_index);
-  }
-  const std::size_t num_row_groups =
-    column_segments.empty() ? handles.size() : static_cast<std::size_t>(max_rg_idx) + 1;
-  md.row_groups.resize(num_row_groups);
-  for (std::size_t rg = 0; rg < num_row_groups; ++rg) {
-    md.row_groups[rg].row_group_index = rg;
-    md.row_groups[rg].columns.resize(projected_cols.size());
+  // One entry per row group in [rg_begin, rg_end)
+  auto const n = rg_end - rg_begin;
+  result.row_groups.resize(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    auto const rg         = rg_begin + i;
+    auto& rg_md           = result.row_groups[i];
+    rg_md.row_group_index = rg;
+    rg_md.row_group_start = plan.row_group_start[rg];
+    rg_md.row_count       = plan.row_count[rg];
+    rg_md.columns.resize(projected_cols.size());
     for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      md.row_groups[rg].columns[ci].column_id =
-        projected_cols[ci].is_rowid ? std::numeric_limits<duckdb::idx_t>::max()
-                                    : projected_cols[ci].storage_idx.GetPrimaryIndex();
-      md.row_groups[rg].columns[ci].is_rowid = projected_cols[ci].is_rowid;
+      rg_md.columns[ci].column_id = projected_cols[ci].is_rowid
+                                      ? std::numeric_limits<duckdb::idx_t>::max()
+                                      : projected_cols[ci].storage_idx.GetPrimaryIndex();
+      rg_md.columns[ci].is_rowid  = projected_cols[ci].is_rowid;
     }
-    if (rg < handles.size()) { md.row_groups[rg].row_group_start = handles[rg].first; }
   }
 
+  // Build segment descriptors
   for (const auto& seg : column_segments) {
-    auto pl = projected_lookup.find(seg.column_id);
-    if (pl == projected_lookup.end()) { continue; }  // not projected
-    const std::size_t ci    = pl->second;
-    const auto rg_idx       = seg.row_group_index;
-    const bool validity_seg = is_validity_path(seg.column_path);
-    const auto compression  = parse_compression_string(seg.compression_type);
-
-    const bool compression_ok = validity_seg ? is_supported_validity_compression(compression)
+    auto pl = plan.projected_lookup.find(seg.column_id);
+    if (pl == plan.projected_lookup.end()) { continue; }  // not projected
+    auto const rg_idx = seg.row_group_index;
+    if (rg_idx < rg_begin || rg_idx >= rg_end) { continue; }
+    auto const ci             = pl->second;
+    auto const local_rgi      = static_cast<std::size_t>(rg_idx) - rg_begin;
+    auto const validity_seg   = is_validity_path(seg.column_path);
+    auto const compression    = parse_compression_string(seg.compression_type);
+    auto const compression_ok = validity_seg ? is_supported_validity_compression(compression)
                                              : is_supported_data_compression(compression);
     if (!compression_ok) {
       refuse(std::string{validity_seg ? "validity" : "data"} + " segment on column " +
              std::to_string(seg.column_id) + " row group " + std::to_string(rg_idx) +
              ": unsupported compression \"" + seg.compression_type + "\"");
-      return md;
+      return result;
     }
 
     auto desc = build_segment_descriptor(seg, compression);
 
     if (!validity_seg && projected_types[ci].is_varchar()) {
-      // Refuse on absent stat so downstream consumers can deref unchecked.
-      // Some(0) is legal data (all-empty row group); decode produces 0 chars.
       desc.max_string_length = parse_segment_max_string_length(seg.segment_stats);
       if (!desc.max_string_length.has_value()) {
         refuse("varchar segment on column " + std::to_string(seg.column_id) + " row group " +
                std::to_string(rg_idx) + ": Max String Length stat absent from segment_stats");
-        return md;
+        return result;
       }
     }
 
-    auto& col_md = md.row_groups[rg_idx].columns[ci];
+    auto& col_md = result.row_groups[local_rgi].columns[ci];
     if (validity_seg) {
       col_md.validity_segments.push_back(std::move(desc));
     } else {
@@ -442,34 +401,8 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-#ifndef NDEBUG
-  // Invariant: DuckDB's typed PartitionRowGroup::GetColumnStatistics returns
-  // max(per-segment) via StringStats::Merge. Catches API drift.
-  for (std::size_t rg_idx = 0; rg_idx < handles.size(); ++rg_idx) {
-    auto& prg = handles[rg_idx].second;
-    if (!prg) { continue; }
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
-      auto stats = prg->GetColumnStatistics(projected_cols[ci].storage_idx);
-      if (!stats || !duckdb::StringStats::HasMaxStringLength(*stats)) { continue; }
-      const auto rg_typed_max   = duckdb::StringStats::MaxStringLength(*stats);
-      const auto& data_segs     = md.row_groups[rg_idx].columns[ci].data_segments;
-      std::uint32_t per_seg_max = 0;
-      for (const auto& seg : data_segs) {
-        if (seg.max_string_length.has_value()) {
-          per_seg_max = std::max(per_seg_max, *seg.max_string_length);
-        }
-      }
-      assert(rg_typed_max == per_seg_max &&
-             "DuckDB rg-level MaxStringLength != max(per-segment) — Merge semantics drifted?");
-    }
-  }
-#endif
-
-  // GetColumnSegmentInfo at v1.5.2 already yields segments in segment_start
-  // order per (column, row group); this sort is a guard against future
-  // upstream changes to that order.
-  for (auto& rg_md : md.row_groups) {
+  // Defensive: ensure data_segments is sorted by segment_start ascending for codec run coalescing
+  for (auto& rg_md : result.row_groups) {
     auto seg_less = [](const duckdb_segment_descriptor& a, const duckdb_segment_descriptor& b) {
       return a.segment_start < b.segment_start;
     };
@@ -479,49 +412,61 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-  compute_segment_bytes_size(
-    md, storage.GetAttached().GetStorageManager().GetBlockManager().GetBlockSize());
-
-  compute_row_counts(md, partition_stats);
-  compute_decoded_byte_budgets(md, projected_types);
-  drop_empty_trailing_row_groups(md);
-
-  // Per-column varchar upper bound, cached on each row group so the
-  // partitioner is a pure read. Walker refuses any row group whose
-  // per-column upper bound hits the cudf int32 chars threshold (cudf
-  // throws there in default-mode make_offsets_child_column).
-  for (auto& rg : md.row_groups) {
-    rg.varchar_bytes_per_col.assign(projected_cols.size(), 0);
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
-      std::size_t total = 0;
-      for (const auto& seg : rg.columns[ci].data_segments) {
-        total += static_cast<std::size_t>(seg.segment_count) *
-                 static_cast<std::size_t>(*seg.max_string_length);
+  // Defensive: if a row group happened to exceed the range of PartitionStatistics, compute the row
+  // count manually.
+  for (auto& rg_md : result.row_groups) {
+    if (rg_md.row_count != 0) { continue; }
+    for (const auto& col_md : rg_md.columns) {
+      if (col_md.is_rowid) { continue; }
+      duckdb::idx_t col_count = 0;
+      for (const auto& d : col_md.data_segments) {
+        col_count += d.segment_count;
       }
-      if (total >= kCudfInt32StringsThreshold) {
-        refuse("row group " + std::to_string(rg.row_group_index) + " column " +
-               std::to_string(rg.columns[ci].column_id) + " varchar chars upper bound (" +
-               std::to_string(total) + ") >= cudf int32 chars threshold");
-        return md;
+      if (col_count > 0) {
+        rg_md.row_count = col_count;
+        break;
       }
-      rg.varchar_bytes_per_col[ci] = total;
     }
   }
 
-  if (md.row_groups.empty()) {
-    // Zero splits would hang the pipeline on the FULL barrier; refuse so
-    // the transparent fallback routes to DuckDB CPU.
-    refuse("no row groups in table (empty or fully pruned)");
-    return md;
+  // Per-segment on-disk byte sizes (computed within this range).
+  compute_segment_bytes_size(result.row_groups, plan.block_size);
+
+  // Per row group, compute: 1) the decoded-byte budget, and
+  //                         2) the per-column varchar char count.
+  // Refuse a varchar column whose char count would overflow cudf's int32 string offsets.
+  for (auto& rg_md : result.row_groups) {
+    rg_md.varchar_bytes_per_col.assign(projected_cols.size(), 0);
+    std::size_t budget = 0;
+    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
+      const auto& col_md = rg_md.columns[ci];
+      if (col_md.is_rowid) {
+        budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
+        continue;
+      }
+      if (projected_types[ci].is_varchar()) {
+        std::size_t chars = 0;
+        for (const auto& seg : col_md.data_segments) {
+          chars += static_cast<std::size_t>(seg.segment_count) *
+                   static_cast<std::size_t>(*seg.max_string_length);
+        }
+        if (chars >= kCudfInt32StringsThreshold) {
+          refuse("row group " + std::to_string(rg_md.row_group_index) + " column " +
+                 std::to_string(col_md.column_id) + " varchar chars upper bound (" +
+                 std::to_string(chars) + ") >= cudf int32 chars threshold");
+          return result;
+        }
+        rg_md.varchar_bytes_per_col[ci] = chars;
+        budget += chars + static_cast<std::size_t>(rg_md.row_count) * sizeof(std::uint32_t);
+      } else {
+        budget +=
+          static_cast<std::size_t>(rg_md.row_count) * projected_types[ci].fixed_width_byte_size();
+      }
+    }
+    rg_md.decoded_bytes_budget = budget;
   }
 
-  md.viable = true;
-  SIRIUS_LOG_DEBUG(
-    "[duckdb_native_metadata] walked {} row groups across {} projected columns; viable=true",
-    md.row_groups.size(),
-    projected_cols.size());
-  return md;
+  return result;
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_native_scan_info.cpp
+++ b/src/op/scan/duckdb_native_scan_info.cpp
@@ -32,9 +32,9 @@ std::unique_ptr<scan_manager::split_provider> duckdb_native_scan_info::make_prov
   // it via io_ctx_shared_for(path). It stays in the signature only to satisfy
   // the combined-runtime scan_info::make_provider(manager, gpu_ioctxs) contract.
   (void)manager;
-  // the duckdb-native decoder currently uses a single ioctx (Phase B lift is per
-  // single-GPU). Pick the first ioctx in the map; pass nullptr when empty so
-  // the split_provider falls through to BufferManager::Pin.
+  // The duckdb-native decoder uses a single ioctx (Phase B lift is per
+  // single-GPU). Pick the first ioctx; the split_provider requires a non-null
+  // io_ctx, so an empty map is a misconfiguration its ctor rejects.
   auto io_ctx = gpu_ioctxs.empty() ? nullptr : gpu_ioctxs.begin()->second;
   return std::make_unique<scan_manager::duckdb_native_split_provider>(std::move(*this),
                                                                       std::move(io_ctx));

--- a/src/op/scan/sirius_gpu_duckdb_native_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_duckdb_native_scan_operator.cpp
@@ -23,6 +23,7 @@
 #include <expression/ast/from_duckdb.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
 #include <log/logging.hpp>
+#include <op/scan/duckdb_native_batch_coalescer.hpp>
 #include <op/scan/duckdb_native_decoder.hpp>
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_duckdb_native_scan_operator.hpp>
@@ -57,6 +58,11 @@ void sirius_gpu_duckdb_native_scan_operator::set_split_connector(
   std::unique_ptr<scan_manager::split_connector> connector)
 {
   _split_connector = std::move(connector);
+  // Fresh connector → fresh coalescer state for this query.
+  _coalescer.reset();
+  _batch_scan_info.reset();
+  _batch_io_ctx.reset();
+  _batch_db_io_object.reset();
 }
 
 std::optional<task_creation_hint> sirius_gpu_duckdb_native_scan_operator::get_next_task_hint()
@@ -72,9 +78,56 @@ bool sirius_gpu_duckdb_native_scan_operator::all_ports_empty()
 
 std::unique_ptr<operator_data> sirius_gpu_duckdb_native_scan_operator::get_next_task_input_data()
 {
-  auto next = _split_connector->get_next_split();
-  if (!next.has_value()) { return nullptr; }
-  return std::move(*next);
+  // The split provider's worker threads parse row-group *ranges* in parallel and
+  // push them (out of order) as raw split_payloads. We coalesce those into
+  // cap-sized batches here, on the single consumer the task creator drives, so
+  // there is exactly one undersized tail batch per scan. get_next_split() blocks
+  // when no range is ready yet, providing natural back-pressure-free waiting.
+  auto make_batch =
+    [this](std::vector<duckdb_row_group_metadata> row_groups) -> std::unique_ptr<operator_data> {
+    auto payload = std::make_unique<scan_manager::duckdb_native_split_provider::split_payload>();
+    payload->scan_info    = _batch_scan_info;
+    payload->io_ctx       = _batch_io_ctx;
+    payload->db_io_object = _batch_db_io_object;
+    payload->row_groups   = std::move(row_groups);
+    return payload;
+  };
+
+  for (;;) {
+    if (_coalescer && _coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
+
+    auto next = _split_connector->get_next_split();
+    if (!next.has_value()) {
+      // Producer closed and drained: emit the single tail batch, if any remains.
+      if (_coalescer) {
+        auto tail = _coalescer->flush();
+        if (!tail.empty()) { return make_batch(std::move(tail)); }
+      }
+      return nullptr;
+    }
+
+    auto* slice =
+      dynamic_cast<scan_manager::duckdb_native_split_provider::split_payload*>(next->get());
+    if (slice == nullptr) {
+      throw std::runtime_error(
+        "[sirius_gpu_duckdb_native_scan_operator] get_next_task_input_data: unexpected "
+        "operator_data type from split connector; expected split_payload.");
+    }
+
+    if (!_coalescer) {
+      // First range: capture the shared scan_info / io handles (identical across
+      // ranges) and size the coalescer from the scan's batch caps + types.
+      _batch_scan_info    = slice->scan_info;
+      _batch_io_ctx       = slice->io_ctx;
+      _batch_db_io_object = slice->db_io_object;
+      _coalescer = std::make_unique<batch_coalescer>(slice->scan_info->approximate_batch_size,
+                                                     slice->scan_info->projected_types);
+    }
+
+    for (auto& rg : slice->row_groups) {
+      _coalescer->push(std::move(rg));
+    }
+  }
 }
 
 std::unique_ptr<operator_data> sirius_gpu_duckdb_native_scan_operator::execute(

--- a/src/scan_manager/duckdb_native_split_provider.cpp
+++ b/src/scan_manager/duckdb_native_split_provider.cpp
@@ -17,88 +17,36 @@
 #include "scan_manager/duckdb_native_split_provider.hpp"
 
 #include "io/io_context.hpp"
-#include "io/types.hpp"
-#include "log/logging.hpp"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
 #include <stdexcept>
+#include <string>
 #include <utility>
-
-// Work placement note: diverges from `parquet_split_provider`. For parquet a
-// scan-manager worker thread parses metadata and emits splits, because each
-// parquet file means real IO. For duckdb-native the metadata is already in
-// memory, so the walker + batch partitioning runs here in the ctor on the
-// query-executor thread; worker threads only claim pre-built batches.
 
 namespace sirius::scan_manager {
 
 namespace {
 
-std::vector<duckdb_native_split_provider::row_group_batch> partition_row_groups_into_batches(
-  const std::vector<op::scan::duckdb_row_group_metadata>& row_groups,
-  std::size_t approximate_batch_size,
-  const std::vector<sirius::logical_type>& projected_types)
+// Row groups per parse range. Smaller ranges balance load and keep the read
+// queue full across the worker pool; larger ranges cut per-range dispatch
+// overhead. Overridable via SIRIUS_METADATA_PARSE_CHUNK for tuning.
+// A `parse range` (row group range) is the unit of work for a scan manager thread
+// providing splits.
+constexpr std::size_t kDefaultParseChunkRowGroups = 8;
+
+std::size_t parse_chunk_row_groups()
 {
-  std::vector<duckdb_native_split_provider::row_group_batch> batches;
-  if (row_groups.empty()) return batches;
-
-  const std::size_t num_cols = projected_types.size();
-  std::vector<bool> is_varchar(num_cols, false);
-  bool any_varchar = false;
-  for (std::size_t c = 0; c < num_cols; ++c) {
-    is_varchar[c] = projected_types[c].is_varchar();
-    any_varchar   = any_varchar || is_varchar[c];
-  }
-
-  // No caps in play → single batch.
-  if (approximate_batch_size == 0 && !any_varchar) {
-    batches.push_back({0, row_groups.size()});
-    return batches;
-  }
-
-  std::size_t batch_first = 0;
-  std::size_t batch_bytes = 0;
-  std::vector<std::size_t> col_bytes(num_cols, 0);
-
-  for (std::size_t i = 0; i < row_groups.size(); ++i) {
-    const auto& rg                  = row_groups[i];
-    const std::size_t this_rg_bytes = rg.decoded_bytes_budget;
-
-    // Only close a non-empty batch; an over-cap row group always lands in
-    // the current batch as its first member (singleton if it's alone).
-    if (i > batch_first) {
-      const bool would_exceed_total =
-        (approximate_batch_size > 0) && (batch_bytes + this_rg_bytes > approximate_batch_size);
-
-      bool would_exceed_varchar = false;
-      if (any_varchar) {
-        for (std::size_t c = 0; c < num_cols; ++c) {
-          if (is_varchar[c] &&
-              col_bytes[c] + rg.varchar_bytes_per_col[c] >= op::scan::kCudfInt32StringsThreshold) {
-            would_exceed_varchar = true;
-            break;
-          }
-        }
-      }
-
-      if (would_exceed_total || would_exceed_varchar) {
-        batches.push_back({batch_first, i - batch_first});
-        batch_first = i;
-        batch_bytes = 0;
-        std::fill(col_bytes.begin(), col_bytes.end(), 0);
-      }
-    }
-
-    batch_bytes += this_rg_bytes;
-    if (any_varchar) {
-      for (std::size_t c = 0; c < num_cols; ++c) {
-        col_bytes[c] += rg.varchar_bytes_per_col[c];
-      }
+  if (char const* env = std::getenv("SIRIUS_METADATA_PARSE_CHUNK")) {
+    try {
+      auto const v = std::stoull(env);
+      if (v > 0) { return static_cast<std::size_t>(v); }
+    } catch (...) {
+      // Unparsable value → fall through to the default.
     }
   }
-  if (batch_first < row_groups.size()) {
-    batches.push_back({batch_first, row_groups.size() - batch_first});
-  }
-  return batches;
+  return kDefaultParseChunkRowGroups;
 }
 
 }  // namespace
@@ -118,57 +66,72 @@ duckdb_native_split_provider::duckdb_native_split_provider(
     throw std::invalid_argument(
       "duckdb_native_split_provider: projected_cols and projected_types must be parallel");
   }
+  if (_io_ctx == nullptr) {
+    throw std::invalid_argument("duckdb_native_split_provider: io_ctx must be non-null");
+  }
+  if (_scan_info->db_path.empty()) {
+    throw std::invalid_argument(
+      "duckdb_native_split_provider: scan_info.db_path must be non-empty");
+  }
 
-  _metadata = op::scan::walk_duckdb_native_metadata(*_scan_info->storage,
-                                                    *_scan_info->context,
-                                                    _scan_info->projected_cols,
-                                                    _scan_info->projected_types);
-  if (!_metadata.viable) {
-    // Empty splits would hang the pipeline on the FULL barrier. The throw
-    // surfaces as a query error and the extension's transparent fallback
-    // routes to DuckDB CPU.
-    SPDLOG_DEBUG("[duckdb_native_split_provider] non-viable: {}",
-                 _metadata.viability_failure_reason);
+  _plan = op::scan::prepare_duckdb_native_walk(*_scan_info->storage,
+                                               *_scan_info->context,
+                                               _scan_info->projected_cols,
+                                               _scan_info->projected_types);
+  if (!_plan.viable) {
+    SPDLOG_DEBUG("[duckdb_native_split_provider] non-viable: {}", _plan.viability_failure_reason);
     throw std::runtime_error("duckdb-native scan rejected query: " +
-                             _metadata.viability_failure_reason);
+                             _plan.viability_failure_reason);
+  }
+  if (_plan.n_row_groups == 0) {
+    // Zero ranges would close the connector empty; keep the historical refuse so
+    // an empty/unreadable table routes to DuckDB CPU.
+    throw std::runtime_error("duckdb-native scan rejected query: no row groups in table");
   }
 
-  // Mint the .db io_object once per query when the manager exposes sirius_ioctx.
-  // The scan task threads this onto every split so reads of .db blocks go through
-  // sirius_ioctx::host_read instead of DuckDB's BufferManager.
-  if (_io_ctx && !_scan_info->db_path.empty()) {
-    _db_io_object = _io_ctx->create_io_object(_scan_info->db_path);
-  }
+  // Mint the .db io_object once per query; the scan task threads it onto every
+  // split so reads of .db blocks go through sirius_ioctx::host_read.
+  _db_io_object = _io_ctx->create_io_object(_scan_info->db_path);
 
-  _batches = partition_row_groups_into_batches(
-    _metadata.row_groups, _scan_info->approximate_batch_size, _scan_info->projected_types);
+  _chunk_row_groups = parse_chunk_row_groups();
+  _num_ranges       = (_plan.n_row_groups + _chunk_row_groups - 1) / _chunk_row_groups;
 }
 
 duckdb_native_split_provider::~duckdb_native_split_provider() = default;
 
 bool duckdb_native_split_provider::has_more_splits() const
 {
-  return _next_batch_idx.load(std::memory_order_relaxed) < _batches.size();
+  return _next_range_idx.load(std::memory_order_relaxed) < _num_ranges;
 }
 
 std::function<std::vector<std::unique_ptr<op::operator_data>>()>
 duckdb_native_split_provider::next_split_provider()
 {
-  std::size_t idx = _next_batch_idx.fetch_add(1, std::memory_order_relaxed);
-  if (idx >= _batches.size()) { return {}; }
+  auto const idx = _next_range_idx.fetch_add(1, std::memory_order_relaxed);
+  if (idx >= _num_ranges) { return {}; }
 
-  row_group_batch batch = _batches[idx];
-  // `_metadata.row_groups[i]` is moved out — batches are disjoint and each
-  // batch is claimed exactly once, so the source entry is never read again.
-  return [this, batch]() -> std::vector<std::unique_ptr<op::operator_data>> {
+  auto const rg_begin = idx * _chunk_row_groups;
+  auto const rg_end   = std::min(rg_begin + _chunk_row_groups, _plan.n_row_groups);
+
+  // The walk reads `_plan` (const after the ctor) and builds its own
+  // QueryContext, so disjoint ranges run concurrently on the worker pool. The
+  // provider outlives every thunk it hands out (split_provider contract).
+  return [this, rg_begin, rg_end]() -> std::vector<std::unique_ptr<op::operator_data>> {
+    auto range = op::scan::walk_duckdb_native_row_group_range(_plan, rg_begin, rg_end);
+    if (!range.viable) {
+      // Rides the worker_state -> connector.close(eptr) channel; the scan
+      // operator rethrows it. Compression-unsupported is a hard error for now;
+      // type-based fallback was already handled by the ctor's prepare step.
+      throw std::runtime_error("duckdb-native scan rejected query: " +
+                               range.viability_failure_reason);
+    }
+
     auto payload          = std::make_unique<split_payload>();
     payload->scan_info    = _scan_info;
     payload->io_ctx       = _io_ctx;
     payload->db_io_object = _db_io_object;
-    payload->row_groups.reserve(batch.count);
-    for (std::size_t i = batch.first_idx; i < batch.first_idx + batch.count; ++i) {
-      payload->row_groups.push_back(std::move(_metadata.row_groups[i]));
-    }
+    payload->row_groups   = std::move(range.row_groups);
+
     std::vector<std::unique_ptr<op::operator_data>> out;
     out.push_back(std::move(payload));
     return out;

--- a/test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
+++ b/test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <op/scan/duckdb_native_batch_coalescer.hpp>
+
+#include <cstddef>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+
+namespace {
+
+logical_type int_type() { return logical_type::make(type_id::INTEGER); }
+logical_type varchar_type() { return logical_type::make(type_id::VARCHAR); }
+
+duckdb_row_group_metadata make_rg(std::size_t index,
+                                  std::size_t rows,
+                                  std::size_t decoded_bytes,
+                                  std::vector<std::size_t> varchar_bytes = {})
+{
+  duckdb_row_group_metadata rg;
+  rg.row_group_index       = index;
+  rg.row_group_start       = index * 100;  // arbitrary, monotone
+  rg.row_count             = rows;
+  rg.decoded_bytes_budget  = decoded_bytes;
+  rg.varchar_bytes_per_col = std::move(varchar_bytes);
+  return rg;
+}
+
+/// Push every row group, then drain ready + tail. Returns the batch sizes in
+/// emission order (ready batches first, tail last).
+std::vector<std::size_t> coalesce_sizes(batch_coalescer& c,
+                                        std::vector<duckdb_row_group_metadata> rgs)
+{
+  std::vector<std::size_t> sizes;
+  for (auto& rg : rgs) {
+    c.push(std::move(rg));
+    while (c.has_ready()) {
+      sizes.push_back(c.pop_ready().size());
+    }
+  }
+  auto tail = c.flush();
+  if (!tail.empty()) { sizes.push_back(tail.size()); }
+  return sizes;
+}
+
+}  // namespace
+
+TEST_CASE("batch_coalescer with no caps yields a single batch", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 5; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/1000));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{5});  // one batch holds all five
+}
+
+TEST_CASE("batch_coalescer splits on the total decoded-byte cap with one tail",
+          "[scan][batch_coalescer]")
+{
+  // cap=1000, each row group 400 bytes: batches close at 2 row groups (800),
+  // since a third (1200) would exceed. Five row groups -> [2, 2, 1].
+  batch_coalescer c(/*approximate_batch_size=*/1000, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 5; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/400));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{2, 2, 1});
+  // Exactly one undersized tail: only the final batch is below the 2-rg fill.
+  REQUIRE(sizes.back() == 1);
+}
+
+TEST_CASE("batch_coalescer keeps an over-cap row group as its own singleton batch",
+          "[scan][batch_coalescer]")
+{
+  // Every row group (400 bytes) exceeds the cap (100) on its own, so each lands
+  // alone: three row groups -> [1, 1, 1]. The provider must never stall.
+  batch_coalescer c(/*approximate_batch_size=*/100, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 3; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/400));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{1, 1, 1});
+}
+
+TEST_CASE("batch_coalescer splits on the per-varchar-column cudf int32 cap",
+          "[scan][batch_coalescer]")
+{
+  // No total cap; one varchar column. Two row groups at 1.5e9 chars each sum to
+  // 3e9 >= kCudfInt32StringsThreshold (2^31-1), so they cannot share a batch.
+  batch_coalescer c(/*approximate_batch_size=*/0, {varchar_type()});
+  constexpr std::size_t kBig = 1'500'000'000ULL;
+  REQUIRE(kBig < kCudfInt32StringsThreshold);
+  REQUIRE(2 * kBig >= kCudfInt32StringsThreshold);
+
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 3; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/0, /*varchar_bytes=*/{kBig}));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{1, 1, 1});
+}
+
+TEST_CASE("batch_coalescer drops empty row groups", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  rgs.push_back(make_rg(0, /*rows=*/100, /*bytes=*/1000));
+  rgs.push_back(make_rg(1, /*rows=*/0, /*bytes=*/0));  // empty: dropped
+  rgs.push_back(make_rg(2, /*rows=*/100, /*bytes=*/1000));
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{2});  // two non-empty row groups, one batch
+}
+
+TEST_CASE("batch_coalescer with only empty row groups yields no batches", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  rgs.push_back(make_rg(0, /*rows=*/0, /*bytes=*/0));
+  rgs.push_back(make_rg(1, /*rows=*/0, /*bytes=*/0));
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes.empty());
+}
+
+TEST_CASE("batch_coalescer preserves total row-group count across the split",
+          "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/1000, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 17; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/300));
+  }
+  auto sizes        = coalesce_sizes(c, std::move(rgs));
+  std::size_t total = 0;
+  for (auto s : sizes) {
+    total += s;
+  }
+  REQUIRE(total == 17);        // no row group lost or duplicated
+  REQUIRE(sizes.size() >= 2);  // actually split
+}

--- a/test/cpp/scan/test_duckdb_native_split_provider.cpp
+++ b/test/cpp/scan/test_duckdb_native_split_provider.cpp
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+#include <cudf/io/datasource.hpp>
+#include <cudf/io/text/byte_range_info.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
 #include <catch.hpp>
 #include <duckdb.hpp>
 #include <duckdb/catalog/catalog.hpp>
@@ -21,13 +27,20 @@
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/storage/data_table.hpp>
+#include <io/io_context.hpp>
+#include <io/types.hpp>
 #include <op/scan/duckdb_native_scan_info.hpp>
 #include <scan_manager/duckdb_native_split_provider.hpp>
 #include <utils/utils.hpp>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace sirius;
@@ -66,28 +79,130 @@ projected_column real_col(duckdb::idx_t col_id)
   return pc;
 }
 
-/// Storage + context only; caller fills in projected_cols / projected_types
-/// / approximate_batch_size.
+/// Storage + context + a dummy db_path (the provider requires a non-empty
+/// db_path; the stub io_ctx ignores it). Caller fills in projected_cols /
+/// projected_types / approximate_batch_size.
 duckdb_native_scan_info make_scan_info(duckdb::DataTable& storage, duckdb::ClientContext& ctx)
 {
   duckdb_native_scan_info info;
   info.storage = &storage;
   info.context = &ctx;
+  info.db_path = "stub.db";
   return info;
 }
 
-/// Drain all splits and return the count.
-std::size_t count_splits(duckdb_native_split_provider& provider)
+/// Drain all ranges single-threaded; flatten every range's row groups. Also
+/// reports the number of ranges the provider emitted.
+struct drained {
+  std::vector<duckdb_row_group_metadata> row_groups;
+  std::size_t range_count = 0;
+};
+
+drained drain_all(duckdb_native_split_provider& provider)
 {
-  std::size_t n = 0;
+  drained out;
   while (provider.has_more_splits()) {
     auto factory = provider.next_split_provider();
     if (!factory) break;
     auto payloads = factory();
     if (payloads.empty()) break;
-    ++n;
+    ++out.range_count;
+    for (auto& p : payloads) {
+      auto* batch = dynamic_cast<duckdb_native_split_provider::split_payload*>(p.get());
+      REQUIRE(batch != nullptr);
+      REQUIRE(batch->scan_info != nullptr);
+      for (auto& rg : batch->row_groups) {
+        out.row_groups.push_back(std::move(rg));
+      }
+    }
   }
-  return n;
+  return out;
+}
+
+// Minimal in-process sirius_ioctx so the provider can hold non-null IO handles.
+// The slicing / metadata paths under test never read bytes, so the read API
+// throws if exercised. Mirrors test_datasource_factory.cpp's mock_ioctx.
+class stub_io_object : public sirius::io::sirius_io_object {
+ public:
+  const std::string& raw_file_cache_id() const noexcept override { return _id; }
+  const std::string& object_path() const noexcept override { return _id; }
+  std::size_t size() const noexcept override { return 0; }
+
+ private:
+  std::string _id = "stub";
+};
+
+class stub_ioctx : public sirius::io::sirius_ioctx {
+ public:
+  void shutdown() override {}
+
+  std::shared_ptr<sirius::io::sirius_io_object> create_io_object(std::string) override
+  {
+    return std::make_shared<stub_io_object>();
+  }
+
+  std::unique_ptr<cudf::io::datasource> make_datasource(
+    std::shared_ptr<sirius::io::sirius_io_object>) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  [[nodiscard]] bool supports(std::string_view) const override { return true; }
+
+  std::size_t host_read_io(sirius::io::sirius_io_object&,
+                           std::size_t,
+                           std::size_t,
+                           std::uint8_t*) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  void host_read_async_io(sirius::io::sirius_io_object&,
+                          std::size_t,
+                          std::size_t,
+                          std::uint8_t*,
+                          sirius::io::io_completion_handler) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  std::size_t device_read_io(sirius::io::sirius_io_object&,
+                             std::size_t,
+                             std::size_t,
+                             std::uint8_t*,
+                             rmm::cuda_stream_view) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  void device_read_async_io(sirius::io::sirius_io_object&,
+                            std::size_t,
+                            std::size_t,
+                            std::uint8_t*,
+                            rmm::cuda_stream_view,
+                            sirius::io::io_completion_handler) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  void host_read_ranges_async_io(sirius::io::sirius_io_object&,
+                                 std::vector<cudf::io::text::byte_range_info> const&,
+                                 std::span<cudf::host_span<std::byte>>,
+                                 sirius::io::io_completion_handler) override
+  {
+    throw std::logic_error("stub_ioctx: IO not used in provider tests");
+  }
+
+  cudf::io::text::byte_range_info compute_physical_range(cudf::io::text::byte_range_info logical,
+                                                         std::size_t) const override
+  {
+    return logical;
+  }
+};
+
+std::shared_ptr<sirius::io::sirius_ioctx> make_mock_ioctx()
+{
+  return std::make_shared<stub_ioctx>();
 }
 
 }  // namespace
@@ -97,7 +212,8 @@ TEST_CASE("duckdb_native_split_provider throws on null storage",
 {
   duckdb_native_scan_info info;
   // info.storage stays null.
-  REQUIRE_THROWS_AS(duckdb_native_split_provider{std::move(info)}, std::invalid_argument);
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), make_mock_ioctx()}),
+                    std::invalid_argument);
 }
 
 TEST_CASE("duckdb_native_split_provider throws on null context",
@@ -111,7 +227,8 @@ TEST_CASE("duckdb_native_split_provider throws on null context",
   duckdb_native_scan_info info;
   info.storage = &storage;
   // info.context stays null.
-  REQUIRE_THROWS_AS(duckdb_native_split_provider{std::move(info)}, std::invalid_argument);
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), make_mock_ioctx()}),
+                    std::invalid_argument);
 }
 
 TEST_CASE("duckdb_native_split_provider throws on projected vectors size mismatch",
@@ -125,7 +242,39 @@ TEST_CASE("duckdb_native_split_provider throws on projected vectors size mismatc
   auto info            = make_scan_info(storage, *con.context);
   info.projected_cols  = {real_col(0)};
   info.projected_types = {};  // empty — parallel-vector violation
-  REQUIRE_THROWS_AS(duckdb_native_split_provider{std::move(info)}, std::invalid_argument);
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), make_mock_ioctx()}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("duckdb_native_split_provider throws on null io_ctx",
+          "[scan][duckdb_native_split_provider]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 16)");
+  auto& storage = get_storage(con, "t");
+
+  auto info            = make_scan_info(storage, *con.context);
+  info.projected_cols  = {real_col(0)};
+  info.projected_types = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), nullptr}),
+                    std::invalid_argument);
+}
+
+TEST_CASE("duckdb_native_split_provider throws on empty db_path",
+          "[scan][duckdb_native_split_provider]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 16)");
+  auto& storage = get_storage(con, "t");
+
+  auto info            = make_scan_info(storage, *con.context);
+  info.db_path         = "";  // override the helper's dummy path
+  info.projected_cols  = {real_col(0)};
+  info.projected_types = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), make_mock_ioctx()}),
+                    std::invalid_argument);
 }
 
 TEST_CASE("duckdb_native_split_provider throws when walker rejects the table",
@@ -141,7 +290,8 @@ TEST_CASE("duckdb_native_split_provider throws when walker rejects the table",
   auto info            = make_scan_info(storage, *con.context);
   info.projected_cols  = {real_col(0)};
   info.projected_types = {sirius::logical_type::make(sirius::type_id::HUGEINT)};
-  REQUIRE_THROWS_AS(duckdb_native_split_provider{std::move(info)}, std::runtime_error);
+  REQUIRE_THROWS_AS((duckdb_native_split_provider{std::move(info), make_mock_ioctx()}),
+                    std::runtime_error);
 }
 
 TEST_CASE("duckdb_native_split_provider emits one batch for a small INTEGER table",
@@ -157,7 +307,7 @@ TEST_CASE("duckdb_native_split_provider emits one batch for a small INTEGER tabl
   info.projected_types        = {sirius::logical_type::make(sirius::type_id::INTEGER)};
   info.approximate_batch_size = 0;  // single-batch fast path
 
-  duckdb_native_split_provider provider{std::move(info)};
+  duckdb_native_split_provider provider{std::move(info), make_mock_ioctx()};
   REQUIRE(provider.has_more_splits());
 
   auto factory = provider.next_split_provider();
@@ -177,46 +327,44 @@ TEST_CASE("duckdb_native_split_provider emits one batch for a small INTEGER tabl
   REQUIRE_FALSE(exhausted_factory);
 }
 
-TEST_CASE("duckdb_native_split_provider splits across batches when batch_size caps",
+TEST_CASE("duckdb_native_split_provider ranges cover all row groups exactly once",
           "[scan][duckdb_native_split_provider]")
 {
   // STANDARD_VECTOR_SIZE is 2048; a row group is up to 122,880 rows in DuckDB
-  // (60 vectors). 800k INTEGER rows guarantees several row groups, and a low
-  // batch cap forces multi-batch output.
+  // (60 vectors). 1.2M INTEGER rows guarantees several row groups, so the
+  // provider hands out multiple parse ranges. Batch *caps* now live in the scan
+  // operator's batch_coalescer (see test_duckdb_native_batch_coalescer); the
+  // provider's job is only to slice row groups into ranges that, taken
+  // together, cover every row group exactly once.
   auto [db_owner, con] = sirius::make_test_db_and_connection();
   exec_ok(con, "CREATE TABLE t(a INTEGER)");
-  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 800000)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 1200000)");
   auto& storage = get_storage(con, "t");
 
-  auto info                   = make_scan_info(storage, *con.context);
-  info.projected_cols         = {real_col(0)};
-  info.projected_types        = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  info.approximate_batch_size = 256 * 1024;  // ~64k INTEGER rows per batch budget
+  auto info            = make_scan_info(storage, *con.context);
+  info.projected_cols  = {real_col(0)};
+  info.projected_types = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
-  duckdb_native_split_provider provider{std::move(info)};
-  std::size_t splits = count_splits(provider);
-  REQUIRE(splits > 1);  // must have produced at least two batches
-}
+  duckdb_native_split_provider provider{std::move(info), make_mock_ioctx()};
+  auto result = drain_all(provider);
 
-TEST_CASE("duckdb_native_split_provider keeps a single oversized row group as its own batch",
-          "[scan][duckdb_native_split_provider]")
-{
-  // Set approximate_batch_size below a single row group's decoded byte cost.
-  // The provider must still produce one singleton batch — not stall on an
-  // unsatisfiable cap.
-  auto [db_owner, con] = sirius::make_test_db_and_connection();
-  exec_ok(con, "CREATE TABLE t(a INTEGER)");
-  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 200000)");
-  auto& storage = get_storage(con, "t");
+  REQUIRE(result.row_groups.size() >= 2);  // several row groups
+  REQUIRE(result.range_count >= 1);
 
-  auto info                   = make_scan_info(storage, *con.context);
-  info.projected_cols         = {real_col(0)};
-  info.projected_types        = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  info.approximate_batch_size = 1;  // anything > 0 row groups exceeds
+  std::sort(result.row_groups.begin(), result.row_groups.end(), [](auto const& a, auto const& b) {
+    return a.row_group_index < b.row_group_index;
+  });
+  // Contiguous coverage from 0 with no gaps or duplicates.
+  for (std::size_t i = 0; i < result.row_groups.size(); ++i) {
+    REQUIRE(result.row_groups[i].row_group_index == i);
+    REQUIRE(result.row_groups[i].row_count > 0);
+  }
+  // Absolute row offsets strictly increase with row-group index.
+  for (std::size_t i = 1; i < result.row_groups.size(); ++i) {
+    REQUIRE(result.row_groups[i].row_group_start > result.row_groups[i - 1].row_group_start);
+  }
 
-  duckdb_native_split_provider provider{std::move(info)};
-  std::size_t splits = count_splits(provider);
-  REQUIRE(splits >= 1);
+  REQUIRE_FALSE(provider.has_more_splits());
 }
 
 TEST_CASE("duckdb_native_split_provider populates payload with scan_info shared_ptr",
@@ -234,7 +382,7 @@ TEST_CASE("duckdb_native_split_provider populates payload with scan_info shared_
   info.projected_types        = {sirius::logical_type::make(sirius::type_id::INTEGER)};
   info.approximate_batch_size = 64 * 1024;
 
-  duckdb_native_split_provider provider{std::move(info)};
+  duckdb_native_split_provider provider{std::move(info), make_mock_ioctx()};
 
   std::shared_ptr<op::scan::duckdb_native_scan_info const> first_scan_info;
   bool any = false;

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -26,6 +26,7 @@
 #include <utils/utils.hpp>
 
 #include <string>
+#include <vector>
 
 using namespace sirius;
 using namespace sirius::op::scan;
@@ -73,6 +74,29 @@ projected_column rowid_col()
   return pc;
 }
 
+/// Compose the production walk seams the way a real caller does — the serial
+/// pre-step plus a single full-table range — into one result. Exercises the
+/// actual parallel-walk functions (`prepare_duckdb_native_walk` +
+/// `walk_duckdb_native_row_group_range`). Trailing-empty dropping and the
+/// empty-table refuse are the scan operator's job now (the batch_coalescer /
+/// split provider), not the walk's, so they are intentionally not replicated.
+struct walk_result {
+  std::vector<duckdb_row_group_metadata> row_groups;
+  bool viable = false;
+  std::string viability_failure_reason;
+};
+
+walk_result walk_all(duckdb::DataTable& storage,
+                     duckdb::ClientContext& ctx,
+                     const std::vector<projected_column>& cols,
+                     const std::vector<sirius::logical_type>& types)
+{
+  auto plan = prepare_duckdb_native_walk(storage, ctx, cols, types);
+  if (!plan.viable) { return {{}, false, std::move(plan.viability_failure_reason)}; }
+  auto range = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
+  return {std::move(range.row_groups), range.viable, std::move(range.viability_failure_reason)};
+}
+
 }  // namespace
 
 TEST_CASE("walker refuses empty projection", "[scan][duckdb_native_walker]")
@@ -82,7 +106,7 @@ TEST_CASE("walker refuses empty projection", "[scan][duckdb_native_walker]")
   exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 100)");
   auto& storage = get_storage(con, "t");
 
-  auto md = walk_duckdb_native_metadata(storage, *con.context, {}, {});
+  auto md = walk_all(storage, *con.context, {}, {});
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("no projected columns") != std::string::npos);
 }
@@ -95,7 +119,7 @@ TEST_CASE("walker refuses parallel-vector mismatch", "[scan][duckdb_native_walke
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("size mismatch") != std::string::npos);
 }
@@ -109,7 +133,7 @@ TEST_CASE("walker refuses HUGEINT type", "[scan][duckdb_native_walker]")
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::HUGEINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("HUGEINT") != std::string::npos);
 }
@@ -125,7 +149,7 @@ TEST_CASE("walker emits descriptors for INTEGER table", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE(md.viability_failure_reason.empty());
   REQUIRE_FALSE(md.row_groups.empty());
@@ -157,7 +181,7 @@ TEST_CASE("walker emits rowid sentinels with no segments", "[scan][duckdb_native
     sirius::logical_type::make(sirius::type_id::INTEGER),
     sirius::logical_type::make(sirius::type_id::BIGINT),
   };
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -186,7 +210,7 @@ TEST_CASE("walker rowid-only projection gets row_count from PartitionStats",
 
   std::vector<projected_column> cols   = {rowid_col()};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::BIGINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -216,7 +240,7 @@ TEST_CASE("walker separates data and validity segments by column_path",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -242,7 +266,7 @@ TEST_CASE("walker populates per-segment max_string_length for VARCHAR",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
   for (const auto& rg : md.row_groups) {
@@ -267,7 +291,7 @@ TEST_CASE("walker accepts all-empty varchar row group (Some(0))", "[scan][duckdb
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
 
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
@@ -299,7 +323,7 @@ TEST_CASE("walker per-segment max_string_length reflects long strings",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -320,7 +344,7 @@ TEST_CASE("walker refuses DECIMAL128 (precision > 18)", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(38, 0)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("DECIMAL128") != std::string::npos);
 }
@@ -335,7 +359,7 @@ TEST_CASE("walker accepts DECIMAL64 (precision <= 18)", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(18, 2)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 }
@@ -351,7 +375,7 @@ TEST_CASE("walker refuses STRUCT projected type", "[scan][duckdb_native_walker]"
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::STRUCT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("STRUCT") != std::string::npos);
 }
@@ -365,7 +389,7 @@ TEST_CASE("walker refuses LIST projected type", "[scan][duckdb_native_walker]")
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::LIST)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("LIST") != std::string::npos);
 }


### PR DESCRIPTION
> **Draft / WIP** — opened to track progress. Cold path is done and a clear
> win; a **warm-cache regression on memory-heavy queries** is diagnosed and
> not yet fixed (see *Known issue* below).

## Problem
The duckdb-native scan's metadata walk issues roughly one cold block read per
(row group × projected column) via `GetColumnSegmentInfo`, and ran **serially
in the split-provider constructor**. Profiling put it at **~95% of cold query
runtime at TPC-H SF30**.

## Change
Split the walk into two phases and parallelize the expensive one across the
existing scan-manager worker pool (reusing `run()` → dispatcher → connector):

- **`prepare_duckdb_native_walk`** — cheap serial pre-step (partition stats,
  type viability, row-group count). Stays in the ctor, so type-based graceful
  fallback to DuckDB CPU is unchanged.
- **`walk_duckdb_native_row_group_range`** — the IO-latency-bound segment walk,
  run per row-group *range* inside the `next_split_provider` thunks so the cold
  reads overlap across threads (safe: const plan, per-worker QueryContext,
  disjoint ranges).
- **`batch_coalescer`** (new, unit-tested) — consumer-side cap-aware batching
  that produces exactly **one tail batch per scan**. Order-independent (rowids
  are absolute per row group).

Also in this PR:
- Removed the old monolithic `walk_duckdb_native_metadata` + its result struct;
  the walker unit tests now drive the `prepare` + `range` seams directly.
- Hardened the provider ctor: require a non-null `io_ctx` and non-empty
  `db_path` (removed the stale `use_sirius_datasource=false` / BufferManager
  fallback path).
- Folded the per-row-group decoded-byte-budget + varchar char-bound into one pass.

Tunable via `SIRIUS_METADATA_PARSE_CHUNK` (row groups per range, default 8);
scan pool via `sirius.executor.scan_manager.num_threads` (default 8; = core
count is optimal).

## Performance — TPC-H SF30 (cold = page cache dropped before each query)

**Cold: universal win.** Aggregate across all 22 queries **54.2 s → 22.1 s
(2.5×)**, range **1.1×–4.3×** per query (default pool 8):

| query | cold × | query | cold × | query | cold × |
|---|---|---|---|---|---|
| q1 | 1.60 | q9 | 2.87 | q17 | 1.91 |
| q2 | 1.30 | q10 | 1.57 | q18 | 1.67 |
| q3 | 3.18 | q11 | 1.67 | q19 | 3.12 |
| q4 | 2.67 | q12 | 3.89 | q20 | 3.59 |
| q5 | 3.46 | q13 | 1.25 | q21 | 1.13 |
| q6 | 3.94 | q14 | 3.88 | q22 | 1.26 |
| q7 | 3.15 | q15 | 3.87 | | |
| q8 | 4.31 | q16 | 1.11 | | |

For q6 specifically, pool = core count (16) gives **2.51 s → 0.54 s (4.7×)**.

**Warm: flat for most, but a regression on memory-heavy queries** (verified,
warm-floor min of 12 runs):

| query | warm ser → par | downgrade/spill log lines (ser → par) |
|---|---|---|
| q6 (control) | 0.18 → 0.20 s | 1 → 1 ✓ |
| **q1** | 0.51 → **1.59 s** | 1 → **82** |
| **q19** | 0.27 → **0.50 s** | 1 → **152** |
| q9 | 0.51 → 0.84 s | 1 → 1 |
| q21 | 1.15 → 1.88 s | 1 → 1 |
| q3 | 0.26 → 0.36 s | 1 → 1 |

## Known issue (WIP) — warm regression
The serial walk was *accidentally throttling decode* (it blocked in the ctor, so
decode only started after the whole walk). The pipelined parallel walk removes
that throttle, so on warm:
1. **memory pressure → downgrade/spill** on memory-heavy queries (q1: 1→82,
   q19: 1→152 downgrade events) — really a pre-existing decode back-pressure gap
   the faster walk exposes; and
2. **flat CPU/dispatch overhead** on multi-scan joins (q9, q21) where the
   many walk thunks contend with decode and the walk is already cache-cheap.

### Next steps
- [ ] Probe a larger default chunk (less pipelining → lower peak memory) to size
      how much of the regression is pipelining-induced.
- [ ] Add decode back-pressure (cap in-flight batches) so the faster walk speeds
      up *parsing* without raising *decode concurrency* beyond the serial baseline
      — targets the q1/q19 downgrade regressions.
- [ ] Re-confirm warm is flat suite-wide, then mark ready for review.

## Validation
- Unit: `batch_coalescer` 7/7, walker 17/17, split provider 9/9; full suite green
  (one unrelated S3 test flakes under GPU-memory contention, passes solo).
- 22-query harness: 66/66 runs, 436 native-scan uses, **0 errors / 0 fallback**.
- GPU == CPU on q1 / q6 / varchar.
- pre-commit clean.
