### PR TITLE
fix(downgrade): stop monitor spinning when no downgrade target is viable

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -328,7 +328,9 @@ void downgrade_executor::processing_loop()
     // Wait for all in-flight work to finish (predicate also checked in workers)
     _pool->wait_all();
 
-    if (disk_not_configured && !req->satisfied.load()) {
+    // Monitor requests are gated by has_viable_downgrade_target() and warn once per stall episode
+    // in monitor_loop(); only warn here for one-shot (external) requests to avoid log spam.
+    if (disk_not_configured && !req->satisfied.load() && !req->is_monitor_request) {
       SIRIUS_LOG_WARN(
         "[downgrade] [{}] downgrade request not satisfied and disk memory space is not configured; "
         "data cannot be spilled to disk. Consider configuring a disk memory space to enable "
@@ -369,22 +371,91 @@ void downgrade_executor::processing_loop()
   }
 }
 
+bool downgrade_executor::has_disk_tier() const
+{
+  return !_reservation_manager.get_memory_spaces_for_tier(cucascade::memory::Tier::DISK).empty();
+}
+
+bool downgrade_executor::has_viable_downgrade_target() const
+{
+  using cucascade::memory::Tier;
+
+  // DISK is an effectively unbounded sink and a valid target for any source tier.
+  if (has_disk_tier()) { return true; }
+
+  // Without a disk tier, only a GPU source has a lower tier to downgrade to (HOST). processing_loop
+  // only adds HOST target spaces when the source is GPU, so a HOST (or other) source has no target
+  // at all and can never free anything -- it must back off rather than re-fire.
+  if (_space_id.tier != Tier::GPU) { return false; }
+
+  // GPU source, no disk: viable iff some HOST space can currently accept a reservation. Probe with
+  // exactly the operation a downgrade performs -- make_reservation_or_null of one chunk, released
+  // immediately (RAII). This is the ground truth: HOST reserve() is bounded by _allocated_bytes,
+  // which reflects BOTH live reservations AND already-stored downgraded data, so neither
+  // get_total_reserved_memory nor get_available_memory alone captures whether a downgrade can land.
+  // (The chunk-sized probe matches the chunked allocator's rounding; a sub-chunk request would
+  // succeed against a remainder that no real batch could use.)
+  for (const auto* hs : _reservation_manager.get_memory_spaces_for_tier(Tier::HOST)) {
+    if (!hs) { continue; }
+    // The manager owns these spaces mutably; the span just exposes them as const. make_reservation
+    // mutates accounting, so we need a mutable handle.
+    auto* host         = const_cast<cucascade::memory::memory_space*>(hs);
+    size_t probe_bytes = 1;
+    if (const auto* chunked = host->get_chunked_resource_info()) {
+      probe_bytes = chunked->max_chunk_bytes();
+    }
+    // A chunk larger than this space's reservation limit can never be reserved (the HOST allocator
+    // throws on an over-limit request), so such a space cannot accept a downgrade -- skip it. The
+    // try/catch is belt-and-suspenders: this runs on the monitor thread, which must never throw.
+    if (probe_bytes > host->get_max_memory()) { continue; }
+    try {
+      if (auto probe = host->make_reservation_or_null(probe_bytes)) { return true; }
+    } catch (const std::exception& e) {
+      SIRIUS_LOG_DEBUG("[downgrade] [{}] host viability probe failed: {}", _source_label, e.what());
+    }
+  }
+  return false;
+}
+
 void downgrade_executor::monitor_loop()
 {
   using namespace std::chrono_literals;
 
+  // Monitor-thread-local; throttles the back-off warning to once per stall episode.
+  bool backed_off = false;
+
   while (_running.load()) {
     if (_memory_space && _memory_space->should_downgrade_memory()) {
-      size_t amount = _memory_space->get_amount_to_downgrade();
-      if (amount > 0) {
-        auto req                = std::make_unique<downgrade_request>();
-        req->is_monitor_request = true;
-        req->predicate          = [&freed = req->bytes_freed, amount]() {
-          return freed.load(std::memory_order_relaxed) >= amount;
-        };
-        // Fire-and-forget: monitor does not wait for the result
-        _request_queue.push(std::move(req));
+      // Stateless viability gate: only issue a downgrade request when one could plausibly free
+      // memory. When idle GPU batches' only lower tier is a full HOST and no DISK is configured,
+      // re-firing would just re-scan every repository and the task queue, free nothing, and spam
+      // the log every monitor_period_ms (~100x/s by default) forever. Skipping the cycle backs
+      // off cleanly; because this is re-checked every cycle the monitor resumes the instant host
+      // frees or pressure drops -- there is no latched state to get wedged on.
+      if (has_viable_downgrade_target()) {
+        backed_off    = false;
+        size_t amount = _memory_space->get_amount_to_downgrade();
+        if (amount > 0) {
+          auto req                = std::make_unique<downgrade_request>();
+          req->is_monitor_request = true;
+          req->predicate          = [&freed = req->bytes_freed, amount]() {
+            return freed.load(std::memory_order_relaxed) >= amount;
+          };
+          _monitor_requests_issued.fetch_add(1, std::memory_order_relaxed);
+          // Fire-and-forget: monitor does not wait for the result
+          _request_queue.push(std::move(req));
+        }
+      } else if (!backed_off) {
+        SIRIUS_LOG_WARN(
+          "[downgrade] [{}] memory pressure but no viable downgrade target (host full, no disk "
+          "configured); backing off until memory is released. Consider configuring a disk memory "
+          "space to enable spilling.",
+          _source_label);
+        backed_off = true;
       }
+    } else {
+      // Pressure gone -- reset so the next stall episode warns again.
+      backed_off = false;
     }
     // Brief sleep to avoid busy-spinning; the monitor re-checks after each interval
     std::this_thread::sleep_for(std::chrono::milliseconds(_config.monitor_period_ms));

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -148,10 +148,39 @@ class downgrade_executor {
    */
   std::future<size_t> request_downgrade(std::function<bool()> predicate);
 
+  /**
+   * @brief Whether a DISK tier is configured (an effectively unbounded spill sink).
+   *
+   * Used by callers (e.g. the GPU pipeline executor) to decide whether an unsatisfiable
+   * reservation can ever be relieved by spilling, or whether retrying is futile.
+   */
+  bool has_disk_tier() const;
+
+  /**
+   * @brief Number of downgrade requests the monitor loop has issued (test-only).
+   *
+   * Lets tests observe whether the monitor has gone quiescent (count stops rising)
+   * or is actively issuing requests.
+   */
+  size_t monitor_requests_issued_for_testing() const
+  {
+    return _monitor_requests_issued.load(std::memory_order_relaxed);
+  }
+
  private:
   void processing_loop();
   void monitor_loop();
   void cancel_pending_requests();
+
+  /**
+   * @brief Whether a downgrade from this executor's source tier could plausibly free memory.
+   *
+   * DISK is an effectively unbounded sink, so if it is configured a downgrade can always make
+   * progress. Otherwise progress is only possible if some HOST space still has capacity to accept
+   * data. Re-evaluated on every monitor cycle so the monitor backs off when stuck and resumes the
+   * instant conditions change -- no latched state, no missed wakeup.
+   */
+  bool has_viable_downgrade_target() const;
 
  private:
   exec::downgrade_executor_config _config;
@@ -160,6 +189,7 @@ class downgrade_executor {
   std::thread _processing_thread;
   std::thread _monitor_thread;
   std::atomic<bool> _running{false};
+  std::atomic<size_t> _monitor_requests_issued{0};
   std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;
 
   cucascade::shared_data_repository_manager& _data_repo_mgr;

--- a/test/cpp/downgrade/test_downgrade_disk.cpp
+++ b/test/cpp/downgrade/test_downgrade_disk.cpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include "data/convertible_data_batch.hpp"
+#include "downgrade/downgrade_executor.hpp"
 #include "memory/sirius_memory_reservation_manager.hpp"
 
 // data utilities
@@ -28,6 +29,8 @@
 // cucascade
 #include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/data_repository.hpp>
+#include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/disk_data_representation.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
@@ -38,8 +41,11 @@
 
 #include <rmm/cuda_stream.hpp>
 
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace sirius::parallel;
@@ -103,6 +109,45 @@ std::vector<std::unique_ptr<cucascade::memory::reservation>> exhaust_host_capaci
     held.push_back(std::move(res));
   }
   return held;
+}
+
+const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
+
+// Build a manager with a small HOST tier and NO disk, with a low GPU downgrade trigger so that
+// modest GPU pressure is enough to keep should_downgrade_memory() true. Used to reproduce the
+// "monitor spins because nothing can be downgraded" scenario.
+std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_no_disk_pressure_manager()
+{
+  sirius::converter_registry::reset_for_testing();
+
+  cucascade::memory::reservation_manager_configurator builder;
+  const size_t gpu_capacity  = 256ull << 20;  // 256 MB
+  const size_t host_capacity = 2ull << 20;    // 2 MB — exhausted quickly
+
+  builder.set_number_of_gpus(1)
+    .set_gpu_usage_limit(gpu_capacity)
+    .set_reservation_fraction_per_gpu(0.9)
+    .set_downgrade_fractions_per_gpu(0.1, 0.05)  // trigger GPU downgrade under modest pressure
+    .set_per_host_capacity(host_capacity)
+    .use_host_per_gpu()
+    .set_reservation_fraction_per_host(0.75)
+    .set_downgrade_fractions_per_host(0.1, 0.05);  // also let a HOST monitor reach pressure
+  // No set_disk_mounting_point — DISK tier is absent.
+
+  auto space_configs = builder.build();
+  auto manager =
+    std::make_unique<sirius::memory::sirius_memory_reservation_manager>(std::move(space_configs));
+  sirius::converter_registry::initialize();
+  return manager;
+}
+
+downgrade_executor make_monitoring_executor(cucascade::shared_data_repository_manager& repo_mgr,
+                                            cucascade::memory::memory_space* gpu_space,
+                                            sirius::memory::sirius_memory_reservation_manager& mgr)
+{
+  sirius::exec::downgrade_executor_config config{
+    .thread_pool = {.num_threads = 1, .thread_name_prefix = "downgrade"}, .monitor_period_ms = 10};
+  return downgrade_executor(config, repo_mgr, GPU_SPACE_ID, gpu_space, mgr);
 }
 
 }  // namespace
@@ -265,4 +310,176 @@ TEST_CASE("Downgrade task returns false when HOST full and no DISK tier", "[down
   REQUIRE_FALSE(converted.has_value());
   // Batch must remain on GPU
   REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::GPU);
+}
+
+// Regression: before the fix, the monitor thread fired a downgrade request every
+// monitor_period_ms (10ms) whenever GPU memory was under pressure -- even when nothing could be
+// downgraded (HOST full, no DISK configured) -- spinning forever (~100 fruitless full repo+queue
+// scans and warnings per second). The stateless viability gate must back off instead.
+TEST_CASE("monitor backs off when no downgrade target is viable (no disk)", "[downgrade_disk]")
+{
+  auto mem_mgr    = make_no_disk_pressure_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  // Exhaust HOST so no downgrade can be accepted there; with no DISK there is no viable target.
+  auto held_host = exhaust_host_capacity(*mem_mgr);
+  REQUIRE_FALSE(held_host.empty());
+
+  // Create GPU pressure (reservation-only bookkeeping) so should_downgrade_memory() stays true.
+  auto gpu_hold = gpu_space->make_reservation_or_null(128ull << 20);
+  REQUIRE(gpu_hold);
+  REQUIRE(gpu_space->should_downgrade_memory());
+
+  cucascade::shared_data_repository_manager repo_mgr;
+  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  using namespace std::chrono_literals;
+  // Sample two windows. With the gate, the monitor never issues a request (target check happens
+  // before firing), so the count stays flat across both windows.
+  std::this_thread::sleep_for(300ms);
+  size_t n1 = executor.monitor_requests_issued_for_testing();
+  std::this_thread::sleep_for(300ms);
+  size_t n2 = executor.monitor_requests_issued_for_testing();
+
+  executor.stop();
+
+  REQUIRE(n2 == n1);  // backed off: no continued firing
+  REQUIRE(n1 <= 1);   // at most a single startup-race request before the gate engaged
+}
+
+// The gate is stateless: it re-checks viability every cycle, so the monitor must resume firing the
+// instant a target becomes available again -- here, when HOST capacity is released.
+TEST_CASE("monitor resumes after a downgrade target frees up (no disk)", "[downgrade_disk]")
+{
+  auto mem_mgr    = make_no_disk_pressure_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  auto held_host = exhaust_host_capacity(*mem_mgr);
+  REQUIRE_FALSE(held_host.empty());
+
+  auto gpu_hold = gpu_space->make_reservation_or_null(128ull << 20);
+  REQUIRE(gpu_hold);
+  REQUIRE(gpu_space->should_downgrade_memory());
+
+  cucascade::shared_data_repository_manager repo_mgr;
+  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  using namespace std::chrono_literals;
+  // Confirm it is backed off (count stable while HOST is full).
+  std::this_thread::sleep_for(200ms);
+  size_t stalled = executor.monitor_requests_issued_for_testing();
+  std::this_thread::sleep_for(200ms);
+  REQUIRE(executor.monitor_requests_issued_for_testing() == stalled);
+
+  // Release HOST capacity -> a downgrade target is viable again. GPU pressure (gpu_hold) is still
+  // held, so should_downgrade_memory() remains true and the monitor should start firing again.
+  held_host.clear();
+
+  size_t before = executor.monitor_requests_issued_for_testing();
+  std::this_thread::sleep_for(300ms);
+  size_t after = executor.monitor_requests_issued_for_testing();
+
+  executor.stop();
+
+  REQUIRE(after > before);  // resumed firing once a target became viable
+}
+
+// The viability gate must reflect HOST being full of *real stored downgraded data*, not just held
+// reservations: a downgrade conversion makes a reservation on HOST, so the gate probes with that
+// exact operation. This fills HOST by converting real batches (the production path) and verifies
+// the GPU monitor backs off -- a reservation-count-only check would wrongly see headroom here.
+TEST_CASE("monitor backs off when HOST is full of stored downgraded data (no disk)",
+          "[downgrade_disk]")
+{
+  auto mem_mgr    = make_no_disk_pressure_manager();
+  auto* gpu_space = get_gpu_space(*mem_mgr);
+  REQUIRE(gpu_space != nullptr);
+
+  rmm::cuda_stream stream;
+  std::vector<const cucascade::memory::memory_space*> host_targets;
+  for (auto* hs : mem_mgr->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST)) {
+    host_targets.push_back(hs);
+  }
+
+  // Convert GPU batches to HOST until HOST can no longer accept one. Keep them alive so HOST stays
+  // full via stored allocations (the conversion's transient reservation is gone afterwards).
+  std::vector<std::shared_ptr<cucascade::data_batch>> on_host;
+  for (int i = 0; i < 64; ++i) {
+    auto batch = make_gpu_batch(*gpu_space, 100000);
+    sirius::convertible_data_batch conv(batch);
+    auto res = conv.convert(host_targets, stream, *mem_mgr, false);
+    if (!res.has_value()) { break; }  // HOST full
+    REQUIRE(get_batch_tier(*batch) == cucascade::memory::Tier::HOST);
+    on_host.push_back(std::move(batch));
+  }
+  REQUIRE_FALSE(on_host.empty());
+  // Confirm HOST is genuinely full: one more conversion must fail.
+  {
+    auto extra = make_gpu_batch(*gpu_space, 100000);
+    sirius::convertible_data_batch conv(extra);
+    REQUIRE_FALSE(conv.convert(host_targets, stream, *mem_mgr, false).has_value());
+  }
+
+  auto gpu_hold = gpu_space->make_reservation_or_null(128ull << 20);
+  REQUIRE(gpu_hold);
+  REQUIRE(gpu_space->should_downgrade_memory());
+
+  cucascade::shared_data_repository_manager repo_mgr;
+  auto executor = make_monitoring_executor(repo_mgr, gpu_space, *mem_mgr);
+  executor.start();
+
+  using namespace std::chrono_literals;
+  std::this_thread::sleep_for(300ms);
+  size_t n1 = executor.monitor_requests_issued_for_testing();
+  std::this_thread::sleep_for(300ms);
+  size_t n2 = executor.monitor_requests_issued_for_testing();
+
+  executor.stop();
+
+  REQUIRE(n2 == n1);
+  REQUIRE(n1 <= 1);
+}
+
+// A downgrade executor bound to a HOST source has no target when no disk is configured (HOST cannot
+// downgrade to itself; processing_loop only adds HOST targets for GPU sources). Even under HOST
+// memory pressure it must back off rather than fire monitor requests every cycle.
+TEST_CASE("HOST-source monitor backs off when no disk is configured", "[downgrade_disk]")
+{
+  auto mem_mgr = make_no_disk_pressure_manager();
+
+  auto* host_space = mem_mgr->get_memory_space(cucascade::memory::Tier::HOST, 0);
+  if (!host_space) {
+    auto spaces = mem_mgr->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
+    if (!spaces.empty()) {
+      host_space = const_cast<cucascade::memory::memory_space*>(spaces.front());
+    }
+  }
+  REQUIRE(host_space != nullptr);
+
+  // Create HOST pressure so should_downgrade_memory() on the HOST space is true.
+  auto host_hold = host_space->make_reservation_or_null(1ull << 20);
+  REQUIRE(host_hold);
+  REQUIRE(host_space->should_downgrade_memory());
+
+  sirius::exec::downgrade_executor_config config{
+    .thread_pool       = {.num_threads = 1, .thread_name_prefix = "downgrade-host"},
+    .monitor_period_ms = 10};
+  cucascade::shared_data_repository_manager repo_mgr;
+  downgrade_executor executor(config, repo_mgr, host_space->get_id(), host_space, *mem_mgr);
+  executor.start();
+
+  using namespace std::chrono_literals;
+  std::this_thread::sleep_for(300ms);
+  size_t n1 = executor.monitor_requests_issued_for_testing();
+  std::this_thread::sleep_for(300ms);
+  size_t n2 = executor.monitor_requests_issued_for_testing();
+
+  executor.stop();
+
+  REQUIRE(n2 == n1);  // HOST source with no disk has no target -> never fires
+  REQUIRE(n1 == 0);
 }


### PR DESCRIPTION
## Problem

The downgrade executor's monitor thread polls each memory space every `monitor_period_ms` (default **10 ms**) and enqueues a downgrade request whenever the space is under pressure. But when nothing can actually be downgraded — idle batches' only lower tier is a **full HOST** and **no DISK tier is configured** — every request re-scans all data repositories + the pipeline task queue, frees **0 bytes**, logs a warning, and the cycle repeats. The result is an indefinite spin: ~100 fruitless full scans and warning logs per second, forever, until GPU pressure happens to drop on its own.

```mermaid
flowchart TD
    A([monitor wakes every 10ms]) --> B{should_downgrade_memory?}
    B -- no --> A
    B -- yes --> C[enqueue downgrade_request]
    C --> D[processing_loop re-scans<br/>ALL repos + task queue]
    D --> E{anything convertible<br/>to a lower tier?}
    E -- yes --> G[convert &rarr; free memory] --> A
    E -- "HOST full, no DISK" --> F[free 0 bytes<br/>log warning]
    F -. "spins ~100x/sec forever" .-> A
    style F fill:#ffd0d0,stroke:#c0392b,color:#000
```

## Fix

Add a **stateless viability gate** to `monitor_loop()`: only enqueue a request when a downgrade could plausibly free memory. It's re-evaluated every cycle (no latched state), so the monitor backs off when stuck and **resumes automatically** the instant conditions change — no missed wakeups. The monitor isn't on the correctness-critical path (the pipeline executor drives downgrade on demand independently), so backing off can never deadlock a query.

```mermaid
flowchart TD
    A([monitor wakes]) --> B{should_downgrade_memory?}
    B -- no --> A
    B -- yes --> C{has_viable_downgrade_target?}
    C -- yes --> D[enqueue downgrade_request] --> A
    C -- "no (host full, no disk)" --> E[back off: skip cycle,<br/>warn once per episode]
    E -. "resumes when memory frees" .-> A
    style E fill:#d0f0d0,stroke:#27ae60,color:#000
```

`has_viable_downgrade_target()` mirrors what `processing_loop` actually does:

```mermaid
flowchart TD
    A([has_viable_downgrade_target]) --> B{DISK tier configured?}
    B -- "yes (unbounded sink)" --> V([viable])
    B -- no --> C{source tier == GPU?}
    C -- "no" --> N([not viable:<br/>HOST/other cannot self-downgrade])
    C -- yes --> D[probe each HOST space:<br/>make_reservation_or_null of one chunk,<br/>released immediately]
    D --> E{probe succeeds?}
    E -- yes --> V
    E -- no --> N
    style V fill:#d0f0d0,stroke:#27ae60,color:#000
    style N fill:#ffd0d0,stroke:#c0392b,color:#000
```

Why a **probe** rather than a capacity number: HOST `reserve()` is bounded by *allocated bytes*, which reflect **both** live reservations **and** already-stored downgraded data — so neither reserved-bytes nor available-bytes alone is correct. Probing with the exact operation a downgrade performs is the ground truth. The probe is guarded against over-limit throws so it can never terminate the monitor thread.

## Not included

A pipeline-executor "fail fast" (abort instead of burning the bounded 100-retry budget) was prototyped but **dropped**: at reservation time only a conservative *estimate* and an *ambiguous* partial reservation are available, so it would spuriously fail queries blocked by transient cross-GPU batch-lock contention or by conservative size estimates that would actually fit. The existing bounded retry already terminates safely.

## Tests (`test/cpp/downgrade/test_downgrade_disk.cpp`)

- Monitor stops spinning when stuck (host full, no disk)
- Monitor resumes after host capacity frees
- Monitor backs off when HOST is full of **real stored downgraded data** (not just held reservations)
- HOST-source executor backs off (no disk &rarr; no target)

## Verification

- `[downgrade_disk] [downgrade_lifecycle] [downgrade_executor]` — 26 cases pass
- `[gpu_pipeline_executor]` — unchanged, passes
- `pre-commit run -a` clean
