### PR TITLE
feat(join): enable BUILD_PROBE mode for MARK joins

### DIFF
--- a/src/include/op/sirius_physical_hash_join.hpp
+++ b/src/include/op/sirius_physical_hash_join.hpp
@@ -18,6 +18,7 @@
 
 #include "cudf/cudf_utils.hpp"
 #include "cudf/join/distinct_hash_join.hpp"
+#include "cudf/join/filtered_join.hpp"
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/execution/join_hashtable.hpp"
 #include "duckdb/execution/operator/join/perfect_hash_join_executor.hpp"
@@ -179,6 +180,8 @@ class sirius_physical_hash_join : public sirius_physical_partition_consumer_oper
   std::unique_ptr<cudf::hash_join> _hash_table;  // hash object to be used in BUILD_PROBE mode
   std::unique_ptr<cudf::distinct_hash_join>
     _distinct_hash_table;  // used instead of _hash_table when build keys are proven unique
+  std::unique_ptr<cudf::filtered_join>
+    _filtered_table;  // reusable build-on-right semi-join object for MARK joins in BUILD_PROBE mode
   std::optional<::cucascade::read_only_data_batch>
     _build_table;  // owned build table for BUILD_PROBE mode, to materialize build side results
   std::vector<std::unique_ptr<cudf::column>>

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -76,6 +76,19 @@ static cudf::filtered_join make_right_filtered_join(cudf::table_view const& righ
 #endif
 }
 
+// Heap-allocated variant for BUILD_PROBE mode, where one filtered_join is built once on the right
+// (filter) keys and reused across many streamed left probe batches via semi_join.
+static std::unique_ptr<cudf::filtered_join> make_right_filtered_join_ptr(
+  cudf::table_view const& right_keys, rmm::cuda_stream_view stream)
+{
+#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 8)
+  return std::make_unique<cudf::filtered_join>(right_keys, cudf::null_equality::UNEQUAL, stream);
+#else
+  return std::make_unique<cudf::filtered_join>(
+    right_keys, cudf::null_equality::UNEQUAL, cudf::set_as_build_table::RIGHT, stream);
+#endif
+}
+
 // Build the semi-join hash table on the left/output side and probe with the (larger) right side.
 // Wins over make_right_filtered_join only when the left side is substantially smaller than the
 // right; gated by mark_join_build_switch_ratio at the call site.
@@ -400,11 +413,14 @@ void sirius_physical_hash_join::update_join_exec_mode(int num_partitions,
                                                       bool build_foldable_to_single_batch)
 {
   std::lock_guard<std::mutex> lg(op_state_mutex);
+  // MARK joins are eligible for BUILD_PROBE: a persistent cudf::filtered_join is built once on the
+  // right (filter) side and reused across streamed left probe batches via semi_join.
+  // SEMI/ANTI/RIGHT remain excluded (handled in STANDARD mode for now).
   if (num_partitions == 1 && build_side_bytes < _max_build_hash_table_bytes &&
       build_foldable_to_single_batch && join_type != duckdb::JoinType::SEMI &&
       join_type != duckdb::JoinType::RIGHT_SEMI && join_type != duckdb::JoinType::ANTI &&
       join_type != duckdb::JoinType::RIGHT_ANTI && join_type != duckdb::JoinType::RIGHT &&
-      join_type != duckdb::JoinType::MARK && _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
+      _join_mode != HASH_JOIN_MODE::MIXED_JOIN) {
     // Switch to a more efficient join strategy for small datasets. The
     // build_foldable_to_single_batch gate matches the runtime invariant in
     // get_next_task_input_data_for_build_probe — BUILD_PROBE requires the
@@ -903,8 +919,15 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
         _build_table              = build_batch_ro;
-        if (unique_build_keys &&
-            (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
+        if (join_type == duckdb::JoinType::MARK) {
+          // MARK: build a reusable filtered_join on the right (filter) keys; each probe batch's
+          // semi_join returns left-row match indices for resolve_mark_join_result.
+          _filtered_table = make_right_filtered_join_ptr(build_keys, stream);
+          SIRIUS_LOG_DEBUG(
+            "sirius_physical_hash_join id {}: using filtered_join (BUILD_PROBE MARK)",
+            this->get_operator_id());
+        } else if (unique_build_keys &&
+                   (join_type == duckdb::JoinType::INNER || join_type == duckdb::JoinType::LEFT)) {
           _distinct_hash_table = std::make_unique<cudf::distinct_hash_join>(
             build_keys, cudf::null_equality::UNEQUAL, 0.5, stream);
           SIRIUS_LOG_DEBUG(
@@ -930,7 +953,16 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                  stream);
       cudf::table_view probe_keys = probe_keys_result.keys;
 
-      left_full  = get_cudf_table_view(input_batches[0]);
+      left_full = get_cudf_table_view(input_batches[0]);
+
+      if (join_type == duckdb::JoinType::MARK) {
+        // Reuse the persistent filtered_join (built on the right/filter side): probe with this left
+        // batch to get its matched left-row indices, then materialize all left rows + BOOL8 mark.
+        auto semi_indices = _filtered_table->semi_join(probe_keys, stream);
+        return resolve_mark_join_result(
+          *semi_indices, left_full, lhs_output_columns.col_idxs, input_batches[0], stream);
+      }
+
       right_full = _build_table.value()
                      .get_data()
                      ->cast<cucascade::gpu_table_representation>()
@@ -1250,6 +1282,7 @@ void sirius_physical_hash_join::on_finalize_operator()
   if (_join_mode == HASH_JOIN_MODE::BUILD_PROBE) {
     _hash_table.reset();
     _distinct_hash_table.reset();
+    _filtered_table.reset();
     _build_table = std::nullopt;
     _built_table_cast_columns.clear();
     _hash_table_build_state = BUILD_HASH_TABLE_STATE::DESTROYED;

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -1631,6 +1631,40 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
     "on n.n_nationkey = c.c_nationkey;");
 }
 
+//===----------------------------------------------------------------------===//
+// MARK join tests (issue #921: BUILD_PROBE mode for MARK join)
+//
+// `OR` combined with `IN (subquery)`, and `IN (subquery)` projected as a value,
+// both lower to a HASH_JOIN with "Join Type: MARK" in DuckDB. A large probe
+// (orders, 150k) over a small build/filter subquery (customer subset) drives the
+// planner into BUILD_PROBE, where one cudf::filtered_join is built on the right
+// (filter) side and reused across the streamed left probe batches.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - mark join via OR + IN subquery parquet",
+                 "[integration][gpu_execution][parquet][markjoin]")
+{
+  // OR forces the IN membership to be materialized as a MARK join rather than a
+  // semi join; the customer subset is the small build side.
+  compare_gpu_vs_cpu(
+    "select count(*) as n from orders "
+    "where o_orderkey < 0 "
+    "   or o_custkey in (select c_custkey from customer where c_nationkey < 3);");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - mark join via projected IN subquery parquet",
+                 "[integration][gpu_execution][parquet][markjoin]")
+{
+  // Projecting the IN result as a boolean value produces a MARK join; grouping on
+  // the mark exercises both the matched (true) and unmatched (false) partitions.
+  compare_gpu_vs_cpu(
+    "select (o_custkey in (select c_custkey from customer where c_nationkey < 3)) as is_member, "
+    "       count(*) as n "
+    "from orders group by 1 order by 1;");
+}
+
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - basic semi join misfit 0",
                  "[integration][gpu_execution][semijoin]")

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -250,3 +250,40 @@ TEST_CASE("sirius_physical_hash_join mark join - duplicate keys on right side",
   REQUIRE(copy_column_to_host<int32_t>(out_view.column(1)) == left_payload);
   REQUIRE(copy_column_to_host<bool>(out_view.column(2)) == std::vector<bool>{false, true, false});
 }
+
+TEST_CASE("sirius_physical_hash_join mark join - build-on-left (cudf::mark_join) path",
+          "[physical_mark_join]")
+{
+  auto* space = get_shared_mem_space();
+  REQUIRE(space);
+
+  std::vector<int32_t> left_ids     = {10, 20, 30, 40};
+  std::vector<int32_t> left_payload = {1, 2, 3, 4};
+  auto left_batch                   = make_two_column_batch<int32_t, int32_t>(
+    *space, left_ids, left_payload, cudf::type_id::INT32, std::nullopt, cudf::type_id::INT32);
+
+  // Right (probe) side is larger than the left (output) side; only {20, 40} match.
+  std::vector<int32_t> right_ids = {20, 40, 11, 12, 13, 14, 15, 16};
+  auto right_batch = make_numeric_batch<int32_t>(*space, right_ids, cudf::type_id::INT32);
+
+  auto f = create_mark_join();
+  // Force the adaptive switch: with ratio 1.0 and right_rows (8) >= left_rows (4), the join must
+  // build on the left via cudf::mark_join and probe with the right. Output must stay identical to
+  // the filtered_join path.
+  f.hash_join->mark_join_build_switch_ratio = 1.0;
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> inputs{left_batch, right_batch};
+  auto outputs =
+    f.hash_join->execute(pipelineable_operator_data(inputs), cudf::get_default_stream());
+
+  REQUIRE(dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches().size() == 1);
+  auto out_view = sirius::get_cudf_table_view(
+    *dynamic_cast<const pipelineable_operator_data&>(*outputs).get_data_batches()[0]);
+  REQUIRE(out_view.num_columns() == 3);
+  REQUIRE(out_view.num_rows() == static_cast<cudf::size_type>(left_ids.size()));
+
+  REQUIRE(copy_column_to_host<int32_t>(out_view.column(0)) == left_ids);
+  REQUIRE(copy_column_to_host<int32_t>(out_view.column(1)) == left_payload);
+  REQUIRE(copy_column_to_host<bool>(out_view.column(2)) ==
+          std::vector<bool>{false, true, false, true});
+}


### PR DESCRIPTION
## Summary

Enables Sirius's `BUILD_PROBE` execution mode for `MARK` joins — closes #921 (follow-up to #510 / #924).

Previously `MARK` was explicitly excluded from `BUILD_PROBE` and always ran STANDARD single-shot. With a small build/filter side and a large probe side, a `MARK` join now builds **one** reusable `cudf::filtered_join` on the right (filter) keys and probes it with each streamed left batch, reusing the hash table across probes — the same reuse model the other join types already use in `BUILD_PROBE`.

## Why `cudf::filtered_join` (and not `cudf::mark_join`)

In `BUILD_PROBE` the persistent hash table lives on the **right** side and we need **left-row** match indices for the mark column:

| API | builds on | `semi_join` returns | fits BUILD_PROBE MARK? |
|---|---|---|---|
| `cudf::filtered_join` | right (filter) | probe-side = **left** indices | ✅ yes |
| `cudf::mark_join` | left | build-side = **left**, but build must be left | ❌ would require building on left, breaking reuse-on-right |

So `filtered_join` is the only one that keeps the reusable table on the right while still yielding left-row marks. Both branches funnel through the existing `resolve_mark_join_result` to scatter matches into the `BOOL8` mark.

## Changes

- Drop the `MARK` exclusion from `update_join_exec_mode` (SEMI / ANTI / RIGHT remain excluded).
- Persist `std::unique_ptr<cudf::filtered_join> _filtered_table`; build it once on the right keys in the BUILD_PROBE build phase.
- Probe phase: `_filtered_table->semi_join(probe_keys)` → `resolve_mark_join_result` to emit all left rows + the mark.
- Reset `_filtered_table` in `on_finalize_operator`.

## Testing

- New `[markjoin]` integration tests in `test_gpu_execution_tpch.cpp` cover both MARK-producing shapes — `OR + IN` and projected `IN` — over a 150k-row probe (`orders`) against a small build subset (`customer` where `c_nationkey < 3`); both compare GPU vs CPU.
- Debug logs confirm the new path runs: `using filtered_join (BUILD_PROBE MARK)`.
- Regression: `[physical_mark_join] [semijoin] [markjoin] [hash_join] [join]` — 127 cases pass.

## Merge order

Stacked on #924 — **merge after #924 lands**. Until then this PR's diff also shows #924's two commits; they drop out automatically once #924 is merged into `dev`.