### PR TITLE
WIP: fix(agg): ensure first() ungrouped aggregate returns deterministic results

### DIFF
--- a/src/include/data/data_batch_utils.hpp
+++ b/src/include/data/data_batch_utils.hpp
@@ -114,6 +114,33 @@ inline std::shared_ptr<cucascade::data_batch> make_data_batch(
   return std::make_shared<cucascade::data_batch>(get_next_batch_id(), std::move(gpu_repr));
 }
 
+/// Overload that uses a caller-supplied @p batch_id instead of allocating a fresh one.
+/// Used by sirius_gpu_scan_operator::execute() to propagate the ID pre-assigned in
+/// get_next_task_input_data() (under the scan-order mutex) so that output batch IDs
+/// reflect split-pull order rather than task-completion order.
+inline std::shared_ptr<cucascade::data_batch> make_data_batch(
+  cudf::table&& table,
+  cucascade::memory::memory_space& memory_space,
+  rmm::cuda_stream_view writer_stream,
+  uint64_t batch_id)
+{
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
+    std::make_unique<cudf::table>(std::move(table)), memory_space, writer_stream);
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
+/// @copydoc make_data_batch(cudf::table&&, memory_space&, rmm::cuda_stream_view, uint64_t)
+inline std::shared_ptr<cucascade::data_batch> make_data_batch(
+  std::unique_ptr<cudf::table> table,
+  cucascade::memory::memory_space& memory_space,
+  rmm::cuda_stream_view writer_stream,
+  uint64_t batch_id)
+{
+  auto gpu_repr = std::make_unique<cucascade::gpu_table_representation>(
+    std::move(table), memory_space, writer_stream);
+  return std::make_shared<cucascade::data_batch>(batch_id, std::move(gpu_repr));
+}
+
 /**
  * @brief Create a shared_ptr<data_batch> from a unique_ptr<cudf::table>, recording the writer
  * event.

--- a/src/include/op/scan/duckdb_scan_task.hpp
+++ b/src/include/op/scan/duckdb_scan_task.hpp
@@ -50,6 +50,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace sirius::op::scan {
 //===----------------------------------------------------------------------===//
@@ -317,9 +318,13 @@ class duckdb_scan_task_local_state : public sirius::pipeline::sirius_pipeline_ta
   /**
    * @brief Creates a data batch from the current state of the column builders.
    *
+   * @param batch_id Pre-assigned batch ID to use. If omitted, a new ID is allocated via
+   *                 get_next_batch_id(). Pass a pre-assigned ID (obtained before scheduling the
+   *                 successor task) to guarantee that this batch's ID is lower than any batch
+   *                 the successor task could produce, preserving scan order in batch IDs.
    * @return A shared pointer to the created data batch.
    */
-  std::shared_ptr<data_batch> make_data_batch();
+  std::shared_ptr<data_batch> make_data_batch(std::optional<uint64_t> batch_id = std::nullopt);
 
  private:
   //===----------Fields----------===//

--- a/src/include/op/scan/sirius_gpu_scan_operator.hpp
+++ b/src/include/op/scan/sirius_gpu_scan_operator.hpp
@@ -23,6 +23,7 @@
 
 // standard library
 #include <memory>
+#include <mutex>
 #include <optional>
 
 namespace sirius::scan_manager {
@@ -158,6 +159,9 @@ class sirius_gpu_scan_operator : public sirius_physical_operator {
   std::unique_ptr<io::ingestible_table_info> _table_info;
   std::shared_ptr<io::gpu_ingestible> _ingestible;
   std::unique_ptr<scan_manager::split_connector> _split_connector;
+  // Serializes split-pull and pre_assigned_batch_id assignment so that batch IDs
+  // reflect split-pull order (scan order) rather than task-completion order.
+  std::mutex _scan_order_mutex_;
 };
 
 }  // namespace sirius::op::scan

--- a/src/include/op/sirius_physical_operator.hpp
+++ b/src/include/op/sirius_physical_operator.hpp
@@ -93,6 +93,12 @@ class operator_data {
    */
   [[nodiscard]] virtual operator_data_type get_type() const { return operator_data_type::BASE; }
 
+  // Batch ID pre-assigned by sirius_gpu_scan_operator::get_next_task_input_data() while
+  // holding the scan-order mutex, so that assignment order matches split-pull order.
+  // execute() uses this as the output data_batch's ID instead of calling get_next_batch_id()
+  // at completion time, which would be non-deterministic under concurrent execution.
+  uint64_t pre_assigned_batch_id = 0;
+
   /**
    * @brief Whether this operator_data refers to GPU-resident data already paid
    *        for upstream (e.g. a pinned-cache batch). Defaults to false.

--- a/src/include/op/sirius_physical_ungrouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate.hpp
@@ -24,7 +24,10 @@
 #include "expression/ast/node.hpp"
 #include "op/sirius_physical_operator.hpp"
 
+#include <cstdint>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 
 namespace sirius {
 namespace op {
@@ -46,10 +49,21 @@ class sirius_physical_ungrouped_aggregate : public sirius_physical_operator {
 
   bool is_source() const override { return true; }
 
+  // Returns the source (scan) batch ID that produced the local aggregate output with
+  // `output_batch_id`. Used by the merge operator to sort partial results in scan order
+  // before selecting NTH_ELEMENT(0) for the first() aggregate.
+  uint64_t get_source_batch_id(uint64_t output_batch_id) const;
+
  public:
   bool is_sink() const override { return true; }
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
+
+ private:
+  // Maps output_batch_id -> source (scan) batch_id.  Populated by execute() and
+  // read by sirius_physical_ungrouped_aggregate_merge to restore scan order.
+  mutable std::mutex source_id_mutex_;
+  std::unordered_map<uint64_t, uint64_t> output_to_source_id_;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
+++ b/src/include/op/sirius_physical_ungrouped_aggregate_merge.hpp
@@ -48,7 +48,7 @@ class sirius_physical_ungrouped_aggregate_merge : public sirius_physical_operato
   //! The aggregates that have to be computed
   duckdb::vector<std::unique_ptr<sirius::ast::node>> aggregates;
 
-  sirius_physical_operator* child_op;
+  sirius_physical_operator* child_op = nullptr;
   sirius_physical_operator* get_child_op() const { return child_op; }
 
   bool is_source() const override { return true; }

--- a/src/op/scan/duckdb_scan_task.cpp
+++ b/src/op/scan/duckdb_scan_task.cpp
@@ -441,7 +441,8 @@ void duckdb_scan_task_local_state::initialize_local_table_function_state(
   }
 }
 
-std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_batch()
+std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_batch(
+  std::optional<uint64_t> batch_id)
 {
   using data_batch               = cucascade::data_batch;
   using host_table_allocation    = cucascade::memory::host_table_allocation;
@@ -463,8 +464,8 @@ std::shared_ptr<cucascade::data_batch> duckdb_scan_task_local_state::make_data_b
   // Make the host table representation
   auto table = std::make_unique<host_data_representation>(std::move(table_allocation), _host_space);
 
-  // Create the data batch and return
-  return std::make_shared<data_batch>(get_next_batch_id(), std::move(table));
+  // Use the pre-assigned ID if provided, otherwise allocate a fresh one.
+  return std::make_shared<data_batch>(batch_id.value_or(get_next_batch_id()), std::move(table));
 }
 
 //===----------------------------------------------------------------------===//
@@ -582,6 +583,14 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
     if (STANDARD_VECTOR_SIZE + l_state._row_offset >= l_state._estimated_rows_per_batch) { break; }
   }
 
+  // Pre-assign this task's batch ID BEFORE scheduling the successor task.
+  // Without this, a concurrent successor task could race to call get_next_batch_id() first
+  // and receive a lower ID than this task's batch, breaking scan order in batch IDs.
+  // Holding a lower ID here guarantees: batch_id(task N) < batch_id(task N+1) for any N,
+  // which the first() aggregate merge uses to select the earliest-scanned value.
+  auto const this_batch_id =
+    l_state._row_offset > 0 ? std::make_optional(get_next_batch_id()) : std::nullopt;
+
   // Add tasks back to the queue if the local scan state is not finished
   if (!l_state._local_state_drained) {
     // Create a new local state, passing the existing local_tf_state to continue the scan
@@ -605,7 +614,7 @@ std::unique_ptr<op::operator_data> duckdb_scan_task::compute_task(rmm::cuda_stre
   // Make data batch and push to repository
   if (l_state._row_offset > 0) {
     return std::make_unique<op::pipelineable_operator_data>(
-      std::vector<std::shared_ptr<cucascade::data_batch>>{l_state.make_data_batch()});
+      std::vector<std::shared_ptr<cucascade::data_batch>>{l_state.make_data_batch(this_batch_id)});
   }
 
   return std::make_unique<op::pipelineable_operator_data>(

--- a/src/op/scan/sirius_gpu_scan_operator.cpp
+++ b/src/op/scan/sirius_gpu_scan_operator.cpp
@@ -124,11 +124,24 @@ bool sirius_gpu_scan_operator::all_ports_empty()
 
 std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::get_next_task_input_data()
 {
-  // Delegate to the ingestible. The unprepared path pulls directly from the connector.
-  if (_ingestible) { return _ingestible->consume_next_input(*_split_connector); }
-  auto next = _split_connector->get_next_split();
-  if (!next.has_value()) { return nullptr; }
-  return std::move(*next);
+  // Hold the scan-order mutex for the entire pull + batch-ID assignment so that
+  // pre_assigned_batch_id values reflect split-pull order (scan order).
+  // Without this, concurrent callers could race: thread A pulls split 0 then
+  // thread B pulls split 1, but B calls get_next_batch_id() first, giving split 0
+  // a higher ID than split 1 and breaking the ordering that first() relies on.
+  std::lock_guard<std::mutex> lg(_scan_order_mutex_);
+
+  std::unique_ptr<op::operator_data> input;
+  if (_ingestible) {
+    input = _ingestible->consume_next_input(*_split_connector);
+  } else {
+    auto next = _split_connector->get_next_split();
+    if (!next.has_value()) { return nullptr; }
+    input = std::move(*next);
+  }
+
+  if (input) { input->pre_assigned_batch_id = get_next_batch_id(); }
+  return input;
 }
 
 //===----------------------------------------------------------------------===//
@@ -224,7 +237,11 @@ std::unique_ptr<op::operator_data> sirius_gpu_scan_operator::execute(
       "scan_operator_input or scan_operator_with_pinned_table_input.");
   }
 
-  auto batch = sirius::make_data_batch(std::move(table), *mem_space, stream);
+  // Use the batch ID pre-assigned in get_next_task_input_data() rather than calling
+  // get_next_batch_id() here. Pre-assignment happens under _scan_order_mutex_ so IDs
+  // reflect split-pull order (scan order); assigning here would be completion order.
+  auto batch =
+    sirius::make_data_batch(std::move(table), *mem_space, stream, input_data.pre_assigned_batch_id);
   std::vector<std::shared_ptr<::cucascade::data_batch>> batches;
   batches.push_back(std::move(batch));
   return std::make_unique<pipelineable_operator_data>(std::move(batches));

--- a/src/op/sirius_physical_ungrouped_aggregate.cpp
+++ b/src/op/sirius_physical_ungrouped_aggregate.cpp
@@ -45,6 +45,7 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/gpu_data_representation.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <optional>
 
@@ -384,10 +385,25 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate::execute(
       std::make_unique<cucascade::gpu_table_representation>(std::move(out_table), *space, stream);
     std::unique_ptr<cucascade::idata_representation> output_data = std::move(out_repr);
     auto const batch_id                                          = ::sirius::get_next_batch_id();
+
+    // Record output_batch_id -> source (scan) batch_id so the merge operator can restore
+    // scan order when selecting NTH_ELEMENT(0) for first() aggregates.
+    {
+      std::lock_guard<std::mutex> lg(source_id_mutex_);
+      output_to_source_id_[batch_id] = batch.get_batch_id();
+    }
+
     outputs.push_back(std::make_shared<cucascade::data_batch>(batch_id, std::move(output_data)));
   }
 
   return std::make_unique<pipelineable_operator_data>(outputs);
+}
+
+uint64_t sirius_physical_ungrouped_aggregate::get_source_batch_id(uint64_t output_batch_id) const
+{
+  std::lock_guard<std::mutex> lg(source_id_mutex_);
+  auto it = output_to_source_id_.find(output_batch_id);
+  return (it != output_to_source_id_.end()) ? it->second : output_batch_id;
 }
 
 // Helper to deep copy the aggregate AST expressions (used by the merge overload below).
@@ -452,6 +468,31 @@ std::unique_ptr<operator_data> sirius_physical_ungrouped_aggregate_merge::execut
   }
 
   auto layout = build_aggregate_layout(aggregates);
+
+  // For NTH_ELEMENT (first()) aggregates, sort partial results by their source scan
+  // batch ID so that NTH_ELEMENT(0) always selects the value from the earliest-scanned
+  // batch, matching DuckDB's first() semantics. Without this, concurrent pipeline tasks
+  // push results in non-deterministic completion order and first() may return a value
+  // from any batch.
+  if (input_batches.size() > 1) {
+    bool has_nth_element = std::any_of(
+      layout.merge_kinds.begin(), layout.merge_kinds.end(), [](cudf::aggregation::Kind k) {
+        return k == cudf::aggregation::Kind::NTH_ELEMENT;
+      });
+    if (has_nth_element) {
+      auto* local_agg = dynamic_cast<sirius_physical_ungrouped_aggregate*>(child_op);
+      if (local_agg) {
+        std::stable_sort(input_batches.begin(),
+                         input_batches.end(),
+                         [&local_agg](const cucascade::read_only_data_batch& a,
+                                      const cucascade::read_only_data_batch& b) {
+                           return local_agg->get_source_batch_id(a.get_batch_id()) <
+                                  local_agg->get_source_batch_id(b.get_batch_id());
+                         });
+      }
+    }
+  }
+
   std::shared_ptr<cucascade::data_batch> merged_batch;
   if (input_batches.size() == 1) {
     merged_batch = cucascade::data_batch::to_idle(std::move(input_batches[0]));

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -4642,6 +4642,35 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
 }
 
 //===----------------------------------------------------------------------===//
+// first() ungrouped aggregate tests
+//
+// first() uses NTH_ELEMENT(0) in the merge phase. Before the batch-ordering
+// fix, results were non-deterministic when the table spanned multiple scan
+// batches.
+//
+// Note: compare_gpu_vs_cpu() is only reliable for first() on tables small
+// enough to fit in a single scan batch. For multi-batch tables (e.g. lineitem
+// parquet), Sirius and DuckDB may read row groups in different physical orders,
+// so they legitimately disagree on which row is "first" — this is not a bug.
+// Multi-batch ordering correctness is covered by the C++ unit test
+// [merge_ungrouped_agg][first] in test_gpu_merge_impl.cpp.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - first() integer on nation",
+                 "[integration][gpu_execution][cpu_source][first]")
+{
+  compare_gpu_vs_cpu("select first(n_nationkey) from nation;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - first() varchar on nation",
+                 "[integration][gpu_execution][cpu_source][first]")
+{
+  compare_gpu_vs_cpu("select first(n_name) from nation;");
+}
+
+//===----------------------------------------------------------------------===//
 // pin_table tests
 //===----------------------------------------------------------------------===//
 

--- a/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
+++ b/test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
@@ -23,9 +23,18 @@
 #include "scan/test_utils.hpp"
 #include "utils/utils.hpp"
 
+#include <cudf/column/column_factories.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/utilities/bit.hpp>
 
 #include <cucascade/memory/memory_space.hpp>
+#include <duckdb/planner/expression/bound_aggregate_expression.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <expression/ast/from_duckdb.hpp>
+#include <expression/ast/node.hpp>
+#include <helper/type_conversions.hpp>
+#include <op/sirius_physical_ungrouped_aggregate.hpp>
+#include <op/sirius_physical_ungrouped_aggregate_merge.hpp>
 
 using namespace sirius;
 using namespace cucascade;
@@ -1084,4 +1093,184 @@ TEST_CASE("Merge order-by with mixed empty and non-empty local order-by results"
                                                      *mem_space);
   ro_batches.clear();
   validate_order_by(input.batches, *output_batch, order_key_idx, column_order);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers and tests for first() batch-ordering correctness
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Creates a 1-row INT32 batch whose single column holds `value`.
+// Represents a local first() partial result (one scalar per input batch).
+std::shared_ptr<cucascade::data_batch> make_single_value_batch(int32_t value,
+                                                               memory_space& mem_space)
+{
+  auto stream = cudf::get_default_stream();
+  auto scalar = cudf::make_numeric_scalar(cudf::data_type{cudf::type_id::INT32}, stream);
+  scalar->set_valid_async(true, stream);
+  using ScalarType = cudf::scalar_type_t<int32_t>;
+  static_cast<ScalarType*>(scalar.get())->set_value(value, stream);
+  auto col = cudf::make_column_from_scalar(*scalar, 1, stream, mem_space.get_default_allocator());
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto table =
+    std::make_unique<cudf::table>(std::move(cols), stream, mem_space.get_default_allocator());
+  return sirius::make_data_batch(std::move(table), mem_space, stream);
+}
+
+// Reads the single INT32 value from a 1-row, 1-column batch.
+int32_t read_single_int32(cucascade::data_batch& batch)
+{
+  auto ro = batch.to_read_only();
+  auto tv = ro.get_data()->cast<cucascade::gpu_table_representation>().get_table_view();
+  int32_t v{};
+  cudaMemcpy(&v, tv.column(0).data<int32_t>(), sizeof(v), cudaMemcpyDeviceToHost);
+  return v;
+}
+
+}  // namespace
+
+// Build a first(col0 :: INT32) aggregate node list for use in local/merge operator constructors.
+// Mirrors the pattern from test_physical_ungrouped_aggregate.cpp.
+namespace {
+
+duckdb::unique_ptr<duckdb::Expression> make_first_expr()
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.push_back(
+    duckdb::make_uniq<duckdb::BoundReferenceExpression>(duckdb::LogicalType::INTEGER, 0));
+  return duckdb::make_uniq<duckdb::BoundAggregateExpression>(
+    duckdb::AggregateFunction("first",
+                              {duckdb::LogicalType::INTEGER},
+                              duckdb::LogicalType::INTEGER,
+                              0,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr),
+    std::move(children),
+    nullptr,
+    nullptr,
+    duckdb::AggregateType::NON_DISTINCT);
+}
+
+duckdb::vector<std::unique_ptr<sirius::ast::node>> make_first_aggregate_nodes()
+{
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs;
+  exprs.push_back(make_first_expr());
+  duckdb::vector<std::unique_ptr<sirius::ast::node>> out;
+  out.reserve(exprs.size());
+  for (auto& e : exprs) {
+    out.push_back(e ? sirius::ast::from_duckdb(*e) : nullptr);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE("Ungrouped merge NTH_ELEMENT respects batch ordering",
+          "[operator][merge_ungrouped_agg][first]")
+{
+  // Simulate two local first() partial results: batch A (value 10) was scanned before
+  // batch B (value 20).  Batch A is created first, so batch_id(A) < batch_id(B).
+  auto* mem_space = get_shared_mem_space();
+
+  auto batch_a = make_single_value_batch(10, *mem_space);
+  auto batch_b = make_single_value_batch(20, *mem_space);
+
+  REQUIRE(batch_a->get_batch_id() < batch_b->get_batch_id());
+
+  const std::vector<cudf::aggregation::Kind> aggregates = {cudf::aggregation::Kind::NTH_ELEMENT};
+  const std::vector<std::optional<cudf::size_type>> nth_index = {0};
+
+  SECTION("In scan order [A, B] -> first() returns A's value (10)")
+  {
+    std::vector<read_only_data_batch> ro;
+    ro.push_back(batch_a->to_read_only());
+    ro.push_back(batch_b->to_read_only());
+    auto result = gpu_merge_impl::merge_ungrouped_aggregate(
+      ro, aggregates, nth_index, cudf::get_default_stream(), *mem_space);
+    ro.clear();
+    REQUIRE(read_single_int32(*result) == 10);
+  }
+
+  SECTION("Reverse order [B, A] sorted by batch_id -> first() returns A's value (10, the fix)")
+  {
+    std::vector<read_only_data_batch> ro;
+    ro.push_back(batch_b->to_read_only());
+    ro.push_back(batch_a->to_read_only());
+
+    // Reproduce the sort that sirius_physical_ungrouped_aggregate_merge applies
+    // when any NTH_ELEMENT aggregate is present.
+    std::stable_sort(
+      ro.begin(), ro.end(), [](const read_only_data_batch& x, const read_only_data_batch& y) {
+        return x.get_batch_id() < y.get_batch_id();
+      });
+
+    auto result = gpu_merge_impl::merge_ungrouped_aggregate(
+      ro, aggregates, nth_index, cudf::get_default_stream(), *mem_space);
+    ro.clear();
+    REQUIRE(read_single_int32(*result) == 10);
+  }
+}
+
+TEST_CASE("sirius_physical_ungrouped_aggregate_merge first() uses source batch ordering",
+          "[operator][merge_ungrouped_agg][first]")
+{
+  // Regression test for non-deterministic first() under concurrent scan tasks.
+  //
+  // Two scan batches arrive at the local aggregate in reverse completion order
+  // (B finishes before A even though A was scanned first). The merge operator
+  // must still return A's value (10) because the source_id mapping records
+  // scan order, not completion order.
+  //
+  // This test exercises the full production path:
+  //   sirius_physical_ungrouped_aggregate::execute()   -> populates output_to_source_id_
+  //   sirius_physical_ungrouped_aggregate_merge::execute() -> sorts by source_batch_id
+  // Neither the dynamic_cast(child_op) branch nor the source-ID lookup is
+  // exercised by the existing [first] test that calls gpu_merge_impl directly.
+  auto* mem_space = get_shared_mem_space();
+  REQUIRE(mem_space);
+
+  duckdb::vector<sirius::logical_type> types =
+    sirius::from_duckdb_vec({duckdb::LogicalType::INTEGER});
+
+  sirius_physical_ungrouped_aggregate local_op(
+    types, make_first_aggregate_nodes(), 0, duckdb::TupleDataValidityType::CANNOT_HAVE_NULL_VALUES);
+
+  // The child_op constructor deep-copies aggregates and sets child_op = &local_op.
+  // The merge's execute() uses child_op to resolve output_batch_id -> source_batch_id.
+  sirius_physical_ungrouped_aggregate_merge merge_op(&local_op);
+
+  // batch_a is created first → lower batch_id = scan-order first.
+  auto batch_a = make_single_value_batch(10, *mem_space);
+  auto batch_b = make_single_value_batch(20, *mem_space);
+  REQUIRE(batch_a->get_batch_id() < batch_b->get_batch_id());
+
+  // Simulate reverse completion order: task for B finishes before task for A.
+  auto out_b = local_op.execute(pipelineable_operator_data({batch_b}), cudf::get_default_stream());
+  auto out_a = local_op.execute(pipelineable_operator_data({batch_a}), cudf::get_default_stream());
+
+  // Feed the partial results to the merge in completion order [B_out, A_out].
+  std::vector<std::shared_ptr<cucascade::data_batch>> merge_inputs;
+  for (auto& b : dynamic_cast<const pipelineable_operator_data&>(*out_b).get_data_batches()) {
+    merge_inputs.push_back(b);
+  }
+  for (auto& b : dynamic_cast<const pipelineable_operator_data&>(*out_a).get_data_batches()) {
+    merge_inputs.push_back(b);
+  }
+
+  auto result =
+    merge_op.execute(pipelineable_operator_data(merge_inputs), cudf::get_default_stream());
+
+  auto& result_batches =
+    dynamic_cast<const pipelineable_operator_data&>(*result).get_data_batches();
+  REQUIRE(result_batches.size() == 1);
+
+  // A was scanned first (lower source batch_id), so first() must return 10, not 20.
+  REQUIRE(read_single_int32(*result_batches[0]) == 10);
 }


### PR DESCRIPTION
## Context

`first()` without `ORDER BY` is non-deterministic by SQL definition — no engine
is required to return the same row as another. However, a single engine must
return the same result for the same query on the same data across repeated runs.
Before this fix, Sirius violated that contract: concurrent scan tasks raced to
claim batch IDs, so the value returned by `first()` could change between runs
depending on thread scheduling.

Note that the current implementation is incorrect hence I've marked this as draft and WIP.