### PR TITLE
Migrate release_table() calls to release_or_copy_table()

### DIFF
--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -198,15 +198,17 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
       batches.push_back(pinned->batch);
       return std::make_unique<pipelineable_operator_data>(std::move(batches));
     }
-    auto ro_batch  = pinned->batch->to_read_only();
-    auto* batch_mr = ro_batch.get_memory_space();
+    ::cucascade::memory::memory_space* batch_mr = nullptr;
+    {
+      auto ro_batch = pinned->batch->to_read_only();
+      batch_mr      = ro_batch.get_memory_space();
+    }
     if (!batch_mr) {
       throw std::runtime_error(
         "[sirius_gpu_scan_operator::execute] pinned batch has no memory_space; "
         "prepare_for_processing must have produced a GPU-resident batch.");
     }
-    auto& gpu_rep     = ro_batch.get_data()->cast<::cucascade::gpu_table_representation>();
-    auto owning_input = gpu_rep.release_table(stream);
+    auto owning_input = ::cucascade::data_batch::release_or_copy_table(pinned->batch, stream);
 
     table = _ingestible->post_filter_and_project(
       std::move(owning_input), *pinned->filter_info, *batch_mr, stream);

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -200,12 +200,10 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
 
   // Post-merge projection: handle AVG (SUM/COUNT) and COUNT DISTINCT (list element count).
   // Release ownership of the merged table's columns so we can move (not copy) them.
-  // Acquire EXCLUSIVE lock since release_table() is a mutating operation
-  auto merged_mut    = merged->to_mutable();
-  auto* space        = merged_mut.get_memory_space();
-  auto mr            = space->get_default_allocator();
-  auto& gpu_rep      = merged_mut.get_data()->cast<cucascade::gpu_table_representation>();
-  auto merged_cols   = gpu_rep.release_table(stream)->release();
+  auto* space = input_batches[0].get_memory_space();
+  auto mr     = space->get_default_allocator();
+  auto merged_cols =
+    cucascade::data_batch::release_or_copy_table(std::move(merged), stream)->release();
   int num_group_cols = static_cast<int>(group_idx.size());
 
   std::vector<std::unique_ptr<cudf::column>> output_cols;

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -210,10 +210,9 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     {
       auto output_ro = output_batch->to_read_only();
       space          = output_ro.get_memory_space();
-      auto& gpu_rep  = output_ro.get_data()->cast<cucascade::gpu_table_representation>();
-      auto table     = gpu_rep.release_table(stream);
-      columns        = table->release();
     }  // read lock released here
+    columns =
+      cucascade::data_batch::release_or_copy_table(std::move(output_batch), stream)->release();
 
     // Select output columns using the batch column map.
     // projection_ids[0..expected_output_columns) are the output columns


### PR DESCRIPTION
Migrate the three release_table() call sites onto the new refcount-checked data_batch::release_or_copy_table(), which steals zero-copy only when the batch is uniquely owned and deep-copies otherwise:

- grouped_aggregate_merge.
- table_scan projection
- gpu_scan

cuCascade PR - https://github.com/NVIDIA/cuCascade/pull/148
Closes issue https://github.com/sirius-db/sirius/issues/925

Will put this PR on draft till the cuCascade PR is merged