### PR TITLE
feat(starrocks): register the compute node as a shared-data worker

### DIFF
--- a/experimental/starrocks/src/lib.rs
+++ b/experimental/starrocks/src/lib.rs
@@ -150,6 +150,9 @@ pub struct ComputeNodeConfig {
     pub http_port: u16,
     #[arg(long, default_value_t = 8060)]
     pub brpc_port: u16,
+    /// TODO: run a real starlet/worker agent on this advertised port.
+    #[arg(long, default_value_t = 9070)]
+    pub starlet_port: u16,
     #[arg(long)]
     pub arrow_flight_port: Option<u16>,
     #[arg(skip = default_compute_node_version())]
@@ -165,6 +168,7 @@ impl Default for ComputeNodeConfig {
             thrift_port: 9060,
             http_port: 8040,
             brpc_port: 8060,
+            starlet_port: 9070,
             arrow_flight_port: None,
             version: default_compute_node_version(),
         }
@@ -432,17 +436,17 @@ impl ComputeNodeHeartbeatHandler {
             .map(i32::from)
             .unwrap_or(PORT_DISABLED);
         TBackendInfo::new(
-            i32::from(self.config.thrift_port),     // be_port
-            i32::from(self.config.http_port),       // http_port
-            Some(BE_RPC_PORT_DISABLED),             // be_rpc_port
-            Some(i32::from(self.config.brpc_port)), // brpc_port
-            Some(self.config.version.clone()),      // version
-            Some(self.hardware_cores),              // num_hardware_cores
-            None,                                   // starlet_port
-            Some(self.reboot_time_secs),            // reboot_time
-            Some(false),                            // is_set_storage_path (CN has no storage)
-            Some(MEM_LIMIT_UNSET),                  // mem_limit_bytes
-            Some(arrow_flight_port),                // arrow_flight_port
+            i32::from(self.config.thrift_port),        // be_port
+            i32::from(self.config.http_port),          // http_port
+            Some(BE_RPC_PORT_DISABLED),                // be_rpc_port
+            Some(i32::from(self.config.brpc_port)),    // brpc_port
+            Some(self.config.version.clone()),         // version
+            Some(self.hardware_cores),                 // num_hardware_cores
+            Some(i32::from(self.config.starlet_port)), // starlet_port
+            Some(self.reboot_time_secs),               // reboot_time
+            Some(false),                               // is_set_storage_path (CN has no storage)
+            Some(MEM_LIMIT_UNSET),                     // mem_limit_bytes
+            Some(arrow_flight_port),                   // arrow_flight_port
         )
     }
 }


### PR DESCRIPTION
## What

In shared-data mode the StarRocks FE schedules queries only onto compute nodes registered in the warehouse's **star-manager worker group** — not the `ALTER SYSTEM ADD COMPUTE NODE` list. The FE registers a CN as a worker (`StarOSAgent.addWorker`) only when its heartbeat advertises a **non-zero `starlet_port`**:

```java
// HeartbeatMgr (shared-data, on OK heartbeat)
int starletPort = computeNode.getStarletPort();
if (starletPort != 0) {
    getStarOSAgent().addWorker(id, host:starletPort, workerGroupId);
}
```

The Rust CN advertised no starlet port, so the default warehouse's worker group was empty and every query failed with:

```
ERROR 5904 (42000): Warehouse default_warehouse is not available.
```

(`SHOW COMPUTE NODES` showed the symptom: `WorkerId = -1`, `StarletPort = 0`.)

## Change

Advertise a configurable starlet port (default `9070`, `--starlet-port`) in the heartbeat `TBackendInfo`. The FE then runs `addWorker`, the CN joins the warehouse worker group, and the warehouse can schedule fragments onto it.

## Verified

With this change the CN registers as a worker, the warehouse becomes available, and a `SELECT … FROM FILES('file://…parquet')` schedules and dispatches a fragment to the CN over brpc.

## Caveat / follow-up

No starlet/worker agent listens on the port yet, so the star manager logs `sending heartbeat to worker …:9070 failed, GRPC:UNAVAILABLE`. Worker-group membership plus the FE heartbeat liveness are sufficient for query scheduling, so this is benign noise; a real starlet/worker agent is left as a follow-up (noted as a TODO in the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
