### PR TITLE
perf(bench): add --cluster to generate sorted TPC-H DuckDB datasets

### DIFF
--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -25,6 +25,48 @@ pixi run bash generate_tpch_data.sh 100
 pixi run bash generate_tpch_data.sh 100 /data/tpch_sf100 16
 ```
 
+### Clustered (sorted) DuckDB datasets for zone-map pruning
+
+`--cluster` (duckdb format only) physically sorts tables at load so each row group's
+per-column min/max becomes selective. This is what makes Sirius's native-scan row-group
+pruning (`mark_row_groups_pruned_by_filter_stats`) actually skip work on date-filtered
+queries — on an unsorted dbgen dataset every row group spans the full date range and
+nothing prunes. It writes a fresh, compact `tpch_sf<SF>_sorted.duckdb` (dbgen → staging →
+sorted copy, so there is no dead-block bloat).
+
+```bash
+# Sort lineitem by l_shipdate and orders by o_orderdate (defaults)
+pixi run bash generate_tpch_data.sh 10 --format duckdb --cluster
+# → test_datasets/tpch_sf10_sorted.duckdb
+
+# Override the sort keys (implies --cluster); "table:col,table:col,..."
+pixi run bash generate_tpch_data.sh 10 --format duckdb \
+    --cluster-keys "lineitem:l_shipdate,orders:o_orderdate"
+```
+
+Benchmark it through the unchanged native runner and validate against DuckDB CPU:
+
+```bash
+export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
+./test/tpch_performance/benchmark_and_validate.sh \
+    --data-source duckdb --duckdb-file ./test_datasets/tpch_sf10_sorted.duckdb 10
+```
+
+Confirm pruning fired (looking for `stats-pruned N row groups` / a reduced `decoded split`):
+
+```bash
+SIRIUS_NATIVE_SCAN_VERIFY=1 OUTPUT_DIR=/tmp/cluster_verify \
+  ./test/tpch_performance/run_tpch_duckdb.sh \
+    --duckdb-file ./test_datasets/tpch_sf10_sorted.duckdb sirius 10 1 6
+grep -oE 'stats-pruned [0-9]+ row groups' /tmp/cluster_verify/sirius_*.log
+```
+
+> **Why duckdb-only.** Sorting works for parquet too in principle, but the default
+> tpchgen-rs (Arrow) writes `DECIMAL` as `FIXED_LEN_BYTE_ARRAY`, which trips Sirius's
+> `skip_pushdown_due_to_flba` and disables row-group pruning for the *whole* parquet file —
+> so a sorted parquet wouldn't prune. The duckdb path stores decimals as `INT64` and prunes
+> correctly. `--cluster` therefore errors if combined with `--format parquet`.
+
 ### From DuckDB's built-in TPC-H generator
 
 ```bash

--- a/test/tpch_performance/generate_tpch_data.sh
+++ b/test/tpch_performance/generate_tpch_data.sh
@@ -3,21 +3,36 @@
 #
 # Usage:
 #   ./generate_tpch_data.sh <scale_factor> [--format duckdb|parquet] [--output <path>] [--jobs N]
+#   ./generate_tpch_data.sh <scale_factor> --format duckdb --cluster [--cluster-keys <spec>]
 #   ./generate_tpch_data.sh <scale_factor> [output_dir] [jobs]     # backward-compatible
 #
 # Arguments:
-#   scale_factor  - TPC-H scale factor (e.g. 1, 10, 100)
-#   --format      - Output format: 'parquet' (default) or 'duckdb'
-#   --output      - Output path (default depends on format)
-#   --jobs        - Number of parallel jobs for parquet generation (default: nproc)
+#   scale_factor    - TPC-H scale factor (e.g. 1, 10, 100)
+#   --format        - Output format: 'parquet' (default) or 'duckdb'
+#   --output        - Output path (default depends on format)
+#   --jobs          - Number of parallel jobs for parquet generation (default: nproc)
+#   --cluster       - (duckdb only) physically sort tables at load so on-disk zone
+#                     maps (per-row-group min/max) become selective. This is what
+#                     makes Sirius's native-scan row-group pruning effective on
+#                     date-filtered queries. Default sort keys cluster the fact and
+#                     order tables on their date columns.
+#   --cluster-keys  - Override the sort keys, as "table:col,table:col,...".
+#                     Default: "lineitem:l_shipdate,orders:o_orderdate". Implies --cluster.
 #
 # Parquet format uses tpchgen-rs for optimized row groups and compression.
 # DuckDB format uses DuckDB's built-in dbgen() extension.
+#
+# --cluster is duckdb-only on purpose: tpchgen-rs writes Arrow Decimal128 as
+# FIXED_LEN_BYTE_ARRAY, which trips Sirius's `skip_pushdown_due_to_flba` and
+# disables row-group pruning for the whole parquet file (so sorting wouldn't help).
+# The duckdb path stores decimals as INT64 and prunes correctly.
 #
 # Examples:
 #   cd test/tpch_performance
 #   pixi run bash generate_tpch_data.sh 100
 #   pixi run bash generate_tpch_data.sh 100 --format duckdb
+#   pixi run bash generate_tpch_data.sh 100 --format duckdb --cluster
+#   pixi run bash generate_tpch_data.sh 10 --format duckdb --cluster-keys "lineitem:l_shipdate,orders:o_orderdate"
 #   pixi run bash generate_tpch_data.sh 100 --format parquet --output /data/tpch_sf100
 #
 # Or it can be called standalone if rust, python, and pyarrow are in PATH.
@@ -29,10 +44,11 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DUCKDB="$PROJECT_DIR/build/release/duckdb"
 
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <scale_factor> [--format duckdb|parquet] [--output <path>] [--jobs N]"
+    echo "Usage: $0 <scale_factor> [--format duckdb|parquet] [--output <path>] [--jobs N] [--cluster] [--cluster-keys <spec>]"
     echo "Examples:"
-    echo "  $0 100                        # SF100, parquet (default)"
-    echo "  $0 100 --format duckdb        # SF100, duckdb database"
+    echo "  $0 100                          # SF100, parquet (default)"
+    echo "  $0 100 --format duckdb          # SF100, duckdb database"
+    echo "  $0 100 --format duckdb --cluster  # SF100, duckdb database sorted on date columns"
     echo "  $0 100 --format parquet --output /data/tpch_sf100"
     exit 1
 fi
@@ -43,6 +59,12 @@ shift
 FORMAT="parquet"
 OUTPUT=""
 JOBS="$(nproc)"
+CLUSTER="false"
+# Default clustering keys: sort the fact/order tables on their date columns so
+# date-range predicates prune row groups. Override with --cluster-keys.
+CLUSTER_KEYS="lineitem:l_shipdate,orders:o_orderdate"
+# Fixed TPC-H table set (used by the clustered duckdb build).
+TPCH_TABLES="nation region part supplier partsupp customer orders lineitem"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -56,6 +78,15 @@ while [ $# -gt 0 ]; do
             ;;
         --jobs)
             JOBS="$2"
+            shift 2
+            ;;
+        --cluster)
+            CLUSTER="true"
+            shift
+            ;;
+        --cluster-keys)
+            CLUSTER_KEYS="$2"
+            CLUSTER="true"
             shift 2
             ;;
         *)
@@ -75,10 +106,23 @@ if [ "$FORMAT" != "duckdb" ] && [ "$FORMAT" != "parquet" ]; then
     exit 1
 fi
 
+if [ "$CLUSTER" = "true" ] && [ "$FORMAT" != "duckdb" ]; then
+    echo "ERROR: --cluster is only supported with --format duckdb."
+    echo "       Parquet clustering is intentionally not implemented: tpchgen-rs writes Arrow"
+    echo "       Decimal128 as FIXED_LEN_BYTE_ARRAY, which disables Sirius row-group pruning for"
+    echo "       the whole file (skip_pushdown_due_to_flba). Use --format duckdb."
+    exit 1
+fi
+
 # --- Set default output path ---
 if [ -z "$OUTPUT" ]; then
     if [ "$FORMAT" = "duckdb" ]; then
-        OUTPUT="$PROJECT_DIR/test_datasets/tpch_sf${SF}.duckdb"
+        if [ "$CLUSTER" = "true" ]; then
+            # Distinct name so the sorted dataset can coexist with the unsorted one.
+            OUTPUT="$PROJECT_DIR/test_datasets/tpch_sf${SF}_sorted.duckdb"
+        else
+            OUTPUT="$PROJECT_DIR/test_datasets/tpch_sf${SF}.duckdb"
+        fi
     else
         OUTPUT="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
     fi
@@ -129,15 +173,64 @@ elif [ "$FORMAT" = "duckdb" ]; then
         exit 1
     fi
 
-    if [ -f "$OUTPUT" ]; then
-        echo "WARNING: Database file already exists, will overwrite tables"
-    fi
+    if [ "$CLUSTER" = "true" ]; then
+        # Clustered build. dbgen into a staging database, then write a *fresh*,
+        # COMPACT database with the requested tables physically sorted (ORDER BY at
+        # load). A fresh copy — rather than an in-place CREATE+DROP — avoids leaving
+        # dead blocks behind, which would roughly double the file size and inflate
+        # cold-scan reads of un-pruned data.
+        STAGING="${OUTPUT%.duckdb}.staging.duckdb"
+        rm -f "$OUTPUT" "$OUTPUT".wal "$STAGING" "$STAGING".wal
+        trap 'rm -f "$STAGING" "$STAGING".wal' EXIT
 
-    echo "Generating TPC-H SF${SF} data into $OUTPUT ..."
-    "$DUCKDB" "$OUTPUT" -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=${SF});"
+        echo "Generating TPC-H SF${SF} (staging) ..."
+        "$DUCKDB" "$STAGING" -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=${SF}); CHECKPOINT;"
+
+        # Parse --cluster-keys "table:col,table:col" into a lookup.
+        declare -A SORT_COL
+        IFS=',' read -ra _pairs <<< "$CLUSTER_KEYS" || true
+        for _p in "${_pairs[@]}"; do
+            _t="${_p%%:*}"
+            _c="${_p##*:}"
+            [ -z "$_t" ] && continue
+            case " $TPCH_TABLES " in
+                *" $_t "*) SORT_COL["$_t"]="$_c" ;;
+                *) echo "WARNING: --cluster-keys references unknown table '$_t' (ignored)" ;;
+            esac
+        done
+
+        # Build the fresh, sorted database from the staging copy.
+        BUILD_SQL="ATTACH '${STAGING}' AS s (READ_ONLY);"
+        echo "Clustering tables:"
+        for _t in $TPCH_TABLES; do
+            if [ -n "${SORT_COL[$_t]:-}" ]; then
+                BUILD_SQL+=" CREATE TABLE ${_t} AS FROM s.${_t} ORDER BY ${SORT_COL[$_t]};"
+                echo "  ${_t} ORDER BY ${SORT_COL[$_t]}"
+            else
+                BUILD_SQL+=" CREATE TABLE ${_t} AS FROM s.${_t};"
+            fi
+        done
+        BUILD_SQL+=" CHECKPOINT;"
+
+        echo "Writing sorted database into $OUTPUT ..."
+        "$DUCKDB" "$OUTPUT" -c "$BUILD_SQL"
+
+        rm -f "$STAGING" "$STAGING".wal
+        trap - EXIT
+    else
+        if [ -f "$OUTPUT" ]; then
+            echo "WARNING: Database file already exists, will overwrite tables"
+        fi
+
+        echo "Generating TPC-H SF${SF} data into $OUTPUT ..."
+        "$DUCKDB" "$OUTPUT" -c "INSTALL tpch; LOAD tpch; CALL dbgen(sf=${SF});"
+    fi
 fi
 
 echo ""
 echo "TPC-H SF${SF} data generation complete."
-echo "  Format: $FORMAT"
-echo "  Output: $OUTPUT"
+echo "  Format:  $FORMAT"
+echo "  Output:  $OUTPUT"
+if [ "$CLUSTER" = "true" ]; then
+    echo "  Cluster: $CLUSTER_KEYS"
+fi


### PR DESCRIPTION
## What

Adds `--cluster` / `--cluster-keys` to `generate_tpch_data.sh` (**duckdb format only**) to physically sort tables at load, so Sirius's native-scan row-group pruning becomes effective on date-filtered queries. Default keys: `lineitem:l_shipdate, orders:o_orderdate` (overridable via `--cluster-keys "table:col,..."`).

- Writes a fresh, **compact** `tpch_sf<SF>_sorted.duckdb` (dbgen → staging → sorted copy) — no dead-block bloat that would inflate cold scans.
- **Runners unchanged.** Benchmark via the existing native path:
  `benchmark_and_validate.sh --data-source duckdb --duckdb-file <sorted.duckdb> <SF>`
- Parquet is intentionally excluded — see *Why parquet is excluded* below; `--cluster` + `--format parquet` errors.

## Why

On an unsorted dbgen dataset every row group's `l_shipdate`/`o_orderdate` min/max spans the **full ~7-year range**, so date predicates prune nothing. Sorting on the date column makes the per-row-group min/max tight and monotonic, so the existing pruner (`mark_row_groups_pruned_by_filter_stats`, `src/op/scan/duckdb_native_metadata.cpp`) skips row groups before they're decoded to the GPU.

## Results — SF10, all 22 queries, Sirius native scan (sorted vs unsorted, warm best-of-2)

Both runs validate **22/22 success** against the DuckDB CPU oracle (identical results — sorting changes layout, not answers). Net wall-time **1.18× faster**; per-query speedup tracks how many row groups get pruned, up to **4.3×**.

| Query | RG pruned | Unsorted (s) | Sorted (s) | Speedup |
|---|--:|--:|--:|--:|
| Q1 | 232 | 0.271 | 0.192 | 1.41× |
| Q2 | 0 | 0.070 | 0.081 | 0.86× |
| Q3 | 290 | 0.192 | 0.141 | 1.36× |
| Q4 | 118 | 0.151 | 0.151 | 1.00× |
| Q5 | 103 | 0.201 | 0.222 | 0.91× |
| Q6 | 414 | 0.161 | 0.050 | 3.22× |
| Q7 | 339 | 0.222 | 0.132 | 1.68× |
| Q8 | 85 | 0.222 | 0.241 | 0.92× |
| Q9 | 0 | 0.293 | 0.303 | 0.97× |
| Q10 | 363 | 0.222 | 0.151 | 1.47× |
| Q11 | 0 | 0.061 | 0.071 | 0.86× |
| Q12 | 408 | 0.161 | 0.080 | 2.01× |
| Q13 | 0 | 0.181 | 0.191 | 0.95× |
| Q14 | 481 | 0.161 | 0.040 | 4.03× |
| Q15 | 470 | 0.172 | 0.040 | 4.30× |
| Q16 | 0 | 0.061 | 0.060 | 1.02× |
| Q17 | 0 | 0.242 | 0.262 | 0.92× |
| Q18 | 0 | 0.251 | 0.332 | 0.76× |
| Q19 | 0 | 0.222 | 0.211 | 1.05× |
| Q20 | 414 | 0.201 | 0.082 | 2.45× |
| Q21 | 58 | 0.413 | 0.463 | 0.89× |
| Q22 | 0 | 0.070 | 0.060 | 1.17× |
| **Total** | | **4.20** | **3.56** | **1.18×** |

(SF10: lineitem = 489 row groups, orders = 123. "RG pruned" = total row groups skipped across the query's scans.)

**Honest trade-off.** Sorting `lineitem` by `l_shipdate` helps every query that filters on a lineitem/orders date (high-pruning rows) but **mildly hurts a few join-heavy queries that read `lineitem` in full** (Q18 0.76×, Q17/Q13 ~0.93×, Q21 0.89×) — sorting on the date destroys dbgen's natural `l_orderkey` ordering that those joins benefited from. Queries that prune nothing and don't depend on orderkey order are within measurement noise (sub-100ms). A table can only be physically sorted one way; this picks the date dimension, which is a net win here and the dimension most TPC-H predicates filter on. The cross-table case (prune `lineitem` from an `orders`-only predicate, e.g. Q4) is out of scope and would need join-aware pruning.

## Why parquet is excluded

Sorting works for parquet *in principle*, but the harness's default parquet generator (tpchgen-rs / Arrow) writes `DECIMAL` as `FIXED_LEN_BYTE_ARRAY`. Sirius's parquet scan (`parquet_gpu_ingestible.cpp`) sets `skip_pushdown_due_to_flba` if **any** column is FLBA-decimal, disabling row-group pruning for the **whole file** — so a sorted parquet wouldn't prune at all. The duckdb path stores decimals as `INT64` and prunes correctly (verified). Sorted parquet would need DuckDB-generated, INT-decimal files; deferred.

## Test plan

- `generate_tpch_data.sh <SF> --format duckdb --cluster` → compact sorted DB, monotonic non-overlapping per-row-group date ranges (`pragma_storage_info`).
- `--cluster` + `--format parquet` errors; unknown table in `--cluster-keys` warns and is skipped.
- End-to-end through `run_tpch_duckdb.sh` / `benchmark_and_validate.sh --data-source duckdb`: pruning fires (`stats-pruned N row groups`), results validate 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
