### PR TITLE
refactor(starrocks): let BRPC handlers return a response attachment

### DIFF
--- a/experimental/starrocks/build.rs
+++ b/experimental/starrocks/build.rs
@@ -113,13 +113,14 @@ impl ServiceGenerator for BrpcServiceGenerator {
             let output_type: syn::Type =
                 syn::parse_str(&method.output_type).expect("method output type should parse");
             // `+ Send` keeps the dispatch future Send so connections can be spawned; an `async fn`
-            // impl satisfies this return-position-impl-trait signature.
+            // impl satisfies this return-position-impl-trait signature. The reply is wrapped in
+            // `prpc::Reply` so a handler may attach bytes (e.g. `fetch_data`'s `TResultBatch`).
             quote! {
                 fn #method_ident(
                     &self,
                     _request: #input_type,
                     _attachment: Vec<u8>,
-                ) -> impl Future<Output = Result<#output_type, crate::prpc::Error>> + Send {
+                ) -> impl Future<Output = Result<crate::prpc::Reply<#output_type>, crate::prpc::Error>> + Send {
                     async move {
                         Err(crate::prpc::Error::method_not_implemented(methods::#const_ident))
                     }
@@ -149,8 +150,11 @@ impl ServiceGenerator for BrpcServiceGenerator {
                 ) -> Result<crate::prpc::Response, crate::prpc::Error> {
                     let request = #input_type::decode(request_bytes.as_slice())
                         .map_err(|err| crate::prpc::Error::invalid_request(methods::#const_ident, err))?;
-                    let response = inner.#method_ident(request, attachment).await?;
-                    Ok(crate::prpc::Response::new(response.encode_to_vec()))
+                    let reply = inner.#method_ident(request, attachment).await?;
+                    Ok(crate::prpc::Response::with_attachment(
+                        reply.message.encode_to_vec(),
+                        reply.attachment,
+                    ))
                 }
             }
         });

--- a/experimental/starrocks/src/brpc.rs
+++ b/experimental/starrocks/src/brpc.rs
@@ -303,7 +303,7 @@ mod tests {
         }
 
         fn call(&mut self, _request: prpc::Request) -> Self::Future {
-            ready(Ok(prpc::Response::new(Vec::new())))
+            ready(Ok(prpc::Response::with_attachment(Vec::new(), Vec::new())))
         }
     }
 

--- a/experimental/starrocks/src/compute_node_service.rs
+++ b/experimental/starrocks/src/compute_node_service.rs
@@ -47,15 +47,14 @@ impl PInternalService for SiriusComputeNodeService {
         &self,
         request: PExecPlanFragmentRequest,
         attachment: Vec<u8>,
-    ) -> Result<PExecPlanFragmentResult, crate::prpc::Error> {
-        Ok(
-            match self
-                .translate_single_attachment(request.attachment_protocol.as_deref(), &attachment)
-            {
-                Ok(()) => Self::exec_plan_result(Self::ok_status()),
-                Err(err) => Self::exec_plan_result(Self::internal_error(err)),
-            },
-        )
+    ) -> Result<crate::prpc::Reply<PExecPlanFragmentResult>, crate::prpc::Error> {
+        let result = match self
+            .translate_single_attachment(request.attachment_protocol.as_deref(), &attachment)
+        {
+            Ok(()) => Self::exec_plan_result(Self::ok_status()),
+            Err(err) => Self::exec_plan_result(Self::internal_error(err)),
+        };
+        Ok(result.into())
     }
 
     /// Handles FE batch fragment dispatch by translating every per-instance fragment.
@@ -64,19 +63,18 @@ impl PInternalService for SiriusComputeNodeService {
         &self,
         request: PExecBatchPlanFragmentsRequest,
         attachment: Vec<u8>,
-    ) -> Result<PExecBatchPlanFragmentsResult, crate::prpc::Error> {
-        Ok(
-            match self
-                .translate_batch_attachment(request.attachment_protocol.as_deref(), &attachment)
-            {
-                Ok(()) => PExecBatchPlanFragmentsResult {
-                    status: Some(Self::ok_status()),
-                },
-                Err(err) => PExecBatchPlanFragmentsResult {
-                    status: Some(Self::internal_error(err)),
-                },
+    ) -> Result<crate::prpc::Reply<PExecBatchPlanFragmentsResult>, crate::prpc::Error> {
+        let result = match self
+            .translate_batch_attachment(request.attachment_protocol.as_deref(), &attachment)
+        {
+            Ok(()) => PExecBatchPlanFragmentsResult {
+                status: Some(Self::ok_status()),
             },
-        )
+            Err(err) => PExecBatchPlanFragmentsResult {
+                status: Some(Self::internal_error(err)),
+            },
+        };
+        Ok(result.into())
     }
 
     /// Infers the schema of the FILES() target so the FE can resolve the table function.
@@ -85,8 +83,8 @@ impl PInternalService for SiriusComputeNodeService {
         &self,
         _request: PGetFileSchemaRequest,
         attachment: Vec<u8>,
-    ) -> Result<PGetFileSchemaResult, crate::prpc::Error> {
-        Ok(match Self::file_schema_from_attachment(&attachment).await {
+    ) -> Result<crate::prpc::Reply<PGetFileSchemaResult>, crate::prpc::Error> {
+        let result = match Self::file_schema_from_attachment(&attachment).await {
             Ok(schema) => PGetFileSchemaResult {
                 status: Self::ok_status(),
                 schema,
@@ -95,7 +93,8 @@ impl PInternalService for SiriusComputeNodeService {
                 status: Self::internal_error(err),
                 schema: Vec::new(),
             },
-        })
+        };
+        Ok(result.into())
     }
 }
 

--- a/experimental/starrocks/src/prpc.rs
+++ b/experimental/starrocks/src/prpc.rs
@@ -63,10 +63,31 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    /// Builds a protobuf-body-only response.
-    pub(crate) fn new(body: Vec<u8>) -> Self {
+    /// Builds a response whose protobuf body is accompanied by an optional BRPC attachment.
+    /// Result-bearing RPCs such as `fetch_data` ship the serialized `TResultBatch` here; other
+    /// RPCs pass an empty attachment.
+    pub(crate) fn with_attachment(body: Vec<u8>, attachment: Vec<u8>) -> Self {
+        Self { body, attachment }
+    }
+}
+
+/// A typed RPC handler result: the protobuf response message plus an optional BRPC attachment.
+///
+/// Every StarRocks BRPC reply may carry an attachment, so the generated service trait returns
+/// this wrapper. Handlers that have no attachment return the bare message via `.into()`.
+#[derive(Clone, Debug)]
+pub(crate) struct Reply<M> {
+    /// Protobuf response message.
+    pub(crate) message: M,
+    /// Optional response attachment bytes.
+    pub(crate) attachment: Vec<u8>,
+}
+
+impl<M> From<M> for Reply<M> {
+    /// Wraps a bare protobuf message as an attachment-less reply.
+    fn from(message: M) -> Self {
         Self {
-            body,
+            message,
             attachment: Vec::new(),
         }
     }


### PR DESCRIPTION
## What

The generated `PInternalService` BRPC facade always built a **body-only** response. StarRocks result delivery (`fetch_data`) needs to return the serialized `TResultBatch` as the BRPC **response attachment**, so this generalizes the handler return type ahead of that work.

- Add `prpc::Reply<M> { message, attachment }` with `From<M>` for the common attachment-less case, and `Response::with_attachment`.
- The generated router now returns `Reply<#output>` per method and emits `Response::with_attachment(body, attachment)`.
- Existing handlers (`exec_plan_fragment`, `exec_batch_plan_fragments`, `get_file_schema`) return the bare message via `.into()`.

**Behavior-preserving** — every RPC still returns exactly the same bytes; this only opens a place for a response attachment. The first consumer (`fetch_data`) lands in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
