### PR TITLE
Update quent dependencies to latest commit on main

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "serde",
  "thiserror",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "ciborium",
  "dashmap",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "ciborium",
  "quent-collector-proto",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "prost",
  "tonic",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-exporter-collector",
  "quent-exporter-msgpack",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "async-trait",
  "quent-collector-client",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-model",
  "serde",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "serde",
  "thiserror",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=5f405cbf4f4b21bf9153669f2fa52baab51d2d10#5f405cbf4f4b21bf9153669f2fa52baab51d2d10"
+source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
 dependencies = [
  "quent-analyzer",
  "quent-time",

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,18 +6,19 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 sirius-telemetry-ui = { path = "../ui" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+# Tracks a pinned commit from quent's main branch.
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
 rustc-hash = "2"
 smallvec = "1"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -14,4 +14,5 @@ instrumentation-model = { path = "../model" }
 [build-dependencies]
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+# Tracks a pinned commit from quent's main branch.
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -4,8 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+# Tracks a pinned commit from quent's main branch.
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
 uuid = "1"

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,15 +12,17 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model" }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+# Tracks a pinned commit from quent's main branch.
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 sirius-telemetry-ui = { path = "../ui" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10" }
+# Tracks a pinned commit from quent's main branch.
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
 ts-rs = { version = "11", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/ui/Cargo.toml
+++ b/rust/crates/telemetry/ui/Cargo.toml
@@ -4,7 +4,8 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "5f405cbf4f4b21bf9153669f2fa52baab51d2d10", features = ["ts"] }
+# Tracks a pinned commit from quent's main branch.
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7", features = ["ts"] }
 serde = { version = "1", features = ["derive"] }
 ts-rs = { version = "11", features = ["uuid-impl", "serde-json-impl"] }
 uuid = { version = "1", features = ["serde"] }


### PR DESCRIPTION
We were tracking a commit on a branch. This now tracks the latest commit on main: https://github.com/rapidsai/quent/commit/023b8c2179aba16f1bdefe430049f4fa2a424fc7