### PR TITLE
ci(experimental): add workflow for experimental/starrocks

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -1,0 +1,69 @@
+# NOTICE - Actions permissions policy (Settings > Actions > General):
+#   - "Allow sirius-db, and select non-sirius-db, actions and reusable workflows"
+#     - Allow actions created by GitHub: YES (covers actions/*)
+#     - Allow actions by Marketplace verified creators: NO
+#     - Explicitly allowed third-party actions:
+#       prefix-dev/setup-pixi@*
+#       mozilla-actions/sccache-action@*
+#     - Require actions to be pinned to a full-length commit SHA: NO
+#
+# Adding a new action? You must:
+#   1. Pin it to a full-length commit SHA (e.g. uses: owner/repo@<40-char-sha> # vX.Y.Z)
+#   2. If it is not from sirius-db, GitHub, or the explicitly allowed third-party actions above, add it to the
+#      project-level allowlist above before merging
+name: Experimental
+
+on:
+  pull_request:
+    paths:
+      - 'experimental/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  starrocks:
+    name: starrocks
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: experimental/starrocks
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: false
+
+      - name: Init starrocks submodule
+        working-directory: ${{ github.workspace }}
+        run: git submodule update --init --depth=1 experimental/starrocks/starrocks
+
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          cache: false
+          pixi-version: v0.70.2
+          manifest-path: experimental/starrocks/pixi.toml
+          environments: cn
+
+      - name: fmt
+        run: pixi run -e cn cargo fmt --all -- --check
+
+      - name: clippy
+        run: pixi run -e cn cargo clippy --all-targets -- -D warnings
+
+      - name: test
+        run: pixi run -e cn cargo test --workspace
+
+  experimental:
+    name: experimental
+    runs-on: ubuntu-24.04
+    needs: [starrocks]
+    if: always()
+    steps:
+      - name: All checks ok
+        if: ${{ needs.starrocks.result == 'success' }}
+        run: exit 0
+      - name: Some checks failed
+        if: ${{ needs.starrocks.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     paths:
       - 'experimental/**'
+      - '.github/workflows/experimental.yml'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
Adds `.github/workflows/experimental.yml` — a CI workflow that runs on PRs touching `experimental/**` and on every merge group entry.

**Job: `starrocks`**
- Shallow-inits only `experimental/starrocks/starrocks` (needed by the thrift build script)
- Sets up the pixi `cn` env (`rust`, `thrift-compiler`, `libprotobuf`)
- Steps: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`

An `experimental` aggregator job provides a single stable status name for branch protection.

Closes #833