### PR TITLE
build(cucascade): build against PR #150 cudf-free-core split

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,11 @@ set(CUCASCADE_BUILD_SHARED_LIBS
 set(CUCASCADE_BUILD_STATIC_LIBS
     ON
     CACHE BOOL "" FORCE)
+# Sirius consumes cucascade's cudf-coupled representations and converters (PR
+# #150 split these into the optional cucascade_cudf target), so build it.
+set(CUCASCADE_BUILD_CUDF
+    ON
+    CACHE BOOL "" FORCE)
 set(CUCASCADE_WARNINGS_AS_ERRORS
     OFF
     CACHE BOOL "" FORCE)
@@ -137,7 +142,9 @@ if(VCPKG_BUILD AND TARGET CUDA::cudart_static)
                                                       Static)
   endfunction()
 
-  foreach(_target cucascade_objects cucascade_static cucascade_shared)
+  foreach(_target
+          cucascade_objects cucascade_static cucascade_shared
+          cucascade_cudf_objects cucascade_cudf_static cucascade_cudf_shared)
     if(TARGET "${_target}")
       sirius_prefer_static_cudart("${_target}")
     endif()
@@ -362,12 +369,16 @@ foreach(_target sirius_extension sirius_loadable_extension)
                                PRIVATE ${SIRIUS_LEGACY_COMPILE_DEFINITIONS})
   endif()
 
+  # cuCascade::cucascade_cudf holds the cudf-coupled representations and
+  # converters Sirius uses; it transitively links the cudf-free core
+  # (cuCascade::cucascade) and cudf::cudf.
   target_link_libraries(
     ${_target}
     cudf::cudf
     rmm::rmm
     spdlog::spdlog
     cuCascade::cucascade
+    cuCascade::cucascade_cudf
     yaml-cpp::yaml-cpp
     telemetry_bridge)
 
@@ -429,11 +440,12 @@ endif()
 
 # Required by DuckDB's export set (duckdb_static -> sirius_extension ->
 # cucascade_static / telemetry_bridge). cucascade upstream PR #126 split
-# topology_discovery into its own static target — list it here so the export set
-# covers the dependency chain.
+# topology_discovery into its own static target, and PR #150 split the
+# cudf-coupled code into cucascade_cudf_static — list both here so the export
+# set covers the full dependency chain.
 install(
-  TARGETS sirius_extension cucascade_static cucascade_topology_discovery_static
-          telemetry_bridge
+  TARGETS sirius_extension cucascade_static cucascade_cudf_static
+          cucascade_topology_discovery_static telemetry_bridge
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
@@ -663,6 +675,7 @@ target_link_libraries(
   rmm::rmm
   spdlog::spdlog
   cuCascade::cucascade
+  cuCascade::cucascade_cudf
   PkgConfig::LIBURING
   PkgConfig::NUMA)
 link_extension_libraries(parquet_benchmark "")

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -25,6 +25,7 @@
 #include "planner/query.hpp"
 #include "sirius_context.hpp"
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/execution/execution_context.hpp>

--- a/src/data/host_parquet_representation_converters.cpp
+++ b/src/data/host_parquet_representation_converters.cpp
@@ -23,7 +23,8 @@
 #include <op/scan/prefetched_data_source.hpp>
 
 // cucascade
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/expression_executor/gpu_expression_executor.cpp
+++ b/src/expression_executor/gpu_expression_executor.cpp
@@ -24,7 +24,7 @@
 #include <sirius/exception.hpp>
 
 // cucascade
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <data/data_batch_utils.hpp>
 
 // duckdb

--- a/src/include/data/cached_data_representation.hpp
+++ b/src/include/data/cached_data_representation.hpp
@@ -19,8 +19,8 @@
 // cucascade
 #include "host_parquet_representation.hpp"
 
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/common.hpp>
-#include <cucascade/data/cpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 // standard library

--- a/src/include/data/convertible_data_batch.hpp
+++ b/src/include/data/convertible_data_batch.hpp
@@ -22,11 +22,11 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/disk_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>

--- a/src/include/data/convertible_gpu_pipeline_task.hpp
+++ b/src/include/data/convertible_gpu_pipeline_task.hpp
@@ -27,9 +27,9 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>

--- a/src/include/data/data_batch_utils.hpp
+++ b/src/include/data/data_batch_utils.hpp
@@ -20,8 +20,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <atomic>
 #include <cstdint>

--- a/src/include/data/sirius_converter_registry.hpp
+++ b/src/include/data/sirius_converter_registry.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <cucascade/data/cpu_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/builtin_converters.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <data/host_parquet_representation_converters.hpp>
 #include <log/logging.hpp>

--- a/src/include/op/aggregate/gpu_aggregate_impl.hpp
+++ b/src/include/op/aggregate/gpu_aggregate_impl.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/cudf_utils.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/op/merge/gpu_merge_impl.hpp
+++ b/src/include/op/merge/gpu_merge_impl.hpp
@@ -19,6 +19,7 @@
 #include <cudf/cudf_utils.hpp>
 #include <cudf/types.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/op/order/gpu_order_impl.hpp
+++ b/src/include/op/order/gpu_order_impl.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/cudf_utils.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/op/partition/gpu_partition_impl.hpp
+++ b/src/include/op/partition/gpu_partition_impl.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/cudf_utils.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/op/result/host_table_chunk_reader.hpp
+++ b/src/include/op/result/host_table_chunk_reader.hpp
@@ -32,9 +32,9 @@
 #include <cudf/types.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/cudf/host_table.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
-#include <cucascade/memory/host_table.hpp>
 
 // standard library
 #include <memory>

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -32,10 +32,10 @@
 #include <sirius_context.hpp>
 
 // cucascade
+#include <cucascade/cudf/host_table.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
-#include <cucascade/memory/host_table.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 

--- a/src/include/op/scan/pinned_table_gpu_ingestible.hpp
+++ b/src/include/op/scan/pinned_table_gpu_ingestible.hpp
@@ -24,7 +24,7 @@
 #include <cudf/column/column.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator_data.hpp
@@ -21,6 +21,7 @@
 #include <op/sirius_physical_operator.hpp>
 
 // cucascade
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/src/include/pipeline/batch_lock_utils.hpp
+++ b/src/include/pipeline/batch_lock_utils.hpp
@@ -20,9 +20,9 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <data/sirius_converter_registry.hpp>
 

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -31,7 +31,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/vector.hpp>

--- a/src/legacy/expression_executor/gpu_expression_executor.cpp
+++ b/src/legacy/expression_executor/gpu_expression_executor.cpp
@@ -24,7 +24,7 @@
 #include <operator/gpu_materialize.hpp>
 
 // cucascade
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <data/data_batch_utils.hpp>
 
 // duckdb

--- a/src/op/result/host_table_chunk_reader.cpp
+++ b/src/op/result/host_table_chunk_reader.cpp
@@ -20,6 +20,7 @@
 #include <op/result/host_table_chunk_reader.hpp>
 
 // cucascade
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
 // duckdb
@@ -43,21 +44,25 @@ host_table_chunk_reader::column_reader::column_reader(
   }
   size       = static_cast<size_t>(col.num_rows);
   null_count = static_cast<size_t>(col.null_count);
+  // cucascade's column_metadata::type_id is now a generic int32_t tag (PR #150
+  // decoupled the core from cudf); cast it back to the cudf::type_id it encodes.
+  auto const cudf_type_id = static_cast<cudf::type_id>(col.type_id);
   cudf_col_type =
-    col.scale != 0 ? cudf::data_type(col.type_id, col.scale) : cudf::data_type(col.type_id);
+    col.scale != 0 ? cudf::data_type(cudf_type_id, col.scale) : cudf::data_type(cudf_type_id);
   if (!col.has_null_mask) { null_count = 0; }
 
   data_accessor.initialize(col.data_offset, allocation);
 
   if (null_count > 0) { mask_accessor.initialize(col.null_mask_offset, allocation); }
 
-  if (col.type_id == cudf::type_id::STRING) {
+  if (cudf_type_id == cudf::type_id::STRING) {
     if (col.children.size() != 1) {
       throw std::runtime_error(
         "[host_table_chunk_reader::column_reader::initialize_accessors] STRING type must have one "
         "child node for offsets.");
     }
-    use_int64_offsets = (col.children[0].type_id == cudf::type_id::INT64);
+    use_int64_offsets =
+      (static_cast<cudf::type_id>(col.children[0].type_id) == cudf::type_id::INT64);
     if (use_int64_offsets) {
       offset_accessor_64.initialize(col.children[0].data_offset, allocation);
     } else {

--- a/src/op/scan/cpu_source_task.cpp
+++ b/src/op/scan/cpu_source_task.cpp
@@ -24,9 +24,9 @@
 
 #include <nvtx3/nvtx3.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/cudf/host_table.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
-#include <cucascade/memory/host_table.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <duckdb/common/types/validity_mask.hpp>
 #include <duckdb/common/types/vector.hpp>
@@ -167,7 +167,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
     cudf::size_type nulls = 0;
 
     cucascade::memory::column_metadata col{};
-    col.type_id  = sirius::get_cudf_type(sirius_t).id();
+    col.type_id  = static_cast<int32_t>(sirius::get_cudf_type(sirius_t).id());
     col.num_rows = num_rows;
     col.scale    = 0;
     if (sirius_t.is_decimal()) { col.scale = static_cast<int32_t>(sirius_t.decimal_scale()); }
@@ -219,7 +219,7 @@ static std::shared_ptr<cucascade::data_batch> chunk_to_data_batch(
 
       // Child: offsets
       cucascade::memory::column_metadata offsets_child{};
-      offsets_child.type_id       = cudf::type_id::INT32;
+      offsets_child.type_id       = static_cast<int32_t>(cudf::type_id::INT32);
       offsets_child.num_rows      = num_rows + 1;
       offsets_child.null_count    = 0;
       offsets_child.has_null_mask = false;

--- a/src/op/scan/duckdb_scan_executor.cpp
+++ b/src/op/scan/duckdb_scan_executor.cpp
@@ -17,9 +17,9 @@
 #include "op/scan/duckdb_scan_executor.hpp"
 
 #include "creator/task_creator.hpp"
-#include "cucascade/data/cpu_data_representation.hpp"
+#include "cucascade/cudf/gpu_data_representation.hpp"
+#include "cucascade/cudf/host_data_representation.hpp"
 #include "cucascade/data/data_batch.hpp"
-#include "cucascade/data/gpu_data_representation.hpp"
 #include "data/cached_data_representation.hpp"
 #include "data/data_batch_utils.hpp"
 #include "data/host_parquet_representation.hpp"

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -29,7 +29,7 @@
 #include <op/scan/duckdb_scan_task.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 
 // duckdb
@@ -265,7 +265,7 @@ duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_ro
   if (type.is_varchar()) {
     // VARCHAR column: data buffer + offsets child
     column_metadata offsets_child{};
-    offsets_child.type_id          = cudf::type_id::INT32;
+    offsets_child.type_id          = static_cast<int32_t>(cudf::type_id::INT32);
     offsets_child.num_rows         = static_cast<cudf::size_type>(num_rows + 1);
     offsets_child.null_count       = 0;
     offsets_child.scale            = 0;
@@ -277,7 +277,7 @@ duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_ro
     offsets_child.data_size        = (num_rows + 1) * sizeof(int32_t);
 
     column_metadata col{};
-    col.type_id          = cudf::type_id::STRING;
+    col.type_id          = static_cast<int32_t>(cudf::type_id::STRING);
     col.num_rows         = static_cast<cudf::size_type>(num_rows);
     col.null_count       = static_cast<cudf::size_type>(null_count);
     col.scale            = 0;
@@ -294,7 +294,7 @@ duckdb_scan_task_local_state::column_builder::make_column_metadata(size_t num_ro
     auto cudf_type = sirius::get_cudf_type(type);
 
     column_metadata col{};
-    col.type_id          = cudf_type.id();
+    col.type_id          = static_cast<int32_t>(cudf_type.id());
     col.num_rows         = static_cast<cudf::size_type>(num_rows);
     col.null_count       = static_cast<cudf::size_type>(null_count);
     col.scale            = cudf_type.scale();

--- a/src/op/scan/pinned_table_gpu_ingestible.cpp
+++ b/src/op/scan/pinned_table_gpu_ingestible.cpp
@@ -33,9 +33,9 @@
 #include <cuda_runtime.h>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 
 // standard library

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -29,8 +29,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 // cucascade
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 // standard library

--- a/src/op/sirius_physical_filter.cpp
+++ b/src/op/sirius_physical_filter.cpp
@@ -22,8 +22,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <duckdb/common/exception.hpp>
 
 namespace sirius {

--- a/src/op/sirius_physical_limit.cpp
+++ b/src/op/sirius_physical_limit.cpp
@@ -23,7 +23,7 @@
 
 #include <nvtx3/nvtx3.hpp>
 
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 
 namespace sirius {
 namespace op {

--- a/src/op/sirius_physical_projection.cpp
+++ b/src/op/sirius_physical_projection.cpp
@@ -22,8 +22,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <duckdb/common/exception.hpp>
 
 namespace sirius {

--- a/src/op/sirius_physical_result_collector.cpp
+++ b/src/op/sirius_physical_result_collector.cpp
@@ -27,7 +27,7 @@
 #include <sirius_interface.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>

--- a/src/op/sirius_physical_table_scan.cpp
+++ b/src/op/sirius_physical_table_scan.cpp
@@ -28,8 +28,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <format>
 

--- a/src/op/sirius_physical_top_n.cpp
+++ b/src/op/sirius_physical_top_n.cpp
@@ -33,7 +33,7 @@
 
 #include <nvtx3/nvtx3.hpp>
 
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -42,8 +42,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <limits>
 #include <optional>

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -40,6 +40,7 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
 #include <algorithm>

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -38,6 +38,7 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <cucascade/memory/small_pinned_host_memory_resource.hpp>

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -29,9 +29,9 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/memory_space.hpp>
 

--- a/test/cpp/config/test_context.cpp
+++ b/test/cpp/config/test_context.cpp
@@ -24,8 +24,8 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <cucascade/memory/topology_discovery.hpp>

--- a/test/cpp/data/test_convertible_data_batch.cpp
+++ b/test/cpp/data/test_convertible_data_batch.cpp
@@ -19,7 +19,7 @@
 
 #include <rmm/cuda_stream.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/memory/common.hpp>

--- a/test/cpp/data/test_host_parquet_representation.cpp
+++ b/test/cpp/data/test_host_parquet_representation.cpp
@@ -27,7 +27,8 @@
 #include <memory/sirius_memory_reservation_manager.hpp>
 
 // cucascade
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/builtin_converters.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/memory_space.hpp>

--- a/test/cpp/debug/test_debug_utils.cpp
+++ b/test/cpp/debug/test_debug_utils.cpp
@@ -32,8 +32,8 @@
 #include <cuda_runtime.h>
 
 #include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/test/cpp/downgrade/test_downgrade_disk.cpp
+++ b/test/cpp/downgrade/test_downgrade_disk.cpp
@@ -27,12 +27,12 @@
 #include <utils/utils.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
 #include <cucascade/data/disk_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 
 // cudf / rmm

--- a/test/cpp/downgrade/test_downgrade_executor.cpp
+++ b/test/cpp/downgrade/test_downgrade_executor.cpp
@@ -25,11 +25,11 @@
 #include <utils/utils.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 
 // cudf / rmm

--- a/test/cpp/downgrade/test_downgrade_lifecycle.cpp
+++ b/test/cpp/downgrade/test_downgrade_lifecycle.cpp
@@ -26,11 +26,11 @@
 #include <utils/utils.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 
 // cudf / rmm

--- a/test/cpp/expression_executor/test_gpu_expression_executor.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor.cpp
@@ -21,7 +21,7 @@
 #include <utils/utils.hpp>
 
 // sirius
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>

--- a/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
+++ b/test/cpp/expression_executor/test_gpu_expression_executor_ast_equivalence.cpp
@@ -40,7 +40,7 @@
 #include <utils/utils.hpp>
 
 // sirius — AST types + translators + executor
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>

--- a/test/cpp/memory/test_host_table_utils.cpp
+++ b/test/cpp/memory/test_host_table_utils.cpp
@@ -28,8 +28,8 @@
 #include <op/scan/duckdb_scan_task.hpp>
 
 // cucascade
-#include <cucascade/data/cpu_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 
 // cudf
 #include <cudf/null_mask.hpp>
@@ -702,7 +702,7 @@ TEST_CASE("host_table_utils - metadata offsets match packed data",
 
   auto const& string_col = cols[2];
   REQUIRE(string_col.children.size() == 1);
-  REQUIRE(string_col.children[0].type_id == cudf::type_id::INT64);
+  REQUIRE(static_cast<cudf::type_id>(string_col.children[0].type_id) == cudf::type_id::INT64);
 
   sirius::memory::multiple_blocks_allocation_accessor<int64_t> offset_accessor;
   offset_accessor.initialize(string_col.children[0].data_offset, allocation);

--- a/test/cpp/operator/operator_test_utils.hpp
+++ b/test/cpp/operator/operator_test_utils.hpp
@@ -34,7 +34,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>

--- a/test/cpp/operator/test_physical_filter.cpp
+++ b/test/cpp/operator/test_physical_filter.cpp
@@ -20,7 +20,7 @@
 #include "operator_type_traits.hpp"
 
 #include <catch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>

--- a/test/cpp/operator/test_physical_mark_join.cpp
+++ b/test/cpp/operator/test_physical_mark_join.cpp
@@ -19,7 +19,7 @@
 #include "operator_test_utils.hpp"
 
 #include <catch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/planner/operator/logical_comparison_join.hpp>

--- a/test/cpp/operator/test_physical_result_collector.cpp
+++ b/test/cpp/operator/test_physical_result_collector.cpp
@@ -26,7 +26,7 @@
 #include <sirius_interface.hpp>
 
 // cucascades
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 
 // cudf
 #include <cudf/column/column_factories.hpp>

--- a/test/cpp/operator/test_physical_table_scan.cpp
+++ b/test/cpp/operator/test_physical_table_scan.cpp
@@ -20,7 +20,7 @@
 #include "operator_type_traits.hpp"
 
 #include <catch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/planner/filter/constant_filter.hpp>
 #include <duckdb/planner/table_filter.hpp>

--- a/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_disk_readback.cpp
@@ -25,10 +25,10 @@
 
 #include <rmm/cuda_stream.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/disk_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 
 #include <filesystem>

--- a/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
+++ b/test/cpp/pipeline/test_gpu_pipeline_task_history.cpp
@@ -30,8 +30,8 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cucascade/data/cpu_data_representation.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/reservation_aware_resource_adaptor.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>

--- a/test/cpp/scan/test_pinned_table_gpu_ingestible.cpp
+++ b/test/cpp/scan/test_pinned_table_gpu_ingestible.cpp
@@ -23,7 +23,7 @@
 
 #include "catch.hpp"
 
-#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <op/scan/parquet_gpu_ingestible.hpp>
 #include <op/scan/pinned_table_gpu_ingestible.hpp>

--- a/test/cpp/scan/test_utils.hpp
+++ b/test/cpp/scan/test_utils.hpp
@@ -26,9 +26,9 @@
 #include <data/data_batch_utils.hpp>
 
 // cucascade
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <data/sirius_converter_registry.hpp>
 #include <helper/helper.hpp>

--- a/test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
+++ b/test/cpp/scan_manager/test_pin_table_multi_gpu.cpp
@@ -42,6 +42,8 @@
 #include <cuda_runtime.h>
 
 #include <catch.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <duckdb.hpp>
 #include <spdlog/spdlog.h>

--- a/test/cpp/utils/test_validation_utility.hpp
+++ b/test/cpp/utils/test_validation_utility.hpp
@@ -32,8 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
 #include <data/data_batch_utils.hpp>
 
 #include <iostream>


### PR DESCRIPTION
cuCascade PR #150 splits the library into a cudf-free core (cuCascade::cucascade) and an optional cuCascade::cucascade_cudf target holding the cudf-coupled representations, converters, and bandwidth profiler. Point the submodule at the PR head and adapt Sirius to the new layout.

CMake:
- Force CUCASCADE_BUILD_CUDF=ON and link cuCascade::cucascade_cudf into both extension targets and parquet_benchmark (it transitively pulls the core + cudf::cudf).
- Add the cucascade_cudf_* targets to the VCPKG static-cudart patching loop and cucascade_cudf_static to the DuckDB install/export set.

Includes (headers moved data/,memory/ -> cudf/):
- data/cpu_data_representation.hpp -> cudf/host_data_representation.hpp
- data/gpu_data_representation.hpp -> cudf/gpu_data_representation.hpp
- memory/host_table.hpp           -> cudf/host_table.hpp
- Include cudf/builtin_converters.hpp where register_builtin_converters() is
  called (it moved out of representation_converter.hpp).
- Add explicit cudf/* includes to files that previously obtained these symbols
  transitively via data_batch.hpp, which is now cudf-free.

column_metadata: its type_id field changed from cudf::type_id to an opaque int32_t tag. Cast at write sites (static_cast<int32_t>) and read sites (static_cast<cudf::type_id>), matching cucascade's as_cudf_type_id idiom.

Builds clean (extension + unittest); the converter/host-table/scan unit tests pass on RTX PRO 6000.