### PR TITLE
Parallelize the duckdb-native scan metadata walk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,8 @@ set(TEST_SOURCES
     test/cpp/pipeline/test_task_scheduler.cpp
     test/cpp/scan/bench_decode_codecs.cpp
     test/cpp/scan/test_duckdb_block_layout.cpp
+    test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
+    test/cpp/scan/test_duckdb_native_gpu_ingestible.cpp
     test/cpp/scan/test_duckdb_native_walker.cpp
     test/cpp/scan/test_gpu_decode_alp.cpp
     test/cpp/scan/test_gpu_decode_bitpacking.cpp

--- a/src/include/io/gpu_ingestible.hpp
+++ b/src/include/io/gpu_ingestible.hpp
@@ -38,6 +38,7 @@ class operator_data;
 
 namespace sirius::scan_manager {
 class sirius_scan_manager;
+class split_connector;
 }  // namespace sirius::scan_manager
 
 namespace sirius::io {
@@ -283,6 +284,28 @@ class gpu_ingestible : public std::enable_shared_from_this<gpu_ingestible> {
     post_filter_and_projection_info const& info,
     ::cucascade::memory::memory_space const& mem_space,
     rmm::cuda_stream_view stream) = 0;
+
+  /**
+   * @brief Produce the next per-task input from the connector.
+   *
+   * Called on the scan operator's single consumer thread. The default returns
+   * the next split unchanged; @c duckdb_native_gpu_ingestible coalesces
+   * row-group ranges into cap-sized batches.
+   *
+   * @return The next per-task operator_data, or nullptr once the connector is
+   *         closed and all buffered work has been served.
+   */
+  virtual std::unique_ptr<op::operator_data> consume_next_input(
+    scan_manager::split_connector& connector);
+
+  /**
+   * @brief Whether the ingestible still holds buffered consumer-side work.
+   *
+   * Default: true (no buffer). The duckdb-native override returns false while
+   * its coalescer still holds batches, so the scan is not reported done before
+   * its last batch is served.
+   */
+  [[nodiscard]] virtual bool consumer_drained() const { return true; }
 
   [[nodiscard]] ingestible_table_info const& table_info() const noexcept { return *_table_info; }
 

--- a/src/include/op/scan/duckdb_native_batch_coalescer.hpp
+++ b/src/include/op/scan/duckdb_native_batch_coalescer.hpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "helper/logical_type.hpp"
+#include "op/scan/duckdb_native_metadata.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <utility>
+#include <vector>
+
+namespace sirius::op::scan {
+
+//===----------------------------------------------------------------------===//
+// Streaming, order-independent row-group -> batch coalescer.
+//
+// The single consumer feeds each parsed row group in via push(), in any order;
+// the coalescer packs them into batches under two caps:
+//   - total decoded bytes per batch  <= approximate_batch_size (0 disables), and
+//   - per-varchar-column chars per batch < kCudfInt32StringsThreshold.
+// A batch closes and becomes available via has_ready()/pop_ready() once the next
+// row group would breach a cap. flush() returns the final accumulator remainder.
+// Rowids are absolute per row group (row_group_start), so packing order does not
+// affect correctness.
+//===----------------------------------------------------------------------===//
+class batch_coalescer {
+ public:
+  batch_coalescer(std::size_t approximate_batch_size,
+                  const std::vector<sirius::logical_type>& projected_types)
+    : _cap_bytes(approximate_batch_size)
+  {
+    _is_varchar.reserve(projected_types.size());
+    for (auto const& t : projected_types) {
+      auto const is_v = t.is_varchar();
+      _is_varchar.push_back(is_v);
+      _any_varchar = _any_varchar || is_v;
+    }
+    _current_varchar.assign(projected_types.size(), 0);
+  }
+
+  /// Add one parsed row group. Empty row groups (row_count == 0) are dropped.
+  /// An over-cap row group becomes the sole member of its own batch.
+  void push(duckdb_row_group_metadata rg)
+  {
+    if (rg.row_count == 0) { return; }
+
+    auto const this_bytes = rg.decoded_bytes_budget;
+    if (!_current.empty() && would_close(this_bytes, rg)) { close_current(); }
+
+    _current_bytes += this_bytes;
+    if (_any_varchar) {
+      for (std::size_t c = 0; c < _is_varchar.size(); ++c) {
+        if (_is_varchar[c]) { _current_varchar[c] += rg.varchar_bytes_per_col[c]; }
+      }
+    }
+    _current.push_back(std::move(rg));
+  }
+
+  /// True iff a completed (cap-closed) batch is queued for the consumer.
+  [[nodiscard]] bool has_ready() const { return !_ready.empty(); }
+
+  /// True iff nothing remains: no completed batch queued and no row group
+  /// accumulating.
+  [[nodiscard]] bool empty() const { return _ready.empty() && _current.empty(); }
+
+  /// Pop the oldest completed batch. Precondition: has_ready().
+  std::vector<duckdb_row_group_metadata> pop_ready()
+  {
+    auto batch = std::move(_ready.front());
+    _ready.pop_front();
+    return batch;
+  }
+
+  /// Return the in-progress accumulator as the final tail batch. Call after all
+  /// row groups have been pushed. May be empty.
+  std::vector<duckdb_row_group_metadata> flush()
+  {
+    auto tail = std::move(_current);
+    reset_current();
+    return tail;
+  }
+
+ private:
+  [[nodiscard]] bool would_close(std::size_t this_bytes, const duckdb_row_group_metadata& rg) const
+  {
+    if (_cap_bytes > 0 && _current_bytes + this_bytes > _cap_bytes) { return true; }
+    if (_any_varchar) {
+      for (std::size_t c = 0; c < _is_varchar.size(); ++c) {
+        if (_is_varchar[c] &&
+            _current_varchar[c] + rg.varchar_bytes_per_col[c] >= kCudfInt32StringsThreshold) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void close_current()
+  {
+    _ready.push_back(std::move(_current));
+    reset_current();
+  }
+
+  void reset_current()
+  {
+    _current.clear();
+    _current_bytes = 0;
+    std::fill(_current_varchar.begin(), _current_varchar.end(), std::size_t{0});
+  }
+
+  std::size_t _cap_bytes;
+  std::vector<bool> _is_varchar;
+  bool _any_varchar = false;
+
+  std::vector<duckdb_row_group_metadata> _current;
+  std::size_t _current_bytes = 0;
+  std::vector<std::size_t> _current_varchar;
+  std::deque<std::vector<duckdb_row_group_metadata>> _ready;
+};
+
+}  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_native_decoder.hpp
+++ b/src/include/op/scan/duckdb_native_decoder.hpp
@@ -43,17 +43,14 @@ class duckdb_native_ingestible_table_info;
 /**
  * @brief Per-split payload consumed by @ref decode_duckdb_native_split.
  *
- * Built by @c duckdb_native_gpu_ingestible::next_split_provider from a
- * contiguous run of the walker's @c duckdb_row_group_metadata. The
- * @ref table_info pointer aliases the ingestible's owned bind data and is
- * valid for the lifetime of every emitted split (the ingestible outlives
- * its splits).
+ * Built by @c duckdb_native_gpu_ingestible from a run of
+ * @c duckdb_row_group_metadata. The @ref table_info pointer aliases the
+ * ingestible's owned bind data and is valid for the split's lifetime.
  */
 struct duckdb_native_split_payload {
   std::vector<duckdb_row_group_metadata> row_groups;
-  /// Stable alias into the ingestible's owned bind data. Carries
-  /// @c storage / @c context / @c projected_cols / @c projected_types that
-  /// the decoder reads.
+  /// Alias into the ingestible's owned bind data. Carries @c storage /
+  /// @c context / @c projected_cols / @c projected_types that the decoder reads.
   duckdb_native_ingestible_table_info const* table_info = nullptr;
   /// Sirius IO substrate handles used to read .db blocks via
   /// @c sirius_ioctx::host_read. Required by the decoder, which throws if

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -21,6 +21,7 @@
 #include <io/gpu_ingestible.hpp>
 #include <op/scan/duckdb_native_decoder.hpp>  // duckdb_native_split_payload
 #include <op/scan/duckdb_native_metadata.hpp>
+#include <op/sirius_physical_operator.hpp>  // op::operator_data (raw-range carrier base)
 #include <sirius_config.hpp>
 
 // duckdb
@@ -45,9 +46,12 @@
 
 namespace sirius::scan_manager {
 class sirius_scan_manager;
+class split_connector;
 }  // namespace sirius::scan_manager
 
 namespace sirius::op::scan {
+
+class batch_coalescer;
 
 //===----------------------------------------------------------------------===//
 // duckdb_native_ingestible_table_info
@@ -135,6 +139,27 @@ class duckdb_native_post_filter_and_projection_info : public io::post_filter_and
 };
 
 //===----------------------------------------------------------------------===//
+// duckdb_native_range_input
+//===----------------------------------------------------------------------===//
+/**
+ * @brief Carrier for one parsed row-group range.
+ *
+ * @c consume_next_input feeds the row groups through the @c batch_coalescer to
+ * form @c duckdb_native_split_info batches. Holds only the parsed row groups;
+ * the ingestible owns the shared bind data and IO handles. Never reaches
+ * @c execute().
+ */
+class duckdb_native_range_input : public op::operator_data {
+ public:
+  std::vector<duckdb_row_group_metadata> row_groups;
+
+  [[nodiscard]] op::operator_data_type get_type() const override
+  {
+    return op::operator_data_type::GPU_SCAN;
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // duckdb_native_gpu_ingestible
 //===----------------------------------------------------------------------===//
 class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
@@ -157,13 +182,25 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
     ::cucascade::memory::memory_space const& mem_space,
     rmm::cuda_stream_view stream) override;
 
- private:
-  struct row_group_batch {
-    std::size_t first_idx;
-    std::size_t count;
-  };
+  // -----------------------------
+  // Consumer-side coalescing
+  // -----------------------------
+  /// Pull row-group ranges off the connector, feed them through @ref _coalescer,
+  /// and return cap-sized batches. Flushes the tail batch once the connector is
+  /// closed and drained.
+  std::unique_ptr<op::operator_data> consume_next_input(
+    scan_manager::split_connector& connector) override;
 
-  duckdb_native_metadata _metadata;
+  /// False while @ref _coalescer still holds unserved row groups.
+  [[nodiscard]] bool consumer_drained() const override;
+
+ private:
+  /// Wrap a batch of row groups into a @c scan_operator_input
+  /// (@c duckdb_native_split_info plus optional filter/projection info).
+  std::unique_ptr<op::operator_data> make_batch(std::vector<duckdb_row_group_metadata> row_groups);
+
+  // ---- Walk plan + range claiming (producer side) ----
+  duckdb_native_walk_plan _plan;
   std::shared_ptr<sirius::io::sirius_ioctx> _io_ctx;
   std::shared_ptr<sirius::io::sirius_io_object> _db_io_object;
   /// Pre-built coalesced filter expression. Empty when no translatable
@@ -172,8 +209,13 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   bool _projection_required = false;
   std::size_t _output_arity = 0;
 
-  std::vector<row_group_batch> _batches;
-  std::atomic<std::size_t> _next_batch_idx{0};
+  /// Row groups claimed per range (tunable via SIRIUS_METADATA_PARSE_CHUNK).
+  std::size_t _chunk_row_groups = 1;
+  std::size_t _num_ranges       = 0;
+  std::atomic<std::size_t> _next_range_idx{0};
+
+  // ---- Consumer-side coalescer ----
+  std::unique_ptr<batch_coalescer> _coalescer;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -195,6 +195,11 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   [[nodiscard]] bool consumer_drained() const override;
 
  private:
+  /// Drain all parsed ranges from the connector, finalize global segment byte
+  /// sizes, and feed the coalescer. Blocks until the split provider closes the
+  /// connector.
+  void finalize_metadata(scan_manager::split_connector& connector);
+
   /// Wrap a batch of row groups into a @c scan_operator_input
   /// (@c duckdb_native_split_info plus optional filter/projection info).
   std::unique_ptr<op::operator_data> make_batch(std::vector<duckdb_row_group_metadata> row_groups);
@@ -215,6 +220,7 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   std::atomic<std::size_t> _next_range_idx{0};
 
   // ---- Consumer-side coalescer ----
+  bool _metadata_finalized = false;
   std::unique_ptr<batch_coalescer> _coalescer;
 };
 

--- a/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
+++ b/src/include/op/scan/duckdb_native_gpu_ingestible.hpp
@@ -195,11 +195,6 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   [[nodiscard]] bool consumer_drained() const override;
 
  private:
-  /// Drain all parsed ranges from the connector, finalize global segment byte
-  /// sizes, and feed the coalescer. Blocks until the split provider closes the
-  /// connector.
-  void finalize_metadata(scan_manager::split_connector& connector);
-
   /// Wrap a batch of row groups into a @c scan_operator_input
   /// (@c duckdb_native_split_info plus optional filter/projection info).
   std::unique_ptr<op::operator_data> make_batch(std::vector<duckdb_row_group_metadata> row_groups);
@@ -220,7 +215,6 @@ class duckdb_native_gpu_ingestible : public io::gpu_ingestible {
   std::atomic<std::size_t> _next_range_idx{0};
 
   // ---- Consumer-side coalescer ----
-  bool _metadata_finalized = false;
   std::unique_ptr<batch_coalescer> _coalescer;
 };
 

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -24,6 +24,7 @@
 #include <duckdb/common/enums/compression_type.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/vector.hpp>
+#include <duckdb/function/partition_stats.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
@@ -34,6 +35,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace sirius::op::scan {
@@ -85,8 +87,7 @@ struct duckdb_row_group_metadata {
   std::size_t decoded_bytes_budget = 0;
   /// Parallel to `columns`. For varchar columns: Σ(seg.segment_count ×
   /// *seg.max_string_length) — the upper bound used against the cudf int32
-  /// chars threshold. 0 for non-varchar columns. Populated by the walker so
-  /// downstream partitioning never re-walks segments.
+  /// chars threshold. 0 for non-varchar columns.
   std::vector<std::size_t> varchar_bytes_per_col;
 };
 
@@ -101,30 +102,62 @@ struct duckdb_row_group_metadata {
 constexpr std::size_t kCudfInt32StringsThreshold =
   static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max());
 
-/// When `viable` is false the walker bailed at the first unsupported
-/// segment or type; `row_groups` is partial and must not be consumed.
-struct duckdb_native_metadata {
-  std::vector<duckdb_row_group_metadata> row_groups;
+/// Exposed for direct unit-testing of the codec-rejection logic without
+/// going through DuckDB's codec selection (which is hard to drive into
+/// unsupported codecs in a test).
+bool is_supported_data_compression(duckdb::CompressionType c);
+bool is_supported_validity_compression(duckdb::CompressionType c);
+
+//===----------------------------------------------------------------------===//
+// Two-phase metadata walk:
+//  - prepare_duckdb_native_walk(): one-time setup.
+//  - walk_duckdb_native_row_group_range(): the per-range segment walk; ranges
+//    are walked concurrently.
+//===----------------------------------------------------------------------===//
+
+/// @brief Read PartitionStatistics, validate projected types and partition
+/// `row_start`, and capture the row-group count, block size, and a storage
+/// primary index -> projected column index map. No per-segment IO.
+/// PartitionStatistics touches ClientContext / LocalStorage, which are not
+/// thread-safe, so this runs before the concurrent range walks.
+struct duckdb_native_walk_plan {
+  duckdb::DataTable* storage     = nullptr;
+  duckdb::ClientContext* context = nullptr;
+
+  const std::vector<projected_column>* projected_cols      = nullptr;
+  const std::vector<sirius::logical_type>* projected_types = nullptr;
+  std::unordered_map<duckdb::idx_t, std::size_t>
+    projected_lookup;  /// Map storage primary index -> projected column index (rowid cols
+                       /// excluded).
+
+  //===----------RowGroupCollection data----------===//
+  std::size_t n_row_groups = 0;
+  std::size_t block_size   = 0;
+
+  //===----------PartitionStatistics data: vector across row groups----------===//
+  std::vector<duckdb::idx_t> row_group_start;  ///< Absolute first-row index per row group
+                                               ///< (PartitionStatistics::row_start).
+  std::vector<duckdb::idx_t>
+    row_count;  ///< Rows per row group (PartitionStatistics::count); 0 where unavailable.
+
+  //===----------Row-group pruning inputs----------===//
+  /// Per-row-group handles. Each range walk reads its own row groups' column
+  /// statistics through them while pruning. Ranges are disjoint, so a handle is
+  /// only ever touched by one worker.
+  std::vector<duckdb::shared_ptr<duckdb::PartitionRowGroup>> partition_row_groups;
+  /// Pushed-down filters and their storage-index mapping. Both non-null and
+  /// non-empty enables statistics pruning in the range walk.
+  const duckdb::TableFilterSet* table_filters           = nullptr;
+  const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr;
+
+  //===----------Error Handling----------===//
+  // `viable == false` (with reason) for:
+  //  - unsupported projected types, or
+  //  - an invalid partition `row_start`.
   bool viable = false;
   std::string viability_failure_reason;
-  /// Row-group filter-statistics pruning counters (0 when no filters / pruning disabled).
-  std::size_t pruned_row_groups = 0;  ///< Number of row groups pruned.
-  /// Sum of decoded-byte budgets of pruned row groups.
-  std::size_t pruned_decoded_bytes = 0;
 };
-
-/// Metadata-only walk of `storage` via `DataTable::GetColumnSegmentInfo`
-/// and `GetPartitionStats`. Pins no blocks and reads no bytes.
-///
-/// Returns `viable = false` with a populated `viability_failure_reason`
-/// on the first unsupported segment or type.
-///
-/// Caller is responsible for the operator-level escape gates
-/// (`dynamic_filters`, sample options, virtual columns, type pushdown)
-/// on the originating `LogicalGet`.
-///
-/// @note When both `table_filters` and `column_ids` are non-null, row group pruning is applied
-duckdb_native_metadata walk_duckdb_native_metadata(
+duckdb_native_walk_plan prepare_duckdb_native_walk(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
   const std::vector<projected_column>& projected_cols,
@@ -132,10 +165,31 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   const duckdb::TableFilterSet* table_filters           = nullptr,
   const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr);
 
-/// Exposed for direct unit-testing of the codec-rejection logic without
-/// going through DuckDB's codec selection (which is hard to drive into
-/// unsupported codecs in a test).
-bool is_supported_data_compression(duckdb::CompressionType c);
-bool is_supported_validity_compression(duckdb::CompressionType c);
+/// @brief Walk the projected-column segment metadata for row groups [rg_begin, rg_end)
+/// of `plan`, filling per-row-group
+///  - `decoded_bytes_budget`,
+///  - `varchar_bytes_per_col`, and
+///  - segment `bytes_size`.
+/// When `plan` carries pushed-down filters, row groups a filter proves can hold
+/// no matching rows are dropped from `row_groups`.
+struct duckdb_native_row_group_range {
+  //===----------ColumnSegmentInfo data----------===//
+  std::vector<duckdb_row_group_metadata>
+    row_groups;  ///< rg metadata ranging over [rg_begin, rg_end)
+
+  //===----------Filter-statistics pruning counters----------===//
+  std::size_t pruned_row_groups    = 0;  ///< Row groups dropped by a pushed-down filter.
+  std::size_t pruned_decoded_bytes = 0;  ///< Sum of their decoded-byte budgets.
+
+  //===----------Error Handling----------===//
+  //`viable == false` (with reason) on the first
+  //  - unsupported segment compression, or
+  //  - absent/over-threshold varchar stat.
+  // `row_groups` is then partial and must not be consumed.
+  bool viable = true;
+  std::string viability_failure_reason;
+};
+duckdb_native_row_group_range walk_duckdb_native_row_group_range(
+  const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -141,14 +141,22 @@ struct duckdb_native_walk_plan {
     row_count;  ///< Rows per row group (PartitionStatistics::count); 0 where unavailable.
 
   //===----------Row-group pruning inputs----------===//
-  /// Per-row-group handles. Each range walk reads its own row groups' column
-  /// statistics through them while pruning. Ranges are disjoint, so a handle is
-  /// only ever touched by one worker.
+  /// Per-row-group handles used during the serial prepare step for
+  /// statistics pruning.
   std::vector<duckdb::shared_ptr<duckdb::PartitionRowGroup>> partition_row_groups;
   /// Pushed-down filters and their storage-index mapping. Both non-null and
-  /// non-empty enables statistics pruning in the range walk.
+  /// non-empty enables statistics pruning during prepare.
   const duckdb::TableFilterSet* table_filters           = nullptr;
   const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr;
+  /// True for row groups proven empty by pushed-down filter statistics. Range
+  /// workers skip these row groups entirely.
+  std::vector<bool> row_group_pruned_by_stats;
+  /// Approximate decoded-byte budget for each stat-pruned row group. Exact for
+  /// fixed-width projections; conservative for VARCHAR because per-segment max
+  /// string length is only available after the segment walk.
+  std::vector<std::size_t> pruned_decoded_bytes_by_row_group;
+  std::size_t pruned_row_groups    = 0;
+  std::size_t pruned_decoded_bytes = 0;
 
   //===----------Error Handling----------===//
   // `viable == false` (with reason) for:
@@ -167,19 +175,18 @@ duckdb_native_walk_plan prepare_duckdb_native_walk(
 
 /// @brief Walk the projected-column segment metadata for row groups [rg_begin, rg_end)
 /// of `plan`, filling per-row-group
-///  - `decoded_bytes_budget`,
-///  - `varchar_bytes_per_col`, and
-///  - segment `bytes_size`.
-/// When `plan` carries pushed-down filters, row groups a filter proves can hold
-/// no matching rows are dropped from `row_groups`.
+///  - `decoded_bytes_budget`, and
+///  - `varchar_bytes_per_col`.
+/// Row groups pruned during prepare are skipped. Segment `bytes_size` is filled
+/// later by `finalize_duckdb_native_segment_bytes` after all ranges are collected.
 struct duckdb_native_row_group_range {
   //===----------ColumnSegmentInfo data----------===//
   std::vector<duckdb_row_group_metadata>
     row_groups;  ///< rg metadata ranging over [rg_begin, rg_end)
 
   //===----------Filter-statistics pruning counters----------===//
-  std::size_t pruned_row_groups    = 0;  ///< Row groups dropped by a pushed-down filter.
-  std::size_t pruned_decoded_bytes = 0;  ///< Sum of their decoded-byte budgets.
+  std::size_t pruned_row_groups    = 0;  ///< Row groups skipped by prepare-time pruning.
+  std::size_t pruned_decoded_bytes = 0;  ///< Diagnostic decoded-byte estimate for skipped groups.
 
   //===----------Error Handling----------===//
   //`viable == false` (with reason) on the first
@@ -191,5 +198,12 @@ struct duckdb_native_row_group_range {
 };
 duckdb_native_row_group_range walk_duckdb_native_row_group_range(
   const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
+
+/// Finalize per-segment main-block byte sizes once the complete set of
+/// surviving row groups has been collected. This must see all emitted ranges so
+/// segments at metadata parse chunk boundaries can use the true next segment in
+/// the same DuckDB block instead of falling back to the end of the block.
+void finalize_duckdb_native_segment_bytes(std::vector<duckdb_row_group_metadata>& row_groups,
+                                          std::size_t block_size);
 
 }  // namespace sirius::op::scan

--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -175,10 +175,13 @@ duckdb_native_walk_plan prepare_duckdb_native_walk(
 
 /// @brief Walk the projected-column segment metadata for row groups [rg_begin, rg_end)
 /// of `plan`, filling per-row-group
-///  - `decoded_bytes_budget`, and
-///  - `varchar_bytes_per_col`.
-/// Row groups pruned during prepare are skipped. Segment `bytes_size` is filled
-/// later by `finalize_duckdb_native_segment_bytes` after all ranges are collected.
+///  - `decoded_bytes_budget`,
+///  - `varchar_bytes_per_col`, and
+///  - segment `bytes_size`.
+/// Row groups pruned during prepare are skipped. Segment `bytes_size` is a
+/// per-range upper bound: a segment whose DuckDB block extends past this range is
+/// sized to the block end. Decoders self-bound reads via their segment headers,
+/// so the overshoot only inflates H2D/staging bytes.
 struct duckdb_native_row_group_range {
   //===----------ColumnSegmentInfo data----------===//
   std::vector<duckdb_row_group_metadata>
@@ -198,12 +201,5 @@ struct duckdb_native_row_group_range {
 };
 duckdb_native_row_group_range walk_duckdb_native_row_group_range(
   const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end);
-
-/// Finalize per-segment main-block byte sizes once the complete set of
-/// surviving row groups has been collected. This must see all emitted ranges so
-/// segments at metadata parse chunk boundaries can use the true next segment in
-/// the same DuckDB block instead of falling back to the end of the block.
-void finalize_duckdb_native_segment_bytes(std::vector<duckdb_row_group_metadata>& row_groups,
-                                          std::size_t block_size);
 
 }  // namespace sirius::op::scan

--- a/src/io/gpu_ingestible.cpp
+++ b/src/io/gpu_ingestible.cpp
@@ -16,10 +16,25 @@
 
 #include "io/gpu_ingestible.hpp"
 
+#include "scan_manager/split_connector.hpp"
+
 #include <stdexcept>
 #include <utility>
 
 namespace sirius::io {
+
+//===----------------------------------------------------------------------===//
+// gpu_ingestible — default consumer-side adaptation
+//===----------------------------------------------------------------------===//
+// Returns the next split unchanged. Formats that batch on the consumer side
+// override this.
+std::unique_ptr<op::operator_data> gpu_ingestible::consume_next_input(
+  scan_manager::split_connector& connector)
+{
+  auto next = connector.get_next_split();
+  if (!next.has_value()) { return nullptr; }
+  return std::move(*next);
+}
 
 std::shared_ptr<gpu_ingestible> make_gpu_ingestible(std::unique_ptr<ingestible_table_info> info,
                                                     scan_manager::sirius_scan_manager const& mgr)

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -17,14 +17,17 @@
 // sirius
 #include <expression/ast/from_duckdb.hpp>
 #include <expression_executor/gpu_expression_executor.hpp>
+#include <helper/utils.hpp>
 #include <io/io_context.hpp>
 #include <io/sirius_datasource.hpp>
 #include <log/logging.hpp>
+#include <op/scan/duckdb_native_batch_coalescer.hpp>
 #include <op/scan/duckdb_native_decoder.hpp>
 #include <op/scan/duckdb_native_gpu_ingestible.hpp>
 #include <op/scan/scan_utils.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <scan_manager/sirius_scan_manager.hpp>
+#include <scan_manager/split_connector.hpp>
 
 // cudf
 #include <cudf/table/table.hpp>
@@ -35,8 +38,11 @@
 
 // standard library
 #include <algorithm>
+#include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -44,73 +50,21 @@ namespace sirius::op::scan {
 
 namespace {
 
-// Mirrors duckdb_native_split_provider::partition_row_groups_into_batches.
-struct row_group_batch_local {
-  std::size_t first_idx;
-  std::size_t count;
-};
+// Number of row groups a worker claims and walks per range. Overridable via
+// SIRIUS_METADATA_PARSE_CHUNK.
+constexpr std::size_t DEFAULT_PARSE_CHUNK_ROW_GROUPS = 8;
 
-std::vector<row_group_batch_local> partition_row_groups_into_batches(
-  const std::vector<duckdb_row_group_metadata>& row_groups,
-  std::size_t approximate_batch_size,
-  const std::vector<sirius::logical_type>& projected_types)
+std::size_t parse_chunk_row_groups()
 {
-  std::vector<row_group_batch_local> batches;
-  if (row_groups.empty()) return batches;
-
-  const std::size_t num_cols = projected_types.size();
-  std::vector<bool> is_varchar(num_cols, false);
-  bool any_varchar = false;
-  for (std::size_t c = 0; c < num_cols; ++c) {
-    is_varchar[c] = projected_types[c].is_varchar();
-    any_varchar   = any_varchar || is_varchar[c];
-  }
-
-  if (approximate_batch_size == 0 && !any_varchar) {
-    batches.push_back({0, row_groups.size()});
-    return batches;
-  }
-
-  std::size_t batch_first = 0;
-  std::size_t batch_bytes = 0;
-  std::vector<std::size_t> col_bytes(num_cols, 0);
-
-  for (std::size_t i = 0; i < row_groups.size(); ++i) {
-    const auto& rg                  = row_groups[i];
-    const std::size_t this_rg_bytes = rg.decoded_bytes_budget;
-
-    if (i > batch_first) {
-      const bool would_exceed_total =
-        (approximate_batch_size > 0) && (batch_bytes + this_rg_bytes > approximate_batch_size);
-      bool would_exceed_varchar = false;
-      if (any_varchar) {
-        for (std::size_t c = 0; c < num_cols; ++c) {
-          if (is_varchar[c] &&
-              col_bytes[c] + rg.varchar_bytes_per_col[c] >= kCudfInt32StringsThreshold) {
-            would_exceed_varchar = true;
-            break;
-          }
-        }
-      }
-      if (would_exceed_total || would_exceed_varchar) {
-        batches.push_back({batch_first, i - batch_first});
-        batch_first = i;
-        batch_bytes = 0;
-        std::fill(col_bytes.begin(), col_bytes.end(), 0);
-      }
-    }
-
-    batch_bytes += this_rg_bytes;
-    if (any_varchar) {
-      for (std::size_t c = 0; c < num_cols; ++c) {
-        col_bytes[c] += rg.varchar_bytes_per_col[c];
-      }
+  if (char const* env = std::getenv("SIRIUS_METADATA_PARSE_CHUNK")) {
+    try {
+      auto const v = std::stoull(env);
+      if (v > 0) { return static_cast<std::size_t>(v); }
+    } catch (...) {
+      // Unparsable value → fall through to the default.
     }
   }
-  if (batch_first < row_groups.size()) {
-    batches.push_back({batch_first, row_groups.size() - batch_first});
-  }
-  return batches;
+  return DEFAULT_PARSE_CHUNK_ROW_GROUPS;
 }
 
 }  // namespace
@@ -146,24 +100,27 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
       "[duckdb_native_gpu_ingestible] projected_cols and projected_types must be parallel");
   }
 
-  // Walk metadata once. Pushed-down filters drive row-group pruning in the walk;
-  // column_ids maps each filter to its storage index.
-  _metadata = walk_duckdb_native_metadata(*bind.storage,
-                                          *bind.context,
-                                          bind.projected_cols,
-                                          bind.projected_types,
-                                          bind.table_filters.get(),
-                                          &bind.column_ids);
-  if (!_metadata.viable) {
-    SPDLOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}",
-                 _metadata.viability_failure_reason);
+  // Table-global metadata parse. Pushed-down filters drive row-group pruning in
+  // the range walks; column_ids maps each filter to its storage index.
+  _plan = prepare_duckdb_native_walk(*bind.storage,
+                                     *bind.context,
+                                     bind.projected_cols,
+                                     bind.projected_types,
+                                     bind.table_filters.get(),
+                                     &bind.column_ids);
+  if (!_plan.viable) {
+    SPDLOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}", _plan.viability_failure_reason);
     throw std::runtime_error("duckdb-native scan rejected query: " +
-                             _metadata.viability_failure_reason);
+                             _plan.viability_failure_reason);
+  }
+  if (_plan.n_row_groups == 0) {
+    // Nothing to scan; reject so the table falls back to DuckDB CPU.
+    throw std::runtime_error("duckdb-native scan rejected query: no row groups in table");
   }
 
-  // Resolve the .db file to a datasource once per query when the manager
-  // exposes a backend for db_path; derive the io_ctx + io_object from it
-  // (matches duckdb_native_split_provider) instead of reaching into io_context.
+  // Resolve the .db file to a datasource when the manager exposes a backend for
+  // db_path, and derive the io_ctx + io_object from it. io_ctx stays null when no
+  // backend supports db_path; the decoder rejects the scan at decode time then.
   auto db_datasource = !bind.db_path.empty() ? mgr.create_datasource(bind.db_path) : nullptr;
   _io_ctx            = db_datasource ? db_datasource->io_ctx() : nullptr;
   _db_io_object      = db_datasource ? db_datasource->io_object() : nullptr;
@@ -199,12 +156,13 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
   _output_arity        = bind.output_types.size();
   _projection_required = (_output_arity > 0) && (decoded_cols > _output_arity);
 
-  auto batches = partition_row_groups_into_batches(
-    _metadata.row_groups, bind.approximate_batch_size, bind.projected_types);
-  _batches.reserve(batches.size());
-  for (auto const& b : batches) {
-    _batches.push_back({b.first_idx, b.count});
-  }
+  // Coalescer that packs parsed ranges into cap-sized batches with one tail
+  // batch per scan.
+  _coalescer = std::make_unique<batch_coalescer>(bind.approximate_batch_size, bind.projected_types);
+
+  // Divide the row groups into ranges of _chunk_row_groups each.
+  _chunk_row_groups = parse_chunk_row_groups();
+  _num_ranges       = utils::ceil_div(_plan.n_row_groups, _chunk_row_groups);
 }
 
 duckdb_native_gpu_ingestible::~duckdb_native_gpu_ingestible() = default;
@@ -214,48 +172,96 @@ duckdb_native_gpu_ingestible::~duckdb_native_gpu_ingestible() = default;
 //===----------------------------------------------------------------------===//
 bool duckdb_native_gpu_ingestible::has_more_splits() const
 {
-  return _next_batch_idx.load(std::memory_order_relaxed) < _batches.size();
+  return _next_range_idx.load(std::memory_order_relaxed) < _num_ranges;
 }
 
 std::function<std::vector<std::unique_ptr<op::operator_data>>()>
 duckdb_native_gpu_ingestible::next_split_provider()
 {
-  std::size_t idx = _next_batch_idx.fetch_add(1, std::memory_order_relaxed);
-  if (idx >= _batches.size()) { return {}; }
-  row_group_batch claimed = _batches[idx];
+  auto const idx = _next_range_idx.fetch_add(1, std::memory_order_relaxed);
+  if (idx >= _num_ranges) { return {}; }
 
-  bool const apply_filter        = static_cast<bool>(_filter_expression);
-  bool const has_post_processing = apply_filter || _projection_required;
-  std::size_t const output_arity = _output_arity;
-  bool const projection_required = _projection_required;
+  auto const rg_begin = idx * _chunk_row_groups;
+  auto const rg_end   = std::min(rg_begin + _chunk_row_groups, _plan.n_row_groups);
 
-  return [this, claimed, apply_filter, projection_required, output_arity, has_post_processing]()
-           -> std::vector<std::unique_ptr<op::operator_data>> {
-    auto split_info = std::make_unique<duckdb_native_split_info>();
-    split_info->payload.table_info =
-      &static_cast<duckdb_native_ingestible_table_info const&>(table_info());
-    split_info->payload.io_ctx       = _io_ctx;
-    split_info->payload.db_io_object = _db_io_object;
-    split_info->payload.row_groups.reserve(claimed.count);
-    for (std::size_t i = claimed.first_idx; i < claimed.first_idx + claimed.count; ++i) {
-      split_info->payload.row_groups.push_back(std::move(_metadata.row_groups[i]));
+  // Runs on a worker thread: walk this range and emit one raw range carrier for
+  // the consumer to coalesce. Reads the read-only _plan.
+  return [this, rg_begin, rg_end]() -> std::vector<std::unique_ptr<op::operator_data>> {
+    auto range = walk_duckdb_native_row_group_range(_plan, rg_begin, rg_end);
+    if (!range.viable) {
+      // Surfaced to the consumer through the connector; rejects the query.
+      throw std::runtime_error("duckdb-native scan rejected query: " +
+                               range.viability_failure_reason);
     }
 
-    std::unique_ptr<io::post_filter_and_projection_info> filter_info;
-    if (has_post_processing) {
-      auto pf          = std::make_unique<duckdb_native_post_filter_and_projection_info>();
-      pf->apply_filter = apply_filter;
-      pf->output_arity = projection_required ? output_arity : 0;
-      filter_info      = std::move(pf);
-    }
-
-    auto metadata =
-      std::make_unique<io::scan_and_filter_metadata>(std::move(split_info), std::move(filter_info));
+    auto carrier        = std::make_unique<duckdb_native_range_input>();
+    carrier->row_groups = std::move(range.row_groups);
 
     std::vector<std::unique_ptr<op::operator_data>> out;
-    out.push_back(std::make_unique<scan_operator_input>(std::move(metadata)));
+    out.push_back(std::move(carrier));
     return out;
   };
+}
+
+//===----------------------------------------------------------------------===//
+// consumer-side coalescing
+//===----------------------------------------------------------------------===//
+std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::make_batch(
+  std::vector<duckdb_row_group_metadata> row_groups)
+{
+  auto split_info = std::make_unique<duckdb_native_split_info>();
+  split_info->payload.table_info =
+    &static_cast<duckdb_native_ingestible_table_info const&>(table_info());
+  split_info->payload.io_ctx       = _io_ctx;
+  split_info->payload.db_io_object = _db_io_object;
+  split_info->payload.row_groups   = std::move(row_groups);
+
+  std::unique_ptr<io::post_filter_and_projection_info> filter_info;
+  bool const apply_filter = static_cast<bool>(_filter_expression);
+  if (apply_filter || _projection_required) {
+    auto pf          = std::make_unique<duckdb_native_post_filter_and_projection_info>();
+    pf->apply_filter = apply_filter;
+    pf->output_arity = _projection_required ? _output_arity : 0;
+    filter_info      = std::move(pf);
+  }
+
+  auto metadata =
+    std::make_unique<io::scan_and_filter_metadata>(std::move(split_info), std::move(filter_info));
+  return std::make_unique<scan_operator_input>(std::move(metadata));
+}
+
+std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::consume_next_input(
+  scan_manager::split_connector& connector)
+{
+  // Pull raw row-group ranges off the connector and coalesce them into cap-sized
+  // batches. Rowids are absolute per row group, so packing order is unconstrained.
+  // get_next_split blocks until a range is ready.
+  for (;;) {
+    if (_coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
+
+    auto next = connector.get_next_split();
+    if (!next.has_value()) {
+      // Connector closed and drained: emit the tail batch, if any.
+      auto tail = _coalescer->flush();
+      if (!tail.empty()) { return make_batch(std::move(tail)); }
+      return nullptr;
+    }
+
+    auto* range = dynamic_cast<duckdb_native_range_input*>(next->get());
+    if (range == nullptr) {
+      throw std::runtime_error(
+        "[duckdb_native_gpu_ingestible::consume_next_input] unexpected operator_data type from "
+        "split connector; expected duckdb_native_range_input.");
+    }
+    for (auto& rg : range->row_groups) {
+      _coalescer->push(std::move(rg));
+    }
+  }
+}
+
+bool duckdb_native_gpu_ingestible::consumer_drained() const
+{
+  return _coalescer == nullptr || _coalescer->empty();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -206,6 +206,36 @@ duckdb_native_gpu_ingestible::next_split_provider()
 //===----------------------------------------------------------------------===//
 // consumer-side coalescing
 //===----------------------------------------------------------------------===//
+void duckdb_native_gpu_ingestible::finalize_metadata(scan_manager::split_connector& connector)
+{
+  if (_metadata_finalized) { return; }
+
+  std::vector<duckdb_row_group_metadata> row_groups;
+  for (;;) {
+    auto next = connector.get_next_split();
+    if (!next.has_value()) { break; }
+
+    auto* range = dynamic_cast<duckdb_native_range_input*>(next->get());
+    if (range == nullptr) {
+      throw std::runtime_error(
+        "[duckdb_native_gpu_ingestible::finalize_metadata] unexpected operator_data type from "
+        "split connector; expected duckdb_native_range_input.");
+    }
+    for (auto& rg : range->row_groups) {
+      row_groups.push_back(std::move(rg));
+    }
+  }
+
+  std::sort(row_groups.begin(), row_groups.end(), [](auto const& a, auto const& b) {
+    return a.row_group_index < b.row_group_index;
+  });
+  finalize_duckdb_native_segment_bytes(row_groups, _plan.block_size);
+  for (auto& rg : row_groups) {
+    _coalescer->push(std::move(rg));
+  }
+  _metadata_finalized = true;
+}
+
 std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::make_batch(
   std::vector<duckdb_row_group_metadata> row_groups)
 {
@@ -233,35 +263,21 @@ std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::make_batch(
 std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::consume_next_input(
   scan_manager::split_connector& connector)
 {
-  // Pull raw row-group ranges off the connector and coalesce them into cap-sized
-  // batches. Rowids are absolute per row group, so packing order is unconstrained.
-  // get_next_split blocks until a range is ready.
-  for (;;) {
-    if (_coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
+  // The first consumer call drains every parsed range so segment byte sizes can
+  // be finalized with table-wide visibility. Subsequent calls serve already
+  // coalesced batches.
+  finalize_metadata(connector);
 
-    auto next = connector.get_next_split();
-    if (!next.has_value()) {
-      // Connector closed and drained: emit the tail batch, if any.
-      auto tail = _coalescer->flush();
-      if (!tail.empty()) { return make_batch(std::move(tail)); }
-      return nullptr;
-    }
+  if (_coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
 
-    auto* range = dynamic_cast<duckdb_native_range_input*>(next->get());
-    if (range == nullptr) {
-      throw std::runtime_error(
-        "[duckdb_native_gpu_ingestible::consume_next_input] unexpected operator_data type from "
-        "split connector; expected duckdb_native_range_input.");
-    }
-    for (auto& rg : range->row_groups) {
-      _coalescer->push(std::move(rg));
-    }
-  }
+  auto tail = _coalescer->flush();
+  if (!tail.empty()) { return make_batch(std::move(tail)); }
+  return nullptr;
 }
 
 bool duckdb_native_gpu_ingestible::consumer_drained() const
 {
-  return _coalescer == nullptr || _coalescer->empty();
+  return _metadata_finalized && (_coalescer == nullptr || _coalescer->empty());
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -206,36 +206,6 @@ duckdb_native_gpu_ingestible::next_split_provider()
 //===----------------------------------------------------------------------===//
 // consumer-side coalescing
 //===----------------------------------------------------------------------===//
-void duckdb_native_gpu_ingestible::finalize_metadata(scan_manager::split_connector& connector)
-{
-  if (_metadata_finalized) { return; }
-
-  std::vector<duckdb_row_group_metadata> row_groups;
-  for (;;) {
-    auto next = connector.get_next_split();
-    if (!next.has_value()) { break; }
-
-    auto* range = dynamic_cast<duckdb_native_range_input*>(next->get());
-    if (range == nullptr) {
-      throw std::runtime_error(
-        "[duckdb_native_gpu_ingestible::finalize_metadata] unexpected operator_data type from "
-        "split connector; expected duckdb_native_range_input.");
-    }
-    for (auto& rg : range->row_groups) {
-      row_groups.push_back(std::move(rg));
-    }
-  }
-
-  std::sort(row_groups.begin(), row_groups.end(), [](auto const& a, auto const& b) {
-    return a.row_group_index < b.row_group_index;
-  });
-  finalize_duckdb_native_segment_bytes(row_groups, _plan.block_size);
-  for (auto& rg : row_groups) {
-    _coalescer->push(std::move(rg));
-  }
-  _metadata_finalized = true;
-}
-
 std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::make_batch(
   std::vector<duckdb_row_group_metadata> row_groups)
 {
@@ -263,21 +233,39 @@ std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::make_batch(
 std::unique_ptr<op::operator_data> duckdb_native_gpu_ingestible::consume_next_input(
   scan_manager::split_connector& connector)
 {
-  // The first consumer call drains every parsed range so segment byte sizes can
-  // be finalized with table-wide visibility. Subsequent calls serve already
-  // coalesced batches.
-  finalize_metadata(connector);
+  // Coalesce parsed ranges into cap-sized batches as they arrive, so early
+  // batches decode while later ranges are still being walked. Rowids are
+  // absolute per row group, so packing order is unconstrained. get_next_split
+  // blocks until a range is ready.
+  for (;;) {
+    if (_coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
 
-  if (_coalescer->has_ready()) { return make_batch(_coalescer->pop_ready()); }
+    auto next = connector.get_next_split();
+    if (!next.has_value()) {
+      // Connector closed and drained: emit the single tail batch, if any.
+      auto tail = _coalescer->flush();
+      if (!tail.empty()) { return make_batch(std::move(tail)); }
+      return nullptr;
+    }
 
-  auto tail = _coalescer->flush();
-  if (!tail.empty()) { return make_batch(std::move(tail)); }
-  return nullptr;
+    auto* range = dynamic_cast<duckdb_native_range_input*>(next->get());
+    if (range == nullptr) {
+      throw std::runtime_error(
+        "[duckdb_native_gpu_ingestible::consume_next_input] unexpected operator_data type from "
+        "split connector; expected duckdb_native_range_input.");
+    }
+    for (auto& rg : range->row_groups) {
+      _coalescer->push(std::move(rg));
+    }
+  }
 }
 
 bool duckdb_native_gpu_ingestible::consumer_drained() const
 {
-  return _metadata_finalized && (_coalescer == nullptr || _coalescer->empty());
+  // The scan operator conjoins this with split_connector::is_closed(). Gating on
+  // an empty coalescer ensures a single-split scan (small table, or chunk >=
+  // row-group count) still serves every queued batch, including the tail.
+  return _coalescer == nullptr || _coalescer->empty();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -208,52 +208,89 @@ bool filter_is_prunable(duckdb::TableFilterType t)
   return t != duckdb::TableFilterType::DYNAMIC_FILTER;
 }
 
-/// @brief Drop row groups a pushed-down filter proves can hold no matching rows.
-///
-/// For each prunable filter, evaluate TableFilter::CheckStatistics against the
-/// row group's aggregated per-column statistics
-/// (PartitionRowGroup::GetColumnStatistics). Each range owns a disjoint set of
-/// row groups, so each handle is read by a single thread.
-void prune_row_groups_by_filter_stats(duckdb_native_row_group_range& result,
-                                      const duckdb_native_walk_plan& plan)
+std::size_t estimate_decoded_bytes_budget(duckdb::idx_t row_count,
+                                          const std::vector<projected_column>& projected_cols,
+                                          const std::vector<sirius::logical_type>& projected_types)
 {
-  const auto& table_filters = *plan.table_filters;
-  const auto& column_ids    = *plan.column_ids;
-
-  std::vector<duckdb_row_group_metadata> kept;
-  kept.reserve(result.row_groups.size());
-  std::size_t pruned_bytes = 0;
-
-  for (auto& rg_md : result.row_groups) {
-    auto const rg = rg_md.row_group_index;
-    bool prune    = false;
-    if (rg < plan.partition_row_groups.size() && plan.partition_row_groups[rg]) {
-      auto& prg = *plan.partition_row_groups[rg];
-      for (auto const& [col_idx, filter] : table_filters.filters) {
-        if (!filter_is_prunable(filter->filter_type)) { continue; }
-        if (col_idx >= column_ids.size()) { continue; }  // defensive
-        auto stats =
-          prg.GetColumnStatistics(duckdb::StorageIndex(column_ids[col_idx].GetPrimaryIndex()));
-        if (!stats) { continue; }  // no stats → cannot prune
-        if (filter->CheckStatistics(*stats) == duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE) {
-          prune = true;
-          break;
-        }
-      }
-    }
-    if (prune) {
-      pruned_bytes += rg_md.decoded_bytes_budget;
+  std::size_t budget = 0;
+  for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
+    if (projected_cols[ci].is_rowid) {
+      budget += static_cast<std::size_t>(row_count) * sizeof(std::int64_t);
+    } else if (projected_types[ci].is_varchar()) {
+      // String payload bytes require segment-level max-string stats. At prepare
+      // time we can only account for offsets; this counter is diagnostic.
+      budget += static_cast<std::size_t>(row_count) * sizeof(std::uint32_t);
     } else {
-      kept.push_back(std::move(rg_md));
+      budget += static_cast<std::size_t>(row_count) * projected_types[ci].fixed_width_byte_size();
     }
   }
+  return budget;
+}
 
-  result.pruned_row_groups    = result.row_groups.size() - kept.size();
-  result.pruned_decoded_bytes = pruned_bytes;
-  result.row_groups           = std::move(kept);
+bool column_index_can_have_storage_stats(const duckdb::ColumnIndex& column_id)
+{
+  return column_id.HasPrimaryIndex() && !column_id.IsRowIdColumn() && !column_id.IsEmptyColumn() &&
+         !column_id.IsVirtualColumn();
+}
+
+bool row_group_pruned_by_filter_stats(duckdb::PartitionRowGroup& prg,
+                                      const duckdb::TableFilterSet& table_filters,
+                                      const duckdb::vector<duckdb::ColumnIndex>& column_ids)
+{
+  for (auto const& [col_idx, filter] : table_filters.filters) {
+    if (!filter_is_prunable(filter->filter_type)) { continue; }
+    if (col_idx >= column_ids.size()) { continue; }  // defensive
+    auto const& column_id = column_ids[col_idx];
+    if (!column_index_can_have_storage_stats(column_id)) { continue; }
+
+    auto stats = prg.GetColumnStatistics(duckdb::StorageIndex(column_id.GetPrimaryIndex()));
+    if (!stats) { continue; }  // no stats -> cannot prune
+    if (filter->CheckStatistics(*stats) == duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// @brief Mark row groups a pushed-down filter proves can hold no matching rows.
+///
+/// Runs during prepare, before worker-thread segment walks, because statistics
+/// are available from PartitionRowGroup handles and do not require segment
+/// metadata. This avoids parsing metadata for row groups that will be skipped
+/// and lets the all-pruned case route to DuckDB CPU before the async scan starts.
+void mark_row_groups_pruned_by_filter_stats(duckdb_native_walk_plan& plan)
+{
+  if (plan.table_filters == nullptr || plan.table_filters->filters.empty() ||
+      plan.column_ids == nullptr || plan.column_ids->empty()) {
+    return;
+  }
+
+  const auto& table_filters   = *plan.table_filters;
+  const auto& column_ids      = *plan.column_ids;
+  const auto& projected_cols  = *plan.projected_cols;
+  const auto& projected_types = *plan.projected_types;
+
+  for (std::size_t rg = 0; rg < plan.n_row_groups; ++rg) {
+    if (rg >= plan.partition_row_groups.size() || !plan.partition_row_groups[rg]) { continue; }
+    auto& prg = *plan.partition_row_groups[rg];
+    if (!row_group_pruned_by_filter_stats(prg, table_filters, column_ids)) { continue; }
+
+    plan.row_group_pruned_by_stats[rg] = true;
+    auto const pruned_bytes =
+      estimate_decoded_bytes_budget(plan.row_count[rg], projected_cols, projected_types);
+    plan.pruned_decoded_bytes_by_row_group[rg] = pruned_bytes;
+    ++plan.pruned_row_groups;
+    plan.pruned_decoded_bytes += pruned_bytes;
+  }
 }
 
 }  // namespace
+
+void finalize_duckdb_native_segment_bytes(std::vector<duckdb_row_group_metadata>& row_groups,
+                                          std::size_t block_size)
+{
+  compute_segment_bytes_size(row_groups, block_size);
+}
 
 bool is_supported_data_compression(duckdb::CompressionType c)
 {
@@ -346,6 +383,8 @@ duckdb_native_walk_plan prepare_duckdb_native_walk(
   plan.row_group_start.assign(plan.n_row_groups, 0);
   plan.row_count.assign(plan.n_row_groups, 0);
   plan.partition_row_groups.assign(plan.n_row_groups, nullptr);
+  plan.row_group_pruned_by_stats.assign(plan.n_row_groups, false);
+  plan.pruned_decoded_bytes_by_row_group.assign(plan.n_row_groups, 0);
   for (std::size_t i = 0; i < partition_stats.size(); ++i) {
     auto const& ps = partition_stats[i];
     if (!ps.row_start.IsValid()) {
@@ -367,6 +406,18 @@ duckdb_native_walk_plan prepare_duckdb_native_walk(
   for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
     if (projected_cols[ci].is_rowid) { continue; }
     plan.projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
+  }
+
+  mark_row_groups_pruned_by_filter_stats(plan);
+  if (plan.pruned_row_groups > 0) {
+    SIRIUS_LOG_DEBUG(
+      "[duckdb_native_metadata] prepare stats-pruned {} row groups (~{} decoded bytes)",
+      plan.pruned_row_groups,
+      plan.pruned_decoded_bytes);
+  }
+  if (plan.n_row_groups > 0 && plan.pruned_row_groups == plan.n_row_groups) {
+    refuse("no row groups in table (empty or fully pruned)");
+    return plan;
   }
 
   plan.viable = true;
@@ -392,29 +443,25 @@ duckdb_native_row_group_range walk_duckdb_native_row_group_range(
                      result.viability_failure_reason);
   };
 
-  // Get column segment metadata
-  duckdb::QueryContext qc{*plan.context};
-  duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
-  {
-    nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
-    auto& row_groups = *plan.storage->GetRowGroupCollection();
-    for (std::size_t rg = rg_begin; rg < rg_end; ++rg) {
-      auto row_group = row_groups.GetRowGroup(static_cast<duckdb::idx_t>(rg));
-      if (!row_group) { continue; }
-      for (auto const& pc : projected_cols) {
-        if (pc.is_rowid) { continue; }
-        row_group->GetRawColumnData(pc.storage_idx)
-          .GetColumnSegmentInfo(qc, rg, {pc.storage_idx.GetPrimaryIndex()}, column_segments);
-      }
-    }
-  }
+  auto const n     = rg_end - rg_begin;
+  auto const n_pos = std::numeric_limits<std::size_t>::max();
+  std::vector<std::size_t> local_index_by_rg(n, n_pos);
 
-  // One entry per row group in [rg_begin, rg_end)
-  auto const n = rg_end - rg_begin;
-  result.row_groups.resize(n);
+  // One entry per surviving row group in [rg_begin, rg_end). Row groups that
+  // were stats-pruned during prepare are skipped before any segment metadata is
+  // requested from DuckDB.
   for (std::size_t i = 0; i < n; ++i) {
-    auto const rg         = rg_begin + i;
-    auto& rg_md           = result.row_groups[i];
+    auto const rg = rg_begin + i;
+    if (rg < plan.row_group_pruned_by_stats.size() && plan.row_group_pruned_by_stats[rg]) {
+      ++result.pruned_row_groups;
+      if (rg < plan.pruned_decoded_bytes_by_row_group.size()) {
+        result.pruned_decoded_bytes += plan.pruned_decoded_bytes_by_row_group[rg];
+      }
+      continue;
+    }
+
+    local_index_by_rg[i]  = result.row_groups.size();
+    auto& rg_md           = result.row_groups.emplace_back();
     rg_md.row_group_index = rg;
     rg_md.row_group_start = plan.row_group_start[rg];
     rg_md.row_count       = plan.row_count[rg];
@@ -427,14 +474,35 @@ duckdb_native_row_group_range walk_duckdb_native_row_group_range(
     }
   }
 
+  if (result.row_groups.empty()) { return result; }
+
+  // Get column segment metadata for surviving row groups only.
+  duckdb::QueryContext qc{*plan.context};
+  duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
+  {
+    nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
+    auto& row_groups = *plan.storage->GetRowGroupCollection();
+    for (std::size_t rg = rg_begin; rg < rg_end; ++rg) {
+      if (local_index_by_rg[rg - rg_begin] == n_pos) { continue; }
+      auto row_group = row_groups.GetRowGroup(static_cast<duckdb::idx_t>(rg));
+      if (!row_group) { continue; }
+      for (auto const& pc : projected_cols) {
+        if (pc.is_rowid) { continue; }
+        row_group->GetRawColumnData(pc.storage_idx)
+          .GetColumnSegmentInfo(qc, rg, {pc.storage_idx.GetPrimaryIndex()}, column_segments);
+      }
+    }
+  }
+
   // Build segment descriptors
   for (const auto& seg : column_segments) {
     auto pl = plan.projected_lookup.find(seg.column_id);
     if (pl == plan.projected_lookup.end()) { continue; }  // not projected
     auto const rg_idx = seg.row_group_index;
     if (rg_idx < rg_begin || rg_idx >= rg_end) { continue; }
-    auto const ci             = pl->second;
-    auto const local_rgi      = static_cast<std::size_t>(rg_idx) - rg_begin;
+    auto const ci        = pl->second;
+    auto const local_rgi = local_index_by_rg[static_cast<std::size_t>(rg_idx) - rg_begin];
+    if (local_rgi == n_pos) { continue; }
     auto const validity_seg   = is_validity_path(seg.column_path);
     auto const compression    = parse_compression_string(seg.compression_type);
     auto const compression_ok = validity_seg ? is_supported_validity_compression(compression)
@@ -500,9 +568,6 @@ duckdb_native_row_group_range walk_duckdb_native_row_group_range(
     }
   }
 
-  // Per-segment on-disk byte sizes.
-  compute_segment_bytes_size(result.row_groups, plan.block_size);
-
   // Per row group, compute the decoded-byte budget and per-column varchar char
   // count. Refuse a varchar column whose char count would overflow cudf's int32
   // string offsets.
@@ -535,21 +600,6 @@ duckdb_native_row_group_range walk_duckdb_native_row_group_range(
       }
     }
     rg_md.decoded_bytes_budget = budget;
-  }
-
-  // Drop any row group a pushed-down filter proves can hold no matching rows.
-  if (plan.table_filters != nullptr && !plan.table_filters->filters.empty() &&
-      plan.column_ids != nullptr && !plan.column_ids->empty()) {
-    nvtx3::scoped_range nvtx_prune{"sirius::native_metadata_filter_stats_prune"};
-    prune_row_groups_by_filter_stats(result, plan);
-    if (result.pruned_row_groups > 0) {
-      SIRIUS_LOG_DEBUG(
-        "[duckdb_native_metadata] range [{}, {}) stats-pruned {} row groups (~{} decoded bytes)",
-        rg_begin,
-        rg_end,
-        result.pruned_row_groups,
-        result.pruned_decoded_bytes);
-    }
   }
 
   return result;

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -168,73 +168,16 @@ duckdb_segment_descriptor build_segment_descriptor(const duckdb::ColumnSegmentIn
   return desc;
 }
 
-using row_group_handles =
-  std::vector<std::pair<duckdb::idx_t, duckdb::shared_ptr<duckdb::PartitionRowGroup>>>;
-
-// Use PartitionStatistics::count as the source of truth so rowid-only
-// projections (no data segments to sum) still get a real row_count.
-void compute_row_counts(duckdb_native_metadata& md,
-                        const std::vector<duckdb::PartitionStatistics>& partition_stats)
-{
-  for (auto& rg_md : md.row_groups) {
-    if (rg_md.row_group_index < partition_stats.size()) {
-      rg_md.row_count = partition_stats[rg_md.row_group_index].count;
-      continue;
-    }
-    duckdb::idx_t row_count = 0;
-    for (const auto& col_md : rg_md.columns) {
-      if (col_md.is_rowid) { continue; }
-      duckdb::idx_t col_count = 0;
-      for (const auto& d : col_md.data_segments) {
-        col_count += d.segment_count;
-      }
-      if (col_count > 0) {
-        row_count = col_count;
-        break;
-      }
-    }
-    rg_md.row_count = row_count;
-  }
-}
-
-// Per-segment exact: chars + offsets. Walker refuse-on-absent guarantees
-// every VARCHAR data segment carries Some here.
-void compute_decoded_byte_budgets(duckdb_native_metadata& md,
-                                  const std::vector<sirius::logical_type>& projected_types)
-{
-  for (auto& rg_md : md.row_groups) {
-    std::size_t budget = 0;
-    for (std::size_t ci = 0; ci < rg_md.columns.size(); ++ci) {
-      const auto& col_md = rg_md.columns[ci];
-      if (col_md.is_rowid) {
-        budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
-        continue;
-      }
-      if (projected_types[ci].is_varchar()) {
-        std::size_t chars_total = 0;
-        for (const auto& seg : col_md.data_segments) {
-          chars_total += static_cast<std::size_t>(seg.segment_count) *
-                         static_cast<std::size_t>(*seg.max_string_length);
-        }
-        budget += chars_total + static_cast<std::size_t>(rg_md.row_count) * sizeof(std::uint32_t);
-      } else {
-        budget +=
-          static_cast<std::size_t>(rg_md.row_count) * projected_types[ci].fixed_width_byte_size();
-      }
-    }
-    rg_md.decoded_bytes_budget = budget;
-  }
-}
-
 // ColumnSegmentInfo lacks segment_size. Derive via sorted-by-(block_id,
 // block_offset) delta to the next walked segment; last-in-block falls back
 // to `block_size - block_offset`. Upper bound only: trailing free space and
 // cross-table partial-block neighbors inflate it. Codec headers self-bound
 // reads, so correctness-safe; only H2D and staging bytes pay the overshoot.
-void compute_segment_bytes_size(duckdb_native_metadata& md, std::size_t block_size)
+void compute_segment_bytes_size(std::vector<duckdb_row_group_metadata>& row_groups,
+                                std::size_t block_size)
 {
   std::vector<duckdb_segment_descriptor*> refs;
-  for (auto& rg : md.row_groups) {
+  for (auto& rg : row_groups) {
     for (auto& col : rg.columns) {
       for (auto& s : col.data_segments)
         if (s.block_id >= 0) refs.push_back(&s);
@@ -248,28 +191,10 @@ void compute_segment_bytes_size(duckdb_native_metadata& md, std::size_t block_si
   });
   for (std::size_t i = 0; i < refs.size(); ++i) {
     auto& seg                = *refs[i];
-    const bool last_in_block = i + 1 == refs.size() || refs[i + 1]->block_id != seg.block_id;
-    const std::size_t end =
+    auto const last_in_block = i + 1 == refs.size() || refs[i + 1]->block_id != seg.block_id;
+    auto const end =
       last_in_block ? block_size : static_cast<std::size_t>(refs[i + 1]->block_offset);
     seg.bytes_size = end - static_cast<std::size_t>(seg.block_offset);
-  }
-}
-
-// The walker over-allocates to `max_row_group_index + 1`; row groups
-// whose every projected segment was filtered out arrive here with
-// row_count == 0. Rowid-only entries are kept.
-void drop_empty_trailing_row_groups(duckdb_native_metadata& md)
-{
-  while (!md.row_groups.empty() && md.row_groups.back().row_count == 0) {
-    bool has_rowid = false;
-    for (const auto& col_md : md.row_groups.back().columns) {
-      if (col_md.is_rowid) {
-        has_rowid = true;
-        break;
-      }
-    }
-    if (has_rowid) { break; }
-    md.row_groups.pop_back();
   }
 }
 
@@ -285,23 +210,25 @@ bool filter_is_prunable(duckdb::TableFilterType t)
 
 /// @brief Drop row groups a pushed-down filter proves can hold no matching rows.
 ///
-/// Mirrors duckdb::RowGroup::CheckZonemap: for each prunable filter, evaluate
-/// DuckDB's own TableFilter::CheckStatistics against the row group's aggregated
-/// per-column statistics (PartitionRowGroup::GetColumnStatistics).
-void prune_row_groups_by_filter_stats(duckdb_native_metadata& md,
-                                      const row_group_handles& handles,
-                                      const duckdb::TableFilterSet& table_filters,
-                                      const duckdb::vector<duckdb::ColumnIndex>& column_ids)
+/// For each prunable filter, evaluate TableFilter::CheckStatistics against the
+/// row group's aggregated per-column statistics
+/// (PartitionRowGroup::GetColumnStatistics). Each range owns a disjoint set of
+/// row groups, so each handle is read by a single thread.
+void prune_row_groups_by_filter_stats(duckdb_native_row_group_range& result,
+                                      const duckdb_native_walk_plan& plan)
 {
+  const auto& table_filters = *plan.table_filters;
+  const auto& column_ids    = *plan.column_ids;
+
   std::vector<duckdb_row_group_metadata> kept;
-  kept.reserve(md.row_groups.size());
+  kept.reserve(result.row_groups.size());
   std::size_t pruned_bytes = 0;
 
-  for (auto& rg_md : md.row_groups) {
+  for (auto& rg_md : result.row_groups) {
     auto const rg = rg_md.row_group_index;
     bool prune    = false;
-    if (rg < handles.size() && handles[rg].second) {
-      auto& prg = *handles[rg].second;
+    if (rg < plan.partition_row_groups.size() && plan.partition_row_groups[rg]) {
+      auto& prg = *plan.partition_row_groups[rg];
       for (auto const& [col_idx, filter] : table_filters.filters) {
         if (!filter_is_prunable(filter->filter_type)) { continue; }
         if (col_idx >= column_ids.size()) { continue; }  // defensive
@@ -321,9 +248,9 @@ void prune_row_groups_by_filter_stats(duckdb_native_metadata& md,
     }
   }
 
-  md.pruned_row_groups    = md.row_groups.size() - kept.size();
-  md.pruned_decoded_bytes = pruned_bytes;
-  md.row_groups           = std::move(kept);
+  result.pruned_row_groups    = result.row_groups.size() - kept.size();
+  result.pruned_decoded_bytes = pruned_bytes;
+  result.row_groups           = std::move(kept);
 }
 
 }  // namespace
@@ -357,7 +284,8 @@ bool is_supported_validity_compression(duckdb::CompressionType c)
   }
 }
 
-duckdb_native_metadata walk_duckdb_native_metadata(
+//===----------prepare_duckdb_native_walk----------===//
+duckdb_native_walk_plan prepare_duckdb_native_walk(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
   const std::vector<projected_column>& projected_cols,
@@ -365,72 +293,113 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   const duckdb::TableFilterSet* table_filters,
   const duckdb::vector<duckdb::ColumnIndex>* column_ids)
 {
-  nvtx3::scoped_range nvtx_walk{"sirius::native_metadata_walk"};
+  nvtx3::scoped_range nvtx_prep{"sirius::native_metadata_prepare"};
 
-  duckdb_native_metadata md;
-  md.viable = false;
+  duckdb_native_walk_plan plan;
+  plan.viable          = false;
+  plan.storage         = &storage;
+  plan.context         = &context;
+  plan.projected_cols  = &projected_cols;
+  plan.projected_types = &projected_types;
+  plan.table_filters   = table_filters;
+  plan.column_ids      = column_ids;
 
-  auto refuse = [&md](std::string reason) {
-    md.viability_failure_reason = std::move(reason);
-    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused: {}", md.viability_failure_reason);
+  auto refuse = [&plan](std::string reason) {
+    plan.viability_failure_reason = std::move(reason);
+    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused (prepare): {}",
+                     plan.viability_failure_reason);
   };
 
   if (projected_cols.empty()) {
     refuse("no projected columns");
-    return md;
+    return plan;
   }
   if (projected_cols.size() != projected_types.size()) {
     refuse("projected_cols and projected_types size mismatch");
-    return md;
+    return plan;
   }
 
+  // Type gate
   for (std::size_t ci = 0; ci < projected_types.size(); ++ci) {
     if (projected_cols[ci].is_rowid) { continue; }
     std::string reason;
     if (!is_supported_logical_type(projected_types[ci], reason)) {
       refuse("column " + std::to_string(projected_cols[ci].storage_idx.GetPrimaryIndex()) + ": " +
              reason);
-      return md;
+      return plan;
     }
   }
 
-  // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
-  // iteration order at v1.5.2 — relied on for indexing by row_group_index.
+  // GetPartitionStats touches LocalStorage/ClientContext. Runs before the
+  // concurrent range walks.
   duckdb::vector<duckdb::PartitionStatistics> partition_stats;
   {
+    /// @note Synchronous pread()s happen here when cold.
     nvtx3::scoped_range nvtx_ps{"sirius::native_metadata_partition_stats"};
     partition_stats = storage.GetPartitionStats(context);
   }
-  row_group_handles handles;
-  handles.reserve(partition_stats.size());
+
+  auto const& row_groups = *storage.GetRowGroupCollection();
+  plan.n_row_groups      = row_groups.GetRowGroupCount();
+  plan.block_size = storage.GetAttached().GetStorageManager().GetBlockManager().GetBlockSize();
+
+  plan.row_group_start.assign(plan.n_row_groups, 0);
+  plan.row_count.assign(plan.n_row_groups, 0);
+  plan.partition_row_groups.assign(plan.n_row_groups, nullptr);
   for (std::size_t i = 0; i < partition_stats.size(); ++i) {
-    auto& ps = partition_stats[i];
+    auto const& ps = partition_stats[i];
     if (!ps.row_start.IsValid()) {
-      // Defaulting to 0 would emit wrong rowids; route to CPU instead.
       refuse("partition_stats[" + std::to_string(i) +
              "].row_start is not valid; cannot synthesize rowids");
-      return md;
+      return plan;
     }
-    handles.emplace_back(ps.row_start.GetIndex(), ps.partition_row_group);
+    // PartitionStatistics order matches `RowGroupCollection::SegmentNodes()`
+    // iteration order at v1.5.2.
+    if (i < plan.n_row_groups) {
+      plan.row_group_start[i]      = ps.row_start.GetIndex();
+      plan.row_count[i]            = ps.count;
+      plan.partition_row_groups[i] = ps.partition_row_group;
+    }
   }
 
-  // O(1) skip for non-projected columns in the GetColumnSegmentInfo loop.
-  std::unordered_map<duckdb::idx_t, std::size_t> projected_lookup;
-  projected_lookup.reserve(projected_cols.size());
+  // Lookup to skip non-projected columns in the GetColumnSegmentInfo loop.
+  plan.projected_lookup.reserve(projected_cols.size());
   for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
     if (projected_cols[ci].is_rowid) { continue; }
-    projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
+    plan.projected_lookup.emplace(projected_cols[ci].storage_idx.GetPrimaryIndex(), ci);
   }
 
-  duckdb::QueryContext qc{context};
+  plan.viable = true;
+  return plan;
+}
+
+//===----------walk_duckdb_native_row_group_range----------===//
+duckdb_native_row_group_range walk_duckdb_native_row_group_range(
+  const duckdb_native_walk_plan& plan, std::size_t rg_begin, std::size_t rg_end)
+{
+  duckdb_native_row_group_range result;
+
+  auto const& projected_cols  = *plan.projected_cols;
+  auto const& projected_types = *plan.projected_types;
+
+  rg_end = std::min(rg_end, plan.n_row_groups);
+  if (rg_begin >= rg_end) { return result; }  // viable=true, empty range
+
+  auto refuse = [&result](std::string reason) {
+    result.viable                   = false;
+    result.viability_failure_reason = std::move(reason);
+    SIRIUS_LOG_DEBUG("[duckdb_native_metadata] refused (range): {}",
+                     result.viability_failure_reason);
+  };
+
+  // Get column segment metadata
+  duckdb::QueryContext qc{*plan.context};
   duckdb::vector<duckdb::ColumnSegmentInfo> column_segments;
   {
     nvtx3::scoped_range nvtx_si{"sirius::native_metadata_segment_info"};
-    // Read segment metadata for projected columns only.
-    auto& row_groups        = *storage.GetRowGroupCollection();
-    auto const n_row_groups = row_groups.GetRowGroupCount();
-    for (std::size_t rg = 0; rg < n_row_groups; ++rg) {
-      auto row_group = row_groups.GetRowGroup(rg);
+    auto& row_groups = *plan.storage->GetRowGroupCollection();
+    for (std::size_t rg = rg_begin; rg < rg_end; ++rg) {
+      auto row_group = row_groups.GetRowGroup(static_cast<duckdb::idx_t>(rg));
       if (!row_group) { continue; }
       for (auto const& pc : projected_cols) {
         if (pc.is_rowid) { continue; }
@@ -440,43 +409,41 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-  // Size to max_row_group_index + 1 so rowid-only and all-filtered row
-  // groups still have an entry for rowid synthesis and trailing-empty
-  // pruning to inspect.
-  duckdb::idx_t max_rg_idx = 0;
-  for (const auto& seg : column_segments) {
-    max_rg_idx = std::max(max_rg_idx, seg.row_group_index);
-  }
-  const std::size_t num_row_groups =
-    column_segments.empty() ? handles.size() : static_cast<std::size_t>(max_rg_idx) + 1;
-  md.row_groups.resize(num_row_groups);
-  for (std::size_t rg = 0; rg < num_row_groups; ++rg) {
-    md.row_groups[rg].row_group_index = rg;
-    md.row_groups[rg].columns.resize(projected_cols.size());
+  // One entry per row group in [rg_begin, rg_end)
+  auto const n = rg_end - rg_begin;
+  result.row_groups.resize(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    auto const rg         = rg_begin + i;
+    auto& rg_md           = result.row_groups[i];
+    rg_md.row_group_index = rg;
+    rg_md.row_group_start = plan.row_group_start[rg];
+    rg_md.row_count       = plan.row_count[rg];
+    rg_md.columns.resize(projected_cols.size());
     for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      md.row_groups[rg].columns[ci].column_id =
-        projected_cols[ci].is_rowid ? std::numeric_limits<duckdb::idx_t>::max()
-                                    : projected_cols[ci].storage_idx.GetPrimaryIndex();
-      md.row_groups[rg].columns[ci].is_rowid = projected_cols[ci].is_rowid;
+      rg_md.columns[ci].column_id = projected_cols[ci].is_rowid
+                                      ? std::numeric_limits<duckdb::idx_t>::max()
+                                      : projected_cols[ci].storage_idx.GetPrimaryIndex();
+      rg_md.columns[ci].is_rowid  = projected_cols[ci].is_rowid;
     }
-    if (rg < handles.size()) { md.row_groups[rg].row_group_start = handles[rg].first; }
   }
 
+  // Build segment descriptors
   for (const auto& seg : column_segments) {
-    auto pl = projected_lookup.find(seg.column_id);
-    if (pl == projected_lookup.end()) { continue; }  // not projected
-    const std::size_t ci    = pl->second;
-    const auto rg_idx       = seg.row_group_index;
-    const bool validity_seg = is_validity_path(seg.column_path);
-    const auto compression  = parse_compression_string(seg.compression_type);
-
-    const bool compression_ok = validity_seg ? is_supported_validity_compression(compression)
+    auto pl = plan.projected_lookup.find(seg.column_id);
+    if (pl == plan.projected_lookup.end()) { continue; }  // not projected
+    auto const rg_idx = seg.row_group_index;
+    if (rg_idx < rg_begin || rg_idx >= rg_end) { continue; }
+    auto const ci             = pl->second;
+    auto const local_rgi      = static_cast<std::size_t>(rg_idx) - rg_begin;
+    auto const validity_seg   = is_validity_path(seg.column_path);
+    auto const compression    = parse_compression_string(seg.compression_type);
+    auto const compression_ok = validity_seg ? is_supported_validity_compression(compression)
                                              : is_supported_data_compression(compression);
     if (!compression_ok) {
       refuse(std::string{validity_seg ? "validity" : "data"} + " segment on column " +
              std::to_string(seg.column_id) + " row group " + std::to_string(rg_idx) +
              ": unsupported compression \"" + seg.compression_type + "\"");
-      return md;
+      return result;
     }
 
     auto desc = build_segment_descriptor(seg, compression);
@@ -486,7 +453,7 @@ duckdb_native_metadata walk_duckdb_native_metadata(
       if (compression == duckdb::CompressionType::COMPRESSION_CONSTANT) {
         refuse("varchar segment on column " + std::to_string(seg.column_id) + " row group " +
                std::to_string(rg_idx) + ": CONSTANT compression is unsupported for varchar");
-        return md;
+        return result;
       }
       // Refuse on absent stat so downstream consumers can deref unchecked.
       // Some(0) is legal data (all-empty row group); decode produces 0 chars.
@@ -494,11 +461,11 @@ duckdb_native_metadata walk_duckdb_native_metadata(
       if (!desc.max_string_length.has_value()) {
         refuse("varchar segment on column " + std::to_string(seg.column_id) + " row group " +
                std::to_string(rg_idx) + ": Max String Length stat absent from segment_stats");
-        return md;
+        return result;
       }
     }
 
-    auto& col_md = md.row_groups[rg_idx].columns[ci];
+    auto& col_md = result.row_groups[local_rgi].columns[ci];
     if (validity_seg) {
       col_md.validity_segments.push_back(std::move(desc));
     } else {
@@ -506,34 +473,8 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-#ifndef NDEBUG
-  // Invariant: DuckDB's typed PartitionRowGroup::GetColumnStatistics returns
-  // max(per-segment) via StringStats::Merge. Catches API drift.
-  for (std::size_t rg_idx = 0; rg_idx < handles.size(); ++rg_idx) {
-    auto& prg = handles[rg_idx].second;
-    if (!prg) { continue; }
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
-      auto stats = prg->GetColumnStatistics(projected_cols[ci].storage_idx);
-      if (!stats || !duckdb::StringStats::HasMaxStringLength(*stats)) { continue; }
-      const auto rg_typed_max   = duckdb::StringStats::MaxStringLength(*stats);
-      const auto& data_segs     = md.row_groups[rg_idx].columns[ci].data_segments;
-      std::uint32_t per_seg_max = 0;
-      for (const auto& seg : data_segs) {
-        if (seg.max_string_length.has_value()) {
-          per_seg_max = std::max(per_seg_max, *seg.max_string_length);
-        }
-      }
-      assert(rg_typed_max == per_seg_max &&
-             "DuckDB rg-level MaxStringLength != max(per-segment) — Merge semantics drifted?");
-    }
-  }
-#endif
-
-  // GetColumnSegmentInfo at v1.5.2 already yields segments in segment_start
-  // order per (column, row group); this sort is a guard against future
-  // upstream changes to that order.
-  for (auto& rg_md : md.row_groups) {
+  // Sort data_segments by segment_start ascending for codec run coalescing.
+  for (auto& rg_md : result.row_groups) {
     auto seg_less = [](const duckdb_segment_descriptor& a, const duckdb_segment_descriptor& b) {
       return a.segment_start < b.segment_start;
     };
@@ -543,59 +484,75 @@ duckdb_native_metadata walk_duckdb_native_metadata(
     }
   }
 
-  compute_segment_bytes_size(
-    md, storage.GetAttached().GetStorageManager().GetBlockManager().GetBlockSize());
-
-  compute_row_counts(md, partition_stats);
-  compute_decoded_byte_budgets(md, projected_types);
-
-  // Row-group pruning
-  if (table_filters != nullptr && !table_filters->filters.empty() && column_ids != nullptr &&
-      !column_ids->empty()) {
-    nvtx3::scoped_range nvtx_prune{"sirius::native_metadata_filter_stats_prune"};
-    prune_row_groups_by_filter_stats(md, handles, *table_filters, *column_ids);
-  }
-
-  drop_empty_trailing_row_groups(md);
-
-  // Per-column varchar upper bound, cached on each row group so the
-  // partitioner is a pure read. Walker refuses any row group whose
-  // per-column upper bound hits the cudf int32 chars threshold (cudf
-  // throws there in default-mode make_offsets_child_column).
-  for (auto& rg : md.row_groups) {
-    rg.varchar_bytes_per_col.assign(projected_cols.size(), 0);
-    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
-      if (projected_cols[ci].is_rowid || !projected_types[ci].is_varchar()) { continue; }
-      std::size_t total = 0;
-      for (const auto& seg : rg.columns[ci].data_segments) {
-        total += static_cast<std::size_t>(seg.segment_count) *
-                 static_cast<std::size_t>(*seg.max_string_length);
+  // Compute row_count manually for any row group beyond PartitionStatistics range.
+  for (auto& rg_md : result.row_groups) {
+    if (rg_md.row_count != 0) { continue; }
+    for (const auto& col_md : rg_md.columns) {
+      if (col_md.is_rowid) { continue; }
+      duckdb::idx_t col_count = 0;
+      for (const auto& d : col_md.data_segments) {
+        col_count += d.segment_count;
       }
-      if (total >= kCudfInt32StringsThreshold) {
-        refuse("row group " + std::to_string(rg.row_group_index) + " column " +
-               std::to_string(rg.columns[ci].column_id) + " varchar chars upper bound (" +
-               std::to_string(total) + ") >= cudf int32 chars threshold");
-        return md;
+      if (col_count > 0) {
+        rg_md.row_count = col_count;
+        break;
       }
-      rg.varchar_bytes_per_col[ci] = total;
     }
   }
 
-  if (md.row_groups.empty()) {
-    // Zero splits would hang the pipeline on the FULL barrier; refuse instead.
-    refuse("no row groups in table (empty or fully pruned)");
-    return md;
+  // Per-segment on-disk byte sizes.
+  compute_segment_bytes_size(result.row_groups, plan.block_size);
+
+  // Per row group, compute the decoded-byte budget and per-column varchar char
+  // count. Refuse a varchar column whose char count would overflow cudf's int32
+  // string offsets.
+  for (auto& rg_md : result.row_groups) {
+    rg_md.varchar_bytes_per_col.assign(projected_cols.size(), 0);
+    std::size_t budget = 0;
+    for (std::size_t ci = 0; ci < projected_cols.size(); ++ci) {
+      const auto& col_md = rg_md.columns[ci];
+      if (col_md.is_rowid) {
+        budget += static_cast<std::size_t>(rg_md.row_count) * sizeof(std::int64_t);
+        continue;
+      }
+      if (projected_types[ci].is_varchar()) {
+        std::size_t chars = 0;
+        for (const auto& seg : col_md.data_segments) {
+          chars += static_cast<std::size_t>(seg.segment_count) *
+                   static_cast<std::size_t>(*seg.max_string_length);
+        }
+        if (chars >= kCudfInt32StringsThreshold) {
+          refuse("row group " + std::to_string(rg_md.row_group_index) + " column " +
+                 std::to_string(col_md.column_id) + " varchar chars upper bound (" +
+                 std::to_string(chars) + ") >= cudf int32 chars threshold");
+          return result;
+        }
+        rg_md.varchar_bytes_per_col[ci] = chars;
+        budget += chars + static_cast<std::size_t>(rg_md.row_count) * sizeof(std::uint32_t);
+      } else {
+        budget +=
+          static_cast<std::size_t>(rg_md.row_count) * projected_types[ci].fixed_width_byte_size();
+      }
+    }
+    rg_md.decoded_bytes_budget = budget;
   }
 
-  md.viable = true;
-  SIRIUS_LOG_DEBUG(
-    "[duckdb_native_metadata] walked {} row groups across {} projected columns; "
-    "stats-pruned {} row groups (~{} decoded bytes); viable=true",
-    md.row_groups.size(),
-    projected_cols.size(),
-    md.pruned_row_groups,
-    md.pruned_decoded_bytes);
-  return md;
+  // Drop any row group a pushed-down filter proves can hold no matching rows.
+  if (plan.table_filters != nullptr && !plan.table_filters->filters.empty() &&
+      plan.column_ids != nullptr && !plan.column_ids->empty()) {
+    nvtx3::scoped_range nvtx_prune{"sirius::native_metadata_filter_stats_prune"};
+    prune_row_groups_by_filter_stats(result, plan);
+    if (result.pruned_row_groups > 0) {
+      SIRIUS_LOG_DEBUG(
+        "[duckdb_native_metadata] range [{}, {}) stats-pruned {} row groups (~{} decoded bytes)",
+        rg_begin,
+        rg_end,
+        result.pruned_row_groups,
+        result.pruned_decoded_bytes);
+    }
+  }
+
+  return result;
 }
 
 }  // namespace sirius::op::scan

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -286,12 +286,6 @@ void mark_row_groups_pruned_by_filter_stats(duckdb_native_walk_plan& plan)
 
 }  // namespace
 
-void finalize_duckdb_native_segment_bytes(std::vector<duckdb_row_group_metadata>& row_groups,
-                                          std::size_t block_size)
-{
-  compute_segment_bytes_size(row_groups, block_size);
-}
-
 bool is_supported_data_compression(duckdb::CompressionType c)
 {
   switch (c) {
@@ -567,6 +561,11 @@ duckdb_native_row_group_range walk_duckdb_native_row_group_range(
       }
     }
   }
+
+  // Per-segment on-disk byte sizes, over this range's segments. A segment whose
+  // DuckDB block extends past the range is sized to the block end: an upper
+  // bound, since decoders self-bound reads via their segment headers.
+  compute_segment_bytes_size(result.row_groups, plan.block_size);
 
   // Per row group, compute the decoded-byte budget and per-column varchar char
   // count. Refuse a varchar column whose char count would overflow cudf's int32

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -115,10 +115,17 @@ std::optional<task_creation_hint> sirius_gpu_scan_operator::get_next_task_hint()
   return task_creation_hint{TaskCreationHint::READY, this};
 }
 
-bool sirius_gpu_scan_operator::all_ports_empty() { return _split_connector->is_closed(); }
+bool sirius_gpu_scan_operator::all_ports_empty()
+{
+  // Done when the connector is closed and the ingestible has no buffered work.
+  // The unprepared path has no ingestible.
+  return _split_connector->is_closed() && (!_ingestible || _ingestible->consumer_drained());
+}
 
 std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::get_next_task_input_data()
 {
+  // Delegate to the ingestible. The unprepared path pulls directly from the connector.
+  if (_ingestible) { return _ingestible->consume_next_input(*_split_connector); }
   auto next = _split_connector->get_next_split();
   if (!next.has_value()) { return nullptr; }
   return std::move(*next);

--- a/test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
+++ b/test/cpp/scan/test_duckdb_native_batch_coalescer.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch.hpp>
+#include <op/scan/duckdb_native_batch_coalescer.hpp>
+
+#include <cstddef>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+
+namespace {
+
+logical_type int_type() { return logical_type::make(type_id::INTEGER); }
+logical_type varchar_type() { return logical_type::make(type_id::VARCHAR); }
+
+duckdb_row_group_metadata make_rg(std::size_t index,
+                                  std::size_t rows,
+                                  std::size_t decoded_bytes,
+                                  std::vector<std::size_t> varchar_bytes = {})
+{
+  duckdb_row_group_metadata rg;
+  rg.row_group_index       = index;
+  rg.row_group_start       = index * 100;  // arbitrary, monotone
+  rg.row_count             = rows;
+  rg.decoded_bytes_budget  = decoded_bytes;
+  rg.varchar_bytes_per_col = std::move(varchar_bytes);
+  return rg;
+}
+
+/// Push every row group and drain ready batches, then the tail. Returns batch
+/// sizes in emission order.
+std::vector<std::size_t> coalesce_sizes(batch_coalescer& c,
+                                        std::vector<duckdb_row_group_metadata> rgs)
+{
+  std::vector<std::size_t> sizes;
+  for (auto& rg : rgs) {
+    c.push(std::move(rg));
+    while (c.has_ready()) {
+      sizes.push_back(c.pop_ready().size());
+    }
+  }
+  auto tail = c.flush();
+  if (!tail.empty()) { sizes.push_back(tail.size()); }
+  return sizes;
+}
+
+}  // namespace
+
+TEST_CASE("batch_coalescer with no caps yields a single batch", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 5; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/1000));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{5});  // one batch holds all five
+}
+
+TEST_CASE("batch_coalescer splits on the total decoded-byte cap with one tail",
+          "[scan][batch_coalescer]")
+{
+  // cap=1000, each row group 400 bytes: a batch closes at 2 row groups (800),
+  // since a third (1200) exceeds the cap. Five row groups -> [2, 2, 1].
+  batch_coalescer c(/*approximate_batch_size=*/1000, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 5; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/400));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{2, 2, 1});
+  // Only the final batch is below the 2-row-group fill.
+  REQUIRE(sizes.back() == 1);
+}
+
+TEST_CASE("batch_coalescer keeps an over-cap row group as its own singleton batch",
+          "[scan][batch_coalescer]")
+{
+  // Every row group (400 bytes) exceeds the cap (100) on its own, so each lands
+  // alone: three row groups -> [1, 1, 1].
+  batch_coalescer c(/*approximate_batch_size=*/100, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 3; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/400));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{1, 1, 1});
+}
+
+TEST_CASE("batch_coalescer splits on the per-varchar-column cudf int32 cap",
+          "[scan][batch_coalescer]")
+{
+  // No total cap; one varchar column. Two row groups at 1.5e9 chars each sum to
+  // 3e9 >= kCudfInt32StringsThreshold (2^31-1), so they cannot share a batch.
+  // Three row groups -> [1, 1, 1].
+  batch_coalescer c(/*approximate_batch_size=*/0, {varchar_type()});
+  constexpr std::size_t kBig = 1'500'000'000ULL;
+  REQUIRE(kBig < kCudfInt32StringsThreshold);
+  REQUIRE(2 * kBig >= kCudfInt32StringsThreshold);
+
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 3; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/0, /*varchar_bytes=*/{kBig}));
+  }
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{1, 1, 1});
+}
+
+TEST_CASE("batch_coalescer drops empty row groups", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  rgs.push_back(make_rg(0, /*rows=*/100, /*bytes=*/1000));
+  rgs.push_back(make_rg(1, /*rows=*/0, /*bytes=*/0));  // empty: dropped
+  rgs.push_back(make_rg(2, /*rows=*/100, /*bytes=*/1000));
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes == std::vector<std::size_t>{2});  // two non-empty row groups, one batch
+}
+
+TEST_CASE("batch_coalescer with only empty row groups yields no batches", "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/0, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  rgs.push_back(make_rg(0, /*rows=*/0, /*bytes=*/0));
+  rgs.push_back(make_rg(1, /*rows=*/0, /*bytes=*/0));
+  auto sizes = coalesce_sizes(c, std::move(rgs));
+  REQUIRE(sizes.empty());
+}
+
+TEST_CASE("batch_coalescer preserves total row-group count across the split",
+          "[scan][batch_coalescer]")
+{
+  batch_coalescer c(/*approximate_batch_size=*/1000, {int_type()});
+  std::vector<duckdb_row_group_metadata> rgs;
+  for (std::size_t i = 0; i < 17; ++i) {
+    rgs.push_back(make_rg(i, /*rows=*/100, /*bytes=*/300));
+  }
+  auto sizes        = coalesce_sizes(c, std::move(rgs));
+  std::size_t total = 0;
+  for (auto s : sizes) {
+    total += s;
+  }
+  REQUIRE(total == 17);        // no row group lost or duplicated
+  REQUIRE(sizes.size() >= 2);  // actually split
+}

--- a/test/cpp/scan/test_duckdb_native_gpu_ingestible.cpp
+++ b/test/cpp/scan/test_duckdb_native_gpu_ingestible.cpp
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for duckdb_native_gpu_ingestible: ctor validation, range claiming, and
+// consumer-side coalescing of ranges into cap-sized batches (including the
+// single-split tail case).
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/catalog/catalog.hpp>
+#include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
+#include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
+#include <duckdb/main/client_context.hpp>
+#include <duckdb/storage/data_table.hpp>
+#include <helper/logical_type.hpp>
+#include <io/io_context.hpp>
+#include <io/types.hpp>
+#include <op/scan/duckdb_native_gpu_ingestible.hpp>
+#include <op/scan/sirius_gpu_scan_operator_data.hpp>
+#include <scan_manager/sirius_scan_manager.hpp>
+#include <scan_manager/split_connector.hpp>
+#include <scan_manager/split_provider.hpp>
+#include <utils/utils.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace sirius;
+using namespace sirius::op::scan;
+using namespace sirius::scan_manager;
+
+namespace {
+
+void exec_ok(duckdb::Connection& con, std::string const& q)
+{
+  auto result = con.Query(q);
+  REQUIRE(result);
+  if (result->HasError()) {
+    INFO("query failed: " << q << "\n  error: " << result->GetError());
+    REQUIRE_FALSE(result->HasError());
+  }
+}
+
+duckdb::DataTable& get_storage(duckdb::Connection& con, std::string const& table_name)
+{
+  exec_ok(con, "BEGIN TRANSACTION");
+  auto& ctx     = *con.context;
+  auto& catalog = duckdb::Catalog::GetCatalog(ctx, "");
+  duckdb::CatalogTransaction txn(catalog, ctx);
+  auto& schema = catalog.GetSchema(txn, "main");
+  auto entry   = schema.GetEntry(txn, duckdb::CatalogType::TABLE_ENTRY, table_name);
+  REQUIRE(entry);
+  return entry->Cast<duckdb::DuckTableEntry>().GetStorage();
+}
+
+projected_column real_col(duckdb::idx_t col_id)
+{
+  projected_column pc;
+  pc.storage_idx = duckdb::StorageIndex(col_id);
+  pc.is_rowid    = false;
+  return pc;
+}
+
+// Minimal duckdb-native bind data. Caller fills storage / context / projected
+// vectors / batch size / db_path. column_ids / projection_ids / output_types /
+// table_filters stay empty: no filter and no projection-down.
+std::unique_ptr<io::ingestible_table_info> make_table_info(
+  duckdb::DataTable* storage,
+  duckdb::ClientContext* ctx,
+  std::vector<projected_column> cols,
+  std::vector<sirius::logical_type> types,
+  std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE,
+  std::string db_path                = "")
+{
+  auto info                    = std::make_unique<duckdb_native_ingestible_table_info>();
+  info->storage                = storage;
+  info->context                = ctx;
+  info->db_path                = std::move(db_path);
+  info->projected_cols         = std::move(cols);
+  info->projected_types        = std::move(types);
+  info->approximate_batch_size = approximate_batch_size;
+  return info;
+}
+
+// A scan_manager with the default config (it builds a real local-file uring
+// backend). With an empty db_path the ctor resolves no datasource, so the
+// emitted payloads carry null io handles. The decoder, the only io_ctx
+// consumer, is not driven here.
+std::unique_ptr<sirius_scan_manager> make_scan_manager()
+{
+  return std::make_unique<sirius_scan_manager>(scan_manager_config{});
+}
+
+// Scheduler that runs each enqueued thunk synchronously, so split_provider::run()
+// produces every range and closes the connector before returning.
+struct inline_scheduler {
+  template <typename F>
+  void enqueue(F&& f)
+  {
+    f();
+  }
+};
+
+// Drive the producer directly and flatten the raw row-group ranges it emits.
+// Reports the number of ranges handed out.
+struct drained {
+  std::vector<duckdb_row_group_metadata> row_groups;
+  std::size_t range_count = 0;
+};
+
+drained drain_ranges(duckdb_native_gpu_ingestible& ingestible)
+{
+  drained out;
+  while (ingestible.has_more_splits()) {
+    auto factory = ingestible.next_split_provider();
+    if (!factory) break;
+    auto carriers = factory();
+    if (carriers.empty()) break;
+    ++out.range_count;
+    for (auto& c : carriers) {
+      auto* range = dynamic_cast<duckdb_native_range_input*>(c.get());
+      REQUIRE(range != nullptr);
+      for (auto& rg : range->row_groups) {
+        out.row_groups.push_back(std::move(rg));
+      }
+    }
+  }
+  return out;
+}
+
+// Producer->connector->consumer round-trip: run the producer through a
+// split_connector via the inline scheduler, then drain the consumer's
+// coalescer. Returns each coalesced batch.
+std::vector<std::unique_ptr<op::operator_data>> run_and_consume(
+  duckdb_native_gpu_ingestible& ingestible)
+{
+  split_connector connector;
+  split_provider provider{ingestible};
+  inline_scheduler sched;
+  provider.run(sched, connector);  // pushes all carriers; closes connector on return
+
+  std::vector<std::unique_ptr<op::operator_data>> batches;
+  for (;;) {
+    auto batch = ingestible.consume_next_input(connector);
+    if (!batch) break;
+    batches.push_back(std::move(batch));
+  }
+  // After the consumer returns nullptr the coalescer must be drained.
+  REQUIRE(ingestible.consumer_drained());
+  REQUIRE(connector.is_closed());
+  return batches;
+}
+
+duckdb_native_split_payload const& payload_of(op::operator_data const& batch)
+{
+  auto const* input = dynamic_cast<scan_operator_input const*>(&batch);
+  REQUIRE(input != nullptr);
+  REQUIRE(input->metadata != nullptr);
+  auto const* split_info = dynamic_cast<duckdb_native_split_info const*>(&input->metadata->scan());
+  REQUIRE(split_info != nullptr);
+  return split_info->payload;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// ctor hardening
+//===----------------------------------------------------------------------===//
+TEST_CASE("duckdb_native_gpu_ingestible throws on null storage",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(/*storage=*/nullptr, /*ctx=*/nullptr, {}, {});
+  REQUIRE_THROWS_AS((duckdb_native_gpu_ingestible{std::move(info), *mgr}), std::invalid_argument);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible throws on null context",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 16)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage, /*ctx=*/nullptr, {}, {});
+  REQUIRE_THROWS_AS((duckdb_native_gpu_ingestible{std::move(info), *mgr}), std::invalid_argument);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible throws on projected vectors size mismatch",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 16)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage, con.context.get(), {real_col(0)}, /*types=*/{});
+  REQUIRE_THROWS_AS((duckdb_native_gpu_ingestible{std::move(info), *mgr}), std::invalid_argument);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible leaves io handles null for an empty db_path",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  // With no .db path the ctor resolves no datasource: the io handles stay null
+  // and construction still succeeds. A backend-less scan is rejected by the
+  // decoder, not the ctor; this exercises the null-handle path without driving
+  // the decoder.
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 16)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::INTEGER)});
+  duckdb_native_gpu_ingestible ingestible{std::move(info), *mgr};
+
+  auto batches = run_and_consume(ingestible);
+  REQUIRE_FALSE(batches.empty());
+  auto const& payload = payload_of(*batches[0]);
+  REQUIRE(payload.io_ctx == nullptr);
+  REQUIRE(payload.db_io_object == nullptr);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible throws when walker rejects the table",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  // HUGEINT is unsupported: prepare_duckdb_native_walk reports non-viable and
+  // the ctor surfaces the rejection as a runtime_error.
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a HUGEINT)");
+  exec_ok(con, "INSERT INTO t VALUES (1), (2), (3)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::HUGEINT)});
+  REQUIRE_THROWS_AS((duckdb_native_gpu_ingestible{std::move(info), *mgr}), std::runtime_error);
+}
+
+//===----------------------------------------------------------------------===//
+// producer: range claiming
+//===----------------------------------------------------------------------===//
+TEST_CASE("duckdb_native_gpu_ingestible emits one range for a small INTEGER table",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 1024)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::INTEGER)});
+  duckdb_native_gpu_ingestible ingestible{std::move(info), *mgr};
+  REQUIRE(ingestible.has_more_splits());
+
+  auto factory = ingestible.next_split_provider();
+  REQUIRE(factory);
+  auto carriers = factory();
+  REQUIRE(carriers.size() == 1);
+
+  auto* range = dynamic_cast<duckdb_native_range_input*>(carriers[0].get());
+  REQUIRE(range != nullptr);
+  REQUIRE_FALSE(range->row_groups.empty());
+
+  // After the only range is claimed both signals report exhaustion.
+  REQUIRE_FALSE(ingestible.has_more_splits());
+  auto exhausted = ingestible.next_split_provider();
+  REQUIRE_FALSE(exhausted);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible ranges cover all row groups exactly once",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  // ~1.2M INTEGER rows span several DuckDB row groups (<=122,880 rows each), so
+  // the producer hands out multiple parse ranges. Their union must cover every
+  // row group exactly once.
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 1200000)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::INTEGER)});
+  duckdb_native_gpu_ingestible ingestible{std::move(info), *mgr};
+  auto result = drain_ranges(ingestible);
+
+  REQUIRE(result.row_groups.size() >= 2);
+  REQUIRE(result.range_count >= 1);
+
+  std::sort(result.row_groups.begin(), result.row_groups.end(), [](auto const& a, auto const& b) {
+    return a.row_group_index < b.row_group_index;
+  });
+  for (std::size_t i = 0; i < result.row_groups.size(); ++i) {
+    REQUIRE(result.row_groups[i].row_group_index == i);
+    REQUIRE(result.row_groups[i].row_count > 0);
+  }
+  for (std::size_t i = 1; i < result.row_groups.size(); ++i) {
+    REQUIRE(result.row_groups[i].row_group_start > result.row_groups[i - 1].row_group_start);
+  }
+  REQUIRE_FALSE(ingestible.has_more_splits());
+}
+
+//===----------------------------------------------------------------------===//
+// consumer: coalescing + single-split race
+//===----------------------------------------------------------------------===//
+TEST_CASE("duckdb_native_gpu_ingestible consumer coalesces ranges, covers all row groups once",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 1200000)");
+  auto& storage = get_storage(con, "t");
+
+  // A small byte cap forces the coalescer to close multiple batches across the
+  // parsed ranges.
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::INTEGER)},
+                              /*approximate_batch_size=*/4096);
+  duckdb_native_gpu_ingestible ingestible{std::move(info), *mgr};
+
+  auto batches = run_and_consume(ingestible);
+  REQUIRE(batches.size() >= 2);  // multiple coalesced batches
+
+  // Every batch's payload aliases the same bind data, and the union of their
+  // row groups covers every row group exactly once.
+  duckdb_native_ingestible_table_info const* first_table_info = nullptr;
+  std::vector<duckdb::idx_t> seen_indices;
+  for (auto const& b : batches) {
+    auto const& payload = payload_of(*b);
+    REQUIRE(payload.table_info != nullptr);
+    REQUIRE_FALSE(payload.row_groups.empty());
+    if (first_table_info == nullptr) {
+      first_table_info = payload.table_info;
+    } else {
+      REQUIRE(payload.table_info == first_table_info);
+    }
+    for (auto const& rg : payload.row_groups) {
+      seen_indices.push_back(rg.row_group_index);
+    }
+  }
+  std::sort(seen_indices.begin(), seen_indices.end());
+  for (std::size_t i = 0; i < seen_indices.size(); ++i) {
+    REQUIRE(seen_indices[i] == i);  // contiguous from 0, no gaps or duplicates
+  }
+  REQUIRE(seen_indices.size() >= 2);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible single-split scan serves its batch then drains",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  // A single-split scan (one parse range) must serve its one batch before
+  // reporting drained, not drop it when the connector closes.
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 1024)");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr  = make_scan_manager();
+  auto info = make_table_info(&storage,
+                              con.context.get(),
+                              {real_col(0)},
+                              {sirius::logical_type::make(sirius::type_id::INTEGER)});
+  duckdb_native_gpu_ingestible ingestible{std::move(info), *mgr};
+
+  auto batches = run_and_consume(ingestible);
+  REQUIRE(batches.size() == 1);  // one row group → one tail batch, not dropped
+
+  auto const& payload = payload_of(*batches[0]);
+  REQUIRE_FALSE(payload.row_groups.empty());
+}

--- a/test/cpp/scan/test_duckdb_native_gpu_ingestible.cpp
+++ b/test/cpp/scan/test_duckdb_native_gpu_ingestible.cpp
@@ -24,6 +24,7 @@
 #include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <duckdb/planner/filter/constant_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <helper/logical_type.hpp>
 #include <io/io_context.hpp>
@@ -261,6 +262,31 @@ TEST_CASE("duckdb_native_gpu_ingestible throws when walker rejects the table",
                               {real_col(0)},
                               {sirius::logical_type::make(sirius::type_id::HUGEINT)});
   REQUIRE_THROWS_AS((duckdb_native_gpu_ingestible{std::move(info), *mgr}), std::runtime_error);
+}
+
+TEST_CASE("duckdb_native_gpu_ingestible rejects fully stats-pruned scans",
+          "[scan][duckdb_native_gpu_ingestible]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 300000)");
+  exec_ok(con, "CHECKPOINT");
+  auto& storage = get_storage(con, "t");
+
+  auto mgr          = make_scan_manager();
+  auto info         = make_table_info(&storage,
+                              con.context.get(),
+                                      {real_col(0)},
+                                      {sirius::logical_type::make(sirius::type_id::INTEGER)});
+  auto* native_info = dynamic_cast<duckdb_native_ingestible_table_info*>(info.get());
+  REQUIRE(native_info != nullptr);
+  native_info->table_filters             = duckdb::make_uniq<duckdb::TableFilterSet>();
+  native_info->table_filters->filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
+    duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(1000000));
+  native_info->column_ids.push_back(duckdb::ColumnIndex(0));
+
+  REQUIRE_THROWS_WITH((duckdb_native_gpu_ingestible{std::move(info), *mgr}),
+                      Catch::Contains("fully pruned"));
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -162,7 +162,6 @@ walk_result walk_all(duckdb::DataTable& storage,
             plan.pruned_decoded_bytes};
   }
   auto range = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
-  finalize_duckdb_native_segment_bytes(range.row_groups, plan.block_size);
   return {std::move(range.row_groups),
           range.viable,
           std::move(range.viability_failure_reason),
@@ -688,9 +687,14 @@ TEST_CASE("statistics pruning ignores rowid filters", "[scan][duckdb_native_walk
   REQUIRE(md.pruned_row_groups == 0);
 }
 
-TEST_CASE("walker finalizes segment bytes consistently across parse ranges",
+TEST_CASE("walker per-range segment bytes are a safe over-estimate of the full walk",
           "[scan][duckdb_native_walker][range_bytes]")
 {
+  // The walk sizes each segment's bytes per range, so a segment whose DuckDB
+  // block extends past its range is sized to the block end. Pin the invariant
+  // that makes that safe: per-range bytes_size never under-counts the full-walk
+  // value and never extends past the segment's block, keeping the staged disk
+  // read in bounds. Decoders self-bound reads via their segment headers.
   scoped_temp_db_path tmp;
   auto db_owner = std::make_unique<duckdb::DuckDB>(tmp.path());
   duckdb::Connection con(*db_owner);
@@ -706,10 +710,13 @@ TEST_CASE("walker finalizes segment bytes consistently across parse ranges",
   REQUIRE(plan.viable);
   REQUIRE(plan.n_row_groups >= 2);
 
+  // Full-range walk: every segment sees its in-block neighbor, so bytes_size is
+  // tight.
   auto full = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
   REQUIRE(full.viable);
-  finalize_duckdb_native_segment_bytes(full.row_groups, plan.block_size);
 
+  // Per-row-group walks: the finest chunking, maximizing the chance a block
+  // straddles a range boundary.
   std::vector<duckdb_row_group_metadata> chunked;
   for (std::size_t rg = 0; rg < plan.n_row_groups; ++rg) {
     auto range = walk_duckdb_native_row_group_range(plan, rg, rg + 1);
@@ -718,7 +725,6 @@ TEST_CASE("walker finalizes segment bytes consistently across parse ranges",
       chunked.push_back(std::move(rg_md));
     }
   }
-  finalize_duckdb_native_segment_bytes(chunked, plan.block_size);
 
   std::sort(full.row_groups.begin(), full.row_groups.end(), [](auto const& a, auto const& b) {
     return a.row_group_index < b.row_group_index;
@@ -739,13 +745,17 @@ TEST_CASE("walker finalizes segment bytes consistently across parse ranges",
       for (std::size_t si = 0; si < full_col.data_segments.size(); ++si) {
         auto const& a = full_col.data_segments[si];
         auto const& b = chunked_col.data_segments[si];
+        // Same underlying segments: only the derived byte size may differ.
         REQUIRE(b.block_id == a.block_id);
         REQUIRE(b.block_offset == a.block_offset);
         REQUIRE(b.segment_start == a.segment_start);
-        REQUIRE(b.bytes_size == a.bytes_size);
         if (b.block_id >= 0) {
           saw_disk_segment = true;
           REQUIRE(b.bytes_size > 0);
+          // Never an under-estimate ...
+          REQUIRE(b.bytes_size >= a.bytes_size);
+          // ... and never reads past the end of the segment's block.
+          REQUIRE(static_cast<std::size_t>(b.block_offset) + b.bytes_size <= plan.block_size);
         }
       }
     }

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 using namespace sirius;
 using namespace sirius::op::scan;
@@ -100,6 +101,35 @@ filter_ctx make_constant_filter(duckdb::idx_t col_key,
   return ctx;
 }
 
+/// Runs the pre-step plus a single full-table range and combines them into one
+/// result. Exercises `prepare_duckdb_native_walk` and
+/// `walk_duckdb_native_row_group_range`. Optional filters drive statistics
+/// pruning.
+struct walk_result {
+  std::vector<duckdb_row_group_metadata> row_groups;
+  bool viable = false;
+  std::string viability_failure_reason;
+  std::size_t pruned_row_groups    = 0;
+  std::size_t pruned_decoded_bytes = 0;
+};
+
+walk_result walk_all(duckdb::DataTable& storage,
+                     duckdb::ClientContext& ctx,
+                     const std::vector<projected_column>& cols,
+                     const std::vector<sirius::logical_type>& types,
+                     const duckdb::TableFilterSet* table_filters           = nullptr,
+                     const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr)
+{
+  auto plan = prepare_duckdb_native_walk(storage, ctx, cols, types, table_filters, column_ids);
+  if (!plan.viable) { return {{}, false, std::move(plan.viability_failure_reason), 0, 0}; }
+  auto range = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
+  return {std::move(range.row_groups),
+          range.viable,
+          std::move(range.viability_failure_reason),
+          range.pruned_row_groups,
+          range.pruned_decoded_bytes};
+}
+
 }  // namespace
 
 TEST_CASE("walker refuses empty projection", "[scan][duckdb_native_walker]")
@@ -109,7 +139,7 @@ TEST_CASE("walker refuses empty projection", "[scan][duckdb_native_walker]")
   exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 100)");
   auto& storage = get_storage(con, "t");
 
-  auto md = walk_duckdb_native_metadata(storage, *con.context, {}, {});
+  auto md = walk_all(storage, *con.context, {}, {});
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("no projected columns") != std::string::npos);
 }
@@ -122,7 +152,7 @@ TEST_CASE("walker refuses parallel-vector mismatch", "[scan][duckdb_native_walke
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("size mismatch") != std::string::npos);
 }
@@ -136,7 +166,7 @@ TEST_CASE("walker refuses HUGEINT type", "[scan][duckdb_native_walker]")
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::HUGEINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("HUGEINT") != std::string::npos);
 }
@@ -152,7 +182,7 @@ TEST_CASE("walker emits descriptors for INTEGER table", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE(md.viability_failure_reason.empty());
   REQUIRE_FALSE(md.row_groups.empty());
@@ -184,7 +214,7 @@ TEST_CASE("walker emits rowid sentinels with no segments", "[scan][duckdb_native
     sirius::logical_type::make(sirius::type_id::INTEGER),
     sirius::logical_type::make(sirius::type_id::BIGINT),
   };
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -213,7 +243,7 @@ TEST_CASE("walker rowid-only projection gets row_count from PartitionStats",
 
   std::vector<projected_column> cols   = {rowid_col()};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::BIGINT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -243,7 +273,7 @@ TEST_CASE("walker separates data and validity segments by column_path",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -269,7 +299,7 @@ TEST_CASE("walker populates per-segment max_string_length for VARCHAR",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
   for (const auto& rg : md.row_groups) {
@@ -294,7 +324,7 @@ TEST_CASE("walker accepts all-empty varchar row group (Some(0))", "[scan][duckdb
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
 
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
@@ -326,7 +356,7 @@ TEST_CASE("walker per-segment max_string_length reflects long strings",
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::VARCHAR)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 
@@ -347,7 +377,7 @@ TEST_CASE("walker refuses DECIMAL128 (precision > 18)", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(38, 0)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("DECIMAL128") != std::string::npos);
 }
@@ -362,7 +392,7 @@ TEST_CASE("walker accepts DECIMAL64 (precision <= 18)", "[scan][duckdb_native_wa
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make_decimal(18, 2)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE(md.viable);
   REQUIRE_FALSE(md.row_groups.empty());
 }
@@ -378,7 +408,7 @@ TEST_CASE("walker refuses STRUCT projected type", "[scan][duckdb_native_walker]"
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::STRUCT)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("STRUCT") != std::string::npos);
 }
@@ -392,7 +422,7 @@ TEST_CASE("walker refuses LIST projected type", "[scan][duckdb_native_walker]")
 
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::LIST)};
-  auto md = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto md                              = walk_all(storage, *con.context, cols, ts);
   REQUIRE_FALSE(md.viable);
   REQUIRE(md.viability_failure_reason.find("LIST") != std::string::npos);
 }
@@ -500,7 +530,7 @@ TEST_CASE("statistics pruning drops row groups below a lower-bound filter",
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
   // Baseline: no filter → nothing pruned.
-  auto base = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  auto base = walk_all(storage, *con.context, cols, ts);
   REQUIRE(base.viable);
   REQUIRE(base.pruned_row_groups == 0);
   REQUIRE(base.row_groups.size() >= 2);  // 300k rows > one 122880-row group
@@ -508,8 +538,7 @@ TEST_CASE("statistics pruning drops row groups below a lower-bound filter",
   // a >= 250000 → row groups entirely below 250000 are FILTER_ALWAYS_FALSE.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000));
-  auto pruned =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto pruned = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
 
   REQUIRE(pruned.viable);
   REQUIRE(pruned.pruned_row_groups >= 1);
@@ -540,15 +569,14 @@ TEST_CASE("statistics pruning keeps every row group when the filter matches all"
   // a >= 0 is always true for this data → no row group can be pruned.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(0));
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
 
   REQUIRE(md.viable);
   REQUIRE(md.pruned_row_groups == 0);
   REQUIRE(md.pruned_decoded_bytes == 0);
 }
 
-TEST_CASE("statistics pruning refuses (CPU fallback) when every row group is pruned",
+TEST_CASE("statistics pruning drops every row group when the filter excludes all data",
           "[scan][duckdb_native_walker][pruning]")
 {
   auto [db_owner, con] = sirius::make_test_db_and_connection();
@@ -557,16 +585,18 @@ TEST_CASE("statistics pruning refuses (CPU fallback) when every row group is pru
   std::vector<projected_column> cols   = {real_col(0)};
   std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
 
-  // a >= 1_000_000 exceeds every value → all row groups FILTER_ALWAYS_FALSE.
-  // The walker drops them all and refuses so the query routes to DuckDB CPU
-  // (which correctly returns the empty result).
+  auto base = walk_all(storage, *con.context, cols, ts);
+  REQUIRE(base.viable);
+
+  // a >= 1_000_000 exceeds every value → every row group is FILTER_ALWAYS_FALSE
+  // and the walk keeps none, yielding a viable empty result.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(1000000));
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
 
-  REQUIRE_FALSE(md.viable);
-  REQUIRE(md.viability_failure_reason.find("pruned") != std::string::npos);
+  REQUIRE(md.viable);
+  REQUIRE(md.row_groups.empty());
+  REQUIRE(md.pruned_row_groups == base.row_groups.size());
 }
 
 // Guards the relaxation that lets us prune on any static filter, not just the
@@ -588,8 +618,7 @@ TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
       duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000)));
   ctx.column_ids.push_back(duckdb::ColumnIndex(0));
 
-  auto md =
-    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+  auto md = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
 
   REQUIRE(md.viable);
   REQUIRE(md.pruned_row_groups >= 1);

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -20,6 +20,7 @@
 #include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
 #include <duckdb/common/column_index.hpp>
+#include <duckdb/common/constants.hpp>
 #include <duckdb/common/enums/compression_type.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
@@ -27,9 +28,12 @@
 #include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <op/scan/duckdb_native_metadata.hpp>
+#include <unistd.h>
 #include <utils/utils.hpp>
 
+#include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -87,6 +91,35 @@ struct filter_ctx {
   duckdb::vector<duckdb::ColumnIndex> column_ids;
 };
 
+class scoped_temp_db_path {
+ public:
+  scoped_temp_db_path()
+  {
+    char tmpl[] = "/tmp/sirius_native_range_bytes_XXXXXX";
+    int fd      = ::mkstemp(tmpl);
+    REQUIRE(fd >= 0);
+    ::close(fd);
+    ::unlink(tmpl);
+    _path = tmpl;
+  }
+
+  ~scoped_temp_db_path()
+  {
+    if (!_path.empty()) {
+      std::remove(_path.c_str());
+      std::remove((_path + ".wal").c_str());
+    }
+  }
+
+  scoped_temp_db_path(const scoped_temp_db_path&)            = delete;
+  scoped_temp_db_path& operator=(const scoped_temp_db_path&) = delete;
+
+  const std::string& path() const { return _path; }
+
+ private:
+  std::string _path;
+};
+
 filter_ctx make_constant_filter(duckdb::idx_t col_key,
                                 duckdb::idx_t storage_idx,
                                 duckdb::ExpressionType cmp,
@@ -121,8 +154,15 @@ walk_result walk_all(duckdb::DataTable& storage,
                      const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr)
 {
   auto plan = prepare_duckdb_native_walk(storage, ctx, cols, types, table_filters, column_ids);
-  if (!plan.viable) { return {{}, false, std::move(plan.viability_failure_reason), 0, 0}; }
+  if (!plan.viable) {
+    return {{},
+            false,
+            std::move(plan.viability_failure_reason),
+            plan.pruned_row_groups,
+            plan.pruned_decoded_bytes};
+  }
   auto range = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
+  finalize_duckdb_native_segment_bytes(range.row_groups, plan.block_size);
   return {std::move(range.row_groups),
           range.viable,
           std::move(range.viability_failure_reason),
@@ -576,7 +616,7 @@ TEST_CASE("statistics pruning keeps every row group when the filter matches all"
   REQUIRE(md.pruned_decoded_bytes == 0);
 }
 
-TEST_CASE("statistics pruning drops every row group when the filter excludes all data",
+TEST_CASE("statistics pruning refuses CPU fallback when every row group is pruned",
           "[scan][duckdb_native_walker][pruning]")
 {
   auto [db_owner, con] = sirius::make_test_db_and_connection();
@@ -588,14 +628,15 @@ TEST_CASE("statistics pruning drops every row group when the filter excludes all
   auto base = walk_all(storage, *con.context, cols, ts);
   REQUIRE(base.viable);
 
-  // a >= 1_000_000 exceeds every value → every row group is FILTER_ALWAYS_FALSE
-  // and the walk keeps none, yielding a viable empty result.
+  // a >= 1_000_000 exceeds every value -> every row group is
+  // FILTER_ALWAYS_FALSE. Reject so the query routes to DuckDB CPU, which can
+  // produce the correct empty result without relying on a zero-split GPU scan.
   auto ctx = make_constant_filter(
     0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(1000000));
   auto md = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
 
-  REQUIRE(md.viable);
-  REQUIRE(md.row_groups.empty());
+  REQUIRE_FALSE(md.viable);
+  REQUIRE(md.viability_failure_reason.find("pruned") != std::string::npos);
   REQUIRE(md.pruned_row_groups == base.row_groups.size());
 }
 
@@ -622,4 +663,92 @@ TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
 
   REQUIRE(md.viable);
   REQUIRE(md.pruned_row_groups >= 1);
+}
+
+TEST_CASE("statistics pruning ignores rowid filters", "[scan][duckdb_native_walker][pruning]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 3000)");
+  exec_ok(con, "CHECKPOINT");
+  auto& storage = get_storage(con, "t");
+
+  std::vector<projected_column> cols   = {rowid_col()};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::BIGINT)};
+
+  filter_ctx ctx;
+  ctx.filters.filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
+    duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::BIGINT(0));
+  ctx.column_ids.push_back(duckdb::ColumnIndex(duckdb::COLUMN_IDENTIFIER_ROW_ID));
+
+  auto md = walk_all(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+
+  REQUIRE(md.viable);
+  REQUIRE_FALSE(md.row_groups.empty());
+  REQUIRE(md.pruned_row_groups == 0);
+}
+
+TEST_CASE("walker finalizes segment bytes consistently across parse ranges",
+          "[scan][duckdb_native_walker][range_bytes]")
+{
+  scoped_temp_db_path tmp;
+  auto db_owner = std::make_unique<duckdb::DuckDB>(tmp.path());
+  duckdb::Connection con(*db_owner);
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, 600000)");
+  exec_ok(con, "CHECKPOINT");
+  auto& storage = get_storage(con, "t");
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+
+  auto plan = prepare_duckdb_native_walk(storage, *con.context, cols, ts);
+  REQUIRE(plan.viable);
+  REQUIRE(plan.n_row_groups >= 2);
+
+  auto full = walk_duckdb_native_row_group_range(plan, 0, plan.n_row_groups);
+  REQUIRE(full.viable);
+  finalize_duckdb_native_segment_bytes(full.row_groups, plan.block_size);
+
+  std::vector<duckdb_row_group_metadata> chunked;
+  for (std::size_t rg = 0; rg < plan.n_row_groups; ++rg) {
+    auto range = walk_duckdb_native_row_group_range(plan, rg, rg + 1);
+    REQUIRE(range.viable);
+    for (auto& rg_md : range.row_groups) {
+      chunked.push_back(std::move(rg_md));
+    }
+  }
+  finalize_duckdb_native_segment_bytes(chunked, plan.block_size);
+
+  std::sort(full.row_groups.begin(), full.row_groups.end(), [](auto const& a, auto const& b) {
+    return a.row_group_index < b.row_group_index;
+  });
+  std::sort(chunked.begin(), chunked.end(), [](auto const& a, auto const& b) {
+    return a.row_group_index < b.row_group_index;
+  });
+
+  REQUIRE(chunked.size() == full.row_groups.size());
+  bool saw_disk_segment = false;
+  for (std::size_t rg = 0; rg < full.row_groups.size(); ++rg) {
+    REQUIRE(chunked[rg].row_group_index == full.row_groups[rg].row_group_index);
+    REQUIRE(chunked[rg].columns.size() == full.row_groups[rg].columns.size());
+    for (std::size_t ci = 0; ci < full.row_groups[rg].columns.size(); ++ci) {
+      auto const& full_col    = full.row_groups[rg].columns[ci];
+      auto const& chunked_col = chunked[rg].columns[ci];
+      REQUIRE(chunked_col.data_segments.size() == full_col.data_segments.size());
+      for (std::size_t si = 0; si < full_col.data_segments.size(); ++si) {
+        auto const& a = full_col.data_segments[si];
+        auto const& b = chunked_col.data_segments[si];
+        REQUIRE(b.block_id == a.block_id);
+        REQUIRE(b.block_offset == a.block_offset);
+        REQUIRE(b.segment_start == a.segment_start);
+        REQUIRE(b.bytes_size == a.bytes_size);
+        if (b.block_id >= 0) {
+          saw_disk_segment = true;
+          REQUIRE(b.bytes_size > 0);
+        }
+      }
+    }
+  }
+  REQUIRE(saw_disk_segment);
 }


### PR DESCRIPTION
Parallelizes the DuckDB-native scan's per-row-group metadata walk, which
previously ran serially in the split-provider constructor and dominated cold
query runtime (~95% at TPC-H SF30, where the walk issues roughly one cold block
read per (row group × projected column) via `GetColumnSegmentInfo`).

## Design

The walk is split into a cheap serial pre-step and a parallel per-range walk,
and the scan operator coalesces the parsed ranges into cap-sized batches that
decode while the remaining ranges are still being parsed.

```
 prepare_for_query        ── driver thread (serial, cheap) ───────────────────────────
   duckdb_native_split_provider ctor
     • prepare_duckdb_native_walk()   partition stats · type gate · row-group count   (no segment IO)
     • slice [0..N) into ranges of `chunk` row groups   (SIRIUS_METADATA_PARSE_CHUNK, default 8)
   start_metadata_processing → split_provider::run(pool, connector)   (enqueues N thunks, returns fast)

 ── scan-worker pool (parallel) ──────────────────────┐      split_connector  (mutex + cv FIFO)
   thunk(range 0): walk_..._row_group_range(plan,0,k) │push─┐
   thunk(range 1): walk_..._row_group_range(plan,k,2k)│push─┤   pushed as ranges finish
   thunk(range 2): ...                                │push─┤   the cold GetColumnSegmentInfo reads
        each walks its rows × cols; latencies overlap │     │   for different ranges run concurrently
   ─────────────────────────────────────────────────────┘   ▼
                                                     [ split_payload · split_payload · ... ]
                                                                  │  get_next_split()
                                                                  ▼
 ── scan operator: get_next_task_input_data() ── single consumer ────────────────────
   batch_coalescer  ── push each range's row groups, pack to cap ──┐
     • a batch fills → emit it immediately ───────────────────────┼──► task → decode_duckdb_native_split
       (decode runs while later ranges are still parsing)         │      (pipeline executor + GPU)
     • emits exactly one undersized tail batch per scan           │
   ───────────────────────────────────────────────────────────────┘
```

Components:
- **`prepare_duckdb_native_walk`** — serial pre-step run in the provider ctor:
  partition statistics, projected-type viability, row-group count, block size. No
  per-segment IO, so unsupported types still fall back to DuckDB CPU up front.
- **`walk_duckdb_native_row_group_range`** — the IO-latency-bound segment walk for
  a disjoint row-group range, run inside each `next_split_provider` thunk on the
  scan-worker pool. Reads only immutable post-open segment trees with a per-worker
  `QueryContext`, so disjoint ranges parse concurrently and their cold reads overlap.
- **`batch_coalescer`** (new) — packs parsed row groups into batches bounded by
  `approximate_batch_size` (decoded bytes) and the cudf int32 strings limit
  (per varchar column), emitting one tail batch per scan. The scan operator feeds
  ranges in as they arrive and emits each batch as soon as it fills, so decode
  overlaps the remaining parse. Packing order is irrelevant (rowids are absolute
  per row group).

The provider ctor requires a non-null `io_ctx` and non-empty `db_path`; the old
monolithic `walk_duckdb_native_metadata` is removed and its viability checks now
live in the two new functions.

## Performance — TPC-H SF30 (cold = page cache dropped)

| query | cold (serial walk) | cold (parallel) | speedup |
|---|---|---|---|
| q6  | 2.45 s | 0.63 s | ~3.9× |
| q19 | 3.37 s | 0.98 s | ~3.4× |
| q9  | 4.61 s | 1.55 s | ~3.0× |
| q1  | 3.99 s | 1.95 s | ~2.0× |
| q21 | 3.46 s | 2.61 s | ~1.3× |

Roughly **1.3–4× per query** across all 22 (highest on lineitem-scan-dominated
queries, lowest on join/small-table ones). Warm-cache queries are unaffected.

## Tunables
- `SIRIUS_METADATA_PARSE_CHUNK` — row groups per parse range (default 8).
- `sirius.executor.scan_manager.num_threads` — scan-worker pool size (default 8;
  the metadata reads are IO-latency-bound, so pool = core count is optimal).

## Validation
- Unit tests: `batch_coalescer`, the metadata walker, and the split provider.
- 22-query TPC-H harness: 66/66 runs, 0 fallback / 0 errors.
- GPU results match DuckDB CPU on fixed-width, varchar, and aggregate queries.
