### PR TITLE
Add `cargo` updates to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: cargo
+    directories:
+      - /rust
+      - /experimental/starrocks
+    schedule:
+      interval: daily


### PR DESCRIPTION
Keeps our Rust dependencies up-to-date.