### PR TITLE
fix(cpu-source): dispatch cpu_source_task from task_creator manager_loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ set(EXTENSION_SOURCES
     src/op/scan/parquet_schema_mapping.cpp
     src/op/scan/scan_plan.cpp
     src/op/scan/scan_utils.cpp
+    src/op/scan/cpu_source_task.cpp
     src/op/scan/sirius_gpu_scan_operator.cpp
     src/op/scan/sirius_gpu_scan_operator_data.cpp
     src/op/scan/gpu_ingestible.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -324,16 +324,20 @@ void task_creator::manager_loop()
               this->schedule(consumer);
             }
           } else {
-            _task_scheduler->signal_query_complete();
+            this->signal_query_complete();
           }
-        } catch (...) {
-          SIRIUS_LOG_ERROR("Task Creator: Exception during cpu_source_task execution");
+        } catch (const std::exception& e) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during cpu_source_task execution: {}",
+                           e.what());
           // Do NOT call stop() here: this lambda runs on a _bounded_pool worker
           // thread, and stop() -> do_stop_thread_pool() -> wait_all() would wait
           // for this very task's slot to release — a self-deadlock that also
           // holds _global_state_mutex and hangs the client's drain_after_error().
           // terminate_query() reports the error; the client thread tears the
           // task_creator down via drain_after_error() once future.get() throws.
+          _task_scheduler->terminate_query(std::current_exception());
+        } catch (...) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during cpu_source_task execution");
           _task_scheduler->terminate_query(std::current_exception());
         }
       });

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -17,7 +17,9 @@
 #include "creator/task_creator.hpp"
 
 #include "log/logging.hpp"
+#include "op/scan/cpu_source_task.hpp"
 #include "op/scan/sirius_gpu_scan_operator_data.hpp"
+#include "op/sirius_physical_cpu_source.hpp"
 #include "op/sirius_physical_delim_join.hpp"
 #include "pipeline/gpu_pipeline_task.hpp"
 #include "pipeline/task_scheduler.hpp"
@@ -114,6 +116,11 @@ void task_creator::prepare_for_query(const sirius::planner::query& query)
       std::make_shared<pipeline::gpu_pipeline_task_global_state>(pipeline, telemetry_context);
     _gpu_operator_global_state_map.emplace(operator_id, std::move(gs));
   }
+}
+
+void task_creator::signal_query_complete()
+{
+  if (_task_scheduler) { _task_scheduler->signal_query_complete(); }
 }
 
 void task_creator::drain_pending_tasks()
@@ -230,6 +237,103 @@ void task_creator::manager_loop()
     node = get_operator_for_next_task(node);
 
     if (node == nullptr) { continue; }
+
+    // CPU_SOURCE operators are run as cpu_source_task on the bounded pool rather
+    // than as gpu_pipeline_task. The base all_ports_empty() returns true for
+    // source-only operators (no input ports), so the normal while-loop below
+    // would never fire. Instead we create, reserve memory for, and execute the
+    // cpu_source_task inline, then schedule the downstream consumers.
+    if (auto* cpu_src = dynamic_cast<op::sirius_physical_cpu_source*>(node)) {
+      _bounded_pool->dispatch(std::move(slot), [this, cpu_src]() mutable {
+        try {
+          auto pipeline = cpu_src->get_pipeline();
+
+          // Collect ALL downstream data repositories — one per dependent pipeline
+          // (e.g. CTE reuse can fan the same scan output to multiple pipelines).
+          std::vector<cucascade::shared_data_repository*> data_repos;
+          for (const auto& port_info : pipeline->get_next_ports_after_sink()) {
+            if (auto* repo =
+                  port_info.next_operator->get_port(port_info.next_operator_port_name)->repo) {
+              data_repos.push_back(repo);
+            }
+          }
+          // Terminal pipelines (sink = RESULT_COLLECTOR) have no next ports;
+          // an empty data_repos vector is valid in that case.
+          if (data_repos.empty()) {
+            auto sink = pipeline->get_sink();
+            if (!sink || sink->type != op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+              throw std::runtime_error(
+                "task_creator: cpu_source_op has no downstream data repository");
+            }
+          }
+
+          auto* sirius_ctx_ptr =
+            _client_context->registered_state->Get<duckdb::SiriusContext>("sirius_state").get();
+          auto telemetry_ctx = sirius_ctx_ptr ? sirius_ctx_ptr->get_telemetry_context() : nullptr;
+          auto global_state  = std::make_shared<op::scan::cpu_source_task_global_state>(
+            pipeline, cpu_src, std::move(telemetry_ctx));
+          auto local_state = std::make_unique<op::scan::cpu_source_task_local_state>();
+          auto task_id     = get_next_task_id();
+          auto task        = std::make_unique<op::scan::cpu_source_task>(
+            task_id, std::move(data_repos), std::move(local_state), global_state);
+
+          auto reservation_info = task->get_estimated_reservation_size_info();
+          auto reservation      = _mem_res_mgr.request_reservation(
+            cucascade::memory::any_memory_space_in_tier{cucascade::memory::Tier::HOST},
+            reservation_info.reservation_size);
+          if (!reservation) {
+            // Unlike the GPU path (which blocks for backpressure via the
+            // reservation manager), this throws immediately. CPU sources carry
+            // small data (subquery ColumnDataCollections, statistics results)
+            // so memory exhaustion is rare in practice. A proper retry/backpressure
+            // path could be considered in the future if needed.
+            throw std::runtime_error(
+              "task_creator: failed to acquire HOST memory reservation for cpu_source_task");
+          }
+          task->local_state()->cast<pipeline::sirius_pipeline_task_local_state>().set_reservation(
+            std::move(reservation), reservation_info);
+
+          auto consumers   = task->get_output_consumers();
+          auto stream      = cudf::get_default_stream();
+          auto output_data = task->compute_task(stream);
+          task->publish_output(*output_data, stream);
+          task->telemetry_handle().finalizing({
+            .instance_name = "",
+            .success       = true,
+          });
+          task->telemetry_handle().exit();
+          task->set_telemetry_finalized();
+          task.reset();  // triggers mark_task_completed()
+
+          // Mirror gpu_pipeline_executor's terminal detection: if this is the
+          // terminal pipeline (sink = RESULT_COLLECTOR) and has no downstream
+          // consumers, no GPU task will ever run to call mark_completed().
+          // We must signal completion here. Note: drain_pending_tasks() must NOT
+          // be called from inside the bounded_pool lambda — it calls wait_all()
+          // which would deadlock. wait_for_completion() drains the queues anyway.
+          bool query_complete = false;
+          if (consumers.empty()) {
+            auto sink = pipeline->get_sink();
+            if (sink && sink->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+              query_complete = true;
+            }
+          }
+
+          if (!query_complete) {
+            for (auto* consumer : consumers) {
+              this->schedule(consumer);
+            }
+          } else {
+            _task_scheduler->signal_query_complete();
+          }
+        } catch (...) {
+          SIRIUS_LOG_ERROR("Task Creator: Exception during cpu_source_task execution");
+          _task_scheduler->terminate_query(std::current_exception());
+          stop();
+        }
+      });
+      continue;
+    }
 
     // Dispatch the task creation work to the pool
     _bounded_pool->dispatch(std::move(slot), [this, node]() mutable {

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -328,8 +328,13 @@ void task_creator::manager_loop()
           }
         } catch (...) {
           SIRIUS_LOG_ERROR("Task Creator: Exception during cpu_source_task execution");
+          // Do NOT call stop() here: this lambda runs on a _bounded_pool worker
+          // thread, and stop() -> do_stop_thread_pool() -> wait_all() would wait
+          // for this very task's slot to release — a self-deadlock that also
+          // holds _global_state_mutex and hangs the client's drain_after_error().
+          // terminate_query() reports the error; the client thread tears the
+          // task_creator down via drain_after_error() once future.get() throws.
           _task_scheduler->terminate_query(std::current_exception());
-          stop();
         }
       });
       continue;

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -133,6 +133,15 @@ class task_creator {
   void drain_pending_tasks();
 
   /**
+   * @brief Signal query completion without draining.
+   *
+   * Safe to call from inside a pool thread (unlike drain_pending_tasks). Used by
+   * notify_downstream_pipelines when a terminal RESULT_COLLECTOR pipeline finishes
+   * with zero tasks — the normal gpu_pipeline_executor path is never reached.
+   */
+  void signal_query_complete();
+
+  /**
    * @brief Schedule a task creation info for processing.
    *
    * @param info The task creation info to schedule.

--- a/src/include/op/scan/cpu_source_task.hpp
+++ b/src/include/op/scan/cpu_source_task.hpp
@@ -28,6 +28,8 @@
 #include <pipeline/sirius_pipeline_task_states.hpp>
 #include <pipeline/task_scheduler.hpp>
 
+#include <vector>
+
 namespace sirius::op::scan {
 
 //===----------------------------------------------------------------------===//
@@ -35,8 +37,10 @@ namespace sirius::op::scan {
 //===----------------------------------------------------------------------===//
 class cpu_source_task_global_state : public pipeline::sirius_pipeline_task_global_state {
  public:
-  cpu_source_task_global_state(duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
-                               sirius_physical_cpu_source* source_op);
+  cpu_source_task_global_state(
+    duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
+    sirius_physical_cpu_source* source_op,
+    std::shared_ptr<const telemetry::telemetry_context> telemetry_context);
 
   sirius_physical_cpu_source& get_source_op() { return _op; }
 
@@ -77,7 +81,7 @@ class cpu_source_task_local_state : public pipeline::sirius_pipeline_task_local_
 class cpu_source_task : public pipeline::sirius_pipeline_itask {
  public:
   cpu_source_task(uint64_t task_id,
-                  cucascade::shared_data_repository* data_repo,
+                  std::vector<cucascade::shared_data_repository*> data_repos,
                   std::unique_ptr<cpu_source_task_local_state> local_state,
                   std::shared_ptr<cpu_source_task_global_state> global_state);
 
@@ -93,7 +97,7 @@ class cpu_source_task : public pipeline::sirius_pipeline_itask {
   std::vector<op::sirius_physical_operator*> get_output_consumers() override;
 
  private:
-  cucascade::shared_data_repository* _data_repo;
+  std::vector<cucascade::shared_data_repository*> _data_repos;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/sirius_physical_dummy_scan.hpp
+++ b/src/include/op/sirius_physical_dummy_scan.hpp
@@ -36,6 +36,9 @@ class sirius_physical_dummy_scan : public sirius_physical_operator {
 
  public:
   bool is_source() const override { return true; }
+
+  std::unique_ptr<operator_data> execute(const operator_data& input_data,
+                                         rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/pipeline/task_scheduler.hpp
+++ b/src/include/pipeline/task_scheduler.hpp
@@ -164,6 +164,18 @@ class task_scheduler {
   void terminate_query(std::exception_ptr error);
 
   /**
+   * @brief Signal successful query completion from a task_creator pool thread.
+   *
+   * Called by the cpu_source_task lambda when a terminal CPU-only pipeline
+   * completes without dispatching any downstream GPU tasks (e.g. EMPTY_RESULT,
+   * DUMMY_SCAN → RESULT_COLLECTOR with no intermediate operators). Unlike
+   * gpu_pipeline_executor::mark_completed(), this must NOT call
+   * drain_pending_tasks() — doing so from within a bounded_pool lambda
+   * deadlocks on wait_all(). wait_for_completion() drains the queues anyway.
+   */
+  void signal_query_complete();
+
+  /**
    * @brief Drain all in-flight tasks after a query error.
    *
    * Drains the top-level task queue and waits for each GPU executor to finish

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -33,6 +33,8 @@
 #include <duckdb/common/vector_size.hpp>
 
 #include <cstring>
+#include <format>
+#include <stdexcept>
 
 namespace sirius::op::scan {
 
@@ -375,6 +377,18 @@ void cpu_source_task::publish_output(op::operator_data& output_data, rmm::cuda_s
   // TINYINT sentinel column (1 row) so downstream cudf-based operators see
   // the correct row count.
   auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
+  // Empty _data_repos is only valid for terminal pipelines (sink =
+  // RESULT_COLLECTOR), which today are always EMPTY_RESULT and produce no
+  // batches. Unlike gpu_pipeline_task::publish_output, this path never routes
+  // through the sink — a terminal CPU-source pipeline that produces real
+  // batches would drop them and complete "successfully" with a wrong (empty)
+  // result. Fail the query instead: supporting that shape requires routing
+  // output through the sink, like gpu_pipeline_task::publish_output does.
+  if (_data_repos.empty() && !pipelineable_output.get_data_batches().empty()) {
+    throw std::runtime_error(std::format(
+      "[cpu_source_task] {} batches produced but no downstream repository to publish to",
+      pipelineable_output.get_data_batches().size()));
+  }
   for (auto& batch : pipelineable_output.get_data_batches()) {
     if (!batch) { continue; }
     {

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -40,8 +40,11 @@ namespace sirius::op::scan {
 // cpu_source_task_global_state
 //===----------------------------------------------------------------------===//
 cpu_source_task_global_state::cpu_source_task_global_state(
-  duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline, sirius_physical_cpu_source* source_op)
-  : sirius_pipeline_task_global_state(std::move(pipeline)), _op(*source_op)
+  duckdb::shared_ptr<pipeline::sirius_pipeline> pipeline,
+  sirius_physical_cpu_source* source_op,
+  std::shared_ptr<const telemetry::telemetry_context> telemetry_context)
+  : sirius_pipeline_task_global_state(std::move(pipeline), std::move(telemetry_context)),
+    _op(*source_op)
 {
 }
 
@@ -49,11 +52,11 @@ cpu_source_task_global_state::cpu_source_task_global_state(
 // cpu_source_task
 //===----------------------------------------------------------------------===//
 cpu_source_task::cpu_source_task(uint64_t task_id,
-                                 cucascade::shared_data_repository* data_repo,
+                                 std::vector<cucascade::shared_data_repository*> data_repos,
                                  std::unique_ptr<cpu_source_task_local_state> local_state,
                                  std::shared_ptr<cpu_source_task_global_state> global_state)
   : sirius_pipeline_itask(task_id, std::move(local_state), std::move(global_state)),
-    _data_repo(data_repo)
+    _data_repos(std::move(data_repos))
 {
   if (auto* pipeline = _global_state->cast<cpu_source_task_global_state>().get_pipeline()) {
     pipeline->mark_task_created();
@@ -293,9 +296,9 @@ std::unique_ptr<op::operator_data> cpu_source_task::compute_task(rmm::cuda_strea
   auto& g_state = _global_state->cast<cpu_source_task_global_state>();
   auto& source  = g_state.get_source_op();
 
-  // The reservation was acquired by duckdb_scan_executor::manager_loop before
-  // this task was dispatched. Batches produced below reference memory backed
-  // by this reservation, so it must stay alive on the local state until the
+  // The reservation was acquired by task_creator::manager_loop before this
+  // task was dispatched. Batches produced below reference memory backed by
+  // this reservation, so it must stay alive on the local state until the
   // batches are consumed downstream.
   auto* local = dynamic_cast<cpu_source_task_local_state*>(local_state());
   if (!local) { throw std::runtime_error("[cpu_source_task] Unexpected local state type"); }
@@ -323,30 +326,36 @@ std::unique_ptr<op::operator_data> cpu_source_task::compute_task(rmm::cuda_strea
       chunk.Reset();
     }
   } else if (source.produce_single_row) {
-    // DUMMY_SCAN: produce one row with all-null values. DuckDB's
-    // DataChunk::Initialize allocates but does NOT zero the backing storage,
-    // and chunk_to_data_batch memcpys that backing into the pinned host
-    // allocation. Mark the validity invalid AND zero each fixed-width
-    // vector's data bytes so the produced batch never carries uninitialized
-    // bytes out to downstream operators (which would trip ASAN/MSAN even
-    // though the null mask makes it semantically safe). VARCHAR vectors are
-    // handled safely in chunk_to_data_batch: the loop checks validity before
-    // reading the string_t payload.
+    // DUMMY_SCAN: produce one row. All output columns are set to null.
+    // DuckDB's DataChunk::Initialize allocates but does NOT zero backing
+    // storage, so we explicitly zero and mark invalid to keep ASAN/MSAN clean.
+    //
+    // When source.types is empty (0-output-column DUMMY_SCAN, e.g. SELECT 42),
+    // a 0-column batch would convert to a 0-row cudf::table — cudf derives row
+    // count from columns. We add a TINYINT sentinel column so the cudf table
+    // has exactly 1 row. Downstream constant-expression GPU operators (e.g.
+    // PROJECTION of literals) use num_rows() from the input table; the sentinel
+    // column value is never read.
     duckdb::DataChunk chunk;
-    // source.types is sirius::logical_type post-#643. DataChunk still speaks
-    // DuckDB types — to_duckdb_vec is the unavoidable boundary conversion.
-    chunk.Initialize(duckdb::Allocator::DefaultAllocator(), sirius::to_duckdb_vec(source.types));
+    duckdb::vector<sirius::logical_type> effective_types = source.types;
+    if (effective_types.empty()) {
+      effective_types.push_back(sirius::logical_type::make(sirius::type_id::TINYINT));
+      chunk.Initialize(duckdb::Allocator::DefaultAllocator(), {duckdb::LogicalType::TINYINT});
+    } else {
+      chunk.Initialize(duckdb::Allocator::DefaultAllocator(),
+                       sirius::to_duckdb_vec(effective_types));
+    }
     chunk.SetCardinality(1);
     for (size_t c = 0; c < chunk.data.size(); c++) {
       auto& vec      = chunk.data[c];
       auto& validity = duckdb::FlatVector::Validity(vec);
       validity.SetAllInvalid(1);
-      if (!source.types[c].is_varchar()) {
-        auto type_size = source.types[c].fixed_width_byte_size();
+      if (!effective_types[c].is_varchar()) {
+        auto type_size = effective_types[c].fixed_width_byte_size();
         if (type_size > 0) { std::memset(duckdb::FlatVector::GetData(vec), 0, type_size); }
       }
     }
-    batches.push_back(chunk_to_data_batch(chunk, source.types, mem_space, reservation_ptr));
+    batches.push_back(chunk_to_data_batch(chunk, effective_types, mem_space, reservation_ptr));
   }
   // else: EMPTY_RESULT — produce no data batches
 
@@ -362,9 +371,9 @@ std::unique_ptr<op::operator_data> cpu_source_task::compute_task(rmm::cuda_strea
 
 void cpu_source_task::publish_output(op::operator_data& output_data, rmm::cuda_stream_view stream)
 {
-  // DUMMY_SCAN batches are legitimately 0-byte (0 columns, 1 row of "nothing"),
-  // so publish every valid batch rather than filtering on size_in_bytes.
-  // Downstream operators still need to see the batch to know a row existed.
+  // Publish all valid batches regardless of size. DUMMY_SCAN batches carry a
+  // TINYINT sentinel column (1 row) so downstream cudf-based operators see
+  // the correct row count.
   auto& pipelineable_output = dynamic_cast<op::pipelineable_operator_data&>(output_data);
   for (auto& batch : pipelineable_output.get_data_batches()) {
     if (!batch) { continue; }
@@ -372,7 +381,9 @@ void cpu_source_task::publish_output(op::operator_data& output_data, rmm::cuda_s
       auto ro = batch->to_read_only();
       if (!ro.get_data()) { continue; }
     }
-    _data_repo->add_data_batch(batch);
+    for (auto* repo : _data_repos) {
+      repo->add_data_batch(batch);
+    }
   }
 }
 

--- a/src/op/sirius_physical_dummy_scan.cpp
+++ b/src/op/sirius_physical_dummy_scan.cpp
@@ -19,5 +19,20 @@
 namespace sirius {
 namespace op {
 
+std::unique_ptr<operator_data> sirius_physical_dummy_scan::execute(const operator_data& input_data,
+                                                                   rmm::cuda_stream_view /*stream*/)
+{
+  /// DUMMY_SCAN is the source of its pipeline. The upstream CPU_SOURCE produces
+  /// a single 1-row sentinel batch into this operator's input port; execute()
+  /// must forward that batch unchanged so downstream operators (e.g. a
+  /// PROJECTION of constant expressions) see one input row and produce one
+  /// output row. The base execute() returns an empty batch, which would drop
+  /// the row and yield zero output rows.
+
+  // Forward the upstream CPU_SOURCE's single 1-row sentinel batch unchanged.
+  auto& input = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  return std::make_unique<pipelineable_operator_data>(input.get_data_batches());
+}
+
 }  // namespace op
 }  // namespace sirius

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -332,6 +332,10 @@ void sirius_pipeline::notify_downstream_pipelines(bool original_pipeline)
   // no parent pipeline whose status needs updating. Returning early avoids
   // racing with engine teardown after mark_completed() signals the future.
   if (auto s = get_sink(); s && s->type == op::SiriusPhysicalOperatorType::RESULT_COLLECTOR) {
+    // If the pipeline finished with zero tasks (e.g. WHERE 1=0 empty result or
+    // DUMMY_SCAN), gpu_pipeline_executor is never invoked and mark_completed()
+    // would never be called — signal completion here instead.
+    if (tasks_created.load() == 0 && _task_creator) { _task_creator->signal_query_complete(); }
     return;
   }
 

--- a/src/pipeline/task_scheduler.cpp
+++ b/src/pipeline/task_scheduler.cpp
@@ -185,6 +185,11 @@ void task_scheduler::terminate_query(std::exception_ptr error)
   stop();
 }
 
+void task_scheduler::signal_query_complete()
+{
+  if (_completion_handler) { _completion_handler->mark_completed(); }
+}
+
 void task_scheduler::drain_after_error()
 {
   SIRIUS_LOG_INFO("task_scheduler: draining after error");

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -4674,6 +4674,27 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu("select count(*), min(l_orderkey), max(l_orderkey) from lineitem;");
 }
 
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - empty result (WHERE false)",
+                 "[integration][gpu_execution][cpu_source]")
+{
+  compare_gpu_vs_cpu("select n_nationkey from nation where 1=0;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - dummy scan (SELECT literal)",
+                 "[integration][gpu_execution][cpu_source]")
+{
+  compare_gpu_vs_cpu("select 42 as x;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - values CPU source",
+                 "[integration][gpu_execution][cpu_source]")
+{
+  compare_gpu_vs_cpu("select b from (values (1), (2), (3)) t(b);");
+}
+
 //===----------------------------------------------------------------------===//
 // pin_table tests
 //===----------------------------------------------------------------------===//

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -4695,6 +4695,16 @@ TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
   compare_gpu_vs_cpu("select b from (values (1), (2), (3)) t(b);");
 }
 
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - CPU source with multiple downstream repositories",
+                 "[integration][gpu_execution][cpu_source]")
+{
+  // A VALUES-backed CTE referenced twice fans the cpu_source output out to
+  // multiple downstream data repositories.
+  compare_gpu_vs_cpu(
+    "with t(b) as (values (1), (2), (3)) select a.b, c.b from t a join t c using (b);");
+}
+
 //===----------------------------------------------------------------------===//
 // pin_table tests
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Problem

Queries that route through `CPU_SOURCE` can hang indefinitely. This affects sources such as `VALUES`, `EMPTY_RESULT`, `DUMMY_SCAN`, and DuckDB-materialized `ColumnDataCollection` inputs.

For example:

```sql
SELECT b FROM (VALUES (1), (2), (3)) t(b);
```

The engine builds the physical plan and logs the pipeline DAG, but then waits forever because no task ever publishes data into the downstream repository.

## Root Cause

PR #913 removed `duckdb_scan_executor`, which was the only path that dispatched `cpu_source_task`.

After that cleanup, `task_creator::manager_loop()` attempted to drive all operators through the normal GPU task creation loop:

```cpp
while (!node->all_ports_empty()) {
    // create gpu_pipeline_task from the next input batch
}
```

This does not work for source operators. `CPU_SOURCE` has no input ports, so `all_ports_empty()` returns `true` immediately. The loop never runs, no task is created, and downstream pipelines block waiting for data that is never produced.

`cpu_source_task.cpp` was also no longer included in `CMakeLists.txt`, so the task implementation was not linked.

## Fix

Add an explicit `CPU_SOURCE` path in `task_creator::manager_loop()` before the normal GPU task loop.

When the task creator sees a `sirius_physical_cpu_source`, it now:

- Creates a `cpu_source_task`.
- Acquires a HOST memory reservation.
- Runs `compute_task()` to produce host batches from the DuckDB-side source.
- Calls `publish_output()` to push those batches into downstream repositories.
- Schedules downstream consumers.
- Marks successful task telemetry before task destruction.
- Signals query completion directly for terminal CPU-only pipelines.

This bypasses the normal `while (!node->all_ports_empty())` path, which is only valid for operators driven by input ports.

## Additional Fix: DUMMY_SCAN Row Preservation

Constant-only queries such as:

```sql
SELECT 42 AS x;
```

were returning 0 rows on the GPU path instead of 1 row.

There were two related issues in the `CPU_SOURCE -> DUMMY_SCAN -> PROJECTION` path.

### DUMMY_SCAN Passthrough

After `split_cpu_source()`, the original `DUMMY_SCAN` remains in the GPU pipeline. The upstream `CPU_SOURCE` produces the single input row, but `sirius_physical_dummy_scan` did not override `execute()`, so it used the base operator implementation, which returns an empty batch.

That dropped the row before `PROJECTION`, causing constant expressions to be evaluated over 0 rows.

The fix adds a passthrough `execute()` implementation for `sirius_physical_dummy_scan`, forwarding its input batch unchanged.

### Sentinel Column for 0-Column DUMMY_SCAN

cuDF derives table row count from columns. A 0-column table has 0 rows, even if it logically represents one row.

For 0-output-column `DUMMY_SCAN`, `cpu_source_task` now emits a one-row all-null `TINYINT` sentinel column. This preserves the row count through host-to-GPU conversion so `PROJECTION` can broadcast constants to exactly one row. The projection output contains only the evaluated expression columns, so the sentinel does not reach the final result.

## Tests

Adds regression coverage for:

- `WHERE 1=0` empty-result CPU source.
- Constant-only `DUMMY_SCAN` query.
- `VALUES` query backed by `CPU_SOURCE`.

## Alternatives Considered

**Eager repository pre-population**

Pre-fill downstream repositories during repository wiring. This would avoid a runtime task, but memory reservations are runtime-only, and `_mem_res_mgr` is not available during wiring.

**Host executor in task scheduler**

Submit `cpu_source_task` through a dedicated CPU executor, symmetric with GPU pipeline tasks. This is architecturally cleaner, but requires adding a host executor concept to `task_scheduler`.

**Seed port**

Make source operators appear non-empty so the existing GPU task loop fires. This still fails because the GPU path expects GPU operator global state and eventually looks up `_gpu_operator_global_state_map.at(operator_id)`.

**GPU-resident CPU source output**

Copy CPU source batches directly to device memory and publish GPU batches. This is unnecessary for these small source cases and adds complexity without clear benefit.

## Note

`DUMMY_SCAN` may log a harmless output-type validation warning because the internal sentinel batch has one column while the logical `DUMMY_SCAN` output has zero columns. The sentinel is internal and is dropped by projection before the result is produced.