### PR TITLE
Fold pipelineable downstream ops into merge pipelines after GROUP BY and TOP_N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,7 @@ set(TEST_SOURCES
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
+    test/cpp/pipeline/test_pipeline_merge_fusion.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp
     test/cpp/pipeline/test_sirius_read_parquet_converter.cpp
     test/cpp/pipeline/test_pipeline_memory_history.cpp

--- a/src/include/pipeline/sirius_pipeline_converter.hpp
+++ b/src/include/pipeline/sirius_pipeline_converter.hpp
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace duckdb {
@@ -109,6 +110,22 @@ class sirius_pipeline_converter {
                              duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
                              size_t pipeline_idx);
 
+  //! Fold pipelineable downstream operators into the merge pipeline when possible.
+  //! Returns true when a downstream pipeline was fully absorbed.
+  bool try_fuse_downstream_pipelineable(
+    duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
+    op::sirius_physical_operator* merge_op,
+    op::sirius_physical_operator* original_agg_source,
+    duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
+    size_t from_pipeline_idx);
+
+  void attach_merge_and_fuse_downstream(
+    duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
+    op::sirius_physical_operator* merge_op,
+    op::sirius_physical_operator* original_agg_source,
+    duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
+    size_t from_pipeline_idx);
+
   // Phase 3: Compute plan-time wiring descriptors
   // Runtime materialization is done by `materialize_repository_wiring()` from
   // `pipeline/repository_wiring.hpp`.
@@ -140,6 +157,8 @@ class sirius_pipeline_converter {
   duckdb::vector<duckdb::unique_ptr<op::sirius_physical_operator>> inserted_operators_;
   std::vector<repository_wiring> repository_wirings_;
   std::size_t meta_pipeline_count_ = 0;
+  //! Pipelines absorbed into an upstream merge pipeline during splitting.
+  std::unordered_set<sirius_pipeline*> absorbed_pipelines_;
 };
 
 }  // namespace pipeline

--- a/src/include/pipeline/sirius_pipeline_converter.hpp
+++ b/src/include/pipeline/sirius_pipeline_converter.hpp
@@ -110,8 +110,11 @@ class sirius_pipeline_converter {
                              duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
                              size_t pipeline_idx);
 
-  //! Fold pipelineable downstream operators into the merge pipeline when possible.
-  //! Returns true when a downstream pipeline was fully absorbed.
+  //! Try to absorb the first downstream pipeline sourced from @p original_agg_source
+  //! (HASH_GROUP_BY, UNGROUPED_AGGREGATE, or TOP_N) into @p merge_pipeline.
+  //! Returns true when a downstream pipeline was fully absorbed and should be skipped
+  //! in split_pipelines(). Safe only when downstream is a dead end — see guards in
+  //! the implementation.
   bool try_fuse_downstream_pipelineable(
     duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
     op::sirius_physical_operator* merge_op,
@@ -119,6 +122,9 @@ class sirius_pipeline_converter {
     duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
     size_t from_pipeline_idx);
 
+  //! Finalize a merge pipeline after split_group_aggregate_sink / split_top_n_sink:
+  //! optionally fuse pipelineable downstream ops, set merge as sink if not fused, and
+  //! repoint remaining downstream pipelines from the partial op to @p merge_op.
   void attach_merge_and_fuse_downstream(
     duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
     op::sirius_physical_operator* merge_op,

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -126,6 +126,7 @@ pipeline_conversion_result sirius_pipeline_converter::convert(sirius_meta_pipeli
   scheduled_.clear();
   inserted_operators_.clear();
   repository_wirings_.clear();
+  absorbed_pipelines_.clear();
 
   auto copied_scheduled = schedule_and_copy_pipelines(root_pipeline);
   split_pipelines(copied_scheduled);
@@ -646,6 +647,103 @@ void sirius_pipeline_converter::split_join_sink(
   inserted_operators_.push_back(std::move(concat_op));
 }
 
+namespace {
+
+bool is_fusable_downstream_operator(const op::sirius_physical_operator& op)
+{
+  return !op.is_sink() && !op.is_source();
+}
+
+// Must stay in sync with split_pipelines() sink dispatch: any sink handled by a
+// dedicated split_* function must not be absorbed via downstream fusion.
+bool sink_needs_pipeline_split(op::SiriusPhysicalOperatorType type)
+{
+  return type == op::SiriusPhysicalOperatorType::HASH_JOIN ||
+         type == op::SiriusPhysicalOperatorType::NESTED_LOOP_JOIN ||
+         type == op::SiriusPhysicalOperatorType::HASH_GROUP_BY ||
+         type == op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE ||
+         type == op::SiriusPhysicalOperatorType::ORDER_BY ||
+         type == op::SiriusPhysicalOperatorType::TOP_N ||
+         type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN ||
+         type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN;
+}
+
+}  // namespace
+
+bool sirius_pipeline_converter::try_fuse_downstream_pipelineable(
+  duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
+  op::sirius_physical_operator* merge_op,
+  op::sirius_physical_operator* original_agg_source,
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
+  size_t from_pipeline_idx)
+{
+  // If any downstream pipeline from this aggregate ends in a structural sink, do not fuse.
+  for (size_t j = from_pipeline_idx + 1; j < copied_scheduled.size(); j++) {
+    auto& downstream = copied_scheduled[j];
+    if (downstream->source.get() != original_agg_source) { continue; }
+    if (sink_needs_pipeline_split(downstream->get_sink()->type)) { return false; }
+  }
+
+  for (size_t j = from_pipeline_idx + 1; j < copied_scheduled.size(); j++) {
+    auto& downstream = copied_scheduled[j];
+    if (downstream->source.get() != original_agg_source) { continue; }
+
+    // Do not fuse a pipelineable downstream when a later structural pipeline reads
+    // from its output (e.g. GROUP_BY -> PROJECTION then PROJECTION -> HASH_JOIN).
+    for (size_t k = j + 1; k < copied_scheduled.size(); k++) {
+      auto& later = copied_scheduled[k];
+      if (!sink_needs_pipeline_split(later->get_sink()->type)) { continue; }
+      const auto* later_source = later->source.get();
+      if (later_source == downstream->get_sink().get()) { return false; }
+      for (auto& op_ref : downstream->operators) {
+        if (later_source == &op_ref.get()) { return false; }
+      }
+    }
+
+    for (auto& op_ref : downstream->operators) {
+      if (!is_fusable_downstream_operator(op_ref.get())) { return false; }
+    }
+
+    merge_pipeline->operators.push_back(*merge_op);
+    for (auto& op_ref : downstream->operators) {
+      merge_pipeline->operators.push_back(op_ref);
+    }
+    merge_pipeline->sink = downstream->sink;
+
+    absorbed_pipelines_.insert(downstream.get());
+    return true;
+  }
+  return false;
+}
+
+void sirius_pipeline_converter::attach_merge_and_fuse_downstream(
+  duckdb::shared_ptr<sirius_pipeline>& merge_pipeline,
+  op::sirius_physical_operator* merge_op,
+  op::sirius_physical_operator* original_agg_source,
+  duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
+  size_t from_pipeline_idx)
+{
+  // UNGROUPED_AGGREGATE uses the same physical op as both the partial-aggregate sink and the
+  // merge pipeline source. Folding the downstream pipeline (typically RESULT_COLLECTOR) into the
+  // merge pipeline breaks partial→merge repository wiring and produces wrong merged results
+  // (e.g. avg off by orders of magnitude). Keep merge and downstream as separate pipelines.
+  const bool allow_fusion =
+    original_agg_source->type != op::SiriusPhysicalOperatorType::UNGROUPED_AGGREGATE;
+  const bool fused =
+    allow_fusion &&
+    try_fuse_downstream_pipelineable(
+      merge_pipeline, merge_op, original_agg_source, copied_scheduled, from_pipeline_idx);
+
+  if (!fused) { merge_pipeline->sink = merge_op; }
+
+  // Repoint not-yet-split downstream pipelines to read from the merge op.
+  for (size_t j = from_pipeline_idx + 1; j < copied_scheduled.size(); j++) {
+    auto& downstream = copied_scheduled[j];
+    if (absorbed_pipelines_.count(downstream.get()) > 0) { continue; }
+    if (downstream->source.get() == original_agg_source) { downstream->source = merge_op; }
+  }
+}
+
 void sirius_pipeline_converter::split_group_aggregate_sink(
   duckdb::shared_ptr<sirius_pipeline>& current_pipeline,
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
@@ -674,18 +772,15 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
     partition_pipeline->sink   = partition_ptr;
     scheduled_.push_back(partition_pipeline);
 
-    // Create merge pipeline: PARTITION (source) -> MERGE_OP (sink)
+    // Create merge pipeline: PARTITION (source) -> MERGE_OP -> pipelineable downstream ops
     auto merge_op          = construct_sirius_specific_operator(*group_agg_op, iceberg_cache_);
+    auto* merge_op_ptr     = merge_op.get();
     auto merge_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
     merge_pipeline->source = partition_ptr;
-    merge_pipeline->sink   = merge_op.get();
 
-    // Update downstream pipelines to use MERGE_OP as source
-    for (size_t j = pipeline_idx + 1; j < copied_scheduled.size(); j++) {
-      if (copied_scheduled[j]->source.get() == group_agg_op.get()) {
-        copied_scheduled[j]->source = merge_op.get();
-      }
-    }
+    attach_merge_and_fuse_downstream(
+      merge_pipeline, merge_op_ptr, group_agg_op.get(), copied_scheduled, pipeline_idx);
+
     scheduled_.push_back(merge_pipeline);
     inserted_operators_.push_back(std::move(merge_op));
   } else {
@@ -693,16 +788,13 @@ void sirius_pipeline_converter::split_group_aggregate_sink(
     scheduled_.push_back(current_pipeline);
 
     auto merge_op        = construct_sirius_specific_operator(*group_agg_op, iceberg_cache_);
+    auto* merge_op_ptr   = merge_op.get();
     auto new_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
     new_pipeline->source = group_agg_op;
-    new_pipeline->sink   = merge_op.get();
 
-    // Update downstream pipelines to use MERGE_OP as source
-    for (size_t j = pipeline_idx + 1; j < copied_scheduled.size(); j++) {
-      if (copied_scheduled[j]->source.get() == group_agg_op.get()) {
-        copied_scheduled[j]->source = merge_op.get();
-      }
-    }
+    attach_merge_and_fuse_downstream(
+      new_pipeline, merge_op_ptr, group_agg_op.get(), copied_scheduled, pipeline_idx);
+
     scheduled_.push_back(new_pipeline);
     inserted_operators_.push_back(std::move(merge_op));
   }
@@ -818,18 +910,14 @@ void sirius_pipeline_converter::split_top_n_sink(
     new op::sirius_physical_top_n_merge(topn_ptr));
   auto* merge_ptr = merge_op.get();
 
-  // Pipeline B: TOP_N (source) -> MERGE_TOP_N (sink)
+  // Pipeline B: TOP_N (source) -> MERGE_TOP_N -> pipelineable downstream ops
   auto merge_pipeline    = duckdb::make_shared_ptr<sirius_pipeline>(build_ctx_);
   merge_pipeline->source = top_n_op.get();
-  merge_pipeline->sink   = merge_ptr;
-  scheduled_.push_back(merge_pipeline);
 
-  // Update downstream pipelines to use MERGE_TOP_N as source
-  for (size_t j = pipeline_idx + 1; j < copied_scheduled.size(); j++) {
-    if (copied_scheduled[j]->source.get() == top_n_op.get()) {
-      copied_scheduled[j]->source = merge_ptr;
-    }
-  }
+  attach_merge_and_fuse_downstream(
+    merge_pipeline, merge_ptr, top_n_op.get(), copied_scheduled, pipeline_idx);
+
+  scheduled_.push_back(merge_pipeline);
 
   // Store ownership
   inserted_operators_.push_back(std::move(merge_op));
@@ -950,6 +1038,7 @@ void sirius_pipeline_converter::split_pipelines(
 {
   for (size_t i = 0; i < copied_scheduled.size(); i++) {
     auto current_pipeline = copied_scheduled[i];  // Copy duckdb::shared_ptr to avoid invalidation
+    if (absorbed_pipelines_.count(current_pipeline.get()) > 0) { continue; }
 
     // Preprocessing: replace TABLE_SCAN source with concrete scan operator
     split_table_scan_source(current_pipeline);

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -647,8 +647,11 @@ void sirius_pipeline_converter::split_join_sink(
   inserted_operators_.push_back(std::move(concat_op));
 }
 
+// Merge-pipeline downstream fusion: fold streaming ops (e.g. RESULT_COLLECTOR) into the
+// merge pipeline so they run in the same gpu_pipeline_task as MERGE_GROUP_BY / MERGE_TOP_N.
 namespace {
 
+// Pipelineable intermediates only — not scans (is_source) or structural sinks (is_sink).
 bool is_fusable_downstream_operator(const op::sirius_physical_operator& op)
 {
   return !op.is_sink() && !op.is_source();
@@ -677,7 +680,8 @@ bool sirius_pipeline_converter::try_fuse_downstream_pipelineable(
   duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& copied_scheduled,
   size_t from_pipeline_idx)
 {
-  // If any downstream pipeline from this aggregate ends in a structural sink, do not fuse.
+  // Guard 1: direct consumer is a structural sink — fusion would skip its split_* path.
+  // e.g. GROUP_BY -> HASH_JOIN; join needs its own PARTITION/CONCAT pipelines.
   for (size_t j = from_pipeline_idx + 1; j < copied_scheduled.size(); j++) {
     auto& downstream = copied_scheduled[j];
     if (downstream->source.get() != original_agg_source) { continue; }
@@ -688,8 +692,10 @@ bool sirius_pipeline_converter::try_fuse_downstream_pipelineable(
     auto& downstream = copied_scheduled[j];
     if (downstream->source.get() != original_agg_source) { continue; }
 
-    // Do not fuse a pipelineable downstream when a later structural pipeline reads
-    // from its output (e.g. GROUP_BY -> PROJECTION then PROJECTION -> HASH_JOIN).
+    // Guard 2: a later structural pipeline reads from this candidate's output — keep the
+    // candidate as its own pipeline boundary. e.g. GROUP_BY -> PROJECTION -> HASH_JOIN:
+    // fusing PROJECTION into MERGE_GROUP_BY leaves HASH_JOIN still sourced at PROJECTION, but
+    // attach_merge_and_fuse_downstream only repoints source==GROUP_BY, not source==PROJECTION.
     for (size_t k = j + 1; k < copied_scheduled.size(); k++) {
       auto& later = copied_scheduled[k];
       if (!sink_needs_pipeline_split(later->get_sink()->type)) { continue; }
@@ -700,10 +706,14 @@ bool sirius_pipeline_converter::try_fuse_downstream_pipelineable(
       }
     }
 
+    // Guard 3: every op in the candidate must be a plain intermediate (not source/sink).
+    // e.g. reject a downstream pipeline that still contains a scan or blocking operator.
     for (auto& op_ref : downstream->operators) {
       if (!is_fusable_downstream_operator(op_ref.get())) { return false; }
     }
 
+    // Success: one pipeline runs PARTITION/TOP_N input -> merge -> downstream chain.
+    // The absorbed pipeline must not be scheduled again (see split_pipelines).
     merge_pipeline->operators.push_back(*merge_op);
     for (auto& op_ref : downstream->operators) {
       merge_pipeline->operators.push_back(op_ref);
@@ -736,7 +746,9 @@ void sirius_pipeline_converter::attach_merge_and_fuse_downstream(
 
   if (!fused) { merge_pipeline->sink = merge_op; }
 
-  // Repoint not-yet-split downstream pipelines to read from the merge op.
+  // Always repoint, even when fusion failed — downstream must read merged output, not
+  // partial aggregate/top-N. Only pipelines still sourced at original_agg_source are updated;
+  // consumers wired to intermediate ops (e.g. PROJECTION) are left unchanged.
   for (size_t j = from_pipeline_idx + 1; j < copied_scheduled.size(); j++) {
     auto& downstream = copied_scheduled[j];
     if (absorbed_pipelines_.count(downstream.get()) > 0) { continue; }
@@ -1038,6 +1050,7 @@ void sirius_pipeline_converter::split_pipelines(
 {
   for (size_t i = 0; i < copied_scheduled.size(); i++) {
     auto current_pipeline = copied_scheduled[i];  // Copy duckdb::shared_ptr to avoid invalidation
+    // Downstream pipelines folded into a merge pipeline are already part of scheduled_.
     if (absorbed_pipelines_.count(current_pipeline.get()) > 0) { continue; }
 
     // Preprocessing: replace TABLE_SCAN source with concrete scan operator

--- a/test/cpp/pipeline/test_pipeline_merge_fusion.cpp
+++ b/test/cpp/pipeline/test_pipeline_merge_fusion.cpp
@@ -328,6 +328,7 @@ size_t count_operator_type(const duckdb::vector<duckdb::shared_ptr<sirius_pipeli
 
 }  // namespace
 
+// Downstream is only RESULT_COLLECTOR — no structural consumer, fusion allowed.
 TEST_CASE("merge fusion folds downstream after GROUP BY", "[pipeline_converter][merge_fusion]")
 {
   auto state = setup_and_convert(R"(
@@ -342,6 +343,7 @@ TEST_CASE("merge fusion folds downstream after GROUP BY", "[pipeline_converter][
     has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
 }
 
+// Same dead-end shape as GROUP BY; exercises split_top_n_sink fusion path.
 TEST_CASE("merge fusion folds downstream after TOP_N", "[pipeline_converter][merge_fusion]")
 {
   auto state = setup_and_convert(R"(
@@ -366,7 +368,7 @@ TEST_CASE("merge fusion stops before ORDER BY after GROUP BY", "[pipeline_conver
   )");
 
   const auto& pipelines = state.conversion.scheduled_pipelines;
-  // ORDER BY is a structural sink — fusion is blocked and merge stays on its own pipeline.
+  // Guard 1: ORDER BY is a direct structural sink — fusion blocked, merge stays separate.
   REQUIRE(has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
   REQUIRE_FALSE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
   REQUIRE_FALSE(pipeline_has_merge_with_sink(
@@ -389,7 +391,7 @@ TEST_CASE("merge fusion stops before HASH JOIN after GROUP BY",
   )");
 
   const auto& pipelines = state.conversion.scheduled_pipelines;
-  // Join follows the grouped subquery; merge must not absorb the join sink.
+  // Guard 2: join reads from subquery output; merge must not absorb projection/collector.
   REQUIRE_FALSE(pipeline_has_merge_with_sink(
     pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY, SiriusPhysicalOperatorType::HASH_JOIN));
   REQUIRE(count_build_join_partitions(pipelines) >= 1);
@@ -402,7 +404,7 @@ TEST_CASE("merge fusion does not fold UNGROUPED_AGGREGATE downstream",
   auto state = setup_and_convert("SELECT avg(l_quantity) FROM lineitem");
 
   const auto& pipelines = state.conversion.scheduled_pipelines;
-  // UNGROUPED uses the same op as partial sink and merge source — keep merge separate.
+  // UNGROUPED: same op is partial sink and merge source — fusion disabled in attach_merge.
   REQUIRE(has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_AGGREGATE));
   REQUIRE_FALSE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_AGGREGATE));
 }

--- a/test/cpp/pipeline/test_pipeline_merge_fusion.cpp
+++ b/test/cpp/pipeline/test_pipeline_merge_fusion.cpp
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * @file test_pipeline_merge_fusion.cpp
+ * @brief Regression tests for merge-pipeline downstream fusion in sirius_pipeline_converter.
+ *
+ * Verifies that pipelineable downstream operators fold into merge pipelines while
+ * structural downstream sinks (ORDER BY, HASH JOIN, etc.) remain separate split targets.
+ *
+ * Exercises sirius_pipeline_converter only (no repository materialization) so complex
+ * plans can be inspected without tripping shared data-repo registration limits.
+ */
+
+#include <catch.hpp>
+#include <config.hpp>
+#include <duckdb.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/main/connection.hpp>
+#include <duckdb/main/prepared_statement_data.hpp>
+#include <duckdb/main/settings.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/planner.hpp>
+#include <op/sirius_physical_partition.hpp>
+#include <op/sirius_physical_result_collector.hpp>
+#include <pipeline/sirius_meta_pipeline.hpp>
+#include <pipeline/sirius_pipeline.hpp>
+#include <pipeline/sirius_pipeline_converter.hpp>
+#include <planner/sirius_physical_plan_generator.hpp>
+#include <sirius_context.hpp>
+#include <sirius_extension.hpp>
+#include <sirius_interface.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <source_location>
+#include <string>
+
+using namespace duckdb;
+
+using sirius::sirius_prepared_statement_data;
+using sirius::op::sirius_physical_materialized_collector;
+using sirius::op::sirius_physical_operator;
+using sirius::op::sirius_physical_partition;
+using sirius::op::sirius_physical_result_collector;
+using sirius::op::SiriusPhysicalOperatorType;
+using sirius::pipeline::pipeline_conversion_result;
+using sirius::pipeline::sirius_meta_pipeline;
+using sirius::pipeline::sirius_pipeline;
+using sirius::pipeline::sirius_pipeline_build_state;
+using sirius::pipeline::sirius_pipeline_converter;
+using sirius::planner::sirius_physical_plan_generator;
+
+namespace {
+
+void set_test_config_env()
+{
+  static bool env_set = false;
+  if (!env_set) {
+    std::source_location loc = std::source_location::current();
+    auto cfg_path = std::filesystem::path(loc.file_name()).parent_path().parent_path() / "config" /
+                    "data" / "minimal.yaml";
+    setenv("SIRIUS_CONFIG_FILE", cfg_path.string().c_str(), 1);
+    env_set = true;
+  }
+}
+
+void safe_load_extension(DuckDB& db)
+{
+  try {
+    db.LoadStaticExtension<SiriusExtension>();
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    if (msg.find("already exists") == std::string::npos &&
+        msg.find("already loaded") == std::string::npos) {
+      throw;
+    }
+  }
+}
+
+void safe_init_gpu_buffer(Connection& con)
+{
+  try {
+    con.Query("CALL gpu_buffer_init('1 GB', '1 GB');");
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    if (msg.find("already") == std::string::npos) { throw; }
+  }
+}
+
+void create_minimal_schema(Connection& con)
+{
+  con.Query("DROP TABLE IF EXISTS lineitem;");
+  con.Query("DROP TABLE IF EXISTS orders;");
+
+  con.Query(R"(
+    CREATE TABLE orders (
+      o_orderkey BIGINT NOT NULL UNIQUE PRIMARY KEY,
+      o_custkey INTEGER NOT NULL,
+      o_orderstatus CHAR(1) NOT NULL,
+      o_totalprice DECIMAL(15,2) NOT NULL,
+      o_orderdate DATE NOT NULL,
+      o_orderpriority CHAR(15) NOT NULL,
+      o_clerk CHAR(15) NOT NULL,
+      o_shippriority INTEGER NOT NULL,
+      o_comment VARCHAR(79) NOT NULL
+    );
+  )");
+
+  con.Query(R"(
+    CREATE TABLE lineitem (
+      l_orderkey BIGINT NOT NULL,
+      l_partkey BIGINT NOT NULL,
+      l_suppkey BIGINT NOT NULL,
+      l_linenumber INTEGER NOT NULL,
+      l_quantity DECIMAL(15,2) NOT NULL,
+      l_extendedprice DECIMAL(15,2) NOT NULL,
+      l_discount DECIMAL(15,2) NOT NULL,
+      l_tax DECIMAL(15,2) NOT NULL,
+      l_returnflag CHAR(1) NOT NULL,
+      l_linestatus CHAR(1) NOT NULL,
+      l_shipdate DATE NOT NULL,
+      l_commitdate DATE NOT NULL,
+      l_receiptdate DATE NOT NULL,
+      l_shipinstruct CHAR(25) NOT NULL,
+      l_shipmode CHAR(10) NOT NULL,
+      l_comment VARCHAR(44) NOT NULL
+    );
+  )");
+
+  con.Query(R"(
+    INSERT INTO orders VALUES
+      (1, 1, 'O', 1000.00, '1995-01-01', '1-URGENT', 'Clerk#000000001', 0, 'comment'),
+      (2, 2, 'F', 2000.00, '1996-10-15', '2-HIGH', 'Clerk#000000002', 1, 'comment'),
+      (3, 3, 'F', 3000.00, '1997-06-01', '3-MEDIUM', 'Clerk#000000003', 0, 'comment');
+  )");
+
+  con.Query(R"(
+    INSERT INTO lineitem VALUES
+      (1, 1, 1, 1, 10.00, 1000.00, 0.05, 0.08, 'A', 'F', '1995-01-15', '1995-01-10', '1995-01-20', 'DELIVER IN PERSON', 'TRUCK', 'comment'),
+      (1, 2, 2, 2, 20.00, 2000.00, 0.06, 0.07, 'N', 'O', '1996-06-01', '1996-05-01', '1996-06-15', 'NONE', 'AIR', 'comment'),
+      (2, 1, 1, 1, 15.00, 1500.00, 0.04, 0.06, 'R', 'F', '1994-03-15', '1994-03-10', '1994-03-20', 'COLLECT COD', 'REG AIR', 'comment'),
+      (2, 3, 2, 2, 25.00, 2500.00, 0.03, 0.05, 'A', 'F', '1993-06-01', '1993-05-15', '1993-06-10', 'TAKE BACK RETURN', 'SHIP', 'comment'),
+      (3, 2, 3, 1, 30.00, 3000.00, 0.02, 0.04, 'N', 'O', '1997-07-01', '1997-06-15', '1997-07-15', 'DELIVER IN PERSON', 'TRUCK', 'comment');
+  )");
+}
+
+static duckdb::shared_ptr<sirius_prepared_statement_data> g_sirius_prepared;
+
+duckdb::unique_ptr<sirius_physical_operator> generate_gpu_plan(Connection& con,
+                                                               const std::string& query)
+{
+  con.context->config.enable_optimizer      = true;
+  con.context->config.use_replacement_scans = false;
+
+  set<OptimizerType> disabled_optimizers;
+  disabled_optimizers.insert(OptimizerType::IN_CLAUSE);
+  disabled_optimizers.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+  DBConfig::GetConfig(*con.context).options.disabled_optimizers = disabled_optimizers;
+
+  con.Query("BEGIN TRANSACTION");
+
+  Parser parser(con.context->GetParserOptions());
+  parser.ParseQuery(query);
+
+  Planner planner(*con.context);
+  auto statement_type = parser.statements[0]->type;
+  planner.CreatePlan(std::move(parser.statements[0]));
+  D_ASSERT(planner.plan);
+
+  auto prepared       = make_shared_ptr<PreparedStatementData>(statement_type);
+  prepared->names     = planner.names;
+  prepared->types     = planner.types;
+  prepared->value_map = std::move(planner.value_map);
+
+  duckdb::unique_ptr<duckdb::LogicalOperator> logical_plan = std::move(planner.plan);
+
+  duckdb::Optimizer optimizer(*planner.binder, *con.context);
+  logical_plan = optimizer.Optimize(std::move(logical_plan));
+
+  logical_plan->ResolveOperatorTypes();
+  duckdb::ColumnBindingResolver resolver;
+  duckdb::ColumnBindingResolver::Verify(*logical_plan);
+  resolver.VisitOperator(*logical_plan);
+
+  sirius_physical_plan_generator physical_planner(*con.context);
+  auto sirius_physical_plan = physical_planner.create_plan(std::move(logical_plan));
+
+  g_sirius_prepared =
+    make_shared_ptr<sirius_prepared_statement_data>(prepared, std::move(sirius_physical_plan));
+
+  auto gpu_collector =
+    make_uniq_base<sirius_physical_result_collector, sirius_physical_materialized_collector>(
+      *g_sirius_prepared, *con.context);
+
+  con.Query("COMMIT TRANSACTION");
+
+  return gpu_collector;
+}
+
+struct converter_test_state {
+  duckdb::unique_ptr<DuckDB> db;
+  duckdb::unique_ptr<Connection> con;
+  duckdb::unique_ptr<sirius_physical_operator> gpu_plan;
+  pipeline_conversion_result conversion;
+};
+
+converter_test_state setup_and_convert(const std::string& query)
+{
+  converter_test_state state;
+  set_test_config_env();
+  Config::MODIFIED_PIPELINE = true;
+  unsetenv("SIRIUS_DISABLE");
+  state.db = duckdb::make_uniq<DuckDB>(nullptr);
+  safe_load_extension(*state.db);
+  state.con = duckdb::make_uniq<Connection>(*state.db);
+  safe_init_gpu_buffer(*state.con);
+  create_minimal_schema(*state.con);
+
+  state.gpu_plan = generate_gpu_plan(*state.con, query);
+  REQUIRE(state.gpu_plan != nullptr);
+
+  auto sirius_ctx =
+    state.con->context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx != nullptr);
+  const sirius::operator_params& op_params = sirius_ctx->get_config().get_operator_params();
+
+  sirius::pipeline::pipeline_build_context build_ctx;
+  build_ctx.preserve_insertion_order =
+    duckdb::Settings::Get<duckdb::PreserveInsertionOrderSetting>(*state.con->context);
+  build_ctx.num_gpus = static_cast<int>(sirius_ctx->get_config().get_hw_topology().gpus.size());
+
+  sirius_pipeline_build_state pipeline_state;
+  auto root_pipeline =
+    duckdb::make_shared_ptr<sirius_meta_pipeline>(build_ctx, pipeline_state, nullptr);
+  root_pipeline->build(*state.gpu_plan);
+  root_pipeline->ready();
+
+  sirius_pipeline_converter converter(build_ctx, op_params, nullptr, state.con->context.get());
+  state.conversion = converter.convert(*root_pipeline);
+
+  return state;
+}
+
+size_t count_sink_type(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+                       SiriusPhysicalOperatorType type)
+{
+  size_t count = 0;
+  for (const auto& pipeline : pipelines) {
+    if (pipeline->get_sink()->type == type) { count++; }
+  }
+  return count;
+}
+
+//! True when a merge op and downstream pipelineable ops share one pipeline (fusion succeeded).
+//! Does not require PROJECTION — identity projections are omitted by the planner and fusion may
+//! fold straight into RESULT_COLLECTOR.
+bool has_fused_merge_pipeline(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+                              SiriusPhysicalOperatorType merge_type)
+{
+  for (const auto& pipeline : pipelines) {
+    bool has_merge = false;
+    for (auto& op : pipeline->get_operators()) {
+      if (op.get().type == merge_type) { has_merge = true; }
+    }
+    if (has_merge && pipeline->get_sink()->type != merge_type) { return true; }
+  }
+  return false;
+}
+
+bool has_standalone_merge_pipeline(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+  SiriusPhysicalOperatorType merge_type)
+{
+  for (const auto& pipeline : pipelines) {
+    if (pipeline->get_sink()->type != merge_type) { continue; }
+    if (pipeline->get_operators().size() <= 1) { return true; }
+  }
+  return false;
+}
+
+size_t count_build_join_partitions(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines)
+{
+  size_t count = 0;
+  for (const auto& pipeline : pipelines) {
+    if (pipeline->get_sink()->type != SiriusPhysicalOperatorType::PARTITION) { continue; }
+    auto& partition = pipeline->get_sink()->Cast<sirius_physical_partition>();
+    if (partition.is_build_partition()) { count++; }
+  }
+  return count;
+}
+
+bool pipeline_has_merge_with_sink(
+  const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+  SiriusPhysicalOperatorType merge_type,
+  SiriusPhysicalOperatorType sink_type)
+{
+  for (const auto& pipeline : pipelines) {
+    bool has_merge = false;
+    for (auto& op : pipeline->get_operators()) {
+      if (op.get().type == merge_type) { has_merge = true; }
+    }
+    if (has_merge && pipeline->get_sink()->type == sink_type) { return true; }
+  }
+  return false;
+}
+
+size_t count_operator_type(const duckdb::vector<duckdb::shared_ptr<sirius_pipeline>>& pipelines,
+                           SiriusPhysicalOperatorType type)
+{
+  size_t count = 0;
+  for (const auto& pipeline : pipelines) {
+    for (auto& op : pipeline->get_operators()) {
+      if (op.get().type == type) { count++; }
+    }
+  }
+  return count;
+}
+
+}  // namespace
+
+TEST_CASE("merge fusion folds downstream after GROUP BY", "[pipeline_converter][merge_fusion]")
+{
+  auto state = setup_and_convert(R"(
+    SELECT SUM(l_quantity) AS total, l_returnflag
+    FROM lineitem
+    GROUP BY l_returnflag
+  )");
+
+  const auto& pipelines = state.conversion.scheduled_pipelines;
+  REQUIRE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
+  REQUIRE_FALSE(
+    has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
+}
+
+TEST_CASE("merge fusion folds downstream after TOP_N", "[pipeline_converter][merge_fusion]")
+{
+  auto state = setup_and_convert(R"(
+    SELECT l_extendedprice, l_orderkey
+    FROM lineitem
+    ORDER BY l_extendedprice DESC
+    LIMIT 10
+  )");
+
+  const auto& pipelines = state.conversion.scheduled_pipelines;
+  REQUIRE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_TOP_N));
+  REQUIRE_FALSE(has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_TOP_N));
+}
+
+TEST_CASE("merge fusion stops before ORDER BY after GROUP BY", "[pipeline_converter][merge_fusion]")
+{
+  auto state = setup_and_convert(R"(
+    SELECT SUM(l_quantity) AS total, l_returnflag
+    FROM lineitem
+    GROUP BY l_returnflag
+    ORDER BY total DESC
+  )");
+
+  const auto& pipelines = state.conversion.scheduled_pipelines;
+  // ORDER BY is a structural sink — fusion is blocked and merge stays on its own pipeline.
+  REQUIRE(has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
+  REQUIRE_FALSE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY));
+  REQUIRE_FALSE(pipeline_has_merge_with_sink(
+    pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY, SiriusPhysicalOperatorType::ORDER_BY));
+  REQUIRE(count_sink_type(pipelines, SiriusPhysicalOperatorType::ORDER_BY) >= 1);
+  REQUIRE(count_operator_type(pipelines, SiriusPhysicalOperatorType::MERGE_SORT) >= 1);
+}
+
+TEST_CASE("merge fusion stops before HASH JOIN after GROUP BY",
+          "[pipeline_converter][merge_fusion]")
+{
+  auto state = setup_and_convert(R"(
+    SELECT grouped.total, grouped.l_returnflag, o.o_orderkey
+    FROM (
+      SELECT l_returnflag, l_orderkey, SUM(l_quantity) AS total
+      FROM lineitem
+      GROUP BY l_returnflag, l_orderkey
+    ) grouped
+    JOIN orders o ON grouped.l_orderkey = o.o_orderkey
+  )");
+
+  const auto& pipelines = state.conversion.scheduled_pipelines;
+  // Join follows the grouped subquery; merge must not absorb the join sink.
+  REQUIRE_FALSE(pipeline_has_merge_with_sink(
+    pipelines, SiriusPhysicalOperatorType::MERGE_GROUP_BY, SiriusPhysicalOperatorType::HASH_JOIN));
+  REQUIRE(count_build_join_partitions(pipelines) >= 1);
+  REQUIRE(count_operator_type(pipelines, SiriusPhysicalOperatorType::HASH_JOIN) >= 1);
+}
+
+TEST_CASE("merge fusion does not fold UNGROUPED_AGGREGATE downstream",
+          "[pipeline_converter][merge_fusion]")
+{
+  auto state = setup_and_convert("SELECT avg(l_quantity) FROM lineitem");
+
+  const auto& pipelines = state.conversion.scheduled_pipelines;
+  // UNGROUPED uses the same op as partial sink and merge source — keep merge separate.
+  REQUIRE(has_standalone_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_AGGREGATE));
+  REQUIRE_FALSE(has_fused_merge_pipeline(pipelines, SiriusPhysicalOperatorType::MERGE_AGGREGATE));
+}


### PR DESCRIPTION
## Summary

After `HASH_GROUP_BY` / `TOP_N` splitting, Sirius previously created a small merge pipeline (`PARTITION → MERGE_*`) and then a separate downstream pipeline for streaming ops (typically `RESULT_COLLECTOR`). That extra pipeline boundary is unnecessary when downstream is a dead end.

This PR folds pipelineable downstream operators into the merge pipeline when safe, so merge and collector run in a single `gpu_pipeline_task`:

Before: `PARTITION → MERGE_GROUP_BY | RESULT_COLLECTOR `
After: `PARTITION → MERGE_GROUP_BY → RESULT_COLLECTOR`


Fusion is applied from `split_group_aggregate_sink` and `split_top_n_sink` via `attach_merge_and_fuse_downstream`, with three guards in `try_fuse_downstream_pipelineable`:

- **Guard 1:** block when a direct downstream pipeline ends in a structural sink (`ORDER BY`, `HASH_JOIN`, nested `GROUP BY`, etc.) that needs its own `split_*` path
- **Guard 2:** block when a later structural pipeline reads from the candidate downstream’s output (e.g. `GROUP BY → PROJECTION → HASH_JOIN`) — fusion would remove a pipeline boundary that join wiring still depends on
- **Guard 3:** only absorb pipelines whose operators are plain intermediates (`!is_source() && !is_sink()`)

**UNGROUPED_AGGREGATE is explicitly excluded:** the same physical op is both the partial-aggregate sink and the merge pipeline source. Folding downstream broke partial→merge repository wiring and produced wrong results (e.g. `avg` off by orders of magnitude).

Adds `absorbed_pipelines_` so absorbed downstream pipelines are skipped in `split_pipelines()` and not double-scheduled.

Also includes regression tests in `test_pipeline_merge_fusion.cpp`