### PR TITLE
Enable quent by default

### DIFF
--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -109,7 +109,7 @@ sirius:
     concat_batch_bytes: 5Gi
     max_build_hash_table_bytes: 500Mi
   telemetry:
-    enable_quent: false
+    enable_quent: true
     output_directory: telemetry_data
     engine_name: siriusDB
 ```
@@ -208,7 +208,7 @@ sirius:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enable_quent` | bool | false | Emit Quent telemetry using the ndjson exporter. When false, telemetry uses the noop exporter. |
+| `enable_quent` | bool | true | Emit Quent telemetry using the ndjson exporter. When false, telemetry uses the noop exporter. |
 | `output_directory` | string | `telemetry_data` | Directory for Quent ndjson files. |
 | `engine_name` | string | `siriusDB` | Engine name reported in engine-level telemetry. |
 

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -80,7 +80,7 @@ struct operator_params {
 };
 
 struct telemetry_config {
-  bool enable_quent{false};
+  bool enable_quent{true};
   std::string output_directory{"telemetry_data"};
   std::string engine_name{"siriusDB"};
 };


### PR DESCRIPTION
Enables quent in the default config. The default output directory is included in `.gitignore`.