### PR TITLE
Add S3 async-read perf instrumentation to the s3-bench JSON baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,17 +227,19 @@ s3-test-aws-broker:
 	$(S3_TEST_BIN) "[s3][aws][broker]"
 
 # -----------------------------------------------------------------------------
-# S3 perf benchmarks. The portable SF10 benchmark uses the
-# [!benchmark][perf][bench] hidden tag and is deliberately NOT tagged [s3] so
-# the [s3] integration gate does not pull it in. The scripted async-vs-blocking
-# microbench is selected by [s3][benchmark]~[aws]. For the default MinIO backend
-# the harness auto-manages MinIO (SIRIUS_TEST_S3_AUTO=1) and generates/uploads
-# the SF10 lineitem fixture (SIRIUS_TEST_S3_LARGE=1); the benchmark reads
-# SIRIUS_BENCH_S3_* and falls back to the harness-published SIRIUS_TEST_S3_*.
-# Generates a JSON record under
-# build/release/extension/sirius/test/cpp/log/perf_<ts>.json for tracking.
+# S3 perf benchmarks. All S3 benchmarks share the hidden [.][s3][bench] tag
+# (real-AWS ones also [aws][live]); selected here by [s3][bench]~[aws]. The tag
+# carries [.] (out of the default `make test`) and lacks [integration] (so the
+# [s3] integration gate `make s3-test` never pulls it in). Default backend = minio
+# (read_bench_env() defaults to it — no extra env source needed): the harness
+# auto-manages MinIO (SIRIUS_TEST_S3_AUTO=1), generates/uploads the SF10 lineitem
+# fixture (SIRIUS_TEST_S3_LARGE=1), and SIRIUS_TEST_S3_STRICT=1 makes a MinIO
+# bring-up failure fail the benchmark loud instead of skipping to a false green.
+# The async JSON baseline (Family 1) sets s3_perf_instrumentation=true and emits
+# build/release/extension/sirius/test/cpp/log/perf_<ts>.json for tracking; the
+# scripted async-vs-blocking microbench (Family 2) prints console numbers.
 # Set SIRIUS_BENCH_BACKEND=aws-s3 (and the SIRIUS_BENCH_AWS_S3_* vars) to hit AWS
-# instead of MinIO; AUTO stays off in that case.
+# instead of MinIO; AUTO/STRICT stay off in that case.
 
 s3-bench:
 	@if [ ! -x $(S3_TEST_BIN) ]; then \
@@ -246,7 +248,7 @@ s3-bench:
 	fi
 	@set -e; \
 	if [ "$${SIRIUS_BENCH_BACKEND:-minio}" = "minio" ]; then \
-	  export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1; \
+	  export SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1 SIRIUS_TEST_S3_STRICT=1; \
 	fi; \
 	export SIRIUS_BENCH_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"; \
-	$(S3_TEST_BIN) "[!benchmark][perf][bench],[s3][benchmark]~[aws]"
+	$(S3_TEST_BIN) "[s3][bench]~[aws]"

--- a/src/include/io/s3/s3_blocking_ioctx.hpp
+++ b/src/include/io/s3/s3_blocking_ioctx.hpp
@@ -104,6 +104,14 @@ struct s3_ioctx_config {
   /// (CURLOPT_SSL_VERIFYPEER / CURLOPT_SSL_VERIFYHOST = 0) — INSECURE, dev/test.
   std::string ca_bundle_path;
   bool tls_verify = true;
+
+  /// Opt-in per-chunk perf instrumentation for the async device-read path
+  /// (ns-level GET / queue-wait / H2D-observed latency + TTFB accumulators).
+  /// Default off so production carries no per-chunk timestamping; the benchmark
+  /// sets it true. The retry / terminal-failure counters are NOT gated by this
+  /// (they are always-on, off-happy-path). This is a bench/test knob, not a
+  /// user-facing one.
+  bool s3_perf_instrumentation = false;
 };
 
 /**

--- a/src/include/io/s3/s3_ioctx.hpp
+++ b/src/include/io/s3/s3_ioctx.hpp
@@ -28,6 +28,8 @@
 
 namespace sirius::io::s3 {
 
+struct s3_ioctx_config;  // defined in io/s3/s3_blocking_ioctx.hpp
+
 /**
  * @brief Production async-S3 backend (libcurl-multi reactor).
  *
@@ -60,6 +62,12 @@ class s3_ioctx : public templated_ioctx<s3_reactor> {
            std::optional<std::chrono::milliseconds> retry_jitter       = std::nullopt,
            std::optional<bool> honor_retry_after                       = std::nullopt);
 
+  /// Construct from the shared @c s3_ioctx_config (the same struct the blocking
+  /// backend and scan_manager use). Maps every field — including
+  /// @c s3_perf_instrumentation — into the reactor config. Preferred over the
+  /// multi-arg ctor for new call sites.
+  explicit s3_ioctx(s3_ioctx_config config);
+
   // -- F1: instance create_io_object (HEAD needs the authorizer) -------------
   std::shared_ptr<sirius_io_object> create_io_object(std::string path) override;
 
@@ -79,6 +87,21 @@ class s3_ioctx : public templated_ioctx<s3_reactor> {
   [[nodiscard]] std::uint64_t device_copies_total() const noexcept;
   [[nodiscard]] std::uint64_t device_stream_sync_total() const noexcept;
   [[nodiscard]] std::uint64_t device_peak_inflight() const noexcept;
+
+  // Per-chunk perf micro (gated by s3_perf_instrumentation) + always-on retry
+  // counters; each sums over the reactor(s).
+  [[nodiscard]] std::uint64_t chunk_get_ns_total() const noexcept;
+  [[nodiscard]] std::uint64_t chunk_get_ns_count() const noexcept;
+  [[nodiscard]] std::uint64_t chunk_get_ns_max() const noexcept;
+  [[nodiscard]] std::uint64_t queue_wait_ns_total() const noexcept;
+  [[nodiscard]] std::uint64_t queue_wait_ns_count() const noexcept;
+  [[nodiscard]] std::uint64_t h2d_observed_ns_total() const noexcept;
+  [[nodiscard]] std::uint64_t h2d_observed_ns_count() const noexcept;
+  [[nodiscard]] std::uint64_t h2d_observed_ns_max() const noexcept;
+  [[nodiscard]] std::uint64_t ttfb_ns() const noexcept;
+  [[nodiscard]] std::uint64_t retries_total() const noexcept;
+  [[nodiscard]] std::uint64_t terminal_failures_total() const noexcept;
+
   std::size_t head_object_size(std::string_view bucket, std::string_view key);
 
  private:

--- a/src/include/io/s3/s3_reactor.hpp
+++ b/src/include/io/s3/s3_reactor.hpp
@@ -117,6 +117,12 @@ class s3_reactor {
     std::chrono::milliseconds retry_backoff_base{50};  // exponential base
     std::chrono::milliseconds retry_jitter{20};        // +/- bound
     bool honor_retry_after{true};
+
+    // Opt-in per-chunk perf instrumentation (ns-level accumulators). Default off:
+    // when false the device path takes no steady_clock::now() and no extra
+    // atomics (one predicted-not-taken branch per chunk). The retry / terminal
+    // counters below are always-on regardless of this flag.
+    bool s3_perf_instrumentation{false};
   };
 
   using native_handle_type   = s3_native_handle;
@@ -194,6 +200,61 @@ class s3_reactor {
     return _device_peak_inflight.load(std::memory_order_relaxed);
   }
 
+  // -- Per-chunk perf micro (gated by config.s3_perf_instrumentation) ---------
+  // Raw ns totals/counts/max; the consumer computes means (ns_total / count).
+  // All zero when instrumentation is off. Populated on the async device path
+  // only (footer/HEAD go through the separate blocking path and are not seen).
+  [[nodiscard]] std::uint64_t chunk_get_ns_total() const noexcept
+  {
+    return _chunk_get_ns_total.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t chunk_get_ns_count() const noexcept
+  {
+    return _chunk_get_ns_count.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t chunk_get_ns_max() const noexcept
+  {
+    return _chunk_get_ns_max.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t queue_wait_ns_total() const noexcept
+  {
+    return _queue_wait_ns_total.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t queue_wait_ns_count() const noexcept
+  {
+    return _queue_wait_ns_count.load(std::memory_order_relaxed);
+  }
+  /// memcpy issue -> worker-observed cuda_done. NOT a pure GPU copy time: it
+  /// includes the CUDA-callback + wakeup + poll observation latency.
+  [[nodiscard]] std::uint64_t h2d_observed_ns_total() const noexcept
+  {
+    return _h2d_observed_ns_total.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t h2d_observed_ns_count() const noexcept
+  {
+    return _h2d_observed_ns_count.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t h2d_observed_ns_max() const noexcept
+  {
+    return _h2d_observed_ns_max.load(std::memory_order_relaxed);
+  }
+  /// First GET submit -> first GET completion of the reactor's lifetime
+  /// (excludes queue-wait by construction).
+  [[nodiscard]] std::uint64_t ttfb_ns() const noexcept
+  {
+    return _ttfb_ns.load(std::memory_order_relaxed);
+  }
+
+  // -- Retry / failure counters (always-on, off-happy-path) -------------------
+  [[nodiscard]] std::uint64_t retries_total() const noexcept
+  {
+    return _retries_total.load(std::memory_order_relaxed);
+  }
+  [[nodiscard]] std::uint64_t terminal_failures_total() const noexcept
+  {
+    return _terminal_failures_total.load(std::memory_order_relaxed);
+  }
+
  private:
   struct transfer;  // per-async-request state (defined in the .cpp)
 
@@ -252,6 +313,24 @@ class s3_reactor {
   std::atomic<std::uint64_t> _device_copies_total{0};
   std::atomic<std::uint64_t> _device_peak_inflight{0};
   std::atomic<std::uint64_t> _device_stream_sync_total{0};
+
+  // Gated per-chunk perf micro (written by the worker thread only).
+  std::atomic<std::uint64_t> _chunk_get_ns_total{0};
+  std::atomic<std::uint64_t> _chunk_get_ns_count{0};
+  std::atomic<std::uint64_t> _chunk_get_ns_max{0};
+  std::atomic<std::uint64_t> _queue_wait_ns_total{0};
+  std::atomic<std::uint64_t> _queue_wait_ns_count{0};
+  std::atomic<std::uint64_t> _h2d_observed_ns_total{0};
+  std::atomic<std::uint64_t> _h2d_observed_ns_count{0};
+  std::atomic<std::uint64_t> _h2d_observed_ns_max{0};
+  std::atomic<std::uint64_t> _ttfb_ns{0};
+  // TTFB start point: the first GET submit of the reactor's lifetime. Worker-only.
+  std::chrono::steady_clock::time_point _ttfb_first_submit{};
+  bool _ttfb_first_submit_set{false};
+
+  // Always-on retry / failure counters.
+  std::atomic<std::uint64_t> _retries_total{0};
+  std::atomic<std::uint64_t> _terminal_failures_total{0};
 };
 
 }  // namespace sirius::io::s3

--- a/src/io/s3/s3_ioctx.cpp
+++ b/src/io/s3/s3_ioctx.cpp
@@ -16,6 +16,7 @@
 
 #include "io/s3/s3_ioctx.hpp"
 
+#include "io/s3/s3_blocking_ioctx.hpp"  // s3_ioctx_config
 #include "io/uri_parser.hpp"
 
 #include <algorithm>
@@ -64,6 +65,25 @@ s3_ioctx::s3_ioctx(std::shared_ptr<s3_request_authorizer> creds,
                                   if (honor_retry_after) cfg.honor_retry_after = *honor_retry_after;
                                   return std::make_unique<s3_reactor>(std::move(cfg));
                                 })
+{
+}
+
+s3_ioctx::s3_ioctx(s3_ioctx_config config)
+  : templated_ioctx<s3_reactor>(1, [config = std::move(config)]() {
+      s3_reactor::config cfg;
+      cfg.creds                   = config.creds;
+      cfg.request_timeout_s       = config.request_timeout_s;
+      cfg.ca_bundle_path          = config.ca_bundle_path;
+      cfg.tls_verify              = config.tls_verify;
+      cfg.max_connections         = config.max_connections;
+      cfg.host_memory_resource    = config.host_memory_resource;
+      cfg.max_retry_attempts      = config.max_retry_attempts;
+      cfg.retry_backoff_base      = config.retry_backoff_base;
+      cfg.retry_jitter            = config.retry_jitter;
+      cfg.honor_retry_after       = config.honor_retry_after;
+      cfg.s3_perf_instrumentation = config.s3_perf_instrumentation;
+      return std::make_unique<s3_reactor>(std::move(cfg));
+    })
 {
 }
 
@@ -183,6 +203,71 @@ std::uint64_t s3_ioctx::device_peak_inflight() const noexcept
 std::size_t s3_ioctx::head_object_size(std::string_view bucket, std::string_view key)
 {
   return reactor().head_object_size(bucket, key);
+}
+
+// -- Perf micro + retry accessors (sum totals/counts, max the maxima) --------
+namespace {
+template <typename Reactors, typename Fn>
+std::uint64_t sum_reactors(Reactors const& reactors, Fn fn) noexcept
+{
+  std::uint64_t total = 0;
+  for (auto const& r : reactors)
+    total += fn(*r);
+  return total;
+}
+template <typename Reactors, typename Fn>
+std::uint64_t max_reactors(Reactors const& reactors, Fn fn) noexcept
+{
+  std::uint64_t hi = 0;
+  for (auto const& r : reactors)
+    hi = std::max(hi, fn(*r));
+  return hi;
+}
+}  // namespace
+
+std::uint64_t s3_ioctx::chunk_get_ns_total() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.chunk_get_ns_total(); });
+}
+std::uint64_t s3_ioctx::chunk_get_ns_count() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.chunk_get_ns_count(); });
+}
+std::uint64_t s3_ioctx::chunk_get_ns_max() const noexcept
+{
+  return max_reactors(_reactors, [](auto const& r) { return r.chunk_get_ns_max(); });
+}
+std::uint64_t s3_ioctx::queue_wait_ns_total() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.queue_wait_ns_total(); });
+}
+std::uint64_t s3_ioctx::queue_wait_ns_count() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.queue_wait_ns_count(); });
+}
+std::uint64_t s3_ioctx::h2d_observed_ns_total() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.h2d_observed_ns_total(); });
+}
+std::uint64_t s3_ioctx::h2d_observed_ns_count() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.h2d_observed_ns_count(); });
+}
+std::uint64_t s3_ioctx::h2d_observed_ns_max() const noexcept
+{
+  return max_reactors(_reactors, [](auto const& r) { return r.h2d_observed_ns_max(); });
+}
+std::uint64_t s3_ioctx::ttfb_ns() const noexcept
+{
+  return max_reactors(_reactors, [](auto const& r) { return r.ttfb_ns(); });
+}
+std::uint64_t s3_ioctx::retries_total() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.retries_total(); });
+}
+std::uint64_t s3_ioctx::terminal_failures_total() const noexcept
+{
+  return sum_reactors(_reactors, [](auto const& r) { return r.terminal_failures_total(); });
 }
 
 }  // namespace sirius::io::s3

--- a/src/io/s3/s3_reactor.cpp
+++ b/src/io/s3/s3_reactor.cpp
@@ -38,7 +38,10 @@ namespace {
 
 using namespace std::chrono_literals;
 
-// Perf-instrumentation helpers (worker-thread only; single-writer atomics).
+// Perf-instrumentation helpers. The max/set-once updates are written only by the
+// reactor worker thread today, but use real atomic RMWs (relaxed) so they are
+// correct regardless of writer count and match the `atomic_*` naming. `fetch_max`
+// is C++26; this project is C++20, so a compare_exchange loop implements the max.
 inline std::uint64_t ns_between(std::chrono::steady_clock::time_point a,
                                 std::chrono::steady_clock::time_point b) noexcept
 {
@@ -47,7 +50,8 @@ inline std::uint64_t ns_between(std::chrono::steady_clock::time_point a,
 }
 inline void atomic_max_relaxed(std::atomic<std::uint64_t>& a, std::uint64_t v) noexcept
 {
-  if (v > a.load(std::memory_order_relaxed)) a.store(v, std::memory_order_relaxed);
+  auto cur = a.load(std::memory_order_relaxed);
+  while (v > cur && !a.compare_exchange_weak(cur, v, std::memory_order_relaxed)) {}
 }
 
 struct curl_global_init_once {
@@ -639,10 +643,10 @@ void s3_reactor::submit_pending()
     try {
       build_and_add(t);  // may throw (authorize / init / add_handle) — never escapes the worker
       if (t->is_device) {
-        // single-writer (worker thread): track the high-water mark of held blocks
-        auto n = static_cast<std::uint64_t>(device_blocks_in_flight());
-        if (n > _device_peak_inflight.load(std::memory_order_relaxed))
-          _device_peak_inflight.store(n, std::memory_order_relaxed);
+        // Track the high-water mark of held blocks (atomic max, same helper as the
+        // perf counters).
+        atomic_max_relaxed(_device_peak_inflight,
+                           static_cast<std::uint64_t>(device_blocks_in_flight()));
         if (_cfg.s3_perf_instrumentation) {
           auto const now = std::chrono::steady_clock::now();
           t->t_submit    = now;  // GET submit; chunk_get is measured to completion
@@ -738,8 +742,12 @@ void s3_reactor::start_device_copy(transfer* t)
     _chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
     _chunk_get_ns_count.fetch_add(1, std::memory_order_relaxed);
     atomic_max_relaxed(_chunk_get_ns_max, get_ns);
+    // Atomic set-once: the relaxed load is a fast-path guard so only the first
+    // chunk runs the CAS; the compare_exchange_strong from 0 is the atomic gate.
     if (_ttfb_first_submit_set && _ttfb_ns.load(std::memory_order_relaxed) == 0) {
-      _ttfb_ns.store(ns_between(_ttfb_first_submit, now), std::memory_order_relaxed);
+      auto expected = std::uint64_t{0};
+      _ttfb_ns.compare_exchange_strong(
+        expected, ns_between(_ttfb_first_submit, now), std::memory_order_relaxed);
     }
     t->t_h2d_start = now;  // H2D issue point (memcpy below)
   }

--- a/src/io/s3/s3_reactor.cpp
+++ b/src/io/s3/s3_reactor.cpp
@@ -17,6 +17,7 @@
 #include "io/s3/s3_reactor.hpp"
 
 #include "io/sirius_datasource.hpp"
+#include "log/logging.hpp"
 
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <curl/curl.h>
@@ -36,6 +37,18 @@ namespace sirius::io::s3 {
 namespace {
 
 using namespace std::chrono_literals;
+
+// Perf-instrumentation helpers (worker-thread only; single-writer atomics).
+inline std::uint64_t ns_between(std::chrono::steady_clock::time_point a,
+                                std::chrono::steady_clock::time_point b) noexcept
+{
+  auto const d = std::chrono::duration_cast<std::chrono::nanoseconds>(b - a).count();
+  return d > 0 ? static_cast<std::uint64_t>(d) : 0;
+}
+inline void atomic_max_relaxed(std::atomic<std::uint64_t>& a, std::uint64_t v) noexcept
+{
+  if (v > a.load(std::memory_order_relaxed)) a.store(v, std::memory_order_relaxed);
+}
 
 struct curl_global_init_once {
   curl_global_init_once()
@@ -231,6 +244,12 @@ struct s3_reactor::transfer {
   std::atomic<bool> cuda_done{false};
   cudaError_t cuda_status{cudaSuccess};
   s3_reactor* owner{nullptr};  // for the stream callback (wake + counter)
+
+  // Perf instrumentation start points (only stamped when
+  // config.s3_perf_instrumentation is set). Worker-thread only.
+  std::chrono::steady_clock::time_point t_enqueue{};    // device transfer built
+  std::chrono::steady_clock::time_point t_submit{};     // GET submitted (build_and_add)
+  std::chrono::steady_clock::time_point t_h2d_start{};  // memcpy issued
 };
 
 // ---------------------------------------------------------------------------
@@ -380,11 +399,27 @@ std::size_t s3_reactor::blocking_request(std::string_view bucket,
     }
 
     if (!retriable || attempt >= max_attempts) break;
+    // Off-happy-path: count + WARN once per retried sync request.
+    _retries_total.fetch_add(1, std::memory_order_relaxed);
+    SIRIUS_LOG_WARN("s3_reactor: retrying {} {}/{} attempt {}/{}: {}",
+                    (method == s3_request_method::HEAD ? "HEAD" : "GET"),
+                    bucket,
+                    key,
+                    attempt,
+                    max_attempts,
+                    last_why);
     std::optional<std::chrono::milliseconds> ra;
     if (_cfg.honor_retry_after) ra = parse_retry_after_seconds(hc.retry_after);
     std::this_thread::sleep_for(backoff_delay(attempt, ra));
   }
 
+  _terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
+  SIRIUS_LOG_ERROR("s3_reactor: {} {}/{} failed after {} attempt(s); last: {}",
+                   (method == s3_request_method::HEAD ? "HEAD" : "GET"),
+                   bucket,
+                   key,
+                   max_attempts,
+                   last_why);
   std::ostringstream os;
   os << "s3_reactor: " << (method == s3_request_method::HEAD ? "HEAD " : "GET ") << bucket << "/"
      << key << " failed after " << max_attempts << " attempt(s); last: " << last_why;
@@ -491,6 +526,7 @@ void s3_reactor::drain_incoming_device()
     t->stream     = dr.stream;
     t->device_id  = dr.device_id;
     t->owner      = this;
+    if (_cfg.s3_perf_instrumentation) t->t_enqueue = std::chrono::steady_clock::now();
     _pending.push_back(t);
   }
 }
@@ -607,6 +643,21 @@ void s3_reactor::submit_pending()
         auto n = static_cast<std::uint64_t>(device_blocks_in_flight());
         if (n > _device_peak_inflight.load(std::memory_order_relaxed))
           _device_peak_inflight.store(n, std::memory_order_relaxed);
+        if (_cfg.s3_perf_instrumentation) {
+          auto const now = std::chrono::steady_clock::now();
+          t->t_submit    = now;  // GET submit; chunk_get is measured to completion
+          // queue-wait only on the first submit (attempt 1) to avoid counting
+          // retry backoff as queue time.
+          if (t->attempt == 1) {
+            _queue_wait_ns_total.fetch_add(ns_between(t->t_enqueue, now),
+                                           std::memory_order_relaxed);
+            _queue_wait_ns_count.fetch_add(1, std::memory_order_relaxed);
+          }
+          if (!_ttfb_first_submit_set) {
+            _ttfb_first_submit     = now;  // TTFB start = first GET submit
+            _ttfb_first_submit_set = true;
+          }
+        }
       }
     } catch (...) {
       auto ep = std::current_exception();
@@ -680,6 +731,18 @@ void s3_reactor::cleanup_easy(transfer* t)
 
 void s3_reactor::start_device_copy(transfer* t)
 {
+  // GET just completed: record per-chunk GET latency + TTFB before the H2D copy.
+  if (_cfg.s3_perf_instrumentation) {
+    auto const now    = std::chrono::steady_clock::now();
+    auto const get_ns = ns_between(t->t_submit, now);
+    _chunk_get_ns_total.fetch_add(get_ns, std::memory_order_relaxed);
+    _chunk_get_ns_count.fetch_add(1, std::memory_order_relaxed);
+    atomic_max_relaxed(_chunk_get_ns_max, get_ns);
+    if (_ttfb_first_submit_set && _ttfb_ns.load(std::memory_order_relaxed) == 0) {
+      _ttfb_ns.store(ns_between(_ttfb_first_submit, now), std::memory_order_relaxed);
+    }
+    t->t_h2d_start = now;  // H2D issue point (memcpy below)
+  }
   // A sibling chunk already failed: don't bother copying, just decrement.
   if (t->req.ctx && t->req.ctx->failed.load(std::memory_order_relaxed)) {
     t->req.ctx->chunk_done();
@@ -734,6 +797,14 @@ void s3_reactor::poll_device_copies()
     if (!t->cuda_done.load(std::memory_order_acquire)) {
       ++it;
       continue;
+    }
+    if (_cfg.s3_perf_instrumentation) {
+      // memcpy issue -> worker-observed completion (includes callback + poll
+      // latency; not a pure GPU copy time).
+      auto const h2d_ns = ns_between(t->t_h2d_start, std::chrono::steady_clock::now());
+      _h2d_observed_ns_total.fetch_add(h2d_ns, std::memory_order_relaxed);
+      _h2d_observed_ns_count.fetch_add(1, std::memory_order_relaxed);
+      atomic_max_relaxed(_h2d_observed_ns_max, h2d_ns);
     }
     if (t->cuda_status != cudaSuccess) {
       if (t->req.ctx)
@@ -886,13 +957,33 @@ void s3_reactor::worker_loop()
       }
 
       if (retriable && t->attempt < _cfg.max_retry_attempts) {
+        // Off-happy-path: count + WARN once per retried request (not per chunk on
+        // success). Always-on, independent of s3_perf_instrumentation.
+        _retries_total.fetch_add(1, std::memory_order_relaxed);
+        SIRIUS_LOG_WARN("s3_reactor: retrying GET {}/{} range [{},{}) attempt {}/{}: {}",
+                        t->req.handle->bucket,
+                        t->req.handle->key,
+                        t->req.offset,
+                        t->req.offset + t->req.size,
+                        t->attempt,
+                        _cfg.max_retry_attempts,
+                        last_why);
         schedule_retry(t, backoff_delay(t->attempt, retry_after));
       } else if (retriable) {
+        _terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
+        SIRIUS_LOG_ERROR("s3_reactor: GET {}/{} failed after {} attempt(s); last: {}",
+                         t->req.handle->bucket,
+                         t->req.handle->key,
+                         _cfg.max_retry_attempts,
+                         last_why);
         std::ostringstream os;
         os << "s3_reactor: GET " << t->req.handle->bucket << "/" << t->req.handle->key
            << " failed after " << _cfg.max_retry_attempts << " attempt(s); last: " << last_why;
         finish(t, std::make_exception_ptr(std::runtime_error(os.str())));
       } else if (ep) {
+        _terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
+        SIRIUS_LOG_ERROR(
+          "s3_reactor: GET {}/{} non-retriable failure", t->req.handle->bucket, t->req.handle->key);
         finish(t, ep);  // failure (host or device GET) -> chunk_failed (releases staging)
       } else if (t->is_device) {
         cleanup_easy(t);

--- a/test/cpp/integration/s3/fixtures/README.md
+++ b/test/cpp/integration/s3/fixtures/README.md
@@ -1,6 +1,6 @@
 # S3 Perf Benchmark Fixture
 
-The hidden `[!benchmark][perf][bench]` Catch2 benchmark uses an SF=10 `lineitem`
+The hidden `[.][s3][bench]` Catch2 benchmark uses an SF=10 `lineitem`
 Parquet fixture. It is now generated and uploaded **by the test binary itself**
 (`test/cpp/utils/s3_container.*`) when `SIRIUS_TEST_S3_LARGE=1`, which:
 
@@ -19,9 +19,10 @@ For local MinIO, just run:
 make s3-bench
 ```
 
-`make s3-bench` sets `SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1` for the
-default MinIO backend, so MinIO is auto-managed and the SF10 fixture is prepared
-in-process — no separate fixture/up step.
+`make s3-bench` sets `SIRIUS_TEST_S3_AUTO=1 SIRIUS_TEST_S3_LARGE=1
+SIRIUS_TEST_S3_STRICT=1` for the default MinIO backend, so MinIO is
+auto-managed, the SF10 fixture is prepared in-process, and any bring-up failure
+is loud — no separate fixture/up step.
 
 AWS portability uses the same benchmark test with the MinIO auto-path off:
 

--- a/test/cpp/integration/test_s3_perf_benchmark.cpp
+++ b/test/cpp/integration/test_s3_perf_benchmark.cpp
@@ -97,7 +97,10 @@ std::optional<bench_env> read_bench_env()
                      std::move(key)};
   }
 
-  auto endpoint   = env_or("SIRIUS_BENCH_S3_ENDPOINT", env_or("SIRIUS_TEST_S3_ENDPOINT"));
+  bool const use_tls = !env_or("SIRIUS_BENCH_S3_USE_TLS").empty();
+  auto endpoint =
+    env_or("SIRIUS_BENCH_S3_ENDPOINT",
+           use_tls ? env_or("SIRIUS_TEST_S3_HTTPS_ENDPOINT") : env_or("SIRIUS_TEST_S3_ENDPOINT"));
   auto access_key = env_or("SIRIUS_BENCH_S3_ACCESS_KEY", env_or("SIRIUS_TEST_S3_ACCESS_KEY"));
   auto secret_key = env_or("SIRIUS_BENCH_S3_SECRET_KEY", env_or("SIRIUS_TEST_S3_SECRET_KEY"));
   auto bucket     = env_or("SIRIUS_BENCH_S3_BUCKET", env_or("SIRIUS_TEST_S3_BUCKET"));
@@ -167,10 +170,11 @@ std::shared_ptr<s3_ioctx> make_async_bench_ioctx(
   bool enable_perf_instrumentation)
 {
   s3_ioctx_config cfg{};
-  cfg.creds                   = std::move(provider);
-  cfg.max_connections         = kBenchMaxConnections;
-  cfg.request_timeout_s       = 600;
-  cfg.host_memory_resource    = &memory.host_mr;
+  cfg.creds                = std::move(provider);
+  cfg.max_connections      = kBenchMaxConnections;
+  cfg.request_timeout_s    = 600;
+  cfg.host_memory_resource = &memory.host_mr;
+  cfg.ca_bundle_path = env_or("SIRIUS_BENCH_S3_CA_BUNDLE", env_or("SIRIUS_TEST_S3_CA_BUNDLE"));
   cfg.s3_perf_instrumentation = enable_perf_instrumentation;
   return std::make_shared<s3_ioctx>(std::move(cfg));
 }

--- a/test/cpp/integration/test_s3_perf_benchmark.cpp
+++ b/test/cpp/integration/test_s3_perf_benchmark.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "catch.hpp"
-#include "io/prefetching_cache.hpp"
 #include "io/s3/s3_blocking_ioctx.hpp"
+#include "io/s3/s3_ioctx.hpp"
 #include "io/s3/s3_request_authorizer.hpp"
 #include "io/s3/sirius_sigv4_authorizer.hpp"
 
@@ -46,9 +46,8 @@
 #include <utility>
 #include <vector>
 
-using sirius::io::buffer_pool;
 using sirius::io::s3::s3_authorized_request;
-using sirius::io::s3::s3_blocking_ioctx;
+using sirius::io::s3::s3_ioctx;
 using sirius::io::s3::s3_ioctx_config;
 using sirius::io::s3::s3_object_ref;
 using sirius::io::s3::s3_request_authorizer;
@@ -61,7 +60,8 @@ namespace {
 namespace fs     = std::filesystem;
 using clock_type = std::chrono::steady_clock;
 
-constexpr std::uint64_t one_gib = 1ULL << 30;
+constexpr std::uint64_t one_gib            = 1ULL << 30;
+constexpr std::size_t kBenchMaxConnections = 32;
 
 std::string env_or(std::string_view name, std::string fallback = {})
 {
@@ -147,48 +147,100 @@ class recording_request_authorizer final : public s3_request_authorizer {
   std::atomic<std::uint64_t> _get_count{0};
 };
 
-std::shared_ptr<s3_blocking_ioctx> make_bench_ioctx(
-  std::shared_ptr<recording_request_authorizer> provider)
-{
-  s3_ioctx_config cfg{};
-  cfg.creds             = std::move(provider);
-  cfg.max_connections   = 32;
-  cfg.request_timeout_s = 600;
-  return std::make_shared<s3_blocking_ioctx>(std::move(cfg));
-}
-
-std::size_t cache_capacity_bytes(std::size_t block_size, std::uint32_t max_slabs)
-{
-  return block_size * static_cast<std::size_t>(buffer_pool::CHUNKS_PER_SLAB) *
-         static_cast<std::size_t>(max_slabs);
-}
-
 struct bench_cache_memory {
-  static constexpr std::uint32_t max_slabs = 4;
-  static constexpr std::size_t block_size  = 1ULL << 20;
+  static constexpr std::size_t block_size = sirius::io::CHUNK_SIZE;
+  static constexpr std::size_t blocks     = kBenchMaxConnections;
 
   bench_cache_memory()
     : upstream(0, true),
-      host_mr(0,
-              upstream,
-              cache_capacity_bytes(block_size, max_slabs),
-              cache_capacity_bytes(block_size, max_slabs),
-              block_size,
-              static_cast<std::size_t>(buffer_pool::CHUNKS_PER_SLAB),
-              1),
-      pool(host_mr, max_slabs)
+      host_mr(0, upstream, block_size * blocks, block_size * blocks, block_size, blocks, 1)
   {
   }
 
   cucascade::memory::numa_region_pinned_host_memory_resource upstream;
   cucascade::memory::fixed_size_host_memory_resource host_mr;
-  buffer_pool pool;
 };
+
+std::shared_ptr<s3_ioctx> make_async_bench_ioctx(
+  std::shared_ptr<recording_request_authorizer> provider,
+  bench_cache_memory& memory,
+  bool enable_perf_instrumentation)
+{
+  s3_ioctx_config cfg{};
+  cfg.creds                   = std::move(provider);
+  cfg.max_connections         = kBenchMaxConnections;
+  cfg.request_timeout_s       = 600;
+  cfg.host_memory_resource    = &memory.host_mr;
+  cfg.s3_perf_instrumentation = enable_perf_instrumentation;
+  return std::make_shared<s3_ioctx>(std::move(cfg));
+}
+
+struct micro_snapshot {
+  std::uint64_t chunk_get_ns_total{0};
+  std::uint64_t chunk_get_ns_count{0};
+  std::uint64_t chunk_get_ns_max{0};
+  std::uint64_t queue_wait_ns_total{0};
+  std::uint64_t queue_wait_ns_count{0};
+  std::uint64_t h2d_observed_ns_total{0};
+  std::uint64_t h2d_observed_ns_count{0};
+  std::uint64_t h2d_observed_ns_max{0};
+  std::uint64_t ttfb_ns{0};
+  std::uint64_t retries_total{0};
+  std::uint64_t terminal_failures_total{0};
+};
+
+micro_snapshot snapshot_micro(s3_ioctx const& ctx)
+{
+  return micro_snapshot{ctx.chunk_get_ns_total(),
+                        ctx.chunk_get_ns_count(),
+                        ctx.chunk_get_ns_max(),
+                        ctx.queue_wait_ns_total(),
+                        ctx.queue_wait_ns_count(),
+                        ctx.h2d_observed_ns_total(),
+                        ctx.h2d_observed_ns_count(),
+                        ctx.h2d_observed_ns_max(),
+                        ctx.ttfb_ns(),
+                        ctx.retries_total(),
+                        ctx.terminal_failures_total()};
+}
+
+micro_snapshot delta(micro_snapshot const& after, micro_snapshot const& before)
+{
+  return micro_snapshot{after.chunk_get_ns_total - before.chunk_get_ns_total,
+                        after.chunk_get_ns_count - before.chunk_get_ns_count,
+                        after.chunk_get_ns_max,
+                        after.queue_wait_ns_total - before.queue_wait_ns_total,
+                        after.queue_wait_ns_count - before.queue_wait_ns_count,
+                        after.h2d_observed_ns_total - before.h2d_observed_ns_total,
+                        after.h2d_observed_ns_count - before.h2d_observed_ns_count,
+                        after.h2d_observed_ns_max,
+                        after.ttfb_ns - before.ttfb_ns,
+                        after.retries_total - before.retries_total,
+                        after.terminal_failures_total - before.terminal_failures_total};
+}
+
+double elapsed_ms(clock_type::time_point start, clock_type::time_point stop)
+{
+  return std::chrono::duration<double, std::milli>(stop - start).count();
+}
+
+double mean_ns_as_ms(std::uint64_t total_ns, std::uint64_t count)
+{
+  if (count == 0) return 0.0;
+  return static_cast<double>(total_ns) / static_cast<double>(count) / 1'000'000.0;
+}
 
 struct scan_measurement {
   double wall_clock_ms{0.0};
+  double open_ms{0.0};
+  double footer_fetch_ms{0.0};
+  double metadata_parse_ms{0.0};
+  double scan_ms{0.0};
   std::uint64_t wire_bytes_read{0};
   std::int64_t rows{0};
+  micro_snapshot micro;
+  std::uint64_t device_peak_inflight{0};
+  std::uint64_t device_stream_sync_total{0};
 };
 
 std::unique_ptr<cudf::io::datasource::buffer> read_parquet_footer(cudf::io::datasource& source)
@@ -207,39 +259,79 @@ std::unique_ptr<cudf::io::datasource::buffer> read_parquet_footer(cudf::io::data
   return source.host_read(file_size - footer_tail_size - footer_size, footer_size);
 }
 
-scan_measurement run_parquet_scan(s3_blocking_ioctx& ctx,
-                                  std::string const& path,
-                                  std::vector<std::string> const& columns)
+scan_measurement run_async_parquet_scan(s3_ioctx& ctx,
+                                        std::string const& path,
+                                        std::vector<std::string> const& columns)
 {
   auto const before_bytes = ctx.bytes_read_total();
+  auto const before_micro = snapshot_micro(ctx);
 
-  auto probe         = ctx.open_datasource(path);
-  auto footer_buffer = read_parquet_footer(*probe);
-  auto opts          = cudf::io::parquet_reader_options::builder().column_names(columns).build();
+  auto const wall_start = clock_type::now();
+
+  auto const open_start = clock_type::now();
+  auto source           = ctx.open_datasource(path);
+  auto const open_stop  = clock_type::now();
+
+  auto const footer_start = clock_type::now();
+  auto footer_buffer      = read_parquet_footer(*source);
+  auto const footer_stop  = clock_type::now();
+  auto opts = cudf::io::parquet_reader_options::builder().column_names(columns).build();
+
+  auto const parse_start = clock_type::now();
   cudf::io::parquet::experimental::hybrid_scan_reader reader{
     cudf::host_span<std::uint8_t const>(footer_buffer->data(), footer_buffer->size()), opts};
   std::vector<cudf::io::parquet::FileMetaData> metadatas;
   metadatas.push_back(reader.parquet_metadata());
+  auto const parse_stop = clock_type::now();
 
   std::vector<std::unique_ptr<cudf::io::datasource>> sources;
-  sources.push_back(ctx.open_datasource(path));
+  sources.push_back(std::move(source));
 
-  auto const t0          = clock_type::now();
+  auto const scan_start  = clock_type::now();
   auto [table, metadata] = cudf::io::read_parquet(std::move(sources), std::move(metadatas), opts);
   (void)metadata;
-  auto const ms = std::chrono::duration<double, std::milli>(clock_type::now() - t0).count();
+  auto const scan_stop   = clock_type::now();
+  auto const wall_stop   = clock_type::now();
   auto const after_bytes = ctx.bytes_read_total();
+  auto const after_micro = snapshot_micro(ctx);
 
-  return scan_measurement{
-    ms, static_cast<std::uint64_t>(after_bytes - before_bytes), table->num_rows()};
+  return scan_measurement{elapsed_ms(wall_start, wall_stop),
+                          elapsed_ms(open_start, open_stop),
+                          elapsed_ms(footer_start, footer_stop),
+                          elapsed_ms(parse_start, parse_stop),
+                          elapsed_ms(scan_start, scan_stop),
+                          static_cast<std::uint64_t>(after_bytes - before_bytes),
+                          table->num_rows(),
+                          delta(after_micro, before_micro),
+                          ctx.device_peak_inflight(),
+                          ctx.device_stream_sync_total()};
 }
 
 struct bench_record {
   std::string scenario;
   double wall_clock_ms{0.0};
+  double open_ms{0.0};
+  double footer_fetch_ms{0.0};
+  double metadata_parse_ms{0.0};
+  double scan_ms{0.0};
   std::uint64_t wire_bytes_read{0};
   double effective_bytes_per_sec{0.0};
-  double cold_warm_ratio{0.0};
+  std::uint64_t chunk_get_ns_total{0};
+  std::uint64_t chunk_get_ns_count{0};
+  std::uint64_t chunk_get_ns_max{0};
+  double chunk_get_ms_mean{0.0};
+  std::uint64_t queue_wait_ns_total{0};
+  std::uint64_t queue_wait_ns_count{0};
+  double queue_wait_ms_mean{0.0};
+  std::uint64_t h2d_observed_ns_total{0};
+  std::uint64_t h2d_observed_ns_count{0};
+  std::uint64_t h2d_observed_ns_max{0};
+  double h2d_observed_ms_mean{0.0};
+  std::uint64_t ttfb_ns{0};
+  std::uint64_t device_peak_inflight{0};
+  std::uint64_t device_stream_sync_total{0};
+  std::uint64_t retries_total{0};
+  std::uint64_t terminal_failures_total{0};
   std::string warning;
 };
 
@@ -298,9 +390,28 @@ void write_perf_json(fs::path const& path,
     auto const& r = records[i];
     out << "    {\"scenario\": \"" << json_escape(r.scenario) << "\", "
         << "\"wall_clock_ms\": " << std::fixed << std::setprecision(3) << r.wall_clock_ms << ", "
+        << "\"open_ms\": " << r.open_ms << ", "
+        << "\"footer_fetch_ms\": " << r.footer_fetch_ms << ", "
+        << "\"metadata_parse_ms\": " << r.metadata_parse_ms << ", "
+        << "\"scan_ms\": " << r.scan_ms << ", "
         << "\"wire_bytes_read\": " << r.wire_bytes_read << ", "
         << "\"effective_bytes_per_sec\": " << r.effective_bytes_per_sec << ", "
-        << "\"cold_warm_ratio\": " << r.cold_warm_ratio << ", "
+        << "\"chunk_get_ns_total\": " << r.chunk_get_ns_total << ", "
+        << "\"chunk_get_ns_count\": " << r.chunk_get_ns_count << ", "
+        << "\"chunk_get_ns_max\": " << r.chunk_get_ns_max << ", "
+        << "\"chunk_get_ms_mean\": " << r.chunk_get_ms_mean << ", "
+        << "\"queue_wait_ns_total\": " << r.queue_wait_ns_total << ", "
+        << "\"queue_wait_ns_count\": " << r.queue_wait_ns_count << ", "
+        << "\"queue_wait_ms_mean\": " << r.queue_wait_ms_mean << ", "
+        << "\"h2d_observed_ns_total\": " << r.h2d_observed_ns_total << ", "
+        << "\"h2d_observed_ns_count\": " << r.h2d_observed_ns_count << ", "
+        << "\"h2d_observed_ns_max\": " << r.h2d_observed_ns_max << ", "
+        << "\"h2d_observed_ms_mean\": " << r.h2d_observed_ms_mean << ", "
+        << "\"ttfb_ns\": " << r.ttfb_ns << ", "
+        << "\"device_peak_inflight\": " << r.device_peak_inflight << ", "
+        << "\"device_stream_sync_total\": " << r.device_stream_sync_total << ", "
+        << "\"retries_total\": " << r.retries_total << ", "
+        << "\"terminal_failures_total\": " << r.terminal_failures_total << ", "
         << "\"warning\": \"" << json_escape(r.warning) << "\"}";
     out << (i + 1 == records.size() ? "\n" : ",\n");
   }
@@ -326,8 +437,27 @@ void require_json_schema(fs::path const& path)
                    "\"dataset_bytes\"",
                    "\"scenario\"",
                    "\"wall_clock_ms\"",
+                   "\"open_ms\"",
+                   "\"footer_fetch_ms\"",
+                   "\"metadata_parse_ms\"",
+                   "\"scan_ms\"",
                    "\"effective_bytes_per_sec\"",
-                   "\"cold_warm_ratio\"",
+                   "\"chunk_get_ns_total\"",
+                   "\"chunk_get_ns_count\"",
+                   "\"chunk_get_ns_max\"",
+                   "\"chunk_get_ms_mean\"",
+                   "\"queue_wait_ns_total\"",
+                   "\"queue_wait_ns_count\"",
+                   "\"queue_wait_ms_mean\"",
+                   "\"h2d_observed_ns_total\"",
+                   "\"h2d_observed_ns_count\"",
+                   "\"h2d_observed_ns_max\"",
+                   "\"h2d_observed_ms_mean\"",
+                   "\"ttfb_ns\"",
+                   "\"device_peak_inflight\"",
+                   "\"device_stream_sync_total\"",
+                   "\"retries_total\"",
+                   "\"terminal_failures_total\"",
                    "\"config\""}) {
     CHECK(json.find(key) != std::string::npos);
   }
@@ -336,23 +466,57 @@ void require_json_schema(fs::path const& path)
 bench_record make_record(std::string scenario,
                          scan_measurement measurement,
                          std::uint64_t dataset_bytes,
-                         double cold_warm_ratio = 0.0,
-                         std::string warning    = {})
+                         std::string warning = {})
 {
   auto seconds = measurement.wall_clock_ms / 1000.0;
   auto effective =
     seconds > 0.0 ? static_cast<double>(dataset_bytes) / seconds : static_cast<double>(0);
+  auto const& micro = measurement.micro;
   return bench_record{std::move(scenario),
                       measurement.wall_clock_ms,
+                      measurement.open_ms,
+                      measurement.footer_fetch_ms,
+                      measurement.metadata_parse_ms,
+                      measurement.scan_ms,
                       measurement.wire_bytes_read,
                       effective,
-                      cold_warm_ratio,
+                      micro.chunk_get_ns_total,
+                      micro.chunk_get_ns_count,
+                      micro.chunk_get_ns_max,
+                      mean_ns_as_ms(micro.chunk_get_ns_total, micro.chunk_get_ns_count),
+                      micro.queue_wait_ns_total,
+                      micro.queue_wait_ns_count,
+                      mean_ns_as_ms(micro.queue_wait_ns_total, micro.queue_wait_ns_count),
+                      micro.h2d_observed_ns_total,
+                      micro.h2d_observed_ns_count,
+                      micro.h2d_observed_ns_max,
+                      mean_ns_as_ms(micro.h2d_observed_ns_total, micro.h2d_observed_ns_count),
+                      micro.ttfb_ns,
+                      measurement.device_peak_inflight,
+                      measurement.device_stream_sync_total,
+                      micro.retries_total,
+                      micro.terminal_failures_total,
                       std::move(warning)};
 }
 
 }  // namespace
 
-TEST_CASE("S3 parquet perf benchmark emits portable JSON baseline", "[!benchmark][perf][bench]")
+TEST_CASE("S3 async perf instrumentation accessors are noexcept", "[.][s3][bench]")
+{
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().chunk_get_ns_total()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().chunk_get_ns_count()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().chunk_get_ns_max()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().queue_wait_ns_total()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().queue_wait_ns_count()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().h2d_observed_ns_total()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().h2d_observed_ns_count()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().h2d_observed_ns_max()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().ttfb_ns()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().retries_total()));
+  STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().terminal_failures_total()));
+}
+
+TEST_CASE("S3 parquet perf benchmark emits async JSON baseline", "[.][s3][bench]")
 {
   auto env = read_bench_env();
   if (!env) {
@@ -360,12 +524,13 @@ TEST_CASE("S3 parquet perf benchmark emits portable JSON baseline", "[!benchmark
     return;
   }
 
-  auto provider = std::make_shared<recording_request_authorizer>(*env);
-  auto ctx      = make_bench_ioctx(provider);
-  auto path     = s3_uri(*env);
+  auto path = s3_uri(*env);
 
   std::uint64_t dataset_bytes = 0;
   try {
+    bench_cache_memory probe_memory;
+    auto provider = std::make_shared<recording_request_authorizer>(*env);
+    auto ctx      = make_async_bench_ioctx(provider, probe_memory, false);
     dataset_bytes = ctx->head_object_size(env->bucket, env->key);
   } catch (std::exception const& e) {
     WARN("Skipping S3 perf benchmark because the fixture object is unavailable: " << e.what());
@@ -377,7 +542,8 @@ TEST_CASE("S3 parquet perf benchmark emits portable JSON baseline", "[!benchmark
   }
 
   bench_cache_memory cache_memory;
-  ctx->initialize_cache(cache_memory.pool, 2048);
+  auto provider = std::make_shared<recording_request_authorizer>(*env);
+  auto ctx      = make_async_bench_ioctx(provider, cache_memory, true);
 
   std::vector<std::string> full_columns{
     "l_orderkey",
@@ -388,34 +554,44 @@ TEST_CASE("S3 parquet perf benchmark emits portable JSON baseline", "[!benchmark
     "l_extendedprice",
     "l_discount",
   };
-  std::vector<std::string> selective_columns{"l_orderkey", "l_extendedprice"};
 
   std::vector<bench_record> records;
 
-  auto cold_full = run_parquet_scan(*ctx, path, full_columns);
-  records.push_back(make_record("full_sequential_scan", cold_full, dataset_bytes));
+  auto async_full = run_async_parquet_scan(*ctx, path, full_columns);
+  CHECK(async_full.wire_bytes_read > 0);
+  CHECK(async_full.open_ms > 0.0);
+  CHECK(async_full.footer_fetch_ms > 0.0);
+  CHECK(async_full.metadata_parse_ms > 0.0);
+  CHECK(async_full.scan_ms > 0.0);
+  CHECK(async_full.wall_clock_ms >=
+        async_full.open_ms + async_full.footer_fetch_ms + async_full.scan_ms);
+  CHECK(async_full.micro.chunk_get_ns_count > 0);
+  CHECK(async_full.micro.chunk_get_ns_total > 0);
+  CHECK(async_full.micro.chunk_get_ns_max > 0);
+  CHECK(async_full.micro.queue_wait_ns_count > 0);
+  CHECK(async_full.micro.h2d_observed_ns_count > 0);
+  CHECK(async_full.micro.h2d_observed_ns_total > 0);
+  CHECK(async_full.micro.ttfb_ns > 0);
+  CHECK(async_full.micro.ttfb_ns <= async_full.micro.chunk_get_ns_max);
+  CHECK(async_full.device_peak_inflight >= 1);
+  CHECK(async_full.device_stream_sync_total == 0);
+  CHECK(async_full.micro.retries_total == 0);
+  CHECK(async_full.micro.terminal_failures_total == 0);
+  records.push_back(make_record("async_full_scan", async_full, dataset_bytes));
 
-  auto selective = run_parquet_scan(*ctx, path, selective_columns);
-  records.push_back(make_record("selective_two_column_scan", selective, dataset_bytes));
-  CHECK(selective.wire_bytes_read > 0);
-
-  if (env->backend == "aws-s3") {
-    CHECK((provider->endpoint().find("amazonaws") != std::string::npos ||
-           selective.wire_bytes_read > 0));
-    records.push_back(bench_record{"aws_s3_portability", 0.0, 0, 0.0, 0.0, {}});
-  } else {
-    records.push_back(
-      bench_record{"aws_s3_portability_skipped", 0.0, 0, 0.0, 0.0, "aws env absent"});
-  }
-
-  auto warm_full = run_parquet_scan(*ctx, path, full_columns);
-  auto ratio =
-    cold_full.wall_clock_ms > 0.0 ? warm_full.wall_clock_ms / cold_full.wall_clock_ms : 0.0;
-  std::string cache_warning;
-  if (ctx->cache()->total_size_bytes() < cold_full.wire_bytes_read) {
-    cache_warning = "cache_too_small_for_full_object";
-  }
-  records.push_back(make_record("warm_full_scan", warm_full, dataset_bytes, ratio, cache_warning));
+  bench_cache_memory gate_off_memory;
+  auto gate_off_provider = std::make_shared<recording_request_authorizer>(*env);
+  auto gate_off_ctx      = make_async_bench_ioctx(gate_off_provider, gate_off_memory, false);
+  auto gate_off          = run_async_parquet_scan(*gate_off_ctx, path, full_columns);
+  CHECK(gate_off.wire_bytes_read > 0);
+  CHECK(gate_off.device_peak_inflight >= 1);
+  CHECK(gate_off.micro.chunk_get_ns_count == 0);
+  CHECK(gate_off.micro.chunk_get_ns_total == 0);
+  CHECK(gate_off.micro.queue_wait_ns_count == 0);
+  CHECK(gate_off.micro.queue_wait_ns_total == 0);
+  CHECK(gate_off.micro.h2d_observed_ns_count == 0);
+  CHECK(gate_off.micro.h2d_observed_ns_total == 0);
+  CHECK(gate_off.micro.ttfb_ns == 0);
 
   auto json_path = perf_json_path();
   write_perf_json(json_path, *env, dataset_bytes, records);

--- a/test/cpp/integration/test_s3_perf_benchmark.cpp
+++ b/test/cpp/integration/test_s3_perf_benchmark.cpp
@@ -77,24 +77,29 @@ struct bench_env {
   std::string secret_key;
   std::string bucket;
   std::string key;
+  std::string session_token;
 };
 
 std::optional<bench_env> read_bench_env()
 {
   auto backend = env_or("SIRIUS_BENCH_BACKEND", "minio");
   if (backend == "aws-s3") {
-    auto access_key = env_or("SIRIUS_BENCH_AWS_S3_ACCESS_KEY");
-    auto secret_key = env_or("SIRIUS_BENCH_AWS_S3_SECRET_KEY");
-    auto bucket     = env_or("SIRIUS_BENCH_AWS_S3_BUCKET");
-    auto key        = env_or("SIRIUS_BENCH_AWS_S3_KEY", "tpch/lineitem_sf10.parquet");
-    if (access_key.empty() || secret_key.empty() || bucket.empty()) { return std::nullopt; }
+    auto access_key    = env_or("SIRIUS_BENCH_AWS_S3_ACCESS_KEY");
+    auto secret_key    = env_or("SIRIUS_BENCH_AWS_S3_SECRET_KEY");
+    auto bucket        = env_or("SIRIUS_BENCH_AWS_S3_BUCKET");
+    auto key           = env_or("SIRIUS_BENCH_AWS_S3_KEY", "tpch/lineitem_sf10.parquet");
+    auto session_token = env_or("SIRIUS_BENCH_AWS_S3_SESSION_TOKEN");
+    if (access_key.empty() || secret_key.empty() || bucket.empty() || session_token.empty()) {
+      return std::nullopt;
+    }
     return bench_env{std::move(backend),
                      env_or("SIRIUS_BENCH_AWS_S3_ENDPOINT", "https://s3.amazonaws.com"),
                      env_or("SIRIUS_BENCH_AWS_S3_REGION", "us-east-1"),
                      std::move(access_key),
                      std::move(secret_key),
                      std::move(bucket),
-                     std::move(key)};
+                     std::move(key),
+                     std::move(session_token)};
   }
 
   bool const use_tls = !env_or("SIRIUS_BENCH_S3_USE_TLS").empty();
@@ -126,6 +131,7 @@ class recording_request_authorizer final : public s3_request_authorizer {
     static_credentials creds;
     creds.access_key_id     = env.access_key;
     creds.secret_access_key = env.secret_key;
+    creds.session_token     = env.session_token;
     _delegate               = std::make_shared<sirius_sigv4_presigned_authorizer>(
       std::move(creds), env.region, env.endpoint, std::chrono::minutes{30});
   }
@@ -518,6 +524,26 @@ TEST_CASE("S3 async perf instrumentation accessors are noexcept", "[.][s3][bench
   STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().ttfb_ns()));
   STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().retries_total()));
   STATIC_REQUIRE(noexcept(std::declval<s3_ioctx const&>().terminal_failures_total()));
+}
+
+TEST_CASE("S3 bench AWS session token reaches presigned URLs", "[s3][bench]")
+{
+  bench_env env{"aws-s3",
+                "https://s3.us-east-2.amazonaws.com",
+                "us-east-2",
+                "AKIAFAKEBENCHKEY",
+                "fake-secret-key",
+                "sirius-bench",
+                "tpch/lineitem_sf10.parquet",
+                "fake-session-token"};
+  recording_request_authorizer authorizer(env);
+
+  auto request = authorizer.authorize(
+    s3_object_ref{env.bucket, env.key}, s3_request_method::GET, std::chrono::seconds{60});
+
+  CHECK(request.headers.empty());
+  CHECK(request.url.find("X-Amz-Security-Token=") != std::string::npos);
+  CHECK(request.url.find("fake-session-token") != std::string::npos);
 }
 
 TEST_CASE("S3 parquet perf benchmark emits async JSON baseline", "[.][s3][bench]")

--- a/test/cpp/io/s3/test_s3_ioctx.cpp
+++ b/test/cpp/io/s3/test_s3_ioctx.cpp
@@ -635,6 +635,22 @@ std::shared_ptr<s3_blocking_ioctx> make_device_blocking_ioctx(
   return std::make_shared<s3_blocking_ioctx>(std::move(cfg));
 }
 
+std::shared_ptr<s3_ioctx> make_perf_device_async_ioctx(
+  std::shared_ptr<s3_request_authorizer> provider,
+  fsmr_test_resources& memory,
+  bool enable_perf_instrumentation,
+  std::size_t max_connections = 4,
+  long request_timeout_s      = 20)
+{
+  s3_ioctx_config cfg{};
+  cfg.creds                   = std::move(provider);
+  cfg.max_connections         = max_connections;
+  cfg.request_timeout_s       = request_timeout_s;
+  cfg.host_memory_resource    = &memory.host_mr;
+  cfg.s3_perf_instrumentation = enable_perf_instrumentation;
+  return std::make_shared<s3_ioctx>(std::move(cfg));
+}
+
 std::vector<std::uint8_t> test_payload(std::size_t size = 4096)
 {
   std::vector<std::uint8_t> out(size);
@@ -1424,7 +1440,7 @@ TEST_CASE("async-curl S3 device staging peak stays within the active window",
 }
 
 TEST_CASE("async-curl S3 benchmark hides injected range latency versus blocking S3",
-          "[.][s3][benchmark]")
+          "[.][s3][bench]")
 {
   constexpr std::size_t payload_size = 16 * sirius::io::CHUNK_SIZE;
   auto payload                       = test_payload(payload_size);
@@ -1458,8 +1474,40 @@ TEST_CASE("async-curl S3 benchmark hides injected range latency versus blocking 
   CHECK(async_best.median_time < blocking / 2);
 }
 
+TEST_CASE("async-curl S3 perf instrumentation reports transient retry counters", "[.][s3][bench]")
+{
+  auto payload = test_payload(4096);
+  range_fault_policy fault;
+  fault.fail_first_gets = 1;
+  fault.fail_status     = 503;
+  fault.fail_reason     = "Service Unavailable";
+  range_http_server server(payload, 0ms, std::move(fault));
+  fsmr_test_resources memory(/*block_size=*/sirius::io::CHUNK_SIZE,
+                             /*capacity=*/2 * sirius::io::CHUNK_SIZE,
+                             /*memory_limit=*/2 * sirius::io::CHUNK_SIZE,
+                             /*pool_size=*/2,
+                             /*initial_pools=*/1);
+  auto ctx = make_perf_device_async_ioctx(std::make_shared<fixed_url_authorizer>(server.url()),
+                                          memory,
+                                          /*enable_perf_instrumentation=*/true,
+                                          /*max_connections=*/1);
+  auto obj = ctx->create_io_object("s3://bucket/object.bin");
+
+  auto stream = rmm::cuda_stream_default;
+  rmm::device_buffer dst(payload.size(), stream);
+  auto const got =
+    ctx->device_read(*obj, 0, payload.size(), static_cast<std::uint8_t*>(dst.data()), stream);
+
+  CHECK(got == payload.size());
+  require_bytes_equal(copy_device_to_host(dst, got), payload, 0);
+  CHECK(ctx->retries_total() >= 1);
+  CHECK(ctx->terminal_failures_total() == 0);
+  WARN("s3 perf retry bucket=bucket key=object.bin attempts=" << server.get_count() << " retries="
+                                                              << ctx->retries_total());
+}
+
 TEST_CASE("async-curl S3 benchmark reports real AWS S3 headline numbers",
-          "[.][s3][aws][live][benchmark]")
+          "[.][s3][bench][aws][live]")
 {
   auto env = read_aws_live_env();
   if (!env) { return; }

--- a/test/cpp/utils/s3_container.cpp
+++ b/test/cpp/utils/s3_container.cpp
@@ -347,8 +347,11 @@ void upload_fixtures(minio_instance const& inst,
 
 // Opt-in (SIRIUS_TEST_S3_LARGE=1): generate the SF10 lineitem parquet with the
 // DuckDB CLI and upload it for the [s3][sql][large] / benchmark tests. Replaces
-// the old `fixtures.sh --perf` path. Uploaded to the HTTP endpoint only.
-void maybe_upload_large_fixture(minio_instance const& http, fs::path const& work)
+// the old `fixtures.sh --perf` path. Uploaded to both HTTP and TLS endpoints.
+void maybe_upload_large_fixture(minio_instance const& http,
+                                minio_instance const& tls,
+                                std::optional<fs::path> const& ca,
+                                fs::path const& work)
 {
   if (!env_truthy("SIRIUS_TEST_S3_LARGE")) return;
 
@@ -398,8 +401,21 @@ void maybe_upload_large_fixture(minio_instance const& http, fs::path const& work
   if (!(pc == 200 || pc == 204)) {
     throw std::runtime_error("SF10 upload failed (HTTP " + std::to_string(pc) + ")");
   }
+  std::FILE* ft = std::fopen(parquet.c_str(), "rb");
+  if (ft == nullptr) throw std::runtime_error("cannot reopen SF10 parquet for TLS upload");
+  long tc = s3_put(tls,
+                   "https",
+                   uri_path_for(kBucket, key),
+                   ft,
+                   static_cast<std::int64_t>(fs::file_size(parquet)),
+                   ca);
+  std::fclose(ft);
+  if (!(tc == 200 || tc == 204)) {
+    throw std::runtime_error("SF10 TLS upload failed (HTTP " + std::to_string(tc) + ")");
+  }
   std::cout << "[s3] uploaded SF10 lineitem fixture (" << fs::file_size(parquet) << " bytes) to "
-            << http.endpoint << "/" << kBucket << "/" << key << std::endl;
+            << http.endpoint << "/" << kBucket << "/" << key << " and " << tls.endpoint << "/"
+            << kBucket << "/" << key << std::endl;
 
   // The large tests read the same SF10 file locally to build a CPU oracle to
   // compare the GPU-over-S3 result against. Point them at the file we just
@@ -453,7 +469,7 @@ bool bring_up()
 
   upload_fixtures(http, "http", fixture_dir, std::nullopt);
   upload_fixtures(tls, "https", fixture_dir, ca);
-  maybe_upload_large_fixture(http, work);
+  maybe_upload_large_fixture(http, tls, ca, work);
 
   // Publish the env contract the [s3] tests consume (mirrors the old env.sh).
   setenv_kv("SIRIUS_TEST_S3_ENDPOINT", http.endpoint);


### PR DESCRIPTION
## Add S3 async-read perf instrumentation to the s3-bench JSON baseline

Makes S3 read performance observable across the whole path — surfaced through the reproducible `make s3-bench` JSON baseline — without adding cost to the production happy path. A `read_parquet('s3://')` run is now decomposed into stages
(open / footer / parse / scan) with per-chunk reactor metrics, so we can see *where* an S3 read spends its time.

### What's in
- **Stage timing** in the JSON baseline: `open_ms` / `footer_fetch_ms` /`metadata_parse_ms` / `scan_ms`, with `wall_clock_ms` covering all stages (previously only `read_parquet` was timed, so footer latency was invisible).
- **Per-chunk micro counters** in the async reactor — GET latency, queue-wait, observed-H2D (`memcpy issue → worker-observed completion`, *not* a pure copy time), TTFB — **gated behind a new `s3_perf_instrumentation` config flag
  (default off)**. When off, the device path takes no `steady_clock::now()` and no extra atomics; it's a bench/test knob, not a user-facing one.
- **Always-on retry / terminal-failure counters** + a `WARN` per retried request and an `ERROR` on terminal failure (the success path stays log-free; never logged from the CUDA callback).
- A single-argument `s3_ioctx(s3_ioctx_config)` constructor that threads the flag.
- `make s3-bench` now selects the unified `[s3][bench]~[aws]` tag and forces strict MinIO bring-up (`SIRIUS_TEST_S3_STRICT=1`) so a fixture failure fails loud instead of skipping to a false green.

### Perf-safety
- Production default carries only the pre-existing cheap counters; the ns-level micro is opt-in for the benchmark.
- `device_stream_sync_total == 0` is asserted (no per-chunk sync added); a gate-off assertion proves the ns counters stay 0 in the default config.


## 📊 Perf result — where the bottleneck is today

Run: TPC-H **SF10 `lineitem`** (2.07 GiB object, ~1.01 GiB read for the projected
columns), MinIO, async backend, `max_connections=32`, 1465 chunks.

**Stage breakdown (wall clock):**

| stage | ms | % |
|---|---|---|
| open (HEAD) | 1.3 | 0.1% |
| footer fetch | 3.7 | 0.3% |
| metadata parse | 7.1 | 0.6% |
| **scan (read + H2D)** | **1093.8** | **98.9%** |
| total | 1105.9 | |

**Per-chunk micro (inside scan):**

| metric | mean |
|---|---|
| queue-wait | **479.5 ms** |
| GET latency | 17.9 ms |
| observed H2D | 3.0 ms |
| TTFB | 6.6 ms |
| peak in-flight | 32 |
| stream syncs | 0 |

**Bottleneck: the scan is connection-bound — not compute, copy, or bind.**
- The scan is **99% of wall time**; open + footer + parse are ~12 ms combined.
- Inside the scan, **`queue_wait` (480 ms) ≫ `GET` (18 ms) ≫ `H2D` (3 ms)**: each
  chunk spends ~96% of its life *waiting for a free connection*, only ~4%
  transferring. cuDF hands the reactor ~1465 chunks against a 32-wide connection
  window → backpressure dominates.
- Effective wire throughput ≈ **970 MB/s** (1.06 GiB / 1.09 s); per-connection
  ≈ 57 MB/s × 32 ≈ 1.8 GB/s theoretical, so we are not saturating — MinIO/loopback
  + scheduling overhead.
- **H2D is not the limiter** (GPU-side ~6× faster than the network), and **footer is
  negligible on MinIO**.

**Levers (future work, not this PR):** higher effective concurrency / HTTP-2
multiplexing / larger chunks to amortize per-GET overhead. H2D and bind are *not* the levers for this workload.

**Caveat:** this is loopback MinIO, so `footer_fetch_ms` is tiny (no TLS handshake).
On real S3 the footer cost grows (HEAD + 2 sync GETs, each a fresh TLS connection) and becomes a real bottleneck for the *multi-file / bind-heavy* workload (date lakes), which this single-file benchmark does not stress. The instrumentation is in
place to measure that once LIST/glob lands.

