### PR TITLE
feat(telemetry): adopt quent build-time provenance sidecar (model.qmi)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "serde",
  "thiserror",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "serde",
  "serde_json",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "ciborium",
  "dashmap",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "ciborium",
  "quent-collector-proto",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "prost",
  "tonic",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-exporter-collector",
  "quent-exporter-msgpack",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "async-trait",
  "quent-collector-client",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -1723,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-model",
  "serde",
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "serde",
  "thiserror",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+source = "git+https://github.com/rapidsai/quent.git?rev=90e7ae0802d75737b1a855789df5389862604352#90e7ae0802d75737b1a855789df5389862604352"
 dependencies = [
  "quent-analyzer",
  "quent-time",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1005,6 +1005,7 @@ name = "instrumentation-model"
 version = "0.1.0"
 dependencies = [
  "quent-attributes",
+ "quent-build-info",
  "quent-model",
  "quent-query-engine-model",
  "quent-stdlib",
@@ -1405,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1423,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "serde",
  "thiserror",
@@ -1431,9 +1432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quent-build-info"
+version = "0.1.0"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1446,10 +1456,11 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "ciborium",
  "dashmap",
+ "quent-build-info",
  "quent-collector-proto",
  "quent-exporter",
  "quent-exporter-types",
@@ -1464,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "ciborium",
  "quent-collector-proto",
@@ -1482,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "prost",
  "tonic",
@@ -1493,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1504,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-exporter-collector",
  "quent-exporter-msgpack",
@@ -1518,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "async-trait",
  "quent-collector-client",
@@ -1531,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1540,13 +1551,12 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1555,13 +1565,12 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1570,13 +1579,12 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1587,9 +1595,10 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-attributes",
+ "quent-build-info",
  "quent-events",
  "quent-exporter",
  "quent-exporter-types",
@@ -1603,9 +1612,10 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-attributes",
+ "quent-build-info",
  "quent-events",
  "quent-exporter",
  "quent-instrumentation",
@@ -1618,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1629,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1646,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1657,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1687,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1702,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -1713,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-model",
  "serde",
@@ -1723,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "serde",
  "thiserror",
@@ -1733,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=023b8c2179aba16f1bdefe430049f4fa2a424fc7#023b8c2179aba16f1bdefe430049f4fa2a424fc7"
+source = "git+https://github.com/rapidsai/quent.git?rev=94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee#94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee"
 dependencies = [
  "quent-analyzer",
  "quent-time",

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/src/lib.rs
+++ b/rust/crates/telemetry/analyzer/src/lib.rs
@@ -2,7 +2,7 @@ use instrumentation_model::SiriusEvent;
 use quent_events::Event;
 pub use quent_query_engine_analyzer::QueryEngineModel;
 use quent_query_engine_analyzer::ui::UiAnalyzer;
-use quent_query_engine_ui::{QueryBundle, QueryEntities};
+use quent_query_engine_ui::{OperatorFilter, QueryBundle, QueryEntities, QueryFilter};
 use quent_ui::{
     FiniteStateMachine, ResourceGroupNode, ResourceTree, convert_resource_tree,
     quantity::QuantitySpec,
@@ -36,7 +36,7 @@ use quent_analyzer::{
     },
 };
 use quent_time::{SpanNanoSec, TimeNanoSec, TimeUnixNanoSec, to_nanosecs, to_secs};
-use quent_simulator_ui::{EntityRef, QueryFilter, TaskFilter};
+use quent_simulator_ui::EntityRef;
 use uuid::Uuid;
 
 use crate::{
@@ -60,7 +60,7 @@ struct PlainBuilderSlot<'a> {
     config_idx: usize,
     builder: ResourceTimelineBuilder<'a>,
     resource_id_filter: Arc<HashSet<Uuid>>,
-    task_filter: TaskFilter,
+    task_filter: OperatorFilter,
 }
 
 struct PerStateBuilderSlot<'a> {
@@ -68,14 +68,12 @@ struct PerStateBuilderSlot<'a> {
     config_idx: usize,
     builder: ResourceTimelineByKeyBuilder<'a, &'a str>,
     resource_id_filter: Arc<HashSet<Uuid>>,
-    task_filter: TaskFilter,
+    task_filter: OperatorFilter,
 }
 
 impl UiAnalyzer for SiriusUiAnalyzer {
     type Event = SiriusEvent;
     type EntityRef = EntityRef;
-    type TimelineGlobalParams = QueryFilter;
-    type TimelineParams = TaskFilter;
 
     fn try_new(
         engine_id: Uuid,
@@ -245,7 +243,7 @@ impl UiAnalyzer for SiriusUiAnalyzer {
     // TODO(johanpel): consider reusing the bulk request API with a single entry for requests like this.
     fn single_resource_timeline(
         &self,
-        request: SingleTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+        request: SingleTimelineRequest<QueryFilter, OperatorFilter>,
     ) -> AnalyzerResult<SingleTimelineResponse> {
         // TODO(johanpel): we may want to sanity-check whether the requested
         // resource/group is actually in the resource tree for a given query.
@@ -363,7 +361,7 @@ impl UiAnalyzer for SiriusUiAnalyzer {
 
     fn bulk_resource_timeline(
         &self,
-        request: BulkTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+        request: BulkTimelineRequest<QueryFilter, OperatorFilter>,
     ) -> AnalyzerResult<BulkTimelinesResponse> {
         // Calculate this ASAP to help fail quickly.
         let epoch = self
@@ -380,7 +378,7 @@ impl UiAnalyzer for SiriusUiAnalyzer {
         // each bulk entry. After populating this, we'll build a reverse index,
         // that maps a resource_id to a list of indices in these vecs, for which
         // that resource's usages are relevant.
-        let mut plain_builders: Vec<(String, ResourceTimelineBuilder, HashSet<Uuid>, TaskFilter)> =
+        let mut plain_builders: Vec<(String, ResourceTimelineBuilder, HashSet<Uuid>, OperatorFilter)> =
             Vec::new();
 
         // Prepare them also for keyed builders (building by state).
@@ -388,7 +386,7 @@ impl UiAnalyzer for SiriusUiAnalyzer {
             String,
             ResourceTimelineByKeyBuilder<&str>,
             HashSet<Uuid>,
-            TaskFilter,
+            OperatorFilter,
         )> = Vec::new();
 
         for (entry_id, entry) in request.entries {
@@ -526,7 +524,7 @@ impl UiAnalyzer for SiriusUiAnalyzer {
 
     fn bulk_chunked_resource_timeline(
         &self,
-        request: BulkChunkedTimelineRequest<Self::TimelineGlobalParams, Self::TimelineParams>,
+        request: BulkChunkedTimelineRequest<QueryFilter, OperatorFilter>,
     ) -> AnalyzerResult<BulkChunkedTimelinesResponse> {
         let epoch = self
             .query_engine_model()
@@ -696,7 +694,7 @@ impl SiriusUiAnalyzer {
         &self,
         view: &'a SiriusModelQueryView<'a>,
         entity_filter: EntityFilter,
-        task_filter: &TaskFilter,
+        task_filter: &OperatorFilter,
         time_window: SpanNanoSec,
     ) -> AnalyzerResult<Vec<&'a Task>> {
         if let Some(entity_type_name) = entity_filter.entity_type_name
@@ -723,7 +721,7 @@ impl SiriusUiAnalyzer {
     fn try_prepare_bulk_entry<'a>(
         &self,
         view: &'a SiriusModelQueryView<'a>,
-        request: TimelineRequest<TaskFilter>,
+        request: TimelineRequest<OperatorFilter>,
         tree: &ResourceTreeNode,
     ) -> AnalyzerResult<BulkEntryPrep<'a>> {
         Ok(match request {
@@ -842,6 +840,6 @@ struct BulkEntryPrep<'a> {
     resource_type: &'a ResourceTypeDecl,
     resource_id_filter: HashSet<Uuid>,
     entity_filter: EntityFilter,
-    task_filter: TaskFilter,
+    task_filter: OperatorFilter,
     long_entities_threshold: Option<TimeNanoSec>,
 }

--- a/rust/crates/telemetry/analyzer/src/task.rs
+++ b/rust/crates/telemetry/analyzer/src/task.rs
@@ -17,7 +17,7 @@ use quent_analyzer::{
 };
 use quent_time::{TimeUnixNanoSec, Timestamp, span::SpanUnixNanoSec, to_secs_relative};
 use quent_ui::{FiniteStateMachine, FsmTransition, FsmUsage};
-use quent_simulator_ui::TaskFilter;
+use quent_query_engine_ui::OperatorFilter;
 use uuid::Uuid;
 
 /// The reconstructed Task FSM.
@@ -30,7 +30,7 @@ pub type TaskBuilder = FsmEventsBuilder<ModelTaskTransition>;
 pub trait TaskExt {
     fn pipeline_uuid(&self) -> Option<Uuid>;
     fn executes_physical_operation(&self, physical_operator_id: u32) -> bool;
-    fn matches_filter(&self, filter: &TaskFilter) -> bool;
+    fn matches_filter(&self, filter: &OperatorFilter) -> bool;
     fn active_span(&self) -> Option<SpanUnixNanoSec>;
     fn try_to_ui_fsm(&self, epoch: TimeUnixNanoSec) -> AnalyzerResult<FiniteStateMachine>;
 }
@@ -53,7 +53,7 @@ impl TaskExt for Task {
         })
     }
 
-    fn matches_filter(&self, filter: &TaskFilter) -> bool {
+    fn matches_filter(&self, filter: &OperatorFilter) -> bool {
         filter
             .operator_id
             .is_none_or(|pipeline_uuid| self.pipeline_uuid() == Some(pipeline_uuid))

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -15,4 +15,4 @@ instrumentation-model = { path = "../model" }
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -15,4 +15,4 @@ instrumentation-model = { path = "../model" }
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 
 [dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
 uuid = "1"
+
+[build-dependencies]
+# Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
+# generated ModelSource records Sirius (not quent) as the model's source.
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -5,13 +5,13 @@ edition.workspace = true
 
 [dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }

--- a/rust/crates/telemetry/model/build.rs
+++ b/rust/crates/telemetry/model/build.rs
@@ -1,0 +1,5 @@
+// Captures this crate's git into QUENT_SOURCE_* so the model.qmi sidecar records
+// Sirius as the model source instead of falling back to quent's build info.
+fn main() {
+    quent_build_info::emit_source();
+}

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model" }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "90e7ae0802d75737b1a855789df5389862604352" }
 ts-rs = { version = "11", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model" }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "023b8c2179aba16f1bdefe430049f4fa2a424fc7" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "94e592f6a0a07f02dde9a3e38f236d6eeb91c8ee" }
 ts-rs = { version = "11", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/build.rs
+++ b/rust/crates/telemetry/server/build.rs
@@ -3,16 +3,17 @@ use quent_ui::timeline::{
     request::{BulkTimelineRequest, SingleTimelineRequest},
     response::{BulkTimelinesResponse, SingleTimelineResponse},
 };
-use quent_simulator_ui::{EntityRef, QueryFilter, TaskFilter};
+use quent_query_engine_ui::{OperatorFilter, QueryFilter};
+use quent_simulator_ui::EntityRef;
 use ts_rs::TS;
 
 const TS_OUT_DIR: &str = "./ts-bindings/";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     <QueryBundle<EntityRef> as TS>::export_all_to(TS_OUT_DIR)?;
-    <SingleTimelineRequest<QueryFilter, TaskFilter> as TS>::export_all_to(TS_OUT_DIR)?;
+    <SingleTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
     <SingleTimelineResponse as TS>::export_all_to(TS_OUT_DIR)?;
-    <BulkTimelineRequest<QueryFilter, TaskFilter> as TS>::export_all_to(TS_OUT_DIR)?;
+    <BulkTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
     <BulkTimelinesResponse as TS>::export_all_to(TS_OUT_DIR)?;
     Ok(())
 }

--- a/rust/crates/telemetry/server/src/main.rs
+++ b/rust/crates/telemetry/server/src/main.rs
@@ -7,9 +7,8 @@ use clap::Parser;
 use instrumentation_model::SiriusEvent;
 use quent_collector::server::CollectorServiceOptions;
 use quent_exporter::{
-    ExporterOptions, ImporterOptions, MsgpackExporterOptions, MsgpackImporterOptions,
-    NdjsonExporterOptions, NdjsonImporterOptions, PostcardExporterOptions, PostcardImporterOptions,
-    create_importer,
+    ExporterOptions, FileSystemExporterOptions, FileSystemFormat, FileSystemImporterOptions,
+    ImporterOptions, create_importer,
 };
 use quent_query_engine_server::{
     analyzer_service_router, collector_service,
@@ -33,7 +32,13 @@ mod env {
     pub(crate) const QUENT_ANALYZER_CORS_ADDRESS: &str = "QUENT_ANALYZER_CORS_ADDRESS";
 }
 
-const TELEMETRY_EXTENSIONS: [&str; 3] = ["ndjson", "msgpack", "postcard"];
+// Probed (highest-fidelity first) when auto-detecting the format of an existing
+// context directory, independent of the configured export format.
+const TELEMETRY_FORMATS: [(&str, FileSystemFormat); 3] = [
+    ("postcard", FileSystemFormat::Postcard),
+    ("msgpack", FileSystemFormat::Msgpack),
+    ("ndjson", FileSystemFormat::Ndjson),
+];
 
 #[derive(Parser)]
 struct Args {
@@ -81,12 +86,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let importer_output_dir = output_dir.clone();
     let lister_output_dir = output_dir.clone();
 
-    let exporter = match exporter.as_str() {
-        "ndjson" => ExporterOptions::Ndjson(NdjsonExporterOptions { output_dir }),
-        "msgpack" => ExporterOptions::Msgpack(MsgpackExporterOptions { output_dir }),
-        "postcard" => ExporterOptions::Postcard(PostcardExporterOptions { output_dir }),
+    let format = match exporter.as_str() {
+        "ndjson" => FileSystemFormat::Ndjson,
+        "msgpack" => FileSystemFormat::Msgpack,
+        "postcard" => FileSystemFormat::Postcard,
         other => return Err(format!("unknown exporter: {other}").into()),
     };
+    // Each context exports to `output_dir/<context-id>/events.<ext>` (plus a
+    // `model.qmi` provenance sidecar), so the collector writes under output_dir.
+    let exporter = ExporterOptions::FileSystem(FileSystemExporterOptions {
+        format,
+        root: output_dir,
+    });
 
     let collector = async {
         collector_service::<SiriusEvent>(CollectorServiceOptions { exporter })?
@@ -95,14 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|error| -> Box<dyn std::error::Error> { Box::new(error) })
     };
 
-    let lister = move || {
-        let mut ids = std::collections::HashSet::new();
-        for path in telemetry_file_paths(&lister_output_dir)? {
-            let id = extract_engine_id(&path)?.or_else(|| telemetry_file_stem_uuid(&path));
-            ids.extend(id);
-        }
-        Ok(ids.into_iter().collect())
-    };
+    let lister = move || list_engine_ids(&lister_output_dir);
 
     let importer = move |engine_id| {
         let importer = importer_options_for_engine(&importer_output_dir, engine_id)?;
@@ -128,42 +132,84 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn telemetry_file_paths(output_dir: &Path) -> ServerResult<Vec<PathBuf>> {
-    let mut paths = Vec::new();
-    for entry in std::fs::read_dir(output_dir)? {
-        let path = entry?.path();
-        if path.is_file()
-            && path
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| TELEMETRY_EXTENSIONS.contains(&extension))
-        {
-            paths.push(path);
-        }
-    }
-    paths.sort();
-    Ok(paths)
+/// Detect which event-file format a context directory holds, by probing for
+/// `events.<ext>`. `None` if the directory has no recognized event file.
+fn detect_format(dir: &Path) -> Option<FileSystemFormat> {
+    TELEMETRY_FORMATS
+        .iter()
+        .find(|(extension, _)| dir.join(format!("events.{extension}")).is_file())
+        .map(|(_, format)| *format)
 }
 
-fn telemetry_file_stem_uuid(path: &Path) -> Option<Uuid> {
+/// Map a file extension to its telemetry format, if recognized.
+fn format_for_ext(extension: &str) -> Option<FileSystemFormat> {
+    TELEMETRY_FORMATS
+        .iter()
+        .find(|(known, _)| *known == extension)
+        .map(|(_, format)| *format)
+}
+
+/// Legacy flat telemetry files `<output_dir>/<id>.<ext>`, written before the
+/// per-context-directory layout. Returns `(file_path, format)` sorted by path.
+fn flat_files(output_dir: &Path) -> ServerResult<Vec<(PathBuf, FileSystemFormat)>> {
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(output_dir)? {
+        let path = entry?.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Some(format) = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .and_then(format_for_ext)
+        {
+            files.push((path, format));
+        }
+    }
+    files.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(files)
+}
+
+/// The uuid encoded in a flat telemetry file's stem (`<id>.<ext>`), if any.
+fn file_stem_uuid(path: &Path) -> Option<Uuid> {
     path.file_stem()
         .and_then(|stem| stem.to_str())
         .and_then(|stem| Uuid::parse_str(stem).ok())
 }
 
-fn importer_options_for_path(path: PathBuf) -> Option<ImporterOptions> {
-    match path.extension().and_then(|extension| extension.to_str()) {
-        Some("postcard") => Some(ImporterOptions::Postcard(PostcardImporterOptions { path })),
-        Some("msgpack") => Some(ImporterOptions::Msgpack(MsgpackImporterOptions { path })),
-        Some("ndjson") => Some(ImporterOptions::Ndjson(NdjsonImporterOptions { path })),
-        _ => None,
+/// Per-context export directories under `output_dir`: those named by a uuid that
+/// contain a recognized event file. Returns `(dir_id, dir_path, format)` sorted
+/// by id for stable listing.
+fn context_dirs(output_dir: &Path) -> ServerResult<Vec<(Uuid, PathBuf, FileSystemFormat)>> {
+    let mut dirs = Vec::new();
+    for entry in std::fs::read_dir(output_dir)? {
+        let path = entry?.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(dir_id) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| Uuid::parse_str(name).ok())
+        else {
+            continue;
+        };
+        if let Some(format) = detect_format(&path) {
+            dirs.push((dir_id, path, format));
+        }
     }
+    dirs.sort_by_key(|(dir_id, _, _)| *dir_id);
+    Ok(dirs)
 }
 
-fn extract_engine_id(path: &Path) -> ServerResult<Option<Uuid>> {
-    let Some(importer) = importer_options_for_path(path.to_path_buf()) else {
-        return Ok(None);
-    };
+/// The id of the engine instance recorded in a telemetry capture's events (the
+/// id of its `Engine` event), or `None` if no such event is present. `path` is a
+/// context directory or a flat event file — the importer accepts either.
+fn extract_engine_id(path: &Path, format: FileSystemFormat) -> ServerResult<Option<Uuid>> {
+    let importer = ImporterOptions::FileSystem(FileSystemImporterOptions {
+        format,
+        path: path.to_path_buf(),
+    });
     for event in create_importer::<SiriusEvent>(&importer)? {
         if let SiriusEvent::Engine(_) = event.data {
             return Ok(Some(event.id));
@@ -172,29 +218,85 @@ fn extract_engine_id(path: &Path) -> ServerResult<Option<Uuid>> {
     Ok(None)
 }
 
+/// Engine instance ids discoverable under `output_dir`.
+///
+/// A context directory is keyed on its real `Engine` event id, never the
+/// directory name (an unrelated context id since Quent dropped the engine id at
+/// context creation). Legacy flat files were named by the engine id, so their
+/// stem is a valid fallback. Captures only appear once flushed (exporters buffer
+/// until `force_flush` on drop), so a still-running context is not yet listed.
+fn list_engine_ids(output_dir: &Path) -> ServerResult<Vec<Uuid>> {
+    let mut ids = std::collections::HashSet::new();
+    for (_, path, format) in context_dirs(output_dir)? {
+        if let Some(id) = extract_engine_id(&path, format)? {
+            ids.insert(id);
+        }
+    }
+    for (path, format) in flat_files(output_dir)? {
+        if let Some(id) = extract_engine_id(&path, format)?.or_else(|| file_stem_uuid(&path)) {
+            ids.insert(id);
+        }
+    }
+    Ok(ids.into_iter().collect())
+}
+
 fn importer_options_for_engine(
     output_dir: &Path,
     engine_id: Uuid,
 ) -> ServerResult<ImporterOptions> {
-    for path in telemetry_file_paths(output_dir)? {
-        if extract_engine_id(&path)? == Some(engine_id) {
-            return importer_options_for_path(path).ok_or_else(|| {
-                ServerError::Cache("telemetry file has no supported extension".to_string())
-            });
+    for (_, path, format) in context_dirs(output_dir)? {
+        if extract_engine_id(&path, format)? == Some(engine_id) {
+            return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
+                format,
+                path,
+            }));
         }
     }
 
-    for extension in ["postcard", "msgpack", "ndjson"] {
-        let path = output_dir.join(format!("{engine_id}.{extension}"));
-        if path.exists() {
-            return importer_options_for_path(path).ok_or_else(|| {
-                ServerError::Cache("telemetry file has no supported extension".to_string())
-            });
+    // Legacy flat files: match on engine id, or on the `<id>.<ext>` stem.
+    for (path, format) in flat_files(output_dir)? {
+        if extract_engine_id(&path, format)? == Some(engine_id)
+            || file_stem_uuid(&path) == Some(engine_id)
+        {
+            return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
+                format,
+                path,
+            }));
         }
+    }
+
+    // Fall back to a directory named directly by the engine id.
+    let path = output_dir.join(engine_id.to_string());
+    if let Some(format) = detect_format(&path) {
+        return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
+            format,
+            path,
+        }));
     }
 
     Err(ServerError::Io(std::io::Error::new(
         std::io::ErrorKind::NotFound,
-        format!("no telemetry file found for engine {engine_id}"),
+        format!("no telemetry directory found for engine {engine_id}"),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An events file with no readable `Engine` event must not surface the
+    /// context directory id as an engine id.
+    #[test]
+    fn empty_context_dir_is_not_listed_as_engine() {
+        let root = std::env::temp_dir().join(format!("sirius_telemetry_list_{}", Uuid::now_v7()));
+        let context_id = Uuid::now_v7();
+        let context_dir = root.join(context_id.to_string());
+        std::fs::create_dir_all(&context_dir).unwrap();
+        std::fs::write(context_dir.join("events.ndjson"), b"").unwrap();
+
+        let ids = list_engine_ids(&root).unwrap();
+
+        std::fs::remove_dir_all(&root).unwrap();
+        assert!(ids.is_empty(), "context id leaked as engine id: {ids:?}");
+    }
 }

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -43,7 +43,7 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config)
   : engine_uuid_(uuid::now_v7()),
     worker_uuid_(uuid::now_v7()),
     context_(quent::create_context(
-      engine_uuid_, config.enable_quent ? "ndjson" : "noop", config.output_directory)),
+      config.enable_quent ? "ndjson" : "noop", config.output_directory)),
     engine_observer_(quent::engine::create_observer(*context_)),
     worker_observer_(quent::worker::create_observer(*context_))
 {

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -42,8 +42,8 @@ std::shared_ptr<const telemetry_context> telemetry_context::create(
 telemetry_context::telemetry_context(const sirius::telemetry_config& config)
   : engine_uuid_(uuid::now_v7()),
     worker_uuid_(uuid::now_v7()),
-    context_(quent::create_context(
-      config.enable_quent ? "ndjson" : "noop", config.output_directory)),
+    context_(
+      quent::create_context(config.enable_quent ? "ndjson" : "noop", config.output_directory)),
     engine_observer_(quent::engine::create_observer(*context_)),
     worker_observer_(quent::worker::create_observer(*context_))
 {


### PR DESCRIPTION
Bump the quent dependency to the build-time provenance commit and adopt the stacked breaking changes it carries:

- Write a model.qmi provenance sidecar per context. The model! macro emits the new `ModelSource` impl for `SiriusEvent` automatically; add a build.rs calling `quent_build_info::emit_source()` so the sidecar records Sirius's own git provenance instead of quent's fallback.
- Rewrite the analyzer for the tightened `UiAnalyzer` contract: drop the `TimelineGlobalParams`/`TimelineParams` associated types and use `quent_query_engine_ui::{QueryFilter, OperatorFilter}`.
- Adopt the restructured exporter API (`FileSystem { format, root }`) and the per-context `<dir>/<id>/events.<ext>` layout: rewrite the telemetry server's discovery to scan context directories (keyed on the real `Engine` event id, never the context dir id) with a legacy flat-file fallback, and drop the removed id argument from the `create_context` FFI call.

Engine discovery requires a flushed `Engine` event; a still-running context is not yet listed (events buffer until `force_flush`, as before the bump).

~Draft because this depends on https://github.com/rapidsai/quent/pull/235.~
We're adding this to support Sirius with https://github.com/rapidsai/quent/issues/234.