### PR TITLE
refactor(expression): factor out shared helpers in expr ast code paths     

### DIFF
--- a/src/expression/ast/utils.cpp
+++ b/src/expression/ast/utils.cpp
@@ -32,48 +32,28 @@ namespace sirius::ast {
 
 namespace {
 
-// Deep-clone a single optional child node owner.
-std::unique_ptr<node> clone_child(std::unique_ptr<node> const& child)
-{
-  return child ? clone(*child) : nullptr;
-}
-
-// Deep-clone a vector of child node owners.
-std::vector<std::unique_ptr<node>> clone_children(
-  std::vector<std::unique_ptr<node>> const& children)
+// Map a child-owner transform over a vector of child node owners.
+template <class Xform>
+std::vector<std::unique_ptr<node>> rebuild_children(
+  std::vector<std::unique_ptr<node>> const& children, Xform const& xform)
 {
   std::vector<std::unique_ptr<node>> out;
   out.reserve(children.size());
-  std::ranges::transform(children, std::back_inserter(out), clone_child);
+  std::ranges::transform(children, std::back_inserter(out), xform);
   return out;
 }
 
-// Recurse into an optional child; null slots stay null.
-std::unique_ptr<node> substitute_child(std::unique_ptr<node> const& child,
-                                       std::vector<std::unique_ptr<node>> const& inner_select_list)
-{
-  return child ? substitute_references(*child, inner_select_list) : nullptr;
-}
-
-// Apply substitute_child to every element of a child vector.
-std::vector<std::unique_ptr<node>> substitute_children(
-  std::vector<std::unique_ptr<node>> const& children,
-  std::vector<std::unique_ptr<node>> const& inner_select_list)
-{
-  std::vector<std::unique_ptr<node>> out;
-  out.reserve(children.size());
-  std::ranges::transform(children, std::back_inserter(out), [&](auto const& child) {
-    return substitute_child(child, inner_select_list);
-  });
-  return out;
-}
-
-}  // namespace
-
-std::unique_ptr<node> clone(node const& src)
+// Reconstruct @p src by rebuilding each held alternative, routing every owned
+// child through @p xform (which maps a `unique_ptr<node> const&` to a freshly
+// built child owner; null slots stay null). Both clone() and
+// substitute_references() share this single set of per-alternative arms; they
+// differ only in the child transform and in how the `reference` arm is handled
+// (clone copies it; substitute_references remaps it before delegating here).
+template <class Xform>
+std::unique_ptr<node> rebuild(node const& src, Xform const& xform)
 {
   return std::visit(
-    [](auto const& alt) -> std::unique_ptr<node> {
+    [&](auto const& alt) -> std::unique_ptr<node> {
       using T = std::decay_t<decltype(alt)>;
 
       if constexpr (std::is_same_v<T, reference>) {
@@ -81,46 +61,57 @@ std::unique_ptr<node> clone(node const& src)
       } else if constexpr (std::is_same_v<T, constant>) {
         return std::make_unique<node>(constant{alt.payload, alt.return_type});
       } else if constexpr (std::is_same_v<T, comparison>) {
-        return std::make_unique<node>(
-          comparison{alt.op, clone_child(alt.left), clone_child(alt.right)});
+        return std::make_unique<node>(comparison{alt.op, xform(alt.left), xform(alt.right)});
       } else if constexpr (std::is_same_v<T, conjunction>) {
-        return std::make_unique<node>(conjunction{alt.op, clone_children(alt.children)});
+        return std::make_unique<node>(conjunction{alt.op, rebuild_children(alt.children, xform)});
       } else if constexpr (std::is_same_v<T, between>) {
-        return std::make_unique<node>(between{clone_child(alt.input),
-                                              clone_child(alt.lower),
-                                              clone_child(alt.upper),
+        return std::make_unique<node>(between{xform(alt.input),
+                                              xform(alt.lower),
+                                              xform(alt.upper),
                                               alt.lower_inclusive,
                                               alt.upper_inclusive});
       } else if constexpr (std::is_same_v<T, case_expr>) {
         std::vector<case_expr::when_then> cases;
         cases.reserve(alt.cases.size());
         for (auto const& wt : alt.cases) {
-          cases.push_back(case_expr::when_then{clone_child(wt.when_), clone_child(wt.then_)});
+          cases.push_back(case_expr::when_then{xform(wt.when_), xform(wt.then_)});
         }
         return std::make_unique<node>(
-          case_expr{std::move(cases), clone_child(alt.else_), alt.return_type()});
+          case_expr{std::move(cases), xform(alt.else_), alt.return_type()});
       } else if constexpr (std::is_same_v<T, cast>) {
-        return std::make_unique<node>(cast{clone_child(alt.child), alt.target_type, alt.try_cast});
+        return std::make_unique<node>(cast{xform(alt.child), alt.target_type, alt.try_cast});
       } else if constexpr (std::is_same_v<T, unary_op>) {
-        return std::make_unique<node>(unary_op{alt.op, clone_child(alt.child)});
+        return std::make_unique<node>(unary_op{alt.op, xform(alt.child)});
       } else if constexpr (std::is_same_v<T, coalesce>) {
-        return std::make_unique<node>(coalesce{clone_children(alt.children), alt.return_type()});
+        return std::make_unique<node>(
+          coalesce{rebuild_children(alt.children, xform), alt.return_type()});
       } else if constexpr (std::is_same_v<T, in_list>) {
         return std::make_unique<node>(
-          in_list{clone_child(alt.probe), clone_children(alt.values), alt.negated});
+          in_list{xform(alt.probe), rebuild_children(alt.values, xform), alt.negated});
       } else if constexpr (std::is_same_v<T, function_call>) {
-        return std::make_unique<node>(
-          function_call{alt.function(), clone_children(alt.arguments()), alt.return_type()});
+        return std::make_unique<node>(function_call{
+          alt.function(), rebuild_children(alt.arguments(), xform), alt.return_type()});
       } else if constexpr (std::is_same_v<T, aggregate>) {
-        return std::make_unique<node>(aggregate{
-          alt.function(), clone_children(alt.arguments()), alt.return_type(), alt.distinct()});
+        return std::make_unique<node>(aggregate{alt.function(),
+                                                rebuild_children(alt.arguments(), xform),
+                                                alt.return_type(),
+                                                alt.distinct()});
       } else {
         static_assert(sizeof(T) == 0,
-                      "Unhandled sirius::ast alternative in clone(node) — add a clone arm "
+                      "Unhandled sirius::ast alternative in rebuild(node) — add an arm "
                       "for the new variant member");
       }
     },
     src.v);
+}
+
+}  // namespace
+
+std::unique_ptr<node> clone(node const& src)
+{
+  return rebuild(src, [](std::unique_ptr<node> const& child) -> std::unique_ptr<node> {
+    return child ? clone(*child) : nullptr;
+  });
 }
 
 // Deep-copy @p src, remapping every reference #i to a clone of inner_select_list[i].
@@ -130,73 +121,19 @@ std::unique_ptr<node> clone(node const& src)
 std::unique_ptr<node> substitute_references(
   node const& src, std::vector<std::unique_ptr<node>> const& inner_select_list)
 {
-  return std::visit(
-    [&](auto const& alt) -> std::unique_ptr<node> {
-      using T = std::decay_t<decltype(alt)>;
-
-      if constexpr (std::is_same_v<T, reference>) {
-        // Out-of-range or null inner slots are left unchanged — a null slot is the
-        // from_duckdb signal for an unsupported expression and must not be folded through.
-        if (alt.column_index >= inner_select_list.size() || !inner_select_list[alt.column_index]) {
-          return clone(src);
-        }
-        // Each outer reference site gets its own clone; duplicate sites duplicate work.
-        return clone(*inner_select_list[alt.column_index]);
-      } else if constexpr (std::is_same_v<T, constant>) {
-        return std::make_unique<node>(constant{alt.payload, alt.return_type});
-      } else if constexpr (std::is_same_v<T, comparison>) {
-        return std::make_unique<node>(comparison{alt.op,
-                                                 substitute_child(alt.left, inner_select_list),
-                                                 substitute_child(alt.right, inner_select_list)});
-      } else if constexpr (std::is_same_v<T, conjunction>) {
-        return std::make_unique<node>(
-          conjunction{alt.op, substitute_children(alt.children, inner_select_list)});
-      } else if constexpr (std::is_same_v<T, between>) {
-        return std::make_unique<node>(between{substitute_child(alt.input, inner_select_list),
-                                              substitute_child(alt.lower, inner_select_list),
-                                              substitute_child(alt.upper, inner_select_list),
-                                              alt.lower_inclusive,
-                                              alt.upper_inclusive});
-      } else if constexpr (std::is_same_v<T, case_expr>) {
-        std::vector<case_expr::when_then> cases;
-        cases.reserve(alt.cases.size());
-        for (auto const& wt : alt.cases) {
-          cases.push_back(case_expr::when_then{substitute_child(wt.when_, inner_select_list),
-                                               substitute_child(wt.then_, inner_select_list)});
-        }
-        return std::make_unique<node>(case_expr{
-          std::move(cases), substitute_child(alt.else_, inner_select_list), alt.return_type()});
-      } else if constexpr (std::is_same_v<T, cast>) {
-        return std::make_unique<node>(
-          cast{substitute_child(alt.child, inner_select_list), alt.target_type, alt.try_cast});
-      } else if constexpr (std::is_same_v<T, unary_op>) {
-        return std::make_unique<node>(
-          unary_op{alt.op, substitute_child(alt.child, inner_select_list)});
-      } else if constexpr (std::is_same_v<T, coalesce>) {
-        return std::make_unique<node>(
-          coalesce{substitute_children(alt.children, inner_select_list), alt.return_type()});
-      } else if constexpr (std::is_same_v<T, in_list>) {
-        return std::make_unique<node>(in_list{substitute_child(alt.probe, inner_select_list),
-                                              substitute_children(alt.values, inner_select_list),
-                                              alt.negated});
-      } else if constexpr (std::is_same_v<T, function_call>) {
-        return std::make_unique<node>(
-          function_call{alt.function(),
-                        substitute_children(alt.arguments(), inner_select_list),
-                        alt.return_type()});
-      } else if constexpr (std::is_same_v<T, aggregate>) {
-        return std::make_unique<node>(
-          aggregate{alt.function(),
-                    substitute_children(alt.arguments(), inner_select_list),
-                    alt.return_type(),
-                    alt.distinct()});
-      } else {
-        static_assert(sizeof(T) == 0,
-                      "Unhandled sirius::ast alternative in substitute_references — add a "
-                      "substitute arm for the new variant member");
-      }
-    },
-    src.v);
+  if (src.holds<reference>()) {
+    auto const& ref = src.get<reference>();
+    // Out-of-range or null inner slots are left unchanged — a null slot is the
+    // from_duckdb signal for an unsupported expression and must not be folded through.
+    if (ref.column_index >= inner_select_list.size() || !inner_select_list[ref.column_index]) {
+      return clone(src);
+    }
+    // Each outer reference site gets its own clone; duplicate sites duplicate work.
+    return clone(*inner_select_list[ref.column_index]);
+  }
+  return rebuild(src, [&](std::unique_ptr<node> const& child) -> std::unique_ptr<node> {
+    return child ? substitute_references(*child, inner_select_list) : nullptr;
+  });
 }
 
 }  // namespace sirius::ast

--- a/src/expression/from_duckdb.cpp
+++ b/src/expression/from_duckdb.cpp
@@ -53,13 +53,33 @@
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 
 // standard library
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace sirius::ast {
 
 namespace {
+
+// Translate a sequence of DuckDB child expressions (skipping the first @p start
+// entries), short-circuiting to std::nullopt the moment any child is
+// unsupported (i.e. from_duckdb returns null). Callers treat nullopt as "this
+// whole expression is unsupported" and propagate a null node upward.
+template <class Children>
+std::optional<std::vector<std::unique_ptr<node>>> translate_children(Children const& children,
+                                                                     std::size_t start = 0)
+{
+  std::vector<std::unique_ptr<node>> out;
+  out.reserve(children.size() > start ? children.size() - start : 0);
+  for (std::size_t i = start; i < children.size(); ++i) {
+    auto translated = from_duckdb(*children[i]);
+    if (!translated) { return std::nullopt; }
+    out.push_back(std::move(translated));
+  }
+  return out;
+}
 
 std::unique_ptr<node> translate_reference(duckdb::BoundReferenceExpression const& expr)
 {
@@ -108,14 +128,9 @@ std::unique_ptr<node> translate_conjunction(duckdb::BoundConjunctionExpression c
     case duckdb::ExpressionType::CONJUNCTION_OR: op = conjunction::kind::op_or; break;
     default: return nullptr;
   }
-  std::vector<std::unique_ptr<node>> children;
-  children.reserve(expr.children.size());
-  for (auto const& child : expr.children) {
-    auto translated = from_duckdb(*child);
-    if (!translated) { return nullptr; }
-    children.push_back(std::move(translated));
-  }
-  return std::make_unique<node>(conjunction{op, std::move(children)});
+  auto children = translate_children(expr.children);
+  if (!children) { return nullptr; }
+  return std::make_unique<node>(conjunction{op, std::move(*children)});
 }
 
 std::unique_ptr<node> translate_between(duckdb::BoundBetweenExpression const& expr)
@@ -165,32 +180,22 @@ std::unique_ptr<node> translate_function(duckdb::BoundFunctionExpression const& 
 {
   auto func_id_opt = sirius::from_duckdb_function_name(expr.function.name);
   if (!func_id_opt.has_value()) { return nullptr; }
-  std::vector<std::unique_ptr<node>> arguments;
-  arguments.reserve(expr.children.size());
-  for (auto const& child : expr.children) {
-    auto translated = from_duckdb(*child);
-    if (!translated) { return nullptr; }
-    arguments.push_back(std::move(translated));
-  }
+  auto arguments = translate_children(expr.children);
+  if (!arguments) { return nullptr; }
   auto return_type = sirius::from_duckdb(expr.return_type);
   return std::make_unique<node>(
-    function_call{*func_id_opt, std::move(arguments), std::move(return_type)});
+    function_call{*func_id_opt, std::move(*arguments), std::move(return_type)});
 }
 
 std::unique_ptr<node> translate_aggregate(duckdb::BoundAggregateExpression const& aggr)
 {
   auto agg_id_opt = sirius::from_duckdb_aggregate_name(aggr.function.name);
   if (!agg_id_opt.has_value()) { return nullptr; }
-  std::vector<std::unique_ptr<node>> arguments;
-  arguments.reserve(aggr.children.size());
-  for (auto const& child : aggr.children) {
-    auto translated = from_duckdb(*child);
-    if (!translated) { return nullptr; }
-    arguments.push_back(std::move(translated));
-  }
+  auto arguments = translate_children(aggr.children);
+  if (!arguments) { return nullptr; }
   auto return_type = sirius::from_duckdb(aggr.return_type);
   return std::make_unique<node>(
-    aggregate{*agg_id_opt, std::move(arguments), std::move(return_type), aggr.IsDistinct()});
+    aggregate{*agg_id_opt, std::move(*arguments), std::move(return_type), aggr.IsDistinct()});
 }
 
 std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& expr)
@@ -216,15 +221,10 @@ std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& 
   }
 
   if (op_type == duckdb::ExpressionType::OPERATOR_COALESCE) {
-    std::vector<std::unique_ptr<node>> children;
-    children.reserve(expr.children.size());
-    for (auto const& child : expr.children) {
-      auto translated = from_duckdb(*child);
-      if (!translated) { return nullptr; }
-      children.push_back(std::move(translated));
-    }
+    auto children = translate_children(expr.children);
+    if (!children) { return nullptr; }
     return std::make_unique<node>(
-      coalesce{std::move(children), sirius::from_duckdb(expr.return_type)});
+      coalesce{std::move(*children), sirius::from_duckdb(expr.return_type)});
   }
 
   if (op_type == duckdb::ExpressionType::COMPARE_IN ||
@@ -232,16 +232,11 @@ std::unique_ptr<node> translate_operator(duckdb::BoundOperatorExpression const& 
     D_ASSERT(!expr.children.empty());
     auto probe = from_duckdb(*expr.children[0]);
     if (!probe) { return nullptr; }
-    std::vector<std::unique_ptr<node>> values;
-    values.reserve(expr.children.size() > 0 ? expr.children.size() - 1 : 0);
-    for (size_t i = 1; i < expr.children.size(); ++i) {
-      auto translated = from_duckdb(*expr.children[i]);
-      if (!translated) { return nullptr; }
-      values.push_back(std::move(translated));
-    }
+    auto values = translate_children(expr.children, /*start=*/1);
+    if (!values) { return nullptr; }
     return std::make_unique<node>(in_list{
       /*probe=*/std::move(probe),
-      /*values=*/std::move(values),
+      /*values=*/std::move(*values),
       /*negated=*/op_type == duckdb::ExpressionType::COMPARE_NOT_IN,
     });
   }

--- a/src/expression/join_condition.cpp
+++ b/src/expression/join_condition.cpp
@@ -25,7 +25,6 @@
 // standard library
 #include <stdexcept>
 #include <string>
-#include <utility>
 
 namespace sirius {
 
@@ -64,16 +63,31 @@ duckdb::ExpressionType to_duckdb(comparison_type c)
                            std::to_string(static_cast<int>(c)));
 }
 
+namespace {
+
+// Shared per-condition construction for both wrap_join_conditions overloads.
+// Each side's bound expression is translated to a Sirius AST node and the
+// comparison operator is mapped across; the overloads differ only in their
+// container type, which this helper is agnostic to. Takes a non-const
+// reference to mirror the by-value/drain contract of the callers (the input
+// conditions vector is consumed at the call boundary).
+join_condition wrap_one(duckdb::JoinCondition& c)
+{
+  return join_condition{
+    sirius::ast::from_duckdb(*c.left),
+    sirius::ast::from_duckdb(*c.right),
+    from_duckdb(c.comparison),
+  };
+}
+
+}  // namespace
+
 std::vector<join_condition> wrap_join_conditions(std::vector<duckdb::JoinCondition> conds)
 {
   std::vector<join_condition> out;
   out.reserve(conds.size());
   for (auto& c : conds) {
-    out.push_back(join_condition{
-      sirius::ast::from_duckdb(*c.left),
-      sirius::ast::from_duckdb(*c.right),
-      from_duckdb(c.comparison),
-    });
+    out.push_back(wrap_one(c));
   }
   return out;
 }
@@ -83,11 +97,7 @@ duckdb::vector<join_condition> wrap_join_conditions(duckdb::vector<duckdb::JoinC
   duckdb::vector<join_condition> out;
   out.reserve(conds.size());
   for (auto& c : conds) {
-    out.push_back(join_condition{
-      sirius::ast::from_duckdb(*c.left),
-      sirius::ast::from_duckdb(*c.right),
-      from_duckdb(c.comparison),
-    });
+    out.push_back(wrap_one(c));
   }
   return out;
 }

--- a/test/cpp/expression/ast_test_builders.hpp
+++ b/test/cpp/expression/ast_test_builders.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Shared construction shortcuts for the sirius::ast expression tests. Two small
+// families live here so the per-test-file copies do not drift:
+//   * Sirius AST node builders   — used by the to_duckdb / clone / substitute tests.
+//   * DuckDB bound-expression builders — inputs to the from_duckdb translator tests.
+
+// sirius
+#include "expression/ast/constant.hpp"
+#include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
+#include "expression/value.hpp"
+#include "helper/logical_type.hpp"
+
+// duckdb
+#include <duckdb/common/types/value.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+
+// standard library
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace sirius::ast::test {
+
+// ----------------------------------------------------------------------------
+// Sirius AST node builders
+// ----------------------------------------------------------------------------
+
+// Build a reference node. `type` defaults to the SQLNULL placeholder, matching
+// a default-constructed reference (column_index is all most tests assert on).
+inline std::unique_ptr<node> make_ref(uint32_t idx, sirius::logical_type type = {})
+{
+  return std::make_unique<node>(reference{idx, std::move(type)});
+}
+
+inline std::unique_ptr<node> make_int_const(int32_t v)
+{
+  return std::make_unique<node>(constant{
+    /*payload=*/sirius::value{v},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
+  });
+}
+
+inline std::unique_ptr<node> make_str_const(std::string s)
+{
+  return std::make_unique<node>(constant{
+    /*payload=*/sirius::value{std::move(s)},
+    /*return_type=*/sirius::logical_type::make(sirius::type_id::VARCHAR),
+  });
+}
+
+// ----------------------------------------------------------------------------
+// DuckDB bound-expression builders (inputs to sirius::ast::from_duckdb)
+// ----------------------------------------------------------------------------
+
+inline duckdb::unique_ptr<duckdb::BoundReferenceExpression> make_bound_ref(
+  uint32_t idx, duckdb::LogicalTypeId type = duckdb::LogicalTypeId::INTEGER)
+{
+  return duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType{type}, idx);
+}
+
+inline duckdb::unique_ptr<duckdb::BoundConstantExpression> make_bound_int_const(int32_t v)
+{
+  return duckdb::make_uniq<duckdb::BoundConstantExpression>(duckdb::Value::INTEGER(v));
+}
+
+}  // namespace sirius::ast::test

--- a/test/cpp/expression/test_ast_from_duckdb.cpp
+++ b/test/cpp/expression/test_ast_from_duckdb.cpp
@@ -23,6 +23,7 @@
 // table. One additional case exercises the translator on a real DuckDB Binder
 // output, end-to-end from SQL string to Sirius AST tree.
 
+#include "ast_test_builders.hpp"
 #include "catch.hpp"
 #include "expression/ast/from_duckdb.hpp"
 
@@ -99,6 +100,8 @@ using sirius::ast::in_list;
 using sirius::ast::node;
 using sirius::ast::reference;
 using sirius::ast::unary_op;
+using sirius::ast::test::make_bound_int_const;
+using sirius::ast::test::make_bound_ref;
 
 // ============================================================================
 // BOUND_REFERENCE
@@ -107,7 +110,7 @@ using sirius::ast::unary_op;
 TEST_CASE("ast_from_duckdb - BOUND_REF translates to reference node (column 0)",
           "[ast_from_duckdb]")
 {
-  auto expr = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto expr = make_bound_ref(0);
   auto out  = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
   REQUIRE(out->holds<reference>());
@@ -117,7 +120,7 @@ TEST_CASE("ast_from_duckdb - BOUND_REF translates to reference node (column 0)",
 TEST_CASE("ast_from_duckdb - BOUND_REF translates to reference node (column 5)",
           "[ast_from_duckdb]")
 {
-  auto expr = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 5);
+  auto expr = make_bound_ref(5);
   auto out  = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
   REQUIRE(out->holds<reference>());
@@ -131,7 +134,7 @@ TEST_CASE("ast_from_duckdb - BOUND_REF translates to reference node (column 5)",
 TEST_CASE("ast_from_duckdb - BOUND_CONSTANT INTEGER translates to constant node",
           "[ast_from_duckdb]")
 {
-  auto expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(42));
+  auto expr = make_bound_int_const(42);
   auto out  = sirius::ast::from_duckdb(*expr);
   REQUIRE(out);
   REQUIRE(out->holds<constant>());
@@ -174,8 +177,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CONSTANT NULL of INTEGER preserves type", "[a
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON EQUAL translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_EQUAL, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -192,8 +195,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON EQUAL translates to comparison nod
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOTEQUAL translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_NOTEQUAL, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -205,8 +208,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOTEQUAL translates to comparison 
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHAN translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_LESSTHAN, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -218,8 +221,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHAN translates to comparison 
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHANOREQUALTO translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -231,8 +234,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON LESSTHANOREQUALTO translates to co
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHAN translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_GREATERTHAN, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -244,8 +247,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHAN translates to comparis
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHANOREQUALTO translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -257,8 +260,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON GREATERTHANOREQUALTO translates to
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON DISTINCT_FROM translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_DISTINCT_FROM, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -270,8 +273,8 @@ TEST_CASE("ast_from_duckdb - BOUND_COMPARISON DISTINCT_FROM translates to compar
 TEST_CASE("ast_from_duckdb - BOUND_COMPARISON NOT_DISTINCT_FROM translates to comparison node",
           "[ast_from_duckdb]")
 {
-  auto left  = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
-  auto right = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3));
+  auto left  = make_bound_ref(0);
+  auto right = make_bound_int_const(3);
   auto expr  = duckdb::make_uniq<BoundComparisonExpression>(
     ExpressionType::COMPARE_NOT_DISTINCT_FROM, std::move(left), std::move(right));
   auto out = sirius::ast::from_duckdb(*expr);
@@ -288,10 +291,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION AND translates to conjunction(op_
           "[ast_from_duckdb]")
 {
   auto and_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-  and_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BOOLEAN}, 0));
-  and_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BOOLEAN}, 1));
+  and_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
+  and_expr->children.push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*and_expr);
   REQUIRE(out);
   REQUIRE(out->holds<conjunction>());
@@ -306,10 +307,8 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION OR translates to conjunction(op_o
           "[ast_from_duckdb]")
 {
   auto or_expr = duckdb::make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-  or_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BOOLEAN}, 0));
-  or_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BOOLEAN}, 1));
+  or_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
+  or_expr->children.push_back(make_bound_ref(1, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*or_expr);
   REQUIRE(out);
   REQUIRE(out->holds<conjunction>());
@@ -323,12 +322,11 @@ TEST_CASE("ast_from_duckdb - BOUND_CONJUNCTION OR translates to conjunction(op_o
 TEST_CASE("ast_from_duckdb - BOUND_BETWEEN translates to between node with inclusive bounds",
           "[ast_from_duckdb]")
 {
-  auto bt = duckdb::make_uniq<BoundBetweenExpression>(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10)),
-    /*lower_inclusive=*/true,
-    /*upper_inclusive=*/true);
+  auto bt  = duckdb::make_uniq<BoundBetweenExpression>(make_bound_ref(0),
+                                                      make_bound_int_const(1),
+                                                      make_bound_int_const(10),
+                                                      /*lower_inclusive=*/true,
+                                                      /*upper_inclusive=*/true);
   auto out = sirius::ast::from_duckdb(*bt);
   REQUIRE(out);
   REQUIRE(out->holds<between>());
@@ -352,16 +350,14 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE WHEN/THEN/ELSE translates to case_expr",
 {
   // CASE WHEN col(0) = 1 THEN 10 ELSE 0 END
   auto check_expr = duckdb::make_uniq<BoundComparisonExpression>(
-    ExpressionType::COMPARE_EQUAL,
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0),
-    duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  auto then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10));
+    ExpressionType::COMPARE_EQUAL, make_bound_ref(0), make_bound_int_const(1));
+  auto then_expr = make_bound_int_const(10);
 
   BoundCaseCheck case_check;
   case_check.when_expr = std::move(check_expr);
   case_check.then_expr = std::move(then_expr);
 
-  auto else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
+  auto else_expr = make_bound_int_const(0);
   auto case_node = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
   case_node->else_expr = std::move(else_expr);
   case_node->case_checks.push_back(std::move(case_check));
@@ -382,13 +378,13 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE with unsupported WHEN propagates nullptr
   // The WHEN subexpression is a BoundParameterExpression (unsupported -> nullptr).
   // The whole CASE must collapse to nullptr.
   auto bad_when  = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_when"});
-  auto then_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(10));
+  auto then_expr = make_bound_int_const(10);
 
   BoundCaseCheck case_check;
   case_check.when_expr = std::move(bad_when);
   case_check.then_expr = std::move(then_expr);
 
-  auto else_expr = duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0));
+  auto else_expr = make_bound_int_const(0);
   auto case_node = duckdb::make_uniq<BoundCaseExpression>(LogicalType{LogicalTypeId::INTEGER});
   case_node->else_expr = std::move(else_expr);
   case_node->case_checks.push_back(std::move(case_check));
@@ -403,7 +399,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CASE with unsupported WHEN propagates nullptr
 TEST_CASE("ast_from_duckdb - BOUND_CAST INTEGER -> BIGINT translates to cast node",
           "[ast_from_duckdb]")
 {
-  auto child = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto child = make_bound_ref(0);
   auto cast_expr =
     BoundCastExpression::AddDefaultCastToType(std::move(child), LogicalType{LogicalTypeId::BIGINT});
   auto out = sirius::ast::from_duckdb(*cast_expr);
@@ -418,7 +414,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CAST INTEGER -> BIGINT translates to cast nod
 
 TEST_CASE("ast_from_duckdb - BOUND_CAST honors try_cast = true", "[ast_from_duckdb]")
 {
-  auto child = duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0);
+  auto child     = make_bound_ref(0);
   auto cast_expr = BoundCastExpression::AddDefaultCastToType(
     std::move(child), LogicalType{LogicalTypeId::BIGINT}, /*try_cast=*/true);
   auto out = sirius::ast::from_duckdb(*cast_expr);
@@ -441,9 +437,8 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION '+' resolves to function_id::add", "
       "+", {LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  add_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  add_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  add_expr->children.push_back(make_bound_ref(0));
+  add_expr->children.push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*add_expr);
   REQUIRE(out);
@@ -465,10 +460,9 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION 'substring' resolves to function_id:
                    nullptr),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-  fn_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  fn_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  fn_expr->children.push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
+  fn_expr->children.push_back(make_bound_int_const(1));
+  fn_expr->children.push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*fn_expr);
   REQUIRE(out);
@@ -487,10 +481,9 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION 'substr' alias resolves to function_
                    nullptr),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::VARCHAR}, 0));
-  fn_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(1)));
-  fn_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  fn_expr->children.push_back(make_bound_ref(0, LogicalTypeId::VARCHAR));
+  fn_expr->children.push_back(make_bound_int_const(1));
+  fn_expr->children.push_back(make_bound_int_const(3));
 
   auto out = sirius::ast::from_duckdb(*fn_expr);
   REQUIRE(out);
@@ -505,8 +498,7 @@ TEST_CASE("ast_from_duckdb - BOUND_FUNCTION unknown name returns nullptr", "[ast
     ScalarFunction("nonexistent_fn", {LogicalType::INTEGER}, LogicalType::INTEGER, nullptr),
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>{},
     nullptr);
-  fn_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  fn_expr->children.push_back(make_bound_ref(0));
 
   REQUIRE(sirius::ast::from_duckdb(*fn_expr) == nullptr);
 }
@@ -522,8 +514,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR NOT translates to unary_op(op_not)",
 {
   auto not_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT,
                                                              LogicalType{LogicalTypeId::BOOLEAN});
-  not_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::BOOLEAN}, 0));
+  not_expr->children.push_back(make_bound_ref(0, LogicalTypeId::BOOLEAN));
   auto out = sirius::ast::from_duckdb(*not_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -537,8 +528,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR IS_NULL translates to unary_op(op_is
 {
   auto is_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_IS_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_null_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  is_null_expr->children.push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*is_null_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -550,8 +540,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR IS_NOT_NULL translates to unary_op(o
 {
   auto is_not_null_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType{LogicalTypeId::BOOLEAN});
-  is_not_null_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  is_not_null_expr->children.push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*is_not_null_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -563,8 +552,7 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR TRY translates to unary_op(op_try)",
 {
   auto try_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_TRY,
                                                              LogicalType{LogicalTypeId::INTEGER});
-  try_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  try_expr->children.push_back(make_bound_ref(0));
   auto out = sirius::ast::from_duckdb(*try_expr);
   REQUIRE(out);
   REQUIRE(out->holds<unary_op>());
@@ -576,11 +564,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE translates to coalesce(N ch
 {
   auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
-  coalesce_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  coalesce_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 1));
-  coalesce_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
+  coalesce_expr->children.push_back(make_bound_ref(0));
+  coalesce_expr->children.push_back(make_bound_ref(1));
+  coalesce_expr->children.push_back(make_bound_int_const(0));
 
   auto out = sirius::ast::from_duckdb(*coalesce_expr);
   REQUIRE(out);
@@ -593,11 +579,10 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN translates to in_list(neg
 {
   auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(5)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(8)));
+  in_expr->children.push_back(make_bound_ref(0));
+  in_expr->children.push_back(make_bound_int_const(2));
+  in_expr->children.push_back(make_bound_int_const(5));
+  in_expr->children.push_back(make_bound_int_const(8));
 
   auto out = sirius::ast::from_duckdb(*in_expr);
   REQUIRE(out);
@@ -614,10 +599,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_NOT_IN translates to in_list
 {
   auto in_expr = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_NOT_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
-  in_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(4)));
+  in_expr->children.push_back(make_bound_ref(0));
+  in_expr->children.push_back(make_bound_int_const(2));
+  in_expr->children.push_back(make_bound_int_const(4));
 
   auto out = sirius::ast::from_duckdb(*in_expr);
   REQUIRE(out);
@@ -634,9 +618,8 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR unsupported ExpressionType returns n
   // the demultiplex table; signal fallback via nullptr.
   auto nullif_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_NULLIF, LogicalType{LogicalTypeId::INTEGER});
-  nullif_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
-  nullif_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(0)));
+  nullif_expr->children.push_back(make_bound_ref(0));
+  nullif_expr->children.push_back(make_bound_int_const(0));
 
   REQUIRE(sirius::ast::from_duckdb(*nullif_expr) == nullptr);
 }
@@ -661,8 +644,8 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COMPARE_IN with unsupported probe pr
   auto in_expr   = duckdb::make_uniq<BoundOperatorExpression>(ExpressionType::COMPARE_IN,
                                                             LogicalType{LogicalTypeId::BOOLEAN});
   in_expr->children.push_back(std::move(bad_probe));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(2)));
-  in_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(3)));
+  in_expr->children.push_back(make_bound_int_const(2));
+  in_expr->children.push_back(make_bound_int_const(3));
 
   REQUIRE(sirius::ast::from_duckdb(*in_expr) == nullptr);
 }
@@ -673,10 +656,9 @@ TEST_CASE("ast_from_duckdb - BOUND_OPERATOR COALESCE with unsupported child prop
   auto bad_child     = duckdb::make_uniq<BoundParameterExpression>(std::string{"p_coalesce"});
   auto coalesce_expr = duckdb::make_uniq<BoundOperatorExpression>(
     ExpressionType::OPERATOR_COALESCE, LogicalType{LogicalTypeId::INTEGER});
-  coalesce_expr->children.push_back(
-    duckdb::make_uniq<BoundReferenceExpression>(LogicalType{LogicalTypeId::INTEGER}, 0));
+  coalesce_expr->children.push_back(make_bound_ref(0));
   coalesce_expr->children.push_back(std::move(bad_child));
-  coalesce_expr->children.push_back(duckdb::make_uniq<BoundConstantExpression>(Value::INTEGER(7)));
+  coalesce_expr->children.push_back(make_bound_int_const(7));
 
   REQUIRE(sirius::ast::from_duckdb(*coalesce_expr) == nullptr);
 }

--- a/test/cpp/expression/test_ast_substitute.cpp
+++ b/test/cpp/expression/test_ast_substitute.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "ast_test_builders.hpp"
 #include "catch.hpp"
 #include "expression/ast/function_call.hpp"
 #include "expression/ast/node.hpp"
@@ -30,25 +31,16 @@ using sirius::ast::function_call;
 using sirius::ast::node;
 using sirius::ast::reference;
 using sirius::ast::substitute_references;
-
-namespace {
-
-std::unique_ptr<node> make_reference(uint32_t column_index)
-{
-  return std::make_unique<node>(
-    reference{column_index, sirius::logical_type::make(sirius::type_id::INTEGER)});
-}
-
-}  // namespace
+using sirius::ast::test::make_ref;
 
 TEST_CASE("ast_substitute - remaps a reference through a reordering inner projection",
           "[ast_substitute]")
 {
   std::vector<std::unique_ptr<node>> inner_select_list;
-  inner_select_list.push_back(make_reference(2));
-  inner_select_list.push_back(make_reference(0));
+  inner_select_list.push_back(make_ref(2));
+  inner_select_list.push_back(make_ref(0));
 
-  auto substituted = substitute_references(*make_reference(0), inner_select_list);
+  auto substituted = substitute_references(*make_ref(0), inner_select_list);
 
   REQUIRE(substituted->holds<reference>());
   REQUIRE(substituted->get<reference>().column_index == 2);
@@ -57,11 +49,11 @@ TEST_CASE("ast_substitute - remaps a reference through a reordering inner projec
 TEST_CASE("ast_substitute - substitutes references inside a function call", "[ast_substitute]")
 {
   std::vector<std::unique_ptr<node>> inner_select_list;
-  inner_select_list.push_back(make_reference(4));
+  inner_select_list.push_back(make_ref(4));
 
   std::vector<std::unique_ptr<node>> args;
-  args.push_back(make_reference(0));
-  args.push_back(make_reference(0));
+  args.push_back(make_ref(0));
+  args.push_back(make_ref(0));
   auto outer =
     std::make_unique<node>(function_call{sirius::function_id::add,
                                          std::move(args),

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -25,6 +25,7 @@
 // through from_duckdb(*to_duckdb(node)) and confirms structural equivalence
 // with the original Sirius AST.
 
+#include "ast_test_builders.hpp"
 #include "catch.hpp"
 #include "expression/ast/from_duckdb.hpp"
 #include "expression/ast/to_duckdb.hpp"
@@ -99,27 +100,9 @@ using sirius::ast::unary_op;
 
 namespace {
 
-// ----------------------------------------------------------------------------
-// Helpers — small node-construction shortcuts for the test bodies.
-// ----------------------------------------------------------------------------
-
-std::unique_ptr<node> make_ref(uint32_t idx) { return std::make_unique<node>(reference{idx}); }
-
-std::unique_ptr<node> make_int_const(int32_t v)
-{
-  return std::make_unique<node>(constant{
-    /*payload=*/sirius::value{v},
-    /*return_type=*/sirius::logical_type::make(sirius::type_id::INTEGER),
-  });
-}
-
-std::unique_ptr<node> make_str_const(std::string s)
-{
-  return std::make_unique<node>(constant{
-    /*payload=*/sirius::value{std::move(s)},
-    /*return_type=*/sirius::logical_type::make(sirius::type_id::VARCHAR),
-  });
-}
+using sirius::ast::test::make_int_const;
+using sirius::ast::test::make_ref;
+using sirius::ast::test::make_str_const;
 
 // ----------------------------------------------------------------------------
 // Structural-equality helpers — used by the self-equivalence sweep below to


### PR DESCRIPTION
   
  - `rebuild()` helper collapses clone/substitute_references std::visit arms
  - `translate_children()` replaces copy-pasted null-check loops in 5 translators
  - `wrap_one()` deduplicates the two wrap_join_conditions overloads
  - `ast_test_builders.hpp` centralizes Sirius + DuckDB node builder shortcuts
