### PR TITLE
build: use `ln -sf` to always refresh activation symlinks

### DIFF
--- a/scripts/pixi_activate.sh
+++ b/scripts/pixi_activate.sh
@@ -8,8 +8,8 @@ fi
 clang_cpp="$CONDA_PREFIX/bin/clang-cpp"
 clang_pp="$CONDA_PREFIX/bin/clang++"
 
-if [[ -x "$clang_cpp" && ! -e "$clang_pp" ]]; then
-  ln -s "$clang_cpp" "$clang_pp"
+if [[ -x "$clang_cpp" ]]; then
+  ln -sf "$clang_cpp" "$clang_pp"
 fi
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,9 +17,7 @@ cmake_presets_src="$project_root/cmake/CMakePresets.json"
 cmake_presets_dst="$project_root/duckdb/CMakePresets.json"
 
 rm -f "$project_root/duckdb/CMakeUserPresets.json"
-if [[ ! -e "$cmake_presets_dst" ]]; then
-  ln -s "$cmake_presets_src" "$cmake_presets_dst"
-fi
+ln -sf "$cmake_presets_src" "$cmake_presets_dst"
 
 mkdir -p build
 pixi shell-hook -s bash > $project_root/build/sirius_pixi_env_for_clion.sh


### PR DESCRIPTION
The change replaces guarded `ln -s` calls with unconditional `ln -sf`, so stale symlinks (e.g. after a worktree switch or prefix change) are always refreshed rather than left pointing at the wrong target.