### PR TITLE
Implements using rebind_stream

### DIFF
--- a/.claude/skills/log-analyzer/SKILL.md
+++ b/.claude/skills/log-analyzer/SKILL.md
@@ -198,4 +198,33 @@ After you've localized the issue, recommend the right next step:
 | Re-materialized inputs after a downgrade (per-task view) | `<folder>/memory_history.csv -> peak_bytes_to_materialize_input > 0` |
 | Per-pipeline summary across one query | filter `_pipeline_aggregates.csv` by `query_begin_ts` |
 | How well work was balanced across GPUs (multi-GPU runs) | group `task_outputs.csv` by `gpu_id` (per pipeline or per operator type); see `references/single_query.md` § "GPU balance" |
+| Host (pinned) pool memory at query start/end | `<folder>/query_meta.json -> pool_stats.host` |
+| GPU device memory pool at query start/end (per GPU) | `<folder>/query_meta.json -> pool_stats.gpu[]` |
 | Why my parser run looks weird | `_summary.json -> format_warnings`, then `tools/log_analyzer/README.md` |
+
+## Pool stats: detecting memory leaks across queries
+
+`query_meta.json` contains a `pool_stats` section that captures memory state at the query boundary:
+
+```json
+{
+  "pool_stats": {
+    "host": {
+      "begin": {"allocated_bytes": 5242880, "peak_bytes": 307232768, "free_blocks": 5115},
+      "end":   {"allocated_bytes": 5242880, "peak_bytes": 307232768, "free_blocks": 5115}
+    },
+    "gpu": [
+      {
+        "device_id": 0,
+        "begin": {"allocated_bytes": 0, "peak_bytes": 104857600, "reserved_bytes": 107374182400},
+        "end":   {"allocated_bytes": 0, "peak_bytes": 104857600, "reserved_bytes": 107374182400}
+      }
+    ]
+  }
+}
+```
+
+- **Host pool** (`[query_pool]` log tag): uses a `fixed_size_host_memory_resource` slab allocator. `free_blocks` drops during the query and should return to the QueryBegin value at QueryEnd. A persistent `end.allocated_bytes > begin.allocated_bytes` is a pinned-host memory leak.
+- **GPU pool** (`[gpu_pool]` log tag, one line per GPU): uses a `reservation_aware_resource_adaptor`. `allocated_bytes` reflects live GPU allocations across all streams; `reserved_bytes` reflects the capacity claimed by active reservations. A persistent `end.allocated_bytes > begin.allocated_bytes` is a GPU device memory leak.
+
+The two pool tags are distinguishable in the raw log: host stats use `[query_pool]`, GPU stats use `[gpu_pool]`.

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -428,7 +428,8 @@ void downgrade_executor::monitor_loop()
   bool backed_off = false;
 
   while (_running.load()) {
-    if (_memory_space && _memory_space->should_downgrade_memory()) {
+    if (_memory_space && _memory_space->should_downgrade_memory() &&
+        !_monitor_request_enqueued.load(std::memory_order_relaxed)) {
       // Stateless viability gate: only issue a downgrade request when one could plausibly free
       // memory. When idle GPU batches' only lower tier is a full HOST and no DISK is configured,
       // re-firing would just re-scan every repository and the task queue, free nothing, and spam

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -428,7 +428,6 @@ void downgrade_executor::monitor_loop()
   bool backed_off = false;
 
   while (_running.load()) {
-<<<<<<< HEAD
     if (_memory_space && _memory_space->should_downgrade_memory()) {
       // Stateless viability gate: only issue a downgrade request when one could plausibly free
       // memory. When idle GPU batches' only lower tier is a full HOST and no DISK is configured,
@@ -446,6 +445,7 @@ void downgrade_executor::monitor_loop()
             return freed.load(std::memory_order_relaxed) >= amount;
           };
           _monitor_requests_issued.fetch_add(1, std::memory_order_relaxed);
+          _monitor_request_enqueued.store(true, std::memory_order_relaxed);
           // Fire-and-forget: monitor does not wait for the result
           _request_queue.push(std::move(req));
         }
@@ -456,22 +456,6 @@ void downgrade_executor::monitor_loop()
           "space to enable spilling.",
           _source_label);
         backed_off = true;
-=======
-    if (_memory_space && _memory_space->should_downgrade_memory() &&
-        !_monitor_request_enqueued.load(std::memory_order_relaxed)) {
-      size_t amount = _memory_space->get_amount_to_downgrade();
-      if (amount > 0) {
-        auto req                = std::make_unique<downgrade_request>();
-        req->is_monitor_request = true;
-        req->predicate          = [&freed = req->bytes_freed, amount]() {
-          return freed.load(std::memory_order_relaxed) >= amount;
-        };
-        SIRIUS_LOG_DEBUG(
-          "[downgrade] monitor_loop:  for memory space {} for {} bytes", _source_label, amount);
-        _monitor_request_enqueued.store(true, std::memory_order_relaxed);
-        // Fire-and-forget: monitor does not wait for the result
-        _request_queue.push(std::move(req));
->>>>>>> 906ad8f0 (working stream rebind implementation. Also reduces redundant monitor requests)
       }
     } else {
       // Pressure gone -- reset so the next stall episode warns again.

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -488,9 +488,6 @@ void downgrade_executor::set_pipeline_task_queue(
 
 std::future<size_t> downgrade_executor::request_free_memory(size_t bytes)
 {
-  SIRIUS_LOG_DEBUG("[downgrade] request_free_memory: for memory space {} requesting {} bytes",
-                   _source_label,
-                   bytes);
   auto req       = std::make_unique<downgrade_request>();
   req->predicate = [&freed = req->bytes_freed, bytes]() {
     return freed.load(std::memory_order_relaxed) >= bytes;
@@ -510,8 +507,6 @@ size_t downgrade_executor::request_free_memory_and_wait(size_t bytes)
 
 std::future<size_t> downgrade_executor::request_downgrade(std::function<bool()> predicate)
 {
-  SIRIUS_LOG_DEBUG("[downgrade] request_downgrade: for memory space {} requesting downgrade",
-                   _source_label);
   auto req       = std::make_unique<downgrade_request>();
   req->predicate = std::move(predicate);
   auto future    = req->result.get_future();

--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -259,7 +259,7 @@ void downgrade_executor::processing_loop()
                 if (req_ptr->predicate && req_ptr->predicate()) { req_ptr->satisfied.store(true); }
               }
             } catch (const std::exception& e) {
-              SIRIUS_LOG_ERROR("[downgrade] convert failed: {}", e.what());
+              SIRIUS_LOG_ERROR("[downgrade] convert failed from data repository: {}", e.what());
             }
           });
       }
@@ -319,7 +319,7 @@ void downgrade_executor::processing_loop()
                 if (req_ptr->predicate && req_ptr->predicate()) { req_ptr->satisfied.store(true); }
               }
             } catch (const std::exception& e) {
-              SIRIUS_LOG_ERROR("[downgrade] convert failed: {}", e.what());
+              SIRIUS_LOG_ERROR("[downgrade] convert failed from task queue: {}", e.what());
             }
           });
       }
@@ -346,6 +346,9 @@ void downgrade_executor::processing_loop()
     double throughput_mbs =
       (duration_ms > 0.0) ? (total_bytes / (1024.0 * 1024.0)) / (duration_ms / 1000.0) : 0.0;
     std::string request_label = req->is_monitor_request ? "monitor " : "";
+    if (req->is_monitor_request) {
+      _monitor_request_enqueued.store(false, std::memory_order_relaxed);
+    }
 
     SIRIUS_LOG_DEBUG(
       "[downgrade] [{}] request {}done: {} batches, {} bytes in {:.2f} ms ({:.1f} MB/s) | "
@@ -425,6 +428,7 @@ void downgrade_executor::monitor_loop()
   bool backed_off = false;
 
   while (_running.load()) {
+<<<<<<< HEAD
     if (_memory_space && _memory_space->should_downgrade_memory()) {
       // Stateless viability gate: only issue a downgrade request when one could plausibly free
       // memory. When idle GPU batches' only lower tier is a full HOST and no DISK is configured,
@@ -452,6 +456,22 @@ void downgrade_executor::monitor_loop()
           "space to enable spilling.",
           _source_label);
         backed_off = true;
+=======
+    if (_memory_space && _memory_space->should_downgrade_memory() &&
+        !_monitor_request_enqueued.load(std::memory_order_relaxed)) {
+      size_t amount = _memory_space->get_amount_to_downgrade();
+      if (amount > 0) {
+        auto req                = std::make_unique<downgrade_request>();
+        req->is_monitor_request = true;
+        req->predicate          = [&freed = req->bytes_freed, amount]() {
+          return freed.load(std::memory_order_relaxed) >= amount;
+        };
+        SIRIUS_LOG_DEBUG(
+          "[downgrade] monitor_loop:  for memory space {} for {} bytes", _source_label, amount);
+        _monitor_request_enqueued.store(true, std::memory_order_relaxed);
+        // Fire-and-forget: monitor does not wait for the result
+        _request_queue.push(std::move(req));
+>>>>>>> 906ad8f0 (working stream rebind implementation. Also reduces redundant monitor requests)
       }
     } else {
       // Pressure gone -- reset so the next stall episode warns again.
@@ -484,6 +504,9 @@ void downgrade_executor::set_pipeline_task_queue(
 
 std::future<size_t> downgrade_executor::request_free_memory(size_t bytes)
 {
+  SIRIUS_LOG_DEBUG("[downgrade] request_free_memory: for memory space {} requesting {} bytes",
+                   _source_label,
+                   bytes);
   auto req       = std::make_unique<downgrade_request>();
   req->predicate = [&freed = req->bytes_freed, bytes]() {
     return freed.load(std::memory_order_relaxed) >= bytes;
@@ -503,6 +526,8 @@ size_t downgrade_executor::request_free_memory_and_wait(size_t bytes)
 
 std::future<size_t> downgrade_executor::request_downgrade(std::function<bool()> predicate)
 {
+  SIRIUS_LOG_DEBUG("[downgrade] request_downgrade: for memory space {} requesting downgrade",
+                   _source_label);
   auto req       = std::make_unique<downgrade_request>();
   req->predicate = std::move(predicate);
   auto future    = req->result.get_future();

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -118,9 +118,7 @@ class convertible_data_batch : public convertible_data {
       // synchronizes `stream` after the D2H copy and before destroying the source
       // representation, so the free is correctly ordered. No-op for non-GPU-table sources.
       if (cur_space != nullptr && cur_space->get_tier() == cucascade::memory::Tier::GPU) {
-        SIRIUS_LOG_DEBUG("[rebind] convertible_data_batch: (begin)");
         mut.rebind_stream(stream);
-        SIRIUS_LOG_DEBUG("[rebind] convertible_data_batch: (end)");
       }
 
       auto& converter_registry = sirius::converter_registry::get();

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -111,6 +111,18 @@ class convertible_data_batch : public convertible_data {
       auto reservation = mem_space->make_reservation_or_null(data_size);
       if (!reservation) { continue; }
 
+      // When downgrading off the GPU, rebind the source buffers' deallocation stream to this
+      // downgrade stream so that when the conversion below frees the GPU representation, the
+      // free lands on the active (downgrade) stream rather than the stream the data was
+      // originally produced on. We hold the exclusive (mutable) lock here, and convert_to()
+      // synchronizes `stream` after the D2H copy and before destroying the source
+      // representation, so the free is correctly ordered. No-op for non-GPU-table sources.
+      if (cur_space != nullptr && cur_space->get_tier() == cucascade::memory::Tier::GPU) {
+        SIRIUS_LOG_DEBUG("[rebind] convertible_data_batch: (begin)");
+        mut.rebind_stream(stream);
+        SIRIUS_LOG_DEBUG("[rebind] convertible_data_batch: (end)");
+      }
+
       auto& converter_registry = sirius::converter_registry::get();
 
       switch (space->get_tier()) {

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -188,6 +188,7 @@ class downgrade_executor {
   exec::interruptible_mpmc<std::unique_ptr<downgrade_request>> _request_queue;
   std::thread _processing_thread;
   std::thread _monitor_thread;
+  std::atomic<bool> _monitor_request_enqueued{false};
   std::atomic<bool> _running{false};
   std::atomic<size_t> _monitor_requests_issued{0};
   std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -69,23 +69,8 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
     if (current_space != nullptr && rebind_target != nullptr &&
         current_space->get_id() == rebind_target->get_id() &&
         rebind_target->get_tier() == cucascade::memory::Tier::GPU) {
-      // TEMP DIAGNOSTIC (stream-rebind deadlock investigation): log immediately before and
-      // after the rebind so the last rebound batch is pinpointable in a wedged log.
-      SIRIUS_LOG_DEBUG(
-        "[rebind] lock_or_prepare_batch: rebinding batch {} on GPU:{} to stream {} (begin)",
-        batch->get_batch_id(),
-        current_space->get_id().device_id,
-        static_cast<const void*>(stream.value()));
       mut->rebind_stream(stream);
-      SIRIUS_LOG_DEBUG(
-        "[rebind] lock_or_prepare_batch: rebound batch {} on GPU:{} to stream {} (end)",
-        batch->get_batch_id(),
-        current_space->get_id().device_id,
-        static_cast<const void*>(stream.value()));
     }
-  } else {
-    SIRIUS_LOG_DEBUG("[rebind] lock_or_prepare_batch: failed to acquire mutable lock for batch {}",
-                     batch->get_batch_id());
   }
 
   // Acquire a read-only lock

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -53,6 +53,41 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
 {
   if (!batch) { return std::nullopt; }
 
+  // Opportunistic stream rebind (best-effort, non-blocking): if the batch already resides in
+  // the target GPU memory space, rebind its deallocation stream to this task's stream so that
+  // when the task later frees the data the free lands on the active stream's free list rather
+  // than on the stream the data was produced on. We use try_to_mutable() so we never block --
+  // if another reader holds the batch (e.g. a probe task on another GPU sharing a build batch)
+  // or it is otherwise busy, we simply skip the rebind; correctness is unaffected. Gating on a
+  // space match guarantees the stream and the data live on the same device (important for
+  // multi-GPU). The mismatch case below converts via `stream`, which already allocates the new
+  // table on it, so no rebind is needed there.
+  if (auto mut = batch->try_to_mutable()) {
+    const auto* current_space = mut->get_memory_space();
+    const auto* rebind_target =
+      requested_memory_space != nullptr ? requested_memory_space : current_space;
+    if (current_space != nullptr && rebind_target != nullptr &&
+        current_space->get_id() == rebind_target->get_id() &&
+        rebind_target->get_tier() == cucascade::memory::Tier::GPU) {
+      // TEMP DIAGNOSTIC (stream-rebind deadlock investigation): log immediately before and
+      // after the rebind so the last rebound batch is pinpointable in a wedged log.
+      SIRIUS_LOG_DEBUG(
+        "[rebind] lock_or_prepare_batch: rebinding batch {} on GPU:{} to stream {} (begin)",
+        batch->get_batch_id(),
+        current_space->get_id().device_id,
+        static_cast<const void*>(stream.value()));
+      mut->rebind_stream(stream);
+      SIRIUS_LOG_DEBUG(
+        "[rebind] lock_or_prepare_batch: rebound batch {} on GPU:{} to stream {} (end)",
+        batch->get_batch_id(),
+        current_space->get_id().device_id,
+        static_cast<const void*>(stream.value()));
+    }
+  } else {
+    SIRIUS_LOG_DEBUG("[rebind] lock_or_prepare_batch: failed to acquire mutable lock for batch {}",
+                     batch->get_batch_id());
+  }
+
   // Acquire a read-only lock
   auto read_accessor = batch->to_read_only();
 

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -152,6 +152,10 @@ class SiriusContext : public ClientContextState {
   ///        peak, free blocks) at a labeled tag — used for verifying leaks.
   void log_host_pool_stats(std::string_view tag) const;
 
+  /// \brief Log the GPU reservation_aware_resource_adaptor stats (allocated,
+  ///        peak, reserved) per GPU at a labeled tag — used for verifying leaks.
+  void log_gpu_pool_stats(std::string_view tag) const;
+
   [[nodiscard]] const cucascade::memory::system_topology_info& get_hw_topology() const noexcept
   {
     return config_.get_hw_topology();

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -148,13 +148,10 @@ class SiriusContext : public ClientContextState {
   /// \brief Terminate the Sirius context, releasing all resources.
   void terminate();
 
-  /// \brief Log the host fixed_size_host_memory_resource stats (allocated,
-  ///        peak, free blocks) at a labeled tag — used for verifying leaks.
-  void log_host_pool_stats(std::string_view tag) const;
-
-  /// \brief Log the GPU reservation_aware_resource_adaptor stats (allocated,
-  ///        peak, reserved) per GPU at a labeled tag — used for verifying leaks.
-  void log_gpu_pool_stats(std::string_view tag) const;
+  /// \brief Log host and GPU memory pool stats (allocated, peak, and
+  ///        tier-specific capacity fields) at a labeled tag — used for
+  ///        verifying that allocations return to baseline after each query.
+  void log_pool_stats(std::string_view tag) const;
 
   [[nodiscard]] const cucascade::memory::system_topology_info& get_hw_topology() const noexcept
   {

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -252,6 +252,9 @@ void gpu_pipeline_executor::manager_loop()
             return;
           }
 
+          // Sync the stream to ensure all memory is released before the reschedule.
+          exc_stream->synchronize();
+
           // Determine retry count and original task ID for this rescheduled attempt.
           auto* cur_local = dynamic_cast<gpu_pipeline_task_local_state*>(gpu_task->local_state());
           uint32_t next_retry_count = 1;

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -177,7 +177,7 @@ void SiriusContext::log_host_pool_stats(std::string_view tag) const
   auto* fs_mr =
     host_spaces[0]->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
   if (!fs_mr) { return; }
-  spdlog::info("[query_pool] {} allocated={} bytes peak={} bytes free_blocks={}",
+  spdlog::info("[host_pool] {} allocated={} bytes peak={} bytes free_blocks={}",
                tag,
                fs_mr->get_total_allocated_bytes(),
                fs_mr->get_peak_total_allocated_bytes(),

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -39,6 +39,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <cucascade/memory/small_pinned_host_memory_resource.hpp>
 #include <duckdb/common/allocator.hpp>
 #include <duckdb/execution/physical_plan_generator.hpp>
@@ -183,6 +184,27 @@ void SiriusContext::log_host_pool_stats(std::string_view tag) const
                fs_mr->get_free_blocks());
 }
 
+// Log the GPU reservation_aware_resource_adaptor stats at a labeled point, one
+// line per configured GPU. Lets us verify that allocated bytes return to
+// baseline at the end of each query — the leak signature is
+// "QueryEnd allocated != QueryBegin allocated".
+void SiriusContext::log_gpu_pool_stats(std::string_view tag) const
+{
+  if (!memory_manager_) { return; }
+  auto gpu_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
+  for (auto const* space : gpu_spaces) {
+    auto* ra_mr =
+      space->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
+    if (!ra_mr) { continue; }
+    spdlog::info("[gpu_pool] GPU:{} {} allocated={} bytes peak={} bytes reserved={} bytes",
+                 space->get_device_id(),
+                 tag,
+                 ra_mr->get_total_allocated_bytes(),
+                 ra_mr->get_peak_total_allocated_bytes(),
+                 ra_mr->get_total_reserved_bytes());
+  }
+}
+
 void SiriusContext::QueryBegin(ClientContext& context)
 {
   // Suppress all state mutations for internal connections (e.g. iceberg metadata lookups).
@@ -192,6 +214,7 @@ void SiriusContext::QueryBegin(ClientContext& context)
 
   try {
     log_host_pool_stats("QueryBegin");
+    log_gpu_pool_stats("QueryBegin");
 
     // Clear any stale captured plan from a previous query.
     captured_logical_plan_.reset();
@@ -269,6 +292,7 @@ void SiriusContext::QueryEnd()
     if (scan_manager_) { scan_manager_->reset(); }
 
     log_host_pool_stats("QueryEnd");
+    log_gpu_pool_stats("QueryEnd");
   } catch (...) {
     release_query_lifecycle_slot();
     throw;

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -166,33 +166,31 @@ SiriusContext::~SiriusContext() noexcept
   if (is_initialized_) { terminate(); }
 }
 
-// Log the host fixed_size_host_memory_resource stats at a labeled point.
+// Log host and GPU memory pool stats at a labeled point.
 // Lets us verify that allocated bytes return to baseline at the end of each
 // query — the leak signature is "QueryEnd allocated != QueryBegin allocated".
-void SiriusContext::log_host_pool_stats(std::string_view tag) const
+void SiriusContext::log_pool_stats(std::string_view tag) const
 {
   if (!memory_manager_) { return; }
-  auto host_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST);
-  if (host_spaces.empty()) { return; }
-  auto* fs_mr =
-    host_spaces[0]->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
-  if (!fs_mr) { return; }
-  spdlog::info("[host_pool] {} allocated={} bytes peak={} bytes free_blocks={}",
-               tag,
-               fs_mr->get_total_allocated_bytes(),
-               fs_mr->get_peak_total_allocated_bytes(),
-               fs_mr->get_free_blocks());
-}
 
-// Log the GPU reservation_aware_resource_adaptor stats at a labeled point, one
-// line per configured GPU. Lets us verify that allocated bytes return to
-// baseline at the end of each query — the leak signature is
-// "QueryEnd allocated != QueryBegin allocated".
-void SiriusContext::log_gpu_pool_stats(std::string_view tag) const
-{
-  if (!memory_manager_) { return; }
-  auto gpu_spaces = memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU);
-  for (auto const* space : gpu_spaces) {
+  // Host pinned pool (fixed_size_host_memory_resource).
+  for (auto const* space :
+       memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::HOST)) {
+    auto* fs_mr =
+      space->get_memory_resource_as<cucascade::memory::fixed_size_host_memory_resource>();
+    if (fs_mr) {
+      spdlog::info("[host_pool] HOST:{} {} allocated={} bytes peak={} bytes free_blocks={}",
+                   space->get_id().device_id,
+                   tag,
+                   fs_mr->get_total_allocated_bytes(),
+                   fs_mr->get_peak_total_allocated_bytes(),
+                   fs_mr->get_free_blocks());
+    }
+  }
+
+  // GPU device memory pools (reservation_aware_resource_adaptor), one line per GPU.
+  for (auto const* space :
+       memory_manager_->get_memory_spaces_for_tier(cucascade::memory::Tier::GPU)) {
     auto* ra_mr =
       space->get_memory_resource_as<cucascade::memory::reservation_aware_resource_adaptor>();
     if (!ra_mr) { continue; }
@@ -213,8 +211,7 @@ void SiriusContext::QueryBegin(ClientContext& context)
   acquire_query_lifecycle_slot();
 
   try {
-    log_host_pool_stats("QueryBegin");
-    log_gpu_pool_stats("QueryBegin");
+    log_pool_stats("QueryBegin");
 
     // Clear any stale captured plan from a previous query.
     captured_logical_plan_.reset();
@@ -291,8 +288,7 @@ void SiriusContext::QueryEnd()
     // sliced host_data_representation are gone before we drop the providers.
     if (scan_manager_) { scan_manager_->reset(); }
 
-    log_host_pool_stats("QueryEnd");
-    log_gpu_pool_stats("QueryEnd");
+    log_pool_stats("QueryEnd");
   } catch (...) {
     release_query_lifecycle_slot();
     throw;

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -239,7 +239,7 @@ void SiriusContext::QueryBegin(ClientContext& context)
     if (!normalized_query.empty() && normalized_query.back() == ' ') {
       normalized_query.pop_back();
     }
-    SIRIUS_LOG_INFO("QueryBegin: {}", normalized_query);
+    SIRIUS_LOG_INFO("QueryBegin: SQL: {}", normalized_query);
 
     task_creator_->reset();
     task_creator_->set_client_context(context);

--- a/tools/log_analyzer/parse_logs.py
+++ b/tools/log_analyzer/parse_logs.py
@@ -108,7 +108,7 @@ def _extract_pool_stats(lines) -> dict:
     gpu: dict = {}  # device_id -> {"begin": ..., "end": ...}
 
     for line in lines:
-        if patterns.QUERY_BEGIN_ANCHOR in line or patterns.QUERY_END_ANCHOR in line:
+        if patterns.is_query_begin_line(line) or patterns.is_query_end_line(line):
             m = patterns.HOST_POOL_RE.match(line)
             if m:
                 key = "begin" if m.group("tag") == "QueryBegin" else "end"

--- a/tools/log_analyzer/parse_logs.py
+++ b/tools/log_analyzer/parse_logs.py
@@ -109,7 +109,7 @@ def _extract_pool_stats(lines) -> dict:
 
     for line in lines:
         if patterns.QUERY_BEGIN_ANCHOR in line or patterns.QUERY_END_ANCHOR in line:
-            m = patterns.QUERY_POOL_RE.match(line)
+            m = patterns.HOST_POOL_RE.match(line)
             if m:
                 key = "begin" if m.group("tag") == "QueryBegin" else "end"
                 host[key] = {

--- a/tools/log_analyzer/parse_logs.py
+++ b/tools/log_analyzer/parse_logs.py
@@ -97,6 +97,48 @@ def _extract_overview_text(lines):
     return "\n".join(out) if out else ""
 
 
+def _extract_pool_stats(lines) -> dict:
+    """Extract host (pinned) and GPU device memory pool stats from boundary lines.
+
+    Returns a dict with keys "host" and "gpu":
+      - host: {"begin": {allocated_bytes, peak_bytes, free_blocks}, "end": {...}}
+      - gpu: [{"device_id": N, "begin": {allocated_bytes, peak_bytes, reserved_bytes}, "end": {...}}, ...]
+    """
+    host: dict = {}
+    gpu: dict = {}  # device_id -> {"begin": ..., "end": ...}
+
+    for line in lines:
+        if patterns.QUERY_BEGIN_ANCHOR in line or patterns.QUERY_END_ANCHOR in line:
+            m = patterns.QUERY_POOL_RE.match(line)
+            if m:
+                key = "begin" if m.group("tag") == "QueryBegin" else "end"
+                host[key] = {
+                    "allocated_bytes": int(m.group("allocated_bytes")),
+                    "peak_bytes": int(m.group("peak_bytes")),
+                    "free_blocks": int(m.group("free_blocks")),
+                }
+        if patterns.GPU_POOL_ANCHOR in line:
+            m = patterns.GPU_POOL_RE.match(line)
+            if m:
+                dev_id = int(m.group("gpu_id"))
+                key = "begin" if m.group("tag") == "QueryBegin" else "end"
+                if dev_id not in gpu:
+                    gpu[dev_id] = {}
+                gpu[dev_id][key] = {
+                    "allocated_bytes": int(m.group("allocated_bytes")),
+                    "peak_bytes": int(m.group("peak_bytes")),
+                    "reserved_bytes": int(m.group("reserved_bytes")),
+                }
+
+    return {
+        "host": host,
+        "gpu": [
+            {"device_id": dev_id, **dev_stats}
+            for dev_id, dev_stats in sorted(gpu.items())
+        ],
+    }
+
+
 def process_query(seg, out_dir: Path, warnings: FormatWarnings) -> dict:
     """Process a single query segment. Returns the index-row dict."""
     folder_name = _ts_to_folder_name(seg.begin_ts)
@@ -142,12 +184,14 @@ def process_query(seg, out_dir: Path, warnings: FormatWarnings) -> dict:
             duration_ms = None
 
     sql_preview = seg.sql[:120]
+    pool_stats = _extract_pool_stats(seg.lines)
     meta = {
         "begin_ts": seg.begin_ts,
         "end_ts": seg.end_ts,
         "status": seg.status,
         "duration_ms": duration_ms,
         "sql_preview": sql_preview,
+        "pool_stats": pool_stats,
         "counts": {
             "memory_reservations": len(mr_rows),
             "task_inputs": len(ti_rows),

--- a/tools/log_analyzer/patterns.py
+++ b/tools/log_analyzer/patterns.py
@@ -24,12 +24,12 @@ TRACE_TAG = "[trace]"
 DEBUG_TAG = "[debug]"
 
 # --- Query boundaries (info-level) -------------------------------------------
-# Example: "[2026-05-20 14:25:02.368] [info] [:] [query_pool] QueryBegin allocated=5242880 bytes peak=307232768 bytes free_blocks=5115"
-QUERY_BEGIN_ANCHOR = "[info] [:] [query_pool] QueryBegin allocated="
-QUERY_END_ANCHOR = "[info] [:] [query_pool] QueryEnd allocated="
+# Example: "[2026-05-20 14:25:02.368] [info] [:] [host_pool] QueryBegin allocated=5242880 bytes peak=307232768 bytes free_blocks=5115"
+QUERY_BEGIN_ANCHOR = "[info] [:] [host_pool] QueryBegin allocated="
+QUERY_END_ANCHOR = "[info] [:] [host_pool] QueryEnd allocated="
 # Strict regex to extract stats from the host-pool boundary lines.
-QUERY_POOL_RE = re.compile(
-    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] \[query_pool\] "
+HOST_POOL_RE = re.compile(
+    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] \[host_pool\] "
     r"(?P<tag>QueryBegin|QueryEnd) "
     r"allocated=(?P<allocated_bytes>\d+) bytes "
     r"peak=(?P<peak_bytes>\d+) bytes "

--- a/tools/log_analyzer/patterns.py
+++ b/tools/log_analyzer/patterns.py
@@ -14,7 +14,7 @@ that consumes this data can detect mismatched parser versions.
 
 import re
 
-SHAPE_VERSION = "1.3"
+SHAPE_VERSION = "1.6"
 
 # Timestamp at the start of every log line, e.g. "[2026-05-20 14:25:02.368]"
 TS_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\]")
@@ -24,17 +24,32 @@ TRACE_TAG = "[trace]"
 DEBUG_TAG = "[debug]"
 
 # --- Query boundaries (info-level) -------------------------------------------
-# Example: "[2026-05-20 14:25:02.368] [info] [:] [host_pool] QueryBegin allocated=5242880 bytes peak=307232768 bytes free_blocks=5115"
-QUERY_BEGIN_ANCHOR = "[info] [:] [host_pool] QueryBegin allocated="
-QUERY_END_ANCHOR = "[info] [:] [host_pool] QueryEnd allocated="
+# Example: "[2026-06-10 19:52:14.000] [info] [:] [host_pool] HOST:0 QueryBegin allocated=5242880 bytes peak=307232768 bytes free_blocks=5115"
+# HOST:{device_id} was added in the DRY-cleanup refactor (commit e863fd4c).
+# The device_id varies by system so we use helper predicates (below) instead
+# of hardcoding it in anchor strings.
+#
 # Strict regex to extract stats from the host-pool boundary lines.
+# HOST:{device_id} group is optional so older logs (pre-e863fd4c) still parse.
 HOST_POOL_RE = re.compile(
     r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] \[host_pool\] "
+    r"(?:HOST:(?P<host_device_id>-?\d+) )?"
     r"(?P<tag>QueryBegin|QueryEnd) "
     r"allocated=(?P<allocated_bytes>\d+) bytes "
     r"peak=(?P<peak_bytes>\d+) bytes "
     r"free_blocks=(?P<free_blocks>\d+)"
 )
+
+
+# Predicates used by segmenter.py and parse_logs.py to detect query-boundary
+# lines without hardcoding the HOST device_id.
+def is_query_begin_line(line: str) -> bool:
+    return "[host_pool]" in line and "QueryBegin allocated=" in line
+
+
+def is_query_end_line(line: str) -> bool:
+    return "[host_pool]" in line and "QueryEnd allocated=" in line
+
 
 # --- GPU device memory pool stats at query boundaries (info-level) -----------
 # Example: "[2026-06-10 10:00:00.000] [info] [:] [gpu_pool] GPU:0 QueryBegin allocated=1234567890 bytes peak=1234567890 bytes reserved=1234567890 bytes"
@@ -48,13 +63,12 @@ GPU_POOL_RE = re.compile(
     r"reserved=(?P<reserved_bytes>\d+) bytes"
 )
 
-# Example (old): "[2026-05-20 14:25:02.368] [info] [:] QueryBegin: with revenue_view as ..."
-# Example (new): "[2026-05-22 17:33:13.408] [info] [sirius_context.cpp:205] QueryBegin: select ..."
-# Both forms appear in the wild; the second element changed from [:] to a
-# file:line tag in newer Sirius builds.
-QUERY_SQL_ANCHOR = "QueryBegin: "  # distinguished from "QueryBegin allocated=" by ": "
+# Example: "[2026-06-11 ...] [info] [sirius_context.cpp:246] QueryBegin: SQL: select ..."
+# "SQL: " was added to distinguish the SQL line from the pool-stat lines that
+# also begin with "QueryBegin" (e.g. "[host_pool] HOST:-1 QueryBegin allocated=").
+QUERY_SQL_ANCHOR = "QueryBegin: SQL: "
 QUERY_SQL_RE = re.compile(
-    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] QueryBegin: (?P<sql>.*)$"
+    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] QueryBegin: SQL: (?P<sql>.*)$"
 )
 
 # --- Pipeline Overview block -------------------------------------------------

--- a/tools/log_analyzer/patterns.py
+++ b/tools/log_analyzer/patterns.py
@@ -14,7 +14,7 @@ that consumes this data can detect mismatched parser versions.
 
 import re
 
-SHAPE_VERSION = "1.2"
+SHAPE_VERSION = "1.3"
 
 # Timestamp at the start of every log line, e.g. "[2026-05-20 14:25:02.368]"
 TS_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\]")
@@ -27,6 +27,26 @@ DEBUG_TAG = "[debug]"
 # Example: "[2026-05-20 14:25:02.368] [info] [:] [query_pool] QueryBegin allocated=5242880 bytes peak=307232768 bytes free_blocks=5115"
 QUERY_BEGIN_ANCHOR = "[info] [:] [query_pool] QueryBegin allocated="
 QUERY_END_ANCHOR = "[info] [:] [query_pool] QueryEnd allocated="
+# Strict regex to extract stats from the host-pool boundary lines.
+QUERY_POOL_RE = re.compile(
+    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] \[query_pool\] "
+    r"(?P<tag>QueryBegin|QueryEnd) "
+    r"allocated=(?P<allocated_bytes>\d+) bytes "
+    r"peak=(?P<peak_bytes>\d+) bytes "
+    r"free_blocks=(?P<free_blocks>\d+)"
+)
+
+# --- GPU device memory pool stats at query boundaries (info-level) -----------
+# Example: "[2026-06-10 10:00:00.000] [info] [:] [gpu_pool] GPU:0 QueryBegin allocated=1234567890 bytes peak=1234567890 bytes reserved=1234567890 bytes"
+# One line per configured GPU; tag is QueryBegin or QueryEnd.
+GPU_POOL_ANCHOR = "[info] [:] [gpu_pool]"
+GPU_POOL_RE = re.compile(
+    r"\[(?P<ts>[\d\-: .]+)\] \[info\] \[[^\]]+\] \[gpu_pool\] "
+    r"GPU:(?P<gpu_id>\d+) (?P<tag>QueryBegin|QueryEnd) "
+    r"allocated=(?P<allocated_bytes>\d+) bytes "
+    r"peak=(?P<peak_bytes>\d+) bytes "
+    r"reserved=(?P<reserved_bytes>\d+) bytes"
+)
 
 # Example (old): "[2026-05-20 14:25:02.368] [info] [:] QueryBegin: with revenue_view as ..."
 # Example (new): "[2026-05-22 17:33:13.408] [info] [sirius_context.cpp:205] QueryBegin: select ..."

--- a/tools/log_analyzer/segmenter.py
+++ b/tools/log_analyzer/segmenter.py
@@ -1,9 +1,9 @@
 """Split a log file into analytical-SQL query segments.
 
-A "query" runs from a `[host_pool] QueryBegin allocated=` line to the
-matching `[host_pool] QueryEnd allocated=` line. The very next line after
-QueryBegin is expected to carry the SQL text (`QueryBegin: <sql>`); we keep
-only queries whose SQL (case-insensitive) starts with `select ` or `with `.
+A "query" runs from a `[host_pool] HOST:<id> QueryBegin` line to the
+matching `[host_pool] HOST:<id> QueryEnd` line. The SQL text is emitted on a
+separate line as `QueryBegin: SQL: <sql>`; we keep only queries whose SQL
+(case-insensitive) starts with `select ` or `with `.
 
 If a QueryBegin has no QueryEnd (log truncated, crash), the segment is still
 returned with status="incomplete" so downstream can analyze what was captured.
@@ -49,7 +49,7 @@ def segment(lines: List[str]) -> List[QuerySegment]:
     n = len(lines)
     while i < n:
         line = lines[i]
-        if patterns.QUERY_BEGIN_ANCHOR not in line:
+        if not patterns.is_query_begin_line(line):
             i += 1
             continue
 
@@ -83,12 +83,12 @@ def segment(lines: List[str]) -> List[QuerySegment]:
         end_ts = None
         stop_idx = None  # last line that belongs to this segment (inclusive)
         for k in range(sql_idx + 1, n):
-            if patterns.QUERY_END_ANCHOR in lines[k]:
+            if patterns.is_query_end_line(lines[k]):
                 end_idx = k
                 end_ts = _extract_ts(lines[k])
                 stop_idx = k
                 break
-            if patterns.QUERY_BEGIN_ANCHOR in lines[k]:
+            if patterns.is_query_begin_line(lines[k]):
                 # Next query started without our QueryEnd; mark incomplete and
                 # stop just before that next QueryBegin.
                 stop_idx = k - 1

--- a/tools/log_analyzer/segmenter.py
+++ b/tools/log_analyzer/segmenter.py
@@ -1,7 +1,7 @@
 """Split a log file into analytical-SQL query segments.
 
-A "query" runs from a `[query_pool] QueryBegin allocated=` line to the
-matching `[query_pool] QueryEnd allocated=` line. The very next line after
+A "query" runs from a `[host_pool] QueryBegin allocated=` line to the
+matching `[host_pool] QueryEnd allocated=` line. The very next line after
 QueryBegin is expected to carry the SQL text (`QueryBegin: <sql>`); we keep
 only queries whose SQL (case-insensitive) starts with `select ` or `with `.
 


### PR DESCRIPTION
Currently all deallocations happen on the stream on which they allocations were made. This PR adds an API which allows for changing that stream, so that deallocations can be made to happen on the active stream. This API is used when converting a data_batch from GPU to Host so that the deallocations happen on the downgrade executor's stream and not block other task execution streams. It also uses the rebind_stream API when preparing the data for a task to be executed. That way any  input data that is freed, gets deallocated there as well, minimizing  peak memory consumption.

This PR depends on https://github.com/NVIDIA/cuCascade/pull/146

This PR additionally ensures that only one downgrade executor monitor request can exist at a time. This prevents from too many back to back requests. 

It also improves logging of memory state at the beginning and end of a query so that we can monitor and check for memory leaks. 

