### PR TITLE
fix: silence build warnings in hash join and pipeline task

### DIFF
--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -84,7 +84,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
    */
   ~convertible_gpu_pipeline_task() override
   {
-    if (_task) { _queue.push(std::move(_task)); }
+    if (_task) { (void)_queue.push(std::move(_task)); }
   }
 
   /**

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -68,7 +68,7 @@ static bool is_equality(sirius::comparison_type c)
 static cudf::filtered_join make_right_filtered_join(cudf::table_view const& right_keys,
                                                     rmm::cuda_stream_view stream)
 {
-#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 8)
+#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 6)
   return cudf::filtered_join(right_keys, cudf::null_equality::UNEQUAL, stream);
 #else
   return cudf::filtered_join(
@@ -81,7 +81,7 @@ static cudf::filtered_join make_right_filtered_join(cudf::table_view const& righ
 static std::unique_ptr<cudf::filtered_join> make_right_filtered_join_ptr(
   cudf::table_view const& right_keys, rmm::cuda_stream_view stream)
 {
-#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 8)
+#if CUDF_VERSION_MAJOR > 26 || (CUDF_VERSION_MAJOR == 26 && CUDF_VERSION_MINOR >= 6)
   return std::make_unique<cudf::filtered_join>(right_keys, cudf::null_equality::UNEQUAL, stream);
 #else
   return std::make_unique<cudf::filtered_join>(


### PR DESCRIPTION
Lower the cudf `filtered_join` version guard to `26.6`, where the constructor without the deprecated `set_as_build_table` parameter is already available, so the non-deprecated path is compiled instead of the deprecated one.

Explicitly discard the `nodiscard` `push()` result in the `convertible_gpu_pipeline_task` destructor; ignoring a failed push during queue shutdown is intentional.