### PR TITLE
fix: route `spdlog` through `log/logging.hpp` to keep `SPDLOG_ACTIVE_LEVEL=TRACE`

### DIFF
--- a/src/include/data/sirius_converter_registry.hpp
+++ b/src/include/data/sirius_converter_registry.hpp
@@ -20,7 +20,7 @@
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <data/host_parquet_representation_converters.hpp>
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 
 #include <memory>
 #include <mutex>

--- a/src/include/log/logging.hpp
+++ b/src/include/log/logging.hpp
@@ -26,14 +26,25 @@
 #define SIRIUS_LOG_FATAL(...)
 #else  // !__CUDACC__
 
+// Compile in every log level by default. This must be set before spdlog is
+// first included in a translation unit, so this header is the single entry
+// point for spdlog: include <log/logging.hpp> rather than <spdlog/...> so the
+// level is set here first. If spdlog is pulled in earlier, it defaults the
+// level to INFO and silently drops TRACE/DEBUG statements — the post-include
+// check below catches that case.
 #ifndef SPDLOG_ACTIVE_LEVEL
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
-#else
-#warning "SPDLOG_ACTIVE_LEVEL is overridden, output may be lost"
 #endif
 
 #include <spdlog/sinks/daily_file_sink.h>
 #include <spdlog/spdlog.h>
+
+// Warn only if the level was actually raised above TRACE, which compiles out
+// lower-level log statements (e.g. because spdlog was included before this
+// header). SPDLOG_LEVEL_* is defined by the headers above.
+#if SPDLOG_ACTIVE_LEVEL > SPDLOG_LEVEL_TRACE
+#warning "SPDLOG_ACTIVE_LEVEL is above TRACE; lower-level log output is compiled out"
+#endif
 
 #include <string>
 

--- a/src/io/prefetching_cache.cpp
+++ b/src/io/prefetching_cache.cpp
@@ -20,7 +20,7 @@
 
 #include <cuda_runtime.h>
 
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 
 #include <algorithm>
 #include <cassert>

--- a/src/io/sirius_datasource.cpp
+++ b/src/io/sirius_datasource.cpp
@@ -21,7 +21,7 @@
 #include <rmm/device_buffer.hpp>
 
 #include <fcntl.h>
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 #include <sys/stat.h>
 
 #include <algorithm>

--- a/src/io/uring/uring_reactor.cpp
+++ b/src/io/uring/uring_reactor.cpp
@@ -22,8 +22,8 @@
 #include <rmm/cuda_device.hpp>
 
 #include <fcntl.h>
+#include <log/logging.hpp>
 #include <numa.h>
-#include <spdlog/spdlog.h>
 #include <sys/stat.h>
 
 #include <algorithm>

--- a/src/transparent/sirius_optimizer_extension.cpp
+++ b/src/transparent/sirius_optimizer_extension.cpp
@@ -22,7 +22,7 @@
 #include <duckdb/common/types/value.hpp>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/main/config.hpp>
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 
 namespace sirius::transparent {
 

--- a/src/util/segfault_backtrace_handler.cpp
+++ b/src/util/segfault_backtrace_handler.cpp
@@ -28,7 +28,7 @@
 #include <cxxabi.h>
 #include <execinfo.h>
 #include <fcntl.h>
-#include <spdlog/spdlog.h>
+#include <log/logging.hpp>
 #include <sys/syscall.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Several files included `<spdlog/spdlog.h>` directly (or transitively via `sirius_converter_registry.hpp`) before `log/logging.hpp`. spdlog's `common.h` then defaulted `SPDLOG_ACTIVE_LEVEL` to `INFO` before `logging.hpp` could set it to `TRACE`, which fired the `"SPDLOG_ACTIVE_LEVEL is overridden"` #warning and silently compiled out TRACE/DEBUG log statements in those translation units.

Make `logging.hpp` the single spdlog entry point: every file now includes `<log/logging.hpp>` instead of `<spdlog/...>`, so the level is set before spdlog is parsed. `logging.hpp` now warns only when the level was actually raised above `TRACE` (i.e. spdlog leaked in first), which serves as a regression detector for this include discipline rather than firing on any definition.