### PR TITLE
feat(rust): add sirius-sys + sirius crate scaffolding

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,6 +146,24 @@ jobs:
         env:
           CUDAARCHS: "100"
 
+      # Rust bindings (sirius-sys + sirius) — fmt/clippy + build/link the test.
+      # Run on a single representative entry. `cargo test --no-run` compiles the
+      # cxx glue against the Sirius FFI header and links the proof-of-life test
+      # against the single Sirius library built above (build.rs discovers it under
+      # build/release). It is NOT run here: constructing a context does GPU
+      # bring-up, and these are CPU runners — the actual run belongs on a GPU
+      # runner (test workflow).
+      - name: Rust bindings checks
+        if: >-
+          matrix.build.arch == 'x64' && matrix.build.compiler == 'gcc'
+          && matrix.build.build-type == 'release' && matrix.build.environment == 'default'
+          && matrix.build.cudf-channel == 'stable' && matrix.build.variant == 'super'
+        run: |
+          set -euo pipefail
+          pixi run cargo fmt --manifest-path rust/Cargo.toml --package sirius --package sirius-sys --check
+          pixi run cargo clippy --manifest-path rust/Cargo.toml --package sirius --package sirius-sys --all-targets -- -D warnings
+          pixi run cargo test --no-run --manifest-path rust/Cargo.toml --package sirius --package sirius-sys
+
       - name: Build (vcpkg)
         if: matrix.build.environment == 'vcpkg'
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ set(EXTENSION_SOURCES
     src/sirius_context.cpp
     src/sirius_engine.cpp
     src/sirius_extension.cpp
+    src/sirius_ffi.cpp
     src/sirius_interface.cpp
     src/sirius_sql_rewrite.cpp
     src/telemetry/telemetry_context.cpp
@@ -371,6 +372,11 @@ target_link_libraries(
 
 target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
                       PkgConfig::CURL OpenSSL::Crypto)
+
+# The sirius-sys + sirius Rust crates are built by cargo, not CMake (unlike the
+# telemetry bridge above, which CMake drives via Corrosion). Their build.rs
+# discovers the Sirius headers (repo + conda) and links the libsirius artifact
+# this build produces under build/<preset>/; see rust/crates/sirius-sys.
 
 # cucascade upstream PRs #126/#128/#130 moved cucascade to static-CUDA linkage
 # and pulled the NVML *static stub* (libnvidia-ml.a) into libcucascade.a via the

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1265,6 +1265,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "sirius"
+version = "0.1.0"
+dependencies = [
+ "cxx",
+ "sirius-sys",
+]
+
+[[package]]
+name = "sirius-sys"
+version = "0.1.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,7 +2,9 @@
 resolver = "3"
 members = [
     "crates/telemetry/bridge",
-    "crates/telemetry/model"
+    "crates/telemetry/model",
+    "crates/sirius-sys",
+    "crates/sirius"
 ]
 
 [workspace.package]
@@ -10,3 +12,8 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace.dependencies]
+# cxx and cxx-build must resolve to the same version (the generated bridge is
+# version-coupled). The shared "1" caret + the lockfile keep them in lockstep.
+cxx = "1"
+cxx-build = "1"
+sirius-sys = { path = "crates/sirius-sys" }

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,60 @@
+# Sirius Rust bindings
+
+Crates for driving [Sirius](https://github.com/sirius-db/sirius) from Rust
+(sirius-db/sirius #835).
+
+| Crate | Role |
+|-------|------|
+| [`sirius-sys`](crates/sirius-sys) | Low-level [`cxx`](https://cxx.rs) bindings to Sirius's public C-ABI (`src/include/sirius_ffi.h`). |
+| [`sirius`](crates/sirius) | Safe, idiomatic wrapper over `sirius-sys`. |
+
+(The `telemetry/*` crates are unrelated — Rust linked *into* the C++ extension via
+CMake/Corrosion, the opposite direction.)
+
+## Building & testing
+
+The crates compile a small cxx shim against Sirius's headers and **link a Sirius
+library artifact**, so build Sirius first, then use cargo:
+
+```bash
+pixi run make                       # builds the Sirius extension (+ artifact + headers)
+# build + link the tests (no GPU needed):
+pixi run cargo test --no-run --manifest-path rust/Cargo.toml -p sirius -p sirius-sys
+```
+
+`SiriusContext::new()` brings up a **fully initialized** engine (it calls the C++
+`initialize()`, which does GPU bring-up) and tears it down on drop — pure RAII via
+`cxx::UniquePtr`, no uninitialized state. So **running** the proof-of-life test
+needs a GPU, and the runtime loader must find the linked library; until a
+dedicated `libsirius` is installed, point it at the build tree:
+
+```bash
+LD_LIBRARY_PATH="$PWD/build/release/extension/sirius:$LD_LIBRARY_PATH" \
+  pixi run cargo test --manifest-path rust/Cargo.toml -p sirius -p sirius-sys
+```
+
+## Linkage
+
+`build.rs` discovers the Sirius artifact under `$SIRIUS_BUILD_DIR` (default
+`build/release`) and links **one self-contained library** — no hand-maintained
+dependency list:
+
+- **default** → `libsirius.so` (shared; pulls its deps via `DT_NEEDED`). Until a
+  real `libsirius.so` exists, `build.rs` symlinks the DuckDB extension
+  (`sirius.duckdb_extension`) to it.
+- **`--features static`** → `libsirius.a` (self-contained, no runtime deps — the
+  fully static vcpkg build). Requires that bundled archive to exist.
+
+`build.rs` only needs `src/include` to compile the shim, because the bound
+surface is the lightweight `sirius_ffi.h`. That header is the seed of the public
+C++ API `libsirius` will expose; today it is compiled into the DuckDB extension,
+which the bindings link until a dedicated `libsirius` ships (at which point the
+symlink stopgap is no longer used).
+
+## Environment
+
+- `SIRIUS_BUILD_DIR` — Sirius build tree (default `build/release`).
+- `CONDA_PREFIX` — set by `pixi`; used to find the headers and the shared lib's deps.
+- `CARGO_NET_GIT_FETCH_WITH_CLI=true` — only on machines whose git config rewrites
+  `https://github.com/` to SSH (the telemetry crate's `quent` git dep otherwise
+  fails libgit2's ssh-agent path). CI is unaffected.

--- a/rust/crates/sirius-sys/Cargo.toml
+++ b/rust/crates/sirius-sys/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sirius-sys"
+version.workspace = true
+edition.workspace = true
+description = "Low-level cxx (cxx.rs) bindings to the Sirius C++ API."
+license = "Apache-2.0"
+# Links a local Sirius build-tree artifact; not self-contained for crates.io.
+publish = false
+
+[lib]
+name = "sirius_sys"
+
+[features]
+# Link the self-contained `libsirius.a` (Sirius + all static deps bundled; no
+# runtime deps — the fully static vcpkg build) instead of the default
+# `libsirius.so`. Point SIRIUS_BUILD_DIR at the build tree that has the artifact.
+static = []
+
+[dependencies]
+cxx.workspace = true
+
+[build-dependencies]
+cxx-build.workspace = true

--- a/rust/crates/sirius-sys/build.rs
+++ b/rust/crates/sirius-sys/build.rs
@@ -1,0 +1,121 @@
+//! Build script for `sirius-sys`.
+//!
+//! Two jobs:
+//!  1. Compile the cxx bridge glue against Sirius's lightweight public FFI header
+//!     (`src/include/sirius_ffi.h`) — no internal Sirius headers are needed, so
+//!     this is the only include directory.
+//!  2. Link the single Sirius artifact that exports the FFI symbols (no
+//!     hand-maintained transitive dependency list). `cargo:rustc-link-{lib,search}`
+//!     propagate to downstream binaries, e.g. the `sirius` crate's `cargo test`.
+//!
+//! The artifact lives under the CMake build tree (`$SIRIUS_BUILD_DIR`, default
+//! `build/release`); build Sirius first (`pixi run make`). Linkage is selectable:
+//!  * default          — `libsirius.so` (shared; records its deps via DT_NEEDED).
+//!  * `static` feature — `libsirius.a` (self-contained; no runtime deps — the
+//!    fully static vcpkg build).
+//!
+//! A dedicated `libsirius` does not exist yet, so by default the bindings link
+//! the DuckDB extension that carries the exported FFI symbols; `resolve_lib_dir`
+//! symlinks it to `libsirius.so` as a stopgap so `-lsirius` resolves. Once Sirius
+//! ships a real `libsirius`, that symlink path simply isn't taken.
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let repo = manifest
+        .join("../../..")
+        .canonicalize()
+        .expect("resolve repo root from CARGO_MANIFEST_DIR");
+    let build_dir = std::env::var_os("SIRIUS_BUILD_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo.join("build/release"));
+    let static_link = std::env::var_os("CARGO_FEATURE_STATIC").is_some();
+    let ffi_header = repo.join("src/include/sirius_ffi.hpp");
+
+    // 1. Compile the cxx glue against the public FFI header only.
+    cxx_build::bridge("src/lib.rs")
+        .std("c++20")
+        .include(repo.join("src/include"))
+        .compile("sirius_sys");
+
+    // 2. Link the single Sirius artifact.
+    let lib_dir = resolve_lib_dir(&build_dir, static_link);
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    if static_link {
+        println!("cargo:rustc-link-lib=static=sirius");
+    } else {
+        // The shared lib pulls its own deps in via DT_NEEDED; make them findable
+        // at link time by searching the conda/CUDA lib dirs.
+        if let Some(conda) = std::env::var_os("CONDA_PREFIX").map(PathBuf::from) {
+            for dir in conda_lib_dirs(&conda) {
+                println!("cargo:rustc-link-search=native={}", dir.display());
+            }
+        }
+        println!("cargo:rustc-link-lib=dylib=sirius");
+    }
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed={}", ffi_header.display());
+    println!("cargo:rerun-if-changed={}", lib_dir.display());
+    println!("cargo:rerun-if-env-changed=SIRIUS_BUILD_DIR");
+    println!("cargo:rerun-if-env-changed=CONDA_PREFIX");
+}
+
+/// Directory holding the Sirius artifact to link (`libsirius.{a,so}`).
+///
+/// Panics with actionable guidance if nothing is found — the common cause is
+/// forgetting to build Sirius first.
+fn resolve_lib_dir(build_dir: &Path, static_link: bool) -> PathBuf {
+    let candidates = [build_dir.join("extension/sirius"), build_dir.to_path_buf()];
+    let file = if static_link {
+        "libsirius.a"
+    } else {
+        "libsirius.so"
+    };
+
+    if let Some(dir) = candidates.iter().find(|d| d.join(file).is_file()) {
+        return dir.clone();
+    }
+
+    // Dynamic stopgap: symlink libsirius.so -> the DuckDB extension that carries
+    // the exported FFI symbols, until a dedicated libsirius.so exists.
+    if !static_link
+        && let Some(dir) = candidates
+            .iter()
+            .find(|d| d.join("sirius.duckdb_extension").is_file())
+    {
+        let link = dir.join("libsirius.so");
+        if !link.exists() {
+            std::os::unix::fs::symlink(dir.join("sirius.duckdb_extension"), &link)
+                .unwrap_or_else(|e| panic!("symlink {}: {e}", link.display()));
+        }
+        return dir.clone();
+    }
+
+    let looked_for = if static_link {
+        "libsirius.a (a self-contained static bundle)".to_string()
+    } else {
+        format!("{file} (or sirius.duckdb_extension to symlink)")
+    };
+    panic!(
+        "could not find {looked_for} under {} — build Sirius first (`pixi run make`), or point \
+         SIRIUS_BUILD_DIR at the build tree",
+        build_dir.display()
+    );
+}
+
+/// conda env lib dirs (`lib`, `targets/<arch>/lib[/stubs]`) for the shared lib's
+/// transitive deps.
+fn conda_lib_dirs(conda: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![conda.join("lib")];
+    if let Ok(entries) = std::fs::read_dir(conda.join("targets")) {
+        for entry in entries.flatten() {
+            let lib = entry.path().join("lib");
+            dirs.push(lib.join("stubs"));
+            dirs.push(lib);
+        }
+    }
+    dirs.retain(|d| d.is_dir());
+    dirs
+}

--- a/rust/crates/sirius-sys/src/lib.rs
+++ b/rust/crates/sirius-sys/src/lib.rs
@@ -1,0 +1,28 @@
+//! Low-level `cxx` bindings to the Sirius C++ API.
+//!
+//! This crate is intentionally thin: it exposes the C++ types and free functions
+//! declared in the `#[cxx::bridge]` module below and nothing else. Safe, idiomatic
+//! wrappers live in the [`sirius`](https://docs.rs/sirius) crate.
+//!
+//! The bridge binds Sirius's **public C++ surface** (`src/include/sirius_ffi.hpp`):
+//! an RAII [`Context`] held via [`cxx::UniquePtr`]. Constructing it brings up an
+//! initialized engine; dropping the `UniquePtr` tears it down. The header is
+//! lightweight, so the bridge compiles without any of Sirius's internal headers
+//! (cudf/rmm/duckdb). It is the seed of the public API `libsirius` will expose;
+//! the bindings link whichever Sirius artifact provides these symbols (the DuckDB
+//! extension today, a dedicated `libsirius` later — see `build.rs`).
+
+#[cxx::bridge(namespace = "sirius::ffi")]
+mod ffi {
+    unsafe extern "C++" {
+        include!("sirius_ffi.hpp");
+
+        /// RAII handle to an initialized Sirius engine context.
+        type Context;
+
+        /// Construct an initialized [`Context`], owned by the returned `UniquePtr`.
+        fn make_context() -> UniquePtr<Context>;
+    }
+}
+
+pub use ffi::{Context, make_context};

--- a/rust/crates/sirius/Cargo.toml
+++ b/rust/crates/sirius/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sirius"
+version.workspace = true
+edition.workspace = true
+description = "Safe, idiomatic Rust bindings for Sirius, the GPU-native SQL engine."
+license = "Apache-2.0"
+# Transitively links a local Sirius build-tree artifact; not for crates.io.
+publish = false
+
+[features]
+# Forwarded to sirius-sys: link the self-contained libsirius.a (no runtime deps)
+# instead of the default libsirius.so. See sirius-sys for details.
+static = ["sirius-sys/static"]
+
+[dependencies]
+cxx.workspace = true
+sirius-sys.workspace = true

--- a/rust/crates/sirius/build.rs
+++ b/rust/crates/sirius/build.rs
@@ -1,0 +1,15 @@
+//! Build script for `sirius`.
+//!
+//! The Sirius artifact is linked by `sirius-sys`'s build script (its
+//! `cargo:rustc-link-{lib,search}` propagate here). Only one extra linker flag is
+//! needed, and only for the static bundle: it embeds DuckDB's unity-build objects
+//! whose duplicate strong symbols would otherwise conflict (the shared lib
+//! resolves them internally, so the default path needs nothing). `rustc-link-arg`
+//! doesn't propagate across crates, so it is emitted here, where the test binary
+//! that triggers the link is built.
+
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_STATIC").is_some() {
+        println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
+    }
+}

--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -1,0 +1,51 @@
+//! Safe, idiomatic Rust bindings for [Sirius](https://github.com/sirius-db/sirius),
+//! the GPU-native SQL engine.
+//!
+//! This crate wraps the low-level [`sirius-sys`] cxx bindings in safe Rust types
+//! — the entry point for driving Sirius from Rust.
+//!
+//! Today it binds just enough to prove the toolchain links against the real
+//! Sirius library: constructing a [`SiriusContext`]. More of the API surface is
+//! added in later PRs.
+
+use cxx::UniquePtr;
+
+/// An initialized Sirius engine context.
+///
+/// Constructing one brings up the engine (GPU resources included); dropping it
+/// tears the engine down. The `cxx::UniquePtr` owns the C++ object, so lifetime
+/// is pure RAII — there is no uninitialized or manually-freed state.
+pub struct SiriusContext {
+    // RAII handle; read by methods added in later PRs (execute, ...). `expect`
+    // flags this for removal once that happens.
+    #[expect(dead_code, reason = "owned for its RAII lifetime until the API grows")]
+    inner: UniquePtr<sirius_sys::Context>,
+}
+
+impl SiriusContext {
+    /// Bring up a new, initialized Sirius engine context.
+    pub fn new() -> Self {
+        Self {
+            inner: sirius_sys::make_context(),
+        }
+    }
+}
+
+impl Default for SiriusContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SiriusContext;
+
+    /// Proof-of-life: bring up a real Sirius engine context and drop it. This
+    /// links the real Sirius library and exercises the full cxx round-trip +
+    /// `initialize()`/teardown. Requires a GPU (construction does GPU bring-up).
+    #[test]
+    fn constructs_and_drops() {
+        let _ctx = SiriusContext::new();
+    }
+}

--- a/src/include/sirius_ffi.hpp
+++ b/src/include/sirius_ffi.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Public C++ surface for embedding Sirius (FFI use cases, e.g. the Rust
+ * `sirius-sys` crate). Intentionally lightweight — a small RAII wrapper that
+ * forward-declares the heavy internal type — so consumers bind it without
+ * pulling in sirius_context.hpp (and its cudf/rmm/duckdb includes).
+ *
+ * Symbols are exported with default visibility so they survive the loadable
+ * extension's `-fvisibility=hidden`. This is the seed of the public C++ API
+ * `libsirius` will expose; today it is compiled into the DuckDB extension, which
+ * the bindings link against until a dedicated `libsirius` exists.
+ */
+
+#pragma once
+
+#include <memory>
+
+#ifndef SIRIUS_FFI_EXPORT
+#define SIRIUS_FFI_EXPORT __attribute__((visibility("default")))
+#endif
+
+namespace duckdb {
+class SiriusContext;
+}  // namespace duckdb
+
+namespace sirius::ffi {
+
+/// RAII handle to a Sirius engine context.
+///
+/// Constructing a `Context` brings up an initialized engine (it constructs and
+/// `initialize()`s a `duckdb::SiriusContext`); destroying it tears the engine
+/// down. There is no uninitialized state. Held from Rust via `cxx::UniquePtr`,
+/// so it is created by `make_context()` and freed when the `UniquePtr` drops.
+class SIRIUS_FFI_EXPORT Context {
+ public:
+  Context();
+  ~Context();
+
+  Context(const Context&)            = delete;
+  Context& operator=(const Context&) = delete;
+
+ private:
+  std::unique_ptr<duckdb::SiriusContext> context_;
+};
+
+/// Create an initialized [`Context`], owned by the returned `unique_ptr`.
+SIRIUS_FFI_EXPORT std::unique_ptr<Context> make_context();
+
+}  // namespace sirius::ffi

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implementation of the public FFI surface (sirius_ffi.hpp). This is the one
+// translation unit that sees the heavy internal types, so consumers (e.g. the
+// Rust bindings) never include sirius_context.hpp.
+
+#include "sirius_ffi.hpp"
+
+#include "sirius_config.hpp"   // sirius::sirius_config
+#include "sirius_context.hpp"  // duckdb::SiriusContext
+
+namespace sirius::ffi {
+
+Context::Context() : context_(std::make_unique<duckdb::SiriusContext>())
+{
+  sirius::sirius_config config;
+  config.apply_defaults();  // populate default GPU/host/disk memory spaces
+  context_->initialize(config);
+}
+
+// Defined here, where duckdb::SiriusContext is complete: destroying `context_`
+// runs ~SiriusContext (which tears down the initialized engine).
+Context::~Context() = default;
+
+std::unique_ptr<Context> make_context() { return std::make_unique<Context>(); }
+
+}  // namespace sirius::ffi


### PR DESCRIPTION
## What

First cut of Rust bindings for Sirius — two crates in the `rust/` workspace:

- **`sirius-sys`** — low-level [`cxx`](https://cxx.rs) bindings to Sirius's public C++ surface.
- **`sirius`** — safe, idiomatic wrapper.

This is scaffolding: it establishes the crates, the cxx bridge, the build/link integration, and a proof-of-life binding so later PRs can grow the API surface against a stable foundation. Replaces the ad-hoc `libloading` FFI experiment.

Closes #835.

## How it works

- **Public C++ surface** (`src/include/sirius_ffi.hpp` + `src/sirius_ffi.cpp`): an RAII `sirius::ffi::Context` — constructing it brings up an initialized engine (an `initialize()`d `duckdb::SiriusContext`), destroying it tears it down. Exported with default visibility so the symbols survive the loadable extension's `-fvisibility=hidden`. This is the seed of the public C++ API a dedicated `libsirius` will expose; the bindings link whichever artifact carries it (the DuckDB extension today, `libsirius` later).
- **`sirius-sys`** binds only that lightweight header (no internal Sirius headers), holding `Context` via `cxx::UniquePtr`. `build.rs` compiles the glue against `src/include` and links a single self-contained Sirius artifact under `$SIRIUS_BUILD_DIR` (default `build/release`) — no hand-maintained transitive dependency list. Built purely by cargo; CMake builds no Rust.
- **`sirius`** is a thin safe wrapper: `SiriusContext::new()` brings up an initialized engine; dropping it tears it down — pure RAII via `UniquePtr`, no raw pointers, no uninitialized state.
- **Linkage** is a cargo `static` feature: default `libsirius.so` (shared), `--features static` `libsirius.a` (self-contained, no runtime deps — the vcpkg static build).

## Validation

`pixi run make` then `cargo test` brings up a real GPU-initialized `SiriusContext` and drops it (topology discovery → GPU, `sirius_ioctx`, cuDF pinned memory, pipeline executor up + cleanly down): `constructs_and_drops ... ok`. `cargo fmt`/`clippy` clean.

## CI

`check.yml` runs fmt + clippy + `cargo test --no-run` (build + link) on the primary build entry. The actual run needs a GPU (construction does GPU bring-up), so it belongs on a GPU runner (test workflow) — follow-up.

## Follow-ups

- `--features static` (fully-static `libsirius.a`) is wired but unvalidated pending a self-contained bundle.
- Runtime currently needs `LD_LIBRARY_PATH` to find the linked `.so`; a dedicated installed `libsirius.so` (with SONAME) removes that.

---
🤖 Drafted by an AI agent (Claude Code) at the direction of @mbrobbel.
