### PR TITLE
feat(join): adaptively build STANDARD MARK joins on the smaller side

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -105,6 +105,11 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
 
   mutable bool unique_probe_keys = false;
 
+  //! Row-count ratio gate for switching STANDARD-mode MARK joins to cudf::mark_join (build on the
+  //! left/output side) instead of filtered_join (build on the right side). Switch when
+  //! right_rows >= ratio * left_rows; 0 disables. Set from operator_params at planning time.
+  double mark_join_build_switch_ratio = config::DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO;
+
   static void build_join_pipelines(pipeline::sirius_pipeline& current,
                                    pipeline::sirius_meta_pipeline& meta_pipeline,
                                    sirius_physical_operator& op,

--- a/src/include/sirius_config.hpp
+++ b/src/include/sirius_config.hpp
@@ -42,6 +42,21 @@ constexpr uint64_t DEFAULT_MAX_BUILD_HASH_TABLE_BYTES = 500ULL * 1024 * 1024;  /
 /// Fraction of available GPU memory used per sort partition when max_sort_partition_bytes is 0.
 constexpr double DEFAULT_MAX_SORT_PARTITION_MEMORY_FRACTION = 0.33;
 
+/// Row-count ratio gate for switching STANDARD-mode MARK joins to cudf::mark_join (build on the
+/// left/output side) instead of cudf::filtered_join (build on the right side). mark_join only
+/// wins when the left side is much smaller than the right (probe) side.
+///
+/// Provenance: a standalone microbenchmark (see issue #510) compared filtered_join (build right,
+/// probe left) vs. mark_join (build left, probe right) — including the BOOL8 scatter that
+/// resolve_mark_join_result performs — across many left/right size ratios on an NVIDIA L4. The
+/// scatter cost was negligible and identical for both. filtered_join won at or near parity and
+/// only lost once the right side was roughly >= 3-4x the left side, i.e. when mark_join's build
+/// side (left) was substantially smaller. We default to 8.0 (well above the measured ~3-4x
+/// crossover) so the switch only triggers when it is a clear win, leaving headroom for the fact
+/// that the crossover is hardware- and workload-dependent. Recalibrate per GPU; set to 0 to
+/// disable (always use filtered_join).
+constexpr double DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO = 8.0;
+
 }  // namespace config
 
 /// Parameters controlling operator-level resource sizing.
@@ -72,6 +87,14 @@ struct operator_params {
   /// Maximum build-side bytes for switching to BUILD_PROBE join mode.
   /// May be larger than concat_batch_bytes; build-side batches will be concatenated if needed.
   uint64_t max_build_hash_table_bytes = config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES;
+
+  /// For STANDARD-mode MARK joins: build the hash table on the left/output side via
+  /// cudf::mark_join (instead of on the right side via filtered_join) when the right (probe)
+  /// side has at least this many times more rows than the left side. mark_join only wins when
+  /// the left side is substantially smaller; the crossover is hardware-dependent (~3-4x on an
+  /// L4 in the issue #510 microbenchmark, defaulted higher to stay conservative). Set to 0 to
+  /// disable (always use filtered_join).
+  double mark_join_build_switch_ratio = config::DEFAULT_MARK_JOIN_BUILD_SWITCH_RATIO;
 };
 
 struct telemetry_config {

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -20,6 +20,7 @@
 #include "cudf/join/distinct_hash_join.hpp"
 #include "cudf/join/filtered_join.hpp"
 #include "cudf/join/join.hpp"
+#include "cudf/join/mark_join.hpp"
 #include "cudf/join/mixed_join.hpp"
 #include "cudf/table/table_view.hpp"
 #include "cudf/types.hpp"
@@ -73,6 +74,15 @@ static cudf::filtered_join make_right_filtered_join(cudf::table_view const& righ
   return cudf::filtered_join(
     right_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
 #endif
+}
+
+// Build the semi-join hash table on the left/output side and probe with the (larger) right side.
+// Wins over make_right_filtered_join only when the left side is substantially smaller than the
+// right; gated by mark_join_build_switch_ratio at the call site.
+static cudf::mark_join make_left_mark_join(cudf::table_view const& left_keys,
+                                           rmm::cuda_stream_view stream)
+{
+  return cudf::mark_join(left_keys, cudf::null_equality::UNEQUAL, cudf::join_prefilter::NO, stream);
 }
 
 bool sirius_physical_hash_join::are_conditions_supported(
@@ -1188,7 +1198,27 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       right_indices             = filtered_join_object.anti_join(right_keys, stream);
     } else if (join_type == duckdb::JoinType::MARK) {
       // MARK join: output ALL left rows + a BOOL8 column indicating match presence.
-      // Use semi join to find which left rows have matches in the right table.
+      // Use a semi join to find which left rows have matches in the right table; both APIs
+      // return left-side match indices that resolve_mark_join_result scatters into the BOOL8 mark.
+      //
+      // Adaptive build side: filtered_join builds on the right; when the right (probe) side is
+      // much larger than the left (output) side, building on the smaller left via cudf::mark_join
+      // is faster (see issue #510 microbenchmark). Crossover is hardware-dependent and configured
+      // via operator_params::mark_join_build_switch_ratio (0 disables).
+      if (mark_join_build_switch_ratio > 0.0 && left_full.num_rows() > 0 &&
+          static_cast<double>(right_full.num_rows()) >=
+            mark_join_build_switch_ratio * static_cast<double>(left_full.num_rows())) {
+        SIRIUS_LOG_DEBUG(
+          "sirius_physical_hash_join id {}: MARK using cudf::mark_join (build on left, "
+          "left_rows={}, right_rows={})",
+          this->get_operator_id(),
+          left_full.num_rows(),
+          right_full.num_rows());
+        auto mark_join_object = make_left_mark_join(left_keys, stream);
+        auto semi_indices     = mark_join_object.semi_join(right_keys, stream);
+        return resolve_mark_join_result(
+          *semi_indices, left_full, lhs_output_columns.col_idxs, input_batches[0], stream);
+      }
       auto filtered_join_object = make_right_filtered_join(right_keys, stream);
       auto semi_indices         = filtered_join_object.semi_join(left_keys, stream);
       return resolve_mark_join_result(

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -328,8 +328,9 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
       op.estimated_cardinality,
       std::move(op.filter_pushdown),
       op_params.max_build_hash_table_bytes);
-    auto& hj      = join->Cast<sirius::op::sirius_physical_hash_join>();
-    hj.join_stats = std::move(op.join_stats);
+    auto& hj                        = join->Cast<sirius::op::sirius_physical_hash_join>();
+    hj.join_stats                   = std::move(op.join_stats);
+    hj.mark_join_build_switch_ratio = op_params.mark_join_build_switch_ratio;
 
     // --- Detect build-side key uniqueness ---
     // Gate: only for pure equal conditions (not_distinct_from needs null_equality::EQUAL).

--- a/src/sirius_config.cpp
+++ b/src/sirius_config.cpp
@@ -132,6 +132,7 @@ static void from_yaml(const YAML::Node& node, operator_params& opt)
   r.optional("concat_batch_bytes", yaml::bytes(opt.concat_batch_bytes));
   r.optional("sort_sample_bytes", yaml::bytes(opt.sort_sample_bytes));
   r.optional("max_build_hash_table_bytes", yaml::bytes(opt.max_build_hash_table_bytes));
+  r.optional("mark_join_build_switch_ratio", opt.mark_join_build_switch_ratio);
   r.reject_unknown();
 }
 

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1462,6 +1462,19 @@ static void SetMaxBuildHashTableBytes(ClientContext& context, SetScope scope, Va
                    params->max_build_hash_table_bytes);
 }
 
+static void SetMarkJoinBuildSwitchRatio(ClientContext& context, SetScope scope, Value& parameter)
+{
+  auto* params = get_operator_params(context);
+  if (!params) { return; }
+  const double ratio = parameter.GetValue<double>();
+  if (ratio < 0.0) {
+    throw InvalidInputException("mark_join_build_switch_ratio must be >= 0.0, got {}", ratio);
+  }
+  params->mark_join_build_switch_ratio = ratio;
+  SIRIUS_LOG_DEBUG("Updated config MARK_JOIN_BUILD_SWITCH_RATIO to {}",
+                   params->mark_join_build_switch_ratio);
+}
+
 static void SetEnableGpuExecution(ClientContext& context, SetScope scope, Value& parameter)
 {
   SIRIUS_LOG_DEBUG("Updated gpu_execution to {}", BooleanValue::Get(parameter));
@@ -1634,6 +1647,15 @@ void SiriusExtension::InitialGPUConfigs(DBConfig& config)
                             LogicalType::UBIGINT,
                             Value::UBIGINT(sirius::operator_params{}.max_build_hash_table_bytes),
                             SetMaxBuildHashTableBytes);
+
+  config.AddExtensionOption(
+    "mark_join_build_switch_ratio",
+    "For STANDARD-mode MARK joins, build on the left/output side via cudf::mark_join when the "
+    "right (probe) side has at least this many times more rows than the left side (0 disables). "
+    "Hardware-dependent — recalibrate per GPU.",
+    LogicalType::DOUBLE,
+    Value::DOUBLE(sirius::operator_params{}.mark_join_build_switch_ratio),
+    SetMarkJoinBuildSwitchRatio);
 
   config.AddExtensionOption(
     "gpu_execution",


### PR DESCRIPTION
## Status quo and proposal

Equality-only `MARK` joins always build the hash table on the **right** side (`cudf::filtered_join`) and probe with the left. When the right (probe) side is much larger than the left (output) side, building on the **smaller left** side via `cudf::mark_join` and probing with the right is faster.

Closes #920 

## Observations

- `cudf::mark_join` gives us build side indices while building on that very same side.
- `cudf::filtered_join` gives us left rows indices while building on the right side.

| API | Builds hash on | Probes with | **Indices returned** | Use when (smaller side) |
|-----|----------------|-------------|----------------------|--------------------------|
| `cudf::filtered_join` | right (filter) | left | **probe-side** indices | right is smaller → build on right, get left (probe) indices |
| `cudf::mark_join` | left | right | **build-side** indices | left is smaller → build on left, get left (build) indices |

## Changes

An adaptive, output-identical switch:

- New `operator_params::mark_join_build_switch_ratio` (default `8.0`), settable via YAML and the  `mark_join_build_switch_ratio` `SET` option (`0` disables).
- Equality-only `MARK` joins use `cudf::mark_join` when `right_rows >= ratio * left_rows`; otherwise they keep using `cudf::filtered_join`.
- Both paths feed the same `resolve_mark_join_result(...)`, so only the hashed side changes — the output (all left rows + BOOL8 mark column) is identical.

## Benchmark (NVIDIA L4, cuDF 26.06, int32 keys, ~39% match)

Standalone microbenchmark of `filtered_join` (build right) vs. `cudf::mark_join` (build left), including the BOOL8 scatter.

| left rows | right rows | right/left | filtered total (ms) | mark total (ms) | winner |
|----------:|-----------:|-----------:|--------------------:|----------------:|--------|
| 10M | 10M | 1.0  | 11.97 | 24.63 | filtered (2.1x) |
| 4M  | 10M | 2.5  |  9.09 | 11.68 | filtered (1.3x) |
| 3M  | 10M | 3.3  |  8.59 |  8.27 | mark (1.04x)    |
| 2M  | 10M | 5.0  |  8.12 |  3.65 | mark (2.2x)     |
| 1M  | 10M | 10.0 |  7.60 |  1.92 | mark (4.0x)     |

Crossover sits near `right/left ≈ 3.3`; scatter cost was negligible and identical for both. The default `8.0` is set well above the crossover so the switch fires only on a clear win, leaving margin since the crossover is hardware- and workload-dependent.

## Scope

Limited to the `MARK` path (issue #510). `SEMI`/`ANTI` in STANDARD mode have a different per-task batch structure and are left unchanged. A calibration-based approach is planned as a separate engine-level effort.

## Test plan

- [x] `pixi run make test` passes; existing `MARK` correctness tests unchanged (output identical by
      construction).
- [ ] `SET mark_join_build_switch_ratio = 0;` reproduces prior `filtered_join` behavior; a large
      right/left ratio routes through `cudf::mark_join` (debug log).
