### PR TITLE
Use tightened `data_batch`

### DIFF
--- a/docs/super-sirius/data-management.md
+++ b/docs/super-sirius/data-management.md
@@ -14,8 +14,8 @@ A data batch flows through the system in these stages:
                    converting to GPU memory space if needed (lock_or_prepare_batch)
 5. Execution:      GPU task reads data through read_only_data_batch accessors
 6. Output:         operators produce new idle batches, pushed to downstream repositories
-7. Downgrade:      if GPU memory pressure, downgrade executor upgrades to mutable,
-                   converts representation to HOST, releases back to idle
+7. Downgrade:      if GPU memory pressure, downgrade executor acquires a mutable
+                   accessor, converts representation to HOST, releases back to idle
 8. Cleanup:        batch destroyed when shared_ptr ref count reaches zero
 ```
 
@@ -27,7 +27,6 @@ accessible through RAII accessor objects — the idle `shared_ptr<data_batch>` g
 ```
 idle ←→ read_only      (shared lock; multiple concurrent readers)
 idle ←→ mutable_locked (exclusive lock; one writer, no readers)
-read_only ←→ mutable_locked (upgrade/downgrade)
 ```
 
 - **`idle`**: No active locks. Available for locking, cloning, or tier movement.
@@ -35,12 +34,16 @@ read_only ←→ mutable_locked (upgrade/downgrade)
 - **`mutable_locked`**: One `mutable_data_batch` exclusive lock active. Data can be read and mutated.
 
 Key methods on `data_batch`:
-- `batch->to_read_only()` — blocking shared lock → `read_only_data_batch`
-- `batch->to_mutable()` — blocking exclusive lock → `mutable_data_batch`
-- `batch->try_to_read_only()` / `try_to_mutable()` — non-blocking variants returning `std::optional`
-- `data_batch::to_idle(std::move(accessor))` — release lock, return `shared_ptr<data_batch>`
-- `data_batch::readonly_to_mutable(std::move(ro))` — upgrade shared → exclusive
-- `data_batch::mutable_to_readonly(std::move(mut))` — downgrade exclusive → shared
+- `data_batch::make(id, std::unique_ptr<idata_representation>)` - create an idle batch
+- `batch->get_read_only()` - blocking shared lock -> `read_only_data_batch`
+- `batch->get_mutable()` - blocking exclusive lock -> `mutable_data_batch`
+- `batch->try_get_read_only()` / `try_get_mutable()` - non-blocking variants returning `std::optional`
+- `read_only_data_batch::to_idle(std::move(ro))` - release a shared lock, return `shared_ptr<data_batch>`
+- `mutable_data_batch::to_idle(std::move(mut))` - release an exclusive lock, return `shared_ptr<data_batch>`
+
+`read_only_data_batch` and `mutable_data_batch` expose the locked batch core through
+`operator->`. There are no direct read-only-to-mutable or mutable-to-read-only transition
+helpers; release the current accessor, then acquire the next lock mode if needed.
 
 ## Data Repositories
 
@@ -111,14 +114,14 @@ Minimal empty base class. Provides a generic extension point for any type of ope
 
 Extends `operator_data` with batch-based data flow. Holds two optional internal stores that are
 lazily populated from each other on demand:
-- `_data_batches` — `std::vector<shared_ptr<data_batch>>` (idle pointers)
-- `_read_only_data_batches` — `std::vector<read_only_data_batch>` (shared-locked accessors)
+- `_data_batches` — `std::vector<shared_ptr<data_batch>>` (canonical idle batch owners)
+- `_read_only_data_batches` — `std::vector<read_only_data_batch>` (temporary shared-lock cache)
 
 Key methods:
-- `get_data_batches()` — returns idle batch pointers; if only `_read_only_data_batches` exist, calls `data_batch::to_idle()` on copies to populate `_data_batches`.
-- `get_read_only_batches(bool leave_locked)` — acquires `to_read_only()` on each idle batch; if `leave_locked=true`, caches result in `_read_only_data_batches`.
+- `get_data_batches()` — returns canonical idle batch pointers from `_data_batches`; throws if no canonical batch owners exist.
+- `get_read_only_batches(bool leave_locked)` — acquires `get_read_only()` on each idle batch; if `leave_locked=true`, caches result in `_read_only_data_batches`; if a cache already exists, returns cloned read-only locks.
 - `prepare_for_processing(memory_space*, stream)` — **void**, throws on failure. Calls `lock_or_prepare_batch()` for each batch (converts to the target memory space if needed, then acquires a shared lock). Stores resulting `read_only_data_batch` handles in `_read_only_data_batches`. Called by the GPU pipeline executor before `execute()`.
-- `remove_read_only_lock()` — releases `_read_only_data_batches` while ensuring `_data_batches` is populated first (so the data stays alive).
+- `remove_read_only_lock()` — releases `_read_only_data_batches`; `_data_batches` keeps the batches alive.
 - Created by `get_next_task_input_data()` from port pops.
 - Passed through the operator chain during `execute()`.
 

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -291,10 +291,10 @@ void task_creator::manager_loop()
               std::unordered_map<int, size_t> host_bytes;
               for (const auto& batch : pipelineable_input->get_data_batches()) {
                 if (!batch) { continue; }
-                auto ro     = batch->to_read_only();
-                auto* space = ro.get_memory_space();
-                if (!space || !ro.get_data()) { continue; }
-                auto size = ro.get_data()->get_size_in_bytes();
+                auto ro     = batch->get_read_only();
+                auto* space = ro->get_memory_space();
+                if (!space || !ro->get_data()) { continue; }
+                auto size = ro->get_data()->get_size_in_bytes();
                 if (space->get_tier() == cucascade::memory::Tier::GPU) {
                   gpu_bytes[space->get_device_id()] += size;
                 } else if (space->get_tier() == cucascade::memory::Tier::HOST) {
@@ -354,8 +354,8 @@ void task_creator::manager_loop()
               if (auto* cached = dynamic_cast<op::scan::scan_operator_with_pinned_table_input*>(
                     local_state->_input_data.get())) {
                 if (cached->batch) {
-                  auto ro     = cached->batch->to_read_only();
-                  auto* space = ro.get_memory_space();
+                  auto ro     = cached->batch->get_read_only();
+                  auto* space = ro->get_memory_space();
                   if (space) {
                     if (space->get_tier() == cucascade::memory::Tier::GPU) {
                       preferred_device_id = space->get_device_id();

--- a/src/debug_utils.cpp
+++ b/src/debug_utils.cpp
@@ -72,8 +72,8 @@ namespace {
 
 bool is_gpu_tier(cucascade::data_batch& batch, const char* func_name)
 {
-  auto ro    = batch.to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch.get_read_only();
+  auto* data = ro->get_data();
   if (data == nullptr) {
     SIRIUS_LOG_WARN("[SIRIUS_DIAG] {}: batch has no data", func_name);
     return false;

--- a/src/include/data/convertible_data.hpp
+++ b/src/include/data/convertible_data.hpp
@@ -45,7 +45,7 @@ namespace sirius {
  * implementations wrap either a data_batch or a gpu_pipeline_task.
  *
  * Implementations are responsible for:
- * - Acquiring mutable_data_batch via to_mutable() (blocking) or try_to_mutable() (non-blocking)
+ * - Acquiring mutable_data_batch via get_mutable() (blocking) or try_get_mutable() (non-blocking)
  * - Performing the actual data conversion via convert_to on the mutable accessor
  * - RAII automatic state restoration on all exit paths (success, failure, exception)
  */
@@ -64,8 +64,8 @@ class convertible_data {
    * @param target_spaces  Candidate memory spaces to convert into (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no conversion occurred.

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -44,8 +44,8 @@ namespace sirius {
  * @brief Concrete convertible_data wrapping a cucascade::data_batch.
  *
  * Implements the RAII mutable lock / convert / auto-release pattern for a single
- * data_batch. Acquires mutable_data_batch via to_mutable() (blocking) or
- * try_to_mutable() (non-blocking), calls convert_to on the accessor, and relies on
+ * data_batch. Acquires mutable_data_batch via get_mutable() (blocking) or
+ * try_get_mutable() (non-blocking), calls convert_to on the accessor, and relies on
  * the mutable_data_batch destructor to restore the batch to idle on all exit paths
  * (success, failure, exception). No manual state save/restore is needed.
  */
@@ -72,8 +72,8 @@ class convertible_data_batch : public convertible_data {
    * @param target_spaces  Candidate memory spaces to convert into (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no conversion occurred.
@@ -86,21 +86,21 @@ class convertible_data_batch : public convertible_data {
   {
     std::optional<cucascade::mutable_data_batch> mut_opt;
     if (blocking) {
-      mut_opt.emplace(_batch->to_mutable());
+      mut_opt.emplace(_batch->get_mutable());
     } else {
-      mut_opt = _batch->try_to_mutable();
+      mut_opt = _batch->try_get_mutable();
       if (!mut_opt) { return std::nullopt; }
     }
     auto& mut = *mut_opt;
 
     // Check if the batch is already in the target space
-    auto cur_space = mut.get_memory_space();
+    auto cur_space = mut->get_memory_space();
     for (std::size_t idx = 0; idx < target_spaces.size(); ++idx) {
       const auto* space = target_spaces[idx];
       if (cur_space == space) { return std::nullopt; }
     }
 
-    auto data_size = mut.get_data()->get_size_in_bytes();
+    auto data_size = mut->get_data()->get_size_in_bytes();
 
     for (std::size_t idx = 0; idx < target_spaces.size(); ++idx) {
       const auto* space = target_spaces[idx];
@@ -118,22 +118,22 @@ class convertible_data_batch : public convertible_data {
       // synchronizes `stream` after the D2H copy and before destroying the source
       // representation, so the free is correctly ordered. No-op for non-GPU-table sources.
       if (cur_space != nullptr && cur_space->get_tier() == cucascade::memory::Tier::GPU) {
-        mut.rebind_stream(stream);
+        mut->rebind_stream(stream);
       }
 
       auto& converter_registry = sirius::converter_registry::get();
 
       switch (space->get_tier()) {
         case cucascade::memory::Tier::GPU:
-          mut.convert_to<cucascade::gpu_table_representation>(
+          mut->convert_to<cucascade::gpu_table_representation>(
             converter_registry, mem_space, stream);
           break;
         case cucascade::memory::Tier::HOST:
-          mut.convert_to<cucascade::host_data_representation>(
+          mut->convert_to<cucascade::host_data_representation>(
             converter_registry, mem_space, stream);
           break;
         case cucascade::memory::Tier::DISK:
-          mut.convert_to<cucascade::disk_data_representation>(
+          mut->convert_to<cucascade::disk_data_representation>(
             converter_registry, mem_space, stream);
           break;
         default: continue;
@@ -160,8 +160,8 @@ class convertible_data_batch : public convertible_data {
    */
   std::size_t bytes_in_space(cucascade::memory::memory_space* space) const override
   {
-    auto ro = _batch->to_read_only();
-    if (ro.get_memory_space() == space) { return ro.get_data()->get_size_in_bytes(); }
+    auto ro = _batch->get_read_only();
+    if (ro->get_memory_space() == space) { return ro->get_data()->get_size_in_bytes(); }
     return 0;
   }
 
@@ -266,7 +266,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
    * @brief Get the total byte size of all batches in the given memory space.
    *
    * Iterates all partitions front-to-back, summing bytes for batches residing
-   * in the specified space. Accesses batch data via to_read_only() as required
+   * in the specified space. Accesses batch data via get_read_only() as required
    * by the new cucascade API.
    *
    * @param space The memory space to query.
@@ -282,8 +282,8 @@ class convertible_data_batch_provider : public convertible_data_provider {
       for (auto batch_id : batch_ids) {
         auto batch = _repo->get_data_batch_by_id(batch_id, p);
         if (!batch) { continue; }
-        auto ro = batch->to_read_only();
-        if (ro.get_memory_space() == space) { total += ro.get_data()->get_size_in_bytes(); }
+        auto ro = batch->get_read_only();
+        if (ro->get_memory_space() == space) { total += ro->get_data()->get_size_in_bytes(); }
       }
     }
 
@@ -295,7 +295,7 @@ class convertible_data_batch_provider : public convertible_data_provider {
    * @brief Try to get a matching batch by id, checking idle state and memory space.
    *
    * Only considers batches in batch_state::idle. Accesses the memory space via
-   * to_read_only() as required by the new cucascade API (get_memory_space() is
+   * get_read_only() as required by the new cucascade API (get_memory_space() is
    * private on idle data_batch).
    *
    * @param batch_id       The batch ID to retrieve.
@@ -312,9 +312,9 @@ class convertible_data_batch_provider : public convertible_data_provider {
 
     if (batch->get_state() != cucascade::batch_state::idle) { return nullptr; }
 
-    auto ro = batch->try_to_read_only();
+    auto ro = batch->try_get_read_only();
     if (!ro) { return nullptr; }
-    if (ro->get_memory_space() == space) {
+    if ((*ro)->get_memory_space() == space) {
       return std::make_unique<convertible_data_batch>(std::move(batch));
     }
 

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -52,7 +52,7 @@ namespace sirius {
  * all code paths.
  *
  * The convert() method uses the RAII mutable lock pattern: for each data_batch in the
- * task's input data, it acquires a mutable_data_batch via to_mutable() or try_to_mutable(),
+ * task's input data, it acquires a mutable_data_batch via get_mutable() or try_get_mutable(),
  * attempts conversion to a target memory space, and relies on the mutable_data_batch RAII
  * destructor to restore idle state on all exit paths (success, failure, exception).
  */
@@ -98,8 +98,8 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * @param target_spaces  Candidate destination memory spaces (tried in order).
    * @param stream         CUDA stream for asynchronous memory operations.
    * @param res_mgr        Reservation manager for acquiring memory in the target space.
-   * @param blocking       When true, uses to_mutable() (blocks until exclusive lock acquired).
-   *                       When false, uses try_to_mutable() (returns nullopt immediately if
+   * @param blocking       When true, uses get_mutable() (blocks until exclusive lock acquired).
+   *                       When false, uses try_get_mutable() (returns nullopt immediately if
    *                       the lock is unavailable).
    * @return A vector of bytes converted per target space index on success, or nullopt if
    *         no batches were converted.
@@ -122,8 +122,8 @@ class convertible_gpu_pipeline_task : public convertible_data {
 
       // Quick check: skip batches already at a target space (avoid unnecessary locking)
       {
-        auto ro           = batch->to_read_only();
-        auto* batch_space = ro.get_memory_space();
+        auto ro           = batch->get_read_only();
+        auto* batch_space = ro->get_memory_space();
         bool at_target    = false;
         for (const auto* ts : target_spaces) {
           if (batch_space == ts) {
@@ -134,7 +134,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
         if (at_target) { continue; }
       }
 
-      // Delegate to convertible_data_batch which handles to_mutable() internally
+      // Delegate to convertible_data_batch which handles get_mutable() internally
       sirius::convertible_data_batch batch_converter(batch);
       auto result = batch_converter.convert(target_spaces, stream, res_mgr, blocking);
       if (result) {
@@ -153,7 +153,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
    * @brief Get the size in bytes of this task's data in the specified memory space.
    *
    * Sums bytes across all data_batches in the task's input that reside in the
-   * given memory space. Accesses memory space via to_read_only() as required by
+   * given memory space. Accesses memory space via get_read_only() as required by
    * the new cucascade API.
    *
    * @param space The memory space to query.
@@ -166,7 +166,7 @@ class convertible_gpu_pipeline_task : public convertible_data {
 
     std::size_t total = 0;
     for (const auto& ro : operator_data->get_read_only_batches(false)) {
-      if (ro.get_memory_space() == space) { total += ro.get_data()->get_size_in_bytes(); }
+      if (ro->get_memory_space() == space) { total += ro->get_data()->get_size_in_bytes(); }
     }
     return total;
   }
@@ -287,7 +287,7 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
    *        batch_state::idle?
    *
    * Lightweight -- only performs dynamic_casts and state checks. Accesses memory
-   * space via to_read_only().
+   * space via get_read_only().
    *
    * @param task  The task to inspect.
    * @param space The memory space to match.
@@ -302,9 +302,9 @@ class convertible_gpu_pipeline_task_provider : public convertible_data_provider 
     for (const auto& batch : operator_data->get_data_batches()) {
       if (!batch) { continue; }
       if (batch->get_state() != cucascade::batch_state::idle) { continue; }
-      auto ro = batch->try_to_read_only();
+      auto ro = batch->try_get_read_only();
       if (!ro) { continue; }
-      if (ro->get_memory_space() == space) { return true; }
+      if ((*ro)->get_memory_space() == space) { return true; }
     }
 
     return false;

--- a/src/include/data/data_batch_utils.hpp
+++ b/src/include/data/data_batch_utils.hpp
@@ -48,8 +48,8 @@ inline uint64_t get_next_batch_id() { return g_next_batch_id++; }
  * @brief Get a cudf::table_view from a read-only data_batch accessor.
  *
  * Assumes the underlying data_batch contains a gpu_table_representation.
- * The caller MUST already hold the read_only_data_batch (shared lock) — this
- * helper deliberately does NOT internally call batch.to_read_only() because
+ * The caller MUST already hold the read_only_data_batch (shared lock) -- this
+ * helper deliberately does NOT internally call batch.get_read_only() because
  * doing so would let a misuse pattern hide a P1 self-deadlock (acquiring a
  * read lock on a batch that the caller is about to upgrade to mutable).
  *
@@ -58,7 +58,7 @@ inline uint64_t get_next_batch_id() { return g_next_batch_id++; }
  */
 inline cudf::table_view get_cudf_table_view(const cucascade::read_only_data_batch& batch)
 {
-  auto* data = batch.get_data();
+  auto* data = batch->get_data();
   if (data == nullptr) { throw std::runtime_error("data_batch has no data representation"); }
   return data->cast<cucascade::gpu_table_representation>().get_table_view();
 }
@@ -78,11 +78,11 @@ inline cudf::table_view get_cudf_table_view(const cucascade::read_only_data_batc
  * @param batch The idle data batch to extract the table view from.
  * @return cudf::table_view The underlying cudf table view.
  */
-// NOLINTNEXTLINE(readability-non-const-parameter) -- to_read_only() is non-const
+// NOLINTNEXTLINE(readability-non-const-parameter) -- get_read_only() is non-const
 inline cudf::table_view get_cudf_table_view(cucascade::data_batch& batch)
 {
-  auto ro    = batch.to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch.get_read_only();
+  auto* data = ro->get_data();
   if (data == nullptr) { throw std::runtime_error("data_batch has no data representation"); }
   return data->cast<cucascade::gpu_table_representation>().get_table_view();
 }
@@ -111,7 +111,7 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
 {
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), memory_space, writer_stream);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(gpu_repr));
 }
 
 /**
@@ -128,7 +128,7 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
 {
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
     std::move(table), memory_space, writer_stream);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(gpu_repr));
 }
 
 }  // namespace sirius

--- a/src/include/legacy/print.hpp
+++ b/src/include/legacy/print.hpp
@@ -45,7 +45,7 @@ void print_table_contents(cudf::table_view const& table, cudf::size_type max_row
 /**
  * Print the contents of a cucascade::data_batch to stdout (printf).
  * Equivalent to printing the underlying cudf table view.
- * Note: takes non-const ref because to_read_only() acquires a shared lock (non-const).
+ * Note: takes non-const ref because get_read_only() acquires a shared lock.
  */
 // NOLINTNEXTLINE(readability-non-const-parameter)
 void print_data_batch_contents(cucascade::data_batch& batch, cudf::size_type max_rows = 20);

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -174,11 +174,9 @@ class operator_data {
 /**
  * @brief Operator data carrying data batches for pipeline execution.
  *
- * Unifies idle and read-only-locked batch access in a single container. Holds an
- * optional vector of idle data_batch shared_ptrs and/or an optional vector of
- * read_only_data_batch RAII accessors. Lazy conversion is performed on demand:
- *   - get_data_batches() populates _data_batches from _read_only_data_batches if needed
- *   - get_read_only_batches() populates _read_only_data_batches from _data_batches if needed
+ * Unifies idle and read-only-locked batch access in a single container. The
+ * idle data_batch shared_ptr vector is canonical ownership. The optional
+ * read_only_data_batch vector is only a temporary lock cache.
  *
  * prepare_for_processing() locks idle batches and stores the result in
  * _read_only_data_batches. remove_read_only_lock() releases all shared locks.
@@ -196,8 +194,13 @@ class pipelineable_operator_data : public operator_data {
   }
   explicit pipelineable_operator_data(
     std::vector<::cucascade::read_only_data_batch> read_only_data_batches)
-    : _read_only_data_batches(std::move(read_only_data_batches))
   {
+    std::vector<std::shared_ptr<::cucascade::data_batch>> batches;
+    batches.reserve(read_only_data_batches.size());
+    for (auto& ro : read_only_data_batches) {
+      batches.push_back(::cucascade::read_only_data_batch::to_idle(std::move(ro)));
+    }
+    _data_batches = std::move(batches);
   }
 
   [[nodiscard]] operator_data_type get_type() const override
@@ -244,7 +247,7 @@ class pipelineable_operator_data : public operator_data {
     std::size_t total = 0;
     auto ro_batches   = get_read_only_batches(false);
     for (auto const& ro : ro_batches) {
-      if (ro.get_data()) { total += ro.get_data()->get_uncompressed_data_size_in_bytes(); }
+      if (ro->get_data()) { total += ro->get_data()->get_uncompressed_data_size_in_bytes(); }
     }
     return total;
   }

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -56,56 +56,64 @@ inline std::optional<cucascade::read_only_data_batch> lock_or_prepare_batch(
   // Opportunistic stream rebind (best-effort, non-blocking): if the batch already resides in
   // the target GPU memory space, rebind its deallocation stream to this task's stream so that
   // when the task later frees the data the free lands on the active stream's free list rather
-  // than on the stream the data was produced on. We use try_to_mutable() so we never block --
+  // than on the stream the data was produced on. We use try_get_mutable() so we never block --
   // if another reader holds the batch (e.g. a probe task on another GPU sharing a build batch)
   // or it is otherwise busy, we simply skip the rebind; correctness is unaffected. Gating on a
   // space match guarantees the stream and the data live on the same device (important for
   // multi-GPU). The mismatch case below converts via `stream`, which already allocates the new
   // table on it, so no rebind is needed there.
-  if (auto mut = batch->try_to_mutable()) {
-    const auto* current_space = mut->get_memory_space();
+  if (auto mut = batch->try_get_mutable()) {
+    const auto* current_space = (*mut)->get_memory_space();
     const auto* rebind_target =
       requested_memory_space != nullptr ? requested_memory_space : current_space;
     if (current_space != nullptr && rebind_target != nullptr &&
         current_space->get_id() == rebind_target->get_id() &&
         rebind_target->get_tier() == cucascade::memory::Tier::GPU) {
-      mut->rebind_stream(stream);
+      (*mut)->rebind_stream(stream);
     }
   }
 
   // Acquire a read-only lock
-  auto read_accessor = batch->to_read_only();
+  auto read_accessor = batch->get_read_only();
 
   // Determine the target memory space
   const auto* target_space =
-    requested_memory_space != nullptr ? requested_memory_space : read_accessor.get_memory_space();
+    requested_memory_space != nullptr ? requested_memory_space : read_accessor->get_memory_space();
   if (target_space == nullptr) { return std::nullopt; }
 
   // Memory space matches — return the read-only accessor directly
-  if (read_accessor.get_memory_space() != nullptr &&
-      read_accessor.get_memory_space()->get_id() == target_space->get_id()) {
+  if (read_accessor->get_memory_space() != nullptr &&
+      read_accessor->get_memory_space()->get_id() == target_space->get_id()) {
     return std::move(read_accessor);
   }
 
-  // Memory space mismatch — go to mutable, convert in-place, go back to read-only
+  // Memory space mismatch: release the shared lock, take the exclusive lock,
+  // convert in-place, then return a fresh read-only accessor.
+  cucascade::read_only_data_batch::to_idle(std::move(read_accessor));
   auto& registry    = sirius::converter_registry::get();
-  auto mut_accessor = cucascade::data_batch::readonly_to_mutable(std::move(read_accessor));
+  auto mut_accessor = batch->get_mutable();
+
+  if (mut_accessor->get_memory_space() != nullptr &&
+      mut_accessor->get_memory_space()->get_id() == target_space->get_id()) {
+    cucascade::mutable_data_batch::to_idle(std::move(mut_accessor));
+    return batch->get_read_only();
+  }
 
   switch (target_space->get_tier()) {
     case cucascade::memory::Tier::GPU:
-      mut_accessor.convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
+      mut_accessor->convert_to<cucascade::gpu_table_representation>(registry, target_space, stream);
       break;
     case cucascade::memory::Tier::HOST:
-      mut_accessor.convert_to<cucascade::host_data_representation>(registry, target_space, stream);
+      mut_accessor->convert_to<cucascade::host_data_representation>(registry, target_space, stream);
       break;
     default:
       SIRIUS_LOG_ERROR("lock_or_prepare_batch: unsupported target tier for batch {}",
-                       mut_accessor.get_batch_id());
+                       mut_accessor->get_batch_id());
       return std::nullopt;
   }
 
-  // Downgrade the exclusive lock back to a shared read-only lock
-  return cucascade::data_batch::mutable_to_readonly(std::move(mut_accessor));
+  cucascade::mutable_data_batch::to_idle(std::move(mut_accessor));
+  return batch->get_read_only();
 }
 
 }  // namespace pipeline

--- a/src/include/pipeline/gpu_pipeline_task.hpp
+++ b/src/include/pipeline/gpu_pipeline_task.hpp
@@ -105,8 +105,8 @@ class gpu_pipeline_task_local_state : public sirius_pipeline_task_local_state {
       dynamic_cast<const op::pipelineable_operator_data*>(_input_data.get());
     if (pipelineable_input) {
       for (const auto& ro : pipelineable_input->get_read_only_batches(false)) {
-        if (ro.get_data() && ro.get_current_tier() != cucascade::memory::Tier::GPU) {
-          input_size += ro.get_data()->get_uncompressed_data_size_in_bytes();
+        if (ro->get_data() && ro->get_current_tier() != cucascade::memory::Tier::GPU) {
+          input_size += ro->get_data()->get_uncompressed_data_size_in_bytes();
         }
       }
     }

--- a/src/legacy/expression_executor/gpu_expression_executor.cpp
+++ b/src/legacy/expression_executor/gpu_expression_executor.cpp
@@ -257,8 +257,8 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
   output_columns.resize(expressions.size());
 
   // Retrieve the table_view from the data_batch
-  auto input_ro        = input_batch->to_read_only();
-  auto& input_data_rep = input_ro.get_data()->cast<cucascade::gpu_table_representation>();
+  auto input_ro        = input_batch->get_read_only();
+  auto& input_data_rep = input_ro->get_data()->cast<cucascade::gpu_table_representation>();
   input_table          = input_data_rep.get_table_view();
   input_count          = static_cast<cudf::size_type>(input_table.num_rows());
 
@@ -293,12 +293,12 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::execute(
   std::unique_ptr<cucascade::idata_representation> output_data_rep =
     std::make_unique<cucascade::gpu_table_representation>(
       std::make_unique<cudf::table>(std::move(output_columns), execution_stream, resource_ref),
-      *input_ro.get_memory_space(),
+      *input_ro->get_memory_space(),
       execution_stream);
 
   // Create the data batch and return
   auto const batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
+  return cucascade::data_batch::make(batch_id, std::move(output_data_rep));
 }
 
 void GpuExpressionExecutor::Select(GPUIntermediateRelation& input_relation,
@@ -346,8 +346,8 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
   output_columns.clear();
 
   // Retrieve the table_view from the data_batch via read-only accessor
-  auto input_ro        = input_batch->to_read_only();
-  auto& input_data_rep = input_ro.get_data()->cast<cucascade::gpu_table_representation>();
+  auto input_ro        = input_batch->get_read_only();
+  auto& input_data_rep = input_ro->get_data()->cast<cucascade::gpu_table_representation>();
   input_table          = input_data_rep.get_table_view();
   input_count          = static_cast<cudf::size_type>(input_table.num_rows());
 
@@ -361,11 +361,11 @@ std::shared_ptr<cucascade::data_batch> GpuExpressionExecutor::select(
     cudf::apply_boolean_mask(input_table, bitmap->view(), execution_stream, resource_ref);
   std::unique_ptr<cucascade::idata_representation> output_data_rep =
     std::make_unique<cucascade::gpu_table_representation>(
-      std::move(output_table), *input_ro.get_memory_space(), execution_stream);
+      std::move(output_table), *input_ro->get_memory_space(), execution_stream);
 
   // Create the data batch and return
   auto const batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data_rep));
+  return cucascade::data_batch::make(batch_id, std::move(output_data_rep));
 }
 
 std::unique_ptr<cudf::column> GpuExpressionExecutor::ExecuteExpression(idx_t expr_idx)

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -100,7 +100,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   // host allocation. allocate_multiple_blocks(0, ...) is not guaranteed to
   // return an allocation with a usable block, so skip it entirely.
   if (num_rows == 0 || num_cols == 0) {
-    return std::make_shared<cucascade::data_batch>(
+    return cucascade::data_batch::make(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
         host_table_allocation::create(
@@ -136,7 +136,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   }
 
   if (total_size == 0) {
-    return std::make_shared<cucascade::data_batch>(
+    return cucascade::data_batch::make(
       get_next_batch_id(),
       std::make_unique<host_data_representation>(
         host_table_allocation::create(
@@ -266,7 +266,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
   auto table_allocation =
     host_table_allocation::create(std::move(allocation), std::move(columns), offset);
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), &mem_space);
-  return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(table));
+  return cucascade::data_batch::make(get_next_batch_id(), std::move(table));
 }
 
 pipeline::reservation_size_info cpu_source_task::get_estimated_reservation_size_info() const
@@ -369,8 +369,8 @@ void cpu_source_task::publish_output(op::operator_data& output_data, rmm::cuda_s
   for (auto& batch : pipelineable_output.get_data_batches()) {
     if (!batch) { continue; }
     {
-      auto ro = batch->to_read_only();
-      if (!ro.get_data()) { continue; }
+      auto ro = batch->get_read_only();
+      if (!ro->get_data()) { continue; }
     }
     _data_repo->add_data_batch(batch);
   }

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -282,8 +282,8 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
         // clone() lives on the accessors (not on data_batch) — take a scoped
         // read-only accessor (concurrent shared locks are permitted) and
         // clone through it.
-        auto ro = batch->to_read_only();
-        cloned_batches.push_back(ro.clone(get_next_batch_id(), stream));
+        auto ro = batch->get_read_only();
+        cloned_batches.push_back(ro->clone(get_next_batch_id(), stream));
       }
     } else if (is_parquet_scan) {
       for (auto& batch : batches) {
@@ -292,16 +292,16 @@ std::unique_ptr<op::operator_data> duckdb_scan_executor::get_scan_output(
         // idata_representation owned by a brand-new data_batch — its lifetime
         // is independent of the source accessor, so dropping `ro` at
         // end-of-iteration is safe.
-        auto ro         = batch->to_read_only();
-        auto* idata_rep = ro.get_data();
+        auto ro         = batch->get_read_only();
+        auto* idata_rep = ro->get_data();
         if (auto* host_data = dynamic_cast<cached_host_data_representation*>(idata_rep);
             host_data) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
-            get_next_batch_id(), host_data->shallow_clone()));
+          cloned_batches.push_back(
+            cucascade::data_batch::make(get_next_batch_id(), host_data->shallow_clone()));
         } else if (auto* parquet_rep = dynamic_cast<cached_host_parquet_representation*>(idata_rep);
                    parquet_rep) {
-          cloned_batches.push_back(std::make_shared<cucascade::data_batch>(
-            get_next_batch_id(), parquet_rep->shallow_clone()));
+          cloned_batches.push_back(
+            cucascade::data_batch::make(get_next_batch_id(), parquet_rep->shallow_clone()));
         } else {
           throw std::runtime_error("Invalid data representation type");
         }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -464,7 +464,7 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), _host_space);
 
   // Create the data batch and return
-  return std::make_shared<data_batch>(get_next_batch_id(), std::move(table));
+  return data_batch::make(get_next_batch_id(), std::move(table));
 }
 
 //===----------------------------------------------------------------------===//
@@ -540,8 +540,8 @@ void duckdb_scan_task::execute(rmm::cuda_stream_view stream)
     std::size_t output_bytes       = 0;
     for (const auto& batch : pipelineable_output_data.get_data_batches()) {
       if (batch) {
-        auto ro = batch->to_read_only();
-        if (ro.get_data()) { output_bytes += ro.get_data()->get_size_in_bytes(); }
+        auto ro = batch->get_read_only();
+        if (ro->get_data()) { output_bytes += ro->get_data()->get_size_in_bytes(); }
       }
     }
     auto& g_state = _global_state->cast<duckdb_scan_task_global_state>();

--- a/src/op/scan/pinned_table_gpu_ingestible.cpp
+++ b/src/op/scan/pinned_table_gpu_ingestible.cpp
@@ -164,15 +164,13 @@ std::shared_ptr<::cucascade::data_batch> pinned_table_gpu_ingestible::produce_ba
           !_chunk_memory_spaces.empty() ? _chunk_memory_spaces.at(batch_idx) : _memory_space;
         auto gpu_repr = std::make_unique<::cucascade::gpu_table_representation>(
           view, std::move(chunk), alloc_size, *chunk_space, rmm::cuda_stream_view{});
-        return std::make_shared<::cucascade::data_batch>(::sirius::get_next_batch_id(),
-                                                         std::move(gpu_repr));
+        return ::cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
       } else if constexpr (std::is_same_v<T, host_chunk>) {
         // Emit a host-resident batch; the host->GPU upload is deferred to
         // scan_operator_with_pinned_table_input::prepare_for_processing,
         // which has the scheduler-provided target memory_space.
         auto sliced = chunk->slice(std::span<const std::size_t>(_column_indices));
-        return std::make_shared<::cucascade::data_batch>(::sirius::get_next_batch_id(),
-                                                         std::move(sliced));
+        return ::cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(sliced));
       }
     },
     _batches[batch_idx]);

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -51,21 +51,21 @@ void scan_operator_with_pinned_table_input::prepare_for_processing(
   if (batch && requested_memory_space) {
     bool needs_upload = false;
     {
-      auto ro      = batch->to_read_only();
-      needs_upload = ro.get_data() && ro.get_current_tier() != ::cucascade::memory::Tier::GPU;
+      auto ro      = batch->get_read_only();
+      needs_upload = ro->get_data() && ro->get_current_tier() != ::cucascade::memory::Tier::GPU;
     }
     if (needs_upload) {
       auto& registry = ::sirius::converter_registry::get();
-      auto mut       = batch->to_mutable();
-      mut.convert_to<::cucascade::gpu_table_representation>(
+      auto mut       = batch->get_mutable();
+      mut->convert_to<::cucascade::gpu_table_representation>(
         registry, requested_memory_space, stream);
     }
   }
   // Capture the actual memory_space the batch lives on (post any conversion)
   // so execute() can tag its output batch with the right placement.
   if (batch) {
-    auto ro          = batch->to_read_only();
-    gpu_memory_space = ro.get_memory_space();
+    auto ro          = batch->get_read_only();
+    gpu_memory_space = ro->get_memory_space();
   }
 }
 
@@ -75,8 +75,8 @@ std::size_t scan_operator_with_pinned_table_input::get_estimated_size_in_bytes()
   // Use the generic representation accessor so this works for both GPU-resident
   // batches and host_data_representation batches that prepare_for_processing
   // will upgrade to GPU.
-  auto ro          = batch->to_read_only();
-  auto const* data = ro.get_data();
+  auto ro          = batch->get_read_only();
+  auto const* data = ro->get_data();
   if (!data) { return 0; }
   return data->get_size_in_bytes();
 }
@@ -205,14 +205,14 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
       batches.push_back(pinned->batch);
       return std::make_unique<pipelineable_operator_data>(std::move(batches));
     }
-    auto ro_batch  = pinned->batch->to_read_only();
-    auto* batch_mr = ro_batch.get_memory_space();
+    auto ro_batch  = pinned->batch->get_read_only();
+    auto* batch_mr = ro_batch->get_memory_space();
     if (!batch_mr) {
       throw std::runtime_error(
         "[sirius_gpu_scan_operator::execute] pinned batch has no memory_space; "
         "prepare_for_processing must have produced a GPU-resident batch.");
     }
-    auto& gpu_rep     = ro_batch.get_data()->cast<::cucascade::gpu_table_representation>();
+    auto& gpu_rep     = ro_batch->get_data()->cast<::cucascade::gpu_table_representation>();
     auto owning_input = gpu_rep.release_table(stream);
 
     table = _ingestible->post_filter_and_project(

--- a/src/op/sirius_physical_concat.cpp
+++ b/src/op/sirius_physical_concat.cpp
@@ -101,8 +101,8 @@ std::optional<task_creation_hint> sirius_physical_concat::get_next_task_hint()
     size_t pulled_count     = 0;
     for (auto& batch_id : batch_ids) {
       auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
+      auto batch_ro   = batch_idle->get_read_only();
+      auto batch_size = batch_ro->get_data()->get_size_in_bytes();
       total_batch_size += batch_size;
       if (!_concat_all && total_batch_size > _concat_batch_bytes) {
         // This batch pushes us over the threshold — the loop would stop here.
@@ -142,8 +142,8 @@ std::unique_ptr<operator_data> sirius_physical_concat::get_next_task_input_data(
     size_t total_batch_size = 0;
     for (auto& batch_id : batch_ids) {
       auto batch_idle = port_ptr->repo->get_data_batch_by_id(batch_id, i);
-      auto batch_ro   = batch_idle->to_read_only();
-      auto batch_size = batch_ro.get_data()->get_size_in_bytes();
+      auto batch_ro   = batch_idle->get_read_only();
+      auto batch_size = batch_ro->get_data()->get_size_in_bytes();
       total_batch_size += batch_size;
       // Check if the batch size is already exceed the threshold
       if (!_concat_all && total_batch_size > _concat_batch_bytes) {
@@ -179,21 +179,20 @@ std::unique_ptr<operator_data> sirius_physical_concat::execute(const operator_da
     throw std::runtime_error(
       "sirius_physical_concat: input_data is not a partitioned_operator_data");
   }
-  const auto& input_batches = partitioned_input_data->get_read_only_batches();
-  auto partition_idx        = partitioned_input_data->get_partition_idx();
+  auto input_batches = partitioned_input_data->get_read_only_batches();
+  auto partition_idx = partitioned_input_data->get_partition_idx();
   if (input_batches.empty()) {
     return std::make_unique<partitioned_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{}, partition_idx);
   }
 
-  cucascade::memory::memory_space* space = input_batches[0].get_memory_space();
+  cucascade::memory::memory_space* space = input_batches[0]->get_memory_space();
   if (space == nullptr) { throw std::runtime_error("sirius_physical_concat: space is nullptr"); }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
   output_batches.reserve(1);
   if (input_batches.size() == 1) {
-    auto copy   = input_batches[0];
-    auto output = cucascade::data_batch::to_idle(std::move(copy));
+    auto output = cucascade::read_only_data_batch::to_idle(std::move(input_batches[0]));
     output_batches.push_back(std::move(output));
   } else {
     auto merged_batch = gpu_merge_impl::concat(input_batches, stream, *space);

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -54,9 +54,9 @@ std::unique_ptr<operator_data> sirius_physical_filter::execute(const operator_da
 
   for (auto const& batch : input_batches) {
     auto filtered_table = gpu_expression_executor.select(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
     output_batches.push_back(
-      sirius::make_data_batch(std::move(filtered_table), *batch.get_memory_space(), stream));
+      sirius::make_data_batch(std::move(filtered_table), *batch->get_memory_space(), stream));
   }
   return std::make_unique<pipelineable_operator_data>(output_batches);
 }

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate::execute(
   const auto& input_batches = input.get_read_only_batches();
   std::vector<std::shared_ptr<::cucascade::data_batch>> results;
   for (auto const& input_batch : input_batches) {
-    auto* space = input_batch.get_memory_space();
+    auto* space = input_batch->get_memory_space();
     if (!space) { continue; }
     auto result = gpu_aggregate_impl::local_grouped_aggregate(input_batch,
                                                               group_idx,

--- a/src/op/sirius_physical_grouped_aggregate_merge.cpp
+++ b/src/op/sirius_physical_grouped_aggregate_merge.cpp
@@ -183,13 +183,13 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   // Merge multiple batches, or use single batch directly if only one
   std::shared_ptr<::cucascade::data_batch> merged;
   if (input_batches.size() == 1) {
-    merged = input_batches[0].clone(sirius::get_next_batch_id(), stream);
+    merged = input_batches[0]->clone(sirius::get_next_batch_id(), stream);
   } else {
     merged = gpu_merge_impl::merge_grouped_aggregate(input_batches,
                                                      group_idx.size(),
                                                      cudf_aggregates,
                                                      stream,
-                                                     *input_batches[0].get_memory_space());
+                                                     *input_batches[0]->get_memory_space());
   }
 
   // If no post-processing needed, return merged result directly
@@ -201,10 +201,10 @@ std::unique_ptr<operator_data> sirius_physical_grouped_aggregate_merge::execute(
   // Post-merge projection: handle AVG (SUM/COUNT) and COUNT DISTINCT (list element count).
   // Release ownership of the merged table's columns so we can move (not copy) them.
   // Acquire EXCLUSIVE lock since release_table() is a mutating operation
-  auto merged_mut    = merged->to_mutable();
-  auto* space        = merged_mut.get_memory_space();
+  auto merged_mut    = merged->get_mutable();
+  auto* space        = merged_mut->get_memory_space();
   auto mr            = space->get_default_allocator();
-  auto& gpu_rep      = merged_mut.get_data()->cast<cucascade::gpu_table_representation>();
+  auto& gpu_rep      = merged_mut->get_data()->cast<cucascade::gpu_table_representation>();
   auto merged_cols   = gpu_rep.release_table(stream)->release();
   int num_group_cols = static_cast<int>(group_idx.size());
 

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -879,7 +879,7 @@ static std::unique_ptr<operator_data> resolve_mark_join_result(
   auto output_cudf_table = std::make_unique<cudf::table>(std::move(mark_out_cols), stream);
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<::cucascade::data_batch>>{
-      make_data_batch(std::move(output_cudf_table), *left_batch.get_memory_space(), stream)});
+      make_data_batch(std::move(output_cudf_table), *left_batch->get_memory_space(), stream)});
 }
 
 std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator_data& input_data,
@@ -918,7 +918,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       {
         std::lock_guard<std::mutex> lg(op_state_mutex);
         _built_table_cast_columns = std::move(build_keys_result.owned_cast_columns);
-        _build_table              = build_batch_ro;
+        _build_table.emplace(build_batch_ro.clone_read_only_access());
         if (join_type == duckdb::JoinType::MARK) {
           // MARK: build a reusable filtered_join on the right (filter) keys; each probe batch's
           // semi_join returns left-row match indices for resolve_mark_join_result.
@@ -964,7 +964,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
       }
 
       right_full = _build_table.value()
-                     .get_data()
+                     ->get_data()
                      ->cast<cucascade::gpu_table_representation>()
                      .get_table_view();
 
@@ -982,7 +982,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                   lhs_output_columns.col_idxs,
                                                   rhs_output_columns.col_idxs,
                                                   std::move(build_indices),
-                                                  *input_batches[0].get_memory_space(),
+                                                  *input_batches[0]->get_memory_space(),
                                                   stream);
         }
       } else {
@@ -1198,7 +1198,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                                                 lhs_output_columns.col_idxs,
                                                 rhs_output_columns.col_idxs,
                                                 std::move(build_indices),
-                                                *input_batches[0].get_memory_space(),
+                                                *input_batches[0]->get_memory_space(),
                                                 stream);
       }
     } else if (join_type == duckdb::JoinType::INNER) {
@@ -1272,7 +1272,7 @@ std::unique_ptr<operator_data> sirius_physical_hash_join::execute(const operator
                             rhs_output_columns.col_idxs,
                             std::move(left_indices),
                             std::move(right_indices),
-                            *input_batches[0].get_memory_space(),
+                            *input_batches[0]->get_memory_space(),
                             stream);
 }
 

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
     // Check if limit is already exhausted
     if (_remaining_limit.load(std::memory_order_acquire) <= 0) { break; }
 
-    auto view     = batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    auto view     = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
     auto num_rows = static_cast<int64_t>(view.num_rows());
 
     if (num_rows == 0) { continue; }
@@ -108,13 +108,13 @@ std::unique_ptr<operator_data> sirius_physical_streaming_limit::execute(
 
     // cudf::slice returns a vector of table_views; materialize into a table
     auto sliced_table = std::make_unique<cudf::table>(
-      slices.front(), stream, batch.get_memory_space()->get_default_allocator());
+      slices.front(), stream, batch->get_memory_space()->get_default_allocator());
     std::unique_ptr<cucascade::idata_representation> output_data =
       std::make_unique<cucascade::gpu_table_representation>(
-        std::move(sliced_table), *batch.get_memory_space(), stream);
+        std::move(sliced_table), *batch->get_memory_space(), stream);
 
     auto const batch_id = ::sirius::get_next_batch_id();
-    auto output_batch   = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+    auto output_batch   = cucascade::data_batch::make(batch_id, std::move(output_data));
     output_batches.push_back(std::move(output_batch));
   }
 

--- a/src/op/sirius_physical_merge_sort.cpp
+++ b/src/op/sirius_physical_merge_sort.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
   // Find memory space
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
-    if (!space) { space = batch.get_memory_space(); }
+    if (!space) { space = batch->get_memory_space(); }
   }
 
   if (input_batches.empty() || !space) {
@@ -114,7 +114,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
     std::vector<std::shared_ptr<cucascade::data_batch>> outputs;
     if (_final_projections.empty()) {
       auto ro_vec = input.get_read_only_batches();
-      outputs.push_back(cucascade::data_batch::to_idle(std::move(ro_vec[0])));
+      outputs.push_back(cucascade::read_only_data_batch::to_idle(std::move(ro_vec[0])));
     } else {
       outputs.push_back(apply_final_projection(input_batches[0]));
     }
@@ -147,7 +147,7 @@ std::unique_ptr<operator_data> sirius_physical_merge_sort::execute(const operato
     if (_final_projections.empty()) {
       outputs.push_back(std::move(merged_batch));
     } else {
-      auto ro = merged_batch->to_read_only();
+      auto ro = merged_batch->get_read_only();
       outputs.push_back(apply_final_projection(ro));
     }
   }

--- a/src/op/sirius_physical_nested_loop_join.cpp
+++ b/src/op/sirius_physical_nested_loop_join.cpp
@@ -407,7 +407,7 @@ std::unique_ptr<operator_data> sirius_physical_nested_loop_join::execute(
   cudf::table_view left  = get_cudf_table_view(left_batch);
   cudf::table_view right = get_cudf_table_view(right_batch);
 
-  cucascade::memory::memory_space* space = left_batch.get_memory_space();
+  cucascade::memory::memory_space* space = left_batch->get_memory_space();
   if (!space) {
     SIRIUS_LOG_DEBUG(
       "Pipeline {}: nested loop join, 0 output batches because left batch had no memory space",

--- a/src/op/sirius_physical_operator.cpp
+++ b/src/op/sirius_physical_operator.cpp
@@ -41,13 +41,8 @@ pipelineable_operator_data::get_data_batches() const
     if (!_read_only_data_batches) {
       throw std::runtime_error("pipelineable_operator_data:get_data_batches no data batches");
     }
-    std::vector<std::shared_ptr<::cucascade::data_batch>> batches;
-    batches.reserve(_read_only_data_batches->size());
-    for (const auto& ro : *_read_only_data_batches) {
-      auto copy = ro;
-      batches.push_back(::cucascade::data_batch::to_idle(std::move(copy)));
-    }
-    _data_batches = std::move(batches);
+    throw std::runtime_error(
+      "pipelineable_operator_data:get_data_batches missing canonical data batch owners");
   }
   return *_data_batches;
 }
@@ -63,7 +58,7 @@ std::vector<::cucascade::read_only_data_batch> pipelineable_operator_data::get_r
     ro_batches.reserve(_data_batches->size());
     for (const auto& batch : *_data_batches) {
       if (batch) {
-        ro_batches.push_back(batch->to_read_only());
+        ro_batches.push_back(batch->get_read_only());
       } else {
         SIRIUS_LOG_WARN("pipelineable_operator_data: null batch encountered, skipping");
       }
@@ -74,7 +69,12 @@ std::vector<::cucascade::read_only_data_batch> pipelineable_operator_data::get_r
       return std::move(ro_batches);
     }
   }
-  return *_read_only_data_batches;
+  std::vector<::cucascade::read_only_data_batch> ro_batches;
+  ro_batches.reserve(_read_only_data_batches->size());
+  for (const auto& ro : *_read_only_data_batches) {
+    ro_batches.push_back(ro.clone_read_only_access());
+  }
+  return ro_batches;
 }
 
 void pipelineable_operator_data::prepare_for_processing(

--- a/src/op/sirius_physical_order.cpp
+++ b/src/op/sirius_physical_order.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<operator_data> sirius_physical_order::execute(const operator_dat
   output_batches.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
 
     auto sorted_batch = gpu_order_impl::local_order_by(

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -167,7 +167,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
   }
 
   auto const& input_batch_ro = input_batches[0];
-  auto* space                = input_batch_ro.get_memory_space();
+  auto* space                = input_batch_ro->get_memory_space();
 
   if (_num_partitions.value() < 2 || _partition_keys.empty()) {
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
@@ -190,7 +190,7 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
         input_batch_ro, _num_partitions.value(), stream, *space);
       break;
     case PartitionType::NONE: {
-      partitioned_results = {input_batch_ro.clone(sirius::get_next_batch_id(), stream)};
+      partitioned_results = {input_batch_ro->clone(sirius::get_next_batch_id(), stream)};
       break;
     }
     case PartitionType::CUSTOM:
@@ -239,8 +239,8 @@ std::pair<int, uint64_t> sirius_physical_partition::determine_num_partitions()
   for (auto batch_id : batch_ids) {
     auto batch = repo->get_data_batch_by_id(batch_id, 0);
     if (batch) {
-      auto ro = batch->to_read_only();
-      if (ro.get_data()) { total_bytes += ro.get_data()->get_size_in_bytes(); }
+      auto ro = batch->get_read_only();
+      if (ro->get_data()) { total_bytes += ro->get_data()->get_size_in_bytes(); }
     }
   }
   int num_partitions = static_cast<int>(std::max(uint64_t{1}, total_bytes / s_partition_size));

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -57,9 +57,9 @@ std::unique_ptr<operator_data> sirius_physical_projection::execute(const operato
 
   for (auto const& batch : input_batches) {
     auto projected_table = gpu_expression_executor.execute(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
     output_batches.push_back(
-      sirius::make_data_batch(std::move(projected_table), *batch.get_memory_space(), stream));
+      sirius::make_data_batch(std::move(projected_table), *batch->get_memory_space(), stream));
   }
   return std::make_unique<pipelineable_operator_data>(output_batches);
 }

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -126,8 +126,8 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
   auto sink_single_batch = [this,
                             stream](std::shared_ptr<cucascade::data_batch> const& input_batch) {
     // Acquire read-only access to inspect the batch
-    auto ro    = input_batch->to_read_only();
-    auto* data = ro.get_data();
+    auto ro    = input_batch->get_read_only();
+    auto* data = ro->get_data();
 
     if (!data) {
       throw invalid_input_exception(
@@ -156,13 +156,13 @@ void sirius_physical_materialized_collector::sink(const operator_data& input_dat
       auto next_batch_id  = data_repo_mgr.get_next_data_batch_id();
 
       // clone_to: creates new batch with data converted to host_data_representation
-      auto result_batch = ro.clone_to<cucascade::host_data_representation>(
+      auto result_batch = ro->clone_to<cucascade::host_data_representation>(
         registry, next_batch_id, &mem_space, stream);
 
       // Access the result batch's data. Declared outside the if-block so result_ro outlives
       // the branch — data points into it and must not dangle when we reach the assert below.
-      result_ro_opt = result_batch->to_read_only();
-      data          = result_ro_opt->get_data();
+      result_ro_opt = result_batch->get_read_only();
+      data          = (*result_ro_opt)->get_data();
 
     } else if (data->get_current_tier() != cucascade::memory::Tier::HOST) {
       // Data must be in HOST tier (i.e., cannot currently reside in DISK tier)

--- a/src/op/sirius_physical_sort_partition.cpp
+++ b/src/op/sirius_physical_sort_partition.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_partition::execute(
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
     auto input_table = get_cudf_table_view(batch);
     auto num_rows    = input_table.num_rows();

--- a/src/op/sirius_physical_sort_sample.cpp
+++ b/src/op/sirius_physical_sort_sample.cpp
@@ -37,9 +37,9 @@ namespace {
 uint64_t get_batch_bytes(const std::shared_ptr<::cucascade::data_batch>& batch)
 {
   if (!batch) { return 0; }
-  auto ro = batch->to_read_only();
-  if (!ro.get_data()) { return 0; }
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch->get_read_only();
+  if (!ro->get_data()) { return 0; }
+  return ro->get_data()->get_size_in_bytes();
 }
 
 bool repo_has_enough_sample_bytes(::cucascade::shared_data_repository* repo,
@@ -162,8 +162,8 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
                                                                     rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_sort_sample::execute"};
-  auto& input               = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& input_batches = input.get_read_only_batches();
+  auto& input        = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto input_batches = input.get_read_only_batches();
 
   // Fast path: boundaries already computed — just pass through.
   if (_boundary_state.load(std::memory_order_acquire) == BoundaryState::DONE) {
@@ -180,9 +180,9 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   // 1. Collect valid batches and find memory space
   std::vector<::cucascade::read_only_data_batch> valid_batches;
   cucascade::memory::memory_space* space = nullptr;
-  for (auto const& batch : input_batches) {
-    if (!space) { space = batch.get_memory_space(); }
-    valid_batches.push_back(batch);
+  for (auto& batch : input_batches) {
+    if (!space) { space = batch->get_memory_space(); }
+    valid_batches.push_back(std::move(batch));
   }
 
   if (valid_batches.empty() || !space) {
@@ -196,7 +196,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
   try {
     size_t total_sample_bytes = 0;
     for (auto const& batch : valid_batches) {
-      total_sample_bytes += batch.get_data()->get_size_in_bytes();
+      total_sample_bytes += batch->get_data()->get_size_in_bytes();
     }
 
     // 2. Build cudf order vectors from BoundOrderByNode
@@ -225,7 +225,7 @@ std::unique_ptr<operator_data> sirius_physical_sort_sample::execute(const operat
     } else {
       merged_sample_batch = gpu_merge_impl::merge_order_by(
         valid_batches, order_key_idx, column_order, null_precedence, stream, *space);
-      merged_sample_view = get_cudf_table_view(merged_sample_batch->to_read_only());
+      merged_sample_view = get_cudf_table_view(merged_sample_batch->get_read_only());
     }
 
     // 4. Compute number of partitions

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -88,8 +88,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::get_next_task_input_d
     if (!batch) { break; }
     uint64_t batch_bytes = 0;
     {
-      auto ro = batch->to_read_only();
-      if (ro.get_data()) { batch_bytes = ro.get_data()->get_size_in_bytes(); }
+      auto ro = batch->get_read_only();
+      if (ro->get_data()) { batch_bytes = ro->get_data()->get_size_in_bytes(); }
     }
     accumulated_bytes += batch_bytes;
     input_batch.push_back(std::move(batch));
@@ -107,8 +107,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
                                                                    rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_table_scan::execute"};
-  auto& input                  = dynamic_cast<const pipelineable_operator_data&>(input_data);
-  const auto& ro_input_batches = input.get_read_only_batches();
+  auto& input           = dynamic_cast<const pipelineable_operator_data&>(input_data);
+  auto ro_input_batches = input.get_read_only_batches();
 
   // For parquet scan pipelines, filter and projection are already applied in
   // parquet_scan_task and the host_parquet_representation converters.
@@ -132,25 +132,25 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     table_views.reserve(ro_input_batches.size());
     cucascade::memory::memory_space* space = nullptr;
     for (const auto& batch : ro_input_batches) {
-      if (batch.get_data()) {
-        auto& gpu_rep = batch.get_data()->cast<cucascade::gpu_table_representation>();
+      if (batch->get_data()) {
+        auto& gpu_rep = batch->get_data()->cast<cucascade::gpu_table_representation>();
         table_views.push_back(gpu_rep.get_table_view());
-        if (!space) { space = batch.get_memory_space(); }
+        if (!space) { space = batch->get_memory_space(); }
       }
     }
     if (table_views.size() > 1 && space) {
       auto concatenated = cudf::concatenate(table_views, stream, space->get_default_allocator());
       auto concat_rep   = std::make_unique<cucascade::gpu_table_representation>(
         std::move(concatenated), *space, stream);
-      single_batch = std::make_shared<cucascade::data_batch>(0, std::move(concat_rep));
+      single_batch = cucascade::data_batch::make(0, std::move(concat_rep));
     }
   }
 
   // After concatenation (or if only one batch), work with a single batch.
   // For a concatenated batch (new idle), acquire read lock. For a single input batch, use directly.
   ::cucascade::read_only_data_batch batch_ref =
-    single_batch ? single_batch->to_read_only() : ro_input_batches[0];
-  if (!batch_ref.get_data()) { return std::make_unique<pipelineable_operator_data>(); }
+    single_batch ? single_batch->get_read_only() : std::move(ro_input_batches[0]);
+  if (!batch_ref->get_data()) { return std::make_unique<pipelineable_operator_data>(); }
 
   // Apply table filters as a GPU expression if present.
   std::shared_ptr<cucascade::data_batch> output_batch;
@@ -165,11 +165,11 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     sirius::gpu_expression_executor gpu_expression_executor(
       *local_filter_expr, cudf::get_current_device_resource_ref(), stream);
     auto filtered_table = gpu_expression_executor.select(
-      batch_ref.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch_ref->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
     output_batch =
-      sirius::make_data_batch(std::move(filtered_table), *batch_ref.get_memory_space(), stream);
+      sirius::make_data_batch(std::move(filtered_table), *batch_ref->get_memory_space(), stream);
   } else {
-    output_batch = ::cucascade::data_batch::to_idle(std::move(batch_ref));
+    output_batch = ::cucascade::read_only_data_batch::to_idle(std::move(batch_ref));
   }
 
   // After filtering, project away filter-only columns if the batch has more
@@ -184,8 +184,8 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
   // Read batch column count under read-only lock, then release lock before mutation
   std::size_t num_batch_cols = 0;
   {
-    auto output_ro = output_batch->to_read_only();
-    auto& gpu_rep  = output_ro.get_data()->cast<cucascade::gpu_table_representation>();
+    auto output_ro = output_batch->get_read_only();
+    auto& gpu_rep  = output_ro->get_data()->cast<cucascade::gpu_table_representation>();
     num_batch_cols = static_cast<std::size_t>(gpu_rep.get_table_view().num_columns());
   }  // read lock released here
 
@@ -208,9 +208,9 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto batch_id                          = output_batch->get_batch_id();
     cucascade::memory::memory_space* space = nullptr;
     {
-      auto output_ro = output_batch->to_read_only();
-      space          = output_ro.get_memory_space();
-      auto& gpu_rep  = output_ro.get_data()->cast<cucascade::gpu_table_representation>();
+      auto output_ro = output_batch->get_read_only();
+      space          = output_ro->get_memory_space();
+      auto& gpu_rep  = output_ro->get_data()->cast<cucascade::gpu_table_representation>();
       auto table     = gpu_rep.release_table(stream);
       columns        = table->release();
     }  // read lock released here
@@ -237,7 +237,7 @@ std::unique_ptr<operator_data> sirius_physical_table_scan::execute(const operato
     auto projected_table = std::make_unique<cudf::table>(std::move(selected));
     auto projected_rep   = std::make_unique<cucascade::gpu_table_representation>(
       std::move(projected_table), *space, stream);
-    output_batch = std::make_shared<cucascade::data_batch>(batch_id, std::move(projected_rep));
+    output_batch = cucascade::data_batch::make(batch_id, std::move(projected_rep));
   }
 
   std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -172,15 +172,15 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     throw internal_exception("TopN expects a single input batch per execution");
   }
 
-  auto input_batch = input_batches[0];
-  auto* space      = input_batch.get_memory_space();
+  auto const& input_batch = input_batches[0];
+  auto* space             = input_batch->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
   auto input_table_view =
-    input_batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    input_batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
   auto output_table = compute_top_n_table(
     input_table_view, orders, limit, offset, stream, space->get_default_allocator());
   // ro released at end of function
@@ -193,7 +193,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n::execute(const operator_dat
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space, stream);
   std::unique_ptr<cucascade::idata_representation> output_data = std::move(output_repr);
   outputs.push_back(
-    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
+    cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(output_data)));
   return std::make_unique<pipelineable_operator_data>(outputs);
 }
 
@@ -242,7 +242,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   // batches[0]->get_memory_space() == target_space here.
   cucascade::memory::memory_space* space = nullptr;
   for (auto const& batch : input_batches) {
-    space = batch.get_memory_space();
+    space = batch->get_memory_space();
     break;
   }
   if (space == nullptr) {
@@ -257,7 +257,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
   std::vector<cudf::table_view> concat_views;
   for (auto const& batch : input_batches) {
     concat_views.push_back(
-      batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
+      batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view());
   }
 
   if (concat_views.empty()) {
@@ -292,7 +292,7 @@ std::unique_ptr<operator_data> sirius_physical_top_n_merge::execute(const operat
     std::make_unique<cucascade::gpu_table_representation>(std::move(output_table), *space, stream);
   std::unique_ptr<cucascade::idata_representation> output_data = std::move(output_repr);
   outputs.push_back(
-    std::make_shared<cucascade::data_batch>(::sirius::get_next_batch_id(), std::move(output_data)));
+    cucascade::data_batch::make(::sirius::get_next_batch_id(), std::move(output_data)));
   return std::make_unique<pipelineable_operator_data>(outputs);
 }
 

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -280,10 +280,10 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
   outputs.reserve(input_batches.size());
 
   for (auto const& batch : input_batches) {
-    auto* space = batch.get_memory_space();
+    auto* space = batch->get_memory_space();
     if (!space) { continue; }
 
-    auto view = batch.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    auto view = batch->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
 
     std::vector<std::unique_ptr<cudf::column>> cols;
     cols.reserve(layout.local_types.size());
@@ -384,7 +384,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
       std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space, stream);
     std::unique_ptr<cucascade::idata_representation> output_data = std::move(out_repr);
     auto const batch_id                                          = ::sirius::get_next_batch_id();
-    outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
+    outputs.push_back(cucascade::data_batch::make(batch_id, std::move(output_data)));
   }
 
   return std::make_unique<pipelineable_operator_data>(outputs);
@@ -445,7 +445,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
   }
 
-  cucascade::memory::memory_space* space = input_batches[0].get_memory_space();
+  cucascade::memory::memory_space* space = input_batches[0]->get_memory_space();
   if (space == nullptr) {
     return std::make_unique<pipelineable_operator_data>(
       std::vector<std::shared_ptr<cucascade::data_batch>>{});
@@ -454,7 +454,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   auto layout = build_aggregate_layout(aggregates);
   std::shared_ptr<cucascade::data_batch> merged_batch;
   if (input_batches.size() == 1) {
-    merged_batch = cucascade::data_batch::to_idle(std::move(input_batches[0]));
+    merged_batch = cucascade::read_only_data_batch::to_idle(std::move(input_batches[0]));
   } else {
     merged_batch = gpu_merge_impl::merge_ungrouped_aggregate(
       input_batches, layout.merge_kinds, layout.merge_nth_index, stream, *space);
@@ -466,9 +466,9 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   }
 
   // Acquire read access to merged batch to extract table
-  auto merged_ro = merged_batch->to_read_only();
+  auto merged_ro = merged_batch->get_read_only();
   auto merged_view =
-    merged_ro.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+    merged_ro->get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
 
   std::vector<std::unique_ptr<cudf::column>> output_cols;
   output_cols.reserve(layout.aggregates.size());
@@ -493,7 +493,7 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
     std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space, stream);
   std::unique_ptr<cucascade::idata_representation> output_data = std::move(out_repr);
   auto const batch_id                                          = ::sirius::get_next_batch_id();
-  auto output_batch = std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data));
+  auto output_batch = cucascade::data_batch::make(batch_id, std::move(output_data));
 
   return std::make_unique<pipelineable_operator_data>(
     std::vector<std::shared_ptr<cucascade::data_batch>>{std::move(output_batch)});

--- a/src/pipeline/gpu_pipeline_task.cpp
+++ b/src/pipeline/gpu_pipeline_task.cpp
@@ -112,10 +112,10 @@ void log_operator_data(const op::sirius_physical_operator& op,
     const auto& batches = p_data->get_read_only_batches();
     num_batches         = batches.size();
     for (auto const& batch : batches) {
-      if (batch.get_data()) {
+      if (batch->get_data()) {
         auto view = get_cudf_table_view(batch);
         batch_rows += std::to_string(view.num_rows()) + "  ";
-        total_bytes += batch.get_data()->get_size_in_bytes();
+        total_bytes += batch->get_data()->get_size_in_bytes();
       }
     }
   } else {
@@ -466,7 +466,7 @@ void gpu_pipeline_task::execute(rmm::cuda_stream_view stream)
       dynamic_cast<const op::pipelineable_operator_data*>(output_data.get());
     if (pipelineable_output) {
       for (const auto& batch : pipelineable_output->get_read_only_batches(false)) {
-        output_bytes += batch.get_data()->get_size_in_bytes();
+        output_bytes += batch->get_data()->get_size_in_bytes();
       }
     }
     auto& global = _global_state->cast<gpu_pipeline_task_global_state>();
@@ -499,7 +499,7 @@ std::size_t gpu_pipeline_task::get_input_size() const
     dynamic_cast<const op::pipelineable_operator_data*>(local_state._input_data.get());
   if (!pipelineable_input) { return 0; }
   for (const auto& batch : pipelineable_input->get_read_only_batches(false)) {
-    input_size += batch.get_data()->get_size_in_bytes();
+    input_size += batch->get_data()->get_size_in_bytes();
   }
   return input_size;
 }

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -84,14 +84,14 @@ bool enable_p2p_for_test(int num_gpus)
 // equivalent helper in test/cpp/downgrade/test_downgrade_executor.cpp lives
 // in an anonymous namespace and is not reachable from this TU.
 // Phase 18 / DB-03: const dropped from data_batch& parameter (mirrors
-// debug_utils.hpp pattern from plan 18-04). cucascade #117's to_read_only is
-// non-const because it acquires the shared lock.
+// debug_utils.hpp pattern from plan 18-04). cuCascade read accessors are
+// non-const because they acquire a shared lock.
 uint64_t compute_batch_checksum_fnv1a64(cucascade::data_batch& batch, rmm::cuda_stream_view stream)
 {
   // Phase 18 / DB-03 Recipe R1: scoped read-only accessor for the lifetime
   // of gpu_rep, packed, and host_buf — released at function exit.
-  auto ro             = batch.to_read_only();
-  auto const& gpu_rep = ro.get_data()->cast<cucascade::gpu_table_representation>();
+  auto ro             = batch.get_read_only();
+  auto const& gpu_rep = ro->get_data()->cast<cucascade::gpu_table_representation>();
   auto packed         = cudf::pack(gpu_rep.get_table_view(), stream);
   stream.synchronize();
 
@@ -463,13 +463,13 @@ TEST_CASE("gpu_to_gpu round-trip preserves bytes on N>=2 hosts (MGPU-04 + MGPU-0
   REQUIRE(batch != nullptr);
   size_t original_bytes = 0;
   {
-    auto __ro_1    = batch->to_read_only();
-    original_bytes = __ro_1.get_data()->get_size_in_bytes();
+    auto __ro_1    = batch->get_read_only();
+    original_bytes = __ro_1->get_data()->get_size_in_bytes();
   }
   REQUIRE(original_bytes > 0);
   {
-    auto __ro_2 = batch->to_read_only();
-    REQUIRE(__ro_2.get_memory_space()->get_device_id() == 0);
+    auto __ro_2 = batch->get_read_only();
+    REQUIRE(__ro_2->get_memory_space()->get_device_id() == 0);
   }
 
   rmm::cuda_stream stream;
@@ -482,14 +482,14 @@ TEST_CASE("gpu_to_gpu round-trip preserves bytes on N>=2 hosts (MGPU-04 + MGPU-0
   // GPU0 -> GPU1 forward leg.
   // Phase 18 / DB-03 Recipe R8 + R3: scoped mutable accessor.
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu1, stream.view());
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu1, stream.view());
   }
 
   {
-    auto __ro_3 = batch->to_read_only();
-    REQUIRE(__ro_3.get_memory_space()->get_device_id() == 1);
-    REQUIRE(__ro_3.get_data()->get_size_in_bytes() == original_bytes);
+    auto __ro_3 = batch->get_read_only();
+    REQUIRE(__ro_3->get_memory_space()->get_device_id() == 1);
+    REQUIRE(__ro_3->get_data()->get_size_in_bytes() == original_bytes);
   }
 
   // MGPU-06 return leg: Phase 7 Plan 07-01's peer-access enable loop at
@@ -498,15 +498,15 @@ TEST_CASE("gpu_to_gpu round-trip preserves bytes on N>=2 hosts (MGPU-04 + MGPU-0
   // corruption on Ada Lovelace + Sapphire Rapids).
   // Phase 18 / DB-03 Recipe R8 + R3: scoped mutable accessor.
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu0, stream.view());
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu0, stream.view());
   }
 
   {
-    auto __ro_4 = batch->to_read_only();
-    REQUIRE(__ro_4.get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
-    REQUIRE(__ro_4.get_memory_space()->get_device_id() == gpu0->get_device_id());
-    REQUIRE(__ro_4.get_data()->get_size_in_bytes() == original_bytes);
+    auto __ro_4 = batch->get_read_only();
+    REQUIRE(__ro_4->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+    REQUIRE(__ro_4->get_memory_space()->get_device_id() == gpu0->get_device_id());
+    REQUIRE(__ro_4->get_data()->get_size_in_bytes() == original_bytes);
   }
 
   // Final data-integrity gate: post-round-trip checksum must equal

--- a/test/cpp/creator/test_task_creator.cpp
+++ b/test/cpp/creator/test_task_creator.cpp
@@ -615,7 +615,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to the repository so it's not empty
-//   auto batch = std::make_shared<cucascade::data_batch>(1, nullptr);
+//   auto batch = cucascade::data_batch::make(1, nullptr);
 //   data_repo->add_data_batch(batch);
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
@@ -635,8 +635,8 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to both repositories
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
-//   data_repo2->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
+//   data_repo2->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
 //     op, "input1", MemoryBarrierType::PIPELINE, data_repo1.get(), nullptr, nullptr);
@@ -658,7 +658,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data only to first repository
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 //   // data_repo2 is empty
 
 //   mock_pipeline_builder::setup_operator_with_pipeline_port(
@@ -827,7 +827,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to PIPELINE port's repo
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   // Create a mock pipeline that is finished for FULL barrier
 //   auto mock_pipeline = fixture.create_mock_pipeline();
@@ -855,7 +855,7 @@ TEST_CASE("get_operator_for_next_task for operator with data returns the operato
 //   auto data_repo2 = std::make_unique<cucascade::shared_data_repository>();
 
 //   // Add data to PIPELINE port's repo
-//   data_repo1->add_data_batch(std::make_shared<cucascade::data_batch>(1, nullptr));
+//   data_repo1->add_data_batch(cucascade::data_batch::make(1, nullptr));
 
 //   // Create a mock pipeline that is NOT finished for FULL barrier
 //   auto mock_pipeline = fixture.create_mock_pipeline();

--- a/test/cpp/data/test_convertible_data_batch.cpp
+++ b/test/cpp/data/test_convertible_data_batch.cpp
@@ -61,23 +61,23 @@ test_env& env()
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 /// Helper: get the size in bytes of a data_batch's data using a temporary read-only lock.
 inline size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 /// Helper: compare batch's memory_space pointer (returns true if same as given space).
 inline bool batch_in_space(cucascade::data_batch& batch,
                            const cucascade::memory::memory_space* space)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space() == space;
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space() == space;
 }
 
 }  // anonymous namespace
@@ -139,7 +139,7 @@ TEST_CASE("convertible_data_batch_provider get_next_convertible returns last idl
   auto batch2_size = get_batch_size(*batch2);
 
   // Make batch3 non-idle by holding a read-only lock on it
-  auto batch3_lock = batch3->to_read_only();
+  auto batch3_lock = batch3->get_read_only();
 
   repo.add_data_batch(batch1);
   repo.add_data_batch(batch2);
@@ -168,7 +168,7 @@ TEST_CASE("convertible_data_batch_provider get_all_convertible returns all idle 
     *e.gpu_space, std::vector<int32_t>{6, 7, 8, 9}, cudf::type_id::INT32);
 
   // Make batch3 non-idle by holding a read-only lock on it
-  auto batch3_lock = batch3->to_read_only();
+  auto batch3_lock = batch3->get_read_only();
 
   repo.add_data_batch(batch1);
   repo.add_data_batch(batch2);
@@ -215,11 +215,11 @@ TEST_CASE("convertible_data_batch convert fails when batch exclusively locked",
   auto batch = sirius::test::operator_utils::make_numeric_batch(
     *e.gpu_space, std::vector<int32_t>{1, 2, 3}, cudf::type_id::INT32);
 
-  // Hold an exclusive (mutable) lock so that try_to_mutable() inside convert() fails
-  auto exclusive_lock = batch->to_mutable();
+  // Hold an exclusive (mutable) lock so that try_get_mutable() inside convert() fails
+  auto exclusive_lock = batch->get_mutable();
 
   sirius::convertible_data_batch wrapper(batch);
-  // Non-blocking convert: uses try_to_mutable() internally, must return nullopt
+  // Non-blocking convert: uses try_get_mutable() internally, must return nullopt
   auto result = wrapper.convert({e.host_space}, e.stream(), *e.mgr, /*blocking=*/false);
 
   REQUIRE_FALSE(result.has_value());

--- a/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
+++ b/test/cpp/data/test_convertible_gpu_pipeline_task.cpp
@@ -93,15 +93,15 @@ std::unique_ptr<sirius::pipeline::gpu_pipeline_task> make_test_gpu_task(
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 /// Helper: get the size in bytes of a data_batch's data using a temporary read-only lock.
 inline size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 }  // anonymous namespace
@@ -234,7 +234,7 @@ TEST_CASE("non-idle batch skipped by predicate", "[convertible_gpu_pipeline_task
   queue.push(std::move(task));
 
   // Hold an exclusive lock so batch is not idle — provider should skip it
-  auto exclusive_lock = batch->to_mutable();
+  auto exclusive_lock = batch->get_mutable();
 
   sirius::convertible_gpu_pipeline_task_provider provider(queue);
   auto cd = provider.get_next_convertible(e.gpu_space, false);

--- a/test/cpp/downgrade/test_downgrade_disk.cpp
+++ b/test/cpp/downgrade/test_downgrade_disk.cpp
@@ -55,8 +55,8 @@ namespace {
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 cucascade::memory::memory_space* get_gpu_space(

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -47,18 +47,18 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// Helper: get the memory tier of a data_batch via to_read_only()
+/// Helper: get the memory tier of a data_batch via get_read_only()
 cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
-/// Helper: get byte size of a data_batch via to_read_only()
+/// Helper: get byte size of a data_batch via get_read_only()
 size_t get_batch_size(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_data()->get_size_in_bytes();
+  auto ro = batch.get_read_only();
+  return ro->get_data()->get_size_in_bytes();
 }
 
 const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::Tier::GPU, 0);
@@ -324,7 +324,7 @@ TEST_CASE("request_free_memory skips active partitions in first pass", "[downgra
   repo->add_data_batch(batch_p2, 2);
 
   // Lock batch_p1 in read_only state so downgrade executor skips it (state != idle)
-  auto batch_p1_lock = batch_p1->to_read_only();
+  auto batch_p1_lock = batch_p1->get_read_only();
   repo_mgr.add_new_repository(1, "out", std::move(repo));
 
   size_t three_batches = get_batch_size(*batch_p0) * 3;
@@ -370,8 +370,8 @@ TEST_CASE("request_free_memory skips batches already on HOST", "[downgrade_execu
   rmm::cuda_stream conv_stream;
   {
     // Acquire exclusive lock and convert to host representation
-    auto mut = gpu_batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
+    auto mut = gpu_batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, conv_stream);
     // mut goes out of scope → releases exclusive lock, batch returns to idle
   }
   REQUIRE(get_batch_tier(*gpu_batch) == cucascade::memory::Tier::HOST);

--- a/test/cpp/downgrade/test_downgrade_lifecycle.cpp
+++ b/test/cpp/downgrade/test_downgrade_lifecycle.cpp
@@ -56,8 +56,8 @@ const auto GPU_SPACE_ID = cucascade::memory::memory_space_id(cucascade::memory::
 /// Helper: get the tier of a data_batch using a temporary read-only lock.
 inline cucascade::memory::Tier get_batch_tier(cucascade::data_batch& batch)
 {
-  auto ro = batch.to_read_only();
-  return ro.get_memory_space()->get_tier();
+  auto ro = batch.get_read_only();
+  return ro->get_memory_space()->get_tier();
 }
 
 std::unique_ptr<sirius::memory::sirius_memory_reservation_manager> make_test_memory_manager()

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -104,7 +104,7 @@ std::shared_ptr<data_batch> make_input_batch(
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_int32_batch_with_nulls(memory_space& space,
@@ -140,7 +140,7 @@ std::shared_ptr<data_batch> make_int32_batch_with_nulls(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_two_int32_batch_with_nulls(memory_space& space,
@@ -180,7 +180,7 @@ std::shared_ptr<data_batch> make_two_int32_batch_with_nulls(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal64_batch(memory_space& space,
@@ -208,7 +208,7 @@ std::shared_ptr<data_batch> make_decimal64_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal64_two_col_batch(memory_space& space,
@@ -241,7 +241,7 @@ std::shared_ptr<data_batch> make_decimal64_two_col_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal32_batch(memory_space& space,
@@ -269,7 +269,7 @@ std::shared_ptr<data_batch> make_decimal32_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 std::shared_ptr<data_batch> make_decimal128_batch(memory_space& space,
@@ -297,7 +297,7 @@ std::shared_ptr<data_batch> make_decimal128_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 using exp_executor      = ::sirius::gpu_expression_executor;
@@ -341,14 +341,14 @@ exec_result run_execute(memory_space& space,
     ast_nodes.push_back(std::move(n));
   }
   exp_executor executor(ast_nodes, get_resource_ref(space), cudf::get_default_stream(), strategy);
-  auto input_ro     = input_batch->to_read_only();
-  auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
+  auto input_ro     = input_batch->get_read_only();
+  auto& in_repr     = input_ro->get_data()->cast<gpu_table_representation>();
   auto output_table = executor.execute(in_repr.get_table_view());
   REQUIRE(output_table != nullptr);
   auto output_batch = sirius::make_data_batch(
-    std::move(output_table), *input_ro.get_memory_space(), cudf::get_default_stream());
-  auto output_ro = output_batch->to_read_only();
-  auto& out_repr = output_ro.get_data()->cast<gpu_table_representation>();
+    std::move(output_table), *input_ro->get_memory_space(), cudf::get_default_stream());
+  auto output_ro = output_batch->get_read_only();
+  auto& out_repr = output_ro->get_data()->cast<gpu_table_representation>();
   return {input_batch, output_batch, in_repr.get_table_view(), out_repr.get_table_view()};
 }
 
@@ -358,14 +358,14 @@ exec_result run_select(memory_space& space,
                        exp_strategy_enum strategy = MAT)
 {
   exp_executor executor(*node, get_resource_ref(space), cudf::get_default_stream(), strategy);
-  auto input_ro     = input_batch->to_read_only();
-  auto& in_repr     = input_ro.get_data()->cast<gpu_table_representation>();
+  auto input_ro     = input_batch->get_read_only();
+  auto& in_repr     = input_ro->get_data()->cast<gpu_table_representation>();
   auto output_table = executor.select(in_repr.get_table_view());
   REQUIRE(output_table != nullptr);
   auto output_batch = sirius::make_data_batch(
-    std::move(output_table), *input_ro.get_memory_space(), cudf::get_default_stream());
-  auto output_ro = output_batch->to_read_only();
-  auto& out_repr = output_ro.get_data()->cast<gpu_table_representation>();
+    std::move(output_table), *input_ro->get_memory_space(), cudf::get_default_stream());
+  auto output_ro = output_batch->get_read_only();
+  auto& out_repr = output_ro->get_data()->cast<gpu_table_representation>();
   return {input_batch, output_batch, in_repr.get_table_view(), out_repr.get_table_view()};
 }
 
@@ -1734,8 +1734,8 @@ int32_batch make_int32_input(memory_space& space)
 {
   auto batch =
     make_input_batch(space, {cudf::data_type{cudf::type_id::INT32}}, {std::pair<int, int>{0, 100}});
-  auto ro       = batch->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = batch->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   return {batch, in_repr.get_table_view()};
 }
 
@@ -1789,8 +1789,8 @@ TEST_CASE("native_ast - constant VARCHAR", "[expression_executor_ast_native][con
   REQUIRE(space != nullptr);
   auto input =
     make_input_batch(*space, {cudf::data_type{cudf::type_id::STRING}}, {std::pair<int, int>{1, 5}});
-  auto ro       = input->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = input->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   auto hand_ast = std::make_unique<sirius::ast::node>(sirius::ast::constant{
@@ -1852,8 +1852,8 @@ TEST_CASE("native_ast - conjunction AND (MATERIALIZE)",
     make_input_batch(*space,
                      {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
                      {std::pair<int, int>{0, 100}, std::pair<int, int>{0, 100}});
-  auto ro       = input->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = input->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   std::vector<std::unique_ptr<sirius::ast::node>> children;
@@ -1927,8 +1927,8 @@ TEST_CASE("native_ast - unary_op IS_NULL (MATERIALIZE)",
   std::vector<int32_t> values{1, 2, 3, 4, 5};
   std::vector<bool> valids{true, false, true, false, true};
   auto batch    = make_int32_batch_with_nulls(*space, values, valids);
-  auto ro       = batch->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = batch->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   auto hand_ast = std::make_unique<sirius::ast::node>(
@@ -1951,8 +1951,8 @@ TEST_CASE("native_ast - unary_op IS_NOT_NULL (MATERIALIZE)",
   std::vector<int32_t> values{10, 20, 30, 40};
   std::vector<bool> valids{true, false, true, true};
   auto batch    = make_int32_batch_with_nulls(*space, values, valids);
-  auto ro       = batch->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = batch->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   auto hand_ast = std::make_unique<sirius::ast::node>(
@@ -1998,8 +1998,8 @@ TEST_CASE("native_ast - coalesce (MATERIALIZE)", "[expression_executor_ast_nativ
   std::vector<int32_t> values{7, 8, 9, 10, 11};
   std::vector<bool> valids{true, false, true, false, true};
   auto batch    = make_int32_batch_with_nulls(*space, values, valids);
-  auto ro       = batch->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = batch->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   std::vector<std::unique_ptr<sirius::ast::node>> children;
@@ -2049,8 +2049,8 @@ TEST_CASE("native_ast - function_call add (MATERIALIZE)",
     make_input_batch(*space,
                      {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
                      {std::pair<int, int>{0, 50}, std::pair<int, int>{0, 50}});
-  auto ro       = input->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = input->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   std::vector<std::unique_ptr<sirius::ast::node>> args;
@@ -2081,8 +2081,8 @@ TEST_CASE("native_ast - function_call add (AST_INTERPRET)",
     make_input_batch(*space,
                      {cudf::data_type{cudf::type_id::INT32}, cudf::data_type{cudf::type_id::INT32}},
                      {std::pair<int, int>{0, 50}, std::pair<int, int>{0, 50}});
-  auto ro       = input->to_read_only();
-  auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+  auto ro       = input->get_read_only();
+  auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
   auto tv       = in_repr.get_table_view();
 
   std::vector<std::unique_ptr<sirius::ast::node>> args;
@@ -2148,8 +2148,8 @@ TEST_CASE("native_ast - comparison DISTINCT_FROM / NOT_DISTINCT_FROM executes",
 
   {
     auto batch    = make_int32_batch_with_nulls(*space, values, valids);
-    auto ro       = batch->to_read_only();
-    auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+    auto ro       = batch->get_read_only();
+    auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
     auto tv       = in_repr.get_table_view();
 
     auto node = std::make_unique<sirius::ast::node>(sirius::ast::comparison{
@@ -2169,8 +2169,8 @@ TEST_CASE("native_ast - comparison DISTINCT_FROM / NOT_DISTINCT_FROM executes",
 
   {
     auto batch    = make_int32_batch_with_nulls(*space, values, valids);
-    auto ro       = batch->to_read_only();
-    auto& in_repr = ro.get_data()->cast<gpu_table_representation>();
+    auto ro       = batch->get_read_only();
+    auto& in_repr = ro->get_data()->cast<gpu_table_representation>();
     auto tv       = in_repr.get_table_view();
 
     auto node = std::make_unique<sirius::ast::node>(sirius::ast::comparison{

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<data_batch> make_input_batch(
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 using exp_executor      = ::sirius::gpu_expression_executor;
@@ -137,8 +137,8 @@ auto constexpr AST_I    = exp_strategy_enum::AST_INTERPRET;
 // Helper — pull the cudf::table_view out of a data_batch's read-only handle.
 cudf::table_view get_table_view(std::shared_ptr<data_batch> const& batch)
 {
-  auto input_ro = batch->to_read_only();
-  return input_ro.get_data()->cast<gpu_table_representation>().get_table_view();
+  auto input_ro = batch->get_read_only();
+  return input_ro->get_data()->cast<gpu_table_representation>().get_table_view();
 }
 
 // Run a non-owning executor over the given expression pointer and return the

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -345,12 +345,12 @@ cucascade::host_data_representation const& convert_to_host_table(
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
   }
 
-  auto ro    = batch->to_read_only();
-  auto* data = ro.get_data();
+  auto ro    = batch->get_read_only();
+  auto* data = ro->get_data();
   if (!data) { throw std::runtime_error("data_batch has no data after conversion"); }
   return data->cast<cucascade::host_data_representation>();
 }
@@ -476,13 +476,12 @@ TEST_CASE("host_table_utils - pack metadata with gaps across multiple blocks",
     cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
-  auto batch =
-    std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
+  auto batch = cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
   }
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);
@@ -606,13 +605,12 @@ TEST_CASE("host_table_utils - underfilled varchar column truncates rows",
     cucascade::memory::host_table_allocation::create(std::move(allocation), std::move(columns), sz);
   auto host_table =
     std::make_unique<cucascade::host_data_representation>(std::move(table_allocation), host_space);
-  auto batch =
-    std::make_shared<cucascade::data_batch>(sirius::get_next_batch_id(), std::move(host_table));
+  auto batch = cucascade::data_batch::make(sirius::get_next_batch_id(), std::move(host_table));
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
   }
 
   cudf::table_view table_view = sirius::get_cudf_table_view(*batch);

--- a/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
@@ -180,7 +180,7 @@ TEST_CASE("Concatenate multiple data batches", "[operator][merge_concat]")
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -202,7 +202,7 @@ TEST_CASE("Concatenate multiple data batches with different size", "[operator][m
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -224,7 +224,7 @@ TEST_CASE("Concatenate with invalid input", "[operator][merge_concat]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::concat(ro, cudf::get_default_stream(), *mem_space),
                       std::runtime_error);
@@ -244,7 +244,7 @@ TEST_CASE("Concatenate multiple data batches but no input rows", "[operator][mer
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -266,7 +266,7 @@ TEST_CASE("Concatenate mixed empty and non-empty data batches", "[operator][merg
     num_batches, num_input_rows, column_types, {column_types.size(), std::nullopt}, *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::concat(ro_batches, cudf::get_default_stream(), *mem_space);
   ro_batches.clear();
@@ -293,7 +293,7 @@ batches_with_handles create_batches_with_local_ungrouped_agg_result(
     aggregate_idx[i] = i;
   }
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_aggregate_impl::local_ungrouped_aggregate(
       ro_batch, aggregates, aggregate_idx, cudf::get_default_stream(), mem_space);
     result.batches.push_back(std::move(batch));
@@ -430,7 +430,7 @@ TEST_CASE("Ungrouped merge aggregate of min/max/count/sum", "[operator][merge_un
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -454,7 +454,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_ungrouped_aggregate(
                         ro, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space),
@@ -471,7 +471,7 @@ TEST_CASE("Ungrouped merge aggregate with invalid input", "[operator][merge_ungr
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_ungrouped_aggregate(
                         ro, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space),
@@ -500,7 +500,7 @@ TEST_CASE("Ungrouped merge aggregate with empty local aggregate results",
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -531,7 +531,7 @@ TEST_CASE("Ungrouped merge aggregate with mixed empty and non-empty local aggreg
   std::vector<std::optional<cudf::size_type>> merge_nth_index(aggregates.size(), std::nullopt);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_ungrouped_aggregate(
     ro_batches, aggregates, merge_nth_index, cudf::get_default_stream(), *mem_space);
@@ -561,7 +561,7 @@ batches_with_handles create_batches_with_local_grouped_agg_result(
   // Compute local grouped aggregates
   batches_with_handles result;
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_aggregate_impl::local_grouped_aggregate(
       ro_batch, group_idx, aggregates, aggregate_idx, {}, cudf::get_default_stream(), mem_space);
     result.batches.push_back(std::move(batch));
@@ -707,7 +707,7 @@ TEST_CASE("Grouped merge aggregate of min/max/count/sum", "[operator][merge_grou
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -738,7 +738,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_grouped_aggregate(
                         ro, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space),
@@ -754,7 +754,7 @@ TEST_CASE("Grouped merge aggregate with invalid input", "[operator][merge_groupe
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(gpu_merge_impl::merge_grouped_aggregate(
                         ro, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space),
@@ -791,7 +791,7 @@ TEST_CASE("Grouped merge aggregate with empty local aggregate results",
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -830,7 +830,7 @@ TEST_CASE("Grouped merge aggregate with mixed empty and non-empty local aggregat
                                                             *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_grouped_aggregate(
     ro_batches, group_idx.size(), aggregates, cudf::get_default_stream(), *mem_space);
@@ -864,7 +864,7 @@ batches_with_handles create_batches_with_local_orderby_result(
     projections[i] = i;
   }
   for (int i = 0; i < num_batches; ++i) {
-    auto ro_batch = base_input.batches[i]->to_read_only();
+    auto ro_batch = base_input.batches[i]->get_read_only();
     auto batch    = gpu_order_impl::local_order_by(ro_batch,
                                                 order_key_idx,
                                                 column_order,
@@ -939,7 +939,7 @@ TEST_CASE("Merge order-by basic", "[operator][merge_order_by]")
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,
@@ -978,7 +978,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(
       gpu_merge_impl::merge_order_by(
@@ -1000,7 +1000,7 @@ TEST_CASE("Merge order-by with invalid input", "[operator][merge_order_by]")
   {
     std::vector<read_only_data_batch> ro;
     for (auto& b : input2.batches) {
-      ro.push_back(b->to_read_only());
+      ro.push_back(b->get_read_only());
     }
     REQUIRE_THROWS_AS(
       gpu_merge_impl::merge_order_by(
@@ -1034,7 +1034,7 @@ TEST_CASE("Merge order-by with empty local order-by results", "[operator][merge_
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,
@@ -1074,7 +1074,7 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
                                                         *mem_space);
   std::vector<read_only_data_batch> ro_batches;
   for (auto& b : input.batches) {
-    ro_batches.push_back(b->to_read_only());
+    ro_batches.push_back(b->get_read_only());
   }
   auto output_batch = gpu_merge_impl::merge_order_by(ro_batches,
                                                      order_key_idx,

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -129,7 +129,7 @@ inline std::shared_ptr<cucascade::data_batch> concatenate_batches_horizontal(
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
     std::move(concatenated_table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename T>
@@ -209,7 +209,7 @@ inline std::shared_ptr<cucascade::data_batch> make_numeric_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 inline std::unique_ptr<cudf::column> make_string_column(const std::vector<std::string>& values,
@@ -275,7 +275,7 @@ inline std::shared_ptr<cucascade::data_batch> make_string_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
@@ -302,7 +302,7 @@ inline std::shared_ptr<cucascade::data_batch> make_decimal64_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename T>
@@ -336,7 +336,7 @@ inline std::shared_ptr<cucascade::data_batch> make_timestamp_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 template <typename TFirst, typename TSecond>
@@ -433,7 +433,7 @@ inline std::shared_ptr<cucascade::data_batch> make_two_column_batch(
   auto gpu_repr =
     std::make_unique<cucascade::gpu_table_representation>(std::move(table), space, stream);
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+  return cucascade::data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 }  // namespace sirius::test::operator_utils

--- a/test/cpp/operator/test_gpu_partition_impl.cpp
+++ b/test/cpp/operator/test_gpu_partition_impl.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Hash partition basic", "[operator][hash_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -179,7 +179,7 @@ TEST_CASE("Hash partition with invalid input", "[operator][hash_partition]")
   auto input_batch =
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   {
-    auto ro = input_batch->to_read_only();
+    auto ro = input_batch->get_read_only();
     REQUIRE_THROWS_AS(
       gpu_partition_impl::hash_partition(
         ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space),
@@ -203,7 +203,7 @@ TEST_CASE("Hash partition with empty input", "[operator][hash_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -230,7 +230,7 @@ TEST_CASE("Hash partition with all the same partitioning keys", "[operator][hash
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -253,7 +253,7 @@ TEST_CASE("Hash partition with num partitions larger than input size", "[operato
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::hash_partition(
       ro, partition_key_idx, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -323,7 +323,7 @@ TEST_CASE("Evenly partition basic", "[operator][evenly_partition]")
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -345,7 +345,7 @@ TEST_CASE("Evenly partition basic with empty input", "[operator][evenly_partitio
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }
@@ -368,7 +368,7 @@ TEST_CASE("Evenly partition basic with num partitions larger than input size",
     create_batch_with_random_data(num_input_rows, column_types, ranges, *mem_space);
   std::vector<std::shared_ptr<data_batch>> output_batches;
   {
-    auto ro        = input_batch->to_read_only();
+    auto ro        = input_batch->get_read_only();
     output_batches = gpu_partition_impl::evenly_partition(
       ro, num_partitions, cudf::get_default_stream(), *mem_space);
   }

--- a/test/cpp/operator/test_host_table_chunk_reader.cpp
+++ b/test/cpp/operator/test_host_table_chunk_reader.cpp
@@ -217,8 +217,8 @@ host_data_representation const& convert_to_host_table(
 {
   // Verify batch has data (use read-only accessor to check).
   {
-    auto ro = batch->to_read_only();
-    if (!ro.get_data()) { throw std::runtime_error("data_batch has no data representation"); }
+    auto ro = batch->get_read_only();
+    if (!ro->get_data()) { throw std::runtime_error("data_batch has no data representation"); }
   }
 
   auto& manager = sirius_ctx->get_memory_manager();
@@ -235,13 +235,13 @@ host_data_representation const& convert_to_host_table(
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<host_data_representation>(registry, host_space, stream);
   }
 
-  auto ro = batch->to_read_only();
-  if (!ro.get_data()) { throw std::runtime_error("data_batch has no data after conversion"); }
-  return ro.get_data()->cast<host_data_representation>();
+  auto ro = batch->get_read_only();
+  if (!ro->get_data()) { throw std::runtime_error("data_batch has no data after conversion"); }
+  return ro->get_data()->cast<host_data_representation>();
 }
 
 }  // namespace

--- a/test/cpp/operator/test_physical_merge_sort.cpp
+++ b/test/cpp/operator/test_physical_merge_sort.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 // Helper: sort a batch using sirius_physical_order so it can be used as merge input

--- a/test/cpp/operator/test_physical_order.cpp
+++ b/test/cpp/operator/test_physical_order.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<data_batch> make_3col_batch(memory_space& space,
   auto gpu_repr =
     std::make_unique<gpu_table_representation>(std::move(table), space, cudf::get_default_stream());
   auto batch_id = ::sirius::get_next_batch_id();
-  return std::make_shared<data_batch>(batch_id, std::move(gpu_repr));
+  return data_batch::make(batch_id, std::move(gpu_repr));
 }
 
 }  // namespace

--- a/test/cpp/operator/test_physical_partition.cpp
+++ b/test/cpp/operator/test_physical_partition.cpp
@@ -104,8 +104,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with single 
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::move(table), *space, cudf::get_default_stream());
-  auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   // this cardinality is not real, we are setting here this large in order to force more partitions
   // to be made
@@ -228,8 +227,7 @@ TEMPLATE_TEST_CASE("sirius_physical_partition partitions data_batch with two par
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::move(table), *space, cudf::get_default_stream());
-  auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t partition_size = 10000000;
   // this cardinality is not real, we are setting here this large in order to force more partitions
@@ -312,8 +310,7 @@ TEST_CASE(
 
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::move(table), *space, cudf::get_default_stream());
-  auto input_batch =
-    std::make_shared<data_batch>(::sirius::get_next_batch_id(), std::move(gpu_repr));
+  auto input_batch = data_batch::make(::sirius::get_next_batch_id(), std::move(gpu_repr));
 
   std::size_t estimated_cardinality = num_values;
 

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -195,8 +195,8 @@ void convert_batch_to_host(duckdb::shared_ptr<duckdb::SiriusContext> sirius_ctx,
 
   auto& registry = sirius::converter_registry::get();
   {
-    auto mut = batch->to_mutable();
-    mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+    auto mut = batch->get_mutable();
+    mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
   }
 }
 

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -457,7 +457,7 @@ TEST_CASE("parquet_scan with decimal filter sets table_scan passthrough",
   auto table    = std::make_unique<cudf::table>(std::move(cols));
   auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
     std::move(table), *space, cudf::get_default_stream());
-  auto input_batch = std::make_shared<cucascade::data_batch>(0, std::move(gpu_repr));
+  auto input_batch = cucascade::data_batch::make(0, std::move(gpu_repr));
 
   // Filter: col0 > 3.00 (decimal column-vs-literal comparisons translate to cuDF AST)
   auto table_filters   = duckdb::make_uniq<duckdb::TableFilterSet>();

--- a/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
@@ -127,27 +127,27 @@ TEST_CASE("DISK->GPU round-trip conversion via converter registry", "[gpu_pipeli
   rmm::cuda_stream stream;
 
   auto batch = make_gpu_batch(*gpu_space);
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // --- GPU -> DISK ---
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
+      mut->convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
   }
 
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
 
   // --- DISK -> GPU ---
   // This mirrors exactly what lock_or_prepare_batch Tier::GPU arm does when the batch is
   // disk-resident and the target memory space is GPU.
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
   }
 
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 }
 
 TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk]")
@@ -166,7 +166,7 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
 
   const size_t num_rows = 500;
   auto batch            = make_gpu_batch(*gpu_space, num_rows);
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // Snapshot column values before round-trip
   auto table_before = sirius::get_cudf_table_view(*batch);
@@ -177,26 +177,26 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
              cudaMemcpyDeviceToHost);
 
   const size_t size_before = [&batch]() {
-    auto ro = batch->to_read_only();
-    return ro.get_data()->get_size_in_bytes();
+    auto ro = batch->get_read_only();
+    return ro->get_data()->get_size_in_bytes();
   }();
   REQUIRE(size_before > 0);
 
   // GPU -> DISK
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
+      mut->convert_to<cucascade::disk_data_representation>(registry, disk_space, stream));
   }
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::DISK);
 
   // DISK -> GPU
   {
-    auto mut = batch->to_mutable();
+    auto mut = batch->get_mutable();
     REQUIRE_NOTHROW(
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream));
   }
-  REQUIRE(batch->to_read_only().get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
+  REQUIRE(batch->get_read_only()->get_memory_space()->get_tier() == cucascade::memory::Tier::GPU);
 
   // Verify schema and shape
   auto table_after = sirius::get_cudf_table_view(*batch);
@@ -214,8 +214,8 @@ TEST_CASE("DISK->GPU conversion preserves data correctness", "[gpu_pipeline_disk
 
   // Size should be unchanged (same data, same GPU format)
   const size_t size_after = [&batch]() {
-    auto ro = batch->to_read_only();
-    return ro.get_data()->get_size_in_bytes();
+    auto ro = batch->get_read_only();
+    return ro->get_data()->get_size_in_bytes();
   }();
   REQUIRE(size_after == size_before);
 }

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -137,15 +137,15 @@ struct pipeline_task_history_fixture {
 
     auto& registry = sirius::converter_registry::get();
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::host_data_representation>(registry, host_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::host_data_representation>(registry, host_space, stream);
     }
     stream.synchronize();
 
     {
-      auto ro = batch->to_read_only();
-      REQUIRE(ro.get_data() != nullptr);
-      REQUIRE(ro.get_data()->get_current_tier() == cucascade::memory::Tier::HOST);
+      auto ro = batch->get_read_only();
+      REQUIRE(ro->get_data() != nullptr);
+      REQUIRE(ro->get_data()->get_current_tier() == cucascade::memory::Tier::HOST);
     }
     return batch;
   }

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -204,8 +204,8 @@ inline void validate_scanned_batches(
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     }
     auto table_view = sirius::get_cudf_table_view(*batch);
 
@@ -293,8 +293,8 @@ inline void validate_projected_id_price_batches(
   for (auto const& batch : batches) {
     REQUIRE(batch != nullptr);
     {
-      auto mut = batch->to_mutable();
-      mut.convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
+      auto mut = batch->get_mutable();
+      mut->convert_to<cucascade::gpu_table_representation>(registry, gpu_space, stream);
     }
     auto table_view = sirius::get_cudf_table_view(*batch);
 


### PR DESCRIPTION
## Summary
- Migrate Sirius to the tightened `data_batch` API: `make`, `get_read_only`, `get_mutable`, `try_get_*`, and explicit `to_idle` release.
- Apply the migration across active operators, shared helpers, tests, docs, _and_ `src/legacy/`.

## Verification
- `pixi run make`
- `pixi run make legacy-release`
- `pixi run make test` (`1504/1504` passed)
- Legacy TPCH SQLLogicTest passed with `SIRIUS_DISABLE=1`
- TPCH benchmark validation: SF1 `22/22`; SF10 strict `20/22`, with Q8/Q14 passing at `1e-2` float tolerance.