### PR TITLE
feat(scan): prune DuckDB-native row groups via pushed-down filter statistics

### DIFF
--- a/src/include/op/scan/duckdb_native_metadata.hpp
+++ b/src/include/op/scan/duckdb_native_metadata.hpp
@@ -20,9 +20,12 @@
 
 #include <cudf/types.hpp>
 
+#include <duckdb/common/column_index.hpp>
 #include <duckdb/common/enums/compression_type.hpp>
 #include <duckdb/common/types.hpp>
+#include <duckdb/common/vector.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/storage_index.hpp>
 
@@ -104,6 +107,10 @@ struct duckdb_native_metadata {
   std::vector<duckdb_row_group_metadata> row_groups;
   bool viable = false;
   std::string viability_failure_reason;
+  /// Row-group filter-statistics pruning counters (0 when no filters / pruning disabled).
+  std::size_t pruned_row_groups = 0;  ///< Number of row groups pruned.
+  /// Sum of decoded-byte budgets of pruned row groups.
+  std::size_t pruned_decoded_bytes = 0;
 };
 
 /// Metadata-only walk of `storage` via `DataTable::GetColumnSegmentInfo`
@@ -115,11 +122,15 @@ struct duckdb_native_metadata {
 /// Caller is responsible for the operator-level escape gates
 /// (`dynamic_filters`, sample options, virtual columns, type pushdown)
 /// on the originating `LogicalGet`.
+///
+/// @note When both `table_filters` and `column_ids` are non-null, row group pruning is applied
 duckdb_native_metadata walk_duckdb_native_metadata(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
   const std::vector<projected_column>& projected_cols,
-  const std::vector<sirius::logical_type>& projected_types);
+  const std::vector<sirius::logical_type>& projected_types,
+  const duckdb::TableFilterSet* table_filters           = nullptr,
+  const duckdb::vector<duckdb::ColumnIndex>* column_ids = nullptr);
 
 /// Exposed for direct unit-testing of the codec-rejection logic without
 /// going through DuckDB's codec selection (which is hard to drive into

--- a/src/op/scan/duckdb_native_gpu_ingestible.cpp
+++ b/src/op/scan/duckdb_native_gpu_ingestible.cpp
@@ -149,9 +149,14 @@ duckdb_native_gpu_ingestible::duckdb_native_gpu_ingestible(
       "[duckdb_native_gpu_ingestible] projected_cols and projected_types must be parallel");
   }
 
-  // Walk metadata once.
-  _metadata = walk_duckdb_native_metadata(
-    *bind.storage, *bind.context, bind.projected_cols, bind.projected_types);
+  // Walk metadata once. Pushed-down filters drive row-group pruning in the walk;
+  // column_ids maps each filter to its storage index.
+  _metadata = walk_duckdb_native_metadata(*bind.storage,
+                                          *bind.context,
+                                          bind.projected_cols,
+                                          bind.projected_types,
+                                          bind.table_filters.get(),
+                                          &bind.column_ids);
   if (!_metadata.viable) {
     SPDLOG_DEBUG("[duckdb_native_gpu_ingestible] non-viable: {}",
                  _metadata.viability_failure_reason);

--- a/src/op/scan/duckdb_native_metadata.cpp
+++ b/src/op/scan/duckdb_native_metadata.cpp
@@ -20,8 +20,11 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <duckdb/common/column_index.hpp>
+#include <duckdb/common/enums/filter_propagate_result.hpp>
 #include <duckdb/function/partition_stats.hpp>
 #include <duckdb/main/attached_database.hpp>
+#include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/statistics/base_statistics.hpp>
 #include <duckdb/storage/statistics/string_stats.hpp>
@@ -270,6 +273,59 @@ void drop_empty_trailing_row_groups(duckdb_native_metadata& md)
   }
 }
 
+/// @brief Check if the filter can be applied to row-group pruning.
+///
+/// The only filter type we must exclude from statistics pruning is DYNAMIC_FILTER:
+/// its bounds come from a runtime source (e.g. a hash-join build) and are not
+/// currently populated at metadata-walk time.
+bool filter_is_prunable(duckdb::TableFilterType t)
+{
+  return t != duckdb::TableFilterType::DYNAMIC_FILTER;
+}
+
+/// @brief Drop row groups a pushed-down filter proves can hold no matching rows.
+///
+/// Mirrors duckdb::RowGroup::CheckZonemap: for each prunable filter, evaluate
+/// DuckDB's own TableFilter::CheckStatistics against the row group's aggregated
+/// per-column statistics (PartitionRowGroup::GetColumnStatistics).
+void prune_row_groups_by_filter_stats(duckdb_native_metadata& md,
+                                      const row_group_handles& handles,
+                                      const duckdb::TableFilterSet& table_filters,
+                                      const duckdb::vector<duckdb::ColumnIndex>& column_ids)
+{
+  std::vector<duckdb_row_group_metadata> kept;
+  kept.reserve(md.row_groups.size());
+  std::size_t pruned_bytes = 0;
+
+  for (auto& rg_md : md.row_groups) {
+    auto const rg = rg_md.row_group_index;
+    bool prune    = false;
+    if (rg < handles.size() && handles[rg].second) {
+      auto& prg = *handles[rg].second;
+      for (auto const& [col_idx, filter] : table_filters.filters) {
+        if (!filter_is_prunable(filter->filter_type)) { continue; }
+        if (col_idx >= column_ids.size()) { continue; }  // defensive
+        auto stats =
+          prg.GetColumnStatistics(duckdb::StorageIndex(column_ids[col_idx].GetPrimaryIndex()));
+        if (!stats) { continue; }  // no stats → cannot prune
+        if (filter->CheckStatistics(*stats) == duckdb::FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+          prune = true;
+          break;
+        }
+      }
+    }
+    if (prune) {
+      pruned_bytes += rg_md.decoded_bytes_budget;
+    } else {
+      kept.push_back(std::move(rg_md));
+    }
+  }
+
+  md.pruned_row_groups    = md.row_groups.size() - kept.size();
+  md.pruned_decoded_bytes = pruned_bytes;
+  md.row_groups           = std::move(kept);
+}
+
 }  // namespace
 
 bool is_supported_data_compression(duckdb::CompressionType c)
@@ -305,7 +361,9 @@ duckdb_native_metadata walk_duckdb_native_metadata(
   duckdb::DataTable& storage,
   duckdb::ClientContext& context,
   const std::vector<projected_column>& projected_cols,
-  const std::vector<sirius::logical_type>& projected_types)
+  const std::vector<sirius::logical_type>& projected_types,
+  const duckdb::TableFilterSet* table_filters,
+  const duckdb::vector<duckdb::ColumnIndex>* column_ids)
 {
   nvtx3::scoped_range nvtx_walk{"sirius::native_metadata_walk"};
 
@@ -484,6 +542,14 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
   compute_row_counts(md, partition_stats);
   compute_decoded_byte_budgets(md, projected_types);
+
+  // Row-group pruning
+  if (table_filters != nullptr && !table_filters->filters.empty() && column_ids != nullptr &&
+      !column_ids->empty()) {
+    nvtx3::scoped_range nvtx_prune{"sirius::native_metadata_filter_stats_prune"};
+    prune_row_groups_by_filter_stats(md, handles, *table_filters, *column_ids);
+  }
+
   drop_empty_trailing_row_groups(md);
 
   // Per-column varchar upper bound, cached on each row group so the
@@ -518,9 +584,12 @@ duckdb_native_metadata walk_duckdb_native_metadata(
 
   md.viable = true;
   SIRIUS_LOG_DEBUG(
-    "[duckdb_native_metadata] walked {} row groups across {} projected columns; viable=true",
+    "[duckdb_native_metadata] walked {} row groups across {} projected columns; "
+    "stats-pruned {} row groups (~{} decoded bytes); viable=true",
     md.row_groups.size(),
-    projected_cols.size());
+    projected_cols.size(),
+    md.pruned_row_groups,
+    md.pruned_decoded_bytes);
   return md;
 }
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -337,6 +337,7 @@ void sirius_pipeline_converter::insert_duckdb_native_scan_operator(
     table_info->projected_types.push_back(t);
   }
 
+  // Filters drive row-group pruning in the metadata walk and post-decode filtering.
   if (scan_op.table_filters) {
     table_info->table_filters = duckdb::make_uniq<duckdb::TableFilterSet>();
     for (auto& [col_idx, filt] : scan_op.table_filters->filters) {

--- a/test/cpp/scan/test_duckdb_native_walker.cpp
+++ b/test/cpp/scan/test_duckdb_native_walker.cpp
@@ -19,12 +19,17 @@
 #include <duckdb/catalog/catalog.hpp>
 #include <duckdb/catalog/catalog_entry/duck_table_entry.hpp>
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
+#include <duckdb/common/column_index.hpp>
 #include <duckdb/common/enums/compression_type.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <duckdb/planner/filter/constant_filter.hpp>
+#include <duckdb/planner/filter/optional_filter.hpp>
+#include <duckdb/planner/table_filter.hpp>
 #include <duckdb/storage/data_table.hpp>
 #include <op/scan/duckdb_native_metadata.hpp>
 #include <utils/utils.hpp>
 
+#include <cstdint>
 #include <string>
 
 using namespace sirius;
@@ -71,6 +76,28 @@ projected_column rowid_col()
   projected_column pc;
   pc.is_rowid = true;
   return pc;
+}
+
+// A one-column TableFilterSet keyed by the relative scan-column index `col_key`
+// (matching create_table_filter_set's remapping), plus the parallel column_ids
+// mapping that key back to storage index `storage_idx`.
+struct filter_ctx {
+  duckdb::TableFilterSet filters;
+  duckdb::vector<duckdb::ColumnIndex> column_ids;
+};
+
+filter_ctx make_constant_filter(duckdb::idx_t col_key,
+                                duckdb::idx_t storage_idx,
+                                duckdb::ExpressionType cmp,
+                                duckdb::Value constant)
+{
+  filter_ctx ctx;
+  ctx.filters.filters[col_key] =
+    duckdb::make_uniq<duckdb::ConstantFilter>(cmp, std::move(constant));
+  // column_ids must be indexable at col_key; pad with the same storage_idx.
+  ctx.column_ids.resize(col_key + 1, duckdb::ColumnIndex(storage_idx));
+  ctx.column_ids[col_key] = duckdb::ColumnIndex(storage_idx);
+  return ctx;
 }
 
 }  // namespace
@@ -442,4 +469,128 @@ TEST_CASE("CompressionTypeToString output matches walker reverse-map keys",
   REQUIRE(std::string(CompressionTypeToString(CompressionType::COMPRESSION_ROARING)) == "Roaring");
   REQUIRE(std::string(CompressionTypeToString(CompressionType::COMPRESSION_EMPTY)) ==
           "Empty Validity");
+}
+
+//===--------------------------------------------------------------------===//
+// Row-group filter-statistics pruning
+//===--------------------------------------------------------------------===//
+
+// 300k monotonically increasing ints span 3 row groups (122880 each), with tight
+// per-row-group min/max. A `a >= 250000` lower bound makes every row group whose
+// max < 250000 FILTER_ALWAYS_FALSE, so the walker should drop them.
+namespace {
+constexpr int kManyRows = 300000;
+
+duckdb::DataTable& make_monotonic_int_table(duckdb::Connection& con)
+{
+  exec_ok(con, "CREATE TABLE t(a INTEGER)");
+  exec_ok(con, "INSERT INTO t SELECT range FROM range(0, " + std::to_string(kManyRows) + ")");
+  exec_ok(con, "CHECKPOINT");
+  return get_storage(con, "t");
+}
+}  // namespace
+
+TEST_CASE("statistics pruning drops row groups below a lower-bound filter",
+          "[scan][duckdb_native_walker][pruning]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto& storage        = make_monotonic_int_table(con);
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+
+  // Baseline: no filter → nothing pruned.
+  auto base = walk_duckdb_native_metadata(storage, *con.context, cols, ts);
+  REQUIRE(base.viable);
+  REQUIRE(base.pruned_row_groups == 0);
+  REQUIRE(base.row_groups.size() >= 2);  // 300k rows > one 122880-row group
+
+  // a >= 250000 → row groups entirely below 250000 are FILTER_ALWAYS_FALSE.
+  auto ctx = make_constant_filter(
+    0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000));
+  auto pruned =
+    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+
+  REQUIRE(pruned.viable);
+  REQUIRE(pruned.pruned_row_groups >= 1);
+  // Consistency: survivors + pruned == baseline row groups.
+  REQUIRE(pruned.row_groups.size() + pruned.pruned_row_groups == base.row_groups.size());
+  REQUIRE(pruned.row_groups.size() >= 1);
+
+  // Survivors carry fewer rows than the full table (we dropped low row groups),
+  // and none of the pruned bytes are zero (we accounted for real decode work).
+  duckdb::idx_t surviving_rows = 0;
+  for (const auto& rg : pruned.row_groups) {
+    surviving_rows += rg.row_count;
+  }
+  REQUIRE(surviving_rows > 0);
+  REQUIRE(surviving_rows < static_cast<duckdb::idx_t>(kManyRows));
+  REQUIRE(pruned.pruned_decoded_bytes > 0);
+}
+
+TEST_CASE("statistics pruning keeps every row group when the filter matches all",
+          "[scan][duckdb_native_walker][pruning]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto& storage        = make_monotonic_int_table(con);
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+
+  // a >= 0 is always true for this data → no row group can be pruned.
+  auto ctx = make_constant_filter(
+    0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(0));
+  auto md =
+    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+
+  REQUIRE(md.viable);
+  REQUIRE(md.pruned_row_groups == 0);
+  REQUIRE(md.pruned_decoded_bytes == 0);
+}
+
+TEST_CASE("statistics pruning refuses (CPU fallback) when every row group is pruned",
+          "[scan][duckdb_native_walker][pruning]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto& storage        = make_monotonic_int_table(con);
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+
+  // a >= 1_000_000 exceeds every value → all row groups FILTER_ALWAYS_FALSE.
+  // The walker drops them all and refuses so the query routes to DuckDB CPU
+  // (which correctly returns the empty result).
+  auto ctx = make_constant_filter(
+    0, 0, duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(1000000));
+  auto md =
+    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+
+  REQUIRE_FALSE(md.viable);
+  REQUIRE(md.viability_failure_reason.find("pruned") != std::string::npos);
+}
+
+// Guards the relaxation that lets us prune on any static filter, not just the
+// subset re-applied post-decode. An OPTIONAL_FILTER ("not required for query
+// correctness") wrapping a lower-bound still prunes, because OptionalFilter
+// delegates CheckStatistics to its child. Pre-relaxation this pruned nothing.
+TEST_CASE("statistics pruning prunes through an OPTIONAL_FILTER wrapper",
+          "[scan][duckdb_native_walker][pruning]")
+{
+  auto [db_owner, con] = sirius::make_test_db_and_connection();
+  auto& storage        = make_monotonic_int_table(con);
+
+  std::vector<projected_column> cols   = {real_col(0)};
+  std::vector<sirius::logical_type> ts = {sirius::logical_type::make(sirius::type_id::INTEGER)};
+
+  filter_ctx ctx;
+  ctx.filters.filters[0] =
+    duckdb::make_uniq<duckdb::OptionalFilter>(duckdb::make_uniq<duckdb::ConstantFilter>(
+      duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO, duckdb::Value::INTEGER(250000)));
+  ctx.column_ids.push_back(duckdb::ColumnIndex(0));
+
+  auto md =
+    walk_duckdb_native_metadata(storage, *con.context, cols, ts, &ctx.filters, &ctx.column_ids);
+
+  REQUIRE(md.viable);
+  REQUIRE(md.pruned_row_groups >= 1);
 }


### PR DESCRIPTION
## Summary

Adds **row-group statistics pruning** to the GPU-native DuckDB scan
(`GPU_DUCKDB_NATIVE_SCAN`). For each row group, the metadata walk now evaluates
DuckDB's own `TableFilter::CheckStatistics` against the per-row-group column
statistics and **drops any row group a pushed-down filter proves
`FILTER_ALWAYS_FALSE`** — before it is staged, copied to the GPU, or decoded.

This is Phase 0 of pushing filters into the native scan; segment-level
(sub-row-group) pruning is a planned follow-up.

**No performance regression or benefit on TPC-H**

**Multiplicative win where data is clustered.** With `lineitem` ordered by
`l_shipdate`, Q6's 1-of-7-years filter prunes **2070 / 2442 row groups (84.8%)**,
skipping ~7 GB of decode.

Pruning's payoff is data-clustering-dependent (as expected for zone-map-style
pruning); it costs ~nothing when it can't help and is multiplicative when it can.

🤖 Generated with [Claude Code](https://claude.com/claude-code) [Edited by human Kevin Kristensen]
