### PR TITLE
Add `pinned-hot` for the TPCH parquet benchmark path

### DIFF
--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -109,9 +109,9 @@ grep -c 'duckdb_native_gpu_ingestible::materialize_table] decoded split' /tmp/na
 grep -c 'duckdb_native_metadata] refused'                       /tmp/native_verify/sirius_*.log   # expect 0
 ```
 
-> **Note:** `--pinning-mode per-query` is parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine it with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
+> **Note:** `--pinning-mode per-query` and `--pinning-mode pinned-hot` are parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine either with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
 
-#### `--pinning-mode per-query` (PR #721 pin_table)
+#### `--pinning-mode per-query | pinned-hot` (PR #721 pin_table)
 
 When passed `--pinning-mode per-query`, the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the query for `--iterations` runs back-to-back, then `CALL unpin_table(<table>)` for each pinned table. This isolates per-query pinning cost from query execution: the query-iteration timings written to `timings.csv` reflect query-only time on the pinned-cache scan path.
 
@@ -122,6 +122,12 @@ The per-query column-set is sourced from `tpch_pin_columns.py` (must be a supers
 ```
 
 The DuckDB engine ignores the flag (pinning is Sirius-only) and runs as the unchanged baseline. Pinning time is **not** measured — markers (`__TPCH_PIN_BEGIN__`, `__TPCH_UNPIN_BEGIN__`, …) keep pin/unpin `Run Time` lines outside the iteration-time parser window. In single-session mode, every pinned table is unpinned at the end of its query block before the next query's pin calls run — no carry-over even when consecutive queries reference the same table. In multi-session mode the unpin still runs before each per-query process exits, defensively releasing GPU memory back to the allocator.
+
+When passed `--pinning-mode pinned-hot`, the Sirius engine emits one union `CALL pin_table(...)` set before the timed query stream, using the union of referenced columns across all TPC-H queries, then emits one union `CALL unpin_table(...)` set after all queries finish. This keeps the pinned cache hot across query boundaries and excludes pin/unpin time from `timings.csv`. `pinned-hot` requires the default single-session mode; it is rejected with `--multi-session` because fresh DuckDB processes cannot preserve the cross-query cache.
+
+```bash
+./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot --iterations 5 100
+```
 
 To verify a query actually hit the cache, grep `runs/.../sirius/q<N>/sirius.log` for `using cached_split_provider`; the matching-fallback log line is `not all the columns are pinned for this query`.
 
@@ -267,7 +273,7 @@ Output: `reports/<label>_<YYYYMMDD_HHMMSS>/` containing `report.md`, `summary.js
 | `rewrite_parquet.py` | Rewrite parquet with GPU-optimized row groups (cudf or pyarrow fallback) |
 | `performance_test.py` | Python-based benchmark with result verification |
 | `queries.py` | TPC-H query definitions (base SQL) |
-| `tpch_pin_columns.py` | Per-query column → table mapping for `--pinning-mode per-query`; emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
+| `tpch_pin_columns.py` | Per-query and union column → table mapping for `--pinning-mode per-query` / `pinned-hot`; emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
 | `generate_test_data.py` | Generate test data via dbgen |
 | `generate_test_data_tpchgen-rs.py` | Generate test data via tpchgen-rs Python wrapper + query files |
 | `pixi.toml` | Python environment with cudf, pyarrow, rust for tooling |

--- a/test/tpch_performance/benchmark_and_validate.sh
+++ b/test/tpch_performance/benchmark_and_validate.sh
@@ -25,6 +25,7 @@
 # Usage:
 #   export SIRIUS_CONFIG_FILE=...
 #   ./test/tpch_performance/benchmark_and_validate.sh <scale_factor>
+#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb-native <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --report <run_dir>
@@ -32,6 +33,7 @@
 #
 # Example:
 #   ./test/tpch_performance/benchmark_and_validate.sh 1
+#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot --iterations 5 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb --duckdb-file ./performance_test.duckdb 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb-native --duckdb-file ./test_datasets/tpch_sf1.duckdb 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --report runs/2026-03-10_12-00-00_sf1_2iter
@@ -378,9 +380,9 @@ NUM_ITERATIONS="${NUM_ITERATIONS:-2}"
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-1200}"
 
 case "$PINNING_MODE" in
-    none|per-query) ;;
+    none|per-query|pinned-hot) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
@@ -388,7 +390,7 @@ esac
 if [ $# -ne 1 ]; then
     echo "Usage: $0 [--config <config_file>] [--data-source parquet|duckdb|duckdb-native] [--parquet-dir <path>] [--duckdb-file <path>]"
     echo "          [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>]"
-    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query]"
+    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot]"
     echo "          [--float-tolerance <value>] <scale_factor>"
     echo "       $0 --report [--float-tolerance <value>] <run_dir>"
     echo "  --data-source parquet       (default) → run_tpch_parquet.sh + test_datasets/tpch_parquet_sf<SF> or --parquet-dir"
@@ -400,6 +402,16 @@ if [ $# -ne 1 ]; then
     echo "         $0 --data-source duckdb --duckdb-file ./performance_test.duckdb 1"
     echo "         $0 --data-source duckdb-native --duckdb-file ./test_datasets/tpch_sf1.duckdb 1"
     echo "         $0 --multi-session --drop-os-cache --engines sirius 1000  # cold-run with OS cache drops"
+    exit 1
+fi
+
+if [ "$PINNING_MODE" != "none" ] && is_duckdb_source; then
+    echo "ERROR: --pinning-mode is parquet-only; do not combine it with --data-source $DATA_SOURCE."
+    exit 1
+fi
+
+if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ]; then
+    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
     exit 1
 fi
 

--- a/test/tpch_performance/run.md
+++ b/test/tpch_performance/run.md
@@ -51,6 +51,7 @@ Options:
 - `--config <path>` — Sirius config file (default: `~/.sirius/sirius.yaml`)
 - `--parquet-dir <path>` — parquet dataset directory (default: `test_datasets/tpch_parquet_sf<SF>`)
 - `--engines <list>` — space-separated engine list (default: `"sirius duckdb"`)
+- `--pinning-mode none|per-query|pinned-hot` — Sirius-only parquet pinning mode. `per-query` pins each query's referenced columns around that query block; `pinned-hot` pins the union of referenced columns once before the single-session run and unpins after all queries.
 
 Each run creates a directory under `runs/<timestamp>_sf<SF>_2iter/` containing:
 - `run_info.txt` — git branch/revision, tree clean/dirty, build freshness, hostname, memory, CPUs, GPUs, filesystem read benchmark
@@ -78,6 +79,10 @@ SIRIUS_CONFIG_FILE=~/.sirius/sirius.yaml \
 # Run specific queries with custom parquet directory
 SIRIUS_CONFIG_FILE=~/.sirius/sirius.yaml \
   ./test/tpch_performance/run_tpch_parquet.sh --parquet-dir /data/tpch sirius 100 1 3 6
+
+# Run Sirius with union-pinned hot cache across the query stream
+SIRIUS_CONFIG_FILE=~/.sirius/sirius.yaml \
+  ./test/tpch_performance/run_tpch_parquet.sh --pinning-mode pinned-hot --iterations 5 sirius 100 $(seq 1 22)
 ```
 
 Environment variables:

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -341,12 +341,31 @@ run_single_session() {
     TOTAL_ELAPSED=$(echo "$END_TIME - $START_TIME" | bc)
     echo "Total wall-clock time: ${TOTAL_ELAPSED}s"
 
+    local SESSION_OUTPUT_FILE
+    if [ -n "${OUTPUT_DIR:-}" ]; then
+        SESSION_OUTPUT_FILE="$OUTPUT_DIR/session_output.txt"
+    else
+        SESSION_OUTPUT_FILE="$PROJECT_DIR/session_output_${ENGINE}_sf${SF}.txt"
+    fi
+    printf '%s\n' "$FULL_OUTPUT" > "$SESSION_OUTPUT_FILE"
+
     local RUN_STATUS=0
     if [ "$SESSION_EXIT" -eq 124 ]; then
         echo "SESSION TIMEOUT: DuckDB was killed after ${SESSION_TIMEOUT}s"
         RUN_STATUS=124
     elif [ "$SESSION_EXIT" -ne 0 ]; then
         echo "SESSION FAILED: DuckDB exited with code $SESSION_EXIT"
+        echo "DuckDB output saved to $SESSION_OUTPUT_FILE"
+        echo "DuckDB error excerpt:"
+        local ERROR_EXCERPT
+        ERROR_EXCERPT=$(printf '%s\n' "$FULL_OUTPUT" \
+            | grep -iE '(^Error:|Invalid Error|IO Error|Catalog Error|Parser Error|Binder Error|Out of Memory|std::bad_alloc|CUDA|RMM|Exception)' \
+            | head -20)
+        if [ -n "$ERROR_EXCERPT" ]; then
+            printf '%s\n' "$ERROR_EXCERPT"
+        else
+            printf '%s\n' "$FULL_OUTPUT" | tail -40
+        fi
         RUN_STATUS=$SESSION_EXIT
     fi
 
@@ -386,7 +405,10 @@ run_single_session() {
 
         if [ -z "$SECTION" ]; then
             echo "  NO OUTPUT (session may have timed out or crashed before this query)"
-            echo "error: no output (session may have timed out or crashed before this query)" > "$RESULT_FILE"
+            {
+                echo "error: no output (session may have timed out or crashed before this query)"
+                echo "session_output: $SESSION_OUTPUT_FILE"
+            } > "$RESULT_FILE"
             {
                 echo "step,runtime_s"
                 for ((i = 0; i < NUM_ITERATIONS; i++)); do
@@ -609,7 +631,7 @@ fi
 # Split the Sirius log into per-query segments.
 #
 # Under Super Sirius transparent execution, each query iteration is logged as
-# "QueryBegin: <raw SQL>" — there is no `call gpu_execution(...)` wrapper.
+# "QueryBegin: SQL: <raw SQL>" — there is no `call gpu_execution(...)` wrapper.
 # Skip the session prologue (CREATE VIEW for view setup) and any pinning-mode
 # CALLs (pin_table / unpin_table) so the remaining QueryBegin lines correspond
 # 1:1 to user query iterations. We group every NUM_ITERATIONS consecutive
@@ -627,7 +649,7 @@ if [ "$ENGINE" = "sirius" ] && [ "$MULTI_SESSION" = false ] && [ -n "${OUTPUT_DI
         echo "Splitting Sirius log per query (${NUM_ITERATIONS} iterations per query)..."
         readarray -t QB_LINES < <(
             grep -nE 'QueryBegin:' "$LOG_FILE" \
-                | grep -ivE 'QueryBegin: (CREATE VIEW|CALL (pin_table|unpin_table))' \
+                | grep -ivE 'QueryBegin:[[:space:]]*(SQL:[[:space:]]*)?(CREATE VIEW|CALL[[:space:]]+(pin_table|unpin_table))' \
                 | cut -d: -f1
         )
         TOTAL_LOG_LINES=$(wc -l < "$LOG_FILE")

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -72,22 +72,24 @@ while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:
 done
 
 case "$PINNING_MODE" in
-    none|per-query) ;;
+    none|per-query|pinned-hot) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
 
 if [ $# -lt 3 ]; then
-    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] <engine> <scale_factor> <query_numbers...>"
+    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot] <engine> <scale_factor> <query_numbers...>"
     echo "Example: $0 sirius 100 \`seq 1 22\`"
     echo "  --iterations N      Number of iterations per query (default: 2, 1 cold + N-1 warm)"
     echo "  --timeout N         Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
     echo "  --multi-session     Run each query in its own DuckDB process (fresh state per query)"
     echo "  --drop-os-cache     Drop OS filesystem cache before each query (requires --multi-session and sudo)"
     echo "  --pinning-mode MODE 'per-query' calls pin_table for each query's columns before its iterations,"
-    echo "                      then unpin_table afterward. Sirius engine only. Default: 'none'."
+    echo "                      then unpin_table afterward. 'pinned-hot' pins the union of"
+    echo "                      referenced columns once for the whole single-session run."
+    echo "                      Sirius engine only. Default: 'none'."
     exit 1
 fi
 
@@ -119,6 +121,12 @@ if [ "$ENGINE" != "sirius" ] && [ "$ENGINE" != "duckdb" ]; then
     echo "Unknown engine, please use sirius or duckdb"
     exit 1
 fi
+
+if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ] && [ "$ENGINE" = "sirius" ]; then
+    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
+    exit 1
+fi
+
 DUCKDB="$SIRIUS_DUCKDB"
 # Both engines use the same plain SQL queries — transparent execution
 # routes queries through GPU when SiriusContext is initialized.
@@ -228,7 +236,11 @@ fi
 echo "Iterations: $NUM_ITERATIONS (1 cold + $((NUM_ITERATIONS - 1)) warm)"
 if [ "$PINNING_MODE" != "none" ]; then
     if [ "$ENGINE" = "sirius" ]; then
-        echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu})"
+        if [ "$PINNING_MODE" = "per-query" ]; then
+            echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu})"
+        else
+            echo "Pinning mode: $PINNING_MODE (pin_table once before timed queries, tier=${SIRIUS_PIN_TIER:-gpu})"
+        fi
     else
         echo "Pinning mode: $PINNING_MODE (ignored — Sirius-only feature)"
     fi
@@ -251,9 +263,12 @@ run_single_session() {
     local MARKER_PREFIX="__TPCH_MARKER__"
     local END_MARKER="__TPCH_END__"
 
-    local PIN_ENABLED=false
+    local PIN_PER_QUERY=false
+    local PINNED_HOT=false
     if [ "$PINNING_MODE" = "per-query" ] && [ "$ENGINE" = "sirius" ]; then
-        PIN_ENABLED=true
+        PIN_PER_QUERY=true
+    elif [ "$PINNING_MODE" = "pinned-hot" ] && [ "$ENGINE" = "sirius" ]; then
+        PINNED_HOT=true
     fi
 
     local TEMP_SQL
@@ -261,11 +276,17 @@ run_single_session() {
     printf '%s\n' "$VIEW_SQL" > "$TEMP_SQL"
     echo ".timer on" >> "$TEMP_SQL"
 
+    if [ "$PINNED_HOT" = true ]; then
+        echo ".print __TPCH_PIN_BEGIN__ all" >> "$TEMP_SQL"
+        python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin-all "$PARQUET_DIR" >> "$TEMP_SQL"
+        echo ".print __TPCH_PIN_END__ all" >> "$TEMP_SQL"
+    fi
+
     for q in "${VALID_QUERIES[@]}"; do
         local QUERY_FILE="$QUERY_DIR/q${q}.sql"
         # Pin/unpin live OUTSIDE the __TPCH_MARKER__ section so pin/unpin
         # Run Time lines never get counted as query iterations.
-        if [ "$PIN_ENABLED" = true ]; then
+        if [ "$PIN_PER_QUERY" = true ]; then
             echo ".print __TPCH_PIN_BEGIN__ ${q}" >> "$TEMP_SQL"
             python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin "$q" "$PARQUET_DIR" >> "$TEMP_SQL"
             echo ".print __TPCH_PIN_END__ ${q}" >> "$TEMP_SQL"
@@ -276,12 +297,19 @@ run_single_session() {
             cat "$QUERY_FILE" >> "$TEMP_SQL"
             printf '\n' >> "$TEMP_SQL"
         done
-        if [ "$PIN_ENABLED" = true ]; then
+        if [ "$PIN_PER_QUERY" = true ]; then
             echo ".print __TPCH_UNPIN_BEGIN__ ${q}" >> "$TEMP_SQL"
             python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin "$q" >> "$TEMP_SQL"
             echo ".print __TPCH_UNPIN_END__ ${q}" >> "$TEMP_SQL"
         fi
     done
+
+    if [ "$PINNED_HOT" = true ]; then
+        echo ".print __TPCH_UNPIN_BEGIN__ all" >> "$TEMP_SQL"
+        python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin-all >> "$TEMP_SQL"
+        echo ".print __TPCH_UNPIN_END__ all" >> "$TEMP_SQL"
+    fi
+
     echo ".print ${END_MARKER}" >> "$TEMP_SQL"
 
     if [ -n "${OUTPUT_DIR:-}" ]; then
@@ -347,7 +375,7 @@ run_single_session() {
 
         # Extract the section between this query's marker and the next __TPCH_* marker.
         # Stopping at any __TPCH_ prefix keeps pin/unpin Run Time lines (which sit in
-        # __TPCH_PIN_*/__TPCH_UNPIN_* sections when --pinning-mode per-query is on)
+        # __TPCH_PIN_*/__TPCH_UNPIN_* sections when a pinning mode is on)
         # out of the query iteration window.
         local SECTION
         SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" '

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Emit `CALL pin_table(...)` / `CALL unpin_table(...)` SQL for a TPC-H query.
+"""Emit `CALL pin_table(...)` / `CALL unpin_table(...)` SQL for TPC-H.
 
-Used by run_tpch_parquet.sh when --pinning-mode per-query is set.
+Used by run_tpch_parquet.sh when --pinning-mode per-query or pinned-hot is set.
 The path argument passed to pin_table is a glob whose FileSystem::GlobFiles
 expansion must match the file list in the corresponding CREATE VIEW
 read_parquet([...]) call — otherwise the scan_manager path-equality check
@@ -289,10 +289,12 @@ def emit_unpin_all() -> str:
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) < 3:
+    if len(argv) < 2:
         print(
             "Usage: tpch_pin_columns.py pin   <q_num> <parquet_dir>\n"
             "       tpch_pin_columns.py unpin <q_num>\n"
+            "       tpch_pin_columns.py pin-all <parquet_dir>\n"
+            "       tpch_pin_columns.py unpin-all\n"
             "\n"
             "Tier: defaults to 'gpu'; SIRIUS_PIN_TIER=host overrides once host-tier\n"
             "support lands. tier='host' is NOT supported right now — use it today and\n"
@@ -300,7 +302,37 @@ def main(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
-    cmd, q_str, *rest = argv[1:]
+    cmd, *args = argv[1:]
+
+    if cmd == "pin-all":
+        if len(args) != 1:
+            print("pin-all requires <parquet_dir>", file=sys.stderr)
+            return 1
+        try:
+            sys.stdout.write(emit_pin_all(args[0]))
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+        return 0
+    if cmd == "unpin-all":
+        if args:
+            print("unpin-all takes no further arguments", file=sys.stderr)
+            return 1
+        sys.stdout.write(emit_unpin_all())
+        return 0
+
+    if cmd not in {"pin", "unpin"}:
+        print(
+            f"unknown command: {cmd!r} (valid: pin, unpin, pin-all, unpin-all)",
+            file=sys.stderr,
+        )
+        return 1
+
+    if len(args) < 1:
+        print(f"{cmd} requires <q_num>", file=sys.stderr)
+        return 1
+
+    q_str, *rest = args
     try:
         q = int(q_str)
     except ValueError:
@@ -324,9 +356,6 @@ def main(argv: list[str]) -> int:
             print("unpin takes no further arguments", file=sys.stderr)
             return 1
         sys.stdout.write(emit_unpin(q))
-    else:
-        print(f"unknown command: {cmd!r} (valid: pin, unpin)", file=sys.stderr)
-        return 1
     return 0
 
 


### PR DESCRIPTION
Adds `pinned-hot` as additional `pinning-mode` to the tpch benchmark script. This mode will be used to replace the 3 hot runs in nightly benchmarking.