### PR TITLE
feat(starrocks): execute a single RESULT_SINK fragment and return rows

### DIFF
--- a/experimental/starrocks/Cargo.lock
+++ b/experimental/starrocks/Cargo.lock
@@ -1878,6 +1878,8 @@ name = "sirius-starrocks-cn"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrow-array",
+ "arrow-schema",
  "backon",
  "clap",
  "heck",

--- a/experimental/starrocks/Cargo.toml
+++ b/experimental/starrocks/Cargo.toml
@@ -12,6 +12,10 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
+# Pinned to the arrow version `parquet` already pulls in, so the engine→CN result interchange
+# (Arrow C Data Interface) and the parquet schema reader share one arrow build.
+arrow-array = "59"
+arrow-schema = "59"
 backon = { version = "1", default-features = false, features = ["tokio-sleep"] }
 clap = { version = "4", features = ["derive", "env"] }
 mysql_async = { version = "0.37", default-features = false, features = ["minimal-rust"] }
@@ -46,6 +50,8 @@ sirius-engine = ["dep:sirius"]
 
 [dependencies]
 anyhow.workspace = true
+arrow-array.workspace = true
+arrow-schema.workspace = true
 backon.workspace = true
 clap.workspace = true
 mysql_async.workspace = true

--- a/experimental/starrocks/src/compute_node_service.rs
+++ b/experimental/starrocks/src/compute_node_service.rs
@@ -1,10 +1,16 @@
+use std::sync::Arc;
+
+use crate::fragment_executor::{FragmentExecutor, StubExecutor};
 use crate::proto::starrocks::{
     PExecBatchPlanFragmentsRequest, PExecBatchPlanFragmentsResult, PExecPlanFragmentRequest,
-    PExecPlanFragmentResult, PGetFileSchemaRequest, PGetFileSchemaResult, PSlotDescriptor,
-    StatusPb, p_internal_service_brpc::PInternalService,
+    PExecPlanFragmentResult, PFetchDataRequest, PFetchDataResult, PGetFileSchemaRequest,
+    PGetFileSchemaResult, PSlotDescriptor, StatusPb, p_internal_service_brpc::PInternalService,
 };
-use starrocks_plan_translator::PlanTranslator;
+use crate::result_encoder::{self, ThriftBinary};
+use crate::result_store::{FragmentInstanceId, ResultStore};
+use starrocks_plan_translator::{PlanTranslator, TranslatedPlan};
 use starrocks_thrift::{
+    data_sinks::{TDataSinkType, TResultSinkType},
     internal_service::{
         TExecBatchPlanFragmentsParams, TExecPlanFragmentParams, TGetFileSchemaRequest,
     },
@@ -25,6 +31,14 @@ use tracing::{info, instrument};
 pub(crate) struct SiriusComputeNodeService {
     /// Reusable StarRocks thrift-to-Substrait fragment translator.
     translator: PlanTranslator,
+    /// Executes a translated fragment into Arrow result batches.
+    ///
+    /// TODO(starrocks-execute): this is a [`StubExecutor`] until the GPU-backed executor lands.
+    /// The real executor will hold the `Arc<sirius::SiriusContext>` brought up in `main`.
+    executor: Arc<dyn FragmentExecutor>,
+    /// Buffers executed-fragment results for FE `fetch_data` collection. Shared across BRPC
+    /// connections so a `fetch_data` poll sees what an `exec_plan_fragment` buffered.
+    results: Arc<ResultStore>,
 }
 
 impl SiriusComputeNodeService {
@@ -32,29 +46,29 @@ impl SiriusComputeNodeService {
     pub(crate) fn new() -> Self {
         Self {
             translator: PlanTranslator::new(),
+            executor: Arc::new(StubExecutor),
+            results: Arc::new(ResultStore::default()),
         }
     }
 }
 
 impl PInternalService for SiriusComputeNodeService {
-    /// Handles a single FE-dispatched plan fragment thrift attachment.
-    ///
-    /// An OK status here means the fragment was accepted and translated, which is the correct
-    /// dispatch-RPC response; actually executing the fragment and streaming results back is a
-    /// separate, not-yet-implemented RPC surface.
+    /// Handles a single FE-dispatched plan fragment thrift attachment: translate it, and for a
+    /// root RESULT_SINK fragment execute it and buffer the rows for `fetch_data`. An OK status
+    /// means the fragment was accepted (and, for a result fragment, executed and buffered).
     #[instrument(skip_all)]
     async fn exec_plan_fragment(
         &self,
         request: PExecPlanFragmentRequest,
         attachment: Vec<u8>,
     ) -> Result<crate::prpc::Reply<PExecPlanFragmentResult>, crate::prpc::Error> {
-        let result = match self
-            .translate_single_attachment(request.attachment_protocol.as_deref(), &attachment)
+        let status = match self
+            .exec_single_attachment(request.attachment_protocol.as_deref(), &attachment)
         {
-            Ok(()) => Self::exec_plan_result(Self::ok_status()),
-            Err(err) => Self::exec_plan_result(Self::internal_error(err)),
+            Ok(()) => Self::ok_status(),
+            Err(err) => Self::internal_error(err),
         };
-        Ok(result.into())
+        Ok(Self::exec_plan_result(status).into())
     }
 
     /// Handles FE batch fragment dispatch by translating every per-instance fragment.
@@ -64,6 +78,8 @@ impl PInternalService for SiriusComputeNodeService {
         request: PExecBatchPlanFragmentsRequest,
         attachment: Vec<u8>,
     ) -> Result<crate::prpc::Reply<PExecBatchPlanFragmentsResult>, crate::prpc::Error> {
+        // TODO(starrocks-execute): execute + buffer results for batch dispatch too. For the
+        // single-fragment milestone only `exec_plan_fragment` runs the RESULT_SINK fragment.
         let result = match self
             .translate_batch_attachment(request.attachment_protocol.as_deref(), &attachment)
         {
@@ -75,6 +91,51 @@ impl PInternalService for SiriusComputeNodeService {
             },
         };
         Ok(result.into())
+    }
+
+    /// Returns buffered fragment results to the FE, which polls this until end-of-stream. The
+    /// serialized `TResultBatch` rows ride in the BRPC response attachment.
+    #[instrument(skip_all)]
+    async fn fetch_data(
+        &self,
+        request: PFetchDataRequest,
+        _attachment: Vec<u8>,
+    ) -> Result<crate::prpc::Reply<PFetchDataResult>, crate::prpc::Error> {
+        let id = FragmentInstanceId {
+            hi: request.finst_id.hi,
+            lo: request.finst_id.lo,
+        };
+        // An unknown id is an error, not EOS: it means this CN never buffered a result for the
+        // fragment the FE is polling (wrong id, or a dispatch/result-sink path that did not run),
+        // and StarRocks treats a missing result buffer as a failure rather than an empty result.
+        let Some(outcome) = self.results.take_next(id) else {
+            return Ok(Self::fetch_data_result(
+                Self::internal_error(format!(
+                    "no buffered result for fragment instance {}-{}",
+                    id.hi, id.lo
+                )),
+                0,
+                true,
+            )
+            .into());
+        };
+        match outcome.batch {
+            Some(batch) => match batch.to_binary() {
+                Ok(bytes) => Ok(crate::prpc::Reply::with_attachment(
+                    Self::fetch_data_result(Self::ok_status(), outcome.packet_seq, outcome.eos),
+                    bytes,
+                )),
+                Err(err) => Ok(Self::fetch_data_result(
+                    Self::internal_error(err),
+                    outcome.packet_seq,
+                    true,
+                )
+                .into()),
+            },
+            None => Ok(
+                Self::fetch_data_result(Self::ok_status(), outcome.packet_seq, outcome.eos).into(),
+            ),
+        }
     }
 
     /// Infers the schema of the FILES() target so the FE can resolve the table function.
@@ -99,8 +160,8 @@ impl PInternalService for SiriusComputeNodeService {
 }
 
 impl SiriusComputeNodeService {
-    /// Deserializes and translates one binary-thrift TExecPlanFragmentParams attachment.
-    fn translate_single_attachment(
+    /// Deserializes one binary-thrift TExecPlanFragmentParams attachment and processes it.
+    fn exec_single_attachment(
         &self,
         protocol: Option<&str>,
         attachment: &[u8],
@@ -108,7 +169,38 @@ impl SiriusComputeNodeService {
         Self::ensure_binary_protocol(protocol)?;
         let params = Self::deserialize_binary::<TExecPlanFragmentParams>(attachment)
             .map_err(|err| format!("failed to deserialize TExecPlanFragmentParams: {err}"))?;
-        self.translate_and_log_fragment(&params)
+        self.process_fragment(&params)
+    }
+
+    /// Translates one fragment and, when it is a supported RESULT_SINK root, executes it and
+    /// buffers the rows for later `fetch_data`. Shared by single and batch dispatch so both paths
+    /// produce fetchable results for a RESULT_SINK instance.
+    fn process_fragment(
+        &self,
+        params: &TExecPlanFragmentParams,
+    ) -> std::result::Result<(), String> {
+        let translated = self.translate_fragment_logged(params)?;
+        self.execute_and_buffer(params, &translated)
+    }
+
+    /// Executes a RESULT_SINK fragment and buffers its rows. Non-result-sink fragments (e.g. a
+    /// DATA_STREAM_SINK feeding another fragment) are translate-only. An unsupported result-sink
+    /// format or a missing fragment instance id fails loudly so integration gaps surface as an
+    /// error rather than as a silent empty result at `fetch_data`.
+    fn execute_and_buffer(
+        &self,
+        params: &TExecPlanFragmentParams,
+        translated: &TranslatedPlan,
+    ) -> std::result::Result<(), String> {
+        if !Self::is_mysql_result_sink(params)? {
+            return Ok(());
+        }
+        let id = Self::fragment_instance_id(params)
+            .ok_or_else(|| "RESULT_SINK fragment is missing a fragment_instance_id".to_string())?;
+        let result = self.executor.execute(translated)?;
+        let batch = result_encoder::MysqlResultEncoder::encode(&result.batches, 0)?;
+        self.results.insert(id, batch);
+        Ok(())
     }
 
     /// Deserializes a FE batch attachment and merges common params into each instance.
@@ -149,19 +241,20 @@ impl SiriusComputeNodeService {
                 params.resource_info = common.resource_info.clone();
             }
 
-            self.translate_and_log_fragment(&params)
+            self.process_fragment(&params)
                 .map_err(|err| format!("fragment {idx}: {err}"))?;
         }
 
         Ok(())
     }
 
-    /// Converts a StarRocks thrift plan fragment to Substrait and logs substrait-explain output.
+    /// Converts a StarRocks thrift plan fragment to Substrait, logs substrait-explain output, and
+    /// returns the translated plan for execution.
     #[instrument(skip_all)]
-    fn translate_and_log_fragment(
+    fn translate_fragment_logged(
         &self,
         params: &TExecPlanFragmentParams,
-    ) -> std::result::Result<(), String> {
+    ) -> std::result::Result<TranslatedPlan, String> {
         let translated = self
             .translator
             .translate_fragment(params)
@@ -171,7 +264,44 @@ impl SiriusComputeNodeService {
             plan = %translated.explain(),
             "translated StarRocks plan fragment"
         );
-        Ok(())
+        Ok(translated)
+    }
+
+    /// Classifies the fragment output sink: `Ok(true)` for a MySQL text-protocol RESULT_SINK this
+    /// CN can encode, `Ok(false)` for a non-result sink (translate-only), and `Err` for a
+    /// RESULT_SINK whose format is not supported yet (binary rows, HTTP/FILE/Arrow Flight, etc.).
+    /// The encoder only emits MySQL text rows, so other result-sink formats must be rejected
+    /// rather than returned in the wrong wire format.
+    fn is_mysql_result_sink(params: &TExecPlanFragmentParams) -> std::result::Result<bool, String> {
+        let Some(sink) = params
+            .fragment
+            .as_ref()
+            .and_then(|fragment| fragment.output_sink.as_ref())
+        else {
+            return Ok(false);
+        };
+        if sink.type_ != TDataSinkType::RESULT_SINK {
+            return Ok(false);
+        }
+        // A RESULT_SINK with no nested detail defaults to MySQL text rows.
+        let Some(result_sink) = sink.result_sink.as_ref() else {
+            return Ok(true);
+        };
+        if matches!(result_sink.is_binary_row, Some(true)) {
+            return Err("binary-row result sinks are not supported yet".to_string());
+        }
+        match result_sink.type_ {
+            None | Some(TResultSinkType::MYSQL_PROTOCAL) => Ok(true),
+            Some(other) => Err(format!("result sink type {other:?} is not supported yet")),
+        }
+    }
+
+    /// Extracts the fragment instance id the FE later passes to `fetch_data`.
+    fn fragment_instance_id(params: &TExecPlanFragmentParams) -> Option<FragmentInstanceId> {
+        params.params.as_ref().map(|exec| FragmentInstanceId {
+            hi: exec.fragment_instance_id.hi,
+            lo: exec.fragment_instance_id.lo,
+        })
     }
 
     /// Extracts the parquet path from the binary-thrift attachment and infers its schema.
@@ -240,6 +370,16 @@ impl SiriusComputeNodeService {
         }
     }
 
+    /// Builds a `fetch_data` response carrying the FE's packet-sequence and end-of-stream markers.
+    fn fetch_data_result(status: StatusPb, packet_seq: i64, eos: bool) -> PFetchDataResult {
+        PFetchDataResult {
+            status,
+            packet_seq: Some(packet_seq),
+            eos: Some(eos),
+            query_statistics: None,
+        }
+    }
+
     /// StarRocks OK status. For these RPCs OK means "fragment accepted and translated", not
     /// "fragment executed" — execution and result delivery are not implemented yet.
     fn ok_status() -> StatusPb {
@@ -260,22 +400,29 @@ impl SiriusComputeNodeService {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use prost::Message;
     use starrocks_thrift::{
+        data::TResultBatch,
+        data_sinks::{TDataSink, TResultSink},
         descriptors::{TDescriptorTable, TSlotDescriptor, TTableDescriptor, TTupleDescriptor},
-        internal_service::InternalServiceVersion,
+        internal_service::{InternalServiceVersion, TPlanFragmentExecParams},
         partitions::{TDataPartition, TPartitionType},
         plan_nodes::{TFileScanNode, TPlan, TPlanNode, TPlanNodeType},
         planner::TPlanFragment,
-        types::{TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType},
+        types::{
+            TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType, TUniqueId,
+        },
     };
     use thrift::{protocol::TBinaryOutputProtocol, transport::TIoChannel};
     use tower::{Service, ServiceExt};
 
     use super::*;
     use crate::{
-        proto::starrocks::p_internal_service_brpc::{
-            PInternalServiceRouter, SERVICE_NAME, methods,
+        proto::starrocks::{
+            PFetchDataRequest, PUniqueId,
+            p_internal_service_brpc::{PInternalServiceRouter, SERVICE_NAME, methods},
         },
         prpc,
     };
@@ -368,6 +515,248 @@ mod tests {
         let err = call_router(request).unwrap_err();
 
         assert!(err.to_string().contains("service name"));
+    }
+
+    #[test]
+    fn exec_plan_fragment_executes_result_sink_and_fetch_data_drains_it() {
+        // A root RESULT_SINK fragment is executed (stub) and buffered; fetch_data returns the
+        // rows once, then reports end-of-stream. exec and fetch share one service so they share
+        // the result store.
+        let service = SiriusComputeNodeService::new();
+
+        let mut params = supported_fragment();
+        params.fragment.as_mut().unwrap().output_sink = Some(result_sink());
+        params.params = Some(exec_params(TUniqueId::new(0, 1), TUniqueId::new(0, 7)));
+
+        let exec = route(
+            &service,
+            methods::EXEC_PLAN_FRAGMENT,
+            PExecPlanFragmentRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(&params),
+        );
+        let exec = PExecPlanFragmentResult::decode(exec.body.as_slice()).unwrap();
+        assert_eq!(exec.status.status_code, TStatusCode::OK.0);
+
+        // First fetch returns the buffered rows in the attachment, eos = false.
+        let first = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(0, 7),
+            Vec::new(),
+        );
+        let first_result = PFetchDataResult::decode(first.body.as_slice()).unwrap();
+        assert_eq!(first_result.status.status_code, TStatusCode::OK.0);
+        assert_eq!(first_result.eos, Some(false));
+        let batch = SiriusComputeNodeService::deserialize_binary::<TResultBatch>(&first.attachment)
+            .unwrap();
+        // The stub emits one row of "stub" per output column ("id", "name"); each is a MySQL
+        // length-encoded string (len 4, then the bytes).
+        assert_eq!(batch.rows.len(), 1);
+        assert_eq!(
+            batch.rows[0],
+            vec![0x04, b's', b't', b'u', b'b', 0x04, b's', b't', b'u', b'b']
+        );
+
+        // Second fetch reports end-of-stream with no attachment.
+        let second = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(0, 7),
+            Vec::new(),
+        );
+        let second_result = PFetchDataResult::decode(second.body.as_slice()).unwrap();
+        assert_eq!(second_result.eos, Some(true));
+        assert!(second.attachment.is_empty());
+    }
+
+    #[test]
+    fn fetch_data_for_unknown_fragment_is_an_error() {
+        // A poll for an id this CN never buffered must fail loudly, not look like an empty result.
+        let service = SiriusComputeNodeService::new();
+        let response = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(0, 123),
+            Vec::new(),
+        );
+        let result = PFetchDataResult::decode(response.body.as_slice()).unwrap();
+        assert_eq!(result.status.status_code, TStatusCode::INTERNAL_ERROR.0);
+        assert!(
+            result.status.error_msgs[0].contains("no buffered result"),
+            "{:?}",
+            result.status.error_msgs
+        );
+        assert!(response.attachment.is_empty());
+    }
+
+    #[test]
+    fn exec_batch_plan_fragments_buffers_result_sink_instance() {
+        // The FE may dispatch the root via batch dispatch; it must also execute + buffer the
+        // RESULT_SINK instance so fetch_data returns rows instead of a silent empty result.
+        let service = SiriusComputeNodeService::new();
+        let mut root = fragment_params(Some(scan_plan(0, 0)), None);
+        root.fragment.as_mut().unwrap().output_sink = Some(result_sink());
+        root.params = Some(exec_params(TUniqueId::new(0, 1), TUniqueId::new(0, 55)));
+        let batch = TExecBatchPlanFragmentsParams::new(
+            Some(fragment_params(None, Some(desc_table()))),
+            Some(vec![root]),
+        );
+
+        let exec = route(
+            &service,
+            methods::EXEC_BATCH_PLAN_FRAGMENTS,
+            PExecBatchPlanFragmentsRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(&batch),
+        );
+        let exec = PExecBatchPlanFragmentsResult::decode(exec.body.as_slice()).unwrap();
+        assert_eq!(exec.status.unwrap().status_code, TStatusCode::OK.0);
+
+        let fetched = route(
+            &service,
+            methods::FETCH_DATA,
+            fetch_request(0, 55),
+            Vec::new(),
+        );
+        let fetched_result = PFetchDataResult::decode(fetched.body.as_slice()).unwrap();
+        assert_eq!(fetched_result.status.status_code, TStatusCode::OK.0);
+        assert_eq!(fetched_result.eos, Some(false));
+        let result_batch =
+            SiriusComputeNodeService::deserialize_binary::<TResultBatch>(&fetched.attachment)
+                .unwrap();
+        assert_eq!(result_batch.rows.len(), 1);
+    }
+
+    #[test]
+    fn exec_plan_fragment_rejects_unsupported_result_sink_format() {
+        // The encoder only emits MySQL text rows; a non-MySQL result sink must be rejected rather
+        // than returned in the wrong wire format.
+        let service = SiriusComputeNodeService::new();
+        let mut params = supported_fragment();
+        params.fragment.as_mut().unwrap().output_sink =
+            Some(result_sink_typed(TResultSinkType::STATISTIC));
+        params.params = Some(exec_params(TUniqueId::new(0, 1), TUniqueId::new(0, 9)));
+
+        let response = route(
+            &service,
+            methods::EXEC_PLAN_FRAGMENT,
+            PExecPlanFragmentRequest {
+                attachment_protocol: Some("binary".to_string()),
+            }
+            .encode_to_vec(),
+            serialize_binary(&params),
+        );
+        let result = PExecPlanFragmentResult::decode(response.body.as_slice()).unwrap();
+        assert_eq!(result.status.status_code, TStatusCode::INTERNAL_ERROR.0);
+        assert!(
+            result.status.error_msgs[0].contains("not supported"),
+            "{:?}",
+            result.status.error_msgs
+        );
+    }
+
+    fn fetch_request(hi: i64, lo: i64) -> Vec<u8> {
+        PFetchDataRequest {
+            finst_id: PUniqueId { hi, lo },
+        }
+        .encode_to_vec()
+    }
+
+    fn result_sink_typed(kind: TResultSinkType) -> TDataSink {
+        TDataSink::new(
+            TDataSinkType::RESULT_SINK,
+            None,
+            Some(TResultSink::new(Some(kind), None, None, None, None)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn route(
+        service: &SiriusComputeNodeService,
+        method: &str,
+        body: Vec<u8>,
+        attachment: Vec<u8>,
+    ) -> prpc::Response {
+        // Route through a router built from a clone of `service`; the result store is shared via
+        // `Arc`, so buffered results survive across the per-call router clones.
+        let mut router = PInternalServiceRouter::new(service.clone());
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                router
+                    .ready()
+                    .await
+                    .unwrap()
+                    .call(prpc::Request::new(SERVICE_NAME, method, body, attachment))
+                    .await
+            })
+            .unwrap()
+    }
+
+    fn result_sink() -> TDataSink {
+        // Only the sink type is read today (is_result_sink); the per-sink payloads stay None.
+        TDataSink::new(
+            TDataSinkType::RESULT_SINK,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn exec_params(
+        query_id: TUniqueId,
+        fragment_instance_id: TUniqueId,
+    ) -> TPlanFragmentExecParams {
+        // Only the ids are needed to key the result store; scan ranges/senders stay empty.
+        TPlanFragmentExecParams::new(
+            query_id,
+            fragment_instance_id,
+            BTreeMap::new(),
+            BTreeMap::new(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
     }
 
     fn call_exec_plan_fragment(

--- a/experimental/starrocks/src/fragment_executor.rs
+++ b/experimental/starrocks/src/fragment_executor.rs
@@ -1,0 +1,98 @@
+//! Execution of a translated fragment into Arrow result batches.
+//!
+//! The engine→CN result interchange is the Arrow C Data Interface (see the `SiriusExecutor`
+//! TODO). Today a [`StubExecutor`] stands in for the GPU engine so the StarRocks dispatch and
+//! result-return plumbing can be exercised end to end without a build tree or a GPU.
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use starrocks_plan_translator::TranslatedPlan;
+
+/// Output of executing one plan fragment: Arrow batches matching the fragment output schema.
+#[derive(Clone, Debug)]
+pub(crate) struct FragmentResult {
+    /// Result batches in fragment output order. Empty for a fragment with no output columns.
+    pub(crate) batches: Vec<RecordBatch>,
+}
+
+/// Runs a translated fragment and returns its result batches.
+///
+/// This is intentionally a synchronous, fully-materializing seam for the single-fragment
+/// milestone: `exec_plan_fragment` runs it to completion before returning, and `fetch_data` then
+/// drains the buffered rows.
+///
+/// TODO(starrocks-execute): a real GPU executor should not block dispatch on full materialization.
+/// Evolve this into a streaming contract — dispatch registers a running fragment and returns after
+/// startup, the executor pushes Arrow batches (e.g. via an Arrow C stream) into a bounded channel
+/// the `ResultStore` drains, and execution is cancellable from `cancel_plan_fragment`. Large/slow
+/// result queries then stream through `fetch_data` instead of risking dispatch-time timeout/OOM.
+pub(crate) trait FragmentExecutor: std::fmt::Debug + Send + Sync {
+    /// Executes `translated` and returns its Arrow result batches.
+    fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String>;
+}
+
+/// Placeholder executor that fabricates one row so the result path works without a GPU.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct StubExecutor;
+
+impl FragmentExecutor for StubExecutor {
+    fn execute(&self, translated: &TranslatedPlan) -> Result<FragmentResult, String> {
+        // TODO(starrocks-execute): replace with a SiriusExecutor that hands
+        // `translated.to_substrait_bytes()` to the embedded Sirius engine, executes it on the
+        // GPU, and imports the result via the Arrow C Data Interface. That executor will hold an
+        // `Arc<sirius::SiriusContext>` threaded in from `main` (see `BrpcServer::new`). For now
+        // we emit one placeholder string row per output column so the FE→client path is exercised.
+        let names = &translated.output_names;
+        if names.is_empty() {
+            return Ok(FragmentResult {
+                batches: Vec::new(),
+            });
+        }
+        let fields: Vec<Field> = names
+            .iter()
+            .map(|name| Field::new(name, DataType::Utf8, true))
+            .collect();
+        let columns: Vec<ArrayRef> = names
+            .iter()
+            .map(|_| Arc::new(StringArray::from(vec![Some("stub")])) as ArrayRef)
+            .collect();
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .map_err(|err| format!("failed to build stub result batch: {err}"))?;
+        Ok(FragmentResult {
+            batches: vec![batch],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan_with_outputs(names: &[&str]) -> TranslatedPlan {
+        TranslatedPlan {
+            plan: Default::default(),
+            output_names: names.iter().map(|name| name.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn stub_executor_emits_one_row_matching_output_names() {
+        let result = StubExecutor
+            .execute(&plan_with_outputs(&["id", "name"]))
+            .unwrap();
+        assert_eq!(result.batches.len(), 1);
+        let batch = &result.batches[0];
+        assert_eq!(batch.num_columns(), 2);
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.schema().field(0).name(), "id");
+        assert_eq!(batch.schema().field(1).name(), "name");
+    }
+
+    #[test]
+    fn stub_executor_handles_empty_output() {
+        let result = StubExecutor.execute(&plan_with_outputs(&[])).unwrap();
+        assert!(result.batches.is_empty());
+    }
+}

--- a/experimental/starrocks/src/lib.rs
+++ b/experimental/starrocks/src/lib.rs
@@ -47,8 +47,11 @@ use tracing::{debug, info, instrument, warn};
 mod brpc;
 mod compute_node_service;
 mod file_schema;
+mod fragment_executor;
 mod proto;
 mod prpc;
+mod result_encoder;
+mod result_store;
 
 pub use brpc::BrpcServer;
 

--- a/experimental/starrocks/src/prpc.rs
+++ b/experimental/starrocks/src/prpc.rs
@@ -83,6 +83,16 @@ pub(crate) struct Reply<M> {
     pub(crate) attachment: Vec<u8>,
 }
 
+impl<M> Reply<M> {
+    /// Builds a reply whose message is accompanied by an attachment.
+    pub(crate) fn with_attachment(message: M, attachment: Vec<u8>) -> Self {
+        Self {
+            message,
+            attachment,
+        }
+    }
+}
+
 impl<M> From<M> for Reply<M> {
     /// Wraps a bare protobuf message as an attachment-less reply.
     fn from(message: M) -> Self {

--- a/experimental/starrocks/src/result_encoder.rs
+++ b/experimental/starrocks/src/result_encoder.rs
@@ -1,0 +1,205 @@
+//! Encodes executed-fragment output into the StarRocks result wire format.
+//!
+//! StarRocks delivers SELECT results to the FE as a `TResultBatch` whose `rows` are MySQL
+//! text-protocol resultset rows: each column value is a length-encoded string, NULL is the single
+//! byte `0xFB`. The FE forwards those row bodies straight to the MySQL client.
+
+use arrow_array::{
+    Array, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    RecordBatch, StringArray,
+};
+use arrow_schema::DataType;
+use starrocks_thrift::data::TResultBatch;
+use thrift::{
+    protocol::{TBinaryOutputProtocol, TSerializable},
+    transport::{TBufferChannel, TIoChannel},
+};
+
+/// Encodes Arrow result batches into a StarRocks `TResultBatch` of MySQL text rows.
+#[derive(Default)]
+pub(crate) struct MysqlResultEncoder {
+    rows: Vec<Vec<u8>>,
+}
+
+impl MysqlResultEncoder {
+    /// Encodes `batches` into a `TResultBatch` tagged with `packet_seq`.
+    pub(crate) fn encode(batches: &[RecordBatch], packet_seq: i64) -> Result<TResultBatch, String> {
+        let mut encoder = Self::default();
+        for batch in batches {
+            encoder.add_batch(batch)?;
+        }
+        Ok(encoder.into_result_batch(packet_seq))
+    }
+
+    /// Encodes every row of `batch` as a MySQL text row.
+    fn add_batch(&mut self, batch: &RecordBatch) -> Result<(), String> {
+        let columns = batch.columns();
+        for row in 0..batch.num_rows() {
+            let mut encoded = MysqlTextRow::default();
+            for column in columns {
+                encoded.push_cell(Self::render_cell(column.as_ref(), row)?.as_deref());
+            }
+            self.rows.push(encoded.into_bytes());
+        }
+        Ok(())
+    }
+
+    /// Consumes the accumulated rows into a `TResultBatch`.
+    ///
+    /// `is_compressed = false`: the Rust CN never snappy-compresses result rows yet.
+    fn into_result_batch(self, packet_seq: i64) -> TResultBatch {
+        TResultBatch::new(self.rows, false, packet_seq, None)
+    }
+
+    /// Renders one column value as raw text bytes, or `None` for SQL NULL.
+    fn render_cell(array: &dyn Array, row: usize) -> Result<Option<Vec<u8>>, String> {
+        if array.is_null(row) {
+            return Ok(None);
+        }
+        // Render the value as the MySQL client expects in the text protocol: a decimal/string form.
+        macro_rules! render_primitive {
+            ($ty:ty) => {{
+                let typed = Self::downcast::<$ty>(array)?;
+                Ok(Some(typed.value(row).to_string().into_bytes()))
+            }};
+        }
+        match array.data_type() {
+            DataType::Utf8 => {
+                let typed = Self::downcast::<StringArray>(array)?;
+                Ok(Some(typed.value(row).as_bytes().to_vec()))
+            }
+            DataType::Boolean => {
+                let typed = Self::downcast::<BooleanArray>(array)?;
+                Ok(Some(if typed.value(row) {
+                    b"1".to_vec()
+                } else {
+                    b"0".to_vec()
+                }))
+            }
+            DataType::Int8 => render_primitive!(Int8Array),
+            DataType::Int16 => render_primitive!(Int16Array),
+            DataType::Int32 => render_primitive!(Int32Array),
+            DataType::Int64 => render_primitive!(Int64Array),
+            DataType::Float32 => render_primitive!(Float32Array),
+            DataType::Float64 => render_primitive!(Float64Array),
+            // TODO(starrocks-execute): cover the remaining types the translator maps (decimal, date,
+            // datetime, binary) as the real executor lands.
+            other => Err(format!(
+                "result encoding for arrow type {other:?} is not implemented yet"
+            )),
+        }
+    }
+
+    /// Downcasts an Arrow array to a concrete type, mapping a mismatch to a descriptive error.
+    fn downcast<T: 'static>(array: &dyn Array) -> Result<&T, String> {
+        array.as_any().downcast_ref::<T>().ok_or_else(|| {
+            format!(
+                "arrow array did not downcast to {}",
+                std::any::type_name::<T>()
+            )
+        })
+    }
+}
+
+/// One MySQL text-protocol resultset row: a sequence of length-encoded column values.
+#[derive(Default)]
+struct MysqlTextRow {
+    buf: Vec<u8>,
+}
+
+impl MysqlTextRow {
+    /// Appends one column value as a MySQL length-encoded string, or the NULL sentinel `0xFB`.
+    fn push_cell(&mut self, value: Option<&[u8]>) {
+        match value {
+            Some(bytes) => {
+                self.push_length(bytes.len());
+                self.buf.extend_from_slice(bytes);
+            }
+            None => self.buf.push(0xFB),
+        }
+    }
+
+    /// Writes a MySQL `length-encoded integer` prefix. `0xFB` is reserved for NULL, so a one-byte
+    /// length never reaches 251.
+    fn push_length(&mut self, len: usize) {
+        if len < 251 {
+            self.buf.push(len as u8);
+        } else if len < 1 << 16 {
+            self.buf.push(0xFC);
+            self.buf.extend_from_slice(&(len as u16).to_le_bytes());
+        } else if len < 1 << 24 {
+            self.buf.push(0xFD);
+            self.buf.extend_from_slice(&(len as u32).to_le_bytes()[..3]);
+        } else {
+            self.buf.push(0xFE);
+            self.buf.extend_from_slice(&(len as u64).to_le_bytes());
+        }
+    }
+
+    /// Consumes the row into its encoded bytes.
+    fn into_bytes(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// Serializes a thrift value with the binary protocol the FE expects for BRPC attachments.
+pub(crate) trait ThriftBinary {
+    /// Serializes `self` to thrift binary-protocol bytes.
+    fn to_binary(&self) -> Result<Vec<u8>, String>;
+}
+
+impl<T: TSerializable> ThriftBinary for T {
+    fn to_binary(&self) -> Result<Vec<u8>, String> {
+        let channel = TBufferChannel::with_capacity(0, 64 * 1024);
+        let (_, write) = channel
+            .clone()
+            .split()
+            .map_err(|err| format!("failed to split thrift channel: {err}"))?;
+        let mut protocol = TBinaryOutputProtocol::new(write, true);
+        self.write_to_out_protocol(&mut protocol)
+            .map_err(|err| format!("failed to serialize thrift value: {err}"))?;
+        Ok(channel.write_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use arrow_array::ArrayRef;
+    use arrow_schema::{Field, Schema};
+
+    #[test]
+    fn encodes_length_prefixed_text_rows() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("n", DataType::Int64, true),
+            Field::new("s", DataType::Utf8, true),
+        ]));
+        let ids: ArrayRef = Arc::new(Int64Array::from(vec![Some(42), None]));
+        let names: ArrayRef = Arc::new(StringArray::from(vec![Some("hi"), Some("x")]));
+        let batch = RecordBatch::try_new(schema, vec![ids, names]).unwrap();
+
+        let result = MysqlResultEncoder::encode(&[batch], 0).unwrap();
+
+        assert_eq!(result.rows.len(), 2);
+        // Row 0: "42" (len 2) then "hi" (len 2).
+        assert_eq!(result.rows[0], vec![0x02, b'4', b'2', 0x02, b'h', b'i']);
+        // Row 1: NULL int (0xFB) then "x" (len 1).
+        assert_eq!(result.rows[1], vec![0xFB, 0x01, b'x']);
+    }
+
+    #[test]
+    fn long_value_uses_two_byte_length_prefix() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
+        let long = "z".repeat(300);
+        let col: ArrayRef = Arc::new(StringArray::from(vec![Some(long.as_str())]));
+        let batch = RecordBatch::try_new(schema, vec![col]).unwrap();
+
+        let result = MysqlResultEncoder::encode(&[batch], 0).unwrap();
+
+        // 300 = 0x012C, encoded as 0xFC then little-endian u16.
+        assert_eq!(&result.rows[0][..3], &[0xFC, 0x2C, 0x01]);
+        assert_eq!(result.rows[0].len(), 3 + 300);
+    }
+}

--- a/experimental/starrocks/src/result_store.rs
+++ b/experimental/starrocks/src/result_store.rs
@@ -1,0 +1,139 @@
+//! In-memory buffer of executed-fragment results awaiting FE `fetch_data` collection.
+//!
+//! StarRocks dispatches a fragment with `exec_plan_fragment`, then polls `fetch_data` with the
+//! fragment instance id until end-of-stream. This store bridges those two RPCs: the exec handler
+//! buffers a fragment's rows here, and each `fetch_data` poll drains them.
+
+use std::{collections::HashMap, sync::Mutex};
+
+use starrocks_thrift::data::TResultBatch;
+
+/// StarRocks `fragment_instance_id` (a `TUniqueId`), the key the FE passes to `fetch_data`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct FragmentInstanceId {
+    /// High 64 bits of the instance id.
+    pub(crate) hi: i64,
+    /// Low 64 bits of the instance id.
+    pub(crate) lo: i64,
+}
+
+/// One buffered fragment result and where the FE `fetch_data` poll is in draining it.
+#[derive(Debug)]
+enum FragmentState {
+    /// Rows produced, not yet delivered.
+    Pending(TResultBatch),
+    /// Rows delivered; the next poll reports end-of-stream.
+    Drained,
+}
+
+/// What a single `fetch_data` poll should return to the FE.
+#[derive(Debug)]
+pub(crate) struct FetchOutcome {
+    /// Result rows to ship as the response attachment, when present.
+    pub(crate) batch: Option<TResultBatch>,
+    /// Monotonic packet sequence the FE uses to detect lost packets.
+    pub(crate) packet_seq: i64,
+    /// End-of-stream marker; the FE stops polling once true.
+    pub(crate) eos: bool,
+}
+
+/// Process-wide store of fragment results keyed by fragment instance id.
+///
+/// Shared across all BRPC connections via an `Arc` inside the compute-node service, so a
+/// `fetch_data` poll on one connection sees results buffered by an `exec_plan_fragment` on another.
+#[derive(Debug, Default)]
+pub(crate) struct ResultStore {
+    /// Buffered results keyed by fragment instance id.
+    inner: Mutex<HashMap<FragmentInstanceId, FragmentState>>,
+}
+
+impl ResultStore {
+    /// Buffers an executed fragment's result for later `fetch_data` collection.
+    pub(crate) fn insert(&self, id: FragmentInstanceId, batch: TResultBatch) {
+        self.lock().insert(id, FragmentState::Pending(batch));
+    }
+
+    /// Advances the `fetch_data` state machine for one fragment: deliver rows once, then EOS.
+    /// Returns `None` for an id this CN never buffered, which the caller reports as an error
+    /// (StarRocks treats a missing result buffer as a failure, not an empty result). A drained
+    /// fragment stays in the map so a repeat poll still reports EOS rather than reading as unknown.
+    ///
+    /// TODO(starrocks-execute): this is a single-batch, single-poller model. The real executor
+    /// needs (a) chunked/streamed delivery of many batches, (b) safety against duplicate or
+    /// concurrent polls (advance state only after the response is written; keep a per-fragment
+    /// in-flight guard), and (c) eviction of drained entries on `cancel_plan_fragment`/timeout so
+    /// the map does not grow for the process lifetime.
+    pub(crate) fn take_next(&self, id: FragmentInstanceId) -> Option<FetchOutcome> {
+        let mut guard = self.lock();
+        match guard.get_mut(&id) {
+            None => None,
+            Some(state @ FragmentState::Pending(_)) => {
+                let FragmentState::Pending(batch) =
+                    std::mem::replace(state, FragmentState::Drained)
+                else {
+                    unreachable!("state matched Pending")
+                };
+                Some(FetchOutcome {
+                    batch: Some(batch),
+                    packet_seq: 0,
+                    eos: false,
+                })
+            }
+            Some(FragmentState::Drained) => Some(FetchOutcome {
+                batch: None,
+                packet_seq: 1,
+                eos: true,
+            }),
+        }
+    }
+
+    /// Locks the inner map, recovering from a poisoned mutex (state is disposable result data).
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<FragmentInstanceId, FragmentState>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn batch(rows: &[&str]) -> TResultBatch {
+        TResultBatch::new(
+            rows.iter().map(|row| row.as_bytes().to_vec()).collect(),
+            false,
+            0,
+            None,
+        )
+    }
+
+    #[test]
+    fn delivers_rows_once_then_reports_eos_on_repeat_polls() {
+        let store = ResultStore::default();
+        let id = FragmentInstanceId { hi: 1, lo: 2 };
+        store.insert(id, batch(&["a", "b"]));
+
+        let first = store.take_next(id).expect("known fragment");
+        assert!(!first.eos);
+        assert_eq!(first.batch.unwrap().rows.len(), 2);
+
+        // A drained fragment keeps reporting EOS, never reverting to "unknown".
+        let second = store.take_next(id).expect("drained fragment still known");
+        assert!(second.eos);
+        assert!(second.batch.is_none());
+
+        let third = store.take_next(id).expect("drained fragment still known");
+        assert!(third.eos);
+    }
+
+    #[test]
+    fn unknown_fragment_is_none() {
+        let store = ResultStore::default();
+        assert!(
+            store
+                .take_next(FragmentInstanceId { hi: 9, lo: 9 })
+                .is_none()
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #1007 (BRPC reply attachments). Review/merge that first; this branch contains its commit until it lands.

## What

Wires the execute + result-return half of the StarRocks compute node so a single root `RESULT_SINK` fragment runs and returns rows to the FE:

- **`FragmentExecutor` + `StubExecutor`** (`fragment_executor.rs`) — runs a translated fragment into Arrow `RecordBatch`es. The engine→CN interchange is the Arrow C Data Interface; the stub fabricates one placeholder row per output column so the plumbing works without a GPU. The real `SiriusExecutor` (Substrait→GPU) is a documented TODO.
- **`ResultStore`** (`result_store.rs`) — buffers a fragment's rows keyed by `fragment_instance_id`; `fetch_data` drains it (deliver once, then EOS; unknown id is an error, not empty).
- **`result_encoder.rs`** — encodes Arrow batches into a `TResultBatch` of MySQL text-protocol rows (length-encoded; NULL = `0xFB`).
- **`compute_node_service.rs`** — `exec_plan_fragment` / `exec_batch_plan_fragments` now translate, then for a MySQL `RESULT_SINK` fragment execute (stub) and buffer; new **`fetch_data`** handler returns the rows as the BRPC response attachment. Unsupported result-sink formats fail loudly.

Engine stays stubbed, but the translated Substrait plan is correctly typed, so the real executor will run the actual data unchanged.

## Notes
- Functionally also depends (at runtime) on the CN being a shared-data worker (#1004) and on per-tuple descriptor slot keying (#1006); both are separate PRs. This branch compiles and unit-tests independently.
- No-engine tests cover the exec→fetch round-trip, unknown-id error, batch RESULT_SINK buffering, unsupported-sink rejection, the MySQL row encoder, and the result-store state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
