### PR TITLE
build: compile the Substrait->DuckDB reader into libsirius

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,22 @@ if(VCPKG_BUILD)
   endforeach()
 endif()
 
+# DuckDB's unity build emits strong symbols for static constexpr members (e.g.
+# duckdb::TableCatalogEntry::Name) that also appear as inline definitions in
+# headers pulled in by the vendored substrait reader
+# (substrait/src/from_substrait.cpp). Tolerate the benign duplicate on every
+# binary that links both libsirius_extension and libduckdb_static — the duckdb
+# shell, the loadable extension, and the C++ test/bench exes — mirroring the
+# per-target flag already on sirius_unittest / parquet_benchmark (and the Rust
+# bindings).
+foreach(_sirius_link_flags CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS
+                           CMAKE_MODULE_LINKER_FLAGS)
+  string(APPEND ${_sirius_link_flags} " -Wl,--allow-multiple-definition")
+  set(${_sirius_link_flags}
+      "${${_sirius_link_flags}}"
+      CACHE STRING "" FORCE)
+endforeach()
+
 # Dependencies
 find_package(cudf REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
@@ -337,6 +353,32 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/legacy/CMakeLists.txt")
   list(APPEND CUDA_SOURCES ${SIRIUS_LEGACY_CUDA_SOURCES})
 endif()
 
+# Compile the DuckDB substrait extension's Substrait->DuckDB reader directly
+# into the sirius target so the FFI (src/sirius_ffi.cpp) can call
+# `duckdb::SubstraitToDuckDB`. Only the from-substrait direction plus its
+# bundled protobuf (renamespaced to `duckdb::google::protobuf`, no abseil) are
+# compiled in — NOT the substrait SQL functions, to_substrait, or a second
+# loadable extension — so there is no symbol collision with conda/system
+# protobuf or a duplicate extension.
+set(SIRIUS_SUBSTRAIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/substrait")
+file(GLOB_RECURSE SIRIUS_SUBSTRAIT_PROTOBUF_SOURCES
+     "${SIRIUS_SUBSTRAIT_DIR}/third_party/google/protobuf/*.cc")
+set(SIRIUS_SUBSTRAIT_SOURCES
+    ${SIRIUS_SUBSTRAIT_DIR}/src/from_substrait.cpp
+    ${SIRIUS_SUBSTRAIT_DIR}/src/custom_extensions.cpp
+    ${SIRIUS_SUBSTRAIT_DIR}/src/custom_extensions_generated.cpp
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait/substrait/algebra.pb.cc
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait/substrait/extended_expression.pb.cc
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait/substrait/plan.pb.cc
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait/substrait/type.pb.cc
+    ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait/substrait/extensions/extensions.pb.cc
+    ${SIRIUS_SUBSTRAIT_PROTOBUF_SOURCES})
+# The vendored/generated protobuf + substrait TUs are not warning-clean; never
+# fail the build on them.
+set_source_files_properties(${SIRIUS_SUBSTRAIT_SOURCES}
+                            PROPERTIES COMPILE_OPTIONS "-w")
+list(APPEND EXTENSION_SOURCES ${SIRIUS_SUBSTRAIT_SOURCES})
+
 build_static_extension(sirius ${EXTENSION_SOURCES} ${CUDA_SOURCES})
 build_loadable_extension(sirius CPP ${EXTENSION_SOURCES} ${CUDA_SOURCES})
 
@@ -370,6 +412,14 @@ foreach(_target sirius_extension sirius_loadable_extension)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
       $<$<BOOL:${SIRIUS_LEGACY_INCLUDE_DIR}>:$<BUILD_INTERFACE:${SIRIUS_LEGACY_INCLUDE_DIR}>>
   )
+
+  # Substrait->DuckDB reader headers (from_substrait.hpp) and its bundled
+  # protobuf.
+  target_include_directories(
+    ${_target}
+    PRIVATE ${SIRIUS_SUBSTRAIT_DIR}/src/include
+            ${SIRIUS_SUBSTRAIT_DIR}/third_party
+            ${SIRIUS_SUBSTRAIT_DIR}/third_party/substrait)
 
   if(SIRIUS_LEGACY_COMPILE_DEFINITIONS)
     target_compile_definitions(${_target}


### PR DESCRIPTION
Prerequisite build plumbing for the upcoming one-shot `execute_substrait` FFI (Sirius-as-a-library / #835, #545). Split out on its own so the build-integration risk is isolated from the FFI logic.

## What
Compile the vendored DuckDB substrait extension's **Substrait→DuckDB reader** directly into the `sirius` target so `src/sirius_ffi.cpp` can call `duckdb::SubstraitToDuckDB`:
- Adds `substrait/src/from_substrait.cpp` + `custom_extensions{,_generated}.cpp` + the substrait `*.pb.cc` + the bundled protobuf (`third_party/google/protobuf/*.cc`) to `EXTENSION_SOURCES`, with the substrait/protobuf include dirs.
- Generated TUs get `-w` (they're not warning-clean).
- **No** `substrait_extension.cpp` / `to_substrait.cpp` — we don't register substrait SQL functions or a second loadable extension.

## Why it's collision-free
The bundled protobuf is renamespaced to `duckdb::google::protobuf` and pulls in no abseil, so it can't clash with conda/system protobuf or Sirius's `find_package(absl)`.

## `--allow-multiple-definition`
`from_substrait.cpp` ODR-uses DuckDB static-constexpr members (e.g. `TableCatalogEntry::Name`) that DuckDB's unity build also defines, producing a benign duplicate when both `libsirius_extension` and `libduckdb_static` link into the same binary. The repo already tolerates this for `sirius_unittest`/`parquet_benchmark` (CMakeLists:671-674/721-722) and the Rust bindings (`rust/crates/sirius/build.rs`); this extends the same flag to the global linker flags so the duckdb shell + loadable extension link too.

No functional change yet (nothing calls `SubstraitToDuckDB` — that lands with the FFI). Verified: full `pixi run make` builds clean (shell, loadable extension, `sirius_unittest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
