### PR TITLE
feat(expression): Add string concat support

### DIFF
--- a/src/expression/function_id.cpp
+++ b/src/expression/function_id.cpp
@@ -28,10 +28,10 @@ namespace sirius {
 namespace {
 
 // Forward table: DuckDB function name -> Sirius function id.
-// `substring` and `substr` are DuckDB-side aliases for the same function id,
-// so this table has one extra entry beyond the enum cardinality.
+// `substring`/`substr` and `concat`/`||` are DuckDB-side aliases for the same
+// function ids, so this table has two extra entries beyond the enum cardinality.
 // Linear scan; called once per BoundFunctionExpression at executor entry.
-constexpr std::array<std::pair<std::string_view, function_id>, 28> kForwardTable = {{
+constexpr std::array<std::pair<std::string_view, function_id>, 30> kForwardTable = {{
   {"+", function_id::add},
   {"-", function_id::sub},
   {"*", function_id::mul},
@@ -48,6 +48,8 @@ constexpr std::array<std::pair<std::string_view, function_id>, 28> kForwardTable
   {"strlen", function_id::strlen},
   {"length", function_id::length},
   {"regexp_replace", function_id::regexp_replace},
+  {"concat", function_id::concat},  // canonical name (concat() function call)
+  {"||", function_id::concat},      // alias (DuckDB's || operator → ConcatOperatorFun)
   {"year", function_id::year},
   {"month", function_id::month},
   {"day", function_id::day},
@@ -64,21 +66,22 @@ constexpr std::array<std::pair<std::string_view, function_id>, 28> kForwardTable
 
 // Reverse table: Sirius function id -> canonical DuckDB function name.
 // Indexed directly by enum value; never searched.
-constexpr std::array<std::string_view, 27> kReverseTable = {
-  "+",           "-",           "*",           "/",          "//",
-  "%",           "substring",   "~~",          "!~~",        "contains",
-  "prefix",      "suffix",      "strlen",      "length",     "regexp_replace",
-  "year",        "month",       "day",         "hour",       "minute",
-  "second",      "millisecond", "microsecond", "date_trunc", "row",
-  "struct_pack", "error",
+constexpr std::array<std::string_view, 28> kReverseTable = {
+  "+",      "-",           "*",           "/",           "//",
+  "%",      "substring",   "~~",          "!~~",         "contains",
+  "prefix", "suffix",      "strlen",      "length",      "regexp_replace",
+  "concat", "year",        "month",       "day",         "hour",
+  "minute", "second",      "millisecond", "microsecond", "date_trunc",
+  "row",    "struct_pack", "error",
 };
 
-static_assert(static_cast<std::size_t>(function_id::error) + 1 == 27,
-              "function_id::error must be the last entry; cardinality locked at 27.");
-static_assert(kReverseTable.size() == 27,
+static_assert(static_cast<std::size_t>(function_id::error) + 1 == 28,
+              "function_id::error must be the last entry; cardinality locked at 28.");
+static_assert(kReverseTable.size() == 28,
               "kReverseTable must have one slot per function_id value.");
-static_assert(kForwardTable.size() == 28,
-              "kForwardTable has one extra entry for the substring/substr alias.");
+static_assert(
+  kForwardTable.size() == 30,
+  "kForwardTable has two extra entries for the substring/substr and concat/|| aliases.");
 
 // Walks both tables to ensure every enum value has exactly one canonical
 // forward entry whose name matches the reverse table at the same index.

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -312,6 +312,17 @@ std::unique_ptr<cudf::table> gpu_expression_executor::execute(cudf::table_view i
   // The per-result post-processing recovers expression_class + return_type by
   // round-tripping through sirius::ast::to_duckdb.
   for (auto const* ast_expr : _ast_expressions) {
+    if (!ast_expr) {
+      // This is a Sirius bug, not a user error: a null slot means from_duckdb
+      // declined an expression as unsupported, but the planner still routed it
+      // to the GPU executor.  This hard-fails the query instead of falling back to CPU.
+      // TODO fix to ensure the planner never builds a GPU projection containing unsupported
+      // expressions.
+      throw duckdb::InternalException(
+        "[gpu_expression_executor] null expression in select list — "
+        "from_duckdb returned nullptr for an unsupported expression; "
+        "cannot execute on GPU");
+    }
     auto result    = execute(*ast_expr, execution_mode::MATERIALIZE);
     auto duck_expr = sirius::ast::to_duckdb(*ast_expr);
     post_process(*duck_expr, std::move(result));

--- a/src/expression_executor/specializations/gpu_execute_function.cpp
+++ b/src/expression_executor/specializations/gpu_execute_function.cpp
@@ -34,6 +34,7 @@
 #include <cudf/datetime.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/attributes.hpp>
+#include <cudf/strings/combine.hpp>
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/regex/regex_program.hpp>
@@ -296,6 +297,45 @@ execute_result gpu_expression_executor::execute(sirius::ast::function_call const
 
     auto result_column = cudf::datetime::floor_datetimes(
       input.get_column_view(), freq_string_switch(freq_str), _stream, _mr);
+    return execute_result(std::move(result_column));
+  }
+
+  //----------String Concatenation----------//
+  if (resolved_id == function_id::concat) {
+    // Evaluate every argument to a materialized column or scalar.
+    std::vector<execute_result> arg_results;
+    arg_results.reserve(args.size());
+    for (auto const& arg : args) {
+      arg_results.push_back(execute(*arg, execution_mode::MATERIALIZE));
+    }
+
+    // cudf::strings::concatenate takes a table_view — scalars must be expanded
+    // to full-length columns first.
+    auto const num_rows = _input_table.num_rows();
+    std::vector<std::unique_ptr<cudf::column>> scalar_cols;
+    std::vector<cudf::column_view> col_views;
+    col_views.reserve(arg_results.size());
+    for (auto const& res : arg_results) {
+      if (res.is_scalar()) {
+        scalar_cols.push_back(
+          cudf::make_column_from_scalar(res.get_scalar(), num_rows, _stream, _mr));
+        col_views.push_back(scalar_cols.back()->view());
+      } else {
+        col_views.push_back(res.get_column_view());
+      }
+    }
+
+    // SQL concat: any NULL input produces NULL output.  cuDF achieves this with
+    // an invalid (null) narep scalar.
+    cudf::table_view concat_table(col_views);
+    auto result_column = cudf::strings::concatenate(
+      concat_table,
+      cudf::string_scalar("", true, _stream, _mr),   // empty separator between parts
+      cudf::string_scalar("", false, _stream, _mr),  // null narep → null propagation
+      cudf::strings::separator_on_nulls::YES,        // no-op: invalid narep short-circuits before
+                                                     // separator logic runs
+      _stream,
+      _mr);
     return execute_result(std::move(result_column));
   }
 

--- a/src/include/expression/function_id.hpp
+++ b/src/include/expression/function_id.hpp
@@ -31,7 +31,7 @@ namespace sirius {
  * test_function_id.cpp). The order is grouped by category for human
  * readability; integer values are part of the public ABI — new entries go
  * at the end of their category, never in the middle. Cardinality is
- * exactly 27 (D-01).
+ * exactly 28 (D-01).
  */
 enum class function_id : uint16_t {
   // Arithmetic — 6 entries (also the contents of supported_ast_functions)
@@ -42,7 +42,7 @@ enum class function_id : uint16_t {
   int_div,
   mod,
 
-  // String — 9 entries
+  // String — 10 entries
   substring,
   like,
   not_like,
@@ -52,6 +52,7 @@ enum class function_id : uint16_t {
   strlen,
   length,
   regexp_replace,
+  concat,
 
   // Temporal — 9 entries
   year,

--- a/test/cpp/expression/test_function_id.cpp
+++ b/test/cpp/expression/test_function_id.cpp
@@ -41,8 +41,8 @@ using sirius::to_duckdb_function_name;
 static_assert(std::is_enum_v<function_id>, "sirius::function_id must be an enum class.");
 static_assert(sizeof(function_id) == 2,
               "sirius::function_id is uint16_t-backed (D-01 — locked ABI).");
-static_assert(static_cast<uint16_t>(function_id::error) + 1 == 27,
-              "sirius::function_id has exactly 27 entries (D-01 — locked ABI).");
+static_assert(static_cast<uint16_t>(function_id::error) + 1 == 28,
+              "sirius::function_id has exactly 28 entries (D-01 — locked ABI).");
 
 // ============================================================================
 // Round-trip every function_id entry through the name mappers
@@ -181,6 +181,26 @@ TEST_CASE("ast_function_id - regexp_replace round-trips through name mappers", "
   auto const id = from_duckdb_function_name(name);
   REQUIRE(id.has_value());
   REQUIRE(*id == function_id::regexp_replace);
+}
+
+TEST_CASE("ast_function_id - concat round-trips through name mappers", "[ast_function_id]")
+{
+  auto const name = to_duckdb_function_name(function_id::concat);
+  REQUIRE(name == "concat");
+  auto const id = from_duckdb_function_name(name);
+  REQUIRE(id.has_value());
+  REQUIRE(*id == function_id::concat);
+}
+
+TEST_CASE("ast_function_id - concat and || both resolve to function_id::concat",
+          "[ast_function_id]")
+{
+  auto const id_fn = from_duckdb_function_name("concat");
+  auto const id_op = from_duckdb_function_name("||");
+  REQUIRE(id_fn.has_value());
+  REQUIRE(id_op.has_value());
+  REQUIRE(*id_fn == function_id::concat);
+  REQUIRE(*id_op == function_id::concat);
 }
 
 TEST_CASE("ast_function_id - year round-trips through name mappers", "[ast_function_id]")

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -2999,6 +2999,68 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
   compare_gpu_vs_cpu("select n_nationkey, n_name from nation order by n_nationkey;");
 }
 
+//===----------------------------------------------------------------------===//
+// String concat tests
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat || operator parquet",
+                 "[integration][gpu_execution][parquet][string_concat]")
+{
+  compare_gpu_vs_cpu(
+    "SELECT l_orderkey, l_returnflag || '-' || l_linestatus FROM lineitem ORDER BY l_orderkey "
+    "LIMIT 100;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat() function parquet",
+                 "[integration][gpu_execution][parquet][string_concat]")
+{
+  compare_gpu_vs_cpu(
+    "SELECT l_orderkey, concat(l_returnflag, l_linestatus) FROM lineitem ORDER BY l_orderkey LIMIT "
+    "100;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat column with longer varchar parquet",
+                 "[integration][gpu_execution][parquet][string_concat]")
+{
+  compare_gpu_vs_cpu(
+    "SELECT p_partkey, p_brand || ': ' || p_type FROM part ORDER BY p_partkey LIMIT 100;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat in WHERE clause parquet",
+                 "[integration][gpu_execution][parquet][string_concat]")
+{
+  compare_gpu_vs_cpu(
+    "SELECT l_orderkey FROM lineitem WHERE l_returnflag || l_linestatus = 'NF' ORDER BY l_orderkey "
+    "LIMIT 100;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat with nested expression parquet",
+                 "[integration][gpu_execution][parquet][string_concat]")
+{
+  // ORDER BY l_orderkey, l_linenumber for a deterministic primary-key sort —
+  // l_orderkey alone is non-unique in lineitem so LIMIT would pick different rows on GPU vs CPU.
+  compare_gpu_vs_cpu(
+    "SELECT l_orderkey, substring(l_comment, 1, 5) || '...' FROM lineitem "
+    "ORDER BY l_orderkey, l_linenumber LIMIT 100;");
+}
+
+TEST_CASE_METHOD(GPUExecutionParquetFixture,
+                 "gpu_execution - string concat NULL propagation parquet",
+                 "[integration][gpu_execution][parquet][string_concat][nulls]")
+{
+  // TPC-H has no nullable VARCHAR columns; introduce nulls via CASE so that
+  // concat's null-propagation semantics (any NULL input → NULL output) are exercised.
+  compare_gpu_vs_cpu(
+    "SELECT l_orderkey, "
+    "  CASE WHEN l_orderkey % 7 = 0 THEN NULL ELSE l_returnflag END || '-' || l_linestatus "
+    "FROM lineitem ORDER BY l_orderkey, l_linenumber LIMIT 100;");
+}
+
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - cast integer to decimal preserves scale",
                  "[integration][gpu_execution][cast][decimal]")


### PR DESCRIPTION
### Summary

- String concatenation (`col || 'suffix'`, `concat(a, b, ...)`) previously caused a SIGSEGV — `from_duckdb` returned `nullptr` for unrecognised concat expressions, and the GPU executor dereferenced that null pointer. Queries crashed instead of falling back to CPU.
- Adds `function_id::concat` to the closed enum and registers both `"concat"` and `"||"` in the forward lookup table (DuckDB lowers the `||` operator to `ConcatOperatorFun` with name `"||"`).
- Implements the GPU dispatch arm in `gpu_execute_function.cpp` using `cudf::strings::concatenate` with an empty separator and a null narep scalar, which gives standard SQL null-propagation semantics (any NULL input → NULL output).
- Scalar arguments (e.g. the `' suffix'` literal in `col || ' suffix'`) are broadcast to full-length columns via `cudf::make_column_from_scalar` before being passed to `cudf::strings::concatenate`, which only accepts a `table_view`.
- Adds a null guard in the GPU executor loop that throws `InternalException` instead of segfaulting if any future unsupported expression slips through the planner as a null slot.

### Tests

- `test_function_id.cpp`: round-trip tests for `function_id::concat` and the `||` alias.
- `test_gpu_execution_tpch.cpp`: 6 integration tests using TPC-H parquet data covering:
  - `||` operator on short VARCHAR columns (`l_returnflag || '-' || l_linestatus`)
  - `concat()` function
  - Longer VARCHAR columns (`p_brand || ': ' || p_type`)
  - `||` in a WHERE clause predicate
  - `||` with a nested expression argument (`substring(...) || '...'`)
  - NULL propagation via CASE expression to introduce nulls into a non-nullable TPC-H column

Closes https://github.com/sirius-db/sirius/issues/984#issue-4714585127