### PR TITLE
chore(telemetry): bump `quent` to latest `main`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "serde",
  "thiserror",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "serde",
  "serde_json",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1436,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "ciborium",
  "http",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "prost",
  "tonic",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "http",
  "quent-events",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "async-trait",
  "http",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-model",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "serde",
  "thiserror",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
+source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
 dependencies = [
  "quent-analyzer",
  "quent-time",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -470,20 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,12 +723,6 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1406,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1424,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "serde",
  "thiserror",
@@ -1434,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1443,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1456,15 +1436,10 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
- "ciborium",
- "dashmap",
- "quent-build-info",
+ "quent-collector-client",
  "quent-collector-proto",
- "quent-exporter",
- "quent-exporter-types",
- "serde",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1475,9 +1450,10 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "ciborium",
+ "http",
  "quent-collector-proto",
  "quent-events",
  "serde",
@@ -1493,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "prost",
  "tonic",
@@ -1504,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1515,8 +1491,10 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
+ "http",
+ "quent-events",
  "quent-exporter-collector",
  "quent-exporter-msgpack",
  "quent-exporter-ndjson",
@@ -1529,9 +1507,10 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "async-trait",
+ "http",
  "quent-collector-client",
  "quent-events",
  "quent-exporter-types",
@@ -1542,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1551,12 +1530,13 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1565,12 +1545,13 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1579,12 +1560,13 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1595,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1612,23 +1594,26 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
+ "ciborium",
  "quent-attributes",
  "quent-build-info",
+ "quent-collector-client",
  "quent-events",
  "quent-exporter",
  "quent-instrumentation",
  "quent-model-macros",
  "quent-time",
  "serde",
+ "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1639,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1656,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1667,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1676,8 +1661,10 @@ dependencies = [
  "quent-collector",
  "quent-collector-proto",
  "quent-events",
+ "quent-exporter",
  "quent-exporter-types",
  "quent-query-engine-analyzer",
+ "quent-query-engine-model",
  "quent-query-engine-ui",
  "quent-time",
  "quent-ui",
@@ -1697,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1712,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -1723,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-model",
  "serde",
@@ -1733,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "serde",
  "thiserror",
@@ -1743,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=76e99cf7ca9d531d4e56e94021b1f80d97b23c90#76e99cf7ca9d531d4e56e94021b1f80d97b23c90"
+source = "git+https://github.com/rapidsai/quent.git?rev=8b3532cd8b12718b1672674c35dafa6f065d325d#8b3532cd8b12718b1672674c35dafa6f065d325d"
 dependencies = [
  "quent-analyzer",
  "quent-time",
@@ -2461,9 +2448,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts-rs"
-version = "11.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -2473,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "ts-rs-macros"
-version = "11.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/analyzer/src/model.rs
+++ b/rust/crates/telemetry/analyzer/src/model.rs
@@ -166,21 +166,11 @@ impl SiriusModel {
     }
 }
 
-impl
-    FsmCollection<
-        Task,
-        quent_analyzer::fsm::events::TransitionEvent<instrumentation_model::task::TaskTransition>,
-    > for SiriusModel
-{
-    fn fsms<'a>(&'a self) -> impl Iterator<Item = &'a Task> + 'a
-    where
-        Task: 'a,
-    {
-        self.tasks.values()
-    }
+impl FsmCollection for SiriusModel {
+    type Fsm = Task;
 
-    fn contains_fsm_type(&self, type_name: &str) -> bool {
-        !self.tasks.is_empty() && type_name == "task"
+    fn fsms(&self) -> impl Iterator<Item = &Task> {
+        self.tasks.values()
     }
 }
 

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -15,4 +15,4 @@ instrumentation-model = { path = "../model" }
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -15,4 +15,4 @@ instrumentation-model = { path = "../model" }
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -3,15 +3,18 @@ name = "instrumentation-model"
 version.workspace = true
 edition.workspace = true
 
+[features]
+collector = ["quent-model/collector"]
+
 [dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -8,13 +8,13 @@ collector = ["quent-model/collector"]
 
 [dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -10,18 +10,18 @@ swagger = ["quent-query-engine-server/swagger"]
 [dependencies]
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
-instrumentation-model = { path = "../model" }
+instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "76e99cf7ca9d531d4e56e94021b1f80d97b23c90" }
-ts-rs = { version = "11", features = ["uuid-impl", "serde-json-impl"] }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "8b3532cd8b12718b1672674c35dafa6f065d325d" }
+ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }

--- a/rust/crates/telemetry/server/build.rs
+++ b/rust/crates/telemetry/server/build.rs
@@ -5,15 +5,16 @@ use quent_ui::timeline::{
 };
 use quent_query_engine_ui::{OperatorFilter, QueryFilter};
 use quent_simulator_ui::EntityRef;
-use ts_rs::TS;
+use ts_rs::{Config, TS};
 
 const TS_OUT_DIR: &str = "./ts-bindings/";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    <QueryBundle<EntityRef> as TS>::export_all_to(TS_OUT_DIR)?;
-    <SingleTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
-    <SingleTimelineResponse as TS>::export_all_to(TS_OUT_DIR)?;
-    <BulkTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all_to(TS_OUT_DIR)?;
-    <BulkTimelinesResponse as TS>::export_all_to(TS_OUT_DIR)?;
+    let cfg = Config::new().with_out_dir(TS_OUT_DIR);
+    <QueryBundle<EntityRef> as TS>::export_all(&cfg)?;
+    <SingleTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all(&cfg)?;
+    <SingleTimelineResponse as TS>::export_all(&cfg)?;
+    <BulkTimelineRequest<QueryFilter, OperatorFilter> as TS>::export_all(&cfg)?;
+    <BulkTimelinesResponse as TS>::export_all(&cfg)?;
     Ok(())
 }

--- a/rust/crates/telemetry/server/src/main.rs
+++ b/rust/crates/telemetry/server/src/main.rs
@@ -1,23 +1,14 @@
-use std::{
-    net::ToSocketAddrs,
-    path::{Path, PathBuf},
-};
+use std::{net::ToSocketAddrs, path::PathBuf};
 
 use clap::Parser;
-use instrumentation_model::SiriusEvent;
-use quent_collector::server::CollectorServiceOptions;
-use quent_exporter::{
-    ExporterOptions, FileSystemExporterOptions, FileSystemFormat, FileSystemImporterOptions,
-    ImporterOptions, create_importer,
-};
+use instrumentation_model::{Sirius, SiriusContext};
+use quent_exporter::{ExporterOptions, FileSystemExporterOptions, FileSystemFormat};
 use quent_query_engine_server::{
-    analyzer_service_router, collector_service,
-    error::{ServerError, ServerResult},
+    analyzer_cache::index_query_engines, analyzer_service_router, collector_service,
     initialize_tracing,
 };
 use sirius_telemetry_analyzer::SiriusUiAnalyzer;
 use tokio::net::TcpListener;
-use uuid::Uuid;
 
 mod defaults {
     pub(crate) const QUENT_COLLECTOR_ADDRESS: &str = "[::]:7836";
@@ -31,14 +22,6 @@ mod env {
     pub(crate) const QUENT_ANALYZER_ADDRESS: &str = "QUENT_ANALYZER_ADDRESS";
     pub(crate) const QUENT_ANALYZER_CORS_ADDRESS: &str = "QUENT_ANALYZER_CORS_ADDRESS";
 }
-
-// Probed (highest-fidelity first) when auto-detecting the format of an existing
-// context directory, independent of the configured export format.
-const TELEMETRY_FORMATS: [(&str, FileSystemFormat); 3] = [
-    ("postcard", FileSystemFormat::Postcard),
-    ("msgpack", FileSystemFormat::Msgpack),
-    ("ndjson", FileSystemFormat::Ndjson),
-];
 
 #[derive(Parser)]
 struct Args {
@@ -92,25 +75,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "postcard" => FileSystemFormat::Postcard,
         other => return Err(format!("unknown exporter: {other}").into()),
     };
-    // Each context exports to `output_dir/<context-id>/events.<ext>` (plus a
-    // `model.qmi` provenance sidecar), so the collector writes under output_dir.
-    let exporter = ExporterOptions::FileSystem(FileSystemExporterOptions {
+    // Each context exports under `output_dir/<context-id>/<entity>/`, so the
+    // collector writes per-entity streams beneath output_dir.
+    let exporter_kind = ExporterOptions::FileSystem(FileSystemExporterOptions {
         format,
         root: output_dir,
     });
 
+    // The collector builds a fresh sink per incoming context, replaying each
+    // remote source's events under that source's own context id.
     let collector = async {
-        collector_service::<SiriusEvent>(CollectorServiceOptions { exporter })?
-            .serve(collector_addr)
-            .await
-            .map_err(|error| -> Box<dyn std::error::Error> { Box::new(error) })
+        collector_service::<SiriusContext, _>(move |id| {
+            SiriusContext::try_with_id(id, Some(exporter_kind.clone())).map_err(|e| e.to_string())
+        })?
+        .serve(collector_addr)
+        .await
+        .map_err(|error| -> Box<dyn std::error::Error> { Box::new(error) })
     };
 
-    let lister = move || list_engine_ids(&lister_output_dir);
+    // Index the exported contexts by engine instance: each engine's telemetry is
+    // the engine's own context plus its workers' contexts.
+    let lister = move || index_query_engines(&lister_output_dir, format);
 
-    let importer = move |engine_id| {
-        let importer = importer_options_for_engine(&importer_output_dir, engine_id)?;
-        Ok(Box::new(create_importer::<SiriusEvent>(&importer)?) as Box<dyn Iterator<Item = _>>)
+    // Reconstruct one context's umbrella event stream from its per-entity
+    // subdirectories; the analyzer cache chains this across all the contexts that
+    // make up an engine instance.
+    let importer = move |context_id| {
+        let dir = importer_output_dir.join(format!("{context_id}"));
+        Ok(Sirius::import_events(&dir, format)?)
     };
 
     let analyzer = async {
@@ -130,173 +122,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("listening on {collector_addr} and {analyzer_addr}");
     tokio::try_join!(collector, analyzer)?;
     Ok(())
-}
-
-/// Detect which event-file format a context directory holds, by probing for
-/// `events.<ext>`. `None` if the directory has no recognized event file.
-fn detect_format(dir: &Path) -> Option<FileSystemFormat> {
-    TELEMETRY_FORMATS
-        .iter()
-        .find(|(extension, _)| dir.join(format!("events.{extension}")).is_file())
-        .map(|(_, format)| *format)
-}
-
-/// Map a file extension to its telemetry format, if recognized.
-fn format_for_ext(extension: &str) -> Option<FileSystemFormat> {
-    TELEMETRY_FORMATS
-        .iter()
-        .find(|(known, _)| *known == extension)
-        .map(|(_, format)| *format)
-}
-
-/// Legacy flat telemetry files `<output_dir>/<id>.<ext>`, written before the
-/// per-context-directory layout. Returns `(file_path, format)` sorted by path.
-fn flat_files(output_dir: &Path) -> ServerResult<Vec<(PathBuf, FileSystemFormat)>> {
-    let mut files = Vec::new();
-    for entry in std::fs::read_dir(output_dir)? {
-        let path = entry?.path();
-        if !path.is_file() {
-            continue;
-        }
-        if let Some(format) = path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .and_then(format_for_ext)
-        {
-            files.push((path, format));
-        }
-    }
-    files.sort_by(|(a, _), (b, _)| a.cmp(b));
-    Ok(files)
-}
-
-/// The uuid encoded in a flat telemetry file's stem (`<id>.<ext>`), if any.
-fn file_stem_uuid(path: &Path) -> Option<Uuid> {
-    path.file_stem()
-        .and_then(|stem| stem.to_str())
-        .and_then(|stem| Uuid::parse_str(stem).ok())
-}
-
-/// Per-context export directories under `output_dir`: those named by a uuid that
-/// contain a recognized event file. Returns `(dir_id, dir_path, format)` sorted
-/// by id for stable listing.
-fn context_dirs(output_dir: &Path) -> ServerResult<Vec<(Uuid, PathBuf, FileSystemFormat)>> {
-    let mut dirs = Vec::new();
-    for entry in std::fs::read_dir(output_dir)? {
-        let path = entry?.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let Some(dir_id) = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .and_then(|name| Uuid::parse_str(name).ok())
-        else {
-            continue;
-        };
-        if let Some(format) = detect_format(&path) {
-            dirs.push((dir_id, path, format));
-        }
-    }
-    dirs.sort_by_key(|(dir_id, _, _)| *dir_id);
-    Ok(dirs)
-}
-
-/// The id of the engine instance recorded in a telemetry capture's events (the
-/// id of its `Engine` event), or `None` if no such event is present. `path` is a
-/// context directory or a flat event file — the importer accepts either.
-fn extract_engine_id(path: &Path, format: FileSystemFormat) -> ServerResult<Option<Uuid>> {
-    let importer = ImporterOptions::FileSystem(FileSystemImporterOptions {
-        format,
-        path: path.to_path_buf(),
-    });
-    for event in create_importer::<SiriusEvent>(&importer)? {
-        if let SiriusEvent::Engine(_) = event.data {
-            return Ok(Some(event.id));
-        }
-    }
-    Ok(None)
-}
-
-/// Engine instance ids discoverable under `output_dir`.
-///
-/// A context directory is keyed on its real `Engine` event id, never the
-/// directory name (an unrelated context id since Quent dropped the engine id at
-/// context creation). Legacy flat files were named by the engine id, so their
-/// stem is a valid fallback. Captures only appear once flushed (exporters buffer
-/// until `force_flush` on drop), so a still-running context is not yet listed.
-fn list_engine_ids(output_dir: &Path) -> ServerResult<Vec<Uuid>> {
-    let mut ids = std::collections::HashSet::new();
-    for (_, path, format) in context_dirs(output_dir)? {
-        if let Some(id) = extract_engine_id(&path, format)? {
-            ids.insert(id);
-        }
-    }
-    for (path, format) in flat_files(output_dir)? {
-        if let Some(id) = extract_engine_id(&path, format)?.or_else(|| file_stem_uuid(&path)) {
-            ids.insert(id);
-        }
-    }
-    Ok(ids.into_iter().collect())
-}
-
-fn importer_options_for_engine(
-    output_dir: &Path,
-    engine_id: Uuid,
-) -> ServerResult<ImporterOptions> {
-    for (_, path, format) in context_dirs(output_dir)? {
-        if extract_engine_id(&path, format)? == Some(engine_id) {
-            return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
-                format,
-                path,
-            }));
-        }
-    }
-
-    // Legacy flat files: match on engine id, or on the `<id>.<ext>` stem.
-    for (path, format) in flat_files(output_dir)? {
-        if extract_engine_id(&path, format)? == Some(engine_id)
-            || file_stem_uuid(&path) == Some(engine_id)
-        {
-            return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
-                format,
-                path,
-            }));
-        }
-    }
-
-    // Fall back to a directory named directly by the engine id.
-    let path = output_dir.join(engine_id.to_string());
-    if let Some(format) = detect_format(&path) {
-        return Ok(ImporterOptions::FileSystem(FileSystemImporterOptions {
-            format,
-            path,
-        }));
-    }
-
-    Err(ServerError::Io(std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        format!("no telemetry directory found for engine {engine_id}"),
-    )))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// An events file with no readable `Engine` event must not surface the
-    /// context directory id as an engine id.
-    #[test]
-    fn empty_context_dir_is_not_listed_as_engine() {
-        let root = std::env::temp_dir().join(format!("sirius_telemetry_list_{}", Uuid::now_v7()));
-        let context_id = Uuid::now_v7();
-        let context_dir = root.join(context_id.to_string());
-        std::fs::create_dir_all(&context_dir).unwrap();
-        std::fs::write(context_dir.join("events.ndjson"), b"").unwrap();
-
-        let ids = list_engine_ids(&root).unwrap();
-
-        std::fs::remove_dir_all(&root).unwrap();
-        assert!(ids.is_empty(), "context id leaked as engine id: {ids:?}");
-    }
 }


### PR DESCRIPTION
Update the pinned quent rev across the telemetry crates and bump ts-rs from 11 to 12, migrating to the new APIs:

- `build.rs`: `TS::export_all_to(dir)` -> `Config::with_out_dir` + `export_all`
- server: adopt quent's per-context collector sink factory, `EngineIndex` lister (`index_query_engines`), and context-keyed `Sirius::import_events`, mirroring quent's simulator reference server; drop the obsolete custom lister/importer helpers
- model: add a collector feature so `SiriusContext` implements `CollectorSink`
- FsmCollection: handle breaking change

This adopts quent's new per-context/per-entity capture layout; the old flat-file/events.<ext> readers and format auto-detection are gone.

Closes #975
﻿﻿