### PR TITLE
fix(mgpu): enforce partition device pin for cuco-backed operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,6 +520,7 @@ set(TEST_SOURCES
     test/cpp/operator/test_physical_hash_join_mgpu.cpp
     test/cpp/operator/test_physical_order_mgpu.cpp
     test/cpp/operator/test_mgpu_stress.cpp
+    test/cpp/operator/test_partition_memspace_mgpu.cpp
     test/cpp/memory/test_multiple_blocks_allocation_accessor.cpp
     test/cpp/operator/aggregate/test_gpu_merge_impl.cpp
     test/cpp/operator/aggregate/test_physical_grouped_aggregate.cpp

--- a/src/creator/task_creator.cpp
+++ b/src/creator/task_creator.cpp
@@ -61,6 +61,16 @@ task_creator::task_creator(exec::thread_pool_config config,
       _numa_to_gpu[normalized_numa].push_back(static_cast<int>(_sys_topology->gpus[i].id));
     }
   }
+
+  // Device ids that actually have a GPU executor (memory-manager GPU spaces);
+  // partition affinity indexes this, not the physical topology, so the pin
+  // resolves to a real executor when num_gpus < physical GPU count.
+  for (auto const* space : _mem_res_mgr.get_memory_spaces_for_tier(cucascade::memory::Tier::GPU)) {
+    if (space) { _active_gpu_ids.push_back(space->get_device_id()); }
+  }
+  std::sort(_active_gpu_ids.begin(), _active_gpu_ids.end());
+  _active_gpu_ids.erase(std::unique(_active_gpu_ids.begin(), _active_gpu_ids.end()),
+                        _active_gpu_ids.end());
 }
 
 task_creator::~task_creator() { stop(); }
@@ -280,11 +290,12 @@ void task_creator::manager_loop()
             // partitions across GPUs.
             if (auto* partitioned =
                   dynamic_cast<op::partitioned_operator_data*>(pipelineable_input);
-                !preferred_device_id.has_value() && partitioned && _sys_topology &&
-                !_sys_topology->gpus.empty()) {
-              auto n_gpus         = _sys_topology->gpus.size();
-              auto idx            = partitioned->get_partition_idx() % n_gpus;
-              preferred_device_id = static_cast<int>(_sys_topology->gpus[idx].id);
+                !preferred_device_id.has_value() && partitioned && !_active_gpu_ids.empty()) {
+              // Index the active executor set so every task of a partition lands
+              // on the same real GPU (required for cuco tables); the physical
+              // topology would yield phantom pins when num_gpus < physical count.
+              auto idx            = partitioned->get_partition_idx() % _active_gpu_ids.size();
+              preferred_device_id = _active_gpu_ids[idx];
             }
             if (!preferred_device_id.has_value() && pipelineable_input &&
                 !pipelineable_input->get_data_batches().empty()) {

--- a/src/include/creator/task_creator.hpp
+++ b/src/include/creator/task_creator.hpp
@@ -207,6 +207,10 @@ class task_creator {
   std::unordered_map<int, std::vector<int>> _numa_to_gpu;
   /// Round-robin counter for NUMA-affinity routing when multiple GPUs share a NUMA node.
   std::atomic<uint64_t> _numa_to_gpu_rr{0};
+  /// Sorted device ids that actually have a GPU executor (memory-manager GPU
+  /// spaces). Partition affinity indexes this, not the physical topology, so the
+  /// pin resolves to a real executor when num_gpus < physical GPU count.
+  std::vector<int> _active_gpu_ids;
 };
 
 }  // namespace sirius::creator

--- a/src/pipeline/gpu_pipeline_executor.cpp
+++ b/src/pipeline/gpu_pipeline_executor.cpp
@@ -372,6 +372,14 @@ void gpu_pipeline_executor::manager_loop()
           new_local_state->retry_count      = next_retry_count;
           new_local_state->original_task_id = orig_task_id;
 
+          // Preserve the per-task device pin across reschedule. Dropping it lets
+          // an OOM'd partition task scatter to the wrong GPU and touch a cuco
+          // table built on another device (cudaErrorInvalidValue). Only the
+          // local_state pin needs copying; a global-state pin already survives.
+          if (cur_local && cur_local->get_preferred_device_id().has_value()) {
+            new_local_state->set_preferred_device_id(cur_local->get_preferred_device_id().value());
+          }
+
           auto new_task_id =
             _task_creator ? _task_creator->get_next_task_id() : gpu_task->get_task_id();
           auto new_task =

--- a/test/cpp/operator/mgpu_test_utils.hpp
+++ b/test/cpp/operator/mgpu_test_utils.hpp
@@ -67,9 +67,16 @@ struct mgpu_env_params {
   uint64_t concat_batch_bytes         = 100'000'000;
   uint64_t max_build_hash_table_bytes = 90'000'000;
   double usage_limit_fraction         = 0.4;
-  int pipeline_num_threads            = 4;
-  int task_creator_num_threads        = 4;
-  int duckdb_scan_num_threads         = 2;
+  // Absolute per-GPU usage cap in bytes. When non-zero this is emitted as
+  // `usage_limit_bytes` (mutually exclusive with usage_limit_fraction per
+  // sirius_config.cpp:201) so a test can impose a small fixed budget that
+  // forces OOM/reschedule regardless of the host GPU's physical capacity —
+  // essential on big-memory parts (e.g. GB200 ~186 GB) where a fraction
+  // would never trigger pressure at unit-test data scales.
+  uint64_t usage_limit_bytes   = 0;
+  int pipeline_num_threads     = 4;
+  int task_creator_num_threads = 4;
+  int duckdb_scan_num_threads  = 2;
 };
 
 /**
@@ -85,11 +92,13 @@ inline void write_mgpu_yaml(std::filesystem::path const& yaml_path,
     << params.num_gpus
     << "\n"
        "  memory:\n"
-       "    gpu:\n"
-       "      usage_limit_fraction: "
-    << params.usage_limit_fraction
-    << "\n"
-       "      reservation_limit_fraction: 1.0\n"
+       "    gpu:\n";
+  if (params.usage_limit_bytes != 0) {
+    f << "      usage_limit_bytes: " << params.usage_limit_bytes << "\n";
+  } else {
+    f << "      usage_limit_fraction: " << params.usage_limit_fraction << "\n";
+  }
+  f << "      reservation_limit_fraction: 1.0\n"
        "    host:\n"
        "      capacity_bytes: 32000000000\n"
        "      initial_number_pools: 10\n"
@@ -354,7 +363,9 @@ class scoped_log_dir {
  * need: same row count, same string-ToString on every value after a
  * normalized ORDER BY.
  */
-inline void require_gpu_matches_cpu(duckdb::Connection& con, std::string const& inner_query)
+inline void require_gpu_matches_cpu(duckdb::Connection& con,
+                                    std::string const& inner_query,
+                                    bool force_cpu_reference = false)
 {
   auto fb = con.Query("SET enable_duckdb_fallback = false;");
   REQUIRE(fb);
@@ -370,7 +381,23 @@ inline void require_gpu_matches_cpu(duckdb::Connection& con, std::string const& 
   if (gpu_result->HasError()) { UNSCOPED_INFO("gpu_execution error: " << gpu_result->GetError()); }
   REQUIRE_FALSE(gpu_result->HasError());
 
+  // The reference run. By default the plain SELECT is transparently intercepted
+  // and run on the GPU again (a GPU-vs-GPU consistency check). When
+  // force_cpu_reference is set, disable interception around it so it executes on
+  // DuckDB CPU — a true correctness oracle, and immune to GPU memory pressure
+  // (so a tight usage_limit_bytes can't turn the reference into a false
+  // failure). Mirrors compare_gpu_vs_cpu's SET gpu_execution=false pattern.
+  if (force_cpu_reference) {
+    auto off = con.Query("SET gpu_execution=false;");
+    REQUIRE(off);
+    REQUIRE_FALSE(off->HasError());
+  }
   auto cpu_result = con.Query(clean_query + ";");
+  if (force_cpu_reference) {
+    auto on = con.Query("SET gpu_execution=true;");
+    REQUIRE(on);
+    REQUIRE_FALSE(on->HasError());
+  }
   REQUIRE(cpu_result);
   REQUIRE_FALSE(cpu_result->HasError());
 

--- a/test/cpp/operator/test_partition_memspace_mgpu.cpp
+++ b/test/cpp/operator/test_partition_memspace_mgpu.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression for partition device-pin enforcement on cuco-backed operators.
+//
+// A BUILD_PROBE hash_join's single cuco table is only valid on the GPU it was
+// built on; a probe task on another GPU trips cudaErrorInvalidValue (SIGABRT).
+// Two fixed defects let a probe task scatter to the wrong GPU: (1) partition
+// affinity indexed the physical topology, so num_gpus<physical mapped onto a
+// device with no executor (pin dropped); (2) OOM reschedule dropped the pin.
+//
+// A small dim (build) + large fact (probe) keeps it in BUILD_PROBE; a small
+// usage_limit_bytes forces OOM reschedules. The mgpu case SIGABRT'd before the
+// fixes (on a host with >2 GPUs); the single-GPU case is a control where the
+// cross-device hazard can't occur. Both assert GPU result == true CPU reference.
+
+#include "mgpu_test_utils.hpp"
+
+#include <cuda_runtime.h>
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+using sirius::test::mgpu::generate_parquet_surface;
+using sirius::test::mgpu::mgpu_env_params;
+using sirius::test::mgpu::parquet_glob;
+using sirius::test::mgpu::require_gpu_matches_cpu;
+using sirius::test::mgpu::scoped_log_dir;
+using sirius::test::mgpu::scoped_mgpu_env;
+using sirius::test::mgpu::write_mgpu_yaml;
+
+fs::path make_tmp(std::string const& tag)
+{
+  return fs::temp_directory_path() /
+         ("sirius-mgpu-partmemspace-" + tag + "-" + std::to_string(::getpid()));
+}
+
+// Read a uint64 tuning knob from the environment, or fall back to `dflt`
+// (lets the repro be tuned per host without recompiling).
+uint64_t env_u64(char const* name, uint64_t dflt)
+{
+  if (char const* v = std::getenv(name)) {
+    try {
+      return static_cast<uint64_t>(std::stoull(v));
+    } catch (...) {
+      // fall through to default on garbage input
+    }
+  }
+  return dflt;
+}
+
+// Small dim (build) + large fact (probe) → BUILD_PROBE (one shared cuco table),
+// aggregated to one row so the oracle stays tiny while the join drives many
+// probe tasks. fk = range % dim_rows so every probe row matches one build row.
+struct join_surface {
+  fs::path dim_dir;
+  fs::path fact_dir;
+};
+
+join_surface build_join_surface(fs::path const& tmp,
+                                uint64_t fact_rows,
+                                uint64_t dim_rows,
+                                int fact_files)
+{
+  join_surface s{tmp / "dim", tmp / "fact"};
+  generate_parquet_surface(
+    s.dim_dir,
+    "SELECT range AS k, (range % 1000) AS v FROM range(" + std::to_string(dim_rows) + ")",
+    /*num_files=*/1);
+  generate_parquet_surface(s.fact_dir,
+                           "SELECT (range % " + std::to_string(dim_rows) +
+                             ") AS fk, (range % 1000) AS v FROM range(" +
+                             std::to_string(fact_rows) + ")",
+                           fact_files);
+  return s;
+}
+
+std::string join_query(join_surface const& s)
+{
+  return "SELECT COUNT(*) AS c, SUM(f.v) AS sf, SUM(d.v) AS sd "
+         "FROM read_parquet('" +
+         parquet_glob(s.fact_dir) + "') f JOIN read_parquet('" + parquet_glob(s.dim_dir) +
+         "') d ON f.fk = d.k";
+}
+
+// Memory params shared by both variants. The only difference between the
+// multi- and single-GPU TEST_CASEs is num_gpus.
+mgpu_env_params tight_params(int num_gpus)
+{
+  mgpu_env_params params{};
+  params.num_gpus = num_gpus;
+  params.cache    = "none";
+  // Small ABSOLUTE per-GPU budget => OOM/reschedule fires regardless of
+  // physical capacity. Default 512 MiB; override with the env knob below.
+  params.usage_limit_bytes = env_u64("SIRIUS_TEST_PART_MEMSPACE_GPU_BYTES", 512ULL * 1024 * 1024);
+  // Large enough that the small dim stays in BUILD_PROBE mode (one shared
+  // build table) rather than partitioning into MIXED_JOIN.
+  params.max_build_hash_table_bytes = 256'000'000;
+  params.hash_partition_bytes       = 10'000'000;
+  params.concat_batch_bytes         = 50'000'000;
+  params.scan_task_batch_size       = 20'000'000;
+  params.pipeline_num_threads       = 4;
+  params.task_creator_num_threads   = 4;
+  params.duckdb_scan_num_threads    = 2;
+  return params;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// MULTI-GPU regression. Passes with the pin fixes; before them a probe task on
+// the wrong GPU SIGABRT'd in cuco (so a regression aborts the unittest binary).
+//===----------------------------------------------------------------------===//
+TEST_CASE("partition memory-space is enforced across OOM reschedule on multi-GPU",
+          "[mgpu][operator-mgpu][partition][memspace][hash_join][gpu_execution]")
+{
+  if (!sirius::test::mgpu::require_two_gpus()) return;
+
+  auto tmp = make_tmp("mgpu");
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+  fs::create_directories(tmp);
+
+  // Per-FILE fact rows (total probe rows = rows * fact_files). Kept under
+  // usage_limit_bytes so the join completes rather than exhausting OOM retries;
+  // the crash this guards comes from probe-task scatter, not from overflow.
+  uint64_t const rows     = env_u64("SIRIUS_TEST_PART_MEMSPACE_ROWS", 2'000'000);
+  uint64_t const dim_rows = env_u64("SIRIUS_TEST_PART_MEMSPACE_DIM_ROWS", 200'000);
+  int const iterations    = static_cast<int>(env_u64("SIRIUS_TEST_PART_MEMSPACE_ITERS", 5));
+
+  auto surface = build_join_surface(tmp, rows, dim_rows, /*fact_files=*/8);
+
+  scoped_log_dir logs(tmp / "log");
+  auto yaml_path = tmp / "part-memspace-mgpu.yaml";
+  write_mgpu_yaml(yaml_path, tight_params(/*num_gpus=*/2));
+
+  scoped_mgpu_env env(yaml_path);
+  auto con   = env.make_connection();
+  auto query = join_query(surface);
+
+  // Loop to widen the OOM/reschedule race window; a wrong-GPU dispatch fails
+  // the embedded REQUIREs in require_gpu_matches_cpu (HasError or row mismatch).
+  for (int i = 0; i < iterations; ++i) {
+    INFO("multi-gpu iteration " << i << " (rows=" << rows
+                                << ", gpu_bytes=" << tight_params(2).usage_limit_bytes << ")");
+    require_gpu_matches_cpu(con, query, /*force_cpu_reference=*/true);
+  }
+
+  // SIRIUS_TEST_PART_MEMSPACE_KEEP=1 preserves the tmp dir (parquet + log) for
+  // inspection (e.g. grep the log for the "OOM reschedule" WARN).
+  if (!std::getenv("SIRIUS_TEST_PART_MEMSPACE_KEEP")) {
+    fs::remove_all(tmp, ec);
+  } else {
+    WARN("kept repro artifacts at " << tmp.string());
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// SINGLE-GPU control: same partitioned-join-under-OOM path with num_gpus=1.
+// Runs on any host with >=1 GPU. On one device the cross-GPU hazard cannot
+// occur, so this asserts the OOM-reschedule machinery itself stays correct.
+//===----------------------------------------------------------------------===//
+TEST_CASE("partition memory-space repro - single-GPU OOM-reschedule control",
+          "[operator-mgpu][partition][memspace][hash_join][gpu_execution][single_gpu]")
+{
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+  if (device_count < 1) {
+    WARN("partition memspace single-GPU control requires >=1 GPU; none visible — skipping");
+    return;
+  }
+
+  auto tmp = make_tmp("1gpu");
+  std::error_code ec;
+  fs::remove_all(tmp, ec);
+  fs::create_directories(tmp);
+
+  // Per-FILE fact rows (total probe rows = rows * fact_files). Kept under
+  // usage_limit_bytes so the join completes rather than exhausting OOM retries;
+  // the crash this guards comes from probe-task scatter, not from overflow.
+  uint64_t const rows     = env_u64("SIRIUS_TEST_PART_MEMSPACE_ROWS", 2'000'000);
+  uint64_t const dim_rows = env_u64("SIRIUS_TEST_PART_MEMSPACE_DIM_ROWS", 200'000);
+  int const iterations    = static_cast<int>(env_u64("SIRIUS_TEST_PART_MEMSPACE_ITERS", 5));
+
+  auto surface = build_join_surface(tmp, rows, dim_rows, /*fact_files=*/8);
+
+  scoped_log_dir logs(tmp / "log");
+  auto yaml_path = tmp / "part-memspace-1gpu.yaml";
+  write_mgpu_yaml(yaml_path, tight_params(/*num_gpus=*/1));
+
+  scoped_mgpu_env env(yaml_path);
+  auto con   = env.make_connection();
+  auto query = join_query(surface);
+
+  for (int i = 0; i < iterations; ++i) {
+    INFO("single-gpu iteration " << i << " (rows=" << rows << ")");
+    require_gpu_matches_cpu(con, query, /*force_cpu_reference=*/true);
+  }
+
+  if (!std::getenv("SIRIUS_TEST_PART_MEMSPACE_KEEP")) {
+    fs::remove_all(tmp, ec);
+  } else {
+    WARN("kept repro artifacts at " << tmp.string());
+  }
+}


### PR DESCRIPTION
Partitioned operators (BUILD_PROBE hash_join, grouped_aggregate_merge, ...) build a per-partition cuco hash table that is only valid on the GPU it was built on; touching it from a stream bound to another device trips cudaErrorInvalidValue in cuco counter_storage (a hard SIGABRT). The partition device was therefore a correctness constraint but was only *preferred*, not *enforced*, in two places:

1. task_creator partition affinity computed `partition_idx % num_gpus` over the PHYSICAL hardware topology (hw_topology.gpus). When the configured num_gpus is smaller than the physical GPU count (e.g. num_gpus=2 on a 4-GPU box), the modulo mapped onto a device id with no executor; the scheduler treats a pin to a non-existent executor as "no preference" and round-robins the task, so a partition's build + probe tasks scattered across GPUs and a probe touched the build table cross-device. Fixed by indexing the ACTIVE GPU executor set (memory manager GPU spaces — the same set task_scheduler keys executors on) via the new task_creator::_active_gpu_ids.

2. The OOM-reschedule path rebuilt a task's local_state without copying preferred_device_id, demoting a rescheduled probe task to "no preference" and letting it scatter. Fixed by carrying the pin forward.

Adds test/cpp/operator/test_partition_memspace_mgpu.cpp (multi-GPU repro that SIGABRT'd before the fix + single-GPU control) and a usage_limit_bytes knob in mgpu_test_utils.hpp to impose a fixed per-GPU budget on big-memory parts.