### PR TITLE
(Doc) Design draft: S3-over-RDMA transport for the Sirius IO layer

### DIFF
--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -298,30 +298,20 @@ any other gate fails — the decision is STOP: restart the process and
 return to `s3_transport=HTTP`. The build flag stays off by default
 throughout.
 
-## 8. Current Status and Remaining Work
+## 8. Open Risks and Preconditions
 
-The transport machinery in the tree is dormant; the real cuObject
-transfer has not run yet, and the rig gates above will be its first
-exercise. Five gaps close, in order, before the gates run:
+The real cuObject path has not yet completed hardware qualification;
+implementation progress is tracked in the implementation PR. The risks
+below are resolved or measured by the Section 7 gates and do not change
+the V1 safety contract.
 
-1. Factory wiring — the factory does not yet construct the control
-   client; reads cannot route through the normal path.
-2. Endpoint pair — configuration has a single endpoint today.
-3. Envelope admission — chunk admission is eager rather than
-   envelope-bounded.
-4. Retry removal — device reads still carry a legacy multi-attempt retry
-   to be reduced to one-shot.
-5. Completion and gateway hardening — completion validation does not yet
-   check the reply-tag and status legs; gateway exact-write enforcement
-   and descriptor capacity checks are outstanding.
-
-| Risk | Nature |
+| Risk | Treatment |
 |---|---|
-| SDK registration scope | If no planned arena layout can absorb the SDK's registration-to-session binding, the phase stops at preflight |
-| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
-| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
-| No-retry reliability | One-shot reads fail the soak at a transient-fault rate above roughly one in twenty-five million GETs; the soak measures this before any retry is considered |
-| Copy-cost estimate | Pre-copy staging and per-chunk D2D cost are estimates until the hardware gate measures them; the copy should be small against wire time at 100 Gbps |
+| SDK registration scope | Preflight selects a supported registration/session layout; if none of the planned arena layouts can absorb the SDK's binding, the evaluation stops there. |
+| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against a plain S3 endpoint. |
+| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth; hardware qualification records the locality and the performance gate verifies the selected topology. |
+| No-retry reliability | A transient-fault rate above roughly one in twenty-five million GETs fails the soak; the 100-million-GET soak measures this before any retry mechanism is considered. |
+| D2D delivery cost | Staging-window and per-chunk D2D costs are estimates; the performance gate measures delivery end to end into caller-owned RMM, so the copy cost sits inside the 85% bound. |
 
 ## 9. Decisions Requested
 

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -271,9 +271,12 @@ and rejects a presigned-mode authorizer at initialization; the host
 endpoint keeps its configured mode. Descriptor tokens are redacted from
 logs and traces in every profile.
 
-Fault-injection hooks exist only in test builds: release artifacts
-contain none, a production-mode start refuses to run with hooks enabled,
-and hooks cannot be reached through request headers.
+Request-level fault-injection hooks exist only in test builds: release
+artifacts contain none, a production-mode start refuses to run with hooks
+enabled, and hooks cannot be reached through request headers. CUDA
+delivery calls are injectable at construction time for tests.
+Configuration and request headers cannot reach that seam; release builds
+construct with the real CUDA entry points.
 
 The rig may run an unsigned gateway and a non-TLS control plane, but not
 with production data or credentials, and not on an uncontrolled network.

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -56,8 +56,9 @@ byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
   SigV4 / `sirius_datasource` semantics; the REST backend stays the
   config-selectable default; no Parquet-scanner changes.
 - **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
-  gateway); no `AUTO` probe and no runtime HTTP fallback (RDMA failure = I/O
-  error); no AWS-CRT dependency.
+  gateway); no `AUTO` probe and no runtime HTTP fallback (failures surface loudly
+  per D6 and the §2 discipline — never a silent transport switch); no AWS-CRT
+  dependency.
 
 ## 1. Architecture
 
@@ -192,9 +193,10 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
 - **Reactor fail-stop** is the containment shape for failures that do *not*
   corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
   retry contract (appendix). It happens exactly once: new reads fail fast,
-  naming the first fatal error; queued chunks are completed with that error;
-  chunks already in flight finish on their own workers — never resolved on
-  another worker's behalf; and any arena that cannot be proven quiet at
+  naming the first fail-stop error; queued envelopes — and the un-generated
+  chunks of partially-consumed ones — are error-completed with it; chunks
+  already in flight finish on their own workers — never resolved on another
+  worker's behalf; and any arena that cannot be proven quiet at
   teardown is deliberately **leaked rather than freed**, because freeing
   memory a NIC might still write is the very use-after-free this discipline
   exists to prevent. The process stays alive, but RDMA service on this
@@ -216,7 +218,7 @@ the absence of normal teardown.
 | D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level: per §2 the process-fatal hook terminates the process (restart is the recovery); the reactor's fail-stop contains only non-corrupting failures (the ambiguous RDMA outcome) |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
 | D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
@@ -318,8 +320,8 @@ as the plan that closes the gap between the current tree and this design.
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
    registrable allocation path for IO buffers? It unlocks direct-into-RMM
    (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
-   perf instrumentation was re-added for the REST reactor in #1042; the RDMA
+5. **Metrics** — counter set + naming vs the existing S3 counters. Note the REST reactor's
+   perf instrumentation was re-added in #1042; the RDMA
    counters should follow that shape rather than invent a parallel one (see
    the appendix for the proposed set, including the delivery-safety counters).
 6. **Session ownership** — the cuObject SDK documents no whole-client
@@ -350,10 +352,11 @@ as the plan that closes the gap between the current tree and this design.
   now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
   exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
   test.
-- **Fatal CUDA errors are process-level.** The reactor's fail-stop (§2)
-  contains one — it does not recover it. Operators should treat a delivery
-  fatal as "restart required", and the surrounding system must not assume
-  other GPU work on that context keeps functioning.
+- **Fatal CUDA errors are process-level.** The §2 process-fatal hook
+  terminates the process — supervisor restart is the recovery, so operators
+  need a relaunch policy. The reactor's fail-stop contains only the
+  non-corrupting ambiguous-RDMA case: there the process stays alive, but RDMA
+  service on the context requires a restart.
 - Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
   Sirius context (not × GPUs or × queries) — and a process running several
@@ -491,7 +494,7 @@ Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
 `…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
-runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
+runs), `…_fail_stop_total` (reactor fail-stop transitions — the ambiguous-RDMA containment; the process-terminating verdicts leave a fatal log line and an exit code, not a scrapeable counter), `…_arena_leak_total`
 (arenas leaked at teardown because a writer — device stream or remote gateway
 — could not be proven quiet).
 

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -139,6 +139,10 @@ flowchart LR
   C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
 ```
 
+This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
+column projections** (issue #1078, a foreground/background allocation race) —
+this backend is structurally immune to that too, the same way kvikio is.
+
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
@@ -164,6 +168,11 @@ ceiling and multiply sessions. Hence three independent axes:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
+
+**New consumers stay compatible:** the transparent `read_parquet('s3://')` front
+door (#1074, `sirius_httpfs`) resolves its backend per path through
+`create_datasource(path)` and reads with single positional `host_read`s — under
+`s3_transport=RDMA` it works unchanged, with no transport-specific checks.
 
 **Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
 one caller of the vector host-read entry point, which this backend omits — a

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -24,8 +24,8 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — rebased onto the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev` |
-| **Date** | 2026-07-04 |
+| **Status** | Draft for team review — updated for the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev`. Revised 2026-07-15: delivery-failure semantics defined; reactor-state, visibility-policy, and session-model sections expanded |
+| **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
@@ -36,10 +36,13 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`, exactly how the REST backend is built. The benchmark
-proves the cuObject RDMA data path at line rate; the Sirius-specific arena+D2D
-visibility and completion discipline are gated by P3. **Please review the
-decisions table (§3) and the open questions (§5).**
+existing `templated_ioctx`, the same way the REST backend is built. The
+benchmark already proves the cuObject RDMA data path at line rate. What remains
+Sirius-specific is the arena+D2D **visibility discipline**, validated in
+rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
+guarantees that no buffer is ever recycled or handed back while a copy might
+still touch it. **Please review the decisions table (§3) and the open
+questions (§5).**
 
 ## Why
 
@@ -65,6 +68,10 @@ flowchart LR
   arena == "GPU-local D2D (~TB/s)" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
   rmm --> decode["cuDF decode"]
 ```
+
+*(Vocabulary for readers new to the IO framework: an **ioctx** is the
+per-context IO facade the scanner talks to; a **reactor** is the transport
+engine behind it, defined by which read **builders** it provides.)*
 
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
@@ -100,31 +107,72 @@ sequenceDiagram
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
   G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if the platform needs it)
-  W->>S: cudaMemcpyAsync slot -> dst (D2D) + record CUDA event
-  S-->>W: event clears (worker polls, REST's proven pattern)
+  Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
+  W->>W: create the completion event FIRST
+  W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
+  W->>S: wait on the event inline (the D2D is ~3 µs vs a ~350 µs GET)
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
 
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound**. Completion uses the framework's `exec::semi_future` +
-`request_manager`: each chunk reports `chunk_complete` or `report_error` exactly
-once and then releases its manager reference — the future resolves when the last
-chunk does. Nothing runs on a CUDA callback thread; the worker finishes the chunk
-after its CUDA event clears, then recycles the slot. Because the D2D is ~3 µs
-against a ~350 µs network GET, v1 may simply wait on the event inline instead of
-parking copies for a poll loop — a simplification to measure in P2/P3.
+concurrency bound** — and because there is exactly one arena slot per worker, a
+worker always finds a free slot: admission pressure lives in the reactor's
+queue, never in the arena (the queue is currently uncapped; bounding and
+observing queued work is a tracked follow-up). Completion uses the framework's
+`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
+`report_error` exactly once and then releases its manager reference — the
+future resolves when the last chunk does. Nothing runs on a CUDA callback
+thread. The worker waits on its own copy **inline** (parking the worker to
+dodge a ~3 µs wait — right after a ~350 µs network GET — buys nothing); the
+REST backend's event-poll shape remains the documented fallback if
+shared-stream measurements on the rig ever show the inline wait stalling
+workers.
+
+**When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
+the arena slot (its next user would corrupt an in-flight copy) and the caller's
+destination (the caller frees it as soon as its future resolves — while the
+copy may still be writing it). The rule is therefore absolute: **neither the
+slot is recycled nor the future resolved until the stream is proven quiet.**
+
+- The completion event is created **before** the copy is enqueued — if even
+  that fails, nothing is in flight and the error is plainly recoverable.
+- On any CUDA failure after the enqueue, the worker proves quiescence with a
+  real stream sync. A sync call can return an error produced by *earlier*
+  async work — the call itself still waited, so the stream is still proven
+  quiet. The only exception is an error meaning the call never ran at all
+  (e.g. an invalid stream handle); then the worker escalates to a device-wide
+  sync as the stronger proof. (Captured streams fall in that exception too —
+  and are a documented precondition violation: RDMA device reads do not
+  support them.)
+- The verdict is three-way. *Quiet + healthy*: release the slot, report the
+  original error, keep serving. *Quiet + context-fatal* (sticky errors such as
+  an illegal memory access): the CUDA context is dead and nothing can touch the
+  destination anymore — report and **fail-stop**. *Unprovable*: fail-stop.
+- **Fail-stop** happens exactly once. New reads fail fast, naming the first
+  fatal error. Queued chunks are completed with that error. Chunks already in
+  flight finish on their own workers — never resolved on another worker's
+  behalf. And any arena that cannot be proven quiet at teardown is
+  deliberately **leaked rather than freed**: freeing memory a NIC or copy
+  engine might still write is the very use-after-free this discipline exists
+  to prevent.
+- A sticky CUDA error is a **process-level** event: continuing CUDA work just
+  returns the same error. Fail-stop is containment; process restart is the
+  recovery.
+
+Every CUDA call on this delivery path goes through a small seam injected at
+construction time, so all of the failure branches above are fault-injectable in
+ordinary tests without faking CUDA semantics.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — the reactor provides `prep_host_rx` / `prep_device_rx` builders + `enqueue`; credentials and the registered arena live in its `reactor_context` | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused |
+| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`; a chunk completes exactly once, on a worker thread, after its CUDA event clears — never from a CUDA callback | Matches the framework contract (the future resolves when the last chunk releases its manager reference); keeps user code off CUDA's internal threads |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a restart instead of pretending to continue |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
 | D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
@@ -136,7 +184,7 @@ Why D9 works, in one picture:
 flowchart LR
   A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
   B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
+  C --> D["no host staging can sneak in;<br/>the cache's staged-read crash path<br/>is unreachable"]
 ```
 
 This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
@@ -148,31 +196,36 @@ this backend is structurally immune to that too, the same way kvikio is.
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
-**One reactor per node — and what scales with what.** For contrast: the REST
-backend runs **2 reactors per node** (`rest_n_reactors`), unrelated to GPU count —
-its reactors are epoll event loops doing real CPU work (TLS, staging copies), so
-a second one spreads CPU load. The RDMA reactor is *not* an event loop
-(`cuObjGet` blocks): it is a container for the worker pool and the arenas, so
-extra reactors add no throughput — they would only fragment the global in-flight
-ceiling and multiply sessions. Hence three independent axes:
+**One reactor per ioctx — and what scales with what.** The unit is the
+ioctx/`SiriusContext`, not the node: a process running several Sirius contexts
+multiplies workers, arenas, and gateway-budget demand accordingly. For
+contrast: the REST backend runs **2 reactors per ioctx** (`rest_n_reactors`),
+unrelated to GPU count — its reactors are epoll event loops doing real CPU work
+(TLS, staging copies), so a second one spreads CPU load. The RDMA reactor is
+*not* an event loop (`cuObjGet` blocks): it is a container for the worker pool
+and the arenas, so extra reactors add no throughput — they would only fragment
+the global in-flight ceiling and multiply sessions. Hence three independent
+axes:
 
 - **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
   with reactors, not with GPUs.
 - **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
-  arena; a worker sets the request's device and takes a slot from *that* device's
-  arena, so slot and destination are always same-device (never a cross-device
-  copy). A per-GPU reactor would instead make concurrency `GPUs × max_inflight`
-  (e.g. 4×8 = 32 concurrent `cuObjGet`), breaking the global ceiling and risking
-  gateway/NIC overload.
+  arena; a worker sets the request's device (via the framework's RAII device
+  guard) and takes a slot from *that* device's arena, so slot and destination
+  are always same-device (never a cross-device copy). A per-GPU reactor would
+  instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
+  `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
 - **NIC count** is the one thing that eventually justifies more reactors:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
 
-**New consumers stay compatible:** the transparent `read_parquet('s3://')` front
-door (#1074, `sirius_httpfs`) resolves its backend per path through
-`create_datasource(path)` and reads with single positional `host_read`s — under
-`s3_transport=RDMA` it works unchanged, with no transport-specific checks.
+**New consumers stay compatible by design:** the transparent
+`read_parquet('s3://')` front door (#1074, `sirius_httpfs`) resolves its
+backend per path through `create_datasource(path)` and reads with single
+positional `host_read`s — it carries no transport-specific checks, so under
+`s3_transport=RDMA` it should work unchanged; a routing test pins this at
+integration time.
 
 **Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
 one caller of the vector host-read entry point, which this backend omits — a
@@ -186,25 +239,28 @@ change.
 | Phase | Scope | HW |
 |---|---|---|
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Re-add strict descriptor parsing (the migration removed the old validator — a regression); enforce the token's `buf_size` (on the wire but unread); explicit short-write `n == expected` check | — |
+| **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; pin the registration-per-session question | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go; vs-HTTP benchmark | CX-6 |
+| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship 8 workers × 4 MiB as the **100G-floor** default
-   (line rate on the CX-6 rig) with the documented rule "scale in-flight bytes
-   linearly with NIC line rate" (§1) — or should the default self-scale from a
-   detected/configured link speed? 800G-class NICs need ~8× the in-flight bytes
-   and proportionally more workers, which also stresses the blocking-GET
-   thread-per-worker model (§6).
-2. **OWNER-flush ownership** — who verifies whether `…_ORDERING_OWNER` still
-   needs `cuFlushGPUDirectRDMAWrites` for same-device consumers? Neither the
-   benchmark nor Sirius contains any flush handling today — this is from-scratch
-   P3 work and the top correctness risk.
+1. **Sizing defaults** — ship the fixed 100G-floor default from §1's sizing
+   rule, or should the default self-scale from a detected/configured link
+   speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
+2. **Visibility policy validation** — CUDA exposes a per-device
+   GPUDirect-RDMA **write-ordering attribute**: *OWNER* means RDMA writes
+   become visible to the owning device with no extra action; *NONE* means no
+   guarantee — an explicit flush is required before the GPU may read the
+   bytes. The OWNER half of the question is closed on paper: our consumer is a
+   same-device D2D, so **only NONE-ordering platforms need a flush**, and a
+   NONE platform that cannot flush must fail RDMA init loudly (no safe
+   configuration exists). What still needs the rig: wiring the policy **per
+   device** and the decode-immediately-after-GET stress test — still the top
+   correctness gate for P3. Who owns that rig time?
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
@@ -212,23 +268,36 @@ change.
    (drops the <1% D2D) but touches cucascade's memory architecture.
 5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
    perf instrumentation was re-added for the REST reactor in #1042; the RDMA
-   counters should follow that shape rather than invent a parallel one.
-6. **Registration × sessions** — each worker owns its own `cuObjClient` session;
-   is a buffer registration per-session (8 registrations of the same arena) or
-   shareable? SDK-version-dependent (conda 1.2.x vs the validated 1.0.0); shapes
-   the client-wrapper API. Pin on the rig in P3.
+   counters should follow that shape rather than invent a parallel one (see
+   the appendix for the proposed set, including the delivery-safety counters).
+6. **Session ownership** — the cuObject SDK documents no whole-client
+   thread-safety guarantee, so the design prefers **one `cuObjClient` session
+   per worker**; the alternative (one shared client for the pool) requires
+   documented proof of safety plus locking that preserves concurrency. Bound
+   up with it: is a buffer registration per-session (N registrations of the
+   same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
+   vs the validated 1.0.0) and shapes the client-wrapper API; it must be
+   decided on the rig, before activation.
 
 ## 6. Risks
 
-- **CUDA visibility after external RDMA writes** — top correctness risk;
-  confined to one flush-before-D2D point; stress test gates P3.
+- **CUDA visibility after external RDMA writes** — the top correctness risk,
+  now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
+  exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
+  test.
+- **Fatal CUDA errors are process-level.** The reactor's fail-stop (§2)
+  contains one — it does not recover it. Operators should treat a delivery
+  fatal as "restart required", and the surrounding system must not assume
+  other GPU work on that context keeps functioning.
 - Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
-  client process (not × GPUs or × queries).
+  Sirius context (not × GPUs or × queries) — and a process running several
+  contexts multiplies it (§3).
 - Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5); cuObject's blocking GET shapes the worker-pool model — and at
-  800G-class line rates the pool grows ~8× (with the gateway DCI budget growing
-  with it), sharpening the case for an async cuObject API if one appears.
+  threshold, P5 — control-plane **connection reuse** is part of the same
+  measurement); cuObject's blocking GET shapes the worker-pool model, and the
+  pool grows with NIC line rate (§1 sizing), sharpening the case for an async
+  cuObject API if one appears.
 - cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
   reconciled before P3.
 
@@ -243,7 +312,7 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 | Header | Direction | Meaning |
 |---|---|---|
 | `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag (authoritative completion is `cuObjGet`'s `n == expected`, not a reply byte count) |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected` — but that count is only **authoritative once the gateway enforces exact completion** (accepts no short or overlong RDMA piece): the P0b hardening (see below) is therefore a precondition for trusting short-write detection on the real path |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
@@ -255,24 +324,32 @@ Production gateways SigV4-validate the control request before honoring the token
 ### Config (under `object_store_config`)
 
 `s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
-its consumer. The rest are new fields for the integration PR:
+its consumer. Two sizing knobs accompany it:
 
 ```text
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_endpoint / s3_rdma_port   # control-plane endpoint if distinct
-s3_rdma_max_inflight              # worker count = global in-flight ceiling
-                                  #   default 8 — calibrated on the 100G floor; scale with NIC line rate
-s3_rdma_arena_slot_size           # per-chunk arena slot
-                                  #   default 4 MiB — same calibration; workers x slot_size tracks line rate
+s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
+s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
 ```
 
-There is deliberately **no client chunk-size knob**: the transfer granularity is
-the arena slot size, and the server chunks independently. Auth/TLS reuse the
-existing fields (`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+The control plane reuses the shared object-store endpoint carried by the
+authorizer; a distinct RDMA-gateway endpoint knob is added only if activation
+shows the gateway host must differ from the S3 endpoint. There is deliberately
+**no client chunk-size knob**: the transfer granularity is the arena slot size,
+and the server chunks independently. Auth/TLS reuse the existing fields
+(`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+
+**Retry contract** — deliberately independent of the REST policy: retries are
+chunk-level; only client transport failures and short reads retry; CUDA work
+never retries; exhaustion surfaces the last error — and per D6, never a
+transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
-`…_requests_total`, `…_arena_slot_wait_total`, `…_flush_total`,
-`…_short_write_total`, `…_error_total`, `…_inflight_peak`.
+`…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
+`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak` — plus the
+delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
+runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
+(arenas leaked at teardown because the device could not be proven quiet).
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 
@@ -282,12 +359,13 @@ pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
 documented. **Open hardening (P0b):** the migration **removed** the previous
 strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
-`buf_size` field is transmitted but never read server-side (a free capacity check
-not being performed); the client reports success on any 200/206 without an
-`n == expected` short-write check; optional SigV4 in the dev server.
+`buf_size` field is transmitted but never read server-side (a capacity check the
+server could perform for free but currently skips); the client reports success on
+any 200/206 without an `n == expected` short-write check; optional SigV4 in the
+dev server.
 
-> Deeper implementation notes + verified file:line references live in the
-> offline working spec, not this doc.
+> Detailed gateway-hardening notes (file:line specifics) are tracked in the
+> `s3RDMA-benchmarktool` repo.
 </script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script type="module">

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -22,11 +22,11 @@
 <script type="text/markdown" id="src">
 # S3 RDMA Transport for Sirius — V1 Design
 
-Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+Date: 2026-07-20. Author: Sirius Contributors. Benchmark:
 <https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
 on CX-6 RoCE).
 
-## 1. Summary and Scope
+## 1. Summary
 
 - V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
   reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
@@ -50,23 +50,7 @@ on CX-6 RoCE).
 - The prefetch cache is off on the RDMA path in V1. Whether V1 grows a cache
   is decided from the benchmark results, not up front.
 
-### Decisions Requested
-
-| Decision | Proposed V1 position | Question for the team |
-|---|---|---|
-| GPU destination | RDMA lands in a registered arena, followed by D2D into caller-owned RMM | Is the extra GPU-local copy acceptable, rather than registering arbitrary RMM allocations? |
-| Endpoint topology | Existing S3 endpoint for control/metadata; dedicated direct-connect gateway for RDMA data | Is split deployment, with the publisher visibility barrier, acceptable? |
-| Failure policy | Token-bearing GETs are one-shot; uncertain completion causes reactor fail-stop and process restart | Is restart-based recovery acceptable for V1 — no fallback after an RDMA request is selected or fails? |
-| CUDA boundary | After `cudaMemcpyAsync`, anything except a successful event wait is process-fatal | When delivery cannot be proven, is terminating the process and never freeing the arena acceptable? |
-| Concurrency model | Bounded request envelopes and one RDMA session per worker | Is this resource model right? (Registration layout is a preflight result.) |
-| Evaluation gate | A hardware correctness gate, then: objects ≥16 MiB must reach 85% of RDMA link rate, small objects (128 KiB–4 MiB) are measured RDMA-vs-HTTP as a required output, and reliability requires a zero-failure 100M-GET soak | Are these the right GO/STOP criteria? (The small-object routing threshold is a follow-up decision, not set in this PR.) |
-
-Registration scope, reply-tag constants, and GPU write-ordering behavior
-are preflight measurements, not design votes. Worker count, chunk size,
-and slot layout are implementation choices within the proposed V1
-contract.
-
-### Scope
+## 2. Scope and Non-Goals
 
 | Supported in v1 | Not in v1 |
 |---|---|
@@ -74,13 +58,13 @@ contract.
 | Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
-| One-shot device reads | Automatic RDMA retry (one narrowly-proven retry exists only as a pre-approved response to a soak failure, Section 3) |
+| One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
 | Restart-based recovery | Hot recovery of a failed transport context |
 
-Footer and metadata reads use plain HEAD and range GET on the host plane;
-footer caching and known-size open are out of scope.
+Footer caching and known-size open are also out of scope; footer and
+metadata reads are plain HEAD and range GET on the host plane.
 
-## 2. Architecture and Read Path
+## 3. Architecture and Ownership
 
 ```mermaid
 flowchart LR
@@ -99,32 +83,30 @@ flowchart LR
   gw --- store
 ```
 
-The host plane (`s3_endpoint`) is any S3 service and carries HEAD, footer,
-and range GETs with standard SigV4 signing; it retains the existing S3
-surface. The data plane (`s3_rdma_endpoint`) is a cuObject gateway reached
-by direct connection, limited to token-bearing GETs and the publisher HEAD
-used by the visibility barrier below. Both endpoints front the same
-backing store and the same bucket namespace.
+The host plane (`s3_endpoint`) is any S3 service, speaking standard
+SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_endpoint`)
+is a direct-connect cuObject gateway carrying token-bearing GETs plus the
+publisher HEAD of the visibility barrier below; both front the same
+backing store and bucket namespace.
 
-The ioctx owns the reactor, the reactor owns the worker pool, and each
-worker owns its own RDMA session — a shared session across workers is not
-an option. How registration binds to sessions, and therefore the exact
-arena slot layout, is settled at preflight (Section 5). The RMM
-destination belongs to the caller and is never registered with the NIC.
+The ioctx owns the reactor, the reactor the worker pool, and each worker
+its own RDMA session; sessions are not shared. Registration-to-session
+binding — and with it the arena slot layout — is a preflight result
+(Section 7). The caller's RMM destination is not registered with the NIC.
 
-The request queue holds envelopes rather than chunks: a submitter enqueues
-one small descriptor and returns, workers expand it into chunks lazily,
-and admission blocks only at the per-ioctx bound. A per-chunk bound was
-rejected because a read larger than the bound would block its submitter
-until most of its own transfer had completed.
+The request queue holds envelopes, not chunks: a submitter enqueues one
+descriptor and returns, workers expand chunks lazily, and admission
+blocks only at the per-ioctx bound — a per-chunk bound would block a
+large read's submitter on its own transfer.
 
-Consistency between the two endpoints rests on two deployment rules. Keys
-are append-only and immutable: an object, once published, is never
-overwritten or deleted while readable. Before a key becomes queryable, the
+Two deployment rules keep the endpoints consistent. Keys are append-only
+and immutable while readable. Before a key becomes queryable, the
 publisher completes a visibility barrier: HEAD succeeds at both endpoints
-with matching sizes, and content identity is confirmed by a trusted ETag or
-by the full object hash from the publishing manifest. The query path
-itself never sends HEAD to the gateway.
+with matching sizes, and content identity is confirmed by a trusted ETag
+or the publishing manifest's object hash. The query path does not send
+HEAD to the gateway.
+
+## 4. Read Lifecycle
 
 ```mermaid
 sequenceDiagram
@@ -151,163 +133,134 @@ sequenceDiagram
   W-->>S: the request future resolves after all chunks complete
 ```
 
-Object sizes come from HEAD on the host plane; when that HEAD is issued
-relative to open is an implementation choice. The stream capture check
-runs before the GET is issued, in release builds as well as debug builds,
-so a request that cannot be delivered makes no remote write.
+Object sizes come from a host-plane HEAD (its timing relative to open is
+an implementation choice). The stream capture check runs before the GET —
+in release builds too — so an undeliverable request makes no remote
+write.
 
-Exact completion has three legs, all required before a chunk may proceed
-to delivery: a valid reply tag, a successful HTTP status, and a byte count
-that equals the requested size. The concrete accepted values are recorded
-at preflight and used unchanged by every later test.
+A chunk proceeds to delivery on exact completion — valid reply tag,
+successful HTTP status, and a byte count equal to the request — with the
+accepted values recorded at preflight and reused unchanged.
 
-The request future is a fan-in over all chunks: successful resolution
-occurs only after every chunk completes, any chunk error that is not
-process-fatal resolves the request as an error, and a partial result is
-never reported as success.
+Flush policy follows the GPU's RDMA write-ordering attribute, read once
+at initialization: `OWNER` and `ALL_DEVICES` need no flush; `NONE` takes
+one flush after each exact completion, before that chunk's copy; an
+unknown attribute, or `NONE` without a working flush mechanism, fails
+RDMA initialization.
 
-Flush policy follows the GPU's RDMA write-ordering attribute, read once at
-initialization: `OWNER` and `ALL_DEVICES` require no flush; `NONE` requires
-one flush after each exact completion, before that chunk's copy; an unknown
-attribute value, or `NONE` without a working flush mechanism, fails RDMA
-initialization.
+The request future succeeds only after every chunk completes; a chunk
+error that is not process-fatal resolves it as an error, and no partial
+result is reported as success. Callers use the future to decide whether
+the destination is valid.
 
-## 3. Safety Contract
+## 5. Safety and Failure Semantics
 
-The boundary of the delivery contract is the first `cudaMemcpyAsync` call
-for a chunk. Before that call no copy is in flight: a failure that is not
-a sticky CUDA error can be reported and released safely, while a sticky
-error terminates the process even before the boundary. After the call, the
-only completing return is an event wait that reports `cudaSuccess`;
-everything else is treated as an unprovable delivery state. The set of
-sticky CUDA error codes is fixed from the documented CUDA error
-classification and reviewed against the existing classifier in the tree —
-never inferred from rig observation.
+The delivery contract turns on the first `cudaMemcpyAsync` call for a
+chunk. Before it no copy is in flight, so a non-sticky failure reports
+and releases the slot safely; a sticky CUDA error terminates the process
+at any point (the sticky set is CUDA's documented
+classification, checked against the tree's classifier). After the call, only an
+event wait reporting `cudaSuccess` proves the copy has stopped writing,
+so every other outcome is process-fatal. The exception is an
+event-destroy failure after a successful wait: logged, and the success
+stands.
 
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
 | Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
 | Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
-| Sticky CUDA error, or any failure after the copy is enqueued (one exception below) | Process-fatal termination | Not resolved | Never freed |
+| Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
-One narrow exception: an event-destroy failure after a successful wait is
-logged and leaves the successful outcome unchanged.
+A non-exact or unknown RDMA outcome fail-stops the transport: the client
+cannot prove the gateway has stopped writing, so the whole arena becomes
+non-freeable and recovery is a process restart. Shutdown is two-phase — a
+terminal mark that refuses new work, then completion when the last
+in-flight permit releases — so a failing worker never waits on itself.
+Both planes close behind one shared admission gate and surface one
+terminal error: an operation already past its side-effect point (a
+control call started, a transfer issued) completes; queued envelopes and
+their ungenerated chunks error-complete; work claimed but not issued
+aborts and releases its slot; blocked submitters wake.
 
-1. Transport shutdown after a fail-stop is two-phase: a non-blocking
-   terminal mark that immediately refuses new work, and a completion point
-   reached when the last in-flight operation releases its permit, so a
-   failing worker can initiate shutdown without waiting on itself.
-2. After a fail-stop the whole transport context is closed: host-plane and
-   device-plane operations alike are refused through one shared admission
-   gate and surface the same terminal error. Only an operation whose side
-   effect is already in flight — a control call started, a transfer
-   issued — completes that one operation. Everything else is cut off:
-   queued envelopes and the chunks not yet generated from them complete
-   with an error, work claimed but not yet issued is aborted with its slot
-   released, and submitters blocked at the queue bound wake with the
-   terminal error. Recovery is a process restart.
-3. Destination contents are unspecified after any failed read: earlier
-   chunks may already have landed in the caller's buffer, and the
-   error-resolved future is the only authority a caller may consult.
-4. Token-bearing GETs are not retried, hedged, mirrored, cached, or
-   coalesced anywhere between client and gateway; the dedicated
-   direct-connect endpoint enforces this structurally on the path, and a
-   gateway conformance check verifies that the gateway itself performs no
-   internal retry, caching, or coalescing. After a failed soak, a single
-   retry may be enabled only when the client can prove that the request
-   was never issued to the gateway, followed by a full soak re-run from
-   zero.
-5. Normal teardown releases the arena only behind a strict barrier:
-   admission is stopped, no further GETs will be issued, every issued
-   transfer has completed exactly, every enqueued copy is confirmed, and
-   all workers have stopped and joined. After a fail-stop or a
-   process-fatal failure this barrier is never reached: those arenas are
-   never freed while the process lives.
+Destination contents are unspecified after any failed read: earlier
+chunks may already have landed in the caller's buffer.
 
-## 4. Configuration and Security
+Token-bearing GETs are one-shot, and the gateway must not retry, hedge,
+mirror, cache, or coalesce them: a replay can reuse an RDMA descriptor
+after its slot has been reassigned. The direct-connect endpoint enforces
+this on the path, and a gateway conformance check verifies it. The only
+exception is the soak-failure retry of Section 7, for requests provably
+never issued to the gateway.
+
+Normal teardown frees the arena only behind a drain barrier: admission
+stopped, every issued transfer exactly complete, every enqueued copy
+confirmed, all workers joined. After a fail-stop or a process-fatal
+failure the barrier is unreachable, and the arena stays allocated for the
+life of the process.
+
+## 6. Configuration and Security
 
 | Key | Meaning | Default |
 |---|---|---|
 | `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
 | `s3_endpoint` | Host plane: any S3 service | existing setting |
-| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails with an explicit error when unset | none |
+| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset | none |
 | `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
 | `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
 This phase adds no new tuning surface: worker count and arena slot size
-keep their existing settings. Reads are one-shot, so the retry counter
-must read zero; any nonzero value is treated as a defect.
+keep their settings. Reads are one-shot, so the retry counter
+must read zero; a nonzero value is a defect.
 
-Signing is configured per endpoint. The data endpoint requires
-header-signing: the RDMA descriptor token and the `Range` header travel
-inside the SigV4 signature, and a presigned-mode authorizer on the data
-plane fails initialization. The host endpoint keeps its own configured
-signing mode. Descriptor tokens are redacted from logs and traces in every
-profile.
+Signing is per endpoint. The data endpoint requires header-signing (the
+descriptor token and `Range` header travel inside the SigV4 signature)
+and rejects a presigned-mode authorizer at initialization; the host
+endpoint keeps its configured mode. Descriptor tokens are redacted from
+logs and traces in every profile.
 
-The fault-injection hooks used by the validation gates exist only in test
-builds: release artifacts contain none, a production-mode start refuses to
-run when hooks are enabled, and hooks cannot be activated through request
-headers.
+Fault-injection hooks exist only in test builds: release artifacts
+contain none, a production-mode start refuses to run with hooks enabled,
+and hooks cannot be reached through request headers.
 
-The rig profile for this phase may run an unsigned gateway and a non-TLS
-control plane, but must not use production data or production credentials
-and must not be exposed to an uncontrolled network. Gateway-side SigV4
-verification, end-to-end TLS, authorization, replay and token hardening,
-and a signed-profile qualification form a production-qualification gate
-that applies after a GO decision; enabling the production profile requires
-re-running correctness, performance, and soak in full, because unsigned
-rig results do not extrapolate to the signed path.
+The rig may run an unsigned gateway and a non-TLS control plane, but not
+with production data or credentials, and not on an uncontrolled network.
+Gateway-side SigV4 verification, end-to-end TLS, authorization, replay
+and token hardening, and signed-profile qualification form the post-GO
+production gate (Section 7); unsigned rig results do not extrapolate to
+the signed path.
 
-## 5. Validation and Rollout
+## 7. Validation and GO/STOP
 
-Validation runs in three stages on the rig, each gating the next, followed
-by the post-GO production gate. Throughout this section, a **clean run**
-means correct payload checksums and no fail-stops, process-fatal exits, or
-short, missing, or wrong completions.
+Validation runs in three stages on the rig, each gating the next, then
+the post-GO production gate. Throughout this section, a **clean run**
+means correct payload checksums and no fail-stops, process-fatal exits,
+or short, missing, or wrong completions.
 
 | Gate | What runs | Pass condition |
 |---|---|---|
-| Preflight | Rig probes for registration/session shape, the completion constants (accepted HTTP status set, reply-tag value and parse rule, byte count on failed responses), and the GPU write-ordering attribute with flush availability | Results are recorded once and used unchanged by every later test; one arena layout is selected — if none works, the phase stops here |
-| Hardware correctness | Checksum stress at full worker count with one session per worker; slot-reuse churn; flush counting; decode stress on the copy stream; fault injection: missing, wrong, and short replies, an ambiguous transport fault, and a session result with a valid reply tag, `n == expected`, and a non-success HTTP status | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in the outcome Section 3 assigns it, and no failed read is reported as a partial success |
-| Performance | Sustained reads at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB, and 1 GiB; the three small sizes also run the HTTP path for comparison | Each size of 16 MiB or more reaches the 85% bound (85 Gbps on the current 100 Gbps rig); the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run; no Sirius-side host staging or H2D on any RDMA run |
-| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, and there are zero unexpected runner restarts |
-| Production (post-GO) | Gateway-side SigV4 verification, end-to-end TLS, authorization, replay and token hardening, signed-profile qualification | Full correctness, performance, and soak re-run on the signed profile |
+| Preflight | Probes for the registration/session shape, completion constants, and write-ordering attribute with flush availability (Appendix A) | Constants recorded once, reused unchanged by every later test; one arena layout selected, or the phase stops here |
+| Hardware correctness | The correctness workload and fault matrix of Appendix A | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in its Section 5 outcome, and no failed read is reported as a partial success |
+| Performance | Sustained reads at six object sizes from 128 KiB to 1 GiB; the three small sizes also run HTTP for comparison (procedure: Appendix A) | Sizes of 16 MiB and above reach the 85% bound; the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run with no host staging or H2D |
+| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, with zero unexpected runner restarts |
+| Production (post-GO) | The signed/TLS/security profile of Section 6 | Full correctness, performance, and soak re-run on the signed profile |
 
-Performance runs use one configuration frozen after preflight — worker,
-chunk, slot, and arena settings held constant with no per-size tuning —
-against a warm server cache. Object size and RDMA chunk size are distinct:
-transfers keep normal Sirius chunking rather than forcing one RDMA request
-per object. Each size sustains repeated reads for at least ten seconds per
-trial, with two warm-ups and at least seven measured trials. Throughput is
-measured from device-read submission through delivery into the
-caller-owned RMM buffer — queueing, RDMA, required flushes, D2D copies,
-and request completion — excluding one-time initialization, arena
-registration, object HEAD, and warm-up. A large size passes when the
-one-sided 95% Student-t lower confidence bound of the arithmetic mean of
-its measured per-trial throughputs reaches 85% of the link rate; the same
-statistic is computed for both arms at the small sizes. HTTP results never
-determine GO or STOP. The 85% floor is grounded in measurement: the
-standalone benchmark sustains roughly 91 Gbps on the same class of
-hardware.
-
-If the soak fails and the client can prove that the failing request was
-never issued to the gateway, the single pre-approved retry of Section 3
-may be enabled and the full soak re-run from zero; the re-run's outcome
-then decides GO or STOP under the same criteria. A STOP follows when the
-re-run fails, when the failing request cannot be proven never-issued, or
-when any other gate fails; the stop action is to restart the process and
-return to `s3_transport=HTTP`, and the build flag remains off by default
+A failed soak has one recovery path: when the client can prove the
+failing request was never issued, the Section 5 retry may be enabled and
+the full soak re-run from zero, the re-run deciding GO or STOP under the
+same criteria. Otherwise — the re-run fails, the proof cannot be made, or
+any other gate fails — the decision is STOP: restart the process and
+return to `s3_transport=HTTP`. The build flag stays off by default
 throughout.
 
-## 6. Current Status and Risks
+## 8. Current Status and Remaining Work
 
-The transport machinery in the tree is dormant. Five gaps separate it from
-the v1 target, closed in this order before the rig gates run:
+The transport machinery in the tree is dormant; the real cuObject
+transfer has not run yet, and the rig gates above will be its first
+exercise. Five gaps close, in order, before the gates run:
 
-1. Factory wiring — the production factory does not yet construct the
-   control client, so reads cannot route through the normal path.
+1. Factory wiring — the factory does not yet construct the control
+   client; reads cannot route through the normal path.
 2. Endpoint pair — configuration has a single endpoint today.
 3. Envelope admission — chunk admission is eager rather than
    envelope-bounded.
@@ -319,11 +272,68 @@ the v1 target, closed in this order before the rig gates run:
 
 | Risk | Nature |
 |---|---|
-| SDK registration scope | If registration is bound to a session in a way none of the planned arena layouts can absorb, the phase stops at preflight |
+| SDK registration scope | If no planned arena layout can absorb the SDK's registration-to-session binding, the phase stops at preflight |
 | Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
 | GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
-| No-retry reliability | With one-shot reads, a transient-fault rate above roughly one in twenty-five million GETs would fail the soak for a terabyte-scale workload; the soak measures this before any retry mechanism is considered |
-| Copy-cost estimate | The pre-copy staging window and per-chunk D2D cost are estimates until the hardware gate measures them; the copy is expected to be small relative to wire time at 100 Gbps |
+| No-retry reliability | One-shot reads fail the soak at a transient-fault rate above roughly one in twenty-five million GETs; the soak measures this before any retry is considered |
+| Copy-cost estimate | Pre-copy staging and per-chunk D2D cost are estimates until the hardware gate measures them; the copy should be small against wire time at 100 Gbps |
+
+## 9. Decisions Requested
+
+The positions are the ones this document describes; the team is asked:
+
+1. GPU destination (Section 3): is the extra GPU-local copy acceptable,
+   rather than registering arbitrary RMM allocations?
+2. Endpoint topology (Section 3): is split deployment, with the publisher
+   visibility barrier, acceptable?
+3. Failure policy (Section 5): is restart-based recovery acceptable for
+   V1 — no fallback after an RDMA request is selected or fails?
+4. CUDA boundary (Section 5): when delivery cannot be proven, is
+   terminating the process and never freeing the arena acceptable?
+5. Concurrency model (Sections 3 and 6): is the envelope bound with one
+   RDMA session per worker the right resource model? (Registration layout
+   is a preflight result.)
+6. Evaluation gate (Section 7): are these the right GO/STOP criteria?
+   (The small-object routing threshold is a follow-up decision, not set
+   in this PR.)
+
+Registration scope, reply-tag constants, and GPU write-ordering behavior
+are preflight measurements, not design votes. Worker count, chunk size,
+and slot layout are implementation choices within the proposed V1
+contract.
+
+## Appendix A. Qualification Procedure
+
+Preflight records, once, the constants every later test reuses
+unchanged: the registration/session shape and the arena layout it
+permits, the accepted HTTP status set, the reply-tag value and parse
+rule, the byte count reported on failed responses, and the GPU
+write-ordering attribute with flush availability.
+
+The hardware-correctness stage runs checksum stress at full worker count
+with one session per worker, slot-reuse churn, flush counting, and decode
+stress on the copy stream. Its fault matrix injects missing, wrong, and
+short replies; an ambiguous transport fault; and a session result with a
+valid reply tag, `n == expected`, and a non-success HTTP status.
+
+Performance runs use one configuration frozen after preflight — worker,
+chunk, slot, and arena settings held constant, no per-size tuning —
+against a warm server cache, at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB,
+and 1 GiB. Object size and RDMA chunk size are distinct: transfers keep
+normal Sirius chunking rather than forcing one RDMA request per object.
+Each size sustains repeated reads for at least
+ten seconds per trial, with two warm-ups and at least seven measured
+trials. Throughput is measured from device-read submission through
+delivery into the caller-owned RMM buffer — queueing, RDMA, required
+flushes, D2D copies, and request completion — excluding one-time
+initialization, arena registration, object HEAD, and warm-up. A large
+size passes when the one-sided 95% Student-t lower confidence bound of
+the arithmetic mean of its per-trial throughputs reaches 85% of the link
+rate (85 Gbps on the current 100 Gbps rig); the same statistic is
+computed for both arms at the small sizes. HTTP results are a required
+output but do not determine GO or STOP; the 85% floor is grounded in the
+~91 Gbps standalone-benchmark measurement cited in the header.
+
 </script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script type="module">

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -155,10 +155,10 @@ the destination is valid.
 
 ## 5. Safety and Failure Semantics
 
-The safety model has two irreversible boundaries. Issuing the
-token-bearing GET creates a possible remote writer to the registered
-arena; enqueuing `cudaMemcpyAsync` creates a possible local GPU writer
-to caller-owned RMM memory. A failure is recoverable only when Sirius
+The safety model has two irreversible boundaries. A token-bearing GET
+that may have reached the gateway creates a possible remote writer to
+the registered arena; the first `cudaMemcpyAsync` call creates a
+possible local GPU writer to caller-owned RMM memory. A failure is recoverable only when Sirius
 can prove the relevant writer has stopped: an uncertain RDMA completion
 therefore fail-stops the transport, and an uncertain copy is
 process-fatal.
@@ -177,24 +177,25 @@ and arena lifetime.
 stateDiagram-v2
   [*] --> PreIssue: chunk claimed / slot leased
 
-  PreIssue --> RequestError: local failure before GET
-  PreIssue --> RDMAInFlight: issue one-shot token-bearing GET
+  PreIssue --> RequestError: non-sticky local failure (GET provably not issued)
+  PreIssue --> ProcessFatal: sticky CUDA error
+  PreIssue --> RDMAInFlight: token-bearing GET may have reached the gateway
 
   RDMAInFlight --> TransportFailStop: completion non-exact or unknown
   RDMAInFlight --> ReadyToDeliver: exact completion (tag + status + expected bytes)
 
-  ReadyToDeliver --> RequestError: non-sticky error before D2D
+  ReadyToDeliver --> RequestError: non-sticky failure before the first cudaMemcpyAsync call
   ReadyToDeliver --> ProcessFatal: sticky CUDA error
-  ReadyToDeliver --> CopyInFlight: flush if required, enqueue D2D + event
+  ReadyToDeliver --> CopyInFlight: flush if required, then the first cudaMemcpyAsync call (the boundary)
 
-  CopyInFlight --> Delivered: event wait == cudaSuccess
-  CopyInFlight --> ProcessFatal: any other outcome
+  CopyInFlight --> Delivered: event wait reports cudaSuccess
+  CopyInFlight --> ProcessFatal: any error from memcpy, record, or wait
 
   Delivered --> [*]: chunk complete / slot reusable
   RequestError --> [*]: request marked failed / slot released
 
   note right of TransportFailStop
-    Future resolves with an error.
+    The request future errors after issued work settles.
     The arena remains allocated.
     Recovery requires process restart.
   end note
@@ -206,7 +207,7 @@ stateDiagram-v2
 ```
 
 The sticky set is CUDA's documented classification, checked against the
-tree's classifier. After the D2D is enqueued, only an event wait
+tree's classifier. After the first `cudaMemcpyAsync` call, only an event wait
 reporting `cudaSuccess` proves the copy has stopped writing; an
 event-destroy failure after that successful wait is logged and does not
 change the delivery outcome.
@@ -214,9 +215,9 @@ change the delivery outcome.
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
 | Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
-| Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
+| Non-sticky error before the first `cudaMemcpyAsync` call | Report the error; the reactor continues | Error | Slot released |
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
-| Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
+| Sticky CUDA error, or any error at or after the first `cudaMemcpyAsync` call (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
 On entering `TransportFailStop`, the ioctx marks the shared admission
 gate terminal and refuses new work; host- and device-plane operations

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -219,7 +219,7 @@ the absence of normal teardown.
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. Compatibility: the existing pure-virtual `authorize()` stays untouched; the headers-to-sign travel through a **new, separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`) whose default implementation rejects non-empty header sets as unsupported, and which the built-in SigV4 header signer overrides — a defaulted parameter on the existing virtual would break every override, and a same-name overload would make existing three-argument calls ambiguous | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -291,7 +291,7 @@ as the plan that closes the gap between the current tree and this design.
 | **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued (death tests: child process, exit code, no normal teardown), teardown leak, admission deadlock-freedom) | CUDA GPU |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
@@ -387,6 +387,20 @@ server-side (its own config, default 2 MiB) — nothing is negotiated on the wir
 Production gateways SigV4-validate the control request before honoring the
 token, and the token + `Range` are part of that signature (D8): the client
 signs them, the gateway verifies them — an unsigned token is rejected.
+
+### Auth surface extension (D8 mechanics)
+
+The authorizer's request surface is extended so headers added for RDMA are
+part of the SigV4 canonical request. Presigned mode is excluded as a v1
+implementation choice, not a protocol limit: SigV4 query signing can in
+principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner
+signs only `host` today. Compatibility: the existing pure-virtual
+`authorize()` stays untouched; the headers-to-sign travel through a **new,
+separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`)
+whose default implementation rejects non-empty header sets as unsupported,
+and which the built-in SigV4 header signer overrides. A defaulted parameter
+on the existing virtual would break every override, and a same-name overload
+would make existing three-argument calls ambiguous.
 
 ### Config (under `object_store_config`)
 

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -125,6 +125,16 @@ the stream first if a D2D was already queued).
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
+**One reactor, not one per GPU.** Multi-GPU affinity lives at the **arena/slot**
+layer — a worker does `cudaSetDevice(r.device_id)` and takes a slot from *that*
+device's arena, so the slot and `r.dst` are always same-device (never a
+cross-device copy). The single reactor owns one global worker pool. A per-GPU
+reactor would make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
+`cuObjGet`), breaking the global in-flight ceiling and risking gateway/NIC
+overload. Per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity and
+per-device throttling, at the cost of global rate-limit and config complexity —
+is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
+
 ## 4. Rollout
 
 | Phase | Scope | HW |

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -28,11 +28,13 @@ on CX-6 RoCE).
 
 ## 1. Summary
 
-- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
-  reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
-  complete object key written out, not a glob or a listing. The first target
-  workload, TPC-H benchmarking over lakehouse parquet, references every table
-  by exact key, so glob/LIST support is deferred without loss.
+- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for Parquet reads on
+  one GPU, by exact key (`read_parquet('s3://bucket/path/file.parquet')`)
+  or by glob (`read_parquet('s3://bucket/path/*.parquet')`). A glob is
+  resolved on the host control plane with ordinary signed S3 requests
+  (HTTP or HTTPS, following the configured host endpoint and its TLS
+  settings); every matched object is then read by its exact key. The
+  data plane never lists; it only ever serves exact-key reads.
 - Payload lands in a pre-registered GPU arena and is copied to caller-owned
   RMM memory on the caller stream, with zero Sirius-side host staging or H2D
   traffic. Metadata and footer reads remain on the existing S3 path.
@@ -54,15 +56,15 @@ on CX-6 RoCE).
 
 | Supported in v1 | Not in v1 |
 |---|---|
-| Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
+| Exact-key data reads; wildcard glob and S3 LIST resolved on the host control plane | Merging the two listing HTTP legs into one implementation (the signer, parser, and listing interface are already shared); the per-object footer stash at open (RDMA opens with a plain HEAD); custom LIST caps (RDMA uses the built-in limits for now) |
 | Two logical endpoints — host plane + RDMA data plane; the configured addresses may be identical | A single shared endpoint configuration (no separate data-plane settings) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
 | One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
 | Restart-based recovery | Hot recovery of a failed transport context |
 
-Footer caching and known-size open are also out of scope; footer and
-metadata reads are plain HEAD and range GET on the host plane.
+Known-size open is also out of scope; footer and metadata reads are
+plain HEAD and range GET on the host plane.
 
 ## 3. Architecture and Ownership
 

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -36,8 +36,10 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`. The benchmark proves this end-to-end at line rate.
-**Please review the decisions table (§3) and the open questions (§5).**
+existing `templated_ioctx`. The benchmark proves the cuObject RDMA data path at
+line rate; the Sirius-specific arena+D2D visibility and completion discipline
+are gated by P3. **Please review the decisions table (§3) and the open
+questions (§5).**
 
 ## Why
 
@@ -74,8 +76,9 @@ The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
 **not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
 stream through the arena in waves, each chunk D2D-copied to its offset in the
 **full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
-through the same ~8–16 MiB arena — exactly how `s3_reactor` streams through its
-host staging blocks today.
+through the same arena (default ~8 MiB, configurable as `max_inflight ×
+slot_size`) — exactly how `s3_reactor` streams through its host staging blocks
+today.
 
 ## 2. How one read works
 
@@ -126,7 +129,8 @@ gated future spike (§5 Q4).
 
 | Phase | Scope | HW |
 |---|---|---|
-| **P0 ✅ landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`). Residual hardening tracked in the appendix | — |
+| **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
+| **P0b ⏳ gateway hardening open** | Strict descriptor-address parse, explicit short-write (`n == expected`) + capacity checks — today the client returns `size` on any 200/206 and the server only fails on `rdma_n < 0` (see appendix) | — |
 | P1 | Wire `s3_transport` through `scan_manager_config`; backend chosen at scan-manager construction; AUTO→HTTP; config tests | — |
 | P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix | — |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test | CX-6 |

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -22,27 +22,33 @@
 <script type="text/markdown" id="src">
 # S3 RDMA Transport for Sirius — V1 Design
 
-Status: evaluation-prototype design for team review — no production code
-in this PR. Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
 <https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
 on CX-6 RoCE).
 
 ## 1. Summary and Scope
 
-V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
-reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
-complete object key written out, not a glob or a listing. Payload lands
-in a pre-registered GPU arena and is
-copied to caller-owned RMM memory on the caller stream, with zero
-Sirius-side host staging or H2D traffic; metadata and footer reads remain
-on the existing S3 path. There is no automatic probing and no runtime
-fallback to HTTP: when RDMA is selected and cannot serve a request, the
-request fails with an explicit error. GO requires hardware correctness, at
-least 85% of the qualified RDMA link rate for objects of 16 MiB or larger,
-and a zero-failure 100-million-GET soak. For smaller objects the gate
-measures RDMA against HTTP side by side; if RDMA shows no advantage there,
-V1 may add a size-based fallback that routes small objects to the HTTP
-path — a routing choice, distinct from the failure semantics above.
+- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
+  reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
+  complete object key written out, not a glob or a listing. The first target
+  workload, TPC-H benchmarking over lakehouse parquet, references every table
+  by exact key, so glob/LIST support is deferred without loss.
+- Payload lands in a pre-registered GPU arena and is copied to caller-owned
+  RMM memory on the caller stream, with zero Sirius-side host staging or H2D
+  traffic. Metadata and footer reads remain on the existing S3 path.
+- No automatic probing and no runtime fallback to HTTP: when RDMA is selected
+  and cannot serve a request, the request fails with an explicit error. Retry
+  and demotion for the RDMA path belong to the scan-manager layer above the
+  transport, and are added there later rather than inside the transport.
+- GO requires hardware correctness, at least 85% of the qualified RDMA link
+  rate for objects of 16 MiB or larger, and a zero-failure 100-million-GET
+  soak.
+- For smaller objects the gate measures RDMA against HTTP side by side; if
+  RDMA shows no advantage there, V1 may add a size-based fallback that routes
+  small objects to the HTTP path — a routing choice, distinct from the
+  failure semantics above.
+- The prefetch cache is off on the RDMA path in V1. Whether V1 grows a cache
+  is decided from the benchmark results, not up front.
 
 ### Decisions Requested
 

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -70,6 +70,13 @@ plane** (RDMA) writes object bytes straight into the GPU arena. Versus
 staging for a small GPU arena and the H2D copy for a GPU-local D2D (<1%
 overhead). Host reads (footers / HEAD) still go over HTTP.
 
+The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
+**not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
+stream through the arena in waves, each chunk D2D-copied to its offset in the
+**full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
+through the same ~8–16 MiB arena — exactly how `s3_reactor` streams through its
+host staging blocks today.
+
 ## 2. How one read works
 
 ```mermaid

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -116,7 +116,7 @@ sequenceDiagram
   Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
   W->>W: create the completion event FIRST
   W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline (the D2D is ~3 µs vs a ~350 µs GET)
+  W->>S: wait on the event inline (~3 µs est. vs the ~350 µs wire time of one slot)
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
@@ -124,17 +124,23 @@ sequenceDiagram
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
 concurrency bound** — and because there is exactly one arena slot per worker, a
 worker always finds a free slot: admission pressure lives in the reactor's
-queue, which is **capped per ioctx** with blocking admission and depth/wait
-counters (see the config appendix). Completion uses the framework's
+queue, which holds bounded **request envelopes** — a submitter enqueues one
+small envelope per read and returns; workers generate and claim chunks lazily
+from the head envelopes, so an async read never waits on chunk-level progress
+(see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
 future resolves when the last chunk does. (One deliberate exception exists:
 the *unprovable* delivery verdict below terminates the process instead of
 completing the chunk — the framework's "resolve on last release" mechanics
-make any softer form of "never resolved" unimplementable.) Nothing runs on a CUDA callback
+make any softer form of "never resolved" unimplementable. The sticky
+context-fatal verdict also ends in termination, but only after the chunk's
+error is safely reported.) Nothing runs on a CUDA callback
 thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
-(bandwidth-derived) against a ~350 µs network GET at the 100G reference point,
-so parking the worker is not expected to improve throughput. Two caveats keep this a
+(bandwidth-derived) against the ~350 µs it takes just to serialize a 4 MiB
+slot at ~91 Gbps (a wire-time floor, not a measured single-request latency
+under concurrency), so parking the worker is not expected to improve
+throughput. Two caveats keep this a
 hypothesis rather than a settled fact: the event wait covers **all prior work
 on the caller's stream**, not just our D2D, and the ratio shifts at higher
 line rates — a realistic shared-stream saturation test is an explicit
@@ -163,49 +169,57 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   sync as the stronger proof. (Captured streams fall in that exception too —
   and are a documented precondition violation: RDMA device reads do not
   support them.)
-- The verdict is three-way. *Quiet + healthy*: release the slot, report the
-  original error, keep serving. *Quiet + context-fatal* (sticky errors such as
-  an illegal memory access): the CUDA context is dead — no engine can write
-  the destination anymore, so reporting the error is safe — and the reactor
-  **fail-stops**. *Unprovable* (the device-wide sync also failed with a
-  non-sticky code, or could not run): the worker calls a **non-returning
-  process-fatal hook** — log the verdict, then terminate the process. The
-  chunk never completes, so the future never resolves and the caller can never
-  free a destination that may still be written; no arena teardown runs either,
-  so nothing the copy engine might touch is deregistered or freed. Termination
-  is what makes "never resolved" executable — the completion framework
-  resolves a future when its last chunk reference is released, so any design
-  that keeps the process alive must either release (unsafe) or hold the
-  reference forever (a wedged process a watchdog kills anyway). This also
-  matches CUDA's own contract for a corrupted process: terminate and restart.
-- **Fail-stop** happens exactly once. New reads fail fast, naming the first
-  fatal error. Queued chunks are completed with that error. Chunks already in
-  flight finish on their own workers — never resolved on another worker's
-  behalf — for provable outcomes; an unprovable verdict terminates the process
-  instead. And any arena that cannot be proven quiet at teardown is
-  deliberately **leaked rather than freed**: freeing memory a NIC or copy
-  engine might still write is the very use-after-free this discipline exists
-  to prevent.
-- A sticky CUDA error is a **process-level** event: continuing CUDA work just
-  returns the same error. Fail-stop is containment; process restart is the
-  recovery.
+- The verdict is three-way, and both non-recoverable verdicts end in a
+  **non-returning process-fatal hook** (log, then terminate the process; if
+  the hook ever returns, the call site calls `std::terminate`):
+  - *Quiet + healthy*: release the slot, report the original error, keep
+    serving.
+  - *Quiet + context-fatal* (sticky errors such as an illegal memory access):
+    the CUDA context is dead — no engine can write the destination anymore —
+    so the error is reported and logged first, **then the hook fires**.
+    Termination here is CUDA's own contract: a sticky error leaves the process
+    state corrupted, and the documented requirement is to terminate and
+    relaunch. "Restart is the recovery" thereby has an actor.
+  - *Unprovable* (the device-wide sync also failed with a non-sticky code, or
+    could not run): the hook fires **without resolving anything**. The chunk
+    never completes, so the future never resolves and the caller can never
+    free a destination that may still be written; no arena teardown runs
+    either. Termination here is Sirius's use-after-free policy rather than a
+    CUDA requirement: the completion framework resolves a future when its last
+    chunk reference is released, so a design that keeps the process alive must
+    either release (unsafe) or hold the reference forever (a wedged process a
+    watchdog kills anyway).
+- **Reactor fail-stop** is the containment shape for failures that do *not*
+  corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
+  retry contract (appendix). It happens exactly once: new reads fail fast,
+  naming the first fatal error; queued chunks are completed with that error;
+  chunks already in flight finish on their own workers — never resolved on
+  another worker's behalf; and any arena that cannot be proven quiet at
+  teardown is deliberately **leaked rather than freed**, because freeing
+  memory a NIC might still write is the very use-after-free this discipline
+  exists to prevent. The process stays alive, but RDMA service on this
+  context resumes only with a process restart.
 
 Every CUDA call on this delivery path goes through a small seam injected at
-construction time, so all of the failure branches above are fault-injectable in
-ordinary tests without faking CUDA semantics.
+construction time, so the recoverable branches are fault-injectable in
+ordinary tests without faking CUDA semantics. The process-fatal branches are
+different: an in-process test double that returns or throws would exercise
+exactly the stack unwinding production forbids, so the hook is validated by
+**death tests** — a child process asserting the exit code, the fatal log, and
+the absence of normal teardown.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
+| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. The authorizer extension must be additive (a new overload with a defaulted parameter) so existing and downstream custom authorizers keep compiling | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. Compatibility: the existing pure-virtual `authorize()` stays untouched; the headers-to-sign travel through a **new, separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`) whose default implementation rejects non-empty header sets as unsupported, and which the built-in SigV4 header signer overrides — a defaulted parameter on the existing virtual would break every override, and a same-name overload would make existing three-argument calls ambiguous | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -296,7 +310,9 @@ as the plan that closes the gap between the current tree and this design.
    NONE platform that cannot flush must fail RDMA init loudly (no safe
    configuration exists). What still needs the rig: wiring the policy **per
    device** and the decode-immediately-after-GET stress test — still the top
-   correctness gate for P3. Who owns that rig time?
+   correctness gate for P3. Who owns that rig time? (This ruling covers v1's
+   single RDMA path; a future multi-NIC sharding must revisit NVIDIA's
+   multi-ordering-domain exceptions.)
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
@@ -314,11 +330,15 @@ as the plan that closes the gap between the current tree and this design.
    same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
    vs the validated 1.0.0) and shapes the client-wrapper API; it must be
    decided on the rig, before activation.
-7. **Ambiguous-failure fencing** — after a control-plane timeout or reset, the
-   gateway may still hold a descriptor for the slot and keep writing it; the
-   protocol defines what a success response means, but not what silence means.
-   Does the cuObject SDK or the gateway offer a fencing / cancellation
-   primitive (deregister-and-confirm, descriptor revocation)? Without one, the
+7. **Ambiguous-failure fencing and duplicate suppression** — after a
+   control-plane timeout or reset, the gateway may still hold a descriptor for
+   the slot and keep writing it; the protocol defines what a success response
+   means, but not what silence means — and a transparently retried duplicate
+   can succeed while the original is still writing (see the deployment
+   invariants in the appendix), which no client-side rule can detect. Does the
+   cuObject SDK or the gateway offer a fencing / cancellation primitive
+   (deregister-and-confirm, descriptor revocation)? Is a descriptor token
+   single-use at the gateway? Without one, the
    retry contract (appendix) must fail-stop the reactor and mark the entire
    arena non-freeable on any ambiguous failure (per-slot quarantine was
    rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
@@ -377,7 +397,7 @@ its consumer. Two sizing knobs accompany it:
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
-s3_rdma_queue_cap                 # per-ioctx admission bound, in CHUNKS (default 4 x max_inflight)
+s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
 ```
 
 **Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
@@ -390,17 +410,20 @@ granularity is the arena slot size, and the server chunks independently.
 Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
 for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
-**Admission bound (v1):** the reactor's request queue is **capped per ioctx**
-(`s3_rdma_queue_cap`, counted in chunks). Admission blocks once the cap is
-reached, and — because the async read API enqueues synchronously — that blocks
-the submitting thread; this is the accepted v1 API semantics, and a
-deadlock-freedom test (a producer blocked at the cap while workers drain, and
-while the reactor fail-stops) is part of the rollout matrix. A read larger
-than the cap admits in waves as workers drain. Order is FIFO. Fail-stop and
-shutdown wake every blocked producer, which then observes the failure/shutdown
-error. Queue depth-peak and queue-wait counters expose the pressure. The
-process-wide budget is contexts × workers — a deployment running several
-Sirius contexts must size the gateway budget for the sum.
+**Admission bound (v1):** the reactor's queue holds **request envelopes**,
+bounded per ioctx (`s3_rdma_queue_cap`, counted in requests). A submitter
+enqueues one envelope — a small descriptor, not the chunk list — and returns
+immediately; workers generate and claim chunks lazily from the head envelopes,
+FIFO. Per-chunk admission was rejected: with a chunk-counted cap, a read
+larger than the cap would block the submitting thread until most of its own
+transfer had completed, making the async API effectively synchronous. Only a
+full envelope queue blocks a submitter (the bound is on outstanding requests,
+which the scan layer already limits); fail-stop and shutdown wake any blocked
+submitter, which then observes the failure/shutdown error — a
+deadlock-freedom test covers both. Envelope-queue depth-peak and wait counters
+expose the pressure. The process-wide budget is contexts × workers — a
+deployment running several Sirius contexts must size the gateway budget for
+the sum.
 
 **Retry contract** — deliberately independent of the REST policy, and split by
 plane, because the two planes fail differently:
@@ -429,6 +452,25 @@ plane, because the two planes fail differently:
   (§5 Q7) is what would permit a less drastic recovery.
 - Everywhere: CUDA work never retries; exhaustion surfaces the last error —
   and per D6, never a transport switch.
+
+**Deployment invariants (v1, required for the RDMA plane).** The commit-state
+contract above covers failures the *client sees*. A transparent intermediary
+can break it invisibly: a proxy forwards request A (the gateway starts
+writing), the upstream connection drops, the proxy silently retries as
+request B, B succeeds and returns 200 — the client completes the read, reuses
+the slot, and only then does A's late write land. The client saw only success,
+so no fail-stop triggers. v1 therefore requires one of:
+
+- **No automatic intermediary retries** of token-bearing GETs anywhere on the
+  path (the recommended deployment: client connects to the gateway directly,
+  or every proxy in between has retries disabled for these requests); or
+- **Gateway-side exactly-once dedup** keyed on the signed token / a signed
+  request id, so a duplicated request never starts a second RDMA write.
+
+Related requirements: confirm with NVIDIA whether a descriptor token is
+single-use at the gateway (Q7); the control plane runs over TLS; tokens are
+redacted from request logs; and replayed tokens outside the dedup window are
+rejected.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -34,9 +34,11 @@
 Read large Parquet column data from S3 **straight into GPU memory over RDMA**,
 removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
-moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
-scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`, the same way the REST backend is built. The
+moves it to the final RMM buffer. `s3://` URIs, the SigV4 credential machinery,
+and the Parquet scanner are unchanged — the new code is one reactor plus a thin
+ioctx under the existing `templated_ioctx`, the same way the REST backend is
+built. (One auth-surface extension is required: the RDMA token and `Range`
+must be **inside** the SigV4 signature — D8.) The
 benchmark already proves the cuObject RDMA data path at line rate. What remains
 Sirius-specific is the arena+D2D **visibility discipline**, validated in
 rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
@@ -76,7 +78,9 @@ engine behind it, defined by which read **builders** it provides.)*
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
 backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (<1% overhead). Host reads
+small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot —
+under 1% of the transfer at the 100G reference point; a larger share at higher
+line rates, so re-measure before extrapolating). Host reads
 (footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
 `s3_request_authorizer`.
 
@@ -87,13 +91,15 @@ chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 Mi
 
 Both sizing knobs are **config** (`s3_rdma_max_inflight`,
 `s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
-device** — is calibrated on the benchmark's CX-6 **100G** rig, which is the
-*floor* for this transport (line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle).
-Faster NICs scale the same two knobs, not the design: keep the bytes in flight
-(`workers × slot_size`) growing roughly linearly with line rate — e.g.
-~16 × 16 MiB or 64 × 4 MiB ≈ 256 MiB/device for 800G-class NICs — and re-derive
-the knee empirically on the target rig (a P4/P5 sweep). The arena stays trivial
-next to GPU memory at any of these points.
+device** — comes from the benchmark's CX-6 **100G reference configuration**
+(line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page
+cache and the server's 2 MiB chunking, so other topologies must re-measure).
+Faster NICs scale the same two knobs, not the design: the bytes in flight
+(`workers × slot_size`) must grow with line rate, and the knee has to be
+re-derived empirically on the target NIC (a P4/P5 sweep) — the 100G numbers do
+not transfer. Arena memory cost is exact:
+`workers × slot_size × active GPUs` per Sirius context (32 MiB per device at
+the reference defaults).
 
 ## 2. How one read works
 
@@ -118,16 +124,19 @@ sequenceDiagram
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
 concurrency bound** — and because there is exactly one arena slot per worker, a
 worker always finds a free slot: admission pressure lives in the reactor's
-queue, never in the arena (the queue is currently uncapped; bounding and
-observing queued work is a tracked follow-up). Completion uses the framework's
+queue, which is **capped per ioctx** with blocking admission and depth/wait
+counters (see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
 future resolves when the last chunk does. Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline** (parking the worker to
-dodge a ~3 µs wait — right after a ~350 µs network GET — buys nothing); the
-REST backend's event-poll shape remains the documented fallback if
-shared-stream measurements on the rig ever show the inline wait stalling
-workers.
+thread. The worker waits on its own copy **inline**: at the measured 100G
+reference point the D2D is ~3 µs against a ~350 µs network GET, so parking the
+worker is not expected to improve throughput. Two caveats keep this a
+hypothesis rather than a settled fact: the event wait covers **all prior work
+on the caller's stream**, not just our D2D, and the ratio shifts at higher
+line rates — a realistic shared-stream saturation test is an explicit
+activation gate, and the REST backend's event-poll shape is the documented
+fallback if it fails.
 
 **When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
 the arena slot (its next user would corrupt an in-flight copy) and the caller's
@@ -135,10 +144,16 @@ destination (the caller frees it as soon as its future resolves — while the
 copy may still be writing it). The rule is therefore absolute: **neither the
 slot is recycled nor the future resolved until the stream is proven quiet.**
 
-- The completion event is created **before** the copy is enqueued — if even
-  that fails, nothing is in flight and the error is plainly recoverable.
-- On any CUDA failure after the enqueue, the worker proves quiescence with a
-  real stream sync. A sync call can return an error produced by *earlier*
+- The completion event is created **before** the copy is enqueued — if event
+  creation fails, no D2D has been submitted, so releasing the slot and
+  reporting the error is safe.
+- A non-success return from `cudaMemcpyAsync` itself does **not** prove the
+  copy was rejected: async CUDA calls may return errors produced by *earlier*
+  async work, so the enqueue state is unknown. Any non-success here is treated
+  exactly like a post-enqueue failure and goes through the quiescence proof
+  below.
+- On any CUDA failure at or after the enqueue, the worker proves quiescence
+  with a real stream sync. A sync call can return an error produced by earlier
   async work — the call itself still waited, so the stream is still proven
   quiet. The only exception is an error meaning the call never ran at all
   (e.g. an invalid stream handle); then the worker escalates to a device-wide
@@ -147,8 +162,15 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   support them.)
 - The verdict is three-way. *Quiet + healthy*: release the slot, report the
   original error, keep serving. *Quiet + context-fatal* (sticky errors such as
-  an illegal memory access): the CUDA context is dead and nothing can touch the
-  destination anymore — report and **fail-stop**. *Unprovable*: fail-stop.
+  an illegal memory access): the CUDA context is dead — no engine can write
+  the destination anymore, so reporting the error is safe — and the reactor
+  **fail-stops**. *Unprovable* (the device-wide sync also failed with a
+  non-sticky code, or could not run): the request is **never handed back** —
+  its future deliberately does not resolve, because a resolved future licenses
+  the caller to free a destination that may still be written. The reactor
+  fail-stops and escalates to **process-fatal**: the process must be restarted
+  (watchdog territory). A wedged request is the deliberate lesser evil against
+  a silent use-after-free.
 - **Fail-stop** happens exactly once. New reads fail fast, naming the first
   fatal error. Queued chunks are completed with that error. Chunks already in
   flight finish on their own workers — never resolved on another worker's
@@ -171,11 +193,11 @@ ordinary tests without faking CUDA semantics.
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
 | D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a restart instead of pretending to continue |
+| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and the RDMA control plane requires header-signing mode (a presigned URL cannot bind headers added after signing) | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -184,12 +206,13 @@ Why D9 works, in one picture:
 flowchart LR
   A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
   B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["no host staging can sneak in;<br/>the cache's staged-read crash path<br/>is unreachable"]
+  C --> D["the omitted builders make host staging<br/>and the cache's staged-read crash path<br/>unreachable for this backend"]
 ```
 
 This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
 column projections** (issue #1078, a foreground/background allocation race) —
-this backend is structurally immune to that too, the same way kvikio is.
+the omitted builders make that path unreachable for this backend too, the
+same way it is for kvikio.
 
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
@@ -215,7 +238,7 @@ axes:
   are always same-device (never a cross-device copy). A per-GPU reactor would
   instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
   `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
-- **NIC count** is the one thing that eventually justifies more reactors:
+- **NIC count** is what eventually justifies more reactors:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
@@ -241,14 +264,14 @@ change.
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2) | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship the fixed 100G-floor default from §1's sizing
+1. **Sizing defaults** — ship the fixed 100G-reference default from §1's sizing
    rule, or should the default self-scale from a detected/configured link
    speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
 2. **Visibility policy validation** — CUDA exposes a per-device
@@ -278,6 +301,13 @@ change.
    same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
    vs the validated 1.0.0) and shapes the client-wrapper API; it must be
    decided on the rig, before activation.
+7. **Ambiguous-failure fencing** — after a control-plane timeout or reset, the
+   gateway may still hold a descriptor for the slot and keep writing it; the
+   protocol defines what a success response means, but not what silence means.
+   Does the cuObject SDK or the gateway offer a fencing / cancellation
+   primitive (deregister-and-confirm, descriptor revocation)? Without one, the
+   retry contract (appendix) must quarantine the slot and fail the read on any
+   ambiguous failure — a question for NVIDIA as much as for this team.
 
 ## 6. Risks
 
@@ -312,14 +342,16 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 | Header | Direction | Meaning |
 |---|---|---|
 | `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected` — but that count is only **authoritative once the gateway enforces exact completion** (accepts no short or overlong RDMA piece): the P0b hardening (see below) is therefore a precondition for trusting short-write detection on the real path |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected`, and that count is authoritative only when **both** halves hold: the gateway enforces exact completion (accepts no short or overlong RDMA piece), **and** the client requires a valid reply tag before it reports the requested size — an HTTP 200/206 without a legitimate reply must be treated as failure, and the reply payload is never interpreted as a byte count. Both halves are P0b items (see below) and a precondition for trusting short-write detection on the real path |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
 address rides in the token, capacity is the `cuObjGet` `size` arg, and the
 reply tag supersedes the byte-count header. The server chunks transfers
 server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
-Production gateways SigV4-validate the control request before honoring the token.
+Production gateways SigV4-validate the control request before honoring the
+token, and the token + `Range` are part of that signature (D8): the client
+signs them, the gateway verifies them — an unsigned token is rejected.
 
 ### Config (under `object_store_config`)
 
@@ -332,17 +364,42 @@ s3_rdma_max_inflight              # worker count = global in-flight ceiling (def
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
 ```
 
-The control plane reuses the shared object-store endpoint carried by the
-authorizer; a distinct RDMA-gateway endpoint knob is added only if activation
-shows the gateway host must differ from the S3 endpoint. There is deliberately
-**no client chunk-size knob**: the transfer granularity is the arena slot size,
-and the server chunks independently. Auth/TLS reuse the existing fields
-(`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+**Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
+cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
+and the RDMA control requests, under one set of credentials and one signing
+host. A split topology (RDMA gateway separate from the S3 origin) is out of
+scope for v1: it needs two endpoints, two signing hosts, and an explicit
+credential boundary, and is only worth designing if a deployment actually
+requires it. There is deliberately **no client chunk-size knob**: the transfer
+granularity is the arena slot size, and the server chunks independently.
+Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
+for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
-**Retry contract** — deliberately independent of the REST policy: retries are
-chunk-level; only client transport failures and short reads retry; CUDA work
-never retries; exhaustion surfaces the last error — and per D6, never a
-transport switch.
+**Admission bound (v1):** the reactor's request queue is **capped per ioctx**
+(a small configurable multiple of the worker count); admission blocks once the
+cap is reached. Queue depth and queue-wait counters expose the pressure. The
+process-wide budget is contexts × workers — a deployment running several
+Sirius contexts must size the gateway budget for the sum.
+
+**Retry contract** — deliberately independent of the REST policy, and split by
+plane, because the two planes fail differently:
+
+- **Host/HTTP reads** (footers, metadata): retryable on transport failures and
+  short reads. The client owns the write loop into the destination buffer, and
+  a closed connection means no further writes — re-issuing into the same
+  buffer is safe.
+- **RDMA device reads**: retryability is decided by the **commit point**. A
+  failure that provably precedes the control request leaving the client
+  (connection setup, before the token is sent) is retryable. Once the token
+  may have reached the gateway, a timeout or reset without an authoritative
+  reply is **ambiguous**: the gateway holds a descriptor for the slot and may
+  still be writing it — the protocol defines "success response ⇒ transfer
+  complete", but not "no response ⇒ gateway stopped". An ambiguous failure is
+  therefore **not retried in place**: the read fails terminally and the slot
+  is withheld from reuse (quarantined), unless the gateway/SDK provides a
+  fencing or cancellation primitive (§5 Q7 — open question to NVIDIA).
+- Everywhere: CUDA work never retries; exhaustion surfaces the last error —
+  and per D6, never a transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
@@ -361,8 +418,10 @@ strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
 `buf_size` field is transmitted but never read server-side (a capacity check the
 server could perform for free but currently skips); the client reports success on
-any 200/206 without an `n == expected` short-write check; optional SigV4 in the
-dev server.
+any 200/206 without an `n == expected` short-write check **and without requiring
+a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
+of P0b — only after it may the callback report the requested size); optional
+SigV4 in the dev server.
 
 > Detailed gateway-hardening notes (file:line specifics) are tracked in the
 > `s3RDMA-benchmarktool` repo.

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -24,7 +24,7 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15: the body supports the review decisions; implementation detail lives in the appendix |
+| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15; synced 2026-07-16 to the current IO framework (#1087 footer open-hint, #1117 LIST/glob) |
 | **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
@@ -48,10 +48,19 @@ REST backend remains the default; RDMA is selected per context by the existing
 not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
 failures surface per the Safety Contract (§4).
 
-**Decisions requested.** The team is asked to approve five decisions (§6):
+**Current implementation gap (not a v1 design limit).** Exact-key
+`read_parquet('s3://…')` is the supported target; **wildcard glob** resolves
+through S3 LIST, which the framework currently routes to the REST backend
+only — under RDMA selection a glob fails loudly (D6). The P2 control-plane
+parity work closes this (§7) by wiring the hybrid's always-available HTTP
+control client; the RDMA data plane stays dormant until P3. It is a
+compatibility gate, separate from the P3 safety activation gates.
+
+**Decisions requested.** The team is asked to approve six decisions (§6):
 the landing arena + D2D shape, the CUDA failure policy, the
 duplicate-suppression mechanism and ambiguous-completion policy, the
-request-envelope queue model, and cuObject session ownership.
+request-envelope queue model, cuObject session ownership, and the gateway
+topology with its plain-S3 surface.
 
 ## 2. Architecture & Read Path
 
@@ -70,8 +79,11 @@ engine behind it, defined by which read **builders** it provides.)*
 
 On the control plane (HTTP), the descriptor token is the only RDMA-specific
 request header (`Range` travels as usual); the data plane (RDMA) writes object
-bytes straight into the GPU arena. Host reads
-(footers / HEAD) stay on HTTP through the existing SigV4 authorizer. The
+bytes straight into the GPU arena. Host reads stay on
+HTTP through the existing SigV4 authorizer — a surface that now includes the
+framework's footer-probe open hint (one suffix-range GET serves the size and
+the binder's footer reads), S3 LIST for glob, and HEAD; matching it on the
+hybrid is the P2 control-plane parity item (§7). The
 arena is a fixed staging window, not object-sized: a read streams through it
 in slot-sized chunks, each D2D-copied to its offset in the destination buffer
 (copy cost: §7).
@@ -197,9 +209,10 @@ never freed.
 
 Two independent gates apply on the real path. **Completion authority** is a
 P0b gate: the gateway enforces **exact completion** and the client requires a
-**valid reply tag** (appendix protocol). Separately, request **uniqueness**
-(§5) must hold before P3 activation — fail-stop cannot see a duplicate that
-succeeds.
+**valid reply tag** (appendix protocol). Separately, request **uniqueness and
+response–side-effect integrity** (§5) must hold before P3 activation —
+fail-stop cannot see a duplicate that succeeds, and completion authority
+cannot detect a cached or coalesced reply whose RDMA write never happened.
 
 ## 5. Authentication
 
@@ -218,12 +231,23 @@ non-empty header sets, and which the built-in SigV4 header signer overrides.
 The dev benchmark server runs unsigned on an isolated network; production
 gateways validate the signature before honoring the token.
 
-Request uniqueness is an **activation requirement**, not a recovery policy:
-a transparently retried duplicate can *succeed* while the original request is
-still writing, and no client-side rule — fail-stop included — can see it.
-**v1 satisfies it by deployment contract**: the client connects to the
-gateway directly (or every intermediary has automatic retries disabled for
-token-bearing GETs); RDMA must not be enabled otherwise. Gateway-side
+A token-bearing GET is not a safe idempotent read: the response certifies a
+**side effect** (the RDMA write into the slot), and any intermediary behavior
+that decouples the two defeats completion authority silently. A transparent
+retry duplicates the write while the original still runs; an HTTP **cache**
+(keyed on URI/Range — the token is just a header) can return a stored,
+legitimate `x-amz-rdma-reply` with **no write at all**; **request coalescing**
+merges two identical GETs into one upstream fetch — one write, two replies;
+hedging/mirroring duplicates writes. In each case the client sees a valid
+reply and `n == expected` while its slot holds stale bytes — silent
+corruption no client-side rule (fail-stop included) can detect.
+
+**v1 deployment contract (activation requirement):** token-bearing GETs are
+exempt from retry, hedging, mirroring, caching, and request coalescing;
+request and response both carry `Cache-Control: no-store`; any proxy route
+explicitly bypasses caches. Where all of this cannot be proven, the client
+connects **directly to the gateway** — the v1 default. RDMA must not be
+enabled otherwise. Gateway-side
 exactly-once deduplication is a **deferred conditional extension** — the base
 cuObject protocol defines no request-identity tag, so it would need a signed
 identity added to the wire (appendix) and is only worth specifying if a
@@ -236,9 +260,10 @@ are redacted from logs.
 |---|---|---|---|
 | 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
 | 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
-| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the no-intermediary-retry deployment contract (gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
+| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the §5 deployment contract (direct gateway; token-bearing GETs exempt from retry/hedge/mirror/cache/coalesce; gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
 | 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
 | 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
+| 6 | Gateway topology & plain-S3 surface | Single endpoint: the gateway also serves plain S3 (ListObjectsV2 / HEAD / range GET — P0c). "Token-less" means no RDMA descriptor, **not anonymous**: LIST/HEAD/GET stay SigV4-validated and authorized over TLS. SigV4 signs `Host`, so naive forwarding breaks signatures — the production model is **terminate-and-re-sign**: the gateway validates the client's SigV4, authorizes, and re-signs upstream with its own service identity (identity/permission mapping is a deployment definition); a gateway co-located with the storage (same hostname + credential authority) reduces this to internal dispatch. "One credential set" = the **client's** configuration; gateway→upstream credentials are the gateway's own. The benchmark gateway is a reference / conformance implementation | P0c, P2 parity |
 
 Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
 default (fixed 100G reference vs self-scaling) before P4; appetite for a
@@ -259,8 +284,9 @@ multi-NIC sharding would revisit the multi-ordering-domain exceptions.
 |---|---|---|---|
 | P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
 | P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
+| P0c | Gateway **plain S3 surface** (ListObjectsV2 / HEAD / token-less range GET — still SigV4-authenticated; §6 decision 6) for the single-endpoint topology — today it serves object HEAD only and rejects token-less GETs | serves host reads + glob; the P2 parity gate is complete only when this also lands (MinIO covers CI meanwhile) | — |
 | P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
-| P2 | Reactor against a mock client; envelope admission | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom | CUDA GPU |
+| P2 | Reactor against a mock client; envelope admission; hybrid control-plane parity (footer probe, known-size open, S3 LIST capability — this sub-item needs no CUDA GPU) | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom; parity: glob + footer-RTT behavior matches HTTP | CUDA GPU (except the parity sub-item) |
 | P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
 | P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
@@ -285,7 +311,8 @@ Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
 the omitted vector-read path (kvikio has the same gap; a per-segment framework
 fallback is proposed separately). The transparent `read_parquet('s3://')`
 front door (#1074) carries no transport-specific checks and is expected to
-work unchanged — a routing test pins this at integration. Captured CUDA
+work unchanged for exact-key opens — a routing test pins this at integration
+(wildcard glob: the implementation-gap note in §1). Captured CUDA
 streams are unsupported for RDMA device reads.
 
 Risks:
@@ -331,7 +358,8 @@ halves are P0b gates. The server chunks transfers server-side (its own config,
 default 2 MiB); nothing is negotiated on the wire. Signature validation and
 the dev/prod auth posture are defined in §5. Remaining P0b items
 (outcome level): strict descriptor/capacity validation, exact completion,
-mandatory reply validation — code-level specifics are tracked in the
+mandatory reply validation; the plain-S3 surface (LIST/HEAD/token-less GET)
+is the separate P0c item — code-level specifics for both are tracked in the
 `s3RDMA-benchmarktool` repo.
 
 ### Configuration
@@ -341,11 +369,14 @@ s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
 s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
+s3_rdma_perf_instrumentation      # gates the timing counter families (default off; §appendix Metrics)
 ```
 
 Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
-one host serves HEAD/range-GET and RDMA control under one credential set. A
-split topology is deferred until a deployment requires it. There is no client
+one host serves ListObjectsV2, HEAD, plain range-GET, and RDMA control under
+one credential set (the client's — §6 decision 6); growing the gateway's
+plain S3 surface to match is P0c gateway-side work. A split topology (plain S3 host for host/LIST reads, RDMA
+gateway for device reads) is deferred until a deployment requires it. There is no client
 chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
 the existing fields (`s3_signing_mode` — header mode required, §5 —
 `ca_bundle_path`, `tls_verify`).
@@ -369,7 +400,9 @@ never retries; exhaustion surfaces the last error; never a transport switch
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total`, `…_fallback_stream_sync_total`
+`…_queue_depth_peak`, `…_queue_wait_total`, the REST-shaped
+`…_blocking_host_get_count/wall_ns_total/wall_ns_max` (footer-probe GETs
+excluded, mirroring REST's attribution), `…_fallback_stream_sync_total`
 (quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
 the process-terminating verdicts leave a fatal log line and an exit code, not
 a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
@@ -406,8 +439,10 @@ and while the reactor fail-stops).
 
 This document describes the target architecture. The current tree differs in
 the areas the rollout table covers (delivery-failure discipline, retry
-classification, envelope admission, auth surface); P2/P3 implement and test
-them. No production code ships with this PR.
+classification, envelope admission, auth surface, the control-plane parity
+set — footer probe, known-size open, S3 LIST — and the gateway's plain-S3
+surface); P2/P3 (and P0c gateway-side) implement and test them. No production
+code ships with this PR.
 </script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script type="module">

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -42,7 +42,7 @@ must be **inside** the SigV4 signature — D8.) The
 benchmark already proves the cuObject RDMA data path at line rate. What remains
 Sirius-specific is the arena+D2D **visibility discipline**, validated in
 rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
-guarantees that no buffer is ever recycled or handed back while a copy might
+is designed so that no buffer is recycled or handed back while a copy might
 still touch it. **Please review the decisions table (§3) and the open
 questions (§5).**
 
@@ -78,9 +78,9 @@ engine behind it, defined by which read **builders** it provides.)*
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
 backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot —
-under 1% of the transfer at the 100G reference point; a larger share at higher
-line rates, so re-measure before extrapolating). Host reads
+small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot,
+estimated from HBM bandwidth — not yet measured on this path; under 1% of the
+transfer at the 100G reference point, a larger share at higher line rates). Host reads
 (footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
 `s3_request_authorizer`.
 
@@ -128,10 +128,13 @@ queue, which is **capped per ioctx** with blocking admission and depth/wait
 counters (see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
-future resolves when the last chunk does. Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline**: at the measured 100G
-reference point the D2D is ~3 µs against a ~350 µs network GET, so parking the
-worker is not expected to improve throughput. Two caveats keep this a
+future resolves when the last chunk does. (One deliberate exception exists:
+the *unprovable* delivery verdict below terminates the process instead of
+completing the chunk — the framework's "resolve on last release" mechanics
+make any softer form of "never resolved" unimplementable.) Nothing runs on a CUDA callback
+thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
+(bandwidth-derived) against a ~350 µs network GET at the 100G reference point,
+so parking the worker is not expected to improve throughput. Two caveats keep this a
 hypothesis rather than a settled fact: the event wait covers **all prior work
 on the caller's stream**, not just our D2D, and the ratio shifts at higher
 line rates — a realistic shared-stream saturation test is an explicit
@@ -165,16 +168,21 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   an illegal memory access): the CUDA context is dead — no engine can write
   the destination anymore, so reporting the error is safe — and the reactor
   **fail-stops**. *Unprovable* (the device-wide sync also failed with a
-  non-sticky code, or could not run): the request is **never handed back** —
-  its future deliberately does not resolve, because a resolved future licenses
-  the caller to free a destination that may still be written. The reactor
-  fail-stops and escalates to **process-fatal**: the process must be restarted
-  (watchdog territory). A wedged request is the deliberate lesser evil against
-  a silent use-after-free.
+  non-sticky code, or could not run): the worker calls a **non-returning
+  process-fatal hook** — log the verdict, then terminate the process. The
+  chunk never completes, so the future never resolves and the caller can never
+  free a destination that may still be written; no arena teardown runs either,
+  so nothing the copy engine might touch is deregistered or freed. Termination
+  is what makes "never resolved" executable — the completion framework
+  resolves a future when its last chunk reference is released, so any design
+  that keeps the process alive must either release (unsafe) or hold the
+  reference forever (a wedged process a watchdog kills anyway). This also
+  matches CUDA's own contract for a corrupted process: terminate and restart.
 - **Fail-stop** happens exactly once. New reads fail fast, naming the first
   fatal error. Queued chunks are completed with that error. Chunks already in
   flight finish on their own workers — never resolved on another worker's
-  behalf. And any arena that cannot be proven quiet at teardown is
+  behalf — for provable outcomes; an unprovable verdict terminates the process
+  instead. And any arena that cannot be proven quiet at teardown is
   deliberately **leaked rather than freed**: freeing memory a NIC or copy
   engine might still write is the very use-after-free this discipline exists
   to prevent.
@@ -197,7 +205,7 @@ ordinary tests without faking CUDA semantics.
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and the RDMA control plane requires header-signing mode (a presigned URL cannot bind headers added after signing) | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. The authorizer extension must be additive (a new overload with a defaulted parameter) so existing and downstream custom authorizers keep compiling | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -259,13 +267,18 @@ change.
 
 ## 4. Rollout
 
+The delivery-failure discipline (§2), the commit-point retry contract, the
+admission bound, and the signed-token auth surface are **target contracts**:
+implementing and fault-injection-testing them is P2/P3 scope. Read the table
+as the plan that closes the gap between the current tree and this design.
+
 | Phase | Scope | HW |
 |---|---|---|
-| **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
+| **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
+| **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop incl. an active unprovable chunk with queued siblings of the same request, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
@@ -362,6 +375,7 @@ its consumer. Two sizing knobs accompany it:
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
+s3_rdma_queue_cap                 # per-ioctx admission bound, in CHUNKS (default 4 x max_inflight)
 ```
 
 **Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
@@ -369,15 +383,20 @@ cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
 and the RDMA control requests, under one set of credentials and one signing
 host. A split topology (RDMA gateway separate from the S3 origin) is out of
 scope for v1: it needs two endpoints, two signing hosts, and an explicit
-credential boundary, and is only worth designing if a deployment actually
-requires it. There is deliberately **no client chunk-size knob**: the transfer
+credential boundary, and is deferred until a deployment requires it. There is deliberately **no client chunk-size knob**: the transfer
 granularity is the arena slot size, and the server chunks independently.
 Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
 for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
 **Admission bound (v1):** the reactor's request queue is **capped per ioctx**
-(a small configurable multiple of the worker count); admission blocks once the
-cap is reached. Queue depth and queue-wait counters expose the pressure. The
+(`s3_rdma_queue_cap`, counted in chunks). Admission blocks once the cap is
+reached, and — because the async read API enqueues synchronously — that blocks
+the submitting thread; this is the accepted v1 API semantics, and a
+deadlock-freedom test (a producer blocked at the cap while workers drain, and
+while the reactor fail-stops) is part of the rollout matrix. A read larger
+than the cap admits in waves as workers drain. Order is FIFO. Fail-stop and
+shutdown wake every blocked producer, which then observes the failure/shutdown
+error. Queue depth-peak and queue-wait counters expose the pressure. The
 process-wide budget is contexts × workers — a deployment running several
 Sirius contexts must size the gateway budget for the sum.
 
@@ -388,22 +407,31 @@ plane, because the two planes fail differently:
   short reads. The client owns the write loop into the destination buffer, and
   a closed connection means no further writes — re-issuing into the same
   buffer is safe.
-- **RDMA device reads**: retryability is decided by the **commit point**. A
-  failure that provably precedes the control request leaving the client
-  (connection setup, before the token is sent) is retryable. Once the token
-  may have reached the gateway, a timeout or reset without an authoritative
-  reply is **ambiguous**: the gateway holds a descriptor for the slot and may
-  still be writing it — the protocol defines "success response ⇒ transfer
-  complete", but not "no response ⇒ gateway stopped". An ambiguous failure is
-  therefore **not retried in place**: the read fails terminally and the slot
-  is withheld from reuse (quarantined), unless the gateway/SDK provides a
-  fencing or cancellation primitive (§5 Q7 — open question to NVIDIA).
+- **RDMA device reads**: retryability is decided by the **commit point**, so
+  the client wrapper must report a commit state with every failure —
+  `not_sent` / `sent_unknown` / `completed`. A `not_sent` failure (connection
+  setup, before the token left the client) is retryable. Once the token may
+  have reached the gateway (`sent_unknown`), a timeout or reset without an
+  authoritative reply is **ambiguous**: the gateway holds a descriptor and may
+  still be writing — the protocol defines "success response ⇒ transfer
+  complete", but not "no response ⇒ gateway stopped"; a proxy-replayed or
+  duplicated request can even land a late write after an apparent failure.
+  v1 therefore treats the **first ambiguous post-commit failure as a reactor
+  fail-stop**: the read fails, nothing retries in place, and the **entire
+  arena is marked non-freeable** — RDMA registration covers the whole arena,
+  so one slot the gateway may still write makes deregistering or freeing any
+  of it unsafe; teardown leaks it, and RDMA service on this context requires a
+  process restart. Per-slot quarantine was considered and rejected: repeated
+  quarantines drain the slot pool until workers, blocking admission, and
+  shutdown all wait forever. A gateway/SDK fencing or cancellation primitive
+  (§5 Q7) is what would permit a less drastic recovery.
 - Everywhere: CUDA work never retries; exhaustion surfaces the last error —
   and per D6, never a transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
-`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak` — plus the
+`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
+`…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
 runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
 (arenas leaked at teardown because the device could not be proven quiet).
@@ -417,7 +445,7 @@ documented. **Open hardening (P0b):** the migration **removed** the previous
 strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
 `buf_size` field is transmitted but never read server-side (a capacity check the
-server could perform for free but currently skips); the client reports success on
+server already has the data for but currently skips); the client reports success on
 any 200/206 without an `n == expected` short-write check **and without requiring
 a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
 of P0b — only after it may the callback report the requested size); optional

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -24,8 +24,8 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review |
-| **Date** | 2026-06-17 |
+| **Status** | Draft for team review — rebased onto the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev` |
+| **Date** | 2026-07-04 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
@@ -36,20 +36,20 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`. The benchmark proves the cuObject RDMA data path at
-line rate; the Sirius-specific arena+D2D visibility and completion discipline
-are gated by P3. **Please review the decisions table (§3) and the open
-questions (§5).**
+existing `templated_ioctx`, exactly how the REST backend is built. The benchmark
+proves the cuObject RDMA data path at line rate; the Sirius-specific arena+D2D
+visibility and completion discipline are gated by P3. **Please review the
+decisions table (§3) and the open questions (§5).**
 
 ## Why
 
-Sirius reads S3 Parquet today via libcurl range GETs into pinned host staging,
-then `cudaMemcpyAsync` to the GPU (`s3_reactor`) — every byte crosses host
-memory and PCIe **twice**. RDMA-direct removes both legs.
+Sirius reads S3 Parquet today via the REST backend (`rest_ioctx`): libcurl range
+GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU — every
+byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
 
 - **Goals:** large device reads RDMA-direct into GPU memory; keep `s3://` /
-  SigV4 / `sirius_datasource` semantics; HTTP backend stays config-selectable;
-  no Parquet-scanner changes.
+  SigV4 / `sirius_datasource` semantics; the REST backend stays the
+  config-selectable default; no Parquet-scanner changes.
 - **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
   gateway); no `AUTO` probe and no runtime HTTP fallback (RDMA failure = I/O
   error); no AWS-CRT dependency.
@@ -67,18 +67,26 @@ flowchart LR
 ```
 
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
-plane** (RDMA) writes object bytes straight into the GPU arena. Versus
-`s3_reactor` (GET → pinned host staging → PCIe H2D), this backend swaps host
-staging for a small GPU arena and the H2D copy for a GPU-local D2D (<1%
-overhead). Host reads (footers / HEAD) still go over HTTP.
+plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
+backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
+small GPU arena and the H2D copy for a GPU-local D2D (<1% overhead). Host reads
+(footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
+`s3_request_authorizer`.
 
-The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
-**not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
-stream through the arena in waves, each chunk D2D-copied to its offset in the
-**full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
-through the same arena (default ~8 MiB, configurable as `max_inflight ×
-slot_size`) — exactly how `s3_reactor` streams through its host staging blocks
-today.
+The arena is a **fixed per-chunk staging window**, not object-sized: the reactor
+splits a read into slot-sized chunks that stream through the arena in waves, each
+chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 MiB
+(or multi-GB) read flows through the same small arena.
+
+Both sizing knobs are **config** (`s3_rdma_max_inflight`,
+`s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
+device** — is calibrated on the benchmark's CX-6 **100G** rig, which is the
+*floor* for this transport (line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle).
+Faster NICs scale the same two knobs, not the design: keep the bytes in flight
+(`workers × slot_size`) growing roughly linearly with line rate — e.g.
+~16 × 16 MiB or 64 × 4 MiB ≈ 256 MiB/device for 800G-class NICs — and re-derive
+the knee empirically on the target rig (a P4/P5 sweep). The arena stays trivial
+next to GPU memory at any of these points.
 
 ## 2. How one read works
 
@@ -87,81 +95,119 @@ sequenceDiagram
   participant W as reactor worker
   participant A as GPU arena slot
   participant G as cuObject gateway
-  participant S as r.stream (CUDA)
-  W->>A: acquire free slot
+  participant S as CUDA stream
+  W->>A: acquire free slot (slot_pool, reused from the framework)
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
   G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if platform needs)
-  W->>S: cudaMemcpyAsync slot -> r.dst (D2D)
-  S-->>W: completion callback marks done + wakes
-  W->>W: recycle slot, chunk_done()
-  Note over S: cuDF decode runs after, same stream => sees data
+  Note over W: flush GPUDirect writes (only if the platform needs it)
+  W->>S: cudaMemcpyAsync slot -> dst (D2D) + record CUDA event
+  S-->>W: event clears (worker polls, REST's proven pattern)
+  W->>W: chunk_complete + release slot
+  Note over S: the read's future resolves when its last chunk finishes
 ```
 
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound**. The CUDA callback only marks+wakes — it must never call
-`chunk_done()` itself (that fires the user handler synchronously, and not on a
-CUDA thread); the worker finishes the chunk, exactly like `s3_reactor`. On any
-failure the worker calls `chunk_failed` and recycles the slot (sync-draining
-the stream first if a D2D was already queued).
+concurrency bound**. Completion uses the framework's `exec::semi_future` +
+`request_manager`: each chunk reports `chunk_complete` or `report_error` exactly
+once and then releases its manager reference — the future resolves when the last
+chunk does. Nothing runs on a CUDA callback thread; the worker finishes the chunk
+after its CUDA event clears, then recycles the slot. Because the D2D is ~3 µs
+against a ~350 µs network GET, v1 may simply wait on the event inline instead of
+parking copies for a poll loop — a simplification to measure in P2/P3.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
-| D1 | Keep `s3://`; pick transport via `object_store_config.transport {HTTP,RDMA}` (AUTO→HTTP in v1) | No new scheme; the scan manager owns one S3 backend in `_io_ctxs` |
-| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — one reactor + thin overrides (authorizer HEAD, strict range validation, counters) | Reuses chunking / pooling / completion / factory; same shape as `s3_ioctx` |
-| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; `s3_reactor` not instantiated in RDMA mode | Backends are mutually exclusive; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so RDMA can't target it directly. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion: CUDA callback only marks+wakes; the worker calls `chunk_done`/`chunk_failed` | `chunk_done` fires the user handler synchronously — must not run on a CUDA thread (same as `s3_reactor`) |
-| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks / thresholds mask misconfig exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged; Apache-2.0 repo carries no NVIDIA binaries |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | Client always signs; RDMA headers must never bypass auth |
-| **D9** | **Byte-range chunk-prewarm off** in RDMA mode (`enable_chunk_prewarm=false`, keep `enable_prefetch_cache=true`) | `device_read` consults the cache *before* the reactor; a byte-range hit would re-introduce host staging. Global knob ⇒ also disables local-file prewarm (accepted in v1) |
+| D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
+| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — the reactor provides `prep_host_rx` / `prep_device_rx` builders + `enqueue`; credentials and the registered arena live in its `reactor_context` | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused |
+| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
+| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
+| D5 | Completion via `semi_future` + `request_manager`; a chunk completes exactly once, on a worker thread, after its CUDA event clears — never from a CUDA callback | Matches the framework contract (the future resolves when the last chunk releases its manager reference); keeps user code off CUDA's internal threads |
+| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
+| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
+| **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
+
+Why D9 works, in one picture:
+
+```mermaid
+flowchart LR
+  A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
+  B --> C["prefetch cache is never built<br/>for this backend"]
+  C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
+```
 
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
-**One reactor, not one per GPU.** Multi-GPU affinity lives at the **arena/slot**
-layer — a worker does `cudaSetDevice(r.device_id)` and takes a slot from *that*
-device's arena, so the slot and `r.dst` are always same-device (never a
-cross-device copy). The single reactor owns one global worker pool. A per-GPU
-reactor would make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
-`cuObjGet`), breaking the global in-flight ceiling and risking gateway/NIC
-overload. Per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity and
-per-device throttling, at the cost of global rate-limit and config complexity —
-is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
+**One reactor per node — and what scales with what.** For contrast: the REST
+backend runs **2 reactors per node** (`rest_n_reactors`), unrelated to GPU count —
+its reactors are epoll event loops doing real CPU work (TLS, staging copies), so
+a second one spreads CPU load. The RDMA reactor is *not* an event loop
+(`cuObjGet` blocks): it is a container for the worker pool and the arenas, so
+extra reactors add no throughput — they would only fragment the global in-flight
+ceiling and multiply sessions. Hence three independent axes:
+
+- **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
+  with reactors, not with GPUs.
+- **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
+  arena; a worker sets the request's device and takes a slot from *that* device's
+  arena, so slot and destination are always same-device (never a cross-device
+  copy). A per-GPU reactor would instead make concurrency `GPUs × max_inflight`
+  (e.g. 4×8 = 32 concurrent `cuObjGet`), breaking the global ceiling and risking
+  gateway/NIC overload.
+- **NIC count** is the one thing that eventually justifies more reactors:
+  per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
+  of global rate-limit complexity — is the deferred evolution for explicit
+  multi-NIC/NUMA topologies, not v1.
+
+**Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
+one caller of the vector host-read entry point, which this backend omits — a
+native `.db` ATTACHed over s3://+RDMA fails loudly. kvikio has the same gap
+today; a small framework fix (fall back to per-segment single reads when the
+vector path is absent) would close it for both and is proposed as a standalone
+change.
 
 ## 4. Rollout
 
 | Phase | Scope | HW |
 |---|---|---|
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Strict descriptor-address parse, explicit short-write (`n == expected`) + capacity checks — today the client returns `size` on any 200/206 and the server only fails on `rdma_n < 0` (see appendix) | — |
-| P1 | Wire `s3_transport` through `scan_manager_config`; backend chosen at scan-manager construction; AUTO→HTTP; config tests | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test | CX-6 |
+| **P0b ⏳ gateway hardening open** | Re-add strict descriptor parsing (the migration removed the old validator — a regression); enforce the token's `buf_size` (on the wire but unread); explicit short-write `n == expected` check | — |
+| **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; pin the registration-per-session question | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go; vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship `max_inflight = 8` (worker count = global
-   in-flight ceiling) + 1 MiB arena slots? 8 is the benchmark's line-rate knee;
-   or should the client default track a negotiated gateway budget?
-2. **OWNER-flush ownership** — who verifies (against the CUDA docs) whether
-   `…_ORDERING_OWNER` still needs `cuFlushGPUDirectRDMAWrites` for same-device
-   consumers? This is the top correctness risk; it gates P3.
+1. **Sizing defaults** — ship 8 workers × 4 MiB as the **100G-floor** default
+   (line rate on the CX-6 rig) with the documented rule "scale in-flight bytes
+   linearly with NIC line rate" (§1) — or should the default self-scale from a
+   detected/configured link speed? 800G-class NICs need ~8× the in-flight bytes
+   and proportionally more workers, which also stresses the blocking-GET
+   thread-per-worker model (§6).
+2. **OWNER-flush ownership** — who verifies whether `…_ORDERING_OWNER` still
+   needs `cuFlushGPUDirectRDMAWrites` for same-device consumers? Neither the
+   benchmark nor Sirius contains any flush handling today — this is from-scratch
+   P3 work and the top correctness risk.
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
    registrable allocation path for IO buffers? It unlocks direct-into-RMM
    (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters; and should
-   IO counters also be pushed into `telemetry_context` (today pull-only)?
+5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
+   perf instrumentation was re-added for the REST reactor in #1042; the RDMA
+   counters should follow that shape rather than invent a parallel one.
+6. **Registration × sessions** — each worker owns its own `cuObjClient` session;
+   is a buffer registration per-session (8 registrations of the same arena) or
+   shareable? SDK-version-dependent (conda 1.2.x vs the validated 1.0.0); shapes
+   the client-wrapper API. Pin on the rig in P3.
 
 ## 6. Risks
 
@@ -171,7 +217,11 @@ is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
   client process (not × GPUs or × queries).
 - Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5); cuObject's blocking GET shapes the worker-pool model.
+  threshold, P5); cuObject's blocking GET shapes the worker-pool model — and at
+  800G-class line rates the pool grows ~8× (with the gateway DCI budget growing
+  with it), sharpening the case for an async cuObject API if one appears.
+- cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
+  reconciled before P3.
 
 ---
 
@@ -183,40 +233,49 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 
 | Header | Direction | Meaning |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** |
+| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
 | `x-amz-rdma-reply` | gateway → client | RDMA status tag (authoritative completion is `cuObjGet`'s `n == expected`, not a reply byte count) |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
 address rides in the token, capacity is the `cuObjGet` `size` arg, and the
-reply tag supersedes the byte-count header. Production gateways SigV4-validate
-the control request before honoring the token.
+reply tag supersedes the byte-count header. The server chunks transfers
+server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
+Production gateways SigV4-validate the control request before honoring the token.
 
 ### Config (under `object_store_config`)
 
+`s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
+its consumer. The rest are new fields for the integration PR:
+
 ```text
-s3_transport = HTTP | RDMA        # existing enum; AUTO -> HTTP in v1
+s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_endpoint / s3_rdma_port   # control-plane endpoint if distinct
 s3_rdma_max_inflight              # worker count = global in-flight ceiling
-s3_rdma_arena_slot_size           # >= 1 MiB chunk; arena = max_inflight x slot_size
-# P5 maybe: s3_rdma_min_device_read_size (route small reads over HTTP)
+                                  #   default 8 — calibrated on the 100G floor; scale with NIC line rate
+s3_rdma_arena_slot_size           # per-chunk arena slot
+                                  #   default 4 MiB — same calibration; workers x slot_size tracks line rate
 ```
 
-Counters follow the `s3_ioctx` pattern (atomics in the reactor, aggregated by
-the ioctx, pulled via `…_total()` accessors): `s3_rdma_bytes_total`,
+There is deliberately **no client chunk-size knob**: the transfer granularity is
+the arena slot size, and the server chunks independently. Auth/TLS reuse the
+existing fields (`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+
+Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_arena_slot_wait_total`, `…_flush_total`,
 `…_short_write_total`, `…_error_total`, `…_inflight_peak`.
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 
-**Migration landed** (merged to `main`, 2026-06-17): the 4 non-standard headers
-dropped, the server decodes the slot address from the token (works on the
+**Wire migration landed** (merged to `main`, 2026-06-17): the 4 non-standard
+headers dropped, the server decodes the slot address from the token (works on the
 pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
-documented. **Open hardening:** strict descriptor-address parse (a
-`CUOBJ`-prefixed descriptor could parse to a wrong address — reviewed, deferred
-pending a format lock against a real `rdma->desc_str` on the rig); explicit
-short-write (`n == expected`) and capacity checks (today bounded by `Range` +
-the `cuObjGet` `size` arg); optional SigV4 in the dev server.
+documented. **Open hardening (P0b):** the migration **removed** the previous
+strict address validator — today's parse takes the first hex field with no
+length/field validation (and wrongly rejects a legitimate address 0); the token's
+`buf_size` field is transmitted but never read server-side (a free capacity check
+not being performed); the client reports success on any 200/206 without an
+`n == expected` short-write check; optional SigV4 in the dev server.
 
 > Deeper implementation notes + verified file:line references live in the
 > offline working spec, not this doc.

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -20,429 +20,304 @@
 </style></head><body>
 <div id="out">rendering…</div>
 <script type="text/markdown" id="src">
-# S3 RDMA Transport for Sirius — Design for Team Review
+# S3 RDMA Transport for Sirius — V1 Design
 
-| | |
+Status: evaluation-prototype design for team review — no production code
+in this PR. Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+<https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
+on CX-6 RoCE).
+
+## 1. Summary and Scope
+
+V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
+reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
+complete object key written out, not a glob or a listing. Payload lands
+in a pre-registered GPU arena and is
+copied to caller-owned RMM memory on the caller stream, with zero
+Sirius-side host staging or H2D traffic; metadata and footer reads remain
+on the existing S3 path. There is no automatic probing and no runtime
+fallback to HTTP: when RDMA is selected and cannot serve a request, the
+request fails with an explicit error. GO requires hardware correctness, at
+least 85% of the qualified RDMA link rate for objects of 16 MiB or larger,
+and a zero-failure 100-million-GET soak. For smaller objects the gate
+measures RDMA against HTTP side by side; if RDMA shows no advantage there,
+V1 may add a size-based fallback that routes small objects to the HTTP
+path — a routing choice, distinct from the failure semantics above.
+
+### Decisions Requested
+
+| Decision | Proposed V1 position | Question for the team |
+|---|---|---|
+| GPU destination | RDMA lands in a registered arena, followed by D2D into caller-owned RMM | Is the extra GPU-local copy acceptable, rather than registering arbitrary RMM allocations? |
+| Endpoint topology | Existing S3 endpoint for control/metadata; dedicated direct-connect gateway for RDMA data | Is split deployment, with the publisher visibility barrier, acceptable? |
+| Failure policy | Token-bearing GETs are one-shot; uncertain completion causes reactor fail-stop and process restart | Is restart-based recovery acceptable for V1 — no fallback after an RDMA request is selected or fails? |
+| CUDA boundary | After `cudaMemcpyAsync`, anything except a successful event wait is process-fatal | When delivery cannot be proven, is terminating the process and never freeing the arena acceptable? |
+| Concurrency model | Bounded request envelopes and one RDMA session per worker | Is this resource model right? (Registration layout is a preflight result.) |
+| Evaluation gate | A hardware correctness gate, then: objects ≥16 MiB must reach 85% of RDMA link rate, small objects (128 KiB–4 MiB) are measured RDMA-vs-HTTP as a required output, and reliability requires a zero-failure 100M-GET soak | Are these the right GO/STOP criteria? (The small-object routing threshold is a follow-up decision, not set in this PR.) |
+
+Registration scope, reply-tag constants, and GPU write-ordering behavior
+are preflight measurements, not design votes. Worker count, chunk size,
+and slot layout are implementation choices within the proposed V1
+contract.
+
+### Scope
+
+| Supported in v1 | Not in v1 |
 |---|---|
-| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15; synced 2026-07-16 to the current IO framework (#1087 footer open-hint, #1117 LIST/glob) |
-| **Date** | 2026-07-15 |
-| **Author** | Sirius Contributors |
-| **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
+| Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
+| Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
+| Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
+| Basic byte/request/failure metrics | Full metric parity with the REST backend |
+| One-shot device reads | Automatic RDMA retry (one narrowly-proven retry exists only as a pre-approved response to a soak failure, Section 3) |
+| Restart-based recovery | Hot recovery of a failed transport context |
 
-## 1. Summary
+Footer and metadata reads use plain HEAD and range GET on the host plane;
+footer caching and known-size open are out of scope.
 
-**Problem.** Sirius reads S3 Parquet through the REST backend: libcurl range
-GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU. Every
-byte crosses host memory and PCIe twice.
-
-**Proposal.** A cuObject gateway `RDMA_WRITE`s object bytes into a small,
-pre-registered GPU **arena**; a GPU-local copy delivers them to the final RMM
-buffer. The pinned-host staging and the PCIe H2D copy disappear.
-
-**Unchanged.** `s3://` URIs, the SigV4 credential machinery (one surface
-extension — §5), the `sirius_datasource` API, and the Parquet scanner. The
-REST backend remains the default; RDMA is selected per context by the existing
-`s3_transport` config.
-
-**v1 limits.** Requires an RDMA-capable cuObject gateway (plain AWS S3 does
-not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
-failures surface per the Safety Contract (§4).
-
-**Current implementation gap (not a v1 design limit).** Exact-key
-`read_parquet('s3://…')` is the supported target; **wildcard glob** resolves
-through S3 LIST, which the framework currently routes to the REST backend
-only — under RDMA selection a glob fails loudly (D6). The P2 control-plane
-parity work closes this (§7) by wiring the hybrid's always-available HTTP
-control client; the RDMA data plane stays dormant until P3. It is a
-compatibility gate, separate from the P3 safety activation gates.
-
-**Decisions requested.** The team is asked to approve six decisions (§6):
-the landing arena + D2D shape, the CUDA failure policy, the
-duplicate-suppression mechanism and ambiguous-completion policy, the
-request-envelope queue model, cuObject session ownership, and the gateway
-topology with its plain-S3 surface.
-
-## 2. Architecture & Read Path
+## 2. Architecture and Read Path
 
 ```mermaid
 flowchart LR
-  scan["Parquet scan"] --> dr["device_read()"]
-  dr --> ic["s3_rdma_ioctx<br/>(templated_ioctx + cuobj_rdma_reactor)"]
-  ic -- "control plane: HTTP GET<br/>x-amz-rdma-token (SigV4)" --> gw["cuObject gateway"]
-  gw == "data plane: RDMA_WRITE<br/>(GPUDirect)" ==> arena["GPU landing arena<br/>cudaMalloc, registered once"]
-  arena == "GPU-local D2D" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
-  rmm --> decode["cuDF decode"]
+  subgraph proc["Sirius process"]
+    scan["Parquet scan"] --> ioctx["s3_rdma_ioctx"]
+    ioctx --> ctl["control client<br/>(one HTTP attempt per call)"]
+    ioctx --> q["bounded request-envelope queue"]
+    q --> w["workers<br/>(one RDMA session each)"]
+    w --> arena["per-GPU registered arena<br/>(slot layout settled at preflight)"]
+    arena -->|"D2D on the caller stream"| rmm["RMM destination<br/>(caller-owned, not registered)"]
+  end
+  ctl -->|"HEAD / footer / range GET"| s3["s3_endpoint<br/>(any S3 service)"]
+  w -->|"token-bearing signed GET"| gw["s3_rdma_endpoint<br/>(cuObject gateway, direct connect)"]
+  gw -->|"RDMA write"| arena
+  s3 --- store[("same backing store,<br/>immutable keys")]
+  gw --- store
 ```
 
-*(An **ioctx** is the per-context IO facade; a **reactor** is the transport
-engine behind it, defined by which read **builders** it provides.)*
+The host plane (`s3_endpoint`) is any S3 service and carries HEAD, footer,
+and range GETs with standard SigV4 signing; it retains the existing S3
+surface. The data plane (`s3_rdma_endpoint`) is a cuObject gateway reached
+by direct connection, limited to token-bearing GETs and the publisher HEAD
+used by the visibility barrier below. Both endpoints front the same
+backing store and the same bucket namespace.
 
-On the control plane (HTTP), the descriptor token is the only RDMA-specific
-request header (`Range` travels as usual); the data plane (RDMA) writes object
-bytes straight into the GPU arena. Host reads stay on
-HTTP through the existing SigV4 authorizer — a surface that now includes the
-framework's footer-probe open hint (one suffix-range GET serves the size and
-the binder's footer reads), S3 LIST for glob, and HEAD; matching it on the
-hybrid is the P2 control-plane parity item (§7). The
-arena is a fixed staging window, not object-sized: a read streams through it
-in slot-sized chunks, each D2D-copied to its offset in the destination buffer
-(copy cost: §7).
+The ioctx owns the reactor, the reactor owns the worker pool, and each
+worker owns its own RDMA session — a shared session across workers is not
+an option. How registration binds to sessions, and therefore the exact
+arena slot layout, is settled at preflight (Section 5). The RMM
+destination belongs to the caller and is never registered with the NIC.
 
-**Resource model.**
+The request queue holds envelopes rather than chunks: a submitter enqueues
+one small descriptor and returns, workers expand it into chunks lazily,
+and admission blocks only at the per-ioctx bound. A per-chunk bound was
+rejected because a read larger than the bound would block its submitter
+until most of its own transfer had completed.
 
-| Resource | Per ioctx | Per process | Per active GPU |
-|---|---|---|---|
-| Reactor | 1 (not an event loop; owns the worker pool and arenas) | 1 × contexts | — |
-| Workers = in-flight `cuObjGet` ceiling | `max_inflight` | `max_inflight` × contexts | — |
-| Arena memory | `max_inflight × slot_size` × active GPUs | sum over contexts | `max_inflight × slot_size` |
-| Request envelopes (queued reads) | ≤ `s3_rdma_queue_cap` | sum over contexts | — |
-| Gateway slot budget required | `max_inflight` | sum over contexts | — |
-
-Throughput scales with workers; GPU count scales only the arena map (a new
-device lazily gets its own arena; slot and destination are always
-same-device); NIC count is what would eventually justify more reactors
-(deferred sharding, not v1).
-
-**Sizing.** The default — 8 workers × 4 MiB slots = 32 MiB per device — comes
-from the benchmark's CX-6 **100G reference configuration** (line rate at
-8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page cache and
-2 MiB server-side chunking, so other topologies re-measure). Faster NICs scale the two knobs, not the design:
-in-flight bytes (`workers × slot_size`) must grow with line rate, and the knee
-is re-derived on the target NIC (a P4/P5 sweep).
-
-**One read.**
+Consistency between the two endpoints rests on two deployment rules. Keys
+are append-only and immutable: an object, once published, is never
+overwritten or deleted while readable. Before a key becomes queryable, the
+publisher completes a visibility barrier: HEAD succeeds at both endpoints
+with matching sizes, and content identity is confirmed by a trusted ETag or
+by the full object hash from the publishing manifest. The query path
+itself never sends HEAD to the gateway.
 
 ```mermaid
 sequenceDiagram
-  participant W as reactor worker
-  participant A as GPU arena slot
-  participant G as cuObject gateway
-  participant S as CUDA stream
-  W->>A: acquire free slot (slot_pool, reused from the framework)
-  W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
-  G-->>A: RDMA_WRITE bytes into slot
-  G-->>W: HTTP success (200/206) + valid x-amz-rdma-reply: 200
-  Note over W: flush GPUDirect writes (only if the platform requires it — §6)
-  W->>W: create the completion event FIRST
-  W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline
-  W->>W: chunk_complete + release slot
-  Note over S: the read's future resolves when its last chunk finishes
+  participant S as Scanner
+  participant I as s3_rdma_ioctx
+  participant Q as envelope queue
+  participant W as worker
+  participant G as gateway
+  participant C as CUDA runtime
+  S->>I: open exact-key object (size from HEAD on the host plane)
+  S->>I: device read into an RMM destination
+  I->>Q: submit one request envelope (blocks only at the cap)
+  Q->>W: worker claims a chunk (lazy, FIFO)
+  W->>W: stream capture check - before the GET is issued
+  W->>G: signed token-bearing GET (token and Range inside the signature)
+  G-->>W: RDMA write into the arena slot, then the wire reply - HTTP status + reply tag
+  W->>W: session result - transferred byte count n
+  W->>W: exact completion check - reply tag AND HTTP status AND n == expected
+  W->>C: flush (only when the ordering attribute is NONE)
+  W->>C: enqueue the D2D copy and its completion event on the caller stream
+  W->>C: wait on the event from the worker thread
+  C-->>W: cudaSuccess
+  W->>W: complete the chunk and release the slot
+  W-->>S: the request future resolves after all chunks complete
 ```
 
-A submitter enqueues one small **request envelope** and returns; workers
-generate and claim chunks lazily, so an async read never waits on chunk-level
-progress (mechanics: appendix). `cuObjGet` blocks, so the worker pool is the
-concurrency bound; with one arena slot per worker a free slot is always
-available. Each chunk completes exactly once, on its own worker, with the one
-exception defined in §4; the inline wait is a P3 measurement (§7). The
-reactor omits the framework's two staged-read builders, so the prefetch cache
-is never built for this backend — kvikio's minimal profile, which also keeps
-the cache's 2–7× sparse-projection over-read (issue #1078) unreachable here.
+Object sizes come from HEAD on the host plane; when that HEAD is issued
+relative to open is an implementation choice. The stream capture check
+runs before the GET is issued, in release builds as well as debug builds,
+so a request that cannot be delivered makes no remote write.
 
-## 3. Key Decisions
+Exact completion has three legs, all required before a chunk may proceed
+to delivery: a valid reply tag, a successful HTTP status, and a byte count
+that equals the requested size. The concrete accepted values are recorded
+at preflight and used unchanged by every later test.
 
-| # | Decision | Why |
-|---|---|---|
-| D1 | Keep `s3://`; select the backend once, at registry construction (`s3_transport=RDMA` claims the s3 slot instead of restful; `AUTO`→HTTP) | The config field already exists; exactly one s3 backend per context keeps routing unambiguous and the scan side untouched |
-| D2 | One new transport engine under the existing IO framework: a reactor wrapped by a thin ioctx; the shared context carries config, a **client/session factory** (ownership: §6 decision 5), and the flush policy; the per-device arena map is reactor state | Chunking, pooling, completion, `slot_pool`, and the registry factory are reused; arenas belong with the worker pool that fills them |
-| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| D4 | Landing arena + GPU-local D2D, not direct RDMA into RMM buffers | Sirius RMM is `cudaMallocAsync`-backed: not reliably registrable for GPUDirect, and stream-ordered backing means an address may be unbacked when the NIC writes |
-| D5 | Completion via `semi_future` + `request_manager`, inline event wait; nothing completes before delivery is settled per the Safety Contract (§4) | Closes both use-after-free sides: a reused slot under an in-flight copy, and a freed destination still being written |
-| D6 | Explicit `RDMA` opt-in; failures surface per §4 — never a silent transport switch | Fallbacks mask misconfiguration exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); NVIDIA SDKs are never vendored | Default-off builds are unchanged; conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — reconciliation is a real task |
-| D8 | The RDMA token and `Range` are signed; header-signing mode only (details: §5) | An unsigned token is not bound to the request; a gateway could not tell a tampered descriptor from a legitimate one |
-| D9 | Prefetch cache off structurally: the reactor defines only the host-read and device-read builders | Capabilities derive from which builders exist — no flag to set; kvikio already ships this profile |
+The request future is a fan-in over all chunks: successful resolution
+occurs only after every chunk completes, any chunk error that is not
+process-fatal resolves the request as an error, and a partial result is
+never reported as success.
 
-## 4. Safety Contract
+Flush policy follows the GPU's RDMA write-ordering attribute, read once at
+initialization: `OWNER` and `ALL_DEVICES` require no flush; `NONE` requires
+one flush after each exact completion, before that chunk's copy; an unknown
+attribute value, or `NONE` without a working flush mechanism, fails RDMA
+initialization.
 
-Once a D2D copy is enqueued, two buffers are at stake: the arena slot (its
-next user would corrupt an in-flight copy) and the caller's destination (freed
-as soon as its future resolves). Required invariant: **neither the slot is
-recycled nor the future resolved until the stream is proven quiet.**
+## 3. Safety Contract
 
-Pre-enqueue rules: the completion event is created *before* the copy is
-enqueued (a creation failure means nothing is in flight — safe release). A
-non-success return from `cudaMemcpyAsync` does **not** prove the copy was
-rejected — async CUDA calls may return deferred errors from earlier work — so
-the enqueue state is unknown and the failure is handled as post-enqueue.
+The boundary of the delivery contract is the first `cudaMemcpyAsync` call
+for a chunk. Before that call no copy is in flight: a failure that is not
+a sticky CUDA error can be reported and released safely, while a sticky
+error terminates the process even before the boundary. After the call, the
+only completing return is an event wait that reports `cudaSuccess`;
+everything else is treated as an unprovable delivery state. The set of
+sticky CUDA error codes is fixed from the documented CUDA error
+classification and reviewed against the existing classifier in the tree —
+never inferred from rig observation.
 
-Quiescence proof: a real stream sync. An error return from the sync still
-proves quiescence (the wait completed; the error is a deferred report), except
-for codes meaning the call never ran (invalid handle; captured streams, which
-are a documented precondition violation) — those escalate to a device-wide
-sync.
-
-| CUDA outcome | Future / slot | Reactor / process |
-|---|---|---|
-| Quiesced, recoverable | report the error, release the slot | continue serving |
-| Quiesced, context-fatal (sticky error) | safe to report and release — the context is dead, nothing can write `dst` | **process-fatal** |
-| Quiescence unknown | do **not** resolve the future or free anything | **process-fatal** |
-
-**Process-fatal** is a non-returning hook: log the verdict, terminate the
-process (the call site invokes `std::terminate` if the hook ever returns).
-For a sticky error this is CUDA's documented terminate-and-relaunch
-requirement; for the unknown verdict it is this design's use-after-free
-policy — the framework resolves a future when its last chunk reference is
-released, so no in-process "never resolved" exists. Validated by death tests
-(child process: exit code, fatal log, no normal teardown).
-
-| RDMA outcome | Slot / arena | Retry |
-|---|---|---|
-| Not sent (token never left the client) | slot reusable | allowed |
-| Exact completion (valid reply, `n == expected`) | slot reusable after the D2D | not needed |
-| Sent, outcome unknown | **entire arena non-freeable** | none — reactor **fail-stop** |
-
-The client reports a commit state with every failure (`not_sent` /
-`sent_unknown` / `completed`); host/HTTP reads retry freely (the client owns
-the write loop). Registration covers the whole arena, so one slot the gateway
-may still write makes deregistering or freeing any of it unsafe; per-slot
-quarantine was rejected because repeated quarantines drain the pool.
-**Fail-stop** happens exactly once: new reads fail fast with the fail-stop
-error; queued envelopes — and the un-generated chunks of partially-consumed
-ones — are error-completed; chunks already in flight finish on their own
-workers; blocked submitters are woken. The process stays alive —
-fail-stop is reserved for failures that do not corrupt the CUDA process — but
-RDMA service on the context requires a restart. Any arena that cannot be
-proven quiet at teardown, by device stream or by remote gateway, is leaked,
-never freed.
-
-Two independent gates apply on the real path. **Completion authority** is a
-P0b gate: the gateway enforces **exact completion** and the client requires a
-**valid reply tag** (appendix protocol). Separately, request **uniqueness and
-response–side-effect integrity** (§5) must hold before P3 activation —
-fail-stop cannot see a duplicate that succeeds, and completion authority
-cannot detect a cached or coalesced reply whose RDMA write never happened.
-
-## 5. Authentication
-
-The `x-amz-rdma-token` and `Range` headers are inside the SigV4 signature,
-binding object, byte range, and destination capability into one authorized
-request. v1 supports header-signing mode only — an implementation choice, not
-a protocol limit (SigV4 query signing can carry `X-Amz-SignedHeaders`, but the
-Sirius presigner signs only `host` today); RDMA initialization fails under
-`s3_signing_mode = presigned`.
-
-Interface: the existing three-argument virtual `authorize()` is untouched; the
-headers-to-sign travel through a new, separately-named non-pure virtual
-(`authorize_with_headers(request)`) whose default implementation rejects
-non-empty header sets, and which the built-in SigV4 header signer overrides.
-
-The dev benchmark server runs unsigned on an isolated network; production
-gateways validate the signature before honoring the token.
-
-A token-bearing GET is not a safe idempotent read: the response certifies a
-**side effect** (the RDMA write into the slot), and any intermediary behavior
-that decouples the two defeats completion authority silently. A transparent
-retry duplicates the write while the original still runs; an HTTP **cache**
-(keyed on URI/Range — the token is just a header) can return a stored,
-legitimate `x-amz-rdma-reply` with **no write at all**; **request coalescing**
-merges two identical GETs into one upstream fetch — one write, two replies;
-hedging/mirroring duplicates writes. In each case the client sees a valid
-reply and `n == expected` while its slot holds stale bytes — silent
-corruption no client-side rule (fail-stop included) can detect.
-
-**v1 deployment contract (activation requirement):** token-bearing GETs are
-exempt from retry, hedging, mirroring, caching, and request coalescing;
-request and response both carry `Cache-Control: no-store`; any proxy route
-explicitly bypasses caches. Where all of this cannot be proven, the client
-connects **directly to the gateway** — the v1 default. RDMA must not be
-enabled otherwise. Gateway-side
-exactly-once deduplication is a **deferred conditional extension** — the base
-cuObject protocol defines no request-identity tag, so it would need a signed
-identity added to the wire (appendix) and is only worth specifying if a
-deployment requires an intermediary. The control plane runs over TLS; tokens
-are redacted from logs.
-
-## 6. Review Decisions
-
-| # | Decision needed | Recommendation | Blocks |
+| Outcome | Action | Future | Arena |
 |---|---|---|---|
-| 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
-| 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
-| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the §5 deployment contract (direct gateway; token-bearing GETs exempt from retry/hedge/mirror/cache/coalesce; gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
-| 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
-| 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
-| 6 | Gateway topology & plain-S3 surface | Single endpoint: the gateway also serves plain S3 (ListObjectsV2 / HEAD / range GET — P0c). "Token-less" means no RDMA descriptor, **not anonymous**: LIST/HEAD/GET stay SigV4-validated and authorized over TLS. SigV4 signs `Host`, so naive forwarding breaks signatures — the production model is **terminate-and-re-sign**: the gateway validates the client's SigV4, authorizes, and re-signs upstream with its own service identity (identity/permission mapping is a deployment definition); a gateway co-located with the storage (same hostname + credential authority) reduces this to internal dispatch. "One credential set" = the **client's** configuration; gateway→upstream credentials are the gateway's own. The benchmark gateway is a reference / conformance implementation | P0c, P2 parity |
+| Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
+| Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
+| Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
+| Sticky CUDA error, or any failure after the copy is enqueued (one exception below) | Process-fatal termination | Not resolved | Never freed |
 
-Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
-default (fixed 100G reference vs self-scaling) before P4; appetite for a
-registrable cucascade IO sub-MR (unlocks direct-into-RMM); confirmation from
-NVIDIA whether a descriptor token is single-use; counter naming alignment with
-the REST instrumentation.
+One narrow exception: an event-destroy failure after a successful wait is
+logged and leaves the successful outcome unchanged.
 
-Visibility policy is ruled by the CUDA contract, not a vote: the per-device
-write-ordering attribute makes OWNER platforms safe for our same-device D2D
-consumer with no flush; only NONE platforms need one, and a NONE platform that
-cannot flush fails RDMA initialization. P3 work: per-device wiring and the
-decode-after-GET stress test. The ruling covers v1's single RDMA path;
-multi-NIC sharding would revisit the multi-ordering-domain exceptions.
+1. Transport shutdown after a fail-stop is two-phase: a non-blocking
+   terminal mark that immediately refuses new work, and a completion point
+   reached when the last in-flight operation releases its permit, so a
+   failing worker can initiate shutdown without waiting on itself.
+2. After a fail-stop the whole transport context is closed: host-plane and
+   device-plane operations alike are refused through one shared admission
+   gate and surface the same terminal error. Only an operation whose side
+   effect is already in flight — a control call started, a transfer
+   issued — completes that one operation. Everything else is cut off:
+   queued envelopes and the chunks not yet generated from them complete
+   with an error, work claimed but not yet issued is aborted with its slot
+   released, and submitters blocked at the queue bound wake with the
+   terminal error. Recovery is a process restart.
+3. Destination contents are unspecified after any failed read: earlier
+   chunks may already have landed in the caller's buffer, and the
+   error-resolved future is the only authority a caller may consult.
+4. Token-bearing GETs are not retried, hedged, mirrored, cached, or
+   coalesced anywhere between client and gateway; the dedicated
+   direct-connect endpoint enforces this structurally on the path, and a
+   gateway conformance check verifies that the gateway itself performs no
+   internal retry, caching, or coalescing. After a failed soak, a single
+   retry may be enabled only when the client can prove that the request
+   was never issued to the gateway, followed by a full soak re-run from
+   zero.
+5. Normal teardown releases the arena only behind a strict barrier:
+   admission is stopped, no further GETs will be issued, every issued
+   transfer has completed exactly, every enqueued copy is confirmed, and
+   all workers have stopped and joined. After a fail-stop or a
+   process-fatal failure this barrier is never reached: those arenas are
+   never freed while the process lives.
 
-## 7. Rollout & Performance
+## 4. Configuration and Security
 
-| Phase | Scope | Exit criterion | HW |
-|---|---|---|---|
-| P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
-| P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
-| P0c | Gateway **plain S3 surface** (ListObjectsV2 / HEAD / token-less range GET — still SigV4-authenticated; §6 decision 6) for the single-endpoint topology — today it serves object HEAD only and rejects token-less GETs | serves host reads + glob; the P2 parity gate is complete only when this also lands (MinIO covers CI meanwhile) | — |
-| P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
-| P2 | Reactor against a mock client; envelope admission; hybrid control-plane parity (footer probe, known-size open, S3 LIST capability — this sub-item needs no CUDA GPU) | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom; parity: glob + footer-RTT behavior matches HTTP | CUDA GPU (except the parity sub-item) |
-| P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
-| P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
-
-The rollout closes the gap between the current tree and this document: the
-Safety Contract, envelope queue, uniqueness invariants, and auth surface are
-target contracts to be implemented and tested in P2/P3.
-
-**Performance.** The D2D is an estimated ~3 µs per 4 MiB slot (derived from
-HBM bandwidth, not yet measured on this path) against the ~350 µs wire
-serialization of one slot at ~91 Gbps — a wire-time floor, not a measured
-single-request latency under concurrency. That ratio is the basis for the
-inline wait; the caveat is that the event wait covers all prior work on the
-caller's stream, not just this copy. P3 replaces the estimates by measuring
-the total post-RDMA delivery cost (flush, event lifecycle, D2D) under a
-shared-stream saturation test; the REST backend's event-poll shape is the
-documented fallback if that test fails.
-
-## 8. Scope & Risks
-
-Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
-the omitted vector-read path (kvikio has the same gap; a per-segment framework
-fallback is proposed separately). The transparent `read_parquet('s3://')`
-front door (#1074) carries no transport-specific checks and is expected to
-work unchanged for exact-key opens — a routing test pins this at integration
-(wildcard glob: the implementation-gap note in §1). Captured CUDA
-streams are unsupported for RDMA device reads.
-
-Risks:
-
-- GPU-consumer visibility on NONE-ordering platforms — per-device wiring and
-  the P3 stress test are the top correctness gate (§6).
-- Requires a controlled cuObject gateway; NIC↔GPU PCIe affinity across root
-  complexes can silently halve bandwidth (P4 validation).
-- cuObject SDK skew (conda 1.2.x vs the validated 1.0.0 tarball) must be
-  reconciled before P3.
-- Small-read control-plane RTT, including per-request connection setup —
-  measured in P5; an optional whole-read HTTP threshold is the prepared
-  mitigation.
-- The gateway slot budget scales with `max_inflight` × Sirius contexts, not
-  with GPUs or queries (§2 resource model).
-
----
-
-## Appendix — Protocol, configuration, implementation
-
-### Wire protocol
-
-Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags plus
-`Range`. The benchmark's four non-standard headers were removed by the wire
-migration (P0a).
-
-| Header | Direction | Meaning |
+| Key | Meaning | Default |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; encodes the remote slot address and size; signed (§5) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag; never interpreted as a byte count |
+| `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
+| `s3_endpoint` | Host plane: any S3 service | existing setting |
+| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails with an explicit error when unset | none |
+| `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
+| `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
-Conditional extension (deferred): gateway-side exactly-once deduplication
-would require a signed request identity on the wire — the identity field, its
-validity window, dedup retention, and gateway ownership would all need
-definition with NVIDIA (the descriptor token can serve only if it is ruled
-single-use). Not part of v1, which relies on the §5 deployment contract.
+This phase adds no new tuning surface: worker count and arena slot size
+keep their existing settings. Reads are one-shot, so the retry counter
+must read zero; any nonzero value is treated as a defect.
 
-Completion authority: `cuObjGet`'s returned `n == expected` is authoritative
-only when the gateway enforces exact completion (no short or overlong RDMA
-piece) **and** the client requires a valid reply tag before reporting the
-requested size — an HTTP 200/206 without a legitimate reply is a failure. Both
-halves are P0b gates. The server chunks transfers server-side (its own config,
-default 2 MiB); nothing is negotiated on the wire. Signature validation and
-the dev/prod auth posture are defined in §5. Remaining P0b items
-(outcome level): strict descriptor/capacity validation, exact completion,
-mandatory reply validation; the plain-S3 surface (LIST/HEAD/token-less GET)
-is the separate P0c item — code-level specifics for both are tracked in the
-`s3RDMA-benchmarktool` repo.
+Signing is configured per endpoint. The data endpoint requires
+header-signing: the RDMA descriptor token and the `Range` header travel
+inside the SigV4 signature, and a presigned-mode authorizer on the data
+plane fails initialization. The host endpoint keeps its own configured
+signing mode. Descriptor tokens are redacted from logs and traces in every
+profile.
 
-### Configuration
+The fault-injection hooks used by the validation gates exist only in test
+builds: release artifacts contain none, a production-mode start refuses to
+run when hooks are enabled, and hooks cannot be activated through request
+headers.
 
-```text
-s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
-s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
-s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
-s3_rdma_perf_instrumentation      # gates the timing counter families (default off; §appendix Metrics)
-```
+The rig profile for this phase may run an unsigned gateway and a non-TLS
+control plane, but must not use production data or production credentials
+and must not be exposed to an uncontrolled network. Gateway-side SigV4
+verification, end-to-end TLS, authorization, replay and token hardening,
+and a signed-profile qualification form a production-qualification gate
+that applies after a GO decision; enabling the production profile requires
+re-running correctness, performance, and soak in full, because unsigned
+rig results do not extrapolate to the signed path.
 
-Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
-one host serves ListObjectsV2, HEAD, plain range-GET, and RDMA control under
-one credential set (the client's — §6 decision 6); growing the gateway's
-plain S3 surface to match is P0c gateway-side work. A split topology (plain S3 host for host/LIST reads, RDMA
-gateway for device reads) is deferred until a deployment requires it. There is no client
-chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
-the existing fields (`s3_signing_mode` — header mode required, §5 —
-`ca_bundle_path`, `tls_verify`).
+## 5. Validation and Rollout
 
-Admission: the queue holds request envelopes, bounded per ioctx and counted in
-requests. A submitter enqueues one envelope (a small descriptor, not the chunk
-list) and returns; workers generate and claim chunks lazily, FIFO. A per-chunk
-cap was rejected: a read larger than the cap would block its submitter until
-most of its own transfer completed, making the async API effectively
-synchronous. Only a full envelope queue blocks a submitter; fail-stop and
-shutdown wake any blocked submitter with the corresponding error.
+Validation runs in three stages on the rig, each gating the next, followed
+by the post-GO production gate. Throughout this section, a **clean run**
+means correct payload checksums and no fail-stops, process-fatal exits, or
+short, missing, or wrong completions.
 
-Retry: split by plane and commit point. Host/HTTP reads retry on transport
-failures and short reads. RDMA device reads retry only from the `not_sent`
-commit state; `sent_unknown` is terminal per the Safety Contract. CUDA work
-never retries; exhaustion surfaces the last error; never a transport switch
-(D6).
+| Gate | What runs | Pass condition |
+|---|---|---|
+| Preflight | Rig probes for registration/session shape, the completion constants (accepted HTTP status set, reply-tag value and parse rule, byte count on failed responses), and the GPU write-ordering attribute with flush availability | Results are recorded once and used unchanged by every later test; one arena layout is selected — if none works, the phase stops here |
+| Hardware correctness | Checksum stress at full worker count with one session per worker; slot-reuse churn; flush counting; decode stress on the copy stream; fault injection: missing, wrong, and short replies, an ambiguous transport fault, and a session result with a valid reply tag, `n == expected`, and a non-success HTTP status | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in the outcome Section 3 assigns it, and no failed read is reported as a partial success |
+| Performance | Sustained reads at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB, and 1 GiB; the three small sizes also run the HTTP path for comparison | Each size of 16 MiB or more reaches the 85% bound (85 Gbps on the current 100 Gbps rig); the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run; no Sirius-side host staging or H2D on any RDMA run |
+| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, and there are zero unexpected runner restarts |
+| Production (post-GO) | Gateway-side SigV4 verification, end-to-end TLS, authorization, replay and token hardening, signed-profile qualification | Full correctness, performance, and soak re-run on the signed profile |
 
-### Metrics
+Performance runs use one configuration frozen after preflight — worker,
+chunk, slot, and arena settings held constant with no per-size tuning —
+against a warm server cache. Object size and RDMA chunk size are distinct:
+transfers keep normal Sirius chunking rather than forcing one RDMA request
+per object. Each size sustains repeated reads for at least ten seconds per
+trial, with two warm-ups and at least seven measured trials. Throughput is
+measured from device-read submission through delivery into the
+caller-owned RMM buffer — queueing, RDMA, required flushes, D2D copies,
+and request completion — excluding one-time initialization, arena
+registration, object HEAD, and warm-up. A large size passes when the
+one-sided 95% Student-t lower confidence bound of the arithmetic mean of
+its measured per-trial throughputs reaches 85% of the link rate; the same
+statistic is computed for both arms at the small sizes. HTTP results never
+determine GO or STOP. The 85% floor is grounded in measurement: the
+standalone benchmark sustains roughly 91 Gbps on the same class of
+hardware.
 
-Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
-`…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
-`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total`, the REST-shaped
-`…_blocking_host_get_count/wall_ns_total/wall_ns_max` (footer-probe GETs
-excluded, mirroring REST's attribution), `…_fallback_stream_sync_total`
-(quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
-the process-terminating verdicts leave a fatal log line and an exit code, not
-a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
+If the soak fails and the client can prove that the failing request was
+never issued to the gateway, the single pre-approved retry of Section 3
+may be enabled and the full soak re-run from zero; the re-run's outcome
+then decides GO or STOP under the same criteria. A STOP follows when the
+re-run fails, when the failing request cannot be proven never-issued, or
+when any other gate fails; the stop action is to restart the process and
+return to `s3_transport=HTTP`, and the build flag remains off by default
+throughout.
 
-### Implementation notes (framework mapping)
+## 6. Current Status and Risks
 
-`s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>`, built like
-`rest_ioctx`. The reactor provides the `prep_host_rx` / `prep_device_rx`
-builders plus `enqueue`; omitting the two staged-read builders is what derives
-the cache-off capability profile (D9). Completion rides
-`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete`
-or `report_error` exactly once and releases its manager reference; the future
-resolves when the last reference drops — which is why the §4 "unknown"
-verdict must terminate rather than attempt any in-process "never resolved"
-state. The per-device arena map is reactor state; `slot_pool` is reused
-verbatim for slot indexing.
+The transport machinery in the tree is dormant. Five gaps separate it from
+the v1 target, closed in this order before the rig gates run:
 
-### Fault-test matrix (P2, CUDA GPU required; RDMA-rig-free)
+1. Factory wiring — the production factory does not yet construct the
+   control client, so reads cannot route through the normal path.
+2. Endpoint pair — configuration has a single endpoint today.
+3. Envelope admission — chunk admission is eager rather than
+   envelope-bounded.
+4. Retry removal — device reads still carry a legacy multi-attempt retry
+   to be reduced to one-shot.
+5. Completion and gateway hardening — completion validation does not yet
+   check the reply-tag and status legs; gateway exact-write enforcement
+   and descriptor capacity checks are outstanding.
 
-Byte-exact multi-chunk reads; concept checks that both staged-read
-capabilities stay off; event-created-before-enqueue (injected create failure
-never reaches the copy); `cudaMemcpyAsync` non-success routed through the
-quiescence proof; recoverable ladder outcomes release the slot only after the
-proof; process-fatal verdicts exercised as **death tests** (child process:
-exit code, fatal log, no normal teardown — an in-process double that returns
-or throws would exercise the unwinding production forbids) including an active
-unknown-verdict chunk with queued siblings of the same request; fail-stop exactly-once with
-owner-worker completion of in-flight chunks; ambiguous-RDMA fail-stop with
-arena marked non-freeable and teardown leak observed; admission
-deadlock-freedom (submitter blocked at the envelope cap while workers drain
-and while the reactor fail-stops).
-
-### Status
-
-This document describes the target architecture. The current tree differs in
-the areas the rollout table covers (delivery-failure discipline, retry
-classification, envelope admission, auth surface, the control-plane parity
-set — footer probe, known-size open, S3 LIST — and the gateway's plain-S3
-surface); P2/P3 (and P0c gateway-side) implement and test them. No production
-code ships with this PR.
+| Risk | Nature |
+|---|---|
+| SDK registration scope | If registration is bound to a session in a way none of the planned arena layouts can absorb, the phase stops at preflight |
+| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
+| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
+| No-retry reliability | With one-shot reads, a transient-fault rate above roughly one in twenty-five million GETs would fail the soak for a terabyte-scale workload; the soak measures this before any retry mechanism is considered |
+| Copy-cost estimate | The pre-copy staging window and per-chunk D2D cost are estimates until the hardware gate measures them; the copy is expected to be small relative to wire time at 100 Gbps |
 </script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script type="module">

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -155,15 +155,61 @@ the destination is valid.
 
 ## 5. Safety and Failure Semantics
 
-The delivery contract turns on the first `cudaMemcpyAsync` call for a
-chunk. Before it no copy is in flight, so a non-sticky failure reports
-and releases the slot safely; a sticky CUDA error terminates the process
-at any point (the sticky set is CUDA's documented
-classification, checked against the tree's classifier). After the call, only an
-event wait reporting `cudaSuccess` proves the copy has stopped writing,
-so every other outcome is process-fatal. The exception is an
-event-destroy failure after a successful wait: logged, and the success
-stands.
+The safety model has two irreversible boundaries. Issuing the
+token-bearing GET creates a possible remote writer to the registered
+arena; enqueuing `cudaMemcpyAsync` creates a possible local GPU writer
+to caller-owned RMM memory. A failure is recoverable only when Sirius
+can prove the relevant writer has stopped: an uncertain RDMA completion
+therefore fail-stops the transport, and an uncertain copy is
+process-fatal.
+
+The local-delivery half follows the existing REST staged-device-read
+lifecycle — a reactor-owned source slot is retained until the CUDA copy
+on the caller stream is confirmed by an event; the rules here add what
+that lifecycle never faced: remote-writer ambiguity and
+registered-memory lifetime.
+
+The diagram shows the state flow for one chunk; the outcome table below
+remains the normative definition of the effects on the request future
+and arena lifetime.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PreIssue: chunk claimed / slot leased
+
+  PreIssue --> RequestError: local failure before GET
+  PreIssue --> RDMAInFlight: issue one-shot token-bearing GET
+
+  RDMAInFlight --> TransportFailStop: completion non-exact or unknown
+  RDMAInFlight --> ReadyToDeliver: exact completion (tag + status + expected bytes)
+
+  ReadyToDeliver --> RequestError: non-sticky error before D2D
+  ReadyToDeliver --> ProcessFatal: sticky CUDA error
+  ReadyToDeliver --> CopyInFlight: flush if required, enqueue D2D + event
+
+  CopyInFlight --> Delivered: event wait == cudaSuccess
+  CopyInFlight --> ProcessFatal: any other outcome
+
+  Delivered --> [*]: chunk complete / slot reusable
+  RequestError --> [*]: request marked failed / slot released
+
+  note right of TransportFailStop
+    Future resolves with an error.
+    The arena remains allocated.
+    Recovery requires process restart.
+  end note
+
+  note right of ProcessFatal
+    A sticky CUDA error at any phase enters this state.
+    The future is not resolved and the arena is not freed.
+  end note
+```
+
+The sticky set is CUDA's documented classification, checked against the
+tree's classifier. After the D2D is enqueued, only an event wait
+reporting `cudaSuccess` proves the copy has stopped writing; an
+event-destroy failure after that successful wait is logged and does not
+change the delivery outcome.
 
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
@@ -172,16 +218,14 @@ stands.
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
 | Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
-A non-exact or unknown RDMA outcome fail-stops the transport: the client
-cannot prove the gateway has stopped writing, so the whole arena becomes
-non-freeable and recovery is a process restart. Shutdown is two-phase — a
-terminal mark that refuses new work, then completion when the last
-in-flight permit releases — so a failing worker never waits on itself.
-Both planes close behind one shared admission gate and surface one
-terminal error: an operation already past its side-effect point (a
-control call started, a transfer issued) completes; queued envelopes and
-their ungenerated chunks error-complete; work claimed but not issued
-aborts and releases its slot; blocked submitters wake.
+On entering `TransportFailStop`, the ioctx marks the shared admission
+gate terminal and refuses new work; host- and device-plane operations
+alike surface the same terminal error. An operation already past its
+side-effect point (a control call started, a transfer issued) settles;
+queued envelopes and their ungenerated chunks error-complete; work
+claimed but not issued aborts and releases its slot; blocked submitters
+wake. Shutdown completes when the last in-flight permit releases, so the
+worker that triggered the fail-stop never waits on itself.
 
 Destination contents are unspecified after any failed read: earlier
 chunks may already have landed in the caller's buffer.

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -24,43 +24,36 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — updated for the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev`. Revised 2026-07-15: delivery-failure semantics defined; reactor-state, visibility-policy, and session-model sections expanded |
+| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15: the body supports the review decisions; implementation detail lives in the appendix |
 | **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
-## TL;DR
+## 1. Summary
 
-Read large Parquet column data from S3 **straight into GPU memory over RDMA**,
-removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
-`RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
-moves it to the final RMM buffer. `s3://` URIs, the SigV4 credential machinery,
-and the Parquet scanner are unchanged — the new code is one reactor plus a thin
-ioctx under the existing `templated_ioctx`, the same way the REST backend is
-built. (One auth-surface extension is required: the RDMA token and `Range`
-must be **inside** the SigV4 signature — D8.) The
-benchmark already proves the cuObject RDMA data path at line rate. What remains
-Sirius-specific is the arena+D2D **visibility discipline**, validated in
-rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
-is designed so that no buffer is recycled or handed back while a copy might
-still touch it. **Please review the decisions table (§3) and the open
-questions (§5).**
+**Problem.** Sirius reads S3 Parquet through the REST backend: libcurl range
+GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU. Every
+byte crosses host memory and PCIe twice.
 
-## Why
+**Proposal.** A cuObject gateway `RDMA_WRITE`s object bytes into a small,
+pre-registered GPU **arena**; a GPU-local copy delivers them to the final RMM
+buffer. The pinned-host staging and the PCIe H2D copy disappear.
 
-Sirius reads S3 Parquet today via the REST backend (`rest_ioctx`): libcurl range
-GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU — every
-byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
+**Unchanged.** `s3://` URIs, the SigV4 credential machinery (one surface
+extension — §5), the `sirius_datasource` API, and the Parquet scanner. The
+REST backend remains the default; RDMA is selected per context by the existing
+`s3_transport` config.
 
-- **Goals:** large device reads RDMA-direct into GPU memory; keep `s3://` /
-  SigV4 / `sirius_datasource` semantics; the REST backend stays the
-  config-selectable default; no Parquet-scanner changes.
-- **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
-  gateway); no `AUTO` probe and no runtime HTTP fallback (failures surface loudly
-  per D6 and the §2 discipline — never a silent transport switch); no AWS-CRT
-  dependency.
+**v1 limits.** Requires an RDMA-capable cuObject gateway (plain AWS S3 does
+not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
+failures surface per the Safety Contract (§4).
 
-## 1. Architecture
+**Decisions requested.** The team is asked to approve five decisions (§6):
+the landing arena + D2D shape, the CUDA failure policy, the
+duplicate-suppression mechanism and ambiguous-completion policy, the
+request-envelope queue model, and cuObject session ownership.
+
+## 2. Architecture & Read Path
 
 ```mermaid
 flowchart LR
@@ -68,41 +61,44 @@ flowchart LR
   dr --> ic["s3_rdma_ioctx<br/>(templated_ioctx + cuobj_rdma_reactor)"]
   ic -- "control plane: HTTP GET<br/>x-amz-rdma-token (SigV4)" --> gw["cuObject gateway"]
   gw == "data plane: RDMA_WRITE<br/>(GPUDirect)" ==> arena["GPU landing arena<br/>cudaMalloc, registered once"]
-  arena == "GPU-local D2D (~TB/s)" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
+  arena == "GPU-local D2D" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
   rmm --> decode["cuDF decode"]
 ```
 
-*(Vocabulary for readers new to the IO framework: an **ioctx** is the
-per-context IO facade the scanner talks to; a **reactor** is the transport
+*(An **ioctx** is the per-context IO facade; a **reactor** is the transport
 engine behind it, defined by which read **builders** it provides.)*
 
-The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
-plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
-backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot,
-estimated from HBM bandwidth — not yet measured on this path; under 1% of the
-transfer at the 100G reference point, a larger share at higher line rates). Host reads
-(footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
-`s3_request_authorizer`.
+On the control plane (HTTP), the descriptor token is the only RDMA-specific
+request header (`Range` travels as usual); the data plane (RDMA) writes object
+bytes straight into the GPU arena. Host reads
+(footers / HEAD) stay on HTTP through the existing SigV4 authorizer. The
+arena is a fixed staging window, not object-sized: a read streams through it
+in slot-sized chunks, each D2D-copied to its offset in the destination buffer
+(copy cost: §7).
 
-The arena is a **fixed per-chunk staging window**, not object-sized: the reactor
-splits a read into slot-sized chunks that stream through the arena in waves, each
-chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 MiB
-(or multi-GB) read flows through the same small arena.
+**Resource model.**
 
-Both sizing knobs are **config** (`s3_rdma_max_inflight`,
-`s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
-device** — comes from the benchmark's CX-6 **100G reference configuration**
-(line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page
-cache and the server's 2 MiB chunking, so other topologies must re-measure).
-Faster NICs scale the same two knobs, not the design: the bytes in flight
-(`workers × slot_size`) must grow with line rate, and the knee has to be
-re-derived empirically on the target NIC (a P4/P5 sweep) — the 100G numbers do
-not transfer. Arena memory cost is exact:
-`workers × slot_size × active GPUs` per Sirius context (32 MiB per device at
-the reference defaults).
+| Resource | Per ioctx | Per process | Per active GPU |
+|---|---|---|---|
+| Reactor | 1 (not an event loop; owns the worker pool and arenas) | 1 × contexts | — |
+| Workers = in-flight `cuObjGet` ceiling | `max_inflight` | `max_inflight` × contexts | — |
+| Arena memory | `max_inflight × slot_size` × active GPUs | sum over contexts | `max_inflight × slot_size` |
+| Request envelopes (queued reads) | ≤ `s3_rdma_queue_cap` | sum over contexts | — |
+| Gateway slot budget required | `max_inflight` | sum over contexts | — |
 
-## 2. How one read works
+Throughput scales with workers; GPU count scales only the arena map (a new
+device lazily gets its own arena; slot and destination are always
+same-device); NIC count is what would eventually justify more reactors
+(deferred sharding, not v1).
+
+**Sizing.** The default — 8 workers × 4 MiB slots = 32 MiB per device — comes
+from the benchmark's CX-6 **100G reference configuration** (line rate at
+8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page cache and
+2 MiB server-side chunking, so other topologies re-measure). Faster NICs scale the two knobs, not the design:
+in-flight bytes (`workers × slot_size`) must grow with line rate, and the knee
+is re-derived on the target NIC (a P4/P5 sweep).
+
+**One read.**
 
 ```mermaid
 sequenceDiagram
@@ -113,408 +109,305 @@ sequenceDiagram
   W->>A: acquire free slot (slot_pool, reused from the framework)
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
-  G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
+  G-->>W: HTTP success (200/206) + valid x-amz-rdma-reply: 200
+  Note over W: flush GPUDirect writes (only if the platform requires it — §6)
   W->>W: create the completion event FIRST
   W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline (~3 µs est. vs the ~350 µs wire time of one slot)
+  W->>S: wait on the event inline
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
 
-`cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound** — and because there is exactly one arena slot per worker, a
-worker always finds a free slot: admission pressure lives in the reactor's
-queue, which holds bounded **request envelopes** — a submitter enqueues one
-small envelope per read and returns; workers generate and claim chunks lazily
-from the head envelopes, so an async read never waits on chunk-level progress
-(see the config appendix). Completion uses the framework's
-`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
-`report_error` exactly once and then releases its manager reference — the
-future resolves when the last chunk does. (One deliberate exception exists:
-the *unprovable* delivery verdict below terminates the process instead of
-completing the chunk — the framework's "resolve on last release" mechanics
-make any softer form of "never resolved" unimplementable. The sticky
-context-fatal verdict also ends in termination, but only after the chunk's
-error is safely reported.) Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
-(bandwidth-derived) against the ~350 µs it takes just to serialize a 4 MiB
-slot at ~91 Gbps (a wire-time floor, not a measured single-request latency
-under concurrency), so parking the worker is not expected to improve
-throughput. Two caveats keep this a
-hypothesis rather than a settled fact: the event wait covers **all prior work
-on the caller's stream**, not just our D2D, and the ratio shifts at higher
-line rates — a realistic shared-stream saturation test is an explicit
-activation gate, and the REST backend's event-poll shape is the documented
-fallback if it fails.
+A submitter enqueues one small **request envelope** and returns; workers
+generate and claim chunks lazily, so an async read never waits on chunk-level
+progress (mechanics: appendix). `cuObjGet` blocks, so the worker pool is the
+concurrency bound; with one arena slot per worker a free slot is always
+available. Each chunk completes exactly once, on its own worker, with the one
+exception defined in §4; the inline wait is a P3 measurement (§7). The
+reactor omits the framework's two staged-read builders, so the prefetch cache
+is never built for this backend — kvikio's minimal profile, which also keeps
+the cache's 2–7× sparse-projection over-read (issue #1078) unreachable here.
 
-**When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
-the arena slot (its next user would corrupt an in-flight copy) and the caller's
-destination (the caller frees it as soon as its future resolves — while the
-copy may still be writing it). The rule is therefore absolute: **neither the
-slot is recycled nor the future resolved until the stream is proven quiet.**
-
-- The completion event is created **before** the copy is enqueued — if event
-  creation fails, no D2D has been submitted, so releasing the slot and
-  reporting the error is safe.
-- A non-success return from `cudaMemcpyAsync` itself does **not** prove the
-  copy was rejected: async CUDA calls may return errors produced by *earlier*
-  async work, so the enqueue state is unknown. Any non-success here is treated
-  exactly like a post-enqueue failure and goes through the quiescence proof
-  below.
-- On any CUDA failure at or after the enqueue, the worker proves quiescence
-  with a real stream sync. A sync call can return an error produced by earlier
-  async work — the call itself still waited, so the stream is still proven
-  quiet. The only exception is an error meaning the call never ran at all
-  (e.g. an invalid stream handle); then the worker escalates to a device-wide
-  sync as the stronger proof. (Captured streams fall in that exception too —
-  and are a documented precondition violation: RDMA device reads do not
-  support them.)
-- The verdict is three-way, and both non-recoverable verdicts end in a
-  **non-returning process-fatal hook** (log, then terminate the process; if
-  the hook ever returns, the call site calls `std::terminate`):
-  - *Quiet + healthy*: release the slot, report the original error, keep
-    serving.
-  - *Quiet + context-fatal* (sticky errors such as an illegal memory access):
-    the CUDA context is dead — no engine can write the destination anymore —
-    so the error is reported and logged first, **then the hook fires**.
-    Termination here is CUDA's own contract: a sticky error leaves the process
-    state corrupted, and the documented requirement is to terminate and
-    relaunch. "Restart is the recovery" thereby has an actor.
-  - *Unprovable* (the device-wide sync also failed with a non-sticky code, or
-    could not run): the hook fires **without resolving anything**. The chunk
-    never completes, so the future never resolves and the caller can never
-    free a destination that may still be written; no arena teardown runs
-    either. Termination here is Sirius's use-after-free policy rather than a
-    CUDA requirement: the completion framework resolves a future when its last
-    chunk reference is released, so a design that keeps the process alive must
-    either release (unsafe) or hold the reference forever (a wedged process a
-    watchdog kills anyway).
-- **Reactor fail-stop** is the containment shape for failures that do *not*
-  corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
-  retry contract (appendix). It happens exactly once: new reads fail fast,
-  naming the first fail-stop error; queued envelopes — and the un-generated
-  chunks of partially-consumed ones — are error-completed with it; chunks
-  already in flight finish on their own workers — never resolved on another
-  worker's behalf; and any arena that cannot be proven quiet at
-  teardown is deliberately **leaked rather than freed**, because freeing
-  memory a NIC might still write is the very use-after-free this discipline
-  exists to prevent. The process stays alive, but RDMA service on this
-  context resumes only with a process restart.
-
-Every CUDA call on this delivery path goes through a small seam injected at
-construction time, so the recoverable branches are fault-injectable in
-ordinary tests without faking CUDA semantics. The process-fatal branches are
-different: an in-process test double that returns or throws would exercise
-exactly the stack unwinding production forbids, so the hook is validated by
-**death tests** — a child process asserting the exit code, the fatal log, and
-the absence of normal teardown.
-
-## 3. Key decisions
+## 3. Key Decisions
 
 | # | Decision | Why |
 |---|---|---|
-| D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
+| D1 | Keep `s3://`; select the backend once, at registry construction (`s3_transport=RDMA` claims the s3 slot instead of restful; `AUTO`→HTTP) | The config field already exists; exactly one s3 backend per context keeps routing unambiguous and the scan side untouched |
+| D2 | One new transport engine under the existing IO framework: a reactor wrapped by a thin ioctx; the shared context carries config, a **client/session factory** (ownership: §6 decision 5), and the flush policy; the per-device arena map is reactor state | Chunking, pooling, completion, `slot_pool`, and the registry factory are reused; arenas belong with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level: per §2 the process-fatal hook terminates the process (restart is the recovery); the reactor's fail-stop contains only non-corrupting failures (the ambiguous RDMA outcome) |
-| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
-| **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
+| D4 | Landing arena + GPU-local D2D, not direct RDMA into RMM buffers | Sirius RMM is `cudaMallocAsync`-backed: not reliably registrable for GPUDirect, and stream-ordered backing means an address may be unbacked when the NIC writes |
+| D5 | Completion via `semi_future` + `request_manager`, inline event wait; nothing completes before delivery is settled per the Safety Contract (§4) | Closes both use-after-free sides: a reused slot under an in-flight copy, and a freed destination still being written |
+| D6 | Explicit `RDMA` opt-in; failures surface per §4 — never a silent transport switch | Fallbacks mask misconfiguration exactly where RDMA is deliberately deployed |
+| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); NVIDIA SDKs are never vendored | Default-off builds are unchanged; conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — reconciliation is a real task |
+| D8 | The RDMA token and `Range` are signed; header-signing mode only (details: §5) | An unsigned token is not bound to the request; a gateway could not tell a tampered descriptor from a legitimate one |
+| D9 | Prefetch cache off structurally: the reactor defines only the host-read and device-read builders | Capabilities derive from which builders exist — no flag to set; kvikio already ships this profile |
 
-Why D9 works, in one picture:
+## 4. Safety Contract
 
-```mermaid
-flowchart LR
-  A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
-  B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["the omitted builders make host staging<br/>and the cache's staged-read crash path<br/>unreachable for this backend"]
-```
+Once a D2D copy is enqueued, two buffers are at stake: the arena slot (its
+next user would corrupt an in-flight copy) and the caller's destination (freed
+as soon as its future resolves). Required invariant: **neither the slot is
+recycled nor the future resolved until the stream is proven quiet.**
 
-This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
-column projections** (issue #1078, a foreground/background allocation race) —
-the omitted builders make that path unreachable for this backend too, the
-same way it is for kvikio.
+Pre-enqueue rules: the completion event is created *before* the copy is
+enqueued (a creation failure means nothing is in flight — safe release). A
+non-success return from `cudaMemcpyAsync` does **not** prove the copy was
+rejected — async CUDA calls may return deferred errors from earlier work — so
+the enqueue state is unknown and the failure is handled as post-enqueue.
 
-`max_inflight` = worker count = **global** in-flight ceiling (one blocking
-`cuObjGet` per worker); "per-device" applies only to arena placement
-(`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
-gated future spike (§5 Q4).
+Quiescence proof: a real stream sync. An error return from the sync still
+proves quiescence (the wait completed; the error is a deferred report), except
+for codes meaning the call never ran (invalid handle; captured streams, which
+are a documented precondition violation) — those escalate to a device-wide
+sync.
 
-**One reactor per ioctx — and what scales with what.** The unit is the
-ioctx/`SiriusContext`, not the node: a process running several Sirius contexts
-multiplies workers, arenas, and gateway-budget demand accordingly. For
-contrast: the REST backend runs **2 reactors per ioctx** (`rest_n_reactors`),
-unrelated to GPU count — its reactors are epoll event loops doing real CPU work
-(TLS, staging copies), so a second one spreads CPU load. The RDMA reactor is
-*not* an event loop (`cuObjGet` blocks): it is a container for the worker pool
-and the arenas, so extra reactors add no throughput — they would only fragment
-the global in-flight ceiling and multiply sessions. Hence three independent
-axes:
-
-- **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
-  with reactors, not with GPUs.
-- **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
-  arena; a worker sets the request's device (via the framework's RAII device
-  guard) and takes a slot from *that* device's arena, so slot and destination
-  are always same-device (never a cross-device copy). A per-GPU reactor would
-  instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
-  `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
-- **NIC count** is what eventually justifies more reactors:
-  per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
-  of global rate-limit complexity — is the deferred evolution for explicit
-  multi-NIC/NUMA topologies, not v1.
-
-**New consumers stay compatible by design:** the transparent
-`read_parquet('s3://')` front door (#1074, `sirius_httpfs`) resolves its
-backend per path through `create_datasource(path)` and reads with single
-positional `host_read`s — it carries no transport-specific checks, so under
-`s3_transport=RDMA` it should work unchanged; a routing test pins this at
-integration time.
-
-**Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
-one caller of the vector host-read entry point, which this backend omits — a
-native `.db` ATTACHed over s3://+RDMA fails loudly. kvikio has the same gap
-today; a small framework fix (fall back to per-segment single reads when the
-vector path is absent) would close it for both and is proposed as a standalone
-change.
-
-## 4. Rollout
-
-The delivery-failure discipline (§2), the commit-point retry contract, the
-admission bound, and the signed-token auth surface are **target contracts**:
-implementing and fault-injection-testing them is P2/P3 scope. Read the table
-as the plan that closes the gap between the current tree and this design.
-
-| Phase | Scope | HW |
+| CUDA outcome | Future / slot | Reactor / process |
 |---|---|---|
-| **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
-| **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued (death tests: child process, exit code, no normal teardown), teardown leak, admission deadlock-freedom) | CUDA GPU |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
-| P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
+| Quiesced, recoverable | report the error, release the slot | continue serving |
+| Quiesced, context-fatal (sticky error) | safe to report and release — the context is dead, nothing can write `dst` | **process-fatal** |
+| Quiescence unknown | do **not** resolve the future or free anything | **process-fatal** |
 
-## 5. Open questions for team review
+**Process-fatal** is a non-returning hook: log the verdict, terminate the
+process (the call site invokes `std::terminate` if the hook ever returns).
+For a sticky error this is CUDA's documented terminate-and-relaunch
+requirement; for the unknown verdict it is this design's use-after-free
+policy — the framework resolves a future when its last chunk reference is
+released, so no in-process "never resolved" exists. Validated by death tests
+(child process: exit code, fatal log, no normal teardown).
 
-1. **Sizing defaults** — ship the fixed 100G-reference default from §1's sizing
-   rule, or should the default self-scale from a detected/configured link
-   speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
-2. **Visibility policy validation** — CUDA exposes a per-device
-   GPUDirect-RDMA **write-ordering attribute**: *OWNER* means RDMA writes
-   become visible to the owning device with no extra action; *NONE* means no
-   guarantee — an explicit flush is required before the GPU may read the
-   bytes. The OWNER half of the question is closed on paper: our consumer is a
-   same-device D2D, so **only NONE-ordering platforms need a flush**, and a
-   NONE platform that cannot flush must fail RDMA init loudly (no safe
-   configuration exists). What still needs the rig: wiring the policy **per
-   device** and the decode-immediately-after-GET stress test — still the top
-   correctness gate for P3. Who owns that rig time? (This ruling covers v1's
-   single RDMA path; a future multi-NIC sharding must revisit NVIDIA's
-   multi-ordering-domain exceptions.)
-3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
-   (Single-NIC suffices for P3.)
-4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
-   registrable allocation path for IO buffers? It unlocks direct-into-RMM
-   (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters. Note the REST reactor's
-   perf instrumentation was re-added in #1042; the RDMA
-   counters should follow that shape rather than invent a parallel one (see
-   the appendix for the proposed set, including the delivery-safety counters).
-6. **Session ownership** — the cuObject SDK documents no whole-client
-   thread-safety guarantee, so the design prefers **one `cuObjClient` session
-   per worker**; the alternative (one shared client for the pool) requires
-   documented proof of safety plus locking that preserves concurrency. Bound
-   up with it: is a buffer registration per-session (N registrations of the
-   same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
-   vs the validated 1.0.0) and shapes the client-wrapper API; it must be
-   decided on the rig, before activation.
-7. **Ambiguous-failure fencing and duplicate suppression** — after a
-   control-plane timeout or reset, the gateway may still hold a descriptor for
-   the slot and keep writing it; the protocol defines what a success response
-   means, but not what silence means — and a transparently retried duplicate
-   can succeed while the original is still writing (see the deployment
-   invariants in the appendix), which no client-side rule can detect. Does the
-   cuObject SDK or the gateway offer a fencing / cancellation primitive
-   (deregister-and-confirm, descriptor revocation)? Is a descriptor token
-   single-use at the gateway? Without one, the
-   retry contract (appendix) must fail-stop the reactor and mark the entire
-   arena non-freeable on any ambiguous failure (per-slot quarantine was
-   rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
-   as much as for this team.
+| RDMA outcome | Slot / arena | Retry |
+|---|---|---|
+| Not sent (token never left the client) | slot reusable | allowed |
+| Exact completion (valid reply, `n == expected`) | slot reusable after the D2D | not needed |
+| Sent, outcome unknown | **entire arena non-freeable** | none — reactor **fail-stop** |
 
-## 6. Risks
+The client reports a commit state with every failure (`not_sent` /
+`sent_unknown` / `completed`); host/HTTP reads retry freely (the client owns
+the write loop). Registration covers the whole arena, so one slot the gateway
+may still write makes deregistering or freeing any of it unsafe; per-slot
+quarantine was rejected because repeated quarantines drain the pool.
+**Fail-stop** happens exactly once: new reads fail fast with the fail-stop
+error; queued envelopes — and the un-generated chunks of partially-consumed
+ones — are error-completed; chunks already in flight finish on their own
+workers; blocked submitters are woken. The process stays alive —
+fail-stop is reserved for failures that do not corrupt the CUDA process — but
+RDMA service on the context requires a restart. Any arena that cannot be
+proven quiet at teardown, by device stream or by remote gateway, is leaked,
+never freed.
 
-- **CUDA visibility after external RDMA writes** — the top correctness risk,
-  now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
-  exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
-  test.
-- **Fatal CUDA errors are process-level.** The §2 process-fatal hook
-  terminates the process — supervisor restart is the recovery, so operators
-  need a relaunch policy. The reactor's fail-stop contains only the
-  non-corrupting ambiguous-RDMA case: there the process stays alive, but RDMA
-  service on the context requires a restart.
-- Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
-  can silently halve BW. The gateway slot budget must cover `max_inflight` per
-  Sirius context (not × GPUs or × queries) — and a process running several
-  contexts multiplies it (§3).
-- Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5 — control-plane **connection reuse** is part of the same
-  measurement); cuObject's blocking GET shapes the worker-pool model, and the
-  pool grows with NIC line rate (§1 sizing), sharpening the case for an async
-  cuObject API if one appears.
-- cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
+Two independent gates apply on the real path. **Completion authority** is a
+P0b gate: the gateway enforces **exact completion** and the client requires a
+**valid reply tag** (appendix protocol). Separately, request **uniqueness**
+(§5) must hold before P3 activation — fail-stop cannot see a duplicate that
+succeeds.
+
+## 5. Authentication
+
+The `x-amz-rdma-token` and `Range` headers are inside the SigV4 signature,
+binding object, byte range, and destination capability into one authorized
+request. v1 supports header-signing mode only — an implementation choice, not
+a protocol limit (SigV4 query signing can carry `X-Amz-SignedHeaders`, but the
+Sirius presigner signs only `host` today); RDMA initialization fails under
+`s3_signing_mode = presigned`.
+
+Interface: the existing three-argument virtual `authorize()` is untouched; the
+headers-to-sign travel through a new, separately-named non-pure virtual
+(`authorize_with_headers(request)`) whose default implementation rejects
+non-empty header sets, and which the built-in SigV4 header signer overrides.
+
+The dev benchmark server runs unsigned on an isolated network; production
+gateways validate the signature before honoring the token.
+
+Request uniqueness is an **activation requirement**, not a recovery policy:
+a transparently retried duplicate can *succeed* while the original request is
+still writing, and no client-side rule — fail-stop included — can see it.
+**v1 satisfies it by deployment contract**: the client connects to the
+gateway directly (or every intermediary has automatic retries disabled for
+token-bearing GETs); RDMA must not be enabled otherwise. Gateway-side
+exactly-once deduplication is a **deferred conditional extension** — the base
+cuObject protocol defines no request-identity tag, so it would need a signed
+identity added to the wire (appendix) and is only worth specifying if a
+deployment requires an intermediary. The control plane runs over TLS; tokens
+are redacted from logs.
+
+## 6. Review Decisions
+
+| # | Decision needed | Recommendation | Blocks |
+|---|---|---|---|
+| 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
+| 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
+| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the no-intermediary-retry deployment contract (gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
+| 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
+| 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
+
+Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
+default (fixed 100G reference vs self-scaling) before P4; appetite for a
+registrable cucascade IO sub-MR (unlocks direct-into-RMM); confirmation from
+NVIDIA whether a descriptor token is single-use; counter naming alignment with
+the REST instrumentation.
+
+Visibility policy is ruled by the CUDA contract, not a vote: the per-device
+write-ordering attribute makes OWNER platforms safe for our same-device D2D
+consumer with no flush; only NONE platforms need one, and a NONE platform that
+cannot flush fails RDMA initialization. P3 work: per-device wiring and the
+decode-after-GET stress test. The ruling covers v1's single RDMA path;
+multi-NIC sharding would revisit the multi-ordering-domain exceptions.
+
+## 7. Rollout & Performance
+
+| Phase | Scope | Exit criterion | HW |
+|---|---|---|---|
+| P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
+| P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
+| P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
+| P2 | Reactor against a mock client; envelope admission | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom | CUDA GPU |
+| P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
+| P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
+| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
+
+The rollout closes the gap between the current tree and this document: the
+Safety Contract, envelope queue, uniqueness invariants, and auth surface are
+target contracts to be implemented and tested in P2/P3.
+
+**Performance.** The D2D is an estimated ~3 µs per 4 MiB slot (derived from
+HBM bandwidth, not yet measured on this path) against the ~350 µs wire
+serialization of one slot at ~91 Gbps — a wire-time floor, not a measured
+single-request latency under concurrency. That ratio is the basis for the
+inline wait; the caveat is that the event wait covers all prior work on the
+caller's stream, not just this copy. P3 replaces the estimates by measuring
+the total post-RDMA delivery cost (flush, event lifecycle, D2D) under a
+shared-stream saturation test; the REST backend's event-poll shape is the
+documented fallback if that test fails.
+
+## 8. Scope & Risks
+
+Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
+the omitted vector-read path (kvikio has the same gap; a per-segment framework
+fallback is proposed separately). The transparent `read_parquet('s3://')`
+front door (#1074) carries no transport-specific checks and is expected to
+work unchanged — a routing test pins this at integration. Captured CUDA
+streams are unsupported for RDMA device reads.
+
+Risks:
+
+- GPU-consumer visibility on NONE-ordering platforms — per-device wiring and
+  the P3 stress test are the top correctness gate (§6).
+- Requires a controlled cuObject gateway; NIC↔GPU PCIe affinity across root
+  complexes can silently halve bandwidth (P4 validation).
+- cuObject SDK skew (conda 1.2.x vs the validated 1.0.0 tarball) must be
   reconciled before P3.
+- Small-read control-plane RTT, including per-request connection setup —
+  measured in P5; an optional whole-read HTTP threshold is the prepared
+  mitigation.
+- The gateway slot budget scales with `max_inflight` × Sirius contexts, not
+  with GPUs or queries (§2 resource model).
 
 ---
 
-## Appendix — Protocol & config
+## Appendix — Protocol, configuration, implementation
 
-### Control-plane headers
+### Wire protocol
 
-Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
+Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags plus
+`Range`. The benchmark's four non-standard headers were removed by the wire
+migration (P0a).
 
 | Header | Direction | Meaning |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected`, and that count is authoritative only when **both** halves hold: the gateway enforces exact completion (accepts no short or overlong RDMA piece), **and** the client requires a valid reply tag before it reports the requested size — an HTTP 200/206 without a legitimate reply must be treated as failure, and the reply payload is never interpreted as a byte count. Both halves are P0b items (see below) and a precondition for trusting short-write detection on the real path |
+| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; encodes the remote slot address and size; signed (§5) |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag; never interpreted as a byte count |
 
-The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
-`x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
-address rides in the token, capacity is the `cuObjGet` `size` arg, and the
-reply tag supersedes the byte-count header. The server chunks transfers
-server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
-Production gateways SigV4-validate the control request before honoring the
-token, and the token + `Range` are part of that signature (D8): the client
-signs them, the gateway verifies them — an unsigned token is rejected.
+Conditional extension (deferred): gateway-side exactly-once deduplication
+would require a signed request identity on the wire — the identity field, its
+validity window, dedup retention, and gateway ownership would all need
+definition with NVIDIA (the descriptor token can serve only if it is ruled
+single-use). Not part of v1, which relies on the §5 deployment contract.
 
-### Auth surface extension (D8 mechanics)
+Completion authority: `cuObjGet`'s returned `n == expected` is authoritative
+only when the gateway enforces exact completion (no short or overlong RDMA
+piece) **and** the client requires a valid reply tag before reporting the
+requested size — an HTTP 200/206 without a legitimate reply is a failure. Both
+halves are P0b gates. The server chunks transfers server-side (its own config,
+default 2 MiB); nothing is negotiated on the wire. Signature validation and
+the dev/prod auth posture are defined in §5. Remaining P0b items
+(outcome level): strict descriptor/capacity validation, exact completion,
+mandatory reply validation — code-level specifics are tracked in the
+`s3RDMA-benchmarktool` repo.
 
-The authorizer's request surface is extended so headers added for RDMA are
-part of the SigV4 canonical request. Presigned mode is excluded as a v1
-implementation choice, not a protocol limit: SigV4 query signing can in
-principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner
-signs only `host` today. Compatibility: the existing pure-virtual
-`authorize()` stays untouched; the headers-to-sign travel through a **new,
-separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`)
-whose default implementation rejects non-empty header sets as unsupported,
-and which the built-in SigV4 header signer overrides. A defaulted parameter
-on the existing virtual would break every override, and a same-name overload
-would make existing three-argument calls ambiguous.
-
-### Config (under `object_store_config`)
-
-`s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
-its consumer. Two sizing knobs accompany it:
+### Configuration
 
 ```text
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
-s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
+s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
+s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
 s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
 ```
 
-**Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
-cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
-and the RDMA control requests, under one set of credentials and one signing
-host. A split topology (RDMA gateway separate from the S3 origin) is out of
-scope for v1: it needs two endpoints, two signing hosts, and an explicit
-credential boundary, and is deferred until a deployment requires it. There is deliberately **no client chunk-size knob**: the transfer
-granularity is the arena slot size, and the server chunks independently.
-Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
-for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
+Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
+one host serves HEAD/range-GET and RDMA control under one credential set. A
+split topology is deferred until a deployment requires it. There is no client
+chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
+the existing fields (`s3_signing_mode` — header mode required, §5 —
+`ca_bundle_path`, `tls_verify`).
 
-**Admission bound (v1):** the reactor's queue holds **request envelopes**,
-bounded per ioctx (`s3_rdma_queue_cap`, counted in requests). A submitter
-enqueues one envelope — a small descriptor, not the chunk list — and returns
-immediately; workers generate and claim chunks lazily from the head envelopes,
-FIFO. Per-chunk admission was rejected: with a chunk-counted cap, a read
-larger than the cap would block the submitting thread until most of its own
-transfer had completed, making the async API effectively synchronous. Only a
-full envelope queue blocks a submitter (the bound is on outstanding requests,
-which the scan layer already limits); fail-stop and shutdown wake any blocked
-submitter, which then observes the failure/shutdown error — a
-deadlock-freedom test covers both. Envelope-queue depth-peak and wait counters
-expose the pressure. The process-wide budget is contexts × workers — a
-deployment running several Sirius contexts must size the gateway budget for
-the sum.
+Admission: the queue holds request envelopes, bounded per ioctx and counted in
+requests. A submitter enqueues one envelope (a small descriptor, not the chunk
+list) and returns; workers generate and claim chunks lazily, FIFO. A per-chunk
+cap was rejected: a read larger than the cap would block its submitter until
+most of its own transfer completed, making the async API effectively
+synchronous. Only a full envelope queue blocks a submitter; fail-stop and
+shutdown wake any blocked submitter with the corresponding error.
 
-**Retry contract** — deliberately independent of the REST policy, and split by
-plane, because the two planes fail differently:
+Retry: split by plane and commit point. Host/HTTP reads retry on transport
+failures and short reads. RDMA device reads retry only from the `not_sent`
+commit state; `sent_unknown` is terminal per the Safety Contract. CUDA work
+never retries; exhaustion surfaces the last error; never a transport switch
+(D6).
 
-- **Host/HTTP reads** (footers, metadata): retryable on transport failures and
-  short reads. The client owns the write loop into the destination buffer, and
-  a closed connection means no further writes — re-issuing into the same
-  buffer is safe.
-- **RDMA device reads**: retryability is decided by the **commit point**, so
-  the client wrapper must report a commit state with every failure —
-  `not_sent` / `sent_unknown` / `completed`. A `not_sent` failure (connection
-  setup, before the token left the client) is retryable. Once the token may
-  have reached the gateway (`sent_unknown`), a timeout or reset without an
-  authoritative reply is **ambiguous**: the gateway holds a descriptor and may
-  still be writing — the protocol defines "success response ⇒ transfer
-  complete", but not "no response ⇒ gateway stopped"; a proxy-replayed or
-  duplicated request can even land a late write after an apparent failure.
-  v1 therefore treats the **first ambiguous post-commit failure as a reactor
-  fail-stop**: the read fails, nothing retries in place, and the **entire
-  arena is marked non-freeable** — RDMA registration covers the whole arena,
-  so one slot the gateway may still write makes deregistering or freeing any
-  of it unsafe; teardown leaks it, and RDMA service on this context requires a
-  process restart. Per-slot quarantine was considered and rejected: repeated
-  quarantines drain the slot pool until workers, blocking admission, and
-  shutdown all wait forever. A gateway/SDK fencing or cancellation primitive
-  (§5 Q7) is what would permit a less drastic recovery.
-- Everywhere: CUDA work never retries; exhaustion surfaces the last error —
-  and per D6, never a transport switch.
-
-**Deployment invariants (v1, required for the RDMA plane).** The commit-state
-contract above covers failures the *client sees*. A transparent intermediary
-can break it invisibly: a proxy forwards request A (the gateway starts
-writing), the upstream connection drops, the proxy silently retries as
-request B, B succeeds and returns 200 — the client completes the read, reuses
-the slot, and only then does A's late write land. The client saw only success,
-so no fail-stop triggers. v1 therefore requires one of:
-
-- **No automatic intermediary retries** of token-bearing GETs anywhere on the
-  path (the recommended deployment: client connects to the gateway directly,
-  or every proxy in between has retries disabled for these requests); or
-- **Gateway-side exactly-once dedup** keyed on the signed token / a signed
-  request id, so a duplicated request never starts a second RDMA write.
-
-Related requirements: confirm with NVIDIA whether a descriptor token is
-single-use at the gateway (Q7); the control plane runs over TLS; tokens are
-redacted from request logs; and replayed tokens outside the dedup window are
-rejected.
+### Metrics
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total` — plus the
-delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
-runs), `…_fail_stop_total` (reactor fail-stop transitions — the ambiguous-RDMA containment; the process-terminating verdicts leave a fatal log line and an exit code, not a scrapeable counter), `…_arena_leak_total`
-(arenas leaked at teardown because a writer — device stream or remote gateway
-— could not be proven quiet).
+`…_queue_depth_peak`, `…_queue_wait_total`, `…_fallback_stream_sync_total`
+(quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
+the process-terminating verdicts leave a fatal log line and an exit code, not
+a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
 
-### P0 status (in `s3RDMA-benchmarktool`)
+### Implementation notes (framework mapping)
 
-**Wire migration landed** (merged to `main`, 2026-06-17): the 4 non-standard
-headers dropped, the server decodes the slot address from the token (works on the
-pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
-documented. **Open hardening (P0b):** the migration **removed** the previous
-strict address validator — today's parse takes the first hex field with no
-length/field validation (and wrongly rejects a legitimate address 0); the token's
-`buf_size` field is transmitted but never read server-side (a capacity check the
-server already has the data for but currently skips); the client reports success on
-any 200/206 without an `n == expected` short-write check **and without requiring
-a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
-of P0b — only after it may the callback report the requested size); optional
-SigV4 in the dev server.
+`s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>`, built like
+`rest_ioctx`. The reactor provides the `prep_host_rx` / `prep_device_rx`
+builders plus `enqueue`; omitting the two staged-read builders is what derives
+the cache-off capability profile (D9). Completion rides
+`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete`
+or `report_error` exactly once and releases its manager reference; the future
+resolves when the last reference drops — which is why the §4 "unknown"
+verdict must terminate rather than attempt any in-process "never resolved"
+state. The per-device arena map is reactor state; `slot_pool` is reused
+verbatim for slot indexing.
 
-> Detailed gateway-hardening notes (file:line specifics) are tracked in the
-> `s3RDMA-benchmarktool` repo.
+### Fault-test matrix (P2, CUDA GPU required; RDMA-rig-free)
+
+Byte-exact multi-chunk reads; concept checks that both staged-read
+capabilities stay off; event-created-before-enqueue (injected create failure
+never reaches the copy); `cudaMemcpyAsync` non-success routed through the
+quiescence proof; recoverable ladder outcomes release the slot only after the
+proof; process-fatal verdicts exercised as **death tests** (child process:
+exit code, fatal log, no normal teardown — an in-process double that returns
+or throws would exercise the unwinding production forbids) including an active
+unknown-verdict chunk with queued siblings of the same request; fail-stop exactly-once with
+owner-worker completion of in-flight chunks; ambiguous-RDMA fail-stop with
+arena marked non-freeable and teardown leak observed; admission
+deadlock-freedom (submitter blocked at the envelope cap while workers drain
+and while the reactor fail-stops).
+
+### Status
+
+This document describes the target architecture. The current tree differs in
+the areas the rollout table covers (delivery-failure discipline, retry
+classification, envelope admission, auth surface); P2/P3 implement and test
+them. No production code ships with this PR.
 </script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script type="module">

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -1,3 +1,25 @@
+<!doctype html>
+<!-- Generated preview of s3-rdma-transport-design.md (Mermaid via CDN).
+     This is a SNAPSHOT of the .md at generation time — regenerate if the .md
+     changes. GitHub also renders the .md's Mermaid natively in the PR/blob view. -->
+<html><head><meta charset="utf-8">
+<title>S3 RDMA Transport — Design preview</title>
+<style>
+ body{max-width:920px;margin:2rem auto;padding:0 1.2rem;line-height:1.55;
+   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#1f2328}
+ h1{border-bottom:1px solid #d0d7de;padding-bottom:.3em}
+ h2{border-bottom:1px solid #eaecef;padding-bottom:.2em;margin-top:1.6em}
+ table{border-collapse:collapse;margin:1em 0;display:block;overflow:auto}
+ th,td{border:1px solid #d0d7de;padding:6px 10px;text-align:left;vertical-align:top}
+ th{background:#f6f8fa}
+ code{background:#eff1f3;padding:.15em .35em;border-radius:4px;font-size:90%}
+ pre{background:#f6f8fa;padding:12px;border-radius:6px;overflow:auto}
+ pre code{background:none;padding:0}
+ .mermaid{background:#fff;margin:1.2em 0;text-align:center}
+ blockquote{color:#57606a;border-left:.25em solid #d0d7de;padding:0 1em;margin-left:0}
+</style></head><body>
+<div id="out">rendering…</div>
+<script type="text/markdown" id="src">
 # S3 RDMA Transport for Sirius — Design for Team Review
 
 | | |
@@ -177,3 +199,16 @@ the `cuObjGet` `size` arg); optional SigV4 in the dev server.
 
 > Deeper implementation notes + verified file:line references live in the
 > offline working spec, not this doc.
+</script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+const md = document.getElementById('src').textContent;
+document.getElementById('out').innerHTML = marked.parse(md);
+document.querySelectorAll('code.language-mermaid').forEach(c=>{
+  const div=document.createElement('div'); div.className='mermaid';
+  div.textContent=c.textContent; c.closest('pre').replaceWith(div);
+});
+mermaid.initialize({startOnLoad:false,theme:'default'});
+try{ await mermaid.run(); }catch(e){ console.error(e); }
+</script></body></html>

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -55,7 +55,7 @@ on CX-6 RoCE).
 | Supported in v1 | Not in v1 |
 |---|---|
 | Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
-| Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
+| Two logical endpoints — host plane + RDMA data plane; the configured addresses may be identical | A single shared endpoint configuration (no separate data-plane settings) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
 | One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
@@ -77,14 +77,14 @@ flowchart LR
     arena -->|"D2D on the caller stream"| rmm["RMM destination<br/>(caller-owned, not registered)"]
   end
   ctl -->|"HEAD / footer / range GET"| s3["s3_endpoint<br/>(any S3 service)"]
-  w -->|"token-bearing signed GET"| gw["s3_rdma_endpoint<br/>(cuObject gateway, direct connect)"]
+  w -->|"token-bearing signed GET"| gw["s3_rdma_data.endpoint<br/>(cuObject gateway, direct connect)"]
   gw -->|"RDMA write"| arena
   s3 --- store[("same backing store,<br/>immutable keys")]
   gw --- store
 ```
 
 The host plane (`s3_endpoint`) is any S3 service, speaking standard
-SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_endpoint`)
+SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_data.endpoint`)
 is a direct-connect cuObject gateway carrying token-bearing GETs plus the
 publisher HEAD of the visibility barrier below; both front the same
 backing store and bucket namespace.
@@ -105,6 +105,12 @@ publisher completes a visibility barrier: HEAD succeeds at both endpoints
 with matching sizes, and content identity is confirmed by a trusted ETag
 or the publishing manifest's object hash. The query path does not send
 HEAD to the gateway.
+
+For split addresses, the publisher visibility barrier above applies. If
+the two configured addresses are identical and one service serves both
+planes, cross-endpoint checks reduce to that service's native S3
+consistency; immutable keys remain required, and reads do not revalidate
+object versions.
 
 ## 4. Read Lifecycle
 
@@ -222,7 +228,8 @@ change the delivery outcome.
 On entering `TransportFailStop`, the ioctx marks the shared admission
 gate terminal and refuses new work; host- and device-plane operations
 alike surface the same terminal error. An operation already past its
-side-effect point (a control call started, a transfer issued) settles;
+side-effect point — holding the permit acquired when its control call
+starts or its transfer is issued — settles;
 queued envelopes and their ungenerated chunks error-complete; work
 claimed but not issued aborts and releases its slot; blocked submitters
 wake. Shutdown completes when the last in-flight permit releases, so the
@@ -250,7 +257,7 @@ life of the process.
 |---|---|---|
 | `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
 | `s3_endpoint` | Host plane: any S3 service | existing setting |
-| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset | none |
+| `s3_rdma_data.endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset. The `s3_rdma_data` block also carries region, credentials, signing mode, and TLS for the data plane; when its access key is unset, host-plane credentials are inherited as a whole | none |
 | `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
 | `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
@@ -319,8 +326,9 @@ The positions are the ones this document describes; the team is asked:
 
 1. GPU destination (Section 3): is the extra GPU-local copy acceptable,
    rather than registering arbitrary RMM allocations?
-2. Endpoint topology (Section 3): is split deployment, with the publisher
-   visibility barrier, acceptable?
+2. Endpoint topology (Section 3): is the two-plane configuration
+   acceptable — the full publisher barrier for split addresses, native S3
+   consistency plus immutable keys for same-address deployments?
 3. Failure policy (Section 5): is restart-based recovery acceptable for
    V1 — no fallback after an RDMA request is selected or fails?
 4. CUDA boundary (Section 5): when delivery cannot be proven, is

--- a/experimental/s3-rdma-transport-design.html
+++ b/experimental/s3-rdma-transport-design.html
@@ -277,7 +277,7 @@ as the plan that closes the gap between the current tree and this design.
 | **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop incl. an active unprovable chunk with queued siblings of the same request, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued, teardown leak, admission deadlock-freedom) | CUDA GPU |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
@@ -319,8 +319,10 @@ as the plan that closes the gap between the current tree and this design.
    protocol defines what a success response means, but not what silence means.
    Does the cuObject SDK or the gateway offer a fencing / cancellation
    primitive (deregister-and-confirm, descriptor revocation)? Without one, the
-   retry contract (appendix) must quarantine the slot and fail the read on any
-   ambiguous failure — a question for NVIDIA as much as for this team.
+   retry contract (appendix) must fail-stop the reactor and mark the entire
+   arena non-freeable on any ambiguous failure (per-slot quarantine was
+   rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
+   as much as for this team.
 
 ## 6. Risks
 
@@ -434,7 +436,8 @@ Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
 runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
-(arenas leaked at teardown because the device could not be proven quiet).
+(arenas leaked at teardown because a writer — device stream or remote gateway
+— could not be proven quiet).
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -276,30 +276,20 @@ any other gate fails — the decision is STOP: restart the process and
 return to `s3_transport=HTTP`. The build flag stays off by default
 throughout.
 
-## 8. Current Status and Remaining Work
+## 8. Open Risks and Preconditions
 
-The transport machinery in the tree is dormant; the real cuObject
-transfer has not run yet, and the rig gates above will be its first
-exercise. Five gaps close, in order, before the gates run:
+The real cuObject path has not yet completed hardware qualification;
+implementation progress is tracked in the implementation PR. The risks
+below are resolved or measured by the Section 7 gates and do not change
+the V1 safety contract.
 
-1. Factory wiring — the factory does not yet construct the control
-   client; reads cannot route through the normal path.
-2. Endpoint pair — configuration has a single endpoint today.
-3. Envelope admission — chunk admission is eager rather than
-   envelope-bounded.
-4. Retry removal — device reads still carry a legacy multi-attempt retry
-   to be reduced to one-shot.
-5. Completion and gateway hardening — completion validation does not yet
-   check the reply-tag and status legs; gateway exact-write enforcement
-   and descriptor capacity checks are outstanding.
-
-| Risk | Nature |
+| Risk | Treatment |
 |---|---|
-| SDK registration scope | If no planned arena layout can absorb the SDK's registration-to-session binding, the phase stops at preflight |
-| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
-| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
-| No-retry reliability | One-shot reads fail the soak at a transient-fault rate above roughly one in twenty-five million GETs; the soak measures this before any retry is considered |
-| Copy-cost estimate | Pre-copy staging and per-chunk D2D cost are estimates until the hardware gate measures them; the copy should be small against wire time at 100 Gbps |
+| SDK registration scope | Preflight selects a supported registration/session layout; if none of the planned arena layouts can absorb the SDK's binding, the evaluation stops there. |
+| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against a plain S3 endpoint. |
+| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth; hardware qualification records the locality and the performance gate verifies the selected topology. |
+| No-retry reliability | A transient-fault rate above roughly one in twenty-five million GETs fails the soak; the 100-million-GET soak measures this before any retry mechanism is considered. |
+| D2D delivery cost | Staging-window and per-chunk D2D costs are estimates; the performance gate measures delivery end to end into caller-owned RMM, so the copy cost sits inside the 85% bound. |
 
 ## 9. Decisions Requested
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -20,7 +20,7 @@ must be **inside** the SigV4 signature — D8.) The
 benchmark already proves the cuObject RDMA data path at line rate. What remains
 Sirius-specific is the arena+D2D **visibility discipline**, validated in
 rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
-guarantees that no buffer is ever recycled or handed back while a copy might
+is designed so that no buffer is recycled or handed back while a copy might
 still touch it. **Please review the decisions table (§3) and the open
 questions (§5).**
 
@@ -56,9 +56,9 @@ engine behind it, defined by which read **builders** it provides.)*
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
 backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot —
-under 1% of the transfer at the 100G reference point; a larger share at higher
-line rates, so re-measure before extrapolating). Host reads
+small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot,
+estimated from HBM bandwidth — not yet measured on this path; under 1% of the
+transfer at the 100G reference point, a larger share at higher line rates). Host reads
 (footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
 `s3_request_authorizer`.
 
@@ -106,10 +106,13 @@ queue, which is **capped per ioctx** with blocking admission and depth/wait
 counters (see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
-future resolves when the last chunk does. Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline**: at the measured 100G
-reference point the D2D is ~3 µs against a ~350 µs network GET, so parking the
-worker is not expected to improve throughput. Two caveats keep this a
+future resolves when the last chunk does. (One deliberate exception exists:
+the *unprovable* delivery verdict below terminates the process instead of
+completing the chunk — the framework's "resolve on last release" mechanics
+make any softer form of "never resolved" unimplementable.) Nothing runs on a CUDA callback
+thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
+(bandwidth-derived) against a ~350 µs network GET at the 100G reference point,
+so parking the worker is not expected to improve throughput. Two caveats keep this a
 hypothesis rather than a settled fact: the event wait covers **all prior work
 on the caller's stream**, not just our D2D, and the ratio shifts at higher
 line rates — a realistic shared-stream saturation test is an explicit
@@ -143,16 +146,21 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   an illegal memory access): the CUDA context is dead — no engine can write
   the destination anymore, so reporting the error is safe — and the reactor
   **fail-stops**. *Unprovable* (the device-wide sync also failed with a
-  non-sticky code, or could not run): the request is **never handed back** —
-  its future deliberately does not resolve, because a resolved future licenses
-  the caller to free a destination that may still be written. The reactor
-  fail-stops and escalates to **process-fatal**: the process must be restarted
-  (watchdog territory). A wedged request is the deliberate lesser evil against
-  a silent use-after-free.
+  non-sticky code, or could not run): the worker calls a **non-returning
+  process-fatal hook** — log the verdict, then terminate the process. The
+  chunk never completes, so the future never resolves and the caller can never
+  free a destination that may still be written; no arena teardown runs either,
+  so nothing the copy engine might touch is deregistered or freed. Termination
+  is what makes "never resolved" executable — the completion framework
+  resolves a future when its last chunk reference is released, so any design
+  that keeps the process alive must either release (unsafe) or hold the
+  reference forever (a wedged process a watchdog kills anyway). This also
+  matches CUDA's own contract for a corrupted process: terminate and restart.
 - **Fail-stop** happens exactly once. New reads fail fast, naming the first
   fatal error. Queued chunks are completed with that error. Chunks already in
   flight finish on their own workers — never resolved on another worker's
-  behalf. And any arena that cannot be proven quiet at teardown is
+  behalf — for provable outcomes; an unprovable verdict terminates the process
+  instead. And any arena that cannot be proven quiet at teardown is
   deliberately **leaked rather than freed**: freeing memory a NIC or copy
   engine might still write is the very use-after-free this discipline exists
   to prevent.
@@ -175,7 +183,7 @@ ordinary tests without faking CUDA semantics.
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and the RDMA control plane requires header-signing mode (a presigned URL cannot bind headers added after signing) | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. The authorizer extension must be additive (a new overload with a defaulted parameter) so existing and downstream custom authorizers keep compiling | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -237,13 +245,18 @@ change.
 
 ## 4. Rollout
 
+The delivery-failure discipline (§2), the commit-point retry contract, the
+admission bound, and the signed-token auth surface are **target contracts**:
+implementing and fault-injection-testing them is P2/P3 scope. Read the table
+as the plan that closes the gap between the current tree and this design.
+
 | Phase | Scope | HW |
 |---|---|---|
-| **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
+| **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
+| **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop incl. an active unprovable chunk with queued siblings of the same request, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
@@ -340,6 +353,7 @@ its consumer. Two sizing knobs accompany it:
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
+s3_rdma_queue_cap                 # per-ioctx admission bound, in CHUNKS (default 4 x max_inflight)
 ```
 
 **Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
@@ -347,15 +361,20 @@ cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
 and the RDMA control requests, under one set of credentials and one signing
 host. A split topology (RDMA gateway separate from the S3 origin) is out of
 scope for v1: it needs two endpoints, two signing hosts, and an explicit
-credential boundary, and is only worth designing if a deployment actually
-requires it. There is deliberately **no client chunk-size knob**: the transfer
+credential boundary, and is deferred until a deployment requires it. There is deliberately **no client chunk-size knob**: the transfer
 granularity is the arena slot size, and the server chunks independently.
 Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
 for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
 **Admission bound (v1):** the reactor's request queue is **capped per ioctx**
-(a small configurable multiple of the worker count); admission blocks once the
-cap is reached. Queue depth and queue-wait counters expose the pressure. The
+(`s3_rdma_queue_cap`, counted in chunks). Admission blocks once the cap is
+reached, and — because the async read API enqueues synchronously — that blocks
+the submitting thread; this is the accepted v1 API semantics, and a
+deadlock-freedom test (a producer blocked at the cap while workers drain, and
+while the reactor fail-stops) is part of the rollout matrix. A read larger
+than the cap admits in waves as workers drain. Order is FIFO. Fail-stop and
+shutdown wake every blocked producer, which then observes the failure/shutdown
+error. Queue depth-peak and queue-wait counters expose the pressure. The
 process-wide budget is contexts × workers — a deployment running several
 Sirius contexts must size the gateway budget for the sum.
 
@@ -366,22 +385,31 @@ plane, because the two planes fail differently:
   short reads. The client owns the write loop into the destination buffer, and
   a closed connection means no further writes — re-issuing into the same
   buffer is safe.
-- **RDMA device reads**: retryability is decided by the **commit point**. A
-  failure that provably precedes the control request leaving the client
-  (connection setup, before the token is sent) is retryable. Once the token
-  may have reached the gateway, a timeout or reset without an authoritative
-  reply is **ambiguous**: the gateway holds a descriptor for the slot and may
-  still be writing it — the protocol defines "success response ⇒ transfer
-  complete", but not "no response ⇒ gateway stopped". An ambiguous failure is
-  therefore **not retried in place**: the read fails terminally and the slot
-  is withheld from reuse (quarantined), unless the gateway/SDK provides a
-  fencing or cancellation primitive (§5 Q7 — open question to NVIDIA).
+- **RDMA device reads**: retryability is decided by the **commit point**, so
+  the client wrapper must report a commit state with every failure —
+  `not_sent` / `sent_unknown` / `completed`. A `not_sent` failure (connection
+  setup, before the token left the client) is retryable. Once the token may
+  have reached the gateway (`sent_unknown`), a timeout or reset without an
+  authoritative reply is **ambiguous**: the gateway holds a descriptor and may
+  still be writing — the protocol defines "success response ⇒ transfer
+  complete", but not "no response ⇒ gateway stopped"; a proxy-replayed or
+  duplicated request can even land a late write after an apparent failure.
+  v1 therefore treats the **first ambiguous post-commit failure as a reactor
+  fail-stop**: the read fails, nothing retries in place, and the **entire
+  arena is marked non-freeable** — RDMA registration covers the whole arena,
+  so one slot the gateway may still write makes deregistering or freeing any
+  of it unsafe; teardown leaks it, and RDMA service on this context requires a
+  process restart. Per-slot quarantine was considered and rejected: repeated
+  quarantines drain the slot pool until workers, blocking admission, and
+  shutdown all wait forever. A gateway/SDK fencing or cancellation primitive
+  (§5 Q7) is what would permit a less drastic recovery.
 - Everywhere: CUDA work never retries; exhaustion surfaces the last error —
   and per D6, never a transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
-`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak` — plus the
+`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
+`…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
 runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
 (arenas leaked at teardown because the device could not be proven quiet).
@@ -395,7 +423,7 @@ documented. **Open hardening (P0b):** the migration **removed** the previous
 strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
 `buf_size` field is transmitted but never read server-side (a capacity check the
-server could perform for free but currently skips); the client reports success on
+server already has the data for but currently skips); the client reports success on
 any 200/206 without an `n == expected` short-write check **and without requiring
 a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
 of P0b — only after it may the callback report the requested size); optional

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -103,6 +103,16 @@ the stream first if a D2D was already queued).
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
+**One reactor, not one per GPU.** Multi-GPU affinity lives at the **arena/slot**
+layer — a worker does `cudaSetDevice(r.device_id)` and takes a slot from *that*
+device's arena, so the slot and `r.dst` are always same-device (never a
+cross-device copy). The single reactor owns one global worker pool. A per-GPU
+reactor would make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
+`cuObjGet`), breaking the global in-flight ceiling and risking gateway/NIC
+overload. Per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity and
+per-device throttling, at the cost of global rate-limit and config complexity —
+is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
+
 ## 4. Rollout
 
 | Phase | Scope | HW |

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -1,423 +1,298 @@
-# S3 RDMA Transport for Sirius — Design for Team Review
+# S3 RDMA Transport for Sirius — V1 Design
 
-| | |
+Status: evaluation-prototype design for team review — no production code
+in this PR. Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+<https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
+on CX-6 RoCE).
+
+## 1. Summary and Scope
+
+V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
+reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
+complete object key written out, not a glob or a listing. Payload lands
+in a pre-registered GPU arena and is
+copied to caller-owned RMM memory on the caller stream, with zero
+Sirius-side host staging or H2D traffic; metadata and footer reads remain
+on the existing S3 path. There is no automatic probing and no runtime
+fallback to HTTP: when RDMA is selected and cannot serve a request, the
+request fails with an explicit error. GO requires hardware correctness, at
+least 85% of the qualified RDMA link rate for objects of 16 MiB or larger,
+and a zero-failure 100-million-GET soak. For smaller objects the gate
+measures RDMA against HTTP side by side; if RDMA shows no advantage there,
+V1 may add a size-based fallback that routes small objects to the HTTP
+path — a routing choice, distinct from the failure semantics above.
+
+### Decisions Requested
+
+| Decision | Proposed V1 position | Question for the team |
+|---|---|---|
+| GPU destination | RDMA lands in a registered arena, followed by D2D into caller-owned RMM | Is the extra GPU-local copy acceptable, rather than registering arbitrary RMM allocations? |
+| Endpoint topology | Existing S3 endpoint for control/metadata; dedicated direct-connect gateway for RDMA data | Is split deployment, with the publisher visibility barrier, acceptable? |
+| Failure policy | Token-bearing GETs are one-shot; uncertain completion causes reactor fail-stop and process restart | Is restart-based recovery acceptable for V1 — no fallback after an RDMA request is selected or fails? |
+| CUDA boundary | After `cudaMemcpyAsync`, anything except a successful event wait is process-fatal | When delivery cannot be proven, is terminating the process and never freeing the arena acceptable? |
+| Concurrency model | Bounded request envelopes and one RDMA session per worker | Is this resource model right? (Registration layout is a preflight result.) |
+| Evaluation gate | A hardware correctness gate, then: objects ≥16 MiB must reach 85% of RDMA link rate, small objects (128 KiB–4 MiB) are measured RDMA-vs-HTTP as a required output, and reliability requires a zero-failure 100M-GET soak | Are these the right GO/STOP criteria? (The small-object routing threshold is a follow-up decision, not set in this PR.) |
+
+Registration scope, reply-tag constants, and GPU write-ordering behavior
+are preflight measurements, not design votes. Worker count, chunk size,
+and slot layout are implementation choices within the proposed V1
+contract.
+
+### Scope
+
+| Supported in v1 | Not in v1 |
 |---|---|
-| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15; synced 2026-07-16 to the current IO framework (#1087 footer open-hint, #1117 LIST/glob) |
-| **Date** | 2026-07-15 |
-| **Author** | Sirius Contributors |
-| **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
+| Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
+| Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
+| Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
+| Basic byte/request/failure metrics | Full metric parity with the REST backend |
+| One-shot device reads | Automatic RDMA retry (one narrowly-proven retry exists only as a pre-approved response to a soak failure, Section 3) |
+| Restart-based recovery | Hot recovery of a failed transport context |
 
-## 1. Summary
+Footer and metadata reads use plain HEAD and range GET on the host plane;
+footer caching and known-size open are out of scope.
 
-**Problem.** Sirius reads S3 Parquet through the REST backend: libcurl range
-GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU. Every
-byte crosses host memory and PCIe twice.
-
-**Proposal.** A cuObject gateway `RDMA_WRITE`s object bytes into a small,
-pre-registered GPU **arena**; a GPU-local copy delivers them to the final RMM
-buffer. The pinned-host staging and the PCIe H2D copy disappear.
-
-**Unchanged.** `s3://` URIs, the SigV4 credential machinery (one surface
-extension — §5), the `sirius_datasource` API, and the Parquet scanner. The
-REST backend remains the default; RDMA is selected per context by the existing
-`s3_transport` config.
-
-**v1 limits.** Requires an RDMA-capable cuObject gateway (plain AWS S3 does
-not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
-failures surface per the Safety Contract (§4).
-
-**Current implementation gap (not a v1 design limit).** Exact-key
-`read_parquet('s3://…')` is the supported target; **wildcard glob** resolves
-through S3 LIST, which the framework currently routes to the REST backend
-only — under RDMA selection a glob fails loudly (D6). The P2 control-plane
-parity work closes this (§7) by wiring the hybrid's always-available HTTP
-control client; the RDMA data plane stays dormant until P3. It is a
-compatibility gate, separate from the P3 safety activation gates.
-
-**Decisions requested.** The team is asked to approve six decisions (§6):
-the landing arena + D2D shape, the CUDA failure policy, the
-duplicate-suppression mechanism and ambiguous-completion policy, the
-request-envelope queue model, cuObject session ownership, and the gateway
-topology with its plain-S3 surface.
-
-## 2. Architecture & Read Path
+## 2. Architecture and Read Path
 
 ```mermaid
 flowchart LR
-  scan["Parquet scan"] --> dr["device_read()"]
-  dr --> ic["s3_rdma_ioctx<br/>(templated_ioctx + cuobj_rdma_reactor)"]
-  ic -- "control plane: HTTP GET<br/>x-amz-rdma-token (SigV4)" --> gw["cuObject gateway"]
-  gw == "data plane: RDMA_WRITE<br/>(GPUDirect)" ==> arena["GPU landing arena<br/>cudaMalloc, registered once"]
-  arena == "GPU-local D2D" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
-  rmm --> decode["cuDF decode"]
+  subgraph proc["Sirius process"]
+    scan["Parquet scan"] --> ioctx["s3_rdma_ioctx"]
+    ioctx --> ctl["control client<br/>(one HTTP attempt per call)"]
+    ioctx --> q["bounded request-envelope queue"]
+    q --> w["workers<br/>(one RDMA session each)"]
+    w --> arena["per-GPU registered arena<br/>(slot layout settled at preflight)"]
+    arena -->|"D2D on the caller stream"| rmm["RMM destination<br/>(caller-owned, not registered)"]
+  end
+  ctl -->|"HEAD / footer / range GET"| s3["s3_endpoint<br/>(any S3 service)"]
+  w -->|"token-bearing signed GET"| gw["s3_rdma_endpoint<br/>(cuObject gateway, direct connect)"]
+  gw -->|"RDMA write"| arena
+  s3 --- store[("same backing store,<br/>immutable keys")]
+  gw --- store
 ```
 
-*(An **ioctx** is the per-context IO facade; a **reactor** is the transport
-engine behind it, defined by which read **builders** it provides.)*
+The host plane (`s3_endpoint`) is any S3 service and carries HEAD, footer,
+and range GETs with standard SigV4 signing; it retains the existing S3
+surface. The data plane (`s3_rdma_endpoint`) is a cuObject gateway reached
+by direct connection, limited to token-bearing GETs and the publisher HEAD
+used by the visibility barrier below. Both endpoints front the same
+backing store and the same bucket namespace.
 
-On the control plane (HTTP), the descriptor token is the only RDMA-specific
-request header (`Range` travels as usual); the data plane (RDMA) writes object
-bytes straight into the GPU arena. Host reads stay on
-HTTP through the existing SigV4 authorizer — a surface that now includes the
-framework's footer-probe open hint (one suffix-range GET serves the size and
-the binder's footer reads), S3 LIST for glob, and HEAD; matching it on the
-hybrid is the P2 control-plane parity item (§7). The
-arena is a fixed staging window, not object-sized: a read streams through it
-in slot-sized chunks, each D2D-copied to its offset in the destination buffer
-(copy cost: §7).
+The ioctx owns the reactor, the reactor owns the worker pool, and each
+worker owns its own RDMA session — a shared session across workers is not
+an option. How registration binds to sessions, and therefore the exact
+arena slot layout, is settled at preflight (Section 5). The RMM
+destination belongs to the caller and is never registered with the NIC.
 
-**Resource model.**
+The request queue holds envelopes rather than chunks: a submitter enqueues
+one small descriptor and returns, workers expand it into chunks lazily,
+and admission blocks only at the per-ioctx bound. A per-chunk bound was
+rejected because a read larger than the bound would block its submitter
+until most of its own transfer had completed.
 
-| Resource | Per ioctx | Per process | Per active GPU |
-|---|---|---|---|
-| Reactor | 1 (not an event loop; owns the worker pool and arenas) | 1 × contexts | — |
-| Workers = in-flight `cuObjGet` ceiling | `max_inflight` | `max_inflight` × contexts | — |
-| Arena memory | `max_inflight × slot_size` × active GPUs | sum over contexts | `max_inflight × slot_size` |
-| Request envelopes (queued reads) | ≤ `s3_rdma_queue_cap` | sum over contexts | — |
-| Gateway slot budget required | `max_inflight` | sum over contexts | — |
-
-Throughput scales with workers; GPU count scales only the arena map (a new
-device lazily gets its own arena; slot and destination are always
-same-device); NIC count is what would eventually justify more reactors
-(deferred sharding, not v1).
-
-**Sizing.** The default — 8 workers × 4 MiB slots = 32 MiB per device — comes
-from the benchmark's CX-6 **100G reference configuration** (line rate at
-8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page cache and
-2 MiB server-side chunking, so other topologies re-measure). Faster NICs scale the two knobs, not the design:
-in-flight bytes (`workers × slot_size`) must grow with line rate, and the knee
-is re-derived on the target NIC (a P4/P5 sweep).
-
-**One read.**
+Consistency between the two endpoints rests on two deployment rules. Keys
+are append-only and immutable: an object, once published, is never
+overwritten or deleted while readable. Before a key becomes queryable, the
+publisher completes a visibility barrier: HEAD succeeds at both endpoints
+with matching sizes, and content identity is confirmed by a trusted ETag or
+by the full object hash from the publishing manifest. The query path
+itself never sends HEAD to the gateway.
 
 ```mermaid
 sequenceDiagram
-  participant W as reactor worker
-  participant A as GPU arena slot
-  participant G as cuObject gateway
-  participant S as CUDA stream
-  W->>A: acquire free slot (slot_pool, reused from the framework)
-  W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
-  G-->>A: RDMA_WRITE bytes into slot
-  G-->>W: HTTP success (200/206) + valid x-amz-rdma-reply: 200
-  Note over W: flush GPUDirect writes (only if the platform requires it — §6)
-  W->>W: create the completion event FIRST
-  W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline
-  W->>W: chunk_complete + release slot
-  Note over S: the read's future resolves when its last chunk finishes
+  participant S as Scanner
+  participant I as s3_rdma_ioctx
+  participant Q as envelope queue
+  participant W as worker
+  participant G as gateway
+  participant C as CUDA runtime
+  S->>I: open exact-key object (size from HEAD on the host plane)
+  S->>I: device read into an RMM destination
+  I->>Q: submit one request envelope (blocks only at the cap)
+  Q->>W: worker claims a chunk (lazy, FIFO)
+  W->>W: stream capture check - before the GET is issued
+  W->>G: signed token-bearing GET (token and Range inside the signature)
+  G-->>W: RDMA write into the arena slot, then the wire reply - HTTP status + reply tag
+  W->>W: session result - transferred byte count n
+  W->>W: exact completion check - reply tag AND HTTP status AND n == expected
+  W->>C: flush (only when the ordering attribute is NONE)
+  W->>C: enqueue the D2D copy and its completion event on the caller stream
+  W->>C: wait on the event from the worker thread
+  C-->>W: cudaSuccess
+  W->>W: complete the chunk and release the slot
+  W-->>S: the request future resolves after all chunks complete
 ```
 
-A submitter enqueues one small **request envelope** and returns; workers
-generate and claim chunks lazily, so an async read never waits on chunk-level
-progress (mechanics: appendix). `cuObjGet` blocks, so the worker pool is the
-concurrency bound; with one arena slot per worker a free slot is always
-available. Each chunk completes exactly once, on its own worker, with the one
-exception defined in §4; the inline wait is a P3 measurement (§7). The
-reactor omits the framework's two staged-read builders, so the prefetch cache
-is never built for this backend — kvikio's minimal profile, which also keeps
-the cache's 2–7× sparse-projection over-read (issue #1078) unreachable here.
+Object sizes come from HEAD on the host plane; when that HEAD is issued
+relative to open is an implementation choice. The stream capture check
+runs before the GET is issued, in release builds as well as debug builds,
+so a request that cannot be delivered makes no remote write.
 
-## 3. Key Decisions
+Exact completion has three legs, all required before a chunk may proceed
+to delivery: a valid reply tag, a successful HTTP status, and a byte count
+that equals the requested size. The concrete accepted values are recorded
+at preflight and used unchanged by every later test.
 
-| # | Decision | Why |
-|---|---|---|
-| D1 | Keep `s3://`; select the backend once, at registry construction (`s3_transport=RDMA` claims the s3 slot instead of restful; `AUTO`→HTTP) | The config field already exists; exactly one s3 backend per context keeps routing unambiguous and the scan side untouched |
-| D2 | One new transport engine under the existing IO framework: a reactor wrapped by a thin ioctx; the shared context carries config, a **client/session factory** (ownership: §6 decision 5), and the flush policy; the per-device arena map is reactor state | Chunking, pooling, completion, `slot_pool`, and the registry factory are reused; arenas belong with the worker pool that fills them |
-| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| D4 | Landing arena + GPU-local D2D, not direct RDMA into RMM buffers | Sirius RMM is `cudaMallocAsync`-backed: not reliably registrable for GPUDirect, and stream-ordered backing means an address may be unbacked when the NIC writes |
-| D5 | Completion via `semi_future` + `request_manager`, inline event wait; nothing completes before delivery is settled per the Safety Contract (§4) | Closes both use-after-free sides: a reused slot under an in-flight copy, and a freed destination still being written |
-| D6 | Explicit `RDMA` opt-in; failures surface per §4 — never a silent transport switch | Fallbacks mask misconfiguration exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); NVIDIA SDKs are never vendored | Default-off builds are unchanged; conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — reconciliation is a real task |
-| D8 | The RDMA token and `Range` are signed; header-signing mode only (details: §5) | An unsigned token is not bound to the request; a gateway could not tell a tampered descriptor from a legitimate one |
-| D9 | Prefetch cache off structurally: the reactor defines only the host-read and device-read builders | Capabilities derive from which builders exist — no flag to set; kvikio already ships this profile |
+The request future is a fan-in over all chunks: successful resolution
+occurs only after every chunk completes, any chunk error that is not
+process-fatal resolves the request as an error, and a partial result is
+never reported as success.
 
-## 4. Safety Contract
+Flush policy follows the GPU's RDMA write-ordering attribute, read once at
+initialization: `OWNER` and `ALL_DEVICES` require no flush; `NONE` requires
+one flush after each exact completion, before that chunk's copy; an unknown
+attribute value, or `NONE` without a working flush mechanism, fails RDMA
+initialization.
 
-Once a D2D copy is enqueued, two buffers are at stake: the arena slot (its
-next user would corrupt an in-flight copy) and the caller's destination (freed
-as soon as its future resolves). Required invariant: **neither the slot is
-recycled nor the future resolved until the stream is proven quiet.**
+## 3. Safety Contract
 
-Pre-enqueue rules: the completion event is created *before* the copy is
-enqueued (a creation failure means nothing is in flight — safe release). A
-non-success return from `cudaMemcpyAsync` does **not** prove the copy was
-rejected — async CUDA calls may return deferred errors from earlier work — so
-the enqueue state is unknown and the failure is handled as post-enqueue.
+The boundary of the delivery contract is the first `cudaMemcpyAsync` call
+for a chunk. Before that call no copy is in flight: a failure that is not
+a sticky CUDA error can be reported and released safely, while a sticky
+error terminates the process even before the boundary. After the call, the
+only completing return is an event wait that reports `cudaSuccess`;
+everything else is treated as an unprovable delivery state. The set of
+sticky CUDA error codes is fixed from the documented CUDA error
+classification and reviewed against the existing classifier in the tree —
+never inferred from rig observation.
 
-Quiescence proof: a real stream sync. An error return from the sync still
-proves quiescence (the wait completed; the error is a deferred report), except
-for codes meaning the call never ran (invalid handle; captured streams, which
-are a documented precondition violation) — those escalate to a device-wide
-sync.
-
-| CUDA outcome | Future / slot | Reactor / process |
-|---|---|---|
-| Quiesced, recoverable | report the error, release the slot | continue serving |
-| Quiesced, context-fatal (sticky error) | safe to report and release — the context is dead, nothing can write `dst` | **process-fatal** |
-| Quiescence unknown | do **not** resolve the future or free anything | **process-fatal** |
-
-**Process-fatal** is a non-returning hook: log the verdict, terminate the
-process (the call site invokes `std::terminate` if the hook ever returns).
-For a sticky error this is CUDA's documented terminate-and-relaunch
-requirement; for the unknown verdict it is this design's use-after-free
-policy — the framework resolves a future when its last chunk reference is
-released, so no in-process "never resolved" exists. Validated by death tests
-(child process: exit code, fatal log, no normal teardown).
-
-| RDMA outcome | Slot / arena | Retry |
-|---|---|---|
-| Not sent (token never left the client) | slot reusable | allowed |
-| Exact completion (valid reply, `n == expected`) | slot reusable after the D2D | not needed |
-| Sent, outcome unknown | **entire arena non-freeable** | none — reactor **fail-stop** |
-
-The client reports a commit state with every failure (`not_sent` /
-`sent_unknown` / `completed`); host/HTTP reads retry freely (the client owns
-the write loop). Registration covers the whole arena, so one slot the gateway
-may still write makes deregistering or freeing any of it unsafe; per-slot
-quarantine was rejected because repeated quarantines drain the pool.
-**Fail-stop** happens exactly once: new reads fail fast with the fail-stop
-error; queued envelopes — and the un-generated chunks of partially-consumed
-ones — are error-completed; chunks already in flight finish on their own
-workers; blocked submitters are woken. The process stays alive —
-fail-stop is reserved for failures that do not corrupt the CUDA process — but
-RDMA service on the context requires a restart. Any arena that cannot be
-proven quiet at teardown, by device stream or by remote gateway, is leaked,
-never freed.
-
-Two independent gates apply on the real path. **Completion authority** is a
-P0b gate: the gateway enforces **exact completion** and the client requires a
-**valid reply tag** (appendix protocol). Separately, request **uniqueness and
-response–side-effect integrity** (§5) must hold before P3 activation —
-fail-stop cannot see a duplicate that succeeds, and completion authority
-cannot detect a cached or coalesced reply whose RDMA write never happened.
-
-## 5. Authentication
-
-The `x-amz-rdma-token` and `Range` headers are inside the SigV4 signature,
-binding object, byte range, and destination capability into one authorized
-request. v1 supports header-signing mode only — an implementation choice, not
-a protocol limit (SigV4 query signing can carry `X-Amz-SignedHeaders`, but the
-Sirius presigner signs only `host` today); RDMA initialization fails under
-`s3_signing_mode = presigned`.
-
-Interface: the existing three-argument virtual `authorize()` is untouched; the
-headers-to-sign travel through a new, separately-named non-pure virtual
-(`authorize_with_headers(request)`) whose default implementation rejects
-non-empty header sets, and which the built-in SigV4 header signer overrides.
-
-The dev benchmark server runs unsigned on an isolated network; production
-gateways validate the signature before honoring the token.
-
-A token-bearing GET is not a safe idempotent read: the response certifies a
-**side effect** (the RDMA write into the slot), and any intermediary behavior
-that decouples the two defeats completion authority silently. A transparent
-retry duplicates the write while the original still runs; an HTTP **cache**
-(keyed on URI/Range — the token is just a header) can return a stored,
-legitimate `x-amz-rdma-reply` with **no write at all**; **request coalescing**
-merges two identical GETs into one upstream fetch — one write, two replies;
-hedging/mirroring duplicates writes. In each case the client sees a valid
-reply and `n == expected` while its slot holds stale bytes — silent
-corruption no client-side rule (fail-stop included) can detect.
-
-**v1 deployment contract (activation requirement):** token-bearing GETs are
-exempt from retry, hedging, mirroring, caching, and request coalescing;
-request and response both carry `Cache-Control: no-store`; any proxy route
-explicitly bypasses caches. Where all of this cannot be proven, the client
-connects **directly to the gateway** — the v1 default. RDMA must not be
-enabled otherwise. Gateway-side
-exactly-once deduplication is a **deferred conditional extension** — the base
-cuObject protocol defines no request-identity tag, so it would need a signed
-identity added to the wire (appendix) and is only worth specifying if a
-deployment requires an intermediary. The control plane runs over TLS; tokens
-are redacted from logs.
-
-## 6. Review Decisions
-
-| # | Decision needed | Recommendation | Blocks |
+| Outcome | Action | Future | Arena |
 |---|---|---|---|
-| 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
-| 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
-| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the §5 deployment contract (direct gateway; token-bearing GETs exempt from retry/hedge/mirror/cache/coalesce; gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
-| 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
-| 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
-| 6 | Gateway topology & plain-S3 surface | Single endpoint: the gateway also serves plain S3 (ListObjectsV2 / HEAD / range GET — P0c). "Token-less" means no RDMA descriptor, **not anonymous**: LIST/HEAD/GET stay SigV4-validated and authorized over TLS. SigV4 signs `Host`, so naive forwarding breaks signatures — the production model is **terminate-and-re-sign**: the gateway validates the client's SigV4, authorizes, and re-signs upstream with its own service identity (identity/permission mapping is a deployment definition); a gateway co-located with the storage (same hostname + credential authority) reduces this to internal dispatch. "One credential set" = the **client's** configuration; gateway→upstream credentials are the gateway's own. The benchmark gateway is a reference / conformance implementation | P0c, P2 parity |
+| Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
+| Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
+| Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
+| Sticky CUDA error, or any failure after the copy is enqueued (one exception below) | Process-fatal termination | Not resolved | Never freed |
 
-Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
-default (fixed 100G reference vs self-scaling) before P4; appetite for a
-registrable cucascade IO sub-MR (unlocks direct-into-RMM); confirmation from
-NVIDIA whether a descriptor token is single-use; counter naming alignment with
-the REST instrumentation.
+One narrow exception: an event-destroy failure after a successful wait is
+logged and leaves the successful outcome unchanged.
 
-Visibility policy is ruled by the CUDA contract, not a vote: the per-device
-write-ordering attribute makes OWNER platforms safe for our same-device D2D
-consumer with no flush; only NONE platforms need one, and a NONE platform that
-cannot flush fails RDMA initialization. P3 work: per-device wiring and the
-decode-after-GET stress test. The ruling covers v1's single RDMA path;
-multi-NIC sharding would revisit the multi-ordering-domain exceptions.
+1. Transport shutdown after a fail-stop is two-phase: a non-blocking
+   terminal mark that immediately refuses new work, and a completion point
+   reached when the last in-flight operation releases its permit, so a
+   failing worker can initiate shutdown without waiting on itself.
+2. After a fail-stop the whole transport context is closed: host-plane and
+   device-plane operations alike are refused through one shared admission
+   gate and surface the same terminal error. Only an operation whose side
+   effect is already in flight — a control call started, a transfer
+   issued — completes that one operation. Everything else is cut off:
+   queued envelopes and the chunks not yet generated from them complete
+   with an error, work claimed but not yet issued is aborted with its slot
+   released, and submitters blocked at the queue bound wake with the
+   terminal error. Recovery is a process restart.
+3. Destination contents are unspecified after any failed read: earlier
+   chunks may already have landed in the caller's buffer, and the
+   error-resolved future is the only authority a caller may consult.
+4. Token-bearing GETs are not retried, hedged, mirrored, cached, or
+   coalesced anywhere between client and gateway; the dedicated
+   direct-connect endpoint enforces this structurally on the path, and a
+   gateway conformance check verifies that the gateway itself performs no
+   internal retry, caching, or coalescing. After a failed soak, a single
+   retry may be enabled only when the client can prove that the request
+   was never issued to the gateway, followed by a full soak re-run from
+   zero.
+5. Normal teardown releases the arena only behind a strict barrier:
+   admission is stopped, no further GETs will be issued, every issued
+   transfer has completed exactly, every enqueued copy is confirmed, and
+   all workers have stopped and joined. After a fail-stop or a
+   process-fatal failure this barrier is never reached: those arenas are
+   never freed while the process lives.
 
-## 7. Rollout & Performance
+## 4. Configuration and Security
 
-| Phase | Scope | Exit criterion | HW |
-|---|---|---|---|
-| P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
-| P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
-| P0c | Gateway **plain S3 surface** (ListObjectsV2 / HEAD / token-less range GET — still SigV4-authenticated; §6 decision 6) for the single-endpoint topology — today it serves object HEAD only and rejects token-less GETs | serves host reads + glob; the P2 parity gate is complete only when this also lands (MinIO covers CI meanwhile) | — |
-| P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
-| P2 | Reactor against a mock client; envelope admission; hybrid control-plane parity (footer probe, known-size open, S3 LIST capability — this sub-item needs no CUDA GPU) | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom; parity: glob + footer-RTT behavior matches HTTP | CUDA GPU (except the parity sub-item) |
-| P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
-| P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
-
-The rollout closes the gap between the current tree and this document: the
-Safety Contract, envelope queue, uniqueness invariants, and auth surface are
-target contracts to be implemented and tested in P2/P3.
-
-**Performance.** The D2D is an estimated ~3 µs per 4 MiB slot (derived from
-HBM bandwidth, not yet measured on this path) against the ~350 µs wire
-serialization of one slot at ~91 Gbps — a wire-time floor, not a measured
-single-request latency under concurrency. That ratio is the basis for the
-inline wait; the caveat is that the event wait covers all prior work on the
-caller's stream, not just this copy. P3 replaces the estimates by measuring
-the total post-RDMA delivery cost (flush, event lifecycle, D2D) under a
-shared-stream saturation test; the REST backend's event-poll shape is the
-documented fallback if that test fails.
-
-## 8. Scope & Risks
-
-Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
-the omitted vector-read path (kvikio has the same gap; a per-segment framework
-fallback is proposed separately). The transparent `read_parquet('s3://')`
-front door (#1074) carries no transport-specific checks and is expected to
-work unchanged for exact-key opens — a routing test pins this at integration
-(wildcard glob: the implementation-gap note in §1). Captured CUDA
-streams are unsupported for RDMA device reads.
-
-Risks:
-
-- GPU-consumer visibility on NONE-ordering platforms — per-device wiring and
-  the P3 stress test are the top correctness gate (§6).
-- Requires a controlled cuObject gateway; NIC↔GPU PCIe affinity across root
-  complexes can silently halve bandwidth (P4 validation).
-- cuObject SDK skew (conda 1.2.x vs the validated 1.0.0 tarball) must be
-  reconciled before P3.
-- Small-read control-plane RTT, including per-request connection setup —
-  measured in P5; an optional whole-read HTTP threshold is the prepared
-  mitigation.
-- The gateway slot budget scales with `max_inflight` × Sirius contexts, not
-  with GPUs or queries (§2 resource model).
-
----
-
-## Appendix — Protocol, configuration, implementation
-
-### Wire protocol
-
-Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags plus
-`Range`. The benchmark's four non-standard headers were removed by the wire
-migration (P0a).
-
-| Header | Direction | Meaning |
+| Key | Meaning | Default |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; encodes the remote slot address and size; signed (§5) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag; never interpreted as a byte count |
+| `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
+| `s3_endpoint` | Host plane: any S3 service | existing setting |
+| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails with an explicit error when unset | none |
+| `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
+| `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
-Conditional extension (deferred): gateway-side exactly-once deduplication
-would require a signed request identity on the wire — the identity field, its
-validity window, dedup retention, and gateway ownership would all need
-definition with NVIDIA (the descriptor token can serve only if it is ruled
-single-use). Not part of v1, which relies on the §5 deployment contract.
+This phase adds no new tuning surface: worker count and arena slot size
+keep their existing settings. Reads are one-shot, so the retry counter
+must read zero; any nonzero value is treated as a defect.
 
-Completion authority: `cuObjGet`'s returned `n == expected` is authoritative
-only when the gateway enforces exact completion (no short or overlong RDMA
-piece) **and** the client requires a valid reply tag before reporting the
-requested size — an HTTP 200/206 without a legitimate reply is a failure. Both
-halves are P0b gates. The server chunks transfers server-side (its own config,
-default 2 MiB); nothing is negotiated on the wire. Signature validation and
-the dev/prod auth posture are defined in §5. Remaining P0b items
-(outcome level): strict descriptor/capacity validation, exact completion,
-mandatory reply validation; the plain-S3 surface (LIST/HEAD/token-less GET)
-is the separate P0c item — code-level specifics for both are tracked in the
-`s3RDMA-benchmarktool` repo.
+Signing is configured per endpoint. The data endpoint requires
+header-signing: the RDMA descriptor token and the `Range` header travel
+inside the SigV4 signature, and a presigned-mode authorizer on the data
+plane fails initialization. The host endpoint keeps its own configured
+signing mode. Descriptor tokens are redacted from logs and traces in every
+profile.
 
-### Configuration
+The fault-injection hooks used by the validation gates exist only in test
+builds: release artifacts contain none, a production-mode start refuses to
+run when hooks are enabled, and hooks cannot be activated through request
+headers.
 
-```text
-s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
-s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
-s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
-s3_rdma_perf_instrumentation      # gates the timing counter families (default off; §appendix Metrics)
-```
+The rig profile for this phase may run an unsigned gateway and a non-TLS
+control plane, but must not use production data or production credentials
+and must not be exposed to an uncontrolled network. Gateway-side SigV4
+verification, end-to-end TLS, authorization, replay and token hardening,
+and a signed-profile qualification form a production-qualification gate
+that applies after a GO decision; enabling the production profile requires
+re-running correctness, performance, and soak in full, because unsigned
+rig results do not extrapolate to the signed path.
 
-Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
-one host serves ListObjectsV2, HEAD, plain range-GET, and RDMA control under
-one credential set (the client's — §6 decision 6); growing the gateway's
-plain S3 surface to match is P0c gateway-side work. A split topology (plain S3 host for host/LIST reads, RDMA
-gateway for device reads) is deferred until a deployment requires it. There is no client
-chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
-the existing fields (`s3_signing_mode` — header mode required, §5 —
-`ca_bundle_path`, `tls_verify`).
+## 5. Validation and Rollout
 
-Admission: the queue holds request envelopes, bounded per ioctx and counted in
-requests. A submitter enqueues one envelope (a small descriptor, not the chunk
-list) and returns; workers generate and claim chunks lazily, FIFO. A per-chunk
-cap was rejected: a read larger than the cap would block its submitter until
-most of its own transfer completed, making the async API effectively
-synchronous. Only a full envelope queue blocks a submitter; fail-stop and
-shutdown wake any blocked submitter with the corresponding error.
+Validation runs in three stages on the rig, each gating the next, followed
+by the post-GO production gate. Throughout this section, a **clean run**
+means correct payload checksums and no fail-stops, process-fatal exits, or
+short, missing, or wrong completions.
 
-Retry: split by plane and commit point. Host/HTTP reads retry on transport
-failures and short reads. RDMA device reads retry only from the `not_sent`
-commit state; `sent_unknown` is terminal per the Safety Contract. CUDA work
-never retries; exhaustion surfaces the last error; never a transport switch
-(D6).
+| Gate | What runs | Pass condition |
+|---|---|---|
+| Preflight | Rig probes for registration/session shape, the completion constants (accepted HTTP status set, reply-tag value and parse rule, byte count on failed responses), and the GPU write-ordering attribute with flush availability | Results are recorded once and used unchanged by every later test; one arena layout is selected — if none works, the phase stops here |
+| Hardware correctness | Checksum stress at full worker count with one session per worker; slot-reuse churn; flush counting; decode stress on the copy stream; fault injection: missing, wrong, and short replies, an ambiguous transport fault, and a session result with a valid reply tag, `n == expected`, and a non-success HTTP status | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in the outcome Section 3 assigns it, and no failed read is reported as a partial success |
+| Performance | Sustained reads at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB, and 1 GiB; the three small sizes also run the HTTP path for comparison | Each size of 16 MiB or more reaches the 85% bound (85 Gbps on the current 100 Gbps rig); the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run; no Sirius-side host staging or H2D on any RDMA run |
+| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, and there are zero unexpected runner restarts |
+| Production (post-GO) | Gateway-side SigV4 verification, end-to-end TLS, authorization, replay and token hardening, signed-profile qualification | Full correctness, performance, and soak re-run on the signed profile |
 
-### Metrics
+Performance runs use one configuration frozen after preflight — worker,
+chunk, slot, and arena settings held constant with no per-size tuning —
+against a warm server cache. Object size and RDMA chunk size are distinct:
+transfers keep normal Sirius chunking rather than forcing one RDMA request
+per object. Each size sustains repeated reads for at least ten seconds per
+trial, with two warm-ups and at least seven measured trials. Throughput is
+measured from device-read submission through delivery into the
+caller-owned RMM buffer — queueing, RDMA, required flushes, D2D copies,
+and request completion — excluding one-time initialization, arena
+registration, object HEAD, and warm-up. A large size passes when the
+one-sided 95% Student-t lower confidence bound of the arithmetic mean of
+its measured per-trial throughputs reaches 85% of the link rate; the same
+statistic is computed for both arms at the small sizes. HTTP results never
+determine GO or STOP. The 85% floor is grounded in measurement: the
+standalone benchmark sustains roughly 91 Gbps on the same class of
+hardware.
 
-Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
-`…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
-`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total`, the REST-shaped
-`…_blocking_host_get_count/wall_ns_total/wall_ns_max` (footer-probe GETs
-excluded, mirroring REST's attribution), `…_fallback_stream_sync_total`
-(quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
-the process-terminating verdicts leave a fatal log line and an exit code, not
-a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
+If the soak fails and the client can prove that the failing request was
+never issued to the gateway, the single pre-approved retry of Section 3
+may be enabled and the full soak re-run from zero; the re-run's outcome
+then decides GO or STOP under the same criteria. A STOP follows when the
+re-run fails, when the failing request cannot be proven never-issued, or
+when any other gate fails; the stop action is to restart the process and
+return to `s3_transport=HTTP`, and the build flag remains off by default
+throughout.
 
-### Implementation notes (framework mapping)
+## 6. Current Status and Risks
 
-`s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>`, built like
-`rest_ioctx`. The reactor provides the `prep_host_rx` / `prep_device_rx`
-builders plus `enqueue`; omitting the two staged-read builders is what derives
-the cache-off capability profile (D9). Completion rides
-`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete`
-or `report_error` exactly once and releases its manager reference; the future
-resolves when the last reference drops — which is why the §4 "unknown"
-verdict must terminate rather than attempt any in-process "never resolved"
-state. The per-device arena map is reactor state; `slot_pool` is reused
-verbatim for slot indexing.
+The transport machinery in the tree is dormant. Five gaps separate it from
+the v1 target, closed in this order before the rig gates run:
 
-### Fault-test matrix (P2, CUDA GPU required; RDMA-rig-free)
+1. Factory wiring — the production factory does not yet construct the
+   control client, so reads cannot route through the normal path.
+2. Endpoint pair — configuration has a single endpoint today.
+3. Envelope admission — chunk admission is eager rather than
+   envelope-bounded.
+4. Retry removal — device reads still carry a legacy multi-attempt retry
+   to be reduced to one-shot.
+5. Completion and gateway hardening — completion validation does not yet
+   check the reply-tag and status legs; gateway exact-write enforcement
+   and descriptor capacity checks are outstanding.
 
-Byte-exact multi-chunk reads; concept checks that both staged-read
-capabilities stay off; event-created-before-enqueue (injected create failure
-never reaches the copy); `cudaMemcpyAsync` non-success routed through the
-quiescence proof; recoverable ladder outcomes release the slot only after the
-proof; process-fatal verdicts exercised as **death tests** (child process:
-exit code, fatal log, no normal teardown — an in-process double that returns
-or throws would exercise the unwinding production forbids) including an active
-unknown-verdict chunk with queued siblings of the same request; fail-stop exactly-once with
-owner-worker completion of in-flight chunks; ambiguous-RDMA fail-stop with
-arena marked non-freeable and teardown leak observed; admission
-deadlock-freedom (submitter blocked at the envelope cap while workers drain
-and while the reactor fail-stops).
-
-### Status
-
-This document describes the target architecture. The current tree differs in
-the areas the rollout table covers (delivery-failure discipline, retry
-classification, envelope admission, auth surface, the control-plane parity
-set — footer probe, known-size open, S3 LIST — and the gateway's plain-S3
-surface); P2/P3 (and P0c gateway-side) implement and test them. No production
-code ships with this PR.
+| Risk | Nature |
+|---|---|
+| SDK registration scope | If registration is bound to a session in a way none of the planned arena layouts can absorb, the phase stops at preflight |
+| Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
+| GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
+| No-retry reliability | With one-shot reads, a transient-fault rate above roughly one in twenty-five million GETs would fail the soak for a terabyte-scale workload; the soak measures this before any retry mechanism is considered |
+| Copy-cost estimate | The pre-copy staging window and per-chunk D2D cost are estimates until the hardware gate measures them; the copy is expected to be small relative to wire time at 100 Gbps |

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -175,7 +175,7 @@ This reaffirms the inherited `rdma-s3-ioctx-plan.md` v8 decision.
 
 | Phase | Scope | Hardware |
 |---|---|---|
-| P0 | **Migrate** the benchmark to the standard wire protocol (drop the 4 non-standard headers; server derives the slot address from the token, not a header) **and** harden: short-write = error (authoritative check is the `cuObjGet` result), capacity from the `cuObjGet` `size` arg, O_DIRECT edges, document callback-once (Appendix C.3) | none |
+| P0 — **migration landed** | Standard wire protocol **merged** into `s3RDMA-benchmarktool` `main`: 4 non-standard headers dropped, server decodes the slot address from the token, `x-amz-rdma-reply` status, callback-once documented. Residual hardening tracked in C.3 (strict descriptor parse; explicit short-write / capacity checks) | none |
 | P1 | Wire `object_store_config.s3_transport` into `scan_manager_config`; the scan-manager constructor selects the HTTP/RDMA backend; `AUTO`→HTTP; config tests | none |
 | P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix (slot state machine, error paths, concept check) | none |
 | P3 | Real cuObject path: single GPU, arena + D2D, flush semantics, visibility stress test on the dev rig | CX-6 rig |
@@ -469,25 +469,33 @@ the inherited `bytes_read_total` / `device_copies_total` /
 Pushing IO counters into `telemetry_context` (today pull-only) is the open part
 — see §8 Q5.
 
-## C.3 P0 — benchmark protocol migration + hardening (lands in `s3RDMA-benchmarktool`)
+## C.3 P0 — benchmark protocol migration + hardening (in `s3RDMA-benchmarktool`)
 
-P0 is a **wire-protocol migration**, not just hardening: the benchmark today
-sends `x-cuobj-remote-addr` / `x-cuobj-size` / `x-cuobj-chunk-size` and its
-server *requires* the remote-addr header (`client/s3_client.cpp`,
-`server/s3_server.cpp`). Moving to the standard cuObject protocol means:
+**Status — the migration landed (2026-06-17), merged into
+`s3RDMA-benchmarktool` `main`.** The standard-protocol move is done; the
+remaining items below tagged *(open)* are hardening follow-ups.
 
-- Drop the four non-standard headers; the server obtains the slot address by
-  **decoding it from the token** rather than reading `x-cuobj-remote-addr`.
-  Implementation caveat: the pinned SDK is cuObject **1.0.0**, whose
-  `handleGetObject` still takes `remote_buf_start` as an explicit param — so
-  this needs either a server-side token-decode path or an SDK bump toward the
-  public **1.2.0** protocol. Do not assume the old benchmark server runs
-  unchanged.
-- Server enforces the destination capacity (from the `cuObjGet` `size` arg /
-  the fixed arena `slot_size`) and rejects writes larger than the destination.
-- Short positive RDMA writes are errors — the **authoritative** check is
-  `cuObjGet`'s returned `n == expected`; `x-amz-rdma-reply` is the standard
-  status tag (do not assume it itself equals the byte count).
+P0 was a **wire-protocol migration**, not just hardening: the benchmark used to
+send `x-cuobj-remote-addr` / `x-cuobj-size` / `x-cuobj-chunk-size` with the
+server requiring the remote-addr header. The move to the standard cuObject
+protocol:
+
+- **(done)** Dropped the four non-standard headers; the server now obtains the
+  slot address by **decoding it from the token** — `parse_rdma_remote_addr`
+  reads the DC_V1 descriptor's first field. The server-side token-decode path
+  worked on the pinned cuObject **1.0.0** (no SDK bump needed).
+  **(open)** That parse is currently minimal — a marker-prefixed descriptor
+  (cuObject defines `OBJ_RDMA_V1 "CUOBJ"`) could yield a wrong address rather
+  than failing; strict hex validation was reviewed and **deferred** pending a
+  format lock against a real `rdma->desc_str` on the rig.
+- **(open)** Explicit destination-capacity enforcement: today the transfer is
+  bounded by `Range` + the `cuObjGet` `size` arg; no separate server-side
+  "reject writes larger than the destination" check has been added.
+- **(open)** Explicit short-write check: failures surface via the HTTP status
+  (client returns -1 on non-200), but an independent client-side
+  `n == expected` check is not yet wired. `x-amz-rdma-reply` is the standard
+  status tag (don't assume it equals the byte count).
+- **(done)** Callback-once-per-object semantics documented (benchmark
+  `internals.md`).
 - O_DIRECT alignment edge cases.
-- Document callback-once-per-object semantics.
 - Optional stretch: SigV4 validation mode in the benchmark server.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -117,6 +117,10 @@ flowchart LR
   C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
 ```
 
+This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
+column projections** (issue #1078, a foreground/background allocation race) —
+this backend is structurally immune to that too, the same way kvikio is.
+
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
@@ -142,6 +146,11 @@ ceiling and multiply sessions. Hence three independent axes:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
+
+**New consumers stay compatible:** the transparent `read_parquet('s3://')` front
+door (#1074, `sirius_httpfs`) resolves its backend per path through
+`create_datasource(path)` and reads with single positional `host_read`s — under
+`s3_transport=RDMA` it works unchanged, with no transport-specific checks.
 
 **Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
 one caller of the vector host-read entry point, which this backend omits — a

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -33,7 +33,7 @@ on CX-6 RoCE).
 | Supported in v1 | Not in v1 |
 |---|---|
 | Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
-| Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
+| Two logical endpoints — host plane + RDMA data plane; the configured addresses may be identical | A single shared endpoint configuration (no separate data-plane settings) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
 | One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
@@ -55,14 +55,14 @@ flowchart LR
     arena -->|"D2D on the caller stream"| rmm["RMM destination<br/>(caller-owned, not registered)"]
   end
   ctl -->|"HEAD / footer / range GET"| s3["s3_endpoint<br/>(any S3 service)"]
-  w -->|"token-bearing signed GET"| gw["s3_rdma_endpoint<br/>(cuObject gateway, direct connect)"]
+  w -->|"token-bearing signed GET"| gw["s3_rdma_data.endpoint<br/>(cuObject gateway, direct connect)"]
   gw -->|"RDMA write"| arena
   s3 --- store[("same backing store,<br/>immutable keys")]
   gw --- store
 ```
 
 The host plane (`s3_endpoint`) is any S3 service, speaking standard
-SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_endpoint`)
+SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_data.endpoint`)
 is a direct-connect cuObject gateway carrying token-bearing GETs plus the
 publisher HEAD of the visibility barrier below; both front the same
 backing store and bucket namespace.
@@ -83,6 +83,12 @@ publisher completes a visibility barrier: HEAD succeeds at both endpoints
 with matching sizes, and content identity is confirmed by a trusted ETag
 or the publishing manifest's object hash. The query path does not send
 HEAD to the gateway.
+
+For split addresses, the publisher visibility barrier above applies. If
+the two configured addresses are identical and one service serves both
+planes, cross-endpoint checks reduce to that service's native S3
+consistency; immutable keys remain required, and reads do not revalidate
+object versions.
 
 ## 4. Read Lifecycle
 
@@ -200,7 +206,8 @@ change the delivery outcome.
 On entering `TransportFailStop`, the ioctx marks the shared admission
 gate terminal and refuses new work; host- and device-plane operations
 alike surface the same terminal error. An operation already past its
-side-effect point (a control call started, a transfer issued) settles;
+side-effect point — holding the permit acquired when its control call
+starts or its transfer is issued — settles;
 queued envelopes and their ungenerated chunks error-complete; work
 claimed but not issued aborts and releases its slot; blocked submitters
 wake. Shutdown completes when the last in-flight permit releases, so the
@@ -228,7 +235,7 @@ life of the process.
 |---|---|---|
 | `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
 | `s3_endpoint` | Host plane: any S3 service | existing setting |
-| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset | none |
+| `s3_rdma_data.endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset. The `s3_rdma_data` block also carries region, credentials, signing mode, and TLS for the data plane; when its access key is unset, host-plane credentials are inherited as a whole | none |
 | `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
 | `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
@@ -297,8 +304,9 @@ The positions are the ones this document describes; the team is asked:
 
 1. GPU destination (Section 3): is the extra GPU-local copy acceptable,
    rather than registering arbitrary RMM allocations?
-2. Endpoint topology (Section 3): is split deployment, with the publisher
-   visibility barrier, acceptable?
+2. Endpoint topology (Section 3): is the two-plane configuration
+   acceptable — the full publisher barrier for split addresses, native S3
+   consistency plus immutable keys for same-address deployments?
 3. Failure policy (Section 5): is restart-based recovery acceptable for
    V1 — no fallback after an RDMA request is selected or fails?
 4. CUDA boundary (Section 5): when delivery cannot be proven, is

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -1,26 +1,32 @@
 # S3 RDMA Transport for Sirius — V1 Design
 
-Status: evaluation-prototype design for team review — no production code
-in this PR. Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
 <https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
 on CX-6 RoCE).
 
 ## 1. Summary and Scope
 
-V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
-reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
-complete object key written out, not a glob or a listing. Payload lands
-in a pre-registered GPU arena and is
-copied to caller-owned RMM memory on the caller stream, with zero
-Sirius-side host staging or H2D traffic; metadata and footer reads remain
-on the existing S3 path. There is no automatic probing and no runtime
-fallback to HTTP: when RDMA is selected and cannot serve a request, the
-request fails with an explicit error. GO requires hardware correctness, at
-least 85% of the qualified RDMA link rate for objects of 16 MiB or larger,
-and a zero-failure 100-million-GET soak. For smaller objects the gate
-measures RDMA against HTTP side by side; if RDMA shows no advantage there,
-V1 may add a size-based fallback that routes small objects to the HTTP
-path — a routing choice, distinct from the failure semantics above.
+- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
+  reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
+  complete object key written out, not a glob or a listing. The first target
+  workload, TPC-H benchmarking over lakehouse parquet, references every table
+  by exact key, so glob/LIST support is deferred without loss.
+- Payload lands in a pre-registered GPU arena and is copied to caller-owned
+  RMM memory on the caller stream, with zero Sirius-side host staging or H2D
+  traffic. Metadata and footer reads remain on the existing S3 path.
+- No automatic probing and no runtime fallback to HTTP: when RDMA is selected
+  and cannot serve a request, the request fails with an explicit error. Retry
+  and demotion for the RDMA path belong to the scan-manager layer above the
+  transport, and are added there later rather than inside the transport.
+- GO requires hardware correctness, at least 85% of the qualified RDMA link
+  rate for objects of 16 MiB or larger, and a zero-failure 100-million-GET
+  soak.
+- For smaller objects the gate measures RDMA against HTTP side by side; if
+  RDMA shows no advantage there, V1 may add a size-based fallback that routes
+  small objects to the HTTP path — a routing choice, distinct from the
+  failure semantics above.
+- The prefetch cache is off on the RDMA path in V1. Whether V1 grows a cache
+  is decided from the benchmark results, not up front.
 
 ### Decisions Requested
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15: the body supports the review decisions; implementation detail lives in the appendix |
+| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15; synced 2026-07-16 to the current IO framework (#1087 footer open-hint, #1117 LIST/glob) |
 | **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
@@ -26,10 +26,19 @@ REST backend remains the default; RDMA is selected per context by the existing
 not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
 failures surface per the Safety Contract (§4).
 
-**Decisions requested.** The team is asked to approve five decisions (§6):
+**Current implementation gap (not a v1 design limit).** Exact-key
+`read_parquet('s3://…')` is the supported target; **wildcard glob** resolves
+through S3 LIST, which the framework currently routes to the REST backend
+only — under RDMA selection a glob fails loudly (D6). The P2 control-plane
+parity work closes this (§7) by wiring the hybrid's always-available HTTP
+control client; the RDMA data plane stays dormant until P3. It is a
+compatibility gate, separate from the P3 safety activation gates.
+
+**Decisions requested.** The team is asked to approve six decisions (§6):
 the landing arena + D2D shape, the CUDA failure policy, the
 duplicate-suppression mechanism and ambiguous-completion policy, the
-request-envelope queue model, and cuObject session ownership.
+request-envelope queue model, cuObject session ownership, and the gateway
+topology with its plain-S3 surface.
 
 ## 2. Architecture & Read Path
 
@@ -48,8 +57,11 @@ engine behind it, defined by which read **builders** it provides.)*
 
 On the control plane (HTTP), the descriptor token is the only RDMA-specific
 request header (`Range` travels as usual); the data plane (RDMA) writes object
-bytes straight into the GPU arena. Host reads
-(footers / HEAD) stay on HTTP through the existing SigV4 authorizer. The
+bytes straight into the GPU arena. Host reads stay on
+HTTP through the existing SigV4 authorizer — a surface that now includes the
+framework's footer-probe open hint (one suffix-range GET serves the size and
+the binder's footer reads), S3 LIST for glob, and HEAD; matching it on the
+hybrid is the P2 control-plane parity item (§7). The
 arena is a fixed staging window, not object-sized: a read streams through it
 in slot-sized chunks, each D2D-copied to its offset in the destination buffer
 (copy cost: §7).
@@ -175,9 +187,10 @@ never freed.
 
 Two independent gates apply on the real path. **Completion authority** is a
 P0b gate: the gateway enforces **exact completion** and the client requires a
-**valid reply tag** (appendix protocol). Separately, request **uniqueness**
-(§5) must hold before P3 activation — fail-stop cannot see a duplicate that
-succeeds.
+**valid reply tag** (appendix protocol). Separately, request **uniqueness and
+response–side-effect integrity** (§5) must hold before P3 activation —
+fail-stop cannot see a duplicate that succeeds, and completion authority
+cannot detect a cached or coalesced reply whose RDMA write never happened.
 
 ## 5. Authentication
 
@@ -196,12 +209,23 @@ non-empty header sets, and which the built-in SigV4 header signer overrides.
 The dev benchmark server runs unsigned on an isolated network; production
 gateways validate the signature before honoring the token.
 
-Request uniqueness is an **activation requirement**, not a recovery policy:
-a transparently retried duplicate can *succeed* while the original request is
-still writing, and no client-side rule — fail-stop included — can see it.
-**v1 satisfies it by deployment contract**: the client connects to the
-gateway directly (or every intermediary has automatic retries disabled for
-token-bearing GETs); RDMA must not be enabled otherwise. Gateway-side
+A token-bearing GET is not a safe idempotent read: the response certifies a
+**side effect** (the RDMA write into the slot), and any intermediary behavior
+that decouples the two defeats completion authority silently. A transparent
+retry duplicates the write while the original still runs; an HTTP **cache**
+(keyed on URI/Range — the token is just a header) can return a stored,
+legitimate `x-amz-rdma-reply` with **no write at all**; **request coalescing**
+merges two identical GETs into one upstream fetch — one write, two replies;
+hedging/mirroring duplicates writes. In each case the client sees a valid
+reply and `n == expected` while its slot holds stale bytes — silent
+corruption no client-side rule (fail-stop included) can detect.
+
+**v1 deployment contract (activation requirement):** token-bearing GETs are
+exempt from retry, hedging, mirroring, caching, and request coalescing;
+request and response both carry `Cache-Control: no-store`; any proxy route
+explicitly bypasses caches. Where all of this cannot be proven, the client
+connects **directly to the gateway** — the v1 default. RDMA must not be
+enabled otherwise. Gateway-side
 exactly-once deduplication is a **deferred conditional extension** — the base
 cuObject protocol defines no request-identity tag, so it would need a signed
 identity added to the wire (appendix) and is only worth specifying if a
@@ -214,9 +238,10 @@ are redacted from logs.
 |---|---|---|---|
 | 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
 | 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
-| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the no-intermediary-retry deployment contract (gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
+| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the §5 deployment contract (direct gateway; token-bearing GETs exempt from retry/hedge/mirror/cache/coalesce; gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
 | 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
 | 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
+| 6 | Gateway topology & plain-S3 surface | Single endpoint: the gateway also serves plain S3 (ListObjectsV2 / HEAD / range GET — P0c). "Token-less" means no RDMA descriptor, **not anonymous**: LIST/HEAD/GET stay SigV4-validated and authorized over TLS. SigV4 signs `Host`, so naive forwarding breaks signatures — the production model is **terminate-and-re-sign**: the gateway validates the client's SigV4, authorizes, and re-signs upstream with its own service identity (identity/permission mapping is a deployment definition); a gateway co-located with the storage (same hostname + credential authority) reduces this to internal dispatch. "One credential set" = the **client's** configuration; gateway→upstream credentials are the gateway's own. The benchmark gateway is a reference / conformance implementation | P0c, P2 parity |
 
 Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
 default (fixed 100G reference vs self-scaling) before P4; appetite for a
@@ -237,8 +262,9 @@ multi-NIC sharding would revisit the multi-ordering-domain exceptions.
 |---|---|---|---|
 | P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
 | P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
+| P0c | Gateway **plain S3 surface** (ListObjectsV2 / HEAD / token-less range GET — still SigV4-authenticated; §6 decision 6) for the single-endpoint topology — today it serves object HEAD only and rejects token-less GETs | serves host reads + glob; the P2 parity gate is complete only when this also lands (MinIO covers CI meanwhile) | — |
 | P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
-| P2 | Reactor against a mock client; envelope admission | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom | CUDA GPU |
+| P2 | Reactor against a mock client; envelope admission; hybrid control-plane parity (footer probe, known-size open, S3 LIST capability — this sub-item needs no CUDA GPU) | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom; parity: glob + footer-RTT behavior matches HTTP | CUDA GPU (except the parity sub-item) |
 | P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
 | P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
@@ -263,7 +289,8 @@ Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
 the omitted vector-read path (kvikio has the same gap; a per-segment framework
 fallback is proposed separately). The transparent `read_parquet('s3://')`
 front door (#1074) carries no transport-specific checks and is expected to
-work unchanged — a routing test pins this at integration. Captured CUDA
+work unchanged for exact-key opens — a routing test pins this at integration
+(wildcard glob: the implementation-gap note in §1). Captured CUDA
 streams are unsupported for RDMA device reads.
 
 Risks:
@@ -309,7 +336,8 @@ halves are P0b gates. The server chunks transfers server-side (its own config,
 default 2 MiB); nothing is negotiated on the wire. Signature validation and
 the dev/prod auth posture are defined in §5. Remaining P0b items
 (outcome level): strict descriptor/capacity validation, exact completion,
-mandatory reply validation — code-level specifics are tracked in the
+mandatory reply validation; the plain-S3 surface (LIST/HEAD/token-less GET)
+is the separate P0c item — code-level specifics for both are tracked in the
 `s3RDMA-benchmarktool` repo.
 
 ### Configuration
@@ -319,11 +347,14 @@ s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
 s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
+s3_rdma_perf_instrumentation      # gates the timing counter families (default off; §appendix Metrics)
 ```
 
 Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
-one host serves HEAD/range-GET and RDMA control under one credential set. A
-split topology is deferred until a deployment requires it. There is no client
+one host serves ListObjectsV2, HEAD, plain range-GET, and RDMA control under
+one credential set (the client's — §6 decision 6); growing the gateway's
+plain S3 surface to match is P0c gateway-side work. A split topology (plain S3 host for host/LIST reads, RDMA
+gateway for device reads) is deferred until a deployment requires it. There is no client
 chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
 the existing fields (`s3_signing_mode` — header mode required, §5 —
 `ca_bundle_path`, `tls_verify`).
@@ -347,7 +378,9 @@ never retries; exhaustion surfaces the last error; never a transport switch
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total`, `…_fallback_stream_sync_total`
+`…_queue_depth_peak`, `…_queue_wait_total`, the REST-shaped
+`…_blocking_host_get_count/wall_ns_total/wall_ns_max` (footer-probe GETs
+excluded, mirroring REST's attribution), `…_fallback_stream_sync_total`
 (quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
 the process-terminating verdicts leave a fatal log line and an exit code, not
 a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
@@ -384,5 +417,7 @@ and while the reactor fail-stops).
 
 This document describes the target architecture. The current tree differs in
 the areas the rollout table covers (delivery-failure discipline, retry
-classification, envelope admission, auth surface); P2/P3 implement and test
-them. No production code ships with this PR.
+classification, envelope admission, auth surface, the control-plane parity
+set — footer probe, known-size open, S3 LIST — and the gateway's plain-S3
+surface); P2/P3 (and P0c gateway-side) implement and test them. No production
+code ships with this PR.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -2,8 +2,8 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — rebased onto the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev` |
-| **Date** | 2026-07-04 |
+| **Status** | Draft for team review — updated for the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev`. Revised 2026-07-15: delivery-failure semantics defined; reactor-state, visibility-policy, and session-model sections expanded |
+| **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
@@ -14,10 +14,13 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`, exactly how the REST backend is built. The benchmark
-proves the cuObject RDMA data path at line rate; the Sirius-specific arena+D2D
-visibility and completion discipline are gated by P3. **Please review the
-decisions table (§3) and the open questions (§5).**
+existing `templated_ioctx`, the same way the REST backend is built. The
+benchmark already proves the cuObject RDMA data path at line rate. What remains
+Sirius-specific is the arena+D2D **visibility discipline**, validated in
+rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
+guarantees that no buffer is ever recycled or handed back while a copy might
+still touch it. **Please review the decisions table (§3) and the open
+questions (§5).**
 
 ## Why
 
@@ -43,6 +46,10 @@ flowchart LR
   arena == "GPU-local D2D (~TB/s)" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
   rmm --> decode["cuDF decode"]
 ```
+
+*(Vocabulary for readers new to the IO framework: an **ioctx** is the
+per-context IO facade the scanner talks to; a **reactor** is the transport
+engine behind it, defined by which read **builders** it provides.)*
 
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
@@ -78,31 +85,72 @@ sequenceDiagram
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
   G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if the platform needs it)
-  W->>S: cudaMemcpyAsync slot -> dst (D2D) + record CUDA event
-  S-->>W: event clears (worker polls, REST's proven pattern)
+  Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
+  W->>W: create the completion event FIRST
+  W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
+  W->>S: wait on the event inline (the D2D is ~3 µs vs a ~350 µs GET)
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
 
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound**. Completion uses the framework's `exec::semi_future` +
-`request_manager`: each chunk reports `chunk_complete` or `report_error` exactly
-once and then releases its manager reference — the future resolves when the last
-chunk does. Nothing runs on a CUDA callback thread; the worker finishes the chunk
-after its CUDA event clears, then recycles the slot. Because the D2D is ~3 µs
-against a ~350 µs network GET, v1 may simply wait on the event inline instead of
-parking copies for a poll loop — a simplification to measure in P2/P3.
+concurrency bound** — and because there is exactly one arena slot per worker, a
+worker always finds a free slot: admission pressure lives in the reactor's
+queue, never in the arena (the queue is currently uncapped; bounding and
+observing queued work is a tracked follow-up). Completion uses the framework's
+`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
+`report_error` exactly once and then releases its manager reference — the
+future resolves when the last chunk does. Nothing runs on a CUDA callback
+thread. The worker waits on its own copy **inline** (parking the worker to
+dodge a ~3 µs wait — right after a ~350 µs network GET — buys nothing); the
+REST backend's event-poll shape remains the documented fallback if
+shared-stream measurements on the rig ever show the inline wait stalling
+workers.
+
+**When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
+the arena slot (its next user would corrupt an in-flight copy) and the caller's
+destination (the caller frees it as soon as its future resolves — while the
+copy may still be writing it). The rule is therefore absolute: **neither the
+slot is recycled nor the future resolved until the stream is proven quiet.**
+
+- The completion event is created **before** the copy is enqueued — if even
+  that fails, nothing is in flight and the error is plainly recoverable.
+- On any CUDA failure after the enqueue, the worker proves quiescence with a
+  real stream sync. A sync call can return an error produced by *earlier*
+  async work — the call itself still waited, so the stream is still proven
+  quiet. The only exception is an error meaning the call never ran at all
+  (e.g. an invalid stream handle); then the worker escalates to a device-wide
+  sync as the stronger proof. (Captured streams fall in that exception too —
+  and are a documented precondition violation: RDMA device reads do not
+  support them.)
+- The verdict is three-way. *Quiet + healthy*: release the slot, report the
+  original error, keep serving. *Quiet + context-fatal* (sticky errors such as
+  an illegal memory access): the CUDA context is dead and nothing can touch the
+  destination anymore — report and **fail-stop**. *Unprovable*: fail-stop.
+- **Fail-stop** happens exactly once. New reads fail fast, naming the first
+  fatal error. Queued chunks are completed with that error. Chunks already in
+  flight finish on their own workers — never resolved on another worker's
+  behalf. And any arena that cannot be proven quiet at teardown is
+  deliberately **leaked rather than freed**: freeing memory a NIC or copy
+  engine might still write is the very use-after-free this discipline exists
+  to prevent.
+- A sticky CUDA error is a **process-level** event: continuing CUDA work just
+  returns the same error. Fail-stop is containment; process restart is the
+  recovery.
+
+Every CUDA call on this delivery path goes through a small seam injected at
+construction time, so all of the failure branches above are fault-injectable in
+ordinary tests without faking CUDA semantics.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — the reactor provides `prep_host_rx` / `prep_device_rx` builders + `enqueue`; credentials and the registered arena live in its `reactor_context` | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused |
+| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`; a chunk completes exactly once, on a worker thread, after its CUDA event clears — never from a CUDA callback | Matches the framework contract (the future resolves when the last chunk releases its manager reference); keeps user code off CUDA's internal threads |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a restart instead of pretending to continue |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
 | D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
@@ -114,7 +162,7 @@ Why D9 works, in one picture:
 flowchart LR
   A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
   B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
+  C --> D["no host staging can sneak in;<br/>the cache's staged-read crash path<br/>is unreachable"]
 ```
 
 This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
@@ -126,31 +174,36 @@ this backend is structurally immune to that too, the same way kvikio is.
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
-**One reactor per node — and what scales with what.** For contrast: the REST
-backend runs **2 reactors per node** (`rest_n_reactors`), unrelated to GPU count —
-its reactors are epoll event loops doing real CPU work (TLS, staging copies), so
-a second one spreads CPU load. The RDMA reactor is *not* an event loop
-(`cuObjGet` blocks): it is a container for the worker pool and the arenas, so
-extra reactors add no throughput — they would only fragment the global in-flight
-ceiling and multiply sessions. Hence three independent axes:
+**One reactor per ioctx — and what scales with what.** The unit is the
+ioctx/`SiriusContext`, not the node: a process running several Sirius contexts
+multiplies workers, arenas, and gateway-budget demand accordingly. For
+contrast: the REST backend runs **2 reactors per ioctx** (`rest_n_reactors`),
+unrelated to GPU count — its reactors are epoll event loops doing real CPU work
+(TLS, staging copies), so a second one spreads CPU load. The RDMA reactor is
+*not* an event loop (`cuObjGet` blocks): it is a container for the worker pool
+and the arenas, so extra reactors add no throughput — they would only fragment
+the global in-flight ceiling and multiply sessions. Hence three independent
+axes:
 
 - **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
   with reactors, not with GPUs.
 - **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
-  arena; a worker sets the request's device and takes a slot from *that* device's
-  arena, so slot and destination are always same-device (never a cross-device
-  copy). A per-GPU reactor would instead make concurrency `GPUs × max_inflight`
-  (e.g. 4×8 = 32 concurrent `cuObjGet`), breaking the global ceiling and risking
-  gateway/NIC overload.
+  arena; a worker sets the request's device (via the framework's RAII device
+  guard) and takes a slot from *that* device's arena, so slot and destination
+  are always same-device (never a cross-device copy). A per-GPU reactor would
+  instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
+  `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
 - **NIC count** is the one thing that eventually justifies more reactors:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
 
-**New consumers stay compatible:** the transparent `read_parquet('s3://')` front
-door (#1074, `sirius_httpfs`) resolves its backend per path through
-`create_datasource(path)` and reads with single positional `host_read`s — under
-`s3_transport=RDMA` it works unchanged, with no transport-specific checks.
+**New consumers stay compatible by design:** the transparent
+`read_parquet('s3://')` front door (#1074, `sirius_httpfs`) resolves its
+backend per path through `create_datasource(path)` and reads with single
+positional `host_read`s — it carries no transport-specific checks, so under
+`s3_transport=RDMA` it should work unchanged; a routing test pins this at
+integration time.
 
 **Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
 one caller of the vector host-read entry point, which this backend omits — a
@@ -164,25 +217,28 @@ change.
 | Phase | Scope | HW |
 |---|---|---|
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Re-add strict descriptor parsing (the migration removed the old validator — a regression); enforce the token's `buf_size` (on the wire but unread); explicit short-write `n == expected` check | — |
+| **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; pin the registration-per-session question | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go; vs-HTTP benchmark | CX-6 |
+| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship 8 workers × 4 MiB as the **100G-floor** default
-   (line rate on the CX-6 rig) with the documented rule "scale in-flight bytes
-   linearly with NIC line rate" (§1) — or should the default self-scale from a
-   detected/configured link speed? 800G-class NICs need ~8× the in-flight bytes
-   and proportionally more workers, which also stresses the blocking-GET
-   thread-per-worker model (§6).
-2. **OWNER-flush ownership** — who verifies whether `…_ORDERING_OWNER` still
-   needs `cuFlushGPUDirectRDMAWrites` for same-device consumers? Neither the
-   benchmark nor Sirius contains any flush handling today — this is from-scratch
-   P3 work and the top correctness risk.
+1. **Sizing defaults** — ship the fixed 100G-floor default from §1's sizing
+   rule, or should the default self-scale from a detected/configured link
+   speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
+2. **Visibility policy validation** — CUDA exposes a per-device
+   GPUDirect-RDMA **write-ordering attribute**: *OWNER* means RDMA writes
+   become visible to the owning device with no extra action; *NONE* means no
+   guarantee — an explicit flush is required before the GPU may read the
+   bytes. The OWNER half of the question is closed on paper: our consumer is a
+   same-device D2D, so **only NONE-ordering platforms need a flush**, and a
+   NONE platform that cannot flush must fail RDMA init loudly (no safe
+   configuration exists). What still needs the rig: wiring the policy **per
+   device** and the decode-immediately-after-GET stress test — still the top
+   correctness gate for P3. Who owns that rig time?
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
@@ -190,23 +246,36 @@ change.
    (drops the <1% D2D) but touches cucascade's memory architecture.
 5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
    perf instrumentation was re-added for the REST reactor in #1042; the RDMA
-   counters should follow that shape rather than invent a parallel one.
-6. **Registration × sessions** — each worker owns its own `cuObjClient` session;
-   is a buffer registration per-session (8 registrations of the same arena) or
-   shareable? SDK-version-dependent (conda 1.2.x vs the validated 1.0.0); shapes
-   the client-wrapper API. Pin on the rig in P3.
+   counters should follow that shape rather than invent a parallel one (see
+   the appendix for the proposed set, including the delivery-safety counters).
+6. **Session ownership** — the cuObject SDK documents no whole-client
+   thread-safety guarantee, so the design prefers **one `cuObjClient` session
+   per worker**; the alternative (one shared client for the pool) requires
+   documented proof of safety plus locking that preserves concurrency. Bound
+   up with it: is a buffer registration per-session (N registrations of the
+   same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
+   vs the validated 1.0.0) and shapes the client-wrapper API; it must be
+   decided on the rig, before activation.
 
 ## 6. Risks
 
-- **CUDA visibility after external RDMA writes** — top correctness risk;
-  confined to one flush-before-D2D point; stress test gates P3.
+- **CUDA visibility after external RDMA writes** — the top correctness risk,
+  now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
+  exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
+  test.
+- **Fatal CUDA errors are process-level.** The reactor's fail-stop (§2)
+  contains one — it does not recover it. Operators should treat a delivery
+  fatal as "restart required", and the surrounding system must not assume
+  other GPU work on that context keeps functioning.
 - Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
-  client process (not × GPUs or × queries).
+  Sirius context (not × GPUs or × queries) — and a process running several
+  contexts multiplies it (§3).
 - Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5); cuObject's blocking GET shapes the worker-pool model — and at
-  800G-class line rates the pool grows ~8× (with the gateway DCI budget growing
-  with it), sharpening the case for an async cuObject API if one appears.
+  threshold, P5 — control-plane **connection reuse** is part of the same
+  measurement); cuObject's blocking GET shapes the worker-pool model, and the
+  pool grows with NIC line rate (§1 sizing), sharpening the case for an async
+  cuObject API if one appears.
 - cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
   reconciled before P3.
 
@@ -221,7 +290,7 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 | Header | Direction | Meaning |
 |---|---|---|
 | `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag (authoritative completion is `cuObjGet`'s `n == expected`, not a reply byte count) |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected` — but that count is only **authoritative once the gateway enforces exact completion** (accepts no short or overlong RDMA piece): the P0b hardening (see below) is therefore a precondition for trusting short-write detection on the real path |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
@@ -233,24 +302,32 @@ Production gateways SigV4-validate the control request before honoring the token
 ### Config (under `object_store_config`)
 
 `s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
-its consumer. The rest are new fields for the integration PR:
+its consumer. Two sizing knobs accompany it:
 
 ```text
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_endpoint / s3_rdma_port   # control-plane endpoint if distinct
-s3_rdma_max_inflight              # worker count = global in-flight ceiling
-                                  #   default 8 — calibrated on the 100G floor; scale with NIC line rate
-s3_rdma_arena_slot_size           # per-chunk arena slot
-                                  #   default 4 MiB — same calibration; workers x slot_size tracks line rate
+s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
+s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
 ```
 
-There is deliberately **no client chunk-size knob**: the transfer granularity is
-the arena slot size, and the server chunks independently. Auth/TLS reuse the
-existing fields (`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+The control plane reuses the shared object-store endpoint carried by the
+authorizer; a distinct RDMA-gateway endpoint knob is added only if activation
+shows the gateway host must differ from the S3 endpoint. There is deliberately
+**no client chunk-size knob**: the transfer granularity is the arena slot size,
+and the server chunks independently. Auth/TLS reuse the existing fields
+(`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+
+**Retry contract** — deliberately independent of the REST policy: retries are
+chunk-level; only client transport failures and short reads retry; CUDA work
+never retries; exhaustion surfaces the last error — and per D6, never a
+transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
-`…_requests_total`, `…_arena_slot_wait_total`, `…_flush_total`,
-`…_short_write_total`, `…_error_total`, `…_inflight_peak`.
+`…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
+`…_slot_wait_total`, `…_flush_total`, `…_inflight_peak` — plus the
+delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
+runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
+(arenas leaked at teardown because the device could not be proven quiet).
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 
@@ -260,9 +337,10 @@ pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
 documented. **Open hardening (P0b):** the migration **removed** the previous
 strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
-`buf_size` field is transmitted but never read server-side (a free capacity check
-not being performed); the client reports success on any 200/206 without an
-`n == expected` short-write check; optional SigV4 in the dev server.
+`buf_size` field is transmitted but never read server-side (a capacity check the
+server could perform for free but currently skips); the client reports success on
+any 200/206 without an `n == expected` short-write check; optional SigV4 in the
+dev server.
 
-> Deeper implementation notes + verified file:line references live in the
-> offline working spec, not this doc.
+> Detailed gateway-hardening notes (file:line specifics) are tracked in the
+> `s3RDMA-benchmarktool` repo.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -12,9 +12,11 @@
 Read large Parquet column data from S3 **straight into GPU memory over RDMA**,
 removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
-moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
-scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`, the same way the REST backend is built. The
+moves it to the final RMM buffer. `s3://` URIs, the SigV4 credential machinery,
+and the Parquet scanner are unchanged — the new code is one reactor plus a thin
+ioctx under the existing `templated_ioctx`, the same way the REST backend is
+built. (One auth-surface extension is required: the RDMA token and `Range`
+must be **inside** the SigV4 signature — D8.) The
 benchmark already proves the cuObject RDMA data path at line rate. What remains
 Sirius-specific is the arena+D2D **visibility discipline**, validated in
 rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
@@ -54,7 +56,9 @@ engine behind it, defined by which read **builders** it provides.)*
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
 plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
 backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (<1% overhead). Host reads
+small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot —
+under 1% of the transfer at the 100G reference point; a larger share at higher
+line rates, so re-measure before extrapolating). Host reads
 (footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
 `s3_request_authorizer`.
 
@@ -65,13 +69,15 @@ chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 Mi
 
 Both sizing knobs are **config** (`s3_rdma_max_inflight`,
 `s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
-device** — is calibrated on the benchmark's CX-6 **100G** rig, which is the
-*floor* for this transport (line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle).
-Faster NICs scale the same two knobs, not the design: keep the bytes in flight
-(`workers × slot_size`) growing roughly linearly with line rate — e.g.
-~16 × 16 MiB or 64 × 4 MiB ≈ 256 MiB/device for 800G-class NICs — and re-derive
-the knee empirically on the target rig (a P4/P5 sweep). The arena stays trivial
-next to GPU memory at any of these points.
+device** — comes from the benchmark's CX-6 **100G reference configuration**
+(line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page
+cache and the server's 2 MiB chunking, so other topologies must re-measure).
+Faster NICs scale the same two knobs, not the design: the bytes in flight
+(`workers × slot_size`) must grow with line rate, and the knee has to be
+re-derived empirically on the target NIC (a P4/P5 sweep) — the 100G numbers do
+not transfer. Arena memory cost is exact:
+`workers × slot_size × active GPUs` per Sirius context (32 MiB per device at
+the reference defaults).
 
 ## 2. How one read works
 
@@ -96,16 +102,19 @@ sequenceDiagram
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
 concurrency bound** — and because there is exactly one arena slot per worker, a
 worker always finds a free slot: admission pressure lives in the reactor's
-queue, never in the arena (the queue is currently uncapped; bounding and
-observing queued work is a tracked follow-up). Completion uses the framework's
+queue, which is **capped per ioctx** with blocking admission and depth/wait
+counters (see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
 future resolves when the last chunk does. Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline** (parking the worker to
-dodge a ~3 µs wait — right after a ~350 µs network GET — buys nothing); the
-REST backend's event-poll shape remains the documented fallback if
-shared-stream measurements on the rig ever show the inline wait stalling
-workers.
+thread. The worker waits on its own copy **inline**: at the measured 100G
+reference point the D2D is ~3 µs against a ~350 µs network GET, so parking the
+worker is not expected to improve throughput. Two caveats keep this a
+hypothesis rather than a settled fact: the event wait covers **all prior work
+on the caller's stream**, not just our D2D, and the ratio shifts at higher
+line rates — a realistic shared-stream saturation test is an explicit
+activation gate, and the REST backend's event-poll shape is the documented
+fallback if it fails.
 
 **When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
 the arena slot (its next user would corrupt an in-flight copy) and the caller's
@@ -113,10 +122,16 @@ destination (the caller frees it as soon as its future resolves — while the
 copy may still be writing it). The rule is therefore absolute: **neither the
 slot is recycled nor the future resolved until the stream is proven quiet.**
 
-- The completion event is created **before** the copy is enqueued — if even
-  that fails, nothing is in flight and the error is plainly recoverable.
-- On any CUDA failure after the enqueue, the worker proves quiescence with a
-  real stream sync. A sync call can return an error produced by *earlier*
+- The completion event is created **before** the copy is enqueued — if event
+  creation fails, no D2D has been submitted, so releasing the slot and
+  reporting the error is safe.
+- A non-success return from `cudaMemcpyAsync` itself does **not** prove the
+  copy was rejected: async CUDA calls may return errors produced by *earlier*
+  async work, so the enqueue state is unknown. Any non-success here is treated
+  exactly like a post-enqueue failure and goes through the quiescence proof
+  below.
+- On any CUDA failure at or after the enqueue, the worker proves quiescence
+  with a real stream sync. A sync call can return an error produced by earlier
   async work — the call itself still waited, so the stream is still proven
   quiet. The only exception is an error meaning the call never ran at all
   (e.g. an invalid stream handle); then the worker escalates to a device-wide
@@ -125,8 +140,15 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   support them.)
 - The verdict is three-way. *Quiet + healthy*: release the slot, report the
   original error, keep serving. *Quiet + context-fatal* (sticky errors such as
-  an illegal memory access): the CUDA context is dead and nothing can touch the
-  destination anymore — report and **fail-stop**. *Unprovable*: fail-stop.
+  an illegal memory access): the CUDA context is dead — no engine can write
+  the destination anymore, so reporting the error is safe — and the reactor
+  **fail-stops**. *Unprovable* (the device-wide sync also failed with a
+  non-sticky code, or could not run): the request is **never handed back** —
+  its future deliberately does not resolve, because a resolved future licenses
+  the caller to free a destination that may still be written. The reactor
+  fail-stops and escalates to **process-fatal**: the process must be restarted
+  (watchdog territory). A wedged request is the deliberate lesser evil against
+  a silent use-after-free.
 - **Fail-stop** happens exactly once. New reads fail fast, naming the first
   fatal error. Queued chunks are completed with that error. Chunks already in
   flight finish on their own workers — never resolved on another worker's
@@ -149,11 +171,11 @@ ordinary tests without faking CUDA semantics.
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
 | D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a restart instead of pretending to continue |
+| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and the RDMA control plane requires header-signing mode (a presigned URL cannot bind headers added after signing) | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -162,12 +184,13 @@ Why D9 works, in one picture:
 flowchart LR
   A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
   B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["no host staging can sneak in;<br/>the cache's staged-read crash path<br/>is unreachable"]
+  C --> D["the omitted builders make host staging<br/>and the cache's staged-read crash path<br/>unreachable for this backend"]
 ```
 
 This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
 column projections** (issue #1078, a foreground/background allocation race) —
-this backend is structurally immune to that too, the same way kvikio is.
+the omitted builders make that path unreachable for this backend too, the
+same way it is for kvikio.
 
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
@@ -193,7 +216,7 @@ axes:
   are always same-device (never a cross-device copy). A per-GPU reactor would
   instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
   `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
-- **NIC count** is the one thing that eventually justifies more reactors:
+- **NIC count** is what eventually justifies more reactors:
   per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
   of global rate-limit complexity — is the deferred evolution for explicit
   multi-NIC/NUMA topologies, not v1.
@@ -219,14 +242,14 @@ change.
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b ⏳ gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2) | CX-6 |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, teardown leak) | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test. **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship the fixed 100G-floor default from §1's sizing
+1. **Sizing defaults** — ship the fixed 100G-reference default from §1's sizing
    rule, or should the default self-scale from a detected/configured link
    speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
 2. **Visibility policy validation** — CUDA exposes a per-device
@@ -256,6 +279,13 @@ change.
    same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
    vs the validated 1.0.0) and shapes the client-wrapper API; it must be
    decided on the rig, before activation.
+7. **Ambiguous-failure fencing** — after a control-plane timeout or reset, the
+   gateway may still hold a descriptor for the slot and keep writing it; the
+   protocol defines what a success response means, but not what silence means.
+   Does the cuObject SDK or the gateway offer a fencing / cancellation
+   primitive (deregister-and-confirm, descriptor revocation)? Without one, the
+   retry contract (appendix) must quarantine the slot and fail the read on any
+   ambiguous failure — a question for NVIDIA as much as for this team.
 
 ## 6. Risks
 
@@ -290,14 +320,16 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 | Header | Direction | Meaning |
 |---|---|---|
 | `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected` — but that count is only **authoritative once the gateway enforces exact completion** (accepts no short or overlong RDMA piece): the P0b hardening (see below) is therefore a precondition for trusting short-write detection on the real path |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected`, and that count is authoritative only when **both** halves hold: the gateway enforces exact completion (accepts no short or overlong RDMA piece), **and** the client requires a valid reply tag before it reports the requested size — an HTTP 200/206 without a legitimate reply must be treated as failure, and the reply payload is never interpreted as a byte count. Both halves are P0b items (see below) and a precondition for trusting short-write detection on the real path |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
 address rides in the token, capacity is the `cuObjGet` `size` arg, and the
 reply tag supersedes the byte-count header. The server chunks transfers
 server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
-Production gateways SigV4-validate the control request before honoring the token.
+Production gateways SigV4-validate the control request before honoring the
+token, and the token + `Range` are part of that signature (D8): the client
+signs them, the gateway verifies them — an unsigned token is rejected.
 
 ### Config (under `object_store_config`)
 
@@ -310,17 +342,42 @@ s3_rdma_max_inflight              # worker count = global in-flight ceiling (def
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
 ```
 
-The control plane reuses the shared object-store endpoint carried by the
-authorizer; a distinct RDMA-gateway endpoint knob is added only if activation
-shows the gateway host must differ from the S3 endpoint. There is deliberately
-**no client chunk-size knob**: the transfer granularity is the arena slot size,
-and the server chunks independently. Auth/TLS reuse the existing fields
-(`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+**Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
+cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
+and the RDMA control requests, under one set of credentials and one signing
+host. A split topology (RDMA gateway separate from the S3 origin) is out of
+scope for v1: it needs two endpoints, two signing hosts, and an explicit
+credential boundary, and is only worth designing if a deployment actually
+requires it. There is deliberately **no client chunk-size knob**: the transfer
+granularity is the arena slot size, and the server chunks independently.
+Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
+for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
-**Retry contract** — deliberately independent of the REST policy: retries are
-chunk-level; only client transport failures and short reads retry; CUDA work
-never retries; exhaustion surfaces the last error — and per D6, never a
-transport switch.
+**Admission bound (v1):** the reactor's request queue is **capped per ioctx**
+(a small configurable multiple of the worker count); admission blocks once the
+cap is reached. Queue depth and queue-wait counters expose the pressure. The
+process-wide budget is contexts × workers — a deployment running several
+Sirius contexts must size the gateway budget for the sum.
+
+**Retry contract** — deliberately independent of the REST policy, and split by
+plane, because the two planes fail differently:
+
+- **Host/HTTP reads** (footers, metadata): retryable on transport failures and
+  short reads. The client owns the write loop into the destination buffer, and
+  a closed connection means no further writes — re-issuing into the same
+  buffer is safe.
+- **RDMA device reads**: retryability is decided by the **commit point**. A
+  failure that provably precedes the control request leaving the client
+  (connection setup, before the token is sent) is retryable. Once the token
+  may have reached the gateway, a timeout or reset without an authoritative
+  reply is **ambiguous**: the gateway holds a descriptor for the slot and may
+  still be writing it — the protocol defines "success response ⇒ transfer
+  complete", but not "no response ⇒ gateway stopped". An ambiguous failure is
+  therefore **not retried in place**: the read fails terminally and the slot
+  is withheld from reuse (quarantined), unless the gateway/SDK provides a
+  fencing or cancellation primitive (§5 Q7 — open question to NVIDIA).
+- Everywhere: CUDA work never retries; exhaustion surfaces the last error —
+  and per D6, never a transport switch.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
@@ -339,8 +396,10 @@ strict address validator — today's parse takes the first hex field with no
 length/field validation (and wrongly rejects a legitimate address 0); the token's
 `buf_size` field is transmitted but never read server-side (a capacity check the
 server could perform for free but currently skips); the client reports success on
-any 200/206 without an `n == expected` short-write check; optional SigV4 in the
-dev server.
+any 200/206 without an `n == expected` short-write check **and without requiring
+a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
+of P0b — only after it may the callback report the requested size); optional
+SigV4 in the dev server.
 
 > Detailed gateway-hardening notes (file:line specifics) are tracked in the
 > `s3RDMA-benchmarktool` repo.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -94,7 +94,7 @@ sequenceDiagram
   Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
   W->>W: create the completion event FIRST
   W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline (the D2D is ~3 µs vs a ~350 µs GET)
+  W->>S: wait on the event inline (~3 µs est. vs the ~350 µs wire time of one slot)
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
@@ -102,17 +102,23 @@ sequenceDiagram
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
 concurrency bound** — and because there is exactly one arena slot per worker, a
 worker always finds a free slot: admission pressure lives in the reactor's
-queue, which is **capped per ioctx** with blocking admission and depth/wait
-counters (see the config appendix). Completion uses the framework's
+queue, which holds bounded **request envelopes** — a submitter enqueues one
+small envelope per read and returns; workers generate and claim chunks lazily
+from the head envelopes, so an async read never waits on chunk-level progress
+(see the config appendix). Completion uses the framework's
 `exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
 `report_error` exactly once and then releases its manager reference — the
 future resolves when the last chunk does. (One deliberate exception exists:
 the *unprovable* delivery verdict below terminates the process instead of
 completing the chunk — the framework's "resolve on last release" mechanics
-make any softer form of "never resolved" unimplementable.) Nothing runs on a CUDA callback
+make any softer form of "never resolved" unimplementable. The sticky
+context-fatal verdict also ends in termination, but only after the chunk's
+error is safely reported.) Nothing runs on a CUDA callback
 thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
-(bandwidth-derived) against a ~350 µs network GET at the 100G reference point,
-so parking the worker is not expected to improve throughput. Two caveats keep this a
+(bandwidth-derived) against the ~350 µs it takes just to serialize a 4 MiB
+slot at ~91 Gbps (a wire-time floor, not a measured single-request latency
+under concurrency), so parking the worker is not expected to improve
+throughput. Two caveats keep this a
 hypothesis rather than a settled fact: the event wait covers **all prior work
 on the caller's stream**, not just our D2D, and the ratio shifts at higher
 line rates — a realistic shared-stream saturation test is an explicit
@@ -141,49 +147,57 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
   sync as the stronger proof. (Captured streams fall in that exception too —
   and are a documented precondition violation: RDMA device reads do not
   support them.)
-- The verdict is three-way. *Quiet + healthy*: release the slot, report the
-  original error, keep serving. *Quiet + context-fatal* (sticky errors such as
-  an illegal memory access): the CUDA context is dead — no engine can write
-  the destination anymore, so reporting the error is safe — and the reactor
-  **fail-stops**. *Unprovable* (the device-wide sync also failed with a
-  non-sticky code, or could not run): the worker calls a **non-returning
-  process-fatal hook** — log the verdict, then terminate the process. The
-  chunk never completes, so the future never resolves and the caller can never
-  free a destination that may still be written; no arena teardown runs either,
-  so nothing the copy engine might touch is deregistered or freed. Termination
-  is what makes "never resolved" executable — the completion framework
-  resolves a future when its last chunk reference is released, so any design
-  that keeps the process alive must either release (unsafe) or hold the
-  reference forever (a wedged process a watchdog kills anyway). This also
-  matches CUDA's own contract for a corrupted process: terminate and restart.
-- **Fail-stop** happens exactly once. New reads fail fast, naming the first
-  fatal error. Queued chunks are completed with that error. Chunks already in
-  flight finish on their own workers — never resolved on another worker's
-  behalf — for provable outcomes; an unprovable verdict terminates the process
-  instead. And any arena that cannot be proven quiet at teardown is
-  deliberately **leaked rather than freed**: freeing memory a NIC or copy
-  engine might still write is the very use-after-free this discipline exists
-  to prevent.
-- A sticky CUDA error is a **process-level** event: continuing CUDA work just
-  returns the same error. Fail-stop is containment; process restart is the
-  recovery.
+- The verdict is three-way, and both non-recoverable verdicts end in a
+  **non-returning process-fatal hook** (log, then terminate the process; if
+  the hook ever returns, the call site calls `std::terminate`):
+  - *Quiet + healthy*: release the slot, report the original error, keep
+    serving.
+  - *Quiet + context-fatal* (sticky errors such as an illegal memory access):
+    the CUDA context is dead — no engine can write the destination anymore —
+    so the error is reported and logged first, **then the hook fires**.
+    Termination here is CUDA's own contract: a sticky error leaves the process
+    state corrupted, and the documented requirement is to terminate and
+    relaunch. "Restart is the recovery" thereby has an actor.
+  - *Unprovable* (the device-wide sync also failed with a non-sticky code, or
+    could not run): the hook fires **without resolving anything**. The chunk
+    never completes, so the future never resolves and the caller can never
+    free a destination that may still be written; no arena teardown runs
+    either. Termination here is Sirius's use-after-free policy rather than a
+    CUDA requirement: the completion framework resolves a future when its last
+    chunk reference is released, so a design that keeps the process alive must
+    either release (unsafe) or hold the reference forever (a wedged process a
+    watchdog kills anyway).
+- **Reactor fail-stop** is the containment shape for failures that do *not*
+  corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
+  retry contract (appendix). It happens exactly once: new reads fail fast,
+  naming the first fatal error; queued chunks are completed with that error;
+  chunks already in flight finish on their own workers — never resolved on
+  another worker's behalf; and any arena that cannot be proven quiet at
+  teardown is deliberately **leaked rather than freed**, because freeing
+  memory a NIC might still write is the very use-after-free this discipline
+  exists to prevent. The process stays alive, but RDMA service on this
+  context resumes only with a process restart.
 
 Every CUDA call on this delivery path goes through a small seam injected at
-construction time, so all of the failure branches above are fault-injectable in
-ordinary tests without faking CUDA semantics.
+construction time, so the recoverable branches are fault-injectable in
+ordinary tests without faking CUDA semantics. The process-fatal branches are
+different: an in-process test double that returns or throws would exercise
+exactly the stack unwinding production forbids, so the hook is validated by
+**death tests** — a child process asserting the exit code, the fatal log, and
+the absence of normal teardown.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
 | D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client, and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
+| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. The authorizer extension must be additive (a new overload with a defaulted parameter) so existing and downstream custom authorizers keep compiling | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. Compatibility: the existing pure-virtual `authorize()` stays untouched; the headers-to-sign travel through a **new, separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`) whose default implementation rejects non-empty header sets as unsupported, and which the built-in SigV4 header signer overrides — a defaulted parameter on the existing virtual would break every override, and a same-name overload would make existing three-argument calls ambiguous | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -274,7 +288,9 @@ as the plan that closes the gap between the current tree and this design.
    NONE platform that cannot flush must fail RDMA init loudly (no safe
    configuration exists). What still needs the rig: wiring the policy **per
    device** and the decode-immediately-after-GET stress test — still the top
-   correctness gate for P3. Who owns that rig time?
+   correctness gate for P3. Who owns that rig time? (This ruling covers v1's
+   single RDMA path; a future multi-NIC sharding must revisit NVIDIA's
+   multi-ordering-domain exceptions.)
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
@@ -292,11 +308,15 @@ as the plan that closes the gap between the current tree and this design.
    same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
    vs the validated 1.0.0) and shapes the client-wrapper API; it must be
    decided on the rig, before activation.
-7. **Ambiguous-failure fencing** — after a control-plane timeout or reset, the
-   gateway may still hold a descriptor for the slot and keep writing it; the
-   protocol defines what a success response means, but not what silence means.
-   Does the cuObject SDK or the gateway offer a fencing / cancellation
-   primitive (deregister-and-confirm, descriptor revocation)? Without one, the
+7. **Ambiguous-failure fencing and duplicate suppression** — after a
+   control-plane timeout or reset, the gateway may still hold a descriptor for
+   the slot and keep writing it; the protocol defines what a success response
+   means, but not what silence means — and a transparently retried duplicate
+   can succeed while the original is still writing (see the deployment
+   invariants in the appendix), which no client-side rule can detect. Does the
+   cuObject SDK or the gateway offer a fencing / cancellation primitive
+   (deregister-and-confirm, descriptor revocation)? Is a descriptor token
+   single-use at the gateway? Without one, the
    retry contract (appendix) must fail-stop the reactor and mark the entire
    arena non-freeable on any ambiguous failure (per-slot quarantine was
    rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
@@ -355,7 +375,7 @@ its consumer. Two sizing knobs accompany it:
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
 s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
-s3_rdma_queue_cap                 # per-ioctx admission bound, in CHUNKS (default 4 x max_inflight)
+s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
 ```
 
 **Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
@@ -368,17 +388,20 @@ granularity is the arena slot size, and the server chunks independently.
 Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
 for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
 
-**Admission bound (v1):** the reactor's request queue is **capped per ioctx**
-(`s3_rdma_queue_cap`, counted in chunks). Admission blocks once the cap is
-reached, and — because the async read API enqueues synchronously — that blocks
-the submitting thread; this is the accepted v1 API semantics, and a
-deadlock-freedom test (a producer blocked at the cap while workers drain, and
-while the reactor fail-stops) is part of the rollout matrix. A read larger
-than the cap admits in waves as workers drain. Order is FIFO. Fail-stop and
-shutdown wake every blocked producer, which then observes the failure/shutdown
-error. Queue depth-peak and queue-wait counters expose the pressure. The
-process-wide budget is contexts × workers — a deployment running several
-Sirius contexts must size the gateway budget for the sum.
+**Admission bound (v1):** the reactor's queue holds **request envelopes**,
+bounded per ioctx (`s3_rdma_queue_cap`, counted in requests). A submitter
+enqueues one envelope — a small descriptor, not the chunk list — and returns
+immediately; workers generate and claim chunks lazily from the head envelopes,
+FIFO. Per-chunk admission was rejected: with a chunk-counted cap, a read
+larger than the cap would block the submitting thread until most of its own
+transfer had completed, making the async API effectively synchronous. Only a
+full envelope queue blocks a submitter (the bound is on outstanding requests,
+which the scan layer already limits); fail-stop and shutdown wake any blocked
+submitter, which then observes the failure/shutdown error — a
+deadlock-freedom test covers both. Envelope-queue depth-peak and wait counters
+expose the pressure. The process-wide budget is contexts × workers — a
+deployment running several Sirius contexts must size the gateway budget for
+the sum.
 
 **Retry contract** — deliberately independent of the REST policy, and split by
 plane, because the two planes fail differently:
@@ -407,6 +430,25 @@ plane, because the two planes fail differently:
   (§5 Q7) is what would permit a less drastic recovery.
 - Everywhere: CUDA work never retries; exhaustion surfaces the last error —
   and per D6, never a transport switch.
+
+**Deployment invariants (v1, required for the RDMA plane).** The commit-state
+contract above covers failures the *client sees*. A transparent intermediary
+can break it invisibly: a proxy forwards request A (the gateway starts
+writing), the upstream connection drops, the proxy silently retries as
+request B, B succeeds and returns 200 — the client completes the read, reuses
+the slot, and only then does A's late write land. The client saw only success,
+so no fail-stop triggers. v1 therefore requires one of:
+
+- **No automatic intermediary retries** of token-bearing GETs anywhere on the
+  path (the recommended deployment: client connects to the gateway directly,
+  or every proxy in between has retries disabled for these requests); or
+- **Gateway-side exactly-once dedup** keyed on the signed token / a signed
+  request id, so a duplicated request never starts a second RDMA write.
+
+Related requirements: confirm with NVIDIA whether a descriptor token is
+single-use at the gateway (Q7); the control plane runs over TLS; tokens are
+redacted from request logs; and replayed tokens outside the dedup window are
+rejected.
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -1,10 +1,10 @@
 # S3 RDMA Transport for Sirius — V1 Design
 
-Date: 2026-07-17. Author: Sirius Contributors. Benchmark:
+Date: 2026-07-20. Author: Sirius Contributors. Benchmark:
 <https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET
 on CX-6 RoCE).
 
-## 1. Summary and Scope
+## 1. Summary
 
 - V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
   reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
@@ -28,23 +28,7 @@ on CX-6 RoCE).
 - The prefetch cache is off on the RDMA path in V1. Whether V1 grows a cache
   is decided from the benchmark results, not up front.
 
-### Decisions Requested
-
-| Decision | Proposed V1 position | Question for the team |
-|---|---|---|
-| GPU destination | RDMA lands in a registered arena, followed by D2D into caller-owned RMM | Is the extra GPU-local copy acceptable, rather than registering arbitrary RMM allocations? |
-| Endpoint topology | Existing S3 endpoint for control/metadata; dedicated direct-connect gateway for RDMA data | Is split deployment, with the publisher visibility barrier, acceptable? |
-| Failure policy | Token-bearing GETs are one-shot; uncertain completion causes reactor fail-stop and process restart | Is restart-based recovery acceptable for V1 — no fallback after an RDMA request is selected or fails? |
-| CUDA boundary | After `cudaMemcpyAsync`, anything except a successful event wait is process-fatal | When delivery cannot be proven, is terminating the process and never freeing the arena acceptable? |
-| Concurrency model | Bounded request envelopes and one RDMA session per worker | Is this resource model right? (Registration layout is a preflight result.) |
-| Evaluation gate | A hardware correctness gate, then: objects ≥16 MiB must reach 85% of RDMA link rate, small objects (128 KiB–4 MiB) are measured RDMA-vs-HTTP as a required output, and reliability requires a zero-failure 100M-GET soak | Are these the right GO/STOP criteria? (The small-object routing threshold is a follow-up decision, not set in this PR.) |
-
-Registration scope, reply-tag constants, and GPU write-ordering behavior
-are preflight measurements, not design votes. Worker count, chunk size,
-and slot layout are implementation choices within the proposed V1
-contract.
-
-### Scope
+## 2. Scope and Non-Goals
 
 | Supported in v1 | Not in v1 |
 |---|---|
@@ -52,13 +36,13 @@ contract.
 | Split endpoints: host plane + RDMA data plane | Single-endpoint deployment (later option) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
-| One-shot device reads | Automatic RDMA retry (one narrowly-proven retry exists only as a pre-approved response to a soak failure, Section 3) |
+| One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
 | Restart-based recovery | Hot recovery of a failed transport context |
 
-Footer and metadata reads use plain HEAD and range GET on the host plane;
-footer caching and known-size open are out of scope.
+Footer caching and known-size open are also out of scope; footer and
+metadata reads are plain HEAD and range GET on the host plane.
 
-## 2. Architecture and Read Path
+## 3. Architecture and Ownership
 
 ```mermaid
 flowchart LR
@@ -77,32 +61,30 @@ flowchart LR
   gw --- store
 ```
 
-The host plane (`s3_endpoint`) is any S3 service and carries HEAD, footer,
-and range GETs with standard SigV4 signing; it retains the existing S3
-surface. The data plane (`s3_rdma_endpoint`) is a cuObject gateway reached
-by direct connection, limited to token-bearing GETs and the publisher HEAD
-used by the visibility barrier below. Both endpoints front the same
-backing store and the same bucket namespace.
+The host plane (`s3_endpoint`) is any S3 service, speaking standard
+SigV4 HEAD, footer, and range GETs. The data plane (`s3_rdma_endpoint`)
+is a direct-connect cuObject gateway carrying token-bearing GETs plus the
+publisher HEAD of the visibility barrier below; both front the same
+backing store and bucket namespace.
 
-The ioctx owns the reactor, the reactor owns the worker pool, and each
-worker owns its own RDMA session — a shared session across workers is not
-an option. How registration binds to sessions, and therefore the exact
-arena slot layout, is settled at preflight (Section 5). The RMM
-destination belongs to the caller and is never registered with the NIC.
+The ioctx owns the reactor, the reactor the worker pool, and each worker
+its own RDMA session; sessions are not shared. Registration-to-session
+binding — and with it the arena slot layout — is a preflight result
+(Section 7). The caller's RMM destination is not registered with the NIC.
 
-The request queue holds envelopes rather than chunks: a submitter enqueues
-one small descriptor and returns, workers expand it into chunks lazily,
-and admission blocks only at the per-ioctx bound. A per-chunk bound was
-rejected because a read larger than the bound would block its submitter
-until most of its own transfer had completed.
+The request queue holds envelopes, not chunks: a submitter enqueues one
+descriptor and returns, workers expand chunks lazily, and admission
+blocks only at the per-ioctx bound — a per-chunk bound would block a
+large read's submitter on its own transfer.
 
-Consistency between the two endpoints rests on two deployment rules. Keys
-are append-only and immutable: an object, once published, is never
-overwritten or deleted while readable. Before a key becomes queryable, the
+Two deployment rules keep the endpoints consistent. Keys are append-only
+and immutable while readable. Before a key becomes queryable, the
 publisher completes a visibility barrier: HEAD succeeds at both endpoints
-with matching sizes, and content identity is confirmed by a trusted ETag or
-by the full object hash from the publishing manifest. The query path
-itself never sends HEAD to the gateway.
+with matching sizes, and content identity is confirmed by a trusted ETag
+or the publishing manifest's object hash. The query path does not send
+HEAD to the gateway.
+
+## 4. Read Lifecycle
 
 ```mermaid
 sequenceDiagram
@@ -129,163 +111,134 @@ sequenceDiagram
   W-->>S: the request future resolves after all chunks complete
 ```
 
-Object sizes come from HEAD on the host plane; when that HEAD is issued
-relative to open is an implementation choice. The stream capture check
-runs before the GET is issued, in release builds as well as debug builds,
-so a request that cannot be delivered makes no remote write.
+Object sizes come from a host-plane HEAD (its timing relative to open is
+an implementation choice). The stream capture check runs before the GET —
+in release builds too — so an undeliverable request makes no remote
+write.
 
-Exact completion has three legs, all required before a chunk may proceed
-to delivery: a valid reply tag, a successful HTTP status, and a byte count
-that equals the requested size. The concrete accepted values are recorded
-at preflight and used unchanged by every later test.
+A chunk proceeds to delivery on exact completion — valid reply tag,
+successful HTTP status, and a byte count equal to the request — with the
+accepted values recorded at preflight and reused unchanged.
 
-The request future is a fan-in over all chunks: successful resolution
-occurs only after every chunk completes, any chunk error that is not
-process-fatal resolves the request as an error, and a partial result is
-never reported as success.
+Flush policy follows the GPU's RDMA write-ordering attribute, read once
+at initialization: `OWNER` and `ALL_DEVICES` need no flush; `NONE` takes
+one flush after each exact completion, before that chunk's copy; an
+unknown attribute, or `NONE` without a working flush mechanism, fails
+RDMA initialization.
 
-Flush policy follows the GPU's RDMA write-ordering attribute, read once at
-initialization: `OWNER` and `ALL_DEVICES` require no flush; `NONE` requires
-one flush after each exact completion, before that chunk's copy; an unknown
-attribute value, or `NONE` without a working flush mechanism, fails RDMA
-initialization.
+The request future succeeds only after every chunk completes; a chunk
+error that is not process-fatal resolves it as an error, and no partial
+result is reported as success. Callers use the future to decide whether
+the destination is valid.
 
-## 3. Safety Contract
+## 5. Safety and Failure Semantics
 
-The boundary of the delivery contract is the first `cudaMemcpyAsync` call
-for a chunk. Before that call no copy is in flight: a failure that is not
-a sticky CUDA error can be reported and released safely, while a sticky
-error terminates the process even before the boundary. After the call, the
-only completing return is an event wait that reports `cudaSuccess`;
-everything else is treated as an unprovable delivery state. The set of
-sticky CUDA error codes is fixed from the documented CUDA error
-classification and reviewed against the existing classifier in the tree —
-never inferred from rig observation.
+The delivery contract turns on the first `cudaMemcpyAsync` call for a
+chunk. Before it no copy is in flight, so a non-sticky failure reports
+and releases the slot safely; a sticky CUDA error terminates the process
+at any point (the sticky set is CUDA's documented
+classification, checked against the tree's classifier). After the call, only an
+event wait reporting `cudaSuccess` proves the copy has stopped writing,
+so every other outcome is process-fatal. The exception is an
+event-destroy failure after a successful wait: logged, and the success
+stands.
 
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
 | Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
 | Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
-| Sticky CUDA error, or any failure after the copy is enqueued (one exception below) | Process-fatal termination | Not resolved | Never freed |
+| Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
-One narrow exception: an event-destroy failure after a successful wait is
-logged and leaves the successful outcome unchanged.
+A non-exact or unknown RDMA outcome fail-stops the transport: the client
+cannot prove the gateway has stopped writing, so the whole arena becomes
+non-freeable and recovery is a process restart. Shutdown is two-phase — a
+terminal mark that refuses new work, then completion when the last
+in-flight permit releases — so a failing worker never waits on itself.
+Both planes close behind one shared admission gate and surface one
+terminal error: an operation already past its side-effect point (a
+control call started, a transfer issued) completes; queued envelopes and
+their ungenerated chunks error-complete; work claimed but not issued
+aborts and releases its slot; blocked submitters wake.
 
-1. Transport shutdown after a fail-stop is two-phase: a non-blocking
-   terminal mark that immediately refuses new work, and a completion point
-   reached when the last in-flight operation releases its permit, so a
-   failing worker can initiate shutdown without waiting on itself.
-2. After a fail-stop the whole transport context is closed: host-plane and
-   device-plane operations alike are refused through one shared admission
-   gate and surface the same terminal error. Only an operation whose side
-   effect is already in flight — a control call started, a transfer
-   issued — completes that one operation. Everything else is cut off:
-   queued envelopes and the chunks not yet generated from them complete
-   with an error, work claimed but not yet issued is aborted with its slot
-   released, and submitters blocked at the queue bound wake with the
-   terminal error. Recovery is a process restart.
-3. Destination contents are unspecified after any failed read: earlier
-   chunks may already have landed in the caller's buffer, and the
-   error-resolved future is the only authority a caller may consult.
-4. Token-bearing GETs are not retried, hedged, mirrored, cached, or
-   coalesced anywhere between client and gateway; the dedicated
-   direct-connect endpoint enforces this structurally on the path, and a
-   gateway conformance check verifies that the gateway itself performs no
-   internal retry, caching, or coalescing. After a failed soak, a single
-   retry may be enabled only when the client can prove that the request
-   was never issued to the gateway, followed by a full soak re-run from
-   zero.
-5. Normal teardown releases the arena only behind a strict barrier:
-   admission is stopped, no further GETs will be issued, every issued
-   transfer has completed exactly, every enqueued copy is confirmed, and
-   all workers have stopped and joined. After a fail-stop or a
-   process-fatal failure this barrier is never reached: those arenas are
-   never freed while the process lives.
+Destination contents are unspecified after any failed read: earlier
+chunks may already have landed in the caller's buffer.
 
-## 4. Configuration and Security
+Token-bearing GETs are one-shot, and the gateway must not retry, hedge,
+mirror, cache, or coalesce them: a replay can reuse an RDMA descriptor
+after its slot has been reassigned. The direct-connect endpoint enforces
+this on the path, and a gateway conformance check verifies it. The only
+exception is the soak-failure retry of Section 7, for requests provably
+never issued to the gateway.
+
+Normal teardown frees the arena only behind a drain barrier: admission
+stopped, every issued transfer exactly complete, every enqueued copy
+confirmed, all workers joined. After a fail-stop or a process-fatal
+failure the barrier is unreachable, and the arena stays allocated for the
+life of the process.
+
+## 6. Configuration and Security
 
 | Key | Meaning | Default |
 |---|---|---|
 | `s3_transport` | `HTTP` or `RDMA`; explicit opt-in | `HTTP` |
 | `s3_endpoint` | Host plane: any S3 service | existing setting |
-| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails with an explicit error when unset | none |
+| `s3_rdma_endpoint` | Data plane: cuObject gateway; required in RDMA mode — initialization fails when unset | none |
 | `s3_rdma_queue_cap` | Per-ioctx bound on pending request envelopes | not yet defined — set when the bounded queue lands |
 | `SIRIUS_ENABLE_S3_RDMA` | Build flag for the cuObject data plane | off |
 
 This phase adds no new tuning surface: worker count and arena slot size
-keep their existing settings. Reads are one-shot, so the retry counter
-must read zero; any nonzero value is treated as a defect.
+keep their settings. Reads are one-shot, so the retry counter
+must read zero; a nonzero value is a defect.
 
-Signing is configured per endpoint. The data endpoint requires
-header-signing: the RDMA descriptor token and the `Range` header travel
-inside the SigV4 signature, and a presigned-mode authorizer on the data
-plane fails initialization. The host endpoint keeps its own configured
-signing mode. Descriptor tokens are redacted from logs and traces in every
-profile.
+Signing is per endpoint. The data endpoint requires header-signing (the
+descriptor token and `Range` header travel inside the SigV4 signature)
+and rejects a presigned-mode authorizer at initialization; the host
+endpoint keeps its configured mode. Descriptor tokens are redacted from
+logs and traces in every profile.
 
-The fault-injection hooks used by the validation gates exist only in test
-builds: release artifacts contain none, a production-mode start refuses to
-run when hooks are enabled, and hooks cannot be activated through request
-headers.
+Fault-injection hooks exist only in test builds: release artifacts
+contain none, a production-mode start refuses to run with hooks enabled,
+and hooks cannot be reached through request headers.
 
-The rig profile for this phase may run an unsigned gateway and a non-TLS
-control plane, but must not use production data or production credentials
-and must not be exposed to an uncontrolled network. Gateway-side SigV4
-verification, end-to-end TLS, authorization, replay and token hardening,
-and a signed-profile qualification form a production-qualification gate
-that applies after a GO decision; enabling the production profile requires
-re-running correctness, performance, and soak in full, because unsigned
-rig results do not extrapolate to the signed path.
+The rig may run an unsigned gateway and a non-TLS control plane, but not
+with production data or credentials, and not on an uncontrolled network.
+Gateway-side SigV4 verification, end-to-end TLS, authorization, replay
+and token hardening, and signed-profile qualification form the post-GO
+production gate (Section 7); unsigned rig results do not extrapolate to
+the signed path.
 
-## 5. Validation and Rollout
+## 7. Validation and GO/STOP
 
-Validation runs in three stages on the rig, each gating the next, followed
-by the post-GO production gate. Throughout this section, a **clean run**
-means correct payload checksums and no fail-stops, process-fatal exits, or
-short, missing, or wrong completions.
+Validation runs in three stages on the rig, each gating the next, then
+the post-GO production gate. Throughout this section, a **clean run**
+means correct payload checksums and no fail-stops, process-fatal exits,
+or short, missing, or wrong completions.
 
 | Gate | What runs | Pass condition |
 |---|---|---|
-| Preflight | Rig probes for registration/session shape, the completion constants (accepted HTTP status set, reply-tag value and parse rule, byte count on failed responses), and the GPU write-ordering attribute with flush availability | Results are recorded once and used unchanged by every later test; one arena layout is selected — if none works, the phase stops here |
-| Hardware correctness | Checksum stress at full worker count with one session per worker; slot-reuse churn; flush counting; decode stress on the copy stream; fault injection: missing, wrong, and short replies, an ambiguous transport fault, and a session result with a valid reply tag, `n == expected`, and a non-success HTTP status | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in the outcome Section 3 assigns it, and no failed read is reported as a partial success |
-| Performance | Sustained reads at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB, and 1 GiB; the three small sizes also run the HTTP path for comparison | Each size of 16 MiB or more reaches the 85% bound (85 Gbps on the current 100 Gbps rig); the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run; no Sirius-side host staging or H2D on any RDMA run |
-| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, and there are zero unexpected runner restarts |
-| Production (post-GO) | Gateway-side SigV4 verification, end-to-end TLS, authorization, replay and token hardening, signed-profile qualification | Full correctness, performance, and soak re-run on the signed profile |
+| Preflight | Probes for the registration/session shape, completion constants, and write-ordering attribute with flush availability (Appendix A) | Constants recorded once, reused unchanged by every later test; one arena layout selected, or the phase stops here |
+| Hardware correctness | The correctness workload and fault matrix of Appendix A | Checksums correct; flush counts match the ordering attribute; no Sirius-side host staging or H2D; every injected fault ends in its Section 5 outcome, and no failed read is reported as a partial success |
+| Performance | Sustained reads at six object sizes from 128 KiB to 1 GiB; the three small sizes also run HTTP for comparison (procedure: Appendix A) | Sizes of 16 MiB and above reach the 85% bound; the small-size comparison is reported and settles the fallback question of Section 1; every size is a clean run with no host staging or H2D |
+| Reliability | 100 million 4 MiB token-bearing GETs with varied payload patterns | Every GET is a clean run, with zero unexpected runner restarts |
+| Production (post-GO) | The signed/TLS/security profile of Section 6 | Full correctness, performance, and soak re-run on the signed profile |
 
-Performance runs use one configuration frozen after preflight — worker,
-chunk, slot, and arena settings held constant with no per-size tuning —
-against a warm server cache. Object size and RDMA chunk size are distinct:
-transfers keep normal Sirius chunking rather than forcing one RDMA request
-per object. Each size sustains repeated reads for at least ten seconds per
-trial, with two warm-ups and at least seven measured trials. Throughput is
-measured from device-read submission through delivery into the
-caller-owned RMM buffer — queueing, RDMA, required flushes, D2D copies,
-and request completion — excluding one-time initialization, arena
-registration, object HEAD, and warm-up. A large size passes when the
-one-sided 95% Student-t lower confidence bound of the arithmetic mean of
-its measured per-trial throughputs reaches 85% of the link rate; the same
-statistic is computed for both arms at the small sizes. HTTP results never
-determine GO or STOP. The 85% floor is grounded in measurement: the
-standalone benchmark sustains roughly 91 Gbps on the same class of
-hardware.
-
-If the soak fails and the client can prove that the failing request was
-never issued to the gateway, the single pre-approved retry of Section 3
-may be enabled and the full soak re-run from zero; the re-run's outcome
-then decides GO or STOP under the same criteria. A STOP follows when the
-re-run fails, when the failing request cannot be proven never-issued, or
-when any other gate fails; the stop action is to restart the process and
-return to `s3_transport=HTTP`, and the build flag remains off by default
+A failed soak has one recovery path: when the client can prove the
+failing request was never issued, the Section 5 retry may be enabled and
+the full soak re-run from zero, the re-run deciding GO or STOP under the
+same criteria. Otherwise — the re-run fails, the proof cannot be made, or
+any other gate fails — the decision is STOP: restart the process and
+return to `s3_transport=HTTP`. The build flag stays off by default
 throughout.
 
-## 6. Current Status and Risks
+## 8. Current Status and Remaining Work
 
-The transport machinery in the tree is dormant. Five gaps separate it from
-the v1 target, closed in this order before the rig gates run:
+The transport machinery in the tree is dormant; the real cuObject
+transfer has not run yet, and the rig gates above will be its first
+exercise. Five gaps close, in order, before the gates run:
 
-1. Factory wiring — the production factory does not yet construct the
-   control client, so reads cannot route through the normal path.
+1. Factory wiring — the factory does not yet construct the control
+   client; reads cannot route through the normal path.
 2. Endpoint pair — configuration has a single endpoint today.
 3. Envelope admission — chunk admission is eager rather than
    envelope-bounded.
@@ -297,8 +250,64 @@ the v1 target, closed in this order before the rig gates run:
 
 | Risk | Nature |
 |---|---|
-| SDK registration scope | If registration is bound to a session in a way none of the planned arena layouts can absorb, the phase stops at preflight |
+| SDK registration scope | If no planned arena layout can absorb the SDK's registration-to-session binding, the phase stops at preflight |
 | Gateway dependency | The data plane requires a controlled cuObject gateway; the evaluation cannot run against plain S3 |
 | GPU/NIC topology | PCIe placement across root complexes can halve bandwidth and would surface at the hardware gate |
-| No-retry reliability | With one-shot reads, a transient-fault rate above roughly one in twenty-five million GETs would fail the soak for a terabyte-scale workload; the soak measures this before any retry mechanism is considered |
-| Copy-cost estimate | The pre-copy staging window and per-chunk D2D cost are estimates until the hardware gate measures them; the copy is expected to be small relative to wire time at 100 Gbps |
+| No-retry reliability | One-shot reads fail the soak at a transient-fault rate above roughly one in twenty-five million GETs; the soak measures this before any retry is considered |
+| Copy-cost estimate | Pre-copy staging and per-chunk D2D cost are estimates until the hardware gate measures them; the copy should be small against wire time at 100 Gbps |
+
+## 9. Decisions Requested
+
+The positions are the ones this document describes; the team is asked:
+
+1. GPU destination (Section 3): is the extra GPU-local copy acceptable,
+   rather than registering arbitrary RMM allocations?
+2. Endpoint topology (Section 3): is split deployment, with the publisher
+   visibility barrier, acceptable?
+3. Failure policy (Section 5): is restart-based recovery acceptable for
+   V1 — no fallback after an RDMA request is selected or fails?
+4. CUDA boundary (Section 5): when delivery cannot be proven, is
+   terminating the process and never freeing the arena acceptable?
+5. Concurrency model (Sections 3 and 6): is the envelope bound with one
+   RDMA session per worker the right resource model? (Registration layout
+   is a preflight result.)
+6. Evaluation gate (Section 7): are these the right GO/STOP criteria?
+   (The small-object routing threshold is a follow-up decision, not set
+   in this PR.)
+
+Registration scope, reply-tag constants, and GPU write-ordering behavior
+are preflight measurements, not design votes. Worker count, chunk size,
+and slot layout are implementation choices within the proposed V1
+contract.
+
+## Appendix A. Qualification Procedure
+
+Preflight records, once, the constants every later test reuses
+unchanged: the registration/session shape and the arena layout it
+permits, the accepted HTTP status set, the reply-tag value and parse
+rule, the byte count reported on failed responses, and the GPU
+write-ordering attribute with flush availability.
+
+The hardware-correctness stage runs checksum stress at full worker count
+with one session per worker, slot-reuse churn, flush counting, and decode
+stress on the copy stream. Its fault matrix injects missing, wrong, and
+short replies; an ambiguous transport fault; and a session result with a
+valid reply tag, `n == expected`, and a non-success HTTP status.
+
+Performance runs use one configuration frozen after preflight — worker,
+chunk, slot, and arena settings held constant, no per-size tuning —
+against a warm server cache, at 128 KiB, 1 MiB, 4 MiB, 16 MiB, 128 MiB,
+and 1 GiB. Object size and RDMA chunk size are distinct: transfers keep
+normal Sirius chunking rather than forcing one RDMA request per object.
+Each size sustains repeated reads for at least
+ten seconds per trial, with two warm-ups and at least seven measured
+trials. Throughput is measured from device-read submission through
+delivery into the caller-owned RMM buffer — queueing, RDMA, required
+flushes, D2D copies, and request completion — excluding one-time
+initialization, arena registration, object HEAD, and warm-up. A large
+size passes when the one-sided 95% Student-t lower confidence bound of
+the arithmetic mean of its per-trial throughputs reaches 85% of the link
+rate (85 Gbps on the current 100 Gbps rig); the same statistic is
+computed for both arms at the small sizes. HTTP results are a required
+output but do not determine GO or STOP; the 85% floor is grounded in the
+~91 Gbps standalone-benchmark measurement cited in the header.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -48,6 +48,13 @@ plane** (RDMA) writes object bytes straight into the GPU arena. Versus
 staging for a small GPU arena and the H2D copy for a GPU-local D2D (<1%
 overhead). Host reads (footers / HEAD) still go over HTTP.
 
+The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
+**not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
+stream through the arena in waves, each chunk D2D-copied to its offset in the
+**full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
+through the same ~8–16 MiB arena — exactly how `s3_reactor` streams through its
+host staging blocks today.
+
 ## 2. How one read works
 
 ```mermaid

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -6,11 +6,13 @@ on CX-6 RoCE).
 
 ## 1. Summary
 
-- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for exact-key Parquet
-  reads on one GPU: `read_parquet('s3://bucket/path/file.parquet')` with the
-  complete object key written out, not a glob or a listing. The first target
-  workload, TPC-H benchmarking over lakehouse parquet, references every table
-  by exact key, so glob/LIST support is deferred without loss.
+- V1 adds an opt-in RDMA path (`s3_transport=RDMA`) for Parquet reads on
+  one GPU, by exact key (`read_parquet('s3://bucket/path/file.parquet')`)
+  or by glob (`read_parquet('s3://bucket/path/*.parquet')`). A glob is
+  resolved on the host control plane with ordinary signed S3 requests
+  (HTTP or HTTPS, following the configured host endpoint and its TLS
+  settings); every matched object is then read by its exact key. The
+  data plane never lists; it only ever serves exact-key reads.
 - Payload lands in a pre-registered GPU arena and is copied to caller-owned
   RMM memory on the caller stream, with zero Sirius-side host staging or H2D
   traffic. Metadata and footer reads remain on the existing S3 path.
@@ -32,15 +34,15 @@ on CX-6 RoCE).
 
 | Supported in v1 | Not in v1 |
 |---|---|
-| Exact-key `read_parquet('s3://…')` | Wildcard glob and S3 LIST (explicit error at glob expansion) |
+| Exact-key data reads; wildcard glob and S3 LIST resolved on the host control plane | Merging the two listing HTTP legs into one implementation (the signer, parser, and listing interface are already shared); the per-object footer stash at open (RDMA opens with a plain HEAD); custom LIST caps (RDMA uses the built-in limits for now) |
 | Two logical endpoints — host plane + RDMA data plane; the configured addresses may be identical | A single shared endpoint configuration (no separate data-plane settings) |
 | Fixed per-GPU registered arena | Multi-GPU enablement (structure ships, gate covers one GPU) |
 | Basic byte/request/failure metrics | Full metric parity with the REST backend |
 | One-shot device reads | Automatic RDMA retry (a single pre-approved retry exists as a response to a soak failure, Section 5) |
 | Restart-based recovery | Hot recovery of a failed transport context |
 
-Footer caching and known-size open are also out of scope; footer and
-metadata reads are plain HEAD and range GET on the host plane.
+Known-size open is also out of scope; footer and metadata reads are
+plain HEAD and range GET on the host plane.
 
 ## 3. Architecture and Ownership
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -14,8 +14,10 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`. The benchmark proves this end-to-end at line rate.
-**Please review the decisions table (§3) and the open questions (§5).**
+existing `templated_ioctx`. The benchmark proves the cuObject RDMA data path at
+line rate; the Sirius-specific arena+D2D visibility and completion discipline
+are gated by P3. **Please review the decisions table (§3) and the open
+questions (§5).**
 
 ## Why
 
@@ -52,8 +54,9 @@ The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
 **not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
 stream through the arena in waves, each chunk D2D-copied to its offset in the
 **full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
-through the same ~8–16 MiB arena — exactly how `s3_reactor` streams through its
-host staging blocks today.
+through the same arena (default ~8 MiB, configurable as `max_inflight ×
+slot_size`) — exactly how `s3_reactor` streams through its host staging blocks
+today.
 
 ## 2. How one read works
 
@@ -104,7 +107,8 @@ gated future spike (§5 Q4).
 
 | Phase | Scope | HW |
 |---|---|---|
-| **P0 ✅ landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`). Residual hardening tracked in the appendix | — |
+| **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
+| **P0b ⏳ gateway hardening open** | Strict descriptor-address parse, explicit short-write (`n == expected`) + capacity checks — today the client returns `size` on any 200/206 and the server only fails on `rdma_n < 0` (see appendix) | — |
 | P1 | Wire `s3_transport` through `scan_manager_config`; backend chosen at scan-manager construction; AUTO→HTTP; config tests | — |
 | P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix | — |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test | CX-6 |

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -133,10 +133,10 @@ the destination is valid.
 
 ## 5. Safety and Failure Semantics
 
-The safety model has two irreversible boundaries. Issuing the
-token-bearing GET creates a possible remote writer to the registered
-arena; enqueuing `cudaMemcpyAsync` creates a possible local GPU writer
-to caller-owned RMM memory. A failure is recoverable only when Sirius
+The safety model has two irreversible boundaries. A token-bearing GET
+that may have reached the gateway creates a possible remote writer to
+the registered arena; the first `cudaMemcpyAsync` call creates a
+possible local GPU writer to caller-owned RMM memory. A failure is recoverable only when Sirius
 can prove the relevant writer has stopped: an uncertain RDMA completion
 therefore fail-stops the transport, and an uncertain copy is
 process-fatal.
@@ -155,24 +155,25 @@ and arena lifetime.
 stateDiagram-v2
   [*] --> PreIssue: chunk claimed / slot leased
 
-  PreIssue --> RequestError: local failure before GET
-  PreIssue --> RDMAInFlight: issue one-shot token-bearing GET
+  PreIssue --> RequestError: non-sticky local failure (GET provably not issued)
+  PreIssue --> ProcessFatal: sticky CUDA error
+  PreIssue --> RDMAInFlight: token-bearing GET may have reached the gateway
 
   RDMAInFlight --> TransportFailStop: completion non-exact or unknown
   RDMAInFlight --> ReadyToDeliver: exact completion (tag + status + expected bytes)
 
-  ReadyToDeliver --> RequestError: non-sticky error before D2D
+  ReadyToDeliver --> RequestError: non-sticky failure before the first cudaMemcpyAsync call
   ReadyToDeliver --> ProcessFatal: sticky CUDA error
-  ReadyToDeliver --> CopyInFlight: flush if required, enqueue D2D + event
+  ReadyToDeliver --> CopyInFlight: flush if required, then the first cudaMemcpyAsync call (the boundary)
 
-  CopyInFlight --> Delivered: event wait == cudaSuccess
-  CopyInFlight --> ProcessFatal: any other outcome
+  CopyInFlight --> Delivered: event wait reports cudaSuccess
+  CopyInFlight --> ProcessFatal: any error from memcpy, record, or wait
 
   Delivered --> [*]: chunk complete / slot reusable
   RequestError --> [*]: request marked failed / slot released
 
   note right of TransportFailStop
-    Future resolves with an error.
+    The request future errors after issued work settles.
     The arena remains allocated.
     Recovery requires process restart.
   end note
@@ -184,7 +185,7 @@ stateDiagram-v2
 ```
 
 The sticky set is CUDA's documented classification, checked against the
-tree's classifier. After the D2D is enqueued, only an event wait
+tree's classifier. After the first `cudaMemcpyAsync` call, only an event wait
 reporting `cudaSuccess` proves the copy has stopped writing; an
 event-destroy failure after that successful wait is logged and does not
 change the delivery outcome.
@@ -192,9 +193,9 @@ change the delivery outcome.
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
 | Exact RDMA completion and confirmed D2D | Complete; resolve after all chunks | Success | Slot reusable |
-| Non-sticky error before the copy is enqueued | Report the error; the reactor continues | Error | Slot released |
+| Non-sticky error before the first `cudaMemcpyAsync` call | Report the error; the reactor continues | Error | Slot released |
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
-| Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
+| Sticky CUDA error, or any error at or after the first `cudaMemcpyAsync` call (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
 On entering `TransportFailStop`, the ioctx marks the shared admission
 gate terminal and refuses new work; host- and device-plane operations

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -197,7 +197,7 @@ the absence of normal teardown.
 | D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed** — the authorizer's request surface is extended so headers added for RDMA are part of the SigV4 canonical request, and v1 supports the RDMA control plane in **header-signing mode only** — SigV4 query signing can in principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner signs only `host` today, so RDMA init rejects `s3_signing_mode = presigned`. Compatibility: the existing pure-virtual `authorize()` stays untouched; the headers-to-sign travel through a **new, separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`) whose default implementation rejects non-empty header sets as unsupported, and which the built-in SigV4 header signer overrides — a defaulted parameter on the existing virtual would break every override, and a same-name overload would make existing three-argument calls ambiguous | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
 | **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
 
 Why D9 works, in one picture:
@@ -269,7 +269,7 @@ as the plan that closes the gap between the current tree and this design.
 | **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued (death tests: child process, exit code, no normal teardown), teardown leak, admission deadlock-freedom) | CUDA GPU |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
@@ -365,6 +365,20 @@ server-side (its own config, default 2 MiB) — nothing is negotiated on the wir
 Production gateways SigV4-validate the control request before honoring the
 token, and the token + `Range` are part of that signature (D8): the client
 signs them, the gateway verifies them — an unsigned token is rejected.
+
+### Auth surface extension (D8 mechanics)
+
+The authorizer's request surface is extended so headers added for RDMA are
+part of the SigV4 canonical request. Presigned mode is excluded as a v1
+implementation choice, not a protocol limit: SigV4 query signing can in
+principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner
+signs only `host` today. Compatibility: the existing pure-virtual
+`authorize()` stays untouched; the headers-to-sign travel through a **new,
+separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`)
+whose default implementation rejects non-empty header sets as unsupported,
+and which the built-in SigV4 header signer overrides. A defaulted parameter
+on the existing virtual would break every override, and a same-name overload
+would make existing three-argument calls ambiguous.
 
 ### Config (under `object_store_config`)
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -34,8 +34,9 @@ byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
   SigV4 / `sirius_datasource` semantics; the REST backend stays the
   config-selectable default; no Parquet-scanner changes.
 - **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
-  gateway); no `AUTO` probe and no runtime HTTP fallback (RDMA failure = I/O
-  error); no AWS-CRT dependency.
+  gateway); no `AUTO` probe and no runtime HTTP fallback (failures surface loudly
+  per D6 and the §2 discipline — never a silent transport switch); no AWS-CRT
+  dependency.
 
 ## 1. Architecture
 
@@ -170,9 +171,10 @@ slot is recycled nor the future resolved until the stream is proven quiet.**
 - **Reactor fail-stop** is the containment shape for failures that do *not*
   corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
   retry contract (appendix). It happens exactly once: new reads fail fast,
-  naming the first fatal error; queued chunks are completed with that error;
-  chunks already in flight finish on their own workers — never resolved on
-  another worker's behalf; and any arena that cannot be proven quiet at
+  naming the first fail-stop error; queued envelopes — and the un-generated
+  chunks of partially-consumed ones — are error-completed with it; chunks
+  already in flight finish on their own workers — never resolved on another
+  worker's behalf; and any arena that cannot be proven quiet at
   teardown is deliberately **leaked rather than freed**, because freeing
   memory a NIC might still write is the very use-after-free this discipline
   exists to prevent. The process stays alive, but RDMA service on this
@@ -194,7 +196,7 @@ the absence of normal teardown.
 | D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
 | **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level, so the reactor contains it and defers recovery to a process restart |
+| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level: per §2 the process-fatal hook terminates the process (restart is the recovery); the reactor's fail-stop contains only non-corrupting failures (the ambiguous RDMA outcome) |
 | D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
 | D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
 | D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
@@ -296,8 +298,8 @@ as the plan that closes the gap between the current tree and this design.
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
    registrable allocation path for IO buffers? It unlocks direct-into-RMM
    (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
-   perf instrumentation was re-added for the REST reactor in #1042; the RDMA
+5. **Metrics** — counter set + naming vs the existing S3 counters. Note the REST reactor's
+   perf instrumentation was re-added in #1042; the RDMA
    counters should follow that shape rather than invent a parallel one (see
    the appendix for the proposed set, including the delivery-safety counters).
 6. **Session ownership** — the cuObject SDK documents no whole-client
@@ -328,10 +330,11 @@ as the plan that closes the gap between the current tree and this design.
   now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
   exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
   test.
-- **Fatal CUDA errors are process-level.** The reactor's fail-stop (§2)
-  contains one — it does not recover it. Operators should treat a delivery
-  fatal as "restart required", and the surrounding system must not assume
-  other GPU work on that context keeps functioning.
+- **Fatal CUDA errors are process-level.** The §2 process-fatal hook
+  terminates the process — supervisor restart is the recovery, so operators
+  need a relaunch policy. The reactor's fail-stop contains only the
+  non-corrupting ambiguous-RDMA case: there the process stays alive, but RDMA
+  service on the context requires a restart.
 - Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
   Sirius context (not × GPUs or × queries) — and a process running several
@@ -469,7 +472,7 @@ Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
 `…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
-runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
+runs), `…_fail_stop_total` (reactor fail-stop transitions — the ambiguous-RDMA containment; the process-terminating verdicts leave a fatal log line and an exit code, not a scrapeable counter), `…_arena_leak_total`
 (arenas leaked at teardown because a writer — device stream or remote gateway
 — could not be proven quiet).
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -2,43 +2,36 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review — updated for the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev`. Revised 2026-07-15: delivery-failure semantics defined; reactor-state, visibility-policy, and session-model sections expanded |
+| **Status** | Draft for team review — target architecture, no production code in this PR. Restructured 2026-07-15: the body supports the review decisions; implementation detail lives in the appendix |
 | **Date** | 2026-07-15 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
-## TL;DR
+## 1. Summary
 
-Read large Parquet column data from S3 **straight into GPU memory over RDMA**,
-removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
-`RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
-moves it to the final RMM buffer. `s3://` URIs, the SigV4 credential machinery,
-and the Parquet scanner are unchanged — the new code is one reactor plus a thin
-ioctx under the existing `templated_ioctx`, the same way the REST backend is
-built. (One auth-surface extension is required: the RDMA token and `Range`
-must be **inside** the SigV4 signature — D8.) The
-benchmark already proves the cuObject RDMA data path at line rate. What remains
-Sirius-specific is the arena+D2D **visibility discipline**, validated in
-rollout phase P3 (§4). And a strict **delivery-failure discipline** (§2)
-is designed so that no buffer is recycled or handed back while a copy might
-still touch it. **Please review the decisions table (§3) and the open
-questions (§5).**
+**Problem.** Sirius reads S3 Parquet through the REST backend: libcurl range
+GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU. Every
+byte crosses host memory and PCIe twice.
 
-## Why
+**Proposal.** A cuObject gateway `RDMA_WRITE`s object bytes into a small,
+pre-registered GPU **arena**; a GPU-local copy delivers them to the final RMM
+buffer. The pinned-host staging and the PCIe H2D copy disappear.
 
-Sirius reads S3 Parquet today via the REST backend (`rest_ioctx`): libcurl range
-GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU — every
-byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
+**Unchanged.** `s3://` URIs, the SigV4 credential machinery (one surface
+extension — §5), the `sirius_datasource` API, and the Parquet scanner. The
+REST backend remains the default; RDMA is selected per context by the existing
+`s3_transport` config.
 
-- **Goals:** large device reads RDMA-direct into GPU memory; keep `s3://` /
-  SigV4 / `sirius_datasource` semantics; the REST backend stays the
-  config-selectable default; no Parquet-scanner changes.
-- **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
-  gateway); no `AUTO` probe and no runtime HTTP fallback (failures surface loudly
-  per D6 and the §2 discipline — never a silent transport switch); no AWS-CRT
-  dependency.
+**v1 limits.** Requires an RDMA-capable cuObject gateway (plain AWS S3 does
+not apply). Selection is explicit — no `AUTO` probe, no runtime HTTP fallback;
+failures surface per the Safety Contract (§4).
 
-## 1. Architecture
+**Decisions requested.** The team is asked to approve five decisions (§6):
+the landing arena + D2D shape, the CUDA failure policy, the
+duplicate-suppression mechanism and ambiguous-completion policy, the
+request-envelope queue model, and cuObject session ownership.
+
+## 2. Architecture & Read Path
 
 ```mermaid
 flowchart LR
@@ -46,41 +39,44 @@ flowchart LR
   dr --> ic["s3_rdma_ioctx<br/>(templated_ioctx + cuobj_rdma_reactor)"]
   ic -- "control plane: HTTP GET<br/>x-amz-rdma-token (SigV4)" --> gw["cuObject gateway"]
   gw == "data plane: RDMA_WRITE<br/>(GPUDirect)" ==> arena["GPU landing arena<br/>cudaMalloc, registered once"]
-  arena == "GPU-local D2D (~TB/s)" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
+  arena == "GPU-local D2D" ==> rmm["RMM device_buffer<br/>cudaMallocAsync"]
   rmm --> decode["cuDF decode"]
 ```
 
-*(Vocabulary for readers new to the IO framework: an **ioctx** is the
-per-context IO facade the scanner talks to; a **reactor** is the transport
+*(An **ioctx** is the per-context IO facade; a **reactor** is the transport
 engine behind it, defined by which read **builders** it provides.)*
 
-The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
-plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
-backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
-small GPU arena and the H2D copy for a GPU-local D2D (~3 µs per 4 MiB slot,
-estimated from HBM bandwidth — not yet measured on this path; under 1% of the
-transfer at the 100G reference point, a larger share at higher line rates). Host reads
-(footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
-`s3_request_authorizer`.
+On the control plane (HTTP), the descriptor token is the only RDMA-specific
+request header (`Range` travels as usual); the data plane (RDMA) writes object
+bytes straight into the GPU arena. Host reads
+(footers / HEAD) stay on HTTP through the existing SigV4 authorizer. The
+arena is a fixed staging window, not object-sized: a read streams through it
+in slot-sized chunks, each D2D-copied to its offset in the destination buffer
+(copy cost: §7).
 
-The arena is a **fixed per-chunk staging window**, not object-sized: the reactor
-splits a read into slot-sized chunks that stream through the arena in waves, each
-chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 MiB
-(or multi-GB) read flows through the same small arena.
+**Resource model.**
 
-Both sizing knobs are **config** (`s3_rdma_max_inflight`,
-`s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
-device** — comes from the benchmark's CX-6 **100G reference configuration**
-(line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page
-cache and the server's 2 MiB chunking, so other topologies must re-measure).
-Faster NICs scale the same two knobs, not the design: the bytes in flight
-(`workers × slot_size`) must grow with line rate, and the knee has to be
-re-derived empirically on the target NIC (a P4/P5 sweep) — the 100G numbers do
-not transfer. Arena memory cost is exact:
-`workers × slot_size × active GPUs` per Sirius context (32 MiB per device at
-the reference defaults).
+| Resource | Per ioctx | Per process | Per active GPU |
+|---|---|---|---|
+| Reactor | 1 (not an event loop; owns the worker pool and arenas) | 1 × contexts | — |
+| Workers = in-flight `cuObjGet` ceiling | `max_inflight` | `max_inflight` × contexts | — |
+| Arena memory | `max_inflight × slot_size` × active GPUs | sum over contexts | `max_inflight × slot_size` |
+| Request envelopes (queued reads) | ≤ `s3_rdma_queue_cap` | sum over contexts | — |
+| Gateway slot budget required | `max_inflight` | sum over contexts | — |
 
-## 2. How one read works
+Throughput scales with workers; GPU count scales only the arena map (a new
+device lazily gets its own arena; slot and destination are always
+same-device); NIC count is what would eventually justify more reactors
+(deferred sharding, not v1).
+
+**Sizing.** The default — 8 workers × 4 MiB slots = 32 MiB per device — comes
+from the benchmark's CX-6 **100G reference configuration** (line rate at
+8 × 4 MiB; 8 × 1 MiB leaves ~12% idle; measured with warm page cache and
+2 MiB server-side chunking, so other topologies re-measure). Faster NICs scale the two knobs, not the design:
+in-flight bytes (`workers × slot_size`) must grow with line rate, and the knee
+is re-derived on the target NIC (a P4/P5 sweep).
+
+**One read.**
 
 ```mermaid
 sequenceDiagram
@@ -91,405 +87,302 @@ sequenceDiagram
   W->>A: acquire free slot (slot_pool, reused from the framework)
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
-  G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if the platform needs it — §5 Q2)
+  G-->>W: HTTP success (200/206) + valid x-amz-rdma-reply: 200
+  Note over W: flush GPUDirect writes (only if the platform requires it — §6)
   W->>W: create the completion event FIRST
   W->>S: cudaMemcpyAsync slot -> dst (D2D), record the event
-  W->>S: wait on the event inline (~3 µs est. vs the ~350 µs wire time of one slot)
+  W->>S: wait on the event inline
   W->>W: chunk_complete + release slot
   Note over S: the read's future resolves when its last chunk finishes
 ```
 
-`cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound** — and because there is exactly one arena slot per worker, a
-worker always finds a free slot: admission pressure lives in the reactor's
-queue, which holds bounded **request envelopes** — a submitter enqueues one
-small envelope per read and returns; workers generate and claim chunks lazily
-from the head envelopes, so an async read never waits on chunk-level progress
-(see the config appendix). Completion uses the framework's
-`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete` or
-`report_error` exactly once and then releases its manager reference — the
-future resolves when the last chunk does. (One deliberate exception exists:
-the *unprovable* delivery verdict below terminates the process instead of
-completing the chunk — the framework's "resolve on last release" mechanics
-make any softer form of "never resolved" unimplementable. The sticky
-context-fatal verdict also ends in termination, but only after the chunk's
-error is safely reported.) Nothing runs on a CUDA callback
-thread. The worker waits on its own copy **inline**: the D2D is an estimated ~3 µs
-(bandwidth-derived) against the ~350 µs it takes just to serialize a 4 MiB
-slot at ~91 Gbps (a wire-time floor, not a measured single-request latency
-under concurrency), so parking the worker is not expected to improve
-throughput. Two caveats keep this a
-hypothesis rather than a settled fact: the event wait covers **all prior work
-on the caller's stream**, not just our D2D, and the ratio shifts at higher
-line rates — a realistic shared-stream saturation test is an explicit
-activation gate, and the REST backend's event-poll shape is the documented
-fallback if it fails.
+A submitter enqueues one small **request envelope** and returns; workers
+generate and claim chunks lazily, so an async read never waits on chunk-level
+progress (mechanics: appendix). `cuObjGet` blocks, so the worker pool is the
+concurrency bound; with one arena slot per worker a free slot is always
+available. Each chunk completes exactly once, on its own worker, with the one
+exception defined in §4; the inline wait is a P3 measurement (§7). The
+reactor omits the framework's two staged-read builders, so the prefetch cache
+is never built for this backend — kvikio's minimal profile, which also keeps
+the cache's 2–7× sparse-projection over-read (issue #1078) unreachable here.
 
-**When delivery fails.** Once the D2D is enqueued, two buffers are at stake:
-the arena slot (its next user would corrupt an in-flight copy) and the caller's
-destination (the caller frees it as soon as its future resolves — while the
-copy may still be writing it). The rule is therefore absolute: **neither the
-slot is recycled nor the future resolved until the stream is proven quiet.**
-
-- The completion event is created **before** the copy is enqueued — if event
-  creation fails, no D2D has been submitted, so releasing the slot and
-  reporting the error is safe.
-- A non-success return from `cudaMemcpyAsync` itself does **not** prove the
-  copy was rejected: async CUDA calls may return errors produced by *earlier*
-  async work, so the enqueue state is unknown. Any non-success here is treated
-  exactly like a post-enqueue failure and goes through the quiescence proof
-  below.
-- On any CUDA failure at or after the enqueue, the worker proves quiescence
-  with a real stream sync. A sync call can return an error produced by earlier
-  async work — the call itself still waited, so the stream is still proven
-  quiet. The only exception is an error meaning the call never ran at all
-  (e.g. an invalid stream handle); then the worker escalates to a device-wide
-  sync as the stronger proof. (Captured streams fall in that exception too —
-  and are a documented precondition violation: RDMA device reads do not
-  support them.)
-- The verdict is three-way, and both non-recoverable verdicts end in a
-  **non-returning process-fatal hook** (log, then terminate the process; if
-  the hook ever returns, the call site calls `std::terminate`):
-  - *Quiet + healthy*: release the slot, report the original error, keep
-    serving.
-  - *Quiet + context-fatal* (sticky errors such as an illegal memory access):
-    the CUDA context is dead — no engine can write the destination anymore —
-    so the error is reported and logged first, **then the hook fires**.
-    Termination here is CUDA's own contract: a sticky error leaves the process
-    state corrupted, and the documented requirement is to terminate and
-    relaunch. "Restart is the recovery" thereby has an actor.
-  - *Unprovable* (the device-wide sync also failed with a non-sticky code, or
-    could not run): the hook fires **without resolving anything**. The chunk
-    never completes, so the future never resolves and the caller can never
-    free a destination that may still be written; no arena teardown runs
-    either. Termination here is Sirius's use-after-free policy rather than a
-    CUDA requirement: the completion framework resolves a future when its last
-    chunk reference is released, so a design that keeps the process alive must
-    either release (unsafe) or hold the reference forever (a wedged process a
-    watchdog kills anyway).
-- **Reactor fail-stop** is the containment shape for failures that do *not*
-  corrupt the CUDA process — in v1 that is the ambiguous RDMA outcome in the
-  retry contract (appendix). It happens exactly once: new reads fail fast,
-  naming the first fail-stop error; queued envelopes — and the un-generated
-  chunks of partially-consumed ones — are error-completed with it; chunks
-  already in flight finish on their own workers — never resolved on another
-  worker's behalf; and any arena that cannot be proven quiet at
-  teardown is deliberately **leaked rather than freed**, because freeing
-  memory a NIC might still write is the very use-after-free this discipline
-  exists to prevent. The process stays alive, but RDMA service on this
-  context resumes only with a process restart.
-
-Every CUDA call on this delivery path goes through a small seam injected at
-construction time, so the recoverable branches are fault-injectable in
-ordinary tests without faking CUDA semantics. The process-fatal branches are
-different: an in-process test double that returns or throws would exercise
-exactly the stack unwinding production forbids, so the hook is validated by
-**death tests** — a child process asserting the exit code, the fatal log, and
-the absence of normal teardown.
-
-## 3. Key decisions
+## 3. Key Decisions
 
 | # | Decision | Why |
 |---|---|---|
-| D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
-| D2 | Build RDMA as **one new transport engine under the existing IO framework** — a `cuobj_rdma_reactor` wrapped by a thin `s3_rdma_ioctx`; the per-device **arena map is reactor state**, while the shared context carries only config, the transfer client/session factory (per-worker sessions preferred — §5 Q6), and the flush policy *(identifiers: `templated_ioctx`, `prep_host_rx` / `prep_device_rx` builders, `enqueue`)* | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused. Keeping arenas on the reactor (not the shared context) keeps ownership with the worker pool that fills them |
+| D1 | Keep `s3://`; select the backend once, at registry construction (`s3_transport=RDMA` claims the s3 slot instead of restful; `AUTO`→HTTP) | The config field already exists; exactly one s3 backend per context keeps routing unambiguous and the scan side untouched |
+| D2 | One new transport engine under the existing IO framework: a reactor wrapped by a thin ioctx; the shared context carries config, a **client/session factory** (ownership: §6 decision 5), and the flush policy; the per-device arena map is reactor state | Chunking, pooling, completion, `slot_pool`, and the registry factory are reused; arenas belong with the worker pool that fills them |
 | D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; the D2D costs ~3 µs per 4 MiB slot (under 1% at the 100G reference point), with zero host bounce |
-| D5 | Completion via `semi_future` + `request_manager`: a chunk completes exactly once, on its own worker, after an **inline wait** on its CUDA event — and never before delivery is settled per the **§2 quiescence / fail-stop discipline** | Closes both use-after-free sides at once — a reused slot under an in-flight copy, and a freed destination still being written. A fatal CUDA error is process-level: per §2 the process-fatal hook terminates the process (restart is the recovery); the reactor's fail-stop contains only non-corrupting failures (the ambiguous RDMA outcome) |
-| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers. **The `x-amz-rdma-token` and `Range` headers are signed**, and v1 supports the RDMA control plane in **header-signing mode only** (RDMA init rejects `s3_signing_mode = presigned`) — surface mechanics in the appendix's "Auth surface extension" | Standard SigV4 requires `x-amz-*` headers in the signature; an unsigned token is not bound to the request, so a gateway could not distinguish a tampered descriptor from a legitimate one. Signing token + range binds object, byte range, and destination capability into one authorized request |
-| **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
+| D4 | Landing arena + GPU-local D2D, not direct RDMA into RMM buffers | Sirius RMM is `cudaMallocAsync`-backed: not reliably registrable for GPUDirect, and stream-ordered backing means an address may be unbacked when the NIC writes |
+| D5 | Completion via `semi_future` + `request_manager`, inline event wait; nothing completes before delivery is settled per the Safety Contract (§4) | Closes both use-after-free sides: a reused slot under an in-flight copy, and a freed destination still being written |
+| D6 | Explicit `RDMA` opt-in; failures surface per §4 — never a silent transport switch | Fallbacks mask misconfiguration exactly where RDMA is deliberately deployed |
+| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); NVIDIA SDKs are never vendored | Default-off builds are unchanged; conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — reconciliation is a real task |
+| D8 | The RDMA token and `Range` are signed; header-signing mode only (details: §5) | An unsigned token is not bound to the request; a gateway could not tell a tampered descriptor from a legitimate one |
+| D9 | Prefetch cache off structurally: the reactor defines only the host-read and device-read builders | Capabilities derive from which builders exist — no flag to set; kvikio already ships this profile |
 
-Why D9 works, in one picture:
+## 4. Safety Contract
 
-```mermaid
-flowchart LR
-  A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
-  B --> C["prefetch cache is never built<br/>for this backend"]
-  C --> D["the omitted builders make host staging<br/>and the cache's staged-read crash path<br/>unreachable for this backend"]
-```
+Once a D2D copy is enqueued, two buffers are at stake: the arena slot (its
+next user would corrupt an in-flight copy) and the caller's destination (freed
+as soon as its future resolves). Required invariant: **neither the slot is
+recycled nor the future resolved until the stream is proven quiet.**
 
-This is not just hygiene: the armed cache currently **over-reads 2–7× on sparse
-column projections** (issue #1078, a foreground/background allocation race) —
-the omitted builders make that path unreachable for this backend too, the
-same way it is for kvikio.
+Pre-enqueue rules: the completion event is created *before* the copy is
+enqueued (a creation failure means nothing is in flight — safe release). A
+non-success return from `cudaMemcpyAsync` does **not** prove the copy was
+rejected — async CUDA calls may return deferred errors from earlier work — so
+the enqueue state is unknown and the failure is handled as post-enqueue.
 
-`max_inflight` = worker count = **global** in-flight ceiling (one blocking
-`cuObjGet` per worker); "per-device" applies only to arena placement
-(`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
-gated future spike (§5 Q4).
+Quiescence proof: a real stream sync. An error return from the sync still
+proves quiescence (the wait completed; the error is a deferred report), except
+for codes meaning the call never ran (invalid handle; captured streams, which
+are a documented precondition violation) — those escalate to a device-wide
+sync.
 
-**One reactor per ioctx — and what scales with what.** The unit is the
-ioctx/`SiriusContext`, not the node: a process running several Sirius contexts
-multiplies workers, arenas, and gateway-budget demand accordingly. For
-contrast: the REST backend runs **2 reactors per ioctx** (`rest_n_reactors`),
-unrelated to GPU count — its reactors are epoll event loops doing real CPU work
-(TLS, staging copies), so a second one spreads CPU load. The RDMA reactor is
-*not* an event loop (`cuObjGet` blocks): it is a container for the worker pool
-and the arenas, so extra reactors add no throughput — they would only fragment
-the global in-flight ceiling and multiply sessions. Hence three independent
-axes:
-
-- **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
-  with reactors, not with GPUs.
-- **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
-  arena; a worker sets the request's device (via the framework's RAII device
-  guard) and takes a slot from *that* device's arena, so slot and destination
-  are always same-device (never a cross-device copy). A per-GPU reactor would
-  instead make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
-  `cuObjGet`), breaking the global ceiling and risking gateway/NIC overload.
-- **NIC count** is what eventually justifies more reactors:
-  per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
-  of global rate-limit complexity — is the deferred evolution for explicit
-  multi-NIC/NUMA topologies, not v1.
-
-**New consumers stay compatible by design:** the transparent
-`read_parquet('s3://')` front door (#1074, `sirius_httpfs`) resolves its
-backend per path through `create_datasource(path)` and reads with single
-positional `host_read`s — it carries no transport-specific checks, so under
-`s3_transport=RDMA` it should work unchanged; a routing test pins this at
-integration time.
-
-**Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
-one caller of the vector host-read entry point, which this backend omits — a
-native `.db` ATTACHed over s3://+RDMA fails loudly. kvikio has the same gap
-today; a small framework fix (fall back to per-segment single reads when the
-vector path is absent) would close it for both and is proposed as a standalone
-change.
-
-## 4. Rollout
-
-The delivery-failure discipline (§2), the commit-point retry contract, the
-admission bound, and the signed-token auth surface are **target contracts**:
-implementing and fault-injection-testing them is P2/P3 scope. Read the table
-as the plan that closes the gap between the current tree and this design.
-
-| Phase | Scope | HW |
+| CUDA outcome | Future / slot | Reactor / process |
 |---|---|---|
-| **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
-| **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued (death tests: child process, exit code, no normal teardown), teardown leak, admission deadlock-freedom) | CUDA GPU |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
-| P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
-| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
+| Quiesced, recoverable | report the error, release the slot | continue serving |
+| Quiesced, context-fatal (sticky error) | safe to report and release — the context is dead, nothing can write `dst` | **process-fatal** |
+| Quiescence unknown | do **not** resolve the future or free anything | **process-fatal** |
 
-## 5. Open questions for team review
+**Process-fatal** is a non-returning hook: log the verdict, terminate the
+process (the call site invokes `std::terminate` if the hook ever returns).
+For a sticky error this is CUDA's documented terminate-and-relaunch
+requirement; for the unknown verdict it is this design's use-after-free
+policy — the framework resolves a future when its last chunk reference is
+released, so no in-process "never resolved" exists. Validated by death tests
+(child process: exit code, fatal log, no normal teardown).
 
-1. **Sizing defaults** — ship the fixed 100G-reference default from §1's sizing
-   rule, or should the default self-scale from a detected/configured link
-   speed? (Faster NICs also grow the blocking-GET worker pool — §6.)
-2. **Visibility policy validation** — CUDA exposes a per-device
-   GPUDirect-RDMA **write-ordering attribute**: *OWNER* means RDMA writes
-   become visible to the owning device with no extra action; *NONE* means no
-   guarantee — an explicit flush is required before the GPU may read the
-   bytes. The OWNER half of the question is closed on paper: our consumer is a
-   same-device D2D, so **only NONE-ordering platforms need a flush**, and a
-   NONE platform that cannot flush must fail RDMA init loudly (no safe
-   configuration exists). What still needs the rig: wiring the policy **per
-   device** and the decode-immediately-after-GET stress test — still the top
-   correctness gate for P3. Who owns that rig time? (This ruling covers v1's
-   single RDMA path; a future multi-NIC sharding must revisit NVIDIA's
-   multi-ordering-domain exceptions.)
-3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
-   (Single-NIC suffices for P3.)
-4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
-   registrable allocation path for IO buffers? It unlocks direct-into-RMM
-   (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters. Note the REST reactor's
-   perf instrumentation was re-added in #1042; the RDMA
-   counters should follow that shape rather than invent a parallel one (see
-   the appendix for the proposed set, including the delivery-safety counters).
-6. **Session ownership** — the cuObject SDK documents no whole-client
-   thread-safety guarantee, so the design prefers **one `cuObjClient` session
-   per worker**; the alternative (one shared client for the pool) requires
-   documented proof of safety plus locking that preserves concurrency. Bound
-   up with it: is a buffer registration per-session (N registrations of the
-   same arena) or shareable? The answer is SDK-version-dependent (conda 1.2.x
-   vs the validated 1.0.0) and shapes the client-wrapper API; it must be
-   decided on the rig, before activation.
-7. **Ambiguous-failure fencing and duplicate suppression** — after a
-   control-plane timeout or reset, the gateway may still hold a descriptor for
-   the slot and keep writing it; the protocol defines what a success response
-   means, but not what silence means — and a transparently retried duplicate
-   can succeed while the original is still writing (see the deployment
-   invariants in the appendix), which no client-side rule can detect. Does the
-   cuObject SDK or the gateway offer a fencing / cancellation primitive
-   (deregister-and-confirm, descriptor revocation)? Is a descriptor token
-   single-use at the gateway? Without one, the
-   retry contract (appendix) must fail-stop the reactor and mark the entire
-   arena non-freeable on any ambiguous failure (per-slot quarantine was
-   rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
-   as much as for this team.
+| RDMA outcome | Slot / arena | Retry |
+|---|---|---|
+| Not sent (token never left the client) | slot reusable | allowed |
+| Exact completion (valid reply, `n == expected`) | slot reusable after the D2D | not needed |
+| Sent, outcome unknown | **entire arena non-freeable** | none — reactor **fail-stop** |
 
-## 6. Risks
+The client reports a commit state with every failure (`not_sent` /
+`sent_unknown` / `completed`); host/HTTP reads retry freely (the client owns
+the write loop). Registration covers the whole arena, so one slot the gateway
+may still write makes deregistering or freeing any of it unsafe; per-slot
+quarantine was rejected because repeated quarantines drain the pool.
+**Fail-stop** happens exactly once: new reads fail fast with the fail-stop
+error; queued envelopes — and the un-generated chunks of partially-consumed
+ones — are error-completed; chunks already in flight finish on their own
+workers; blocked submitters are woken. The process stays alive —
+fail-stop is reserved for failures that do not corrupt the CUDA process — but
+RDMA service on the context requires a restart. Any arena that cannot be
+proven quiet at teardown, by device stream or by remote gateway, is leaked,
+never freed.
 
-- **CUDA visibility after external RDMA writes** — the top correctness risk,
-  now narrowed (§5 Q2): OWNER is settled by the CUDA contract; the remaining
-  exposure is NONE-ordering platforms, per-device wiring, and the P3 stress
-  test.
-- **Fatal CUDA errors are process-level.** The §2 process-fatal hook
-  terminates the process — supervisor restart is the recovery, so operators
-  need a relaunch policy. The reactor's fail-stop contains only the
-  non-corrupting ambiguous-RDMA case: there the process stays alive, but RDMA
-  service on the context requires a restart.
-- Needs a controlled cuObject gateway (not plain AWS S3). NIC↔GPU PCIe affinity
-  can silently halve BW. The gateway slot budget must cover `max_inflight` per
-  Sirius context (not × GPUs or × queries) — and a process running several
-  contexts multiplies it (§3).
-- Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5 — control-plane **connection reuse** is part of the same
-  measurement); cuObject's blocking GET shapes the worker-pool model, and the
-  pool grows with NIC line rate (§1 sizing), sharpening the case for an async
-  cuObject API if one appears.
-- cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
+Two independent gates apply on the real path. **Completion authority** is a
+P0b gate: the gateway enforces **exact completion** and the client requires a
+**valid reply tag** (appendix protocol). Separately, request **uniqueness**
+(§5) must hold before P3 activation — fail-stop cannot see a duplicate that
+succeeds.
+
+## 5. Authentication
+
+The `x-amz-rdma-token` and `Range` headers are inside the SigV4 signature,
+binding object, byte range, and destination capability into one authorized
+request. v1 supports header-signing mode only — an implementation choice, not
+a protocol limit (SigV4 query signing can carry `X-Amz-SignedHeaders`, but the
+Sirius presigner signs only `host` today); RDMA initialization fails under
+`s3_signing_mode = presigned`.
+
+Interface: the existing three-argument virtual `authorize()` is untouched; the
+headers-to-sign travel through a new, separately-named non-pure virtual
+(`authorize_with_headers(request)`) whose default implementation rejects
+non-empty header sets, and which the built-in SigV4 header signer overrides.
+
+The dev benchmark server runs unsigned on an isolated network; production
+gateways validate the signature before honoring the token.
+
+Request uniqueness is an **activation requirement**, not a recovery policy:
+a transparently retried duplicate can *succeed* while the original request is
+still writing, and no client-side rule — fail-stop included — can see it.
+**v1 satisfies it by deployment contract**: the client connects to the
+gateway directly (or every intermediary has automatic retries disabled for
+token-bearing GETs); RDMA must not be enabled otherwise. Gateway-side
+exactly-once deduplication is a **deferred conditional extension** — the base
+cuObject protocol defines no request-identity tag, so it would need a signed
+identity added to the wire (appendix) and is only worth specifying if a
+deployment requires an intermediary. The control plane runs over TLS; tokens
+are redacted from logs.
+
+## 6. Review Decisions
+
+| # | Decision needed | Recommendation | Blocks |
+|---|---|---|---|
+| 1 | Staging shape | Landing arena + GPU-local D2D; direct-into-RMM stays a gated P5 spike | P2 |
+| 2 | CUDA failure policy | Quiescence proof per §4; sticky and unknown verdicts terminate the process | P3 |
+| 3 | Duplicate suppression & ambiguous completion | Duplicate suppression is an **activation requirement**, met in v1 by the no-intermediary-retry deployment contract (gateway dedup: deferred extension); `sent_unknown` defaults to fail-stop + arena non-freeable, which a gateway fence can only improve | P3 |
+| 4 | Queue model | Bounded request-envelope admission with lazy chunk generation; admission may block only when the envelope cap is full | P2 |
+| 5 | Session ownership | One `cuObjClient` session per worker (the SDK documents no whole-client thread safety); registration scope decided on the rig | P3 |
+
+Follow-up inputs (not votes): CX-6 rig owner and dates for P3–P5; sizing
+default (fixed 100G reference vs self-scaling) before P4; appetite for a
+registrable cucascade IO sub-MR (unlocks direct-into-RMM); confirmation from
+NVIDIA whether a descriptor token is single-use; counter naming alignment with
+the REST instrumentation.
+
+Visibility policy is ruled by the CUDA contract, not a vote: the per-device
+write-ordering attribute makes OWNER platforms safe for our same-device D2D
+consumer with no flush; only NONE platforms need one, and a NONE platform that
+cannot flush fails RDMA initialization. P3 work: per-device wiring and the
+decode-after-GET stress test. The ruling covers v1's single RDMA path;
+multi-NIC sharding would revisit the multi-ordering-domain exceptions.
+
+## 7. Rollout & Performance
+
+| Phase | Scope | Exit criterion | HW |
+|---|---|---|---|
+| P0a | Benchmark wire migration (standard token/reply protocol) | landed | — |
+| P0b | Gateway hardening: descriptor/capacity validation, exact completion, mandatory reply validation | all three enforced (precondition for §4's completion authority) | — |
+| P1 | Backend type + factory + registry selection by `s3_transport` (routing seams merged — #1042) | routing tests extend the existing cutover suite | — |
+| P2 | Reactor against a mock client; envelope admission | fault-injection matrix green (appendix), incl. death tests and admission deadlock-freedom | CUDA GPU |
+| P3 | Real cuObject path, single GPU | visibility stress test; activation gates: completion authority (with P0b), the duplicate-suppression + ambiguous-completion policy, session decision, shared-stream saturation test | CX-6 |
+| P4 | Multi-GPU, NIC affinity, tuning | per-GPU bandwidth sweep confirms near-NIC selection | CX-6 |
+| P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go | vs-HTTP benchmark | CX-6 |
+
+The rollout closes the gap between the current tree and this document: the
+Safety Contract, envelope queue, uniqueness invariants, and auth surface are
+target contracts to be implemented and tested in P2/P3.
+
+**Performance.** The D2D is an estimated ~3 µs per 4 MiB slot (derived from
+HBM bandwidth, not yet measured on this path) against the ~350 µs wire
+serialization of one slot at ~91 Gbps — a wire-time floor, not a measured
+single-request latency under concurrency. That ratio is the basis for the
+inline wait; the caveat is that the event wait covers all prior work on the
+caller's stream, not just this copy. P3 replaces the estimates by measuring
+the total post-RDMA delivery cost (flush, event lifecycle, D2D) under a
+shared-stream saturation test; the REST backend's event-poll shape is the
+documented fallback if that test fails.
+
+## 8. Scope & Risks
+
+Compatibility limits: a DuckDB-native `.db` attached over s3://+RDMA fails at
+the omitted vector-read path (kvikio has the same gap; a per-segment framework
+fallback is proposed separately). The transparent `read_parquet('s3://')`
+front door (#1074) carries no transport-specific checks and is expected to
+work unchanged — a routing test pins this at integration. Captured CUDA
+streams are unsupported for RDMA device reads.
+
+Risks:
+
+- GPU-consumer visibility on NONE-ordering platforms — per-device wiring and
+  the P3 stress test are the top correctness gate (§6).
+- Requires a controlled cuObject gateway; NIC↔GPU PCIe affinity across root
+  complexes can silently halve bandwidth (P4 validation).
+- cuObject SDK skew (conda 1.2.x vs the validated 1.0.0 tarball) must be
   reconciled before P3.
+- Small-read control-plane RTT, including per-request connection setup —
+  measured in P5; an optional whole-read HTTP threshold is the prepared
+  mitigation.
+- The gateway slot budget scales with `max_inflight` × Sirius contexts, not
+  with GPUs or queries (§2 resource model).
 
 ---
 
-## Appendix — Protocol & config
+## Appendix — Protocol, configuration, implementation
 
-### Control-plane headers
+### Wire protocol
 
-Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
+Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags plus
+`Range`. The benchmark's four non-standard headers were removed by the wire
+migration (P0a).
 
 | Header | Direction | Meaning |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
-| `x-amz-rdma-reply` | gateway → client | RDMA status tag. Completion is observed as `cuObjGet`'s returned `n == expected`, and that count is authoritative only when **both** halves hold: the gateway enforces exact completion (accepts no short or overlong RDMA piece), **and** the client requires a valid reply tag before it reports the requested size — an HTTP 200/206 without a legitimate reply must be treated as failure, and the reply payload is never interpreted as a byte count. Both halves are P0b items (see below) and a precondition for trusting short-write detection on the real path |
+| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; encodes the remote slot address and size; signed (§5) |
+| `x-amz-rdma-reply` | gateway → client | RDMA status tag; never interpreted as a byte count |
 
-The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
-`x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
-address rides in the token, capacity is the `cuObjGet` `size` arg, and the
-reply tag supersedes the byte-count header. The server chunks transfers
-server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
-Production gateways SigV4-validate the control request before honoring the
-token, and the token + `Range` are part of that signature (D8): the client
-signs them, the gateway verifies them — an unsigned token is rejected.
+Conditional extension (deferred): gateway-side exactly-once deduplication
+would require a signed request identity on the wire — the identity field, its
+validity window, dedup retention, and gateway ownership would all need
+definition with NVIDIA (the descriptor token can serve only if it is ruled
+single-use). Not part of v1, which relies on the §5 deployment contract.
 
-### Auth surface extension (D8 mechanics)
+Completion authority: `cuObjGet`'s returned `n == expected` is authoritative
+only when the gateway enforces exact completion (no short or overlong RDMA
+piece) **and** the client requires a valid reply tag before reporting the
+requested size — an HTTP 200/206 without a legitimate reply is a failure. Both
+halves are P0b gates. The server chunks transfers server-side (its own config,
+default 2 MiB); nothing is negotiated on the wire. Signature validation and
+the dev/prod auth posture are defined in §5. Remaining P0b items
+(outcome level): strict descriptor/capacity validation, exact completion,
+mandatory reply validation — code-level specifics are tracked in the
+`s3RDMA-benchmarktool` repo.
 
-The authorizer's request surface is extended so headers added for RDMA are
-part of the SigV4 canonical request. Presigned mode is excluded as a v1
-implementation choice, not a protocol limit: SigV4 query signing can in
-principle carry headers via `X-Amz-SignedHeaders`, but Sirius's presigner
-signs only `host` today. Compatibility: the existing pure-virtual
-`authorize()` stays untouched; the headers-to-sign travel through a **new,
-separately-named** non-pure virtual (e.g. `authorize_with_headers(request)`)
-whose default implementation rejects non-empty header sets as unsupported,
-and which the built-in SigV4 header signer overrides. A defaulted parameter
-on the existing virtual would break every override, and a same-name overload
-would make existing three-argument calls ambiguous.
-
-### Config (under `object_store_config`)
-
-`s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
-its consumer. Two sizing knobs accompany it:
+### Configuration
 
 ```text
 s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
-s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — see §1 sizing)
-s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — see §1 sizing)
+s3_rdma_max_inflight              # worker count = global in-flight ceiling (default 8 — §2 sizing)
+s3_rdma_arena_slot_size           # per-chunk arena slot (default 4 MiB — §2 sizing)
 s3_rdma_queue_cap                 # per-ioctx bound on pending read requests (envelopes)
 ```
 
-**Endpoint topology (decided for v1):** the configured S3 endpoint **is** the
-cuObject gateway — one host serves both the ordinary HEAD / range-GET traffic
-and the RDMA control requests, under one set of credentials and one signing
-host. A split topology (RDMA gateway separate from the S3 origin) is out of
-scope for v1: it needs two endpoints, two signing hosts, and an explicit
-credential boundary, and is deferred until a deployment requires it. There is deliberately **no client chunk-size knob**: the transfer
-granularity is the arena slot size, and the server chunks independently.
-Auth/TLS reuse the existing fields (`s3_signing_mode` — header mode required
-for RDMA, D8 — `ca_bundle_path`, `tls_verify`).
+Endpoint topology (v1): the configured S3 endpoint is the cuObject gateway —
+one host serves HEAD/range-GET and RDMA control under one credential set. A
+split topology is deferred until a deployment requires it. There is no client
+chunk-size knob: transfer granularity is the arena slot size. Auth/TLS reuse
+the existing fields (`s3_signing_mode` — header mode required, §5 —
+`ca_bundle_path`, `tls_verify`).
 
-**Admission bound (v1):** the reactor's queue holds **request envelopes**,
-bounded per ioctx (`s3_rdma_queue_cap`, counted in requests). A submitter
-enqueues one envelope — a small descriptor, not the chunk list — and returns
-immediately; workers generate and claim chunks lazily from the head envelopes,
-FIFO. Per-chunk admission was rejected: with a chunk-counted cap, a read
-larger than the cap would block the submitting thread until most of its own
-transfer had completed, making the async API effectively synchronous. Only a
-full envelope queue blocks a submitter (the bound is on outstanding requests,
-which the scan layer already limits); fail-stop and shutdown wake any blocked
-submitter, which then observes the failure/shutdown error — a
-deadlock-freedom test covers both. Envelope-queue depth-peak and wait counters
-expose the pressure. The process-wide budget is contexts × workers — a
-deployment running several Sirius contexts must size the gateway budget for
-the sum.
+Admission: the queue holds request envelopes, bounded per ioctx and counted in
+requests. A submitter enqueues one envelope (a small descriptor, not the chunk
+list) and returns; workers generate and claim chunks lazily, FIFO. A per-chunk
+cap was rejected: a read larger than the cap would block its submitter until
+most of its own transfer completed, making the async API effectively
+synchronous. Only a full envelope queue blocks a submitter; fail-stop and
+shutdown wake any blocked submitter with the corresponding error.
 
-**Retry contract** — deliberately independent of the REST policy, and split by
-plane, because the two planes fail differently:
+Retry: split by plane and commit point. Host/HTTP reads retry on transport
+failures and short reads. RDMA device reads retry only from the `not_sent`
+commit state; `sent_unknown` is terminal per the Safety Contract. CUDA work
+never retries; exhaustion surfaces the last error; never a transport switch
+(D6).
 
-- **Host/HTTP reads** (footers, metadata): retryable on transport failures and
-  short reads. The client owns the write loop into the destination buffer, and
-  a closed connection means no further writes — re-issuing into the same
-  buffer is safe.
-- **RDMA device reads**: retryability is decided by the **commit point**, so
-  the client wrapper must report a commit state with every failure —
-  `not_sent` / `sent_unknown` / `completed`. A `not_sent` failure (connection
-  setup, before the token left the client) is retryable. Once the token may
-  have reached the gateway (`sent_unknown`), a timeout or reset without an
-  authoritative reply is **ambiguous**: the gateway holds a descriptor and may
-  still be writing — the protocol defines "success response ⇒ transfer
-  complete", but not "no response ⇒ gateway stopped"; a proxy-replayed or
-  duplicated request can even land a late write after an apparent failure.
-  v1 therefore treats the **first ambiguous post-commit failure as a reactor
-  fail-stop**: the read fails, nothing retries in place, and the **entire
-  arena is marked non-freeable** — RDMA registration covers the whole arena,
-  so one slot the gateway may still write makes deregistering or freeing any
-  of it unsafe; teardown leaks it, and RDMA service on this context requires a
-  process restart. Per-slot quarantine was considered and rejected: repeated
-  quarantines drain the slot pool until workers, blocking admission, and
-  shutdown all wait forever. A gateway/SDK fencing or cancellation primitive
-  (§5 Q7) is what would permit a less drastic recovery.
-- Everywhere: CUDA work never retries; exhaustion surfaces the last error —
-  and per D6, never a transport switch.
-
-**Deployment invariants (v1, required for the RDMA plane).** The commit-state
-contract above covers failures the *client sees*. A transparent intermediary
-can break it invisibly: a proxy forwards request A (the gateway starts
-writing), the upstream connection drops, the proxy silently retries as
-request B, B succeeds and returns 200 — the client completes the read, reuses
-the slot, and only then does A's late write land. The client saw only success,
-so no fail-stop triggers. v1 therefore requires one of:
-
-- **No automatic intermediary retries** of token-bearing GETs anywhere on the
-  path (the recommended deployment: client connects to the gateway directly,
-  or every proxy in between has retries disabled for these requests); or
-- **Gateway-side exactly-once dedup** keyed on the signed token / a signed
-  request id, so a duplicated request never starts a second RDMA write.
-
-Related requirements: confirm with NVIDIA whether a descriptor token is
-single-use at the gateway (Q7); the control plane runs over TLS; tokens are
-redacted from request logs; and replayed tokens outside the dedup window are
-rejected.
+### Metrics
 
 Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_retries_total`, `…_short_read_total`, `…_error_total`,
 `…_slot_wait_total`, `…_flush_total`, `…_inflight_peak`,
-`…_queue_depth_peak`, `…_queue_wait_total` — plus the
-delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
-runs), `…_fail_stop_total` (reactor fail-stop transitions — the ambiguous-RDMA containment; the process-terminating verdicts leave a fatal log line and an exit code, not a scrapeable counter), `…_arena_leak_total`
-(arenas leaked at teardown because a writer — device stream or remote gateway
-— could not be proven quiet).
+`…_queue_depth_peak`, `…_queue_wait_total`, `…_fallback_stream_sync_total`
+(quiescence-proof runs), `…_fail_stop_total` (reactor fail-stop transitions —
+the process-terminating verdicts leave a fatal log line and an exit code, not
+a scrapeable counter), `…_arena_leak_total` (arenas leaked at teardown per §4).
 
-### P0 status (in `s3RDMA-benchmarktool`)
+### Implementation notes (framework mapping)
 
-**Wire migration landed** (merged to `main`, 2026-06-17): the 4 non-standard
-headers dropped, the server decodes the slot address from the token (works on the
-pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
-documented. **Open hardening (P0b):** the migration **removed** the previous
-strict address validator — today's parse takes the first hex field with no
-length/field validation (and wrongly rejects a legitimate address 0); the token's
-`buf_size` field is transmitted but never read server-side (a capacity check the
-server already has the data for but currently skips); the client reports success on
-any 200/206 without an `n == expected` short-write check **and without requiring
-a valid `x-amz-rdma-reply` tag** (mandatory client-side reply validation is part
-of P0b — only after it may the callback report the requested size); optional
-SigV4 in the dev server.
+`s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>`, built like
+`rest_ioctx`. The reactor provides the `prep_host_rx` / `prep_device_rx`
+builders plus `enqueue`; omitting the two staged-read builders is what derives
+the cache-off capability profile (D9). Completion rides
+`exec::semi_future` + `request_manager`: each chunk reports `chunk_complete`
+or `report_error` exactly once and releases its manager reference; the future
+resolves when the last reference drops — which is why the §4 "unknown"
+verdict must terminate rather than attempt any in-process "never resolved"
+state. The per-device arena map is reactor state; `slot_pool` is reused
+verbatim for slot indexing.
 
-> Detailed gateway-hardening notes (file:line specifics) are tracked in the
-> `s3RDMA-benchmarktool` repo.
+### Fault-test matrix (P2, CUDA GPU required; RDMA-rig-free)
+
+Byte-exact multi-chunk reads; concept checks that both staged-read
+capabilities stay off; event-created-before-enqueue (injected create failure
+never reaches the copy); `cudaMemcpyAsync` non-success routed through the
+quiescence proof; recoverable ladder outcomes release the slot only after the
+proof; process-fatal verdicts exercised as **death tests** (child process:
+exit code, fatal log, no normal teardown — an in-process double that returns
+or throws would exercise the unwinding production forbids) including an active
+unknown-verdict chunk with queued siblings of the same request; fail-stop exactly-once with
+owner-worker completion of in-flight chunks; ambiguous-RDMA fail-stop with
+arena marked non-freeable and teardown leak observed; admission
+deadlock-freedom (submitter blocked at the envelope cap while workers drain
+and while the reactor fail-stops).
+
+### Status
+
+This document describes the target architecture. The current tree differs in
+the areas the rollout table covers (delivery-failure discipline, retry
+classification, envelope admission, auth surface); P2/P3 implement and test
+them. No production code ships with this PR.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -255,7 +255,7 @@ as the plan that closes the gap between the current tree and this design.
 | **P0a — wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
 | **P0b — gateway hardening open** | Strict descriptor parsing, `buf_size` enforcement, exact-completion check (itemized in the appendix). **Also the precondition for trusting short-write detection on the client** | — |
 | **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop incl. an active unprovable chunk with queued siblings of the same request, teardown leak, admission deadlock-freedom) | CUDA GPU |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; RDMA-rig-free matrix (the delivery tests still need a CUDA GPU) incl. compile-time checks that the two staged-read capabilities stay off, plus the **delivery-failure fault-injection matrix** (§2: quiescence proof, fail-stop, the process-fatal hook firing on an active unprovable chunk while siblings of the same request are queued, teardown leak, admission deadlock-freedom) | CUDA GPU |
 | P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; measure the full delivery overhead (flush + event create/record/wait/destroy + D2D, replacing the bandwidth-derived estimates; evaluate per-slot event reuse). **Activation gates:** exact-write authority incl. mandatory reply validation (jointly with P0b), the session-ownership decision (§5 Q6), per-device visibility policy (§5 Q2), the ambiguous-failure fencing answer (§5 Q7), and the shared-stream inline-wait saturation test (§2) | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go (incl. control-plane connection reuse); vs-HTTP benchmark | CX-6 |
@@ -297,8 +297,10 @@ as the plan that closes the gap between the current tree and this design.
    protocol defines what a success response means, but not what silence means.
    Does the cuObject SDK or the gateway offer a fencing / cancellation
    primitive (deregister-and-confirm, descriptor revocation)? Without one, the
-   retry contract (appendix) must quarantine the slot and fail the read on any
-   ambiguous failure — a question for NVIDIA as much as for this team.
+   retry contract (appendix) must fail-stop the reactor and mark the entire
+   arena non-freeable on any ambiguous failure (per-slot quarantine was
+   rejected: repeated quarantines drain the slot pool) — a question for NVIDIA
+   as much as for this team.
 
 ## 6. Risks
 
@@ -412,7 +414,8 @@ Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_queue_depth_peak`, `…_queue_wait_total` — plus the
 delivery-safety set from §2: `…_fallback_stream_sync_total` (quiescence-ladder
 runs), `…_delivery_fatal_total` (fail-stop transitions), `…_arena_leak_total`
-(arenas leaked at teardown because the device could not be proven quiet).
+(arenas leaked at teardown because a writer — device stream or remote gateway
+— could not be proven quiet).
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -133,15 +133,61 @@ the destination is valid.
 
 ## 5. Safety and Failure Semantics
 
-The delivery contract turns on the first `cudaMemcpyAsync` call for a
-chunk. Before it no copy is in flight, so a non-sticky failure reports
-and releases the slot safely; a sticky CUDA error terminates the process
-at any point (the sticky set is CUDA's documented
-classification, checked against the tree's classifier). After the call, only an
-event wait reporting `cudaSuccess` proves the copy has stopped writing,
-so every other outcome is process-fatal. The exception is an
-event-destroy failure after a successful wait: logged, and the success
-stands.
+The safety model has two irreversible boundaries. Issuing the
+token-bearing GET creates a possible remote writer to the registered
+arena; enqueuing `cudaMemcpyAsync` creates a possible local GPU writer
+to caller-owned RMM memory. A failure is recoverable only when Sirius
+can prove the relevant writer has stopped: an uncertain RDMA completion
+therefore fail-stops the transport, and an uncertain copy is
+process-fatal.
+
+The local-delivery half follows the existing REST staged-device-read
+lifecycle — a reactor-owned source slot is retained until the CUDA copy
+on the caller stream is confirmed by an event; the rules here add what
+that lifecycle never faced: remote-writer ambiguity and
+registered-memory lifetime.
+
+The diagram shows the state flow for one chunk; the outcome table below
+remains the normative definition of the effects on the request future
+and arena lifetime.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PreIssue: chunk claimed / slot leased
+
+  PreIssue --> RequestError: local failure before GET
+  PreIssue --> RDMAInFlight: issue one-shot token-bearing GET
+
+  RDMAInFlight --> TransportFailStop: completion non-exact or unknown
+  RDMAInFlight --> ReadyToDeliver: exact completion (tag + status + expected bytes)
+
+  ReadyToDeliver --> RequestError: non-sticky error before D2D
+  ReadyToDeliver --> ProcessFatal: sticky CUDA error
+  ReadyToDeliver --> CopyInFlight: flush if required, enqueue D2D + event
+
+  CopyInFlight --> Delivered: event wait == cudaSuccess
+  CopyInFlight --> ProcessFatal: any other outcome
+
+  Delivered --> [*]: chunk complete / slot reusable
+  RequestError --> [*]: request marked failed / slot released
+
+  note right of TransportFailStop
+    Future resolves with an error.
+    The arena remains allocated.
+    Recovery requires process restart.
+  end note
+
+  note right of ProcessFatal
+    A sticky CUDA error at any phase enters this state.
+    The future is not resolved and the arena is not freed.
+  end note
+```
+
+The sticky set is CUDA's documented classification, checked against the
+tree's classifier. After the D2D is enqueued, only an event wait
+reporting `cudaSuccess` proves the copy has stopped writing; an
+event-destroy failure after that successful wait is logged and does not
+change the delivery outcome.
 
 | Outcome | Action | Future | Arena |
 |---|---|---|---|
@@ -150,16 +196,14 @@ stands.
 | Non-exact or unknown RDMA outcome | Reactor fail-stop; process restart required | Error | Entire arena non-freeable |
 | Sticky CUDA error, or any failure after the copy is enqueued (event-destroy excepted) | Process-fatal termination | Not resolved | Never freed |
 
-A non-exact or unknown RDMA outcome fail-stops the transport: the client
-cannot prove the gateway has stopped writing, so the whole arena becomes
-non-freeable and recovery is a process restart. Shutdown is two-phase — a
-terminal mark that refuses new work, then completion when the last
-in-flight permit releases — so a failing worker never waits on itself.
-Both planes close behind one shared admission gate and surface one
-terminal error: an operation already past its side-effect point (a
-control call started, a transfer issued) completes; queued envelopes and
-their ungenerated chunks error-complete; work claimed but not issued
-aborts and releases its slot; blocked submitters wake.
+On entering `TransportFailStop`, the ioctx marks the shared admission
+gate terminal and refuses new work; host- and device-plane operations
+alike surface the same terminal error. An operation already past its
+side-effect point (a control call started, a transfer issued) settles;
+queued envelopes and their ungenerated chunks error-complete; work
+claimed but not issued aborts and releases its slot; blocked submitters
+wake. Shutdown completes when the last in-flight permit releases, so the
+worker that triggered the fail-stop never waits on itself.
 
 Destination contents are unspecified after any failed read: earlier
 chunks may already have landed in the caller's buffer.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -1,0 +1,493 @@
+# S3 RDMA Transport for Sirius — Design for Team Review
+
+| | |
+|---|---|
+| **Status** | Draft for team review |
+| **Date** | 2026-06-13 |
+| **Author** | Sirius Contributors |
+| **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> (~91 Gbps GPU-mode GET on CX-6 RoCE) |
+| **Background** | Builds on prior internal IO-layer design notes (full working spec; the RDMA-S3-ioctx v8 and IO-layer plans) — not in this repo; this doc is self-contained for review. |
+
+## TL;DR
+
+Add an RDMA transport to the Sirius S3 stack: large parquet column reads are
+`RDMA_WRITE`n by a cuObject-speaking gateway into a small pre-registered GPU
+**landing arena**, then moved to their RMM destination by a GPU-local
+device-to-device copy — eliminating today's pinned-host staging and PCIe H2D
+leg entirely. The `s3://` URI surface, SigV4 auth, datasource abstraction, and
+parquet scanner are unchanged; the new code is one reactor plus a thin ioctx
+under the existing `templated_ioctx` machinery. **Ask: review decisions D1–D9
+and answer the open questions in §8.**
+
+## 1. Motivation & evidence
+
+Sirius reads S3 parquet today via libcurl range GETs into pinned host staging
+blocks, then `cudaMemcpyAsync` H2D (`s3_reactor`). Every byte crosses host
+memory and the PCIe bus twice (NIC→host, host→GPU).
+
+The `s3RDMA-benchmarktool` project (published under sirius-db) proves the
+alternative end-to-end on NVIDIA cuObject: an HTTP control plane carries an
+RDMA descriptor token; the server `RDMA_WRITE`s object bytes **directly into
+client GPU memory** (GPUDirect). Measured: **~91 Gbps sustained GPU-mode GET
+(~91% of line rate) on CX-6 100G RoCE, reaching line rate at 8 client
+threads**; host-mode and GPU-mode throughput are identical, and
+alloc+register is a one-time sub-second cost amortized by a
+register-once / read-many pattern.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Large device reads over RDMA directly into GPU memory; zero host bounce.
+- Preserve `s3://` URIs, SigV4 authorization, `sirius_datasource` semantics,
+  and the existing HTTP backend as a config-selectable alternative.
+- Land behind the existing IO seam — no parquet scanner changes.
+
+**Non-goals (v1)**
+
+- No replacement of the HTTP/libcurl backend; no new URI scheme.
+- No AWS S3 support — this requires an RDMA-capable, cuObject-speaking
+  gateway (on-prem / Sirius-controlled).
+- No `AUTO` capability probing (the existing `AUTO` enum value resolves to
+  HTTP) and **no runtime HTTP fallback**: RDMA failures surface as I/O
+  errors; switching back to HTTP is an operator config action.
+- No AWS-CRT dependency: the client base is the benchmark's bare
+  `cuObjClient` + HTTP control plane.
+
+## 3. Architecture overview
+
+```text
+Parquet/GPU scan
+  → sirius_datasource::device_read(...)              (RMM device_buffer dst)
+  → templated_ioctx<cuobj_rdma_reactor>              (1 MiB chunking — reused)
+  → cuobj_rdma_reactor worker
+      ① acquire free arena slot                      (pre-registered GPU memory)
+      ② cuObjGet → SigV4-signed HTTP control GET
+           x-amz-rdma-token: base64(cuObject RDMA descriptor; encodes slot addr)
+           Range: [off, off+1MiB)
+      ③ gateway validates auth/range/size → RDMA_WRITEs into the slot
+      ④ cuObjGet returns (host-side completion fact)
+      ⑤ [flush if platform requires]                 (visibility, §A.3)
+      ⑥ cudaMemcpyAsync(r.dst ← slot, D2D, r.stream) (GPU-local, ~TB/s)
+      ⑦ callback marks done + wakes → worker recycles slot → chunk_done()
+  → cuDF decode kernels on r.stream                  (stream order ⇒ visible)
+```
+
+Relative to `s3_reactor` (GET → pinned host staging → H2D → stream callback),
+this backend replaces the host staging pool with a small **GPU-resident
+arena** and the PCIe H2D copy with a GPU-local D2D (<1% overhead vs the
+network). The completion discipline — CUDA callback only marks+wakes, a
+worker thread finishes the chunk — is identical to `s3_reactor`'s proven
+pattern. Host reads (parquet footers, HEAD, small metadata) stay on the
+existing HTTP path.
+
+## 4. Key decisions
+
+**D1 — Keep `s3://`; select the transport by config.** *(Decided)*
+`object_store_config::transport { AUTO, HTTP, RDMA }` already exists in
+Sirius. The scan manager selects and owns exactly one S3 backend per Sirius
+context (in `_io_ctxs`): `HTTP` → today's `s3_ioctx`; `RDMA` → the new backend.
+No new URI scheme, no second routing mechanism.
+
+**D2 — Shape: `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>`.**
+*(Decided)* One new reactor satisfying the `io_reactor_c` concept, plus thin
+but load-bearing ioctx overrides: an instance `create_io_object` (HEAD via
+the SigV4 `s3_request_authorizer` — a reactor static can't carry
+credentials), `host_read_ranges_async_io` (strict range validation — errors
+via the handler, not the generic version's silent skip of invalid/too-small
+ranges; footer/prewarm/metadata paths all hit it), and counters. Chunking,
+pooling, async completion, the datasource adapter, and the factory are reused
+unchanged. This mirrors how `s3_ioctx` itself is built.
+
+**D3 — One hybrid ioctx, not two.** *(Decided)* In RDMA mode, host reads
+(footers/HEAD/metadata) go over HTTP and device reads over RDMA — inside the
+same ioctx. Note: `s3_reactor` is **never instantiated** in RDMA mode — the
+HTTP host-read path is the reactor's own sync, SigV4-signed GET; the two
+backends are mutually exclusive per process, never composed. Callers see
+identical `sirius_datasource` semantics across backends.
+
+**D4 — Landing arena + GPU-local D2D, not direct RDMA into RMM buffers.**
+*(Decided; the central design choice)* Super Sirius device memory is
+`rmm::mr::cuda_async_memory_resource` (cudaMallocAsync mempool, via
+cucascade). That memory is (a) not reliably registrable for GPUDirect RDMA
+and (b) stream-ordered — an address may lack physical backing when the NIC
+writes. Therefore the reactor owns a small `cudaMalloc`'d arena per device
+(default `max_inflight × 1 MiB` = 8 MiB at the 8-worker default), registered **once**; RDMA lands
+in arena slots and a `cudaMemcpyAsync` D2D on the request stream delivers to
+the RMM destination. D2D runs at GPU memory bandwidth (~1–2 TB/s) vs
+~12.5 GB/s network ⇒ <1% overhead; bytes never touch host memory. Slot
+exhaustion is natural backpressure. (Direct-into-RMM remains a gated future
+spike — Appendix A.5.)
+
+**D5 — Completion: callback-only-wake; the worker finishes the chunk.**
+*(Decided)* `request_context::chunk_done()` fires the user handler
+synchronously on the last chunk, so it must never be called from a CUDA
+callback thread. The CUDA callback only records the copy status and wakes the
+worker; the worker observes the status → safely recycles the slot → calls
+`chunk_done()`/`chunk_failed()`. Contract: the user handler always fires on a
+reactor/worker thread, with the bytes already in the final `r.dst`. This is
+`s3_reactor`'s exact structure. Exhaustive error paths in Appendix A.2.
+
+**D6 — v1 scope: explicit opt-in, fail loudly.** *(Decided)* RDMA requires
+`s3_transport=RDMA`; `AUTO` resolves to HTTP (no probe). No runtime HTTP
+fallback — a failed RDMA transfer is an I/O error through the existing
+handler path. **All device reads go RDMA in v1** (with the byte-range chunk-prewarm
+off per D9, so nothing short-circuits them) — a small-read HTTP threshold
+is deferred to P5, pending RTT measurements on the rig. Rationale:
+fallbacks and premature thresholds mask misconfiguration in exactly the
+environments where RDMA is deliberately deployed.
+
+**D7 — Optional build feature; never vendor NVIDIA SDKs.** *(Decided)*
+conda-forge ships `libcuobjclient`/`libcufile`; Sirius's lockfile today
+resolves `libcufile` only. Gate the backend behind a build flag (e.g.
+`SIRIUS_ENABLE_S3_RDMA`) that adds the `libcuobjclient` dependency or accepts
+`CUOBJ_SDK_ROOT`; default-off builds are unchanged. Apache-2.0 repos carry no
+NVIDIA binaries (same policy as the benchmark repo).
+
+**D8 — Dev rig is unsigned; production gateways must validate SigV4.**
+*(Decided)* The benchmark's own server (local files + `RDMA_WRITE`) is the
+dev/test rig — it does not validate SigV4 and is for isolated networks only.
+Production gateways must validate SigV4 **before** honoring RDMA headers
+(RDMA headers must never bypass auth). The Sirius client signs
+unconditionally. Vendor appliances with different token formats (e.g. Dell
+ECS/ObjectScale) are out of scope until the token relay is abstracted.
+
+**D9 — Byte-range chunk-prewarm off in RDMA mode.** *(Decided)*
+`sirius_ioctx::device_read` consults the prefetch `_cache` **before**
+`device_read_io`: a byte-range cache hit copies from host-pinned slices to the
+device and never reaches the reactor, which would bypass RDMA and re-introduce
+host staging — directly contradicting "all device reads go RDMA".
+
+The control is **not the backend's** — it lives in `scan_manager_config`:
+`enable_prefetch_cache` (whole cache) and `enable_chunk_prewarm` (the
+byte-range prewarm, ignored when the cache is off). So when
+`s3_transport=RDMA`, the `SiriusContext`/scan-config composition must set
+**`enable_chunk_prewarm = false`** while keeping **`enable_prefetch_cache =
+true`** (metadata-only caching: parquet footer / `describe_parquet` stays on).
+Caveat: `enable_chunk_prewarm` is a global scan-manager knob, so turning it off
+also disables prewarm for local-file (uring) reads in the same context;
+preserving local prewarm alongside RDMA-S3 would require the scanner to
+distinguish the backend — i.e. it would break "zero parquet scanner changes",
+and is deferred. v1 accepts the global off (RDMA deployments are S3-dominated).
+This reaffirms the inherited `rdma-s3-ioctx-plan.md` v8 decision.
+
+## 5. Rollout
+
+| Phase | Scope | Hardware |
+|---|---|---|
+| P0 | **Migrate** the benchmark to the standard wire protocol (drop the 4 non-standard headers; server derives the slot address from the token, not a header) **and** harden: short-write = error (authoritative check is the `cuObjGet` result), capacity from the `cuObjGet` `size` arg, O_DIRECT edges, document callback-once (Appendix C.3) | none |
+| P1 | Wire `object_store_config.s3_transport` into `scan_manager_config`; the scan-manager constructor selects the HTTP/RDMA backend; `AUTO`→HTTP; config tests | none |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix (slot state machine, error paths, concept check) | none |
+| P3 | Real cuObject path: single GPU, arena + D2D, flush semantics, visibility stress test on the dev rig | CX-6 rig |
+| P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity validation), RDMA-internal retries, metrics, tuning | CX-6 rig |
+| P5 | Range coalescing/batching; direct-into-RMM spike; small-read RTT → threshold go/no-go; benchmark vs HTTP path (target ≥ HTTP everywhere, approach ~91 Gbps) | CX-6 rig |
+
+## 6. Risks
+
+1. **CUDA visibility after external RDMA writes** — top correctness risk;
+   confined to one flush-before-copy point; dedicated stress test gates P3.
+2. Requires a controlled cuObject-speaking gateway; plain AWS S3 does not apply.
+3. NIC↔GPU PCIe affinity: cross-root-complex peer DMA is slow or unsupported;
+   silent far-NIC selection is a perf bug (validation step in P4).
+4. Server slot budget: each in-flight GET holds a gateway DCI channel + staging
+   pair; the gateway's `max_concurrency` must cover `max_inflight` per RDMA
+   ioctx / client process (the global worker-pool ceiling), multiplied only
+   across independent Sirius contexts/processes — not by queries or GPU count.
+5. Control-plane RTT + D2D overhead on small reads — measured in P5; an
+   ioctx-level whole-read HTTP threshold is the prepared mitigation if
+   warranted (none ships in v1).
+6. cuObject's blocking GET shapes the concurrency model (worker pool);
+   revisit if an async cuObject API appears.
+
+## 7. First milestone
+
+`s3_transport=RDMA` with `s3://` unchanged; host reads still HTTP (SigV4 as
+today); large device reads through a mockable RDMA client; failures error out
+loudly; zero parquet scanner changes. First code lands on the chain
+`object_store_config.s3_transport → scan_manager_config → sirius_scan_manager
+selects the HTTP vs RDMA backend (held in `_io_ctxs`) →
+sirius_scan_manager::create_datasource() → parquet_gpu_ingestible` (P1+P2),
+then the real client swaps in (P3). `SiriusContext` only composes the
+scan_manager_config from `object_store_config`; the backend is owned by the
+scan manager.
+
+## 8. Open questions for team review
+
+1. **Arena / worker sizing defaults.** Two coupled knobs, both seeded from the
+   benchmark's evidence — the question is whether to ship these starting points
+   (all config-overridable) given Sirius's concurrent-scan profile:
+   - `s3_rdma_max_inflight` (default **8**) is the **worker-thread count**;
+     since each worker runs one blocking `cuObjGet`, it is *also* the global
+     in-flight ceiling (not a per-device bound — see §A.4). The benchmark
+     reaches ~91 Gbps line rate at **8 client threads** (1 ≈ 48 Gbps, 2 ≈ 79,
+     8–32 flat at ~91), so 8 is the knee; below it leaves bandwidth on the
+     table, above it adds threads/sessions for no throughput.
+   - `s3_rdma_arena_slot_size` (default **1 MiB**, = `templated_ioctx`'s chunk)
+     gives a per-device arena = `max_inflight × slot_size` ≈ **8 MiB/device**
+     (worst case: all workers on one device) of registered GPU memory —
+     negligible, so the default errs large/safe.
+   - Coupling to the **server**: each in-flight GET holds one gateway DCI
+     channel + staging pair, so the gateway's `max_concurrency` must cover
+     `max_inflight` total (global, **not** × GPUs). A high client default can
+     starve a small-pool gateway — is 8 the right *client* default, or should
+     it track a negotiated server budget?
+2. **OWNER-ordering flush semantics** — who owns verifying against the CUDA
+   docs/header whether `CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER` still
+   requires `cuFlushGPUDirectRDMAWrites` for same-device consumers (P3 gate)?
+3. **Dev-rig hardware** — can we allocate the CX-6 pair (client GPU node +
+   server node) for P3–P5? Single-NIC is sufficient for P3.
+4. **cucascade registrable IO sub-MR** — is there appetite for a
+   `cudaMalloc`-backed, registrable allocation path for IO destination
+   buffers? It would unlock direct-into-RMM (removing the <1% D2D) — low
+   urgency, but it affects cucascade's memory architecture.
+5. **Metrics integration.** The *mechanism* is settled — follow the existing
+   `s3_ioctx` pattern: `std::atomic` counters live in the reactor, the ioctx
+   aggregates across reactors, and they surface as pull-based
+   `…_total() const noexcept` accessors (mirroring `bytes_read_total` /
+   `device_copies_total` / `device_stream_sync_total`). Genuinely open: (a) the
+   RDMA counter set (Appendix C.2) and its naming alignment with the existing
+   S3 counters; (b) whether IO counters should *also* be pushed into
+   `telemetry_context` — today IO metrics are pull-only, and `telemetry_context`
+   carries plan telemetry, not IO. (Note: P0 changes to `s3RDMA-benchmarktool`
+   are owned by us and coordinated across both repos — not a team decision.)
+
+---
+
+# Appendix A — Detailed data-path design
+
+## A.1 Registration & the landing arena
+
+cuObject can only GET into GPU memory previously registered via
+`cuMemObjGetDescriptor` (sub-second per region; the benchmark measured
+~650–720 ms alloc+register for 128 MiB, one-time). Per-chunk or
+per-`device_buffer` registration would dominate a ~100 µs 1 MiB transfer —
+hence register-once arenas:
+
+- **`s3_rdma_ioctx` constructs `templated_ioctx` with a single reactor**
+  (`n_reactors = 1`): `cuObjGet` blocks, so concurrency lives entirely in that
+  reactor's worker pool — there is no benefit to the multi-reactor round-robin
+  the libcurl backend uses. This makes the reactor the natural owner of the
+  per-device arenas and the inflight budget, with no separate ioctx-level
+  arena manager. (If a future need forces multiple reactors, the arenas +
+  budget must move to a shared ioctx-level `s3_rdma_runtime` — explicitly out
+  of scope for v1.)
+- The reactor maintains an arena **per device**, created lazily on first use:
+  a `cudaMalloc`'d region of `s3_rdma_max_inflight` slots of `slot_size` bytes
+  each (`arena bytes = max_inflight × slot_size`)
+  (`slot_size` ≥ chunk size, default 1 MiB), registered once at creation.
+- A chunk GET targets a free slot; slot acquisition blocks when exhausted
+  (backpressure, like the benchmark server's slot pool).
+- The slot is recycled by the worker only after it observes the
+  copy-completion callback status (§A.2).
+- Why not direct into RMM buffers: `cuda_async_memory_resource` memory is not
+  reliably registrable for GPUDirect (`nvidia_peermem`; dmabuf support for
+  mempools is not established) **and** its backing is stream-ordered — an
+  address may have no physical backing when the NIC writes. The arena
+  (`cudaMalloc`, always backed, registered once) sidesteps both; the D2D on
+  the allocation stream is ordered after the RMM buffer's backing by
+  construction.
+
+## A.2 Completion semantics & error paths
+
+Per chunk request `r` (worker thread): acquire slot → `cuObjGet`-driven
+control GET (`Range: [r.file_off, r.file_off + r.io_size)`; the slot address is
+encoded in `x-amz-rdma-token`) → server `RDMA_WRITE`s → HTTP 200/206 with
+`x-amz-rdma-reply` (RDMA status) → `cuObjGet` returns `n` → flush if required
+(§A.3) → `cudaMemcpyAsync(r.dst, slot, n, DeviceToDevice, r.stream)` →
+register completion callback → worker finishes.
+
+**Completion discipline** (mirrors `s3_reactor`): the CUDA callback only
+records status, release-stores a done flag, and wakes the worker — it never
+calls `chunk_done()` (which fires the user handler synchronously on the last
+chunk) and never recycles the slot. The worker: observe status → safely
+recycle the slot → `chunk_done()` / `chunk_failed(ep)`. The user handler
+always fires on a worker/reactor thread with bytes already in `r.dst`.
+
+**Error paths (exhaustive):**
+
+| Failure | Handling |
+|---|---|
+| `cuObjGet` rc < 0; `n != r.data_size`; HTTP ≠ 200/206; WC error | `chunk_failed(ep)`; slot recycled immediately (no copy queued) |
+| Flush failure | `chunk_failed(ep)`; slot recycled immediately |
+| `cudaMemcpyAsync` enqueue failure | `chunk_failed(ep)`; slot recycled immediately |
+| Callback registration failure **after** the copy was queued | `cudaStreamSynchronize(r.stream)` first (the copy may still read the slot), then `chunk_failed(ep)` |
+| D2D completion error (callback status ≠ `cudaSuccess`) | worker observes, recycles slot, then `chunk_failed(ep)` |
+
+Slot lifetime rule: once the D2D is enqueued, the slot belongs to the stream
+until the worker has observed the callback status (or sync-drained on the
+failure path). No retry across transports; RDMA-internal retries arrive in P4.
+
+Invariant: `align_to_physical` is identity for this backend (the server
+handles O_DIRECT alignment), so `r.data_off == 0` and
+`r.io_size == r.data_size` — asserted.
+
+## A.3 Visibility & ordering
+
+Placement is host-side certain: RDMA reliable-connection semantics + the
+server's WC check guarantee the bytes are in the slot before the HTTP reply;
+`cuObjGet` returning implies placement. GPU-consumer visibility is the only
+work: at init read `CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING` —
+
+- `ALL_DEVICES` (typical modern x86 + Ampere/Hopper): no flush.
+- `OWNER`/`NONE`: `cuFlushGPUDirectRDMAWrites` after `cuObjGet` returns and
+  **before enqueuing that chunk's D2D**, so the copy engine observes the
+  NIC's writes. If per-chunk flush measures hot, batch several completed
+  slots behind one flush. (Exact target/scope enums to be pinned against the
+  CUDA header in P3; whether `OWNER` requires the flush for same-device
+  consumers is verified, not assumed — open question 2.)
+
+Downstream needs nothing: the D2D and the decode kernels share `r.stream`, so
+stream order guarantees the decode sees the copied bytes.
+
+## A.4 Concurrency, multi-GPU, teardown
+
+- **Workers**: `cuObjGet` blocks ⇒ each reactor owns N workers (default 8 —
+  the benchmark's line-rate point), each with its own `cuObjClient` session
+  and a persistent keep-alive control-plane connection — a **libcurl easy
+  handle** (Sirius already links libcurl for `s3_reactor`; the benchmark's
+  cpp-httplib and its connection-per-GET pattern are not carried over). The
+  callback inside `cuObjGet` is synchronous, so a blocking easy-handle request
+  is the right shape; the same connection serves the reactor's host reads.
+  Workers are *not* bound to GPUs.
+- **`s3_rdma_max_inflight` scope**: it is the **worker-thread count**, and
+  because each worker runs one *blocking* `cuObjGet` at a time, it is therefore
+  the **global** ceiling on concurrent in-flight GETs — there is no separate
+  per-device inflight bound. "Per device" applies only to **arena placement**:
+  a worker `cudaSetDevice`s to `r.device_id` and takes a slot from that
+  device's arena, so each active device's arena is sized for the worst case
+  (all workers targeting it) = `max_inflight × slot_size`. Total registered GPU
+  memory = `active_GPUs × max_inflight × slot_size`, but total in-flight stays
+  `max_inflight` regardless of GPU count.
+- **Multi-GPU**: the S3 ioctx is a process singleton; every request carries
+  the caller's device id (stamped at enqueue). Per request:
+  `cudaSetDevice(r.device_id)` → use **that device's** arena → flush on that
+  device's context → D2D on `r.stream`. Slot and `r.dst` are same-device by
+  construction (never a cross-device copy). NIC↔GPU PCIe affinity: list all
+  RoCE NICs in `cufile.json`'s `rdma_dev_addr_list`; cufile selects the
+  nearest NIC per GPU; P4 validates with per-GPU `gdscheck -p` + bandwidth
+  sweeps. With a single NIC all GPUs share ~12.5 GB/s; the gateway slot budget
+  must cover `max_inflight` total (the global worker-pool ceiling), **not**
+  `max_inflight × GPUs` — in-flight is bounded by the worker pool regardless of
+  how the requests spread across devices.
+- **Memory budget**: zero host staging for bulk object bytes (vs `s3_reactor`'s 128 × 1 MiB pinned
+  staging per reactor); device-side cost is the arena (~8 MiB/device at defaults) +
+  descriptors + sessions.
+- **Teardown**: stop intake → workers drain the queue and complete/fail all
+  outstanding D2D completions (the workers are the ones that observe callbacks,
+  so this must happen *before* they exit) → join workers → deregister + free
+  arenas (`cuMemObjPutDescriptor`,
+  `cudaFree`) → destroy sessions. Mirrors the mandated
+  scan_manager → ioctx → pool order.
+
+## A.5 Future: direct-into-RMM (gated spike)
+
+Revisit only if (a) a registrable allocation path for consumer buffers
+appears (dmabuf for mempools, or a cucascade registrable IO sub-MR — §8 Q4),
+and (b) enclosing-region descriptors prove valid for interior
+pointers on the rig. Any large-region registration is bounded by
+`CUOBJ_MAX_MEMORY_REG_SIZE` (4 GiB − 64 KiB), so pool-scale registration
+needs segmenting regardless. Upside is the <1% D2D — low priority.
+
+# Appendix B — Verified source facts
+
+> Line numbers are a snapshot (verified 2026-06-13 against the local tree) and
+> must be re-confirmed before any implementation PR — the IO layer moves.
+
+| Fact | Source |
+|---|---|
+| Super Sirius device memory is `cuda_async_memory_resource` (cudaMallocAsync) | `cucascade/src/memory/memory_space.cpp:121-126`, `memory/common.cpp:256-258` |
+| Only the dead legacy path uses a `cudaMalloc`-backed pool | `sirius/src/legacy/gpu_buffer_manager.cpp:195-196` |
+| The S3 backend is owned by the scan manager (one ioctx in `_io_ctxs`), built from the scan_manager_config; `SiriusContext` only composes that config | `sirius/src/sirius_context.cpp:553`, `sirius/src/scan_manager/sirius_scan_manager.cpp:76` |
+| `create_datasource(path)` is the resolution entry: iterate `_io_ctxs` → `supports → create_io_object → make_datasource` | `sirius/src/scan_manager/sirius_scan_manager.cpp:493` |
+| `device_read()` consults `_cache` before `device_read_io`; a byte-range hit copies host-pinned slices → device, bypassing the reactor. Scan-side byte-range prewarm is gated by `chunk_prewarm_enabled()`; `describe_parquet`'s insert is metadata-only | `sirius/src/io/io_context.cpp:219-226`, `sirius/src/op/scan/parquet_gpu_ingestible.cpp:414` |
+| `s3_ioctx` overrides `host_read_ranges_async_io` for strict validation; the generic `templated_ioctx` version silently skips invalid/too-small ranges | `sirius/src/include/io/s3/s3_ioctx.hpp:67`, `sirius/src/include/io/templated_ioctx.hpp:243` |
+| Per-GPU uring map exists for `file` scheme (contrast) | `sirius/src/sirius_context.cpp:422-464` |
+| Requests carry the caller's device id (stamped at enqueue) | `sirius/src/include/io/templated_ioctx.hpp:328-347` |
+| `s3_reactor` sets device before each H2D copy | `sirius/src/io/s3/s3_reactor.cpp:687-688` |
+| `chunk_done()` fires the user handler synchronously on the last chunk | `sirius/src/include/io/types.hpp:173` |
+| CUDA callback only marks + wakes; reactor thread completes | `s3_reactor.cpp:749` (`cuda_copy_done`), `:728` (`poll_device_copies`) |
+| Callback-registration failure ⇒ sync drain before staging release | `s3_reactor.cpp:713` (and `:705` for enqueue failure) |
+| `is_device_read_preferred` returns unconditional `true` — device reads go RDMA immediately on backend swap | `sirius/src/io/sirius_datasource.cpp:45-47` |
+| `s3_ioctx : templated_ioctx<s3_reactor>` with instance `create_io_object` via the authorizer | `sirius/src/include/io/s3/s3_ioctx.hpp` |
+| `object_store_config::transport { AUTO, HTTP, RDMA }` + SigV4 presigned/header modes already exist | `sirius/src/include/io/object_store_config.hpp` |
+| Sirius `pixi.lock` resolves `libcufile` but not `libcuobjclient` | `sirius/pixi.lock` |
+| `CUOBJ_MAX_MEMORY_REG_SIZE = 4 GiB − 64 KiB` | cuObject SDK `cuobjclient.h:22` |
+| Per the cuObject spec, the client conveys the RDMA descriptor — which **encodes the remote buffer/slot address** — in a single request tag `x-amz-rdma-token` (inserted by `cuObjGet`); the gateway replies with `x-amz-rdma-reply` carrying RDMA status. `cuObjGet`'s `size`/`offset` args (not headers) bound the transfer. **Verified 2026-06-15 against the public doc**: both tags confirmed; the reply tag conveys RDMA **status** (no byte count specified) | cuObject spec §1.3.2 (RDMA GET/PUT workflow) + §1.3.3 (data-flow sequence), docs.nvidia.com/gpudirect-storage/cuobject |
+| Token encodes the address **even on the pinned 1.0.0 SDK**: client `cuMemObjGetRDMAToken(ptr, size, buffer_offset, …)` modifies the descriptor's address/size fields. But local `handleGetObject` still takes `remote_buf_start` as a separate param (1.0.0; public doc is 1.2.0) — see C.3 migration caveat | `s3-over-rdma/third_party/cuobj-1.0.0/.../cuobjclient.h:183`, `cuobjserver.h:227` |
+| Benchmark: ~91 Gbps GPU GET, line rate at 8 threads; register-once pattern | `s3RDMA-benchmarktool/doc/test.md` |
+| `cuObjGet` invokes the client callback once per object; chunking is server-side | `s3RDMA-benchmarktool/doc/internals.md` |
+
+# Appendix C — Protocol & config reference
+
+## C.1 Control-plane headers
+
+Per the cuObject spec (§1.3.2, §1.3.3), the standard RDMA control protocol uses
+exactly **two** custom header tags, plus a standard `Range`:
+
+| Header | Direction | Meaning |
+|---|---|---|
+| `x-amz-rdma-token` | client → gateway | base64 of the opaque cuObject RDMA descriptor; **encodes the remote buffer/slot address** (inserted by `cuObjGet`/`cuObjPut`) |
+| `x-amz-rdma-reply` | gateway → client | standard RDMA status of the offloaded transfer. The **authoritative** short-write check is `cuObjGet`'s returned `n == expected` (not HTTP 200/206 alone); the reply tag carries the status — don't assume it itself equals a byte count unless the reply payload format is confirmed |
+
+Plus standard `Range: bytes=a-b` (206 for range responses). On production
+gateways every control request is SigV4-signed and validated before the RDMA
+tag is honored.
+
+The benchmark had accreted **four** extra headers that are **not** part of the
+cuObject spec; Sirius drops them to stay on the standard protocol:
+
+| Dropped header | Why it's gone |
+|---|---|
+| `x-cuobj-remote-addr` | the remote slot address is encoded inside `x-amz-rdma-token`; a separate header is redundant under the spec |
+| `x-cuobj-chunk-size` | benchmark tuning value, not a cuObject primitive; derive it from the arena `slot_size` or make it gateway config |
+| `x-cuobj-size` | destination capacity is the `cuObjGet` `size` arg, not a wire header; the fixed `slot_size` + bounded `Range` already prevent over-writes |
+| `x-amz-rdma-bytes-transferred` | superseded by the spec's `x-amz-rdma-reply` (RDMA status); the authoritative byte-count check is `cuObjGet`'s return value |
+
+## C.2 Config (under the existing `object_store_config`)
+
+```text
+s3_transport = HTTP | RDMA           # existing enum; AUTO resolves to HTTP in v1
+s3_rdma_endpoint / s3_rdma_port      # control-plane endpoint if distinct
+s3_rdma_chunk_size                  # local 1 MiB chunking (templated_ioctx); NOT a wire header — arena slot_size derives from it
+s3_rdma_max_inflight                # worker count = global in-flight ceiling (NOT per-device; see A.4)
+s3_rdma_arena_slot_size             # ≥ chunk size; arena = max_inflight × slot_size
+```
+
+Possible P5 addition (post-measurement): `s3_rdma_min_device_read_size` — an
+ioctx-level whole-read threshold routing small device reads over HTTP. Not in
+v1.
+
+Proposed counters: `s3_rdma_bytes_total`, `s3_rdma_requests_total`,
+`s3_rdma_arena_slot_wait_total`, `s3_rdma_flush_total`,
+`s3_rdma_short_write_total`, `s3_rdma_error_total`, `s3_rdma_inflight_peak`.
+
+Integration follows the existing `s3_ioctx` pattern (no new mechanism): each is
+a `std::atomic<uint64_t>` in the reactor, the ioctx aggregates across reactors,
+and they surface as pull-based `…_total() const noexcept` accessors alongside
+the inherited `bytes_read_total` / `device_copies_total` /
+`device_stream_sync_total` (`s3_ioctx.cpp:141-169`, `s3_reactor.hpp:250-252`).
+Pushing IO counters into `telemetry_context` (today pull-only) is the open part
+— see §8 Q5.
+
+## C.3 P0 — benchmark protocol migration + hardening (lands in `s3RDMA-benchmarktool`)
+
+P0 is a **wire-protocol migration**, not just hardening: the benchmark today
+sends `x-cuobj-remote-addr` / `x-cuobj-size` / `x-cuobj-chunk-size` and its
+server *requires* the remote-addr header (`client/s3_client.cpp`,
+`server/s3_server.cpp`). Moving to the standard cuObject protocol means:
+
+- Drop the four non-standard headers; the server obtains the slot address by
+  **decoding it from the token** rather than reading `x-cuobj-remote-addr`.
+  Implementation caveat: the pinned SDK is cuObject **1.0.0**, whose
+  `handleGetObject` still takes `remote_buf_start` as an explicit param — so
+  this needs either a server-side token-decode path or an SDK bump toward the
+  public **1.2.0** protocol. Do not assume the old benchmark server runs
+  unchanged.
+- Server enforces the destination capacity (from the `cuObjGet` `size` arg /
+  the fixed arena `slot_size`) and rejects writes larger than the destination.
+- Short positive RDMA writes are errors — the **authoritative** check is
+  `cuObjGet`'s returned `n == expected`; `x-amz-rdma-reply` is the standard
+  status tag (do not assume it itself equals the byte count).
+- O_DIRECT alignment edge cases.
+- Document callback-once-per-object semantics.
+- Optional stretch: SigV4 validation mode in the benchmark server.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -2,8 +2,8 @@
 
 | | |
 |---|---|
-| **Status** | Draft for team review |
-| **Date** | 2026-06-17 |
+| **Status** | Draft for team review — rebased onto the merged REST IO framework (#997) and the S3 cutover (#1042), both on `dev` |
+| **Date** | 2026-07-04 |
 | **Author** | Sirius Contributors |
 | **Benchmark** | <https://github.com/sirius-db/s3RDMA-benchmarktool> — ~91 Gbps GPU-mode GET on CX-6 RoCE |
 
@@ -14,20 +14,20 @@ removing today's pinned-host staging + PCIe H2D copy. A cuObject gateway
 `RDMA_WRITE`s into a small pre-registered GPU **arena**; a GPU-local copy then
 moves it to the final RMM buffer. `s3://` URIs, SigV4 auth, and the Parquet
 scanner are unchanged — the new code is one reactor plus a thin ioctx under the
-existing `templated_ioctx`. The benchmark proves the cuObject RDMA data path at
-line rate; the Sirius-specific arena+D2D visibility and completion discipline
-are gated by P3. **Please review the decisions table (§3) and the open
-questions (§5).**
+existing `templated_ioctx`, exactly how the REST backend is built. The benchmark
+proves the cuObject RDMA data path at line rate; the Sirius-specific arena+D2D
+visibility and completion discipline are gated by P3. **Please review the
+decisions table (§3) and the open questions (§5).**
 
 ## Why
 
-Sirius reads S3 Parquet today via libcurl range GETs into pinned host staging,
-then `cudaMemcpyAsync` to the GPU (`s3_reactor`) — every byte crosses host
-memory and PCIe **twice**. RDMA-direct removes both legs.
+Sirius reads S3 Parquet today via the REST backend (`rest_ioctx`): libcurl range
+GETs into pinned host bounce buffers, then `cudaMemcpyAsync` to the GPU — every
+byte crosses host memory and PCIe **twice**. RDMA-direct removes both legs.
 
 - **Goals:** large device reads RDMA-direct into GPU memory; keep `s3://` /
-  SigV4 / `sirius_datasource` semantics; HTTP backend stays config-selectable;
-  no Parquet-scanner changes.
+  SigV4 / `sirius_datasource` semantics; the REST backend stays the
+  config-selectable default; no Parquet-scanner changes.
 - **Non-goals (v1):** no new URI scheme; no plain-AWS-S3 (needs a cuObject
   gateway); no `AUTO` probe and no runtime HTTP fallback (RDMA failure = I/O
   error); no AWS-CRT dependency.
@@ -45,18 +45,26 @@ flowchart LR
 ```
 
 The **control plane** (HTTP) carries only the RDMA descriptor token; the **data
-plane** (RDMA) writes object bytes straight into the GPU arena. Versus
-`s3_reactor` (GET → pinned host staging → PCIe H2D), this backend swaps host
-staging for a small GPU arena and the H2D copy for a GPU-local D2D (<1%
-overhead). Host reads (footers / HEAD) still go over HTTP.
+plane** (RDMA) writes object bytes straight into the GPU arena. Versus the REST
+backend (GET → pinned host bounce → PCIe H2D), this swaps host staging for a
+small GPU arena and the H2D copy for a GPU-local D2D (<1% overhead). Host reads
+(footers / HEAD) still go over HTTP, reusing `curl_handle` and the SigV4
+`s3_request_authorizer`.
 
-The arena is a **fixed per-chunk staging window** (`max_inflight × 1 MiB`),
-**not** object-sized: `templated_ioctx` splits the read into 1 MiB chunks that
-stream through the arena in waves, each chunk D2D-copied to its offset in the
-**full-size RMM destination buffer**. So a 128 MiB (or multi-GB) read flows
-through the same arena (default ~8 MiB, configurable as `max_inflight ×
-slot_size`) — exactly how `s3_reactor` streams through its host staging blocks
-today.
+The arena is a **fixed per-chunk staging window**, not object-sized: the reactor
+splits a read into slot-sized chunks that stream through the arena in waves, each
+chunk D2D-copied to its offset in the full-size RMM destination buffer. A 128 MiB
+(or multi-GB) read flows through the same small arena.
+
+Both sizing knobs are **config** (`s3_rdma_max_inflight`,
+`s3_rdma_arena_slot_size`). The default — **8 workers × 4 MiB slots = 32 MiB per
+device** — is calibrated on the benchmark's CX-6 **100G** rig, which is the
+*floor* for this transport (line rate at 8 × 4 MiB; 8 × 1 MiB leaves ~12% idle).
+Faster NICs scale the same two knobs, not the design: keep the bytes in flight
+(`workers × slot_size`) growing roughly linearly with line rate — e.g.
+~16 × 16 MiB or 64 × 4 MiB ≈ 256 MiB/device for 800G-class NICs — and re-derive
+the knee empirically on the target rig (a P4/P5 sweep). The arena stays trivial
+next to GPU memory at any of these points.
 
 ## 2. How one read works
 
@@ -65,81 +73,119 @@ sequenceDiagram
   participant W as reactor worker
   participant A as GPU arena slot
   participant G as cuObject gateway
-  participant S as r.stream (CUDA)
-  W->>A: acquire free slot
+  participant S as CUDA stream
+  W->>A: acquire free slot (slot_pool, reused from the framework)
   W->>G: cuObjGet -> HTTP GET (x-amz-rdma-token, Range)
   G-->>A: RDMA_WRITE bytes into slot
   G-->>W: 200 + x-amz-rdma-reply
-  Note over W: flush GPUDirect writes (only if platform needs)
-  W->>S: cudaMemcpyAsync slot -> r.dst (D2D)
-  S-->>W: completion callback marks done + wakes
-  W->>W: recycle slot, chunk_done()
-  Note over S: cuDF decode runs after, same stream => sees data
+  Note over W: flush GPUDirect writes (only if the platform needs it)
+  W->>S: cudaMemcpyAsync slot -> dst (D2D) + record CUDA event
+  S-->>W: event clears (worker polls, REST's proven pattern)
+  W->>W: chunk_complete + release slot
+  Note over S: the read's future resolves when its last chunk finishes
 ```
 
 `cuObjGet` blocks until the RDMA completes, so the **worker pool is the
-concurrency bound**. The CUDA callback only marks+wakes — it must never call
-`chunk_done()` itself (that fires the user handler synchronously, and not on a
-CUDA thread); the worker finishes the chunk, exactly like `s3_reactor`. On any
-failure the worker calls `chunk_failed` and recycles the slot (sync-draining
-the stream first if a D2D was already queued).
+concurrency bound**. Completion uses the framework's `exec::semi_future` +
+`request_manager`: each chunk reports `chunk_complete` or `report_error` exactly
+once and then releases its manager reference — the future resolves when the last
+chunk does. Nothing runs on a CUDA callback thread; the worker finishes the chunk
+after its CUDA event clears, then recycles the slot. Because the D2D is ~3 µs
+against a ~350 µs network GET, v1 may simply wait on the event inline instead of
+parking copies for a poll loop — a simplification to measure in P2/P3.
 
 ## 3. Key decisions
 
 | # | Decision | Why |
 |---|---|---|
-| D1 | Keep `s3://`; pick transport via `object_store_config.transport {HTTP,RDMA}` (AUTO→HTTP in v1) | No new scheme; the scan manager owns one S3 backend in `_io_ctxs` |
-| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — one reactor + thin overrides (authorizer HEAD, strict range validation, counters) | Reuses chunking / pooling / completion / factory; same shape as `s3_ioctx` |
-| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; `s3_reactor` not instantiated in RDMA mode | Backends are mutually exclusive; callers see identical semantics |
-| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so RDMA can't target it directly. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
-| D5 | Completion: CUDA callback only marks+wakes; the worker calls `chunk_done`/`chunk_failed` | `chunk_done` fires the user handler synchronously — must not run on a CUDA thread (same as `s3_reactor`) |
-| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks / thresholds mask misconfig exactly where RDMA is deliberately deployed |
-| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged; Apache-2.0 repo carries no NVIDIA binaries |
-| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | Client always signs; RDMA headers must never bypass auth |
-| **D9** | **Byte-range chunk-prewarm off** in RDMA mode (`enable_chunk_prewarm=false`, keep `enable_prefetch_cache=true`) | `device_read` consults the cache *before* the reactor; a byte-range hit would re-introduce host staging. Global knob ⇒ also disables local-file prewarm (accepted in v1) |
+| D1 | Keep `s3://`; select the backend once, at `io_context_registry` construction: `s3_transport=RDMA` registers the rdma backend for the s3 slot instead of restful (`AUTO`→HTTP) | `s3_transport` already exists in config (parsed, currently unused); exactly one s3 backend per context keeps path routing unambiguous, and the scan side (`ioctx_for_path` / split providers) is untouched |
+| D2 | `s3_rdma_ioctx : templated_ioctx<cuobj_rdma_reactor>` — the reactor provides `prep_host_rx` / `prep_device_rx` builders + `enqueue`; credentials and the registered arena live in its `reactor_context` | Same shape as `rest_ioctx`; chunking, pooling, completion, the `slot_pool`, and the registry factory are all reused |
+| D3 | One hybrid ioctx: host reads → HTTP, device reads → RDMA; the REST backend is not instantiated in RDMA mode | Backends are mutually exclusive per context; callers see identical semantics |
+| **D4** | **Landing arena + GPU-local D2D**, not direct RDMA into RMM buffers | Sirius RMM is `cuda_async_memory_resource` — not registrable for GPUDirect and stream-ordered, so the NIC can't target it. Arena = `cudaMalloc`, registered once; D2D is <1% overhead, zero host bounce |
+| D5 | Completion via `semi_future` + `request_manager`; a chunk completes exactly once, on a worker thread, after its CUDA event clears — never from a CUDA callback | Matches the framework contract (the future resolves when the last chunk releases its manager reference); keeps user code off CUDA's internal threads |
+| D6 | v1: explicit `RDMA` opt-in, fail loudly, no HTTP fallback; all device reads go RDMA | Fallbacks and premature thresholds mask misconfiguration exactly where RDMA is deliberately deployed |
+| D7 | Optional build feature `SIRIUS_ENABLE_S3_RDMA` (conda `libcuobjclient` or `CUOBJ_SDK_ROOT`); never vendor NVIDIA SDKs | Default-off builds unchanged. Note: conda ships cuObject 1.2.x while the benchmark validated 1.0.0 — version reconciliation is a real task, not a drop-in add |
+| D8 | Dev rig = benchmark server (unsigned, isolated net); production gateways must SigV4-validate before honoring RDMA headers | The client always signs; RDMA headers must never bypass auth |
+| **D9** | **Prefetch cache off, structurally**: the reactor defines *only* the host-read and device-read builders and omits the two staged-read ones — the framework then derives "no cache for this backend" on its own | Capabilities are derived from which builders a reactor defines (there is no flag to set); the cache activates only if a backend has a staged-read path. kvikio — Sirius's official fallback backend — already ships this exact minimal profile |
+
+Why D9 works, in one picture:
+
+```mermaid
+flowchart LR
+  A["reactor defines ONLY<br/>host-read + device-read builders"] --> B["framework derives:<br/>no vector read, no staged H2D"]
+  B --> C["prefetch cache is never built<br/>for this backend"]
+  C --> D["no host staging can sneak in;<br/>the cache's null-gap crash path<br/>(SF10) is unreachable"]
+```
 
 `max_inflight` = worker count = **global** in-flight ceiling (one blocking
 `cuObjGet` per worker); "per-device" applies only to arena placement
 (`max_inflight × slot_size` per active GPU, worst case). Direct-into-RMM is a
 gated future spike (§5 Q4).
 
-**One reactor, not one per GPU.** Multi-GPU affinity lives at the **arena/slot**
-layer — a worker does `cudaSetDevice(r.device_id)` and takes a slot from *that*
-device's arena, so the slot and `r.dst` are always same-device (never a
-cross-device copy). The single reactor owns one global worker pool. A per-GPU
-reactor would make concurrency `GPUs × max_inflight` (e.g. 4×8 = 32 concurrent
-`cuObjGet`), breaking the global in-flight ceiling and risking gateway/NIC
-overload. Per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity and
-per-device throttling, at the cost of global rate-limit and config complexity —
-is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
+**One reactor per node — and what scales with what.** For contrast: the REST
+backend runs **2 reactors per node** (`rest_n_reactors`), unrelated to GPU count —
+its reactors are epoll event loops doing real CPU work (TLS, staging copies), so
+a second one spreads CPU load. The RDMA reactor is *not* an event loop
+(`cuObjGet` blocks): it is a container for the worker pool and the arenas, so
+extra reactors add no throughput — they would only fragment the global in-flight
+ceiling and multiply sessions. Hence three independent axes:
+
+- **Throughput** scales with **workers** (= NIC line rate, see §1 sizing) — not
+  with reactors, not with GPUs.
+- **GPU count** scales only the **arena map**: an extra GPU lazily gets its own
+  arena; a worker sets the request's device and takes a slot from *that* device's
+  arena, so slot and destination are always same-device (never a cross-device
+  copy). A per-GPU reactor would instead make concurrency `GPUs × max_inflight`
+  (e.g. 4×8 = 32 concurrent `cuObjGet`), breaking the global ceiling and risking
+  gateway/NIC overload.
+- **NIC count** is the one thing that eventually justifies more reactors:
+  per-GPU / per-NIC **reactor sharding** — tighter NIC↔GPU affinity at the cost
+  of global rate-limit complexity — is the deferred evolution for explicit
+  multi-NIC/NUMA topologies, not v1.
+
+**Known v1 scope limit (not Parquet):** the DuckDB-native `.db` decoder is the
+one caller of the vector host-read entry point, which this backend omits — a
+native `.db` ATTACHed over s3://+RDMA fails loudly. kvikio has the same gap
+today; a small framework fix (fall back to per-segment single reads when the
+vector path is absent) would close it for both and is proposed as a standalone
+change.
 
 ## 4. Rollout
 
 | Phase | Scope | HW |
 |---|---|---|
 | **P0a ✅ wire migration landed** | Standard wire protocol merged into `s3RDMA-benchmarktool` (drop 4 non-standard headers; server decodes the address from the token; `x-amz-rdma-reply`) | — |
-| **P0b ⏳ gateway hardening open** | Strict descriptor-address parse, explicit short-write (`n == expected`) + capacity checks — today the client returns `size` on any 200/206 and the server only fails on `rdma_n < 0` (see appendix) | — |
-| P1 | Wire `s3_transport` through `scan_manager_config`; backend chosen at scan-manager construction; AUTO→HTTP; config tests | — |
-| P2 | `cuobj_rdma_reactor` against a **mock** client; full hardware-free test matrix | — |
-| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test | CX-6 |
+| **P0b ⏳ gateway hardening open** | Re-add strict descriptor parsing (the migration removed the old validator — a regression); enforce the token's `buf_size` (on the wire but unread); explicit short-write `n == expected` check | — |
+| **P1 — unblocked** (#1042 merged) | Add the rdma backend type + factory; the `io_context_registry` constructor picks rdma-vs-rest for the s3 slot by `s3_transport` (`AUTO`→HTTP); routing tests extend the existing cutover suite | — |
+| P2 | `cuobj_rdma_reactor` against a **mock** client; hardware-free matrix incl. compile-time checks that the two staged-read capabilities stay off | — |
+| P3 | Real cuObject path, single GPU; arena + D2D + flush + a visibility stress test; pin the registration-per-session question | CX-6 |
 | P4 | Multi-GPU (per-device arenas, NIC↔GPU affinity), retries, metrics, tuning | CX-6 |
 | P5 | Range coalescing; direct-into-RMM spike; small-read threshold go/no-go; vs-HTTP benchmark | CX-6 |
 
 ## 5. Open questions for team review
 
-1. **Sizing defaults** — ship `max_inflight = 8` (worker count = global
-   in-flight ceiling) + 1 MiB arena slots? 8 is the benchmark's line-rate knee;
-   or should the client default track a negotiated gateway budget?
-2. **OWNER-flush ownership** — who verifies (against the CUDA docs) whether
-   `…_ORDERING_OWNER` still needs `cuFlushGPUDirectRDMAWrites` for same-device
-   consumers? This is the top correctness risk; it gates P3.
+1. **Sizing defaults** — ship 8 workers × 4 MiB as the **100G-floor** default
+   (line rate on the CX-6 rig) with the documented rule "scale in-flight bytes
+   linearly with NIC line rate" (§1) — or should the default self-scale from a
+   detected/configured link speed? 800G-class NICs need ~8× the in-flight bytes
+   and proportionally more workers, which also stresses the blocking-GET
+   thread-per-worker model (§6).
+2. **OWNER-flush ownership** — who verifies whether `…_ORDERING_OWNER` still
+   needs `cuFlushGPUDirectRDMAWrites` for same-device consumers? Neither the
+   benchmark nor Sirius contains any flush handling today — this is from-scratch
+   P3 work and the top correctness risk.
 3. **Dev-rig hardware** — can we allocate the CX-6 pair for P3–P5?
    (Single-NIC suffices for P3.)
 4. **cucascade registrable IO sub-MR** — appetite for a `cudaMalloc`-backed,
    registrable allocation path for IO buffers? It unlocks direct-into-RMM
    (drops the <1% D2D) but touches cucascade's memory architecture.
-5. **Metrics** — counter set + naming vs the existing S3 counters; and should
-   IO counters also be pushed into `telemetry_context` (today pull-only)?
+5. **Metrics** — counter set + naming vs the existing S3 counters. Note the #982
+   perf instrumentation was re-added for the REST reactor in #1042; the RDMA
+   counters should follow that shape rather than invent a parallel one.
+6. **Registration × sessions** — each worker owns its own `cuObjClient` session;
+   is a buffer registration per-session (8 registrations of the same arena) or
+   shareable? SDK-version-dependent (conda 1.2.x vs the validated 1.0.0); shapes
+   the client-wrapper API. Pin on the rig in P3.
 
 ## 6. Risks
 
@@ -149,7 +195,11 @@ is a deferred evolution for explicit multi-NIC/NUMA topologies, not v1.
   can silently halve BW. The gateway slot budget must cover `max_inflight` per
   client process (not × GPUs or × queries).
 - Small-read control-plane RTT overhead (mitigation = optional whole-read
-  threshold, P5); cuObject's blocking GET shapes the worker-pool model.
+  threshold, P5); cuObject's blocking GET shapes the worker-pool model — and at
+  800G-class line rates the pool grows ~8× (with the gateway DCI budget growing
+  with it), sharpening the case for an async cuObject API if one appears.
+- cuObject SDK version skew (conda 1.2.x vs benchmark-validated 1.0.0) — must be
+  reconciled before P3.
 
 ---
 
@@ -161,40 +211,49 @@ Standard cuObject protocol (spec §1.3.2 / §1.3.3): two custom tags + `Range`.
 
 | Header | Direction | Meaning |
 |---|---|---|
-| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** |
+| `x-amz-rdma-token` | client → gateway | base64 cuObject descriptor; **encodes the remote slot address** (and the slot size) |
 | `x-amz-rdma-reply` | gateway → client | RDMA status tag (authoritative completion is `cuObjGet`'s `n == expected`, not a reply byte count) |
 
 The benchmark's four extra headers (`x-cuobj-remote-addr`, `x-cuobj-size`,
 `x-cuobj-chunk-size`, `x-amz-rdma-bytes-transferred`) are **dropped**: the
 address rides in the token, capacity is the `cuObjGet` `size` arg, and the
-reply tag supersedes the byte-count header. Production gateways SigV4-validate
-the control request before honoring the token.
+reply tag supersedes the byte-count header. The server chunks transfers
+server-side (its own config, default 2 MiB) — nothing is negotiated on the wire.
+Production gateways SigV4-validate the control request before honoring the token.
 
 ### Config (under `object_store_config`)
 
+`s3_transport { AUTO, HTTP, RDMA }` already exists and is parsed; this work adds
+its consumer. The rest are new fields for the integration PR:
+
 ```text
-s3_transport = HTTP | RDMA        # existing enum; AUTO -> HTTP in v1
+s3_transport = HTTP | RDMA        # existing; AUTO -> HTTP in v1
 s3_rdma_endpoint / s3_rdma_port   # control-plane endpoint if distinct
 s3_rdma_max_inflight              # worker count = global in-flight ceiling
-s3_rdma_arena_slot_size           # >= 1 MiB chunk; arena = max_inflight x slot_size
-# P5 maybe: s3_rdma_min_device_read_size (route small reads over HTTP)
+                                  #   default 8 — calibrated on the 100G floor; scale with NIC line rate
+s3_rdma_arena_slot_size           # per-chunk arena slot
+                                  #   default 4 MiB — same calibration; workers x slot_size tracks line rate
 ```
 
-Counters follow the `s3_ioctx` pattern (atomics in the reactor, aggregated by
-the ioctx, pulled via `…_total()` accessors): `s3_rdma_bytes_total`,
+There is deliberately **no client chunk-size knob**: the transfer granularity is
+the arena slot size, and the server chunks independently. Auth/TLS reuse the
+existing fields (`s3_signing_mode`, `ca_bundle_path`, `tls_verify`).
+
+Counters follow the REST-reactor instrumentation shape: `s3_rdma_bytes_total`,
 `…_requests_total`, `…_arena_slot_wait_total`, `…_flush_total`,
 `…_short_write_total`, `…_error_total`, `…_inflight_peak`.
 
 ### P0 status (in `s3RDMA-benchmarktool`)
 
-**Migration landed** (merged to `main`, 2026-06-17): the 4 non-standard headers
-dropped, the server decodes the slot address from the token (works on the
+**Wire migration landed** (merged to `main`, 2026-06-17): the 4 non-standard
+headers dropped, the server decodes the slot address from the token (works on the
 pinned cuObject 1.0.0 — no SDK bump), `x-amz-rdma-reply` status, callback-once
-documented. **Open hardening:** strict descriptor-address parse (a
-`CUOBJ`-prefixed descriptor could parse to a wrong address — reviewed, deferred
-pending a format lock against a real `rdma->desc_str` on the rig); explicit
-short-write (`n == expected`) and capacity checks (today bounded by `Range` +
-the `cuObjGet` `size` arg); optional SigV4 in the dev server.
+documented. **Open hardening (P0b):** the migration **removed** the previous
+strict address validator — today's parse takes the first hex field with no
+length/field validation (and wrongly rejects a legitimate address 0); the token's
+`buf_size` field is transmitted but never read server-side (a free capacity check
+not being performed); the client reports success on any 200/206 without an
+`n == expected` short-write check; optional SigV4 in the dev server.
 
 > Deeper implementation notes + verified file:line references live in the
 > offline working spec, not this doc.

--- a/experimental/s3-rdma-transport-design.md
+++ b/experimental/s3-rdma-transport-design.md
@@ -249,9 +249,12 @@ and rejects a presigned-mode authorizer at initialization; the host
 endpoint keeps its configured mode. Descriptor tokens are redacted from
 logs and traces in every profile.
 
-Fault-injection hooks exist only in test builds: release artifacts
-contain none, a production-mode start refuses to run with hooks enabled,
-and hooks cannot be reached through request headers.
+Request-level fault-injection hooks exist only in test builds: release
+artifacts contain none, a production-mode start refuses to run with hooks
+enabled, and hooks cannot be reached through request headers. CUDA
+delivery calls are injectable at construction time for tests.
+Configuration and request headers cannot reach that seam; release builds
+construct with the real CUDA entry points.
 
 The rig may run an unsigned gateway and a non-TLS control plane, but not
 with production data or credentials, and not on an uncontrolled network.


### PR DESCRIPTION
## Summary

Please read the HTML version.

This PR proposes an opt-in RDMA path for exact-key Parquet reads from S3 on a single GPU. For device reads, cuObject writes each chunk into a pre-registered GPU arena, and Sirius copies it into the caller-owned RMM buffer on the caller's CUDA stream. HEAD, footer, and other host reads continue to use the existing S3 path. This avoids Sirius-side host staging and H2D without requiring arbitrary RMM allocations to be registered with the NIC.

The RDMA path uses a dedicated, direct-connect cuObject gateway. Requests enter a bounded queue, each worker owns one RDMA session, and a read completes only after all of its chunks have been delivered. An uncertain RDMA result stops the transport and requires a process restart. Once a D2D copy has been submitted, an unprovable CUDA outcome terminates the process because the arena can no longer be released safely.

The evaluation requires hardware correctness, at least 85% of the qualified RDMA link rate for objects of 16 MiB or larger, and a zero-failure 100-million-GET soak. Smaller objects are measured against HTTP to decide whether V1 should route them by size.

This PR contains design documentation only. The six decisions that need team agreement are listed in Section 1.