### PR TITLE
fix(pipeline): clamp GPU reservation request to the memory space limit

### DIFF
--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -109,6 +109,28 @@ void gpu_pipeline_executor::manager_loop()
     }
     auto reservation_info = gpu_task->get_estimated_reservation_size_info();
     auto bytes_needs      = reservation_info.reservation_size;
+    // Clamp the reservation request to what this memory space can actually
+    // grant (its reservation limit). The history-based estimate can balloon far
+    // past capacity — a small input that once drove a near-cap peak yields a
+    // huge peak/estimate ratio that extrapolates to multi-GiB estimates on a
+    // GiB-budget GPU. make_reservation() then returns only a partial reservation
+    // and the downgrade predicate below (which must reserve the *full*
+    // bytes_needs) can never succeed, so the task livelocks through the
+    // OOM-reschedule loop until the retry cap trips and the query fails. Capping
+    // at get_max_memory() keeps both the reservation and the downgrade target
+    // achievable; any per-batch overflow during execution is still handled by
+    // the OOM-reschedule + tiering path.
+    if (auto const space_max = _memory_space->get_max_memory();
+        space_max > 0 && bytes_needs > space_max) {
+      SIRIUS_LOG_DEBUG(
+        "GPU Pipeline Executor: clamping reservation request {} -> {} bytes (space max) for "
+        "pipeline {} task {}",
+        bytes_needs,
+        space_max,
+        gpu_task->get_pipeline_id(),
+        gpu_task->get_task_id());
+      bytes_needs = space_max;
+    }
     SIRIUS_LOG_TRACE(
       "[GPU:{}] GPU Pipeline Executor: Acquiring memory reservation for pipeline {} of {} bytes "
       "for task {}. Memory available: {}, total reserved: {}, max: {}",


### PR DESCRIPTION
## Problem

A GPU pipeline task sizes its reservation request from the memory-history peak estimate (`peak_memory_estimate + bytes_to_materialize_input`). That estimate extrapolates `input_basis × avg(peak/estimated ratio)`; a small input that once drove a near-capacity peak inflates the ratio, so the request can balloon far past the GPU memory space's reservation limit — observed multi-GiB requests against a GiB-class budget while investigating the SeaweedFS SF10 S3 large gate.

`make_reservation()` then returns only a partial reservation, and the predicate-based downgrade that follows requires reserving the **full** request size — which the space can never satisfy — so `request_downgrade()` frees nothing and the task livelocks through the OOM-reschedule loop until the retry cap (100) trips and the query fails.

## Fix

Clamp the request to `memory_space::get_max_memory()` (the reservation limit) before `make_reservation()`. `make_reservation()` already caps at this limit, so clamping the request loses no reservable memory while keeping both the reservation and the downgrade target achievable. Per-batch overflow during execution is still handled by the existing OOM-reschedule + tiering path. On configs where the estimate already fits under the limit the clamp never fires, so steady-state behaviour is unchanged.

## Testing

- Standard S3 integration gate (`make s3-test`): green (63 cases, no regressions).
- Logs confirm per-task reservation requests are clamped from multi-GiB down to the reservation limit, eliminating the unsatisfiable-reservation OOM-reschedule livelock.

## Scope / not included

This fixes the reservation/downgrade livelock. It does **not** by itself make a single oversized scan batch fit a tight GPU budget — a separate follow-up is needed to chunk large scans into budget-sized batches (the scan currently decodes the whole input into one batch, which is the remaining blocker for the SF10 large-Q1 case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)