### PR TITLE
feat(starrocks): emit local_files reads for file scans

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/error.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/error.rs
@@ -37,6 +37,15 @@ pub enum TranslateError {
         /// Short unsupported reason.
         reason: &'static str,
     },
+    /// A FILE_SCAN broker scan range is outside the supported v1 slice (e.g. a
+    /// non-parquet format or a byte-range split).
+    #[error("unsupported scan range at node {node_id}: {reason}")]
+    UnsupportedScanRange {
+        /// StarRocks plan-node id of the scan.
+        node_id: i32,
+        /// Short unsupported reason.
+        reason: &'static str,
+    },
     /// A StarRocks expression node is outside the supported v1 translation slice.
     #[error("unsupported expression node {node_type:?}: {reason}")]
     UnsupportedExpression {

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! | Plan node        | Substrait relation     |
 //! |------------------|------------------------|
-//! | `FILE_SCAN_NODE` | `ReadRel` (named table) |
+//! | `FILE_SCAN_NODE` | `ReadRel` (local files) |
 //! | `HDFS_SCAN_NODE` | `ReadRel` (named table) |
 //! | `SELECT_NODE`    | `FilterRel`            |
 //! | `PROJECT_NODE`   | `ProjectRel`           |
@@ -75,11 +75,13 @@ pub(crate) mod descriptor_table;
 pub mod error;
 mod expr_translator;
 mod node_translator;
+mod scan_paths;
 pub(crate) mod type_mapper;
 
 use descriptor_table::{DescriptorTable, SlotInfo};
 use error::Result;
 pub use error::TranslateError;
+use scan_paths::ScanFilePaths;
 
 /// Substrait comparison function extension URN used for scalar predicates.
 pub const URN_COMPARISON: &str = "extension:io.substrait:functions_comparison";
@@ -185,8 +187,10 @@ impl PlanTranslator {
             })?;
 
         let desc = DescriptorTable::try_from(desc_tbl)?;
+        let scan_paths = ScanFilePaths::from_fragment(params, &desc)?;
         let mut registry = ExtensionRegistry::new();
-        let mut translated = node_translator::translate_plan(plan, &desc, &mut registry)?;
+        let mut translated =
+            node_translator::translate_plan(plan, &desc, &scan_paths, &mut registry)?;
 
         let output_names = if let Some(output_exprs) = fragment
             .output_exprs

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/node_translator.rs
@@ -1,5 +1,10 @@
 use starrocks_thrift::exprs::TExpr;
 use starrocks_thrift::plan_nodes::{TPlan, TPlanNode, TPlanNodeType};
+use substrait::proto::read_rel::local_files::FileOrFiles;
+use substrait::proto::read_rel::local_files::file_or_files::{
+    FileFormat, ParquetReadOptions, PathType,
+};
+use substrait::proto::read_rel::{LocalFiles, NamedTable, ReadType};
 use substrait::proto::{
     Expression, FilterRel, ProjectRel, ReadRel, Rel, RelCommon, rel, rel_common,
 };
@@ -7,6 +12,7 @@ use substrait::proto::{
 use crate::descriptor_table::DescriptorTable;
 use crate::error::{Result, TranslateError};
 use crate::expr_translator::{self, ExprContext, TranslateExpr};
+use crate::scan_paths::ScanFilePaths;
 use crate::{ExtensionRegistry, URN_BOOLEAN};
 
 /// Partially translated relation plus the StarRocks row layout it emits.
@@ -34,14 +40,26 @@ pub(crate) struct TranslatedRel {
 struct PlanContext<'a> {
     /// Descriptor lookups for row layouts, tables, and scan schemas.
     desc: &'a DescriptorTable,
+    /// Parquet file paths for each scan node, collected from the fragment's broker
+    /// scan ranges. Scans with paths emit a `local_files` read; path-less scans
+    /// fall back to a named-table read.
+    scan_paths: &'a ScanFilePaths,
     /// Substrait extension registry shared across the whole plan.
     registry: &'a mut ExtensionRegistry,
 }
 
 impl<'a> PlanContext<'a> {
     /// Creates a plan translation context.
-    fn new(desc: &'a DescriptorTable, registry: &'a mut ExtensionRegistry) -> Self {
-        Self { desc, registry }
+    fn new(
+        desc: &'a DescriptorTable,
+        scan_paths: &'a ScanFilePaths,
+        registry: &'a mut ExtensionRegistry,
+    ) -> Self {
+        Self {
+            desc,
+            scan_paths,
+            registry,
+        }
     }
 
     /// Creates an expression context for an expression over `row_tuples`.
@@ -186,8 +204,9 @@ fn translate_scan(
     ctx: &mut PlanContext<'_>,
 ) -> Result<TranslatedRel> {
     expect_children(node, &children, 0)?;
+    let file_paths = ctx.scan_paths.for_node(node.node_id);
     let input = TranslatedRel {
-        rel: scan_rel(ctx.desc, tuple_id)?,
+        rel: scan_rel(ctx.desc, tuple_id, file_paths)?,
         row_tuples: vec![tuple_id],
         output_width: ctx.desc.materialized_slot_ids(tuple_id)?.len(),
     };
@@ -226,23 +245,43 @@ fn translate_project(
 pub(crate) fn translate_plan(
     plan: &TPlan,
     desc: &DescriptorTable,
+    scan_paths: &ScanFilePaths,
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedRel> {
-    let mut ctx = PlanContext::new(desc, registry);
+    let mut ctx = PlanContext::new(desc, scan_paths, registry);
     plan.translate(&mut ctx)
 }
 
-/// Builds a Substrait named-table read for a StarRocks scan tuple.
-fn scan_rel(desc: &DescriptorTable, tuple_id: i32) -> Result<Rel> {
+/// Builds a Substrait read for a StarRocks scan tuple.
+///
+/// With `file_paths` present (FILE_SCAN broker ranges) it emits a `local_files`
+/// parquet read so DuckDB's Substrait reader resolves the scan to
+/// `parquet_scan(<paths>)`. v1 assumes parquet files whose column order matches
+/// the scan tuple's slot order, which holds for `FILES()` `SELECT *`. Without
+/// paths (e.g. HDFS scans) it falls back to a named-table read.
+fn scan_rel(desc: &DescriptorTable, tuple_id: i32, file_paths: &[String]) -> Result<Rel> {
+    let read_type = if file_paths.is_empty() {
+        ReadType::NamedTable(NamedTable {
+            names: desc.table_names_for_tuple(tuple_id)?,
+            ..Default::default()
+        })
+    } else {
+        ReadType::LocalFiles(LocalFiles {
+            items: file_paths
+                .iter()
+                .map(|path| FileOrFiles {
+                    path_type: Some(PathType::UriFile(path.clone())),
+                    file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        })
+    };
     Ok(Rel {
         rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
             base_schema: Some(desc.named_struct(tuple_id)?),
-            read_type: Some(substrait::proto::read_rel::ReadType::NamedTable(
-                substrait::proto::read_rel::NamedTable {
-                    names: desc.table_names_for_tuple(tuple_id)?,
-                    ..Default::default()
-                },
-            )),
+            read_type: Some(read_type),
             ..Default::default()
         }))),
     })
@@ -302,7 +341,10 @@ pub(crate) fn project_exprs(
     desc: &DescriptorTable,
     registry: &mut ExtensionRegistry,
 ) -> Result<TranslatedRel> {
-    let mut ctx = PlanContext::new(desc, registry);
+    // Root projections evaluate over already-translated inputs, so there are no
+    // scan nodes to resolve file paths for.
+    let scan_paths = ScanFilePaths::default();
+    let mut ctx = PlanContext::new(desc, &scan_paths, registry);
     project_exprs_with_context(input, exprs, &mut ctx)
 }
 

--- a/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/scan_paths.rs
@@ -1,0 +1,277 @@
+//! Per-scan-node parquet file paths collected from a fragment's broker scan ranges.
+
+use std::collections::HashMap;
+
+use starrocks_thrift::exprs::TExprNodeType;
+use starrocks_thrift::internal_service::{TExecPlanFragmentParams, TScanRangeParams};
+use starrocks_thrift::plan_nodes::{
+    TBrokerRangeDesc, TBrokerScanRangeParams, TFileFormatType, TFileScanType,
+};
+use starrocks_thrift::types::TFileType;
+
+use crate::descriptor_table::DescriptorTable;
+use crate::error::{Result, TranslateError};
+
+/// Parquet file paths for each scan node in a fragment, keyed by plan node id.
+///
+/// Built from the fragment's broker scan ranges so `FILE_SCAN` nodes emit
+/// Substrait `local_files` reads DuckDB resolves as `parquet_scan(<paths>)`.
+/// Nodes without broker ranges have no entry and fall back to a named-table read.
+///
+/// Collection fails closed: only the slice that maps faithfully onto a
+/// `parquet_scan` over local files is accepted — a `FILES()` query (not a load),
+/// reading whole local parquet files whose columns are direct passthroughs to the
+/// scan tuple. Anything else (loads, byte-range splits, remote schemes, casts or
+/// other column transforms, path-derived or flexibly-mapped columns) is rejected
+/// with [`TranslateError::UnsupportedScanRange`] rather than silently producing
+/// wrong results.
+#[derive(Debug, Default)]
+pub(crate) struct ScanFilePaths {
+    by_node: HashMap<i32, Vec<String>>,
+}
+
+impl ScanFilePaths {
+    /// Collects whole-file parquet paths from `params`' broker scan ranges.
+    ///
+    /// Ranges arrive either per node (`per_node_scan_ranges`) or, for pipeline
+    /// fragments, per driver sequence (`node_to_per_driver_seq_scan_ranges`);
+    /// both are collected.
+    pub(crate) fn from_fragment(
+        params: &TExecPlanFragmentParams,
+        desc: &DescriptorTable,
+    ) -> Result<Self> {
+        let mut paths = Self::default();
+        let Some(exec_params) = params.params.as_ref() else {
+            return Ok(paths);
+        };
+        for (node_id, ranges) in &exec_params.per_node_scan_ranges {
+            paths.add_ranges(*node_id, ranges, desc)?;
+        }
+        if let Some(per_driver) = exec_params.node_to_per_driver_seq_scan_ranges.as_ref() {
+            for (node_id, per_seq) in per_driver {
+                // A node must appear in exactly one of the two scan-range maps.
+                // StarRocks keeps them disjoint (LocalFragmentAssignmentStrategy),
+                // but that contract is invisible here, so enforce it locally: a node
+                // in both would have its whole-file paths collected — and read —
+                // twice, silently duplicating rows.
+                if exec_params.per_node_scan_ranges.contains_key(node_id) {
+                    return Err(Self::unsupported(
+                        *node_id,
+                        "scan node appears in both per-node and per-driver scan-range maps",
+                    ));
+                }
+                for ranges in per_seq.values() {
+                    paths.add_ranges(*node_id, ranges, desc)?;
+                }
+            }
+        }
+        Ok(paths)
+    }
+
+    /// Returns the parquet file paths collected for `node_id`, empty when the node
+    /// has no broker scan ranges (it then falls back to a named-table read).
+    pub(crate) fn for_node(&self, node_id: i32) -> &[String] {
+        self.by_node
+            .get(&node_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Validates and appends the whole-file parquet paths in `ranges` to `node_id`.
+    fn add_ranges(
+        &mut self,
+        node_id: i32,
+        ranges: &[TScanRangeParams],
+        desc: &DescriptorTable,
+    ) -> Result<()> {
+        for range in ranges {
+            let Some(broker) = range.scan_range.broker_scan_range.as_ref() else {
+                continue;
+            };
+            Self::check_params(node_id, &broker.params, desc)?;
+            for range_desc in &broker.ranges {
+                Self::check_range(node_id, range_desc)?;
+                self.by_node
+                    .entry(node_id)
+                    .or_default()
+                    .push(range_desc.path.clone());
+            }
+        }
+        Ok(())
+    }
+
+    /// Rejects scan-range params outside the supported `FILES()`-query slice.
+    fn check_params(
+        node_id: i32,
+        params: &TBrokerScanRangeParams,
+        desc: &DescriptorTable,
+    ) -> Result<()> {
+        // Only FILES() *query* scans are plain reads; LOAD and FILES_INSERT carry
+        // load semantics (strict mode, transforms) this translation does not model.
+        if params.file_scan_type != Some(TFileScanType::FILES_QUERY) {
+            return Err(Self::unsupported(
+                node_id,
+                "only FILES() query scans are supported",
+            ));
+        }
+        // A FILES() query sets `use_broker` explicitly: `Some(false)` is direct
+        // access (what Sirius's reader does), `Some(true)` routes through a broker
+        // process, and an absent value also selects the broker filesystem. Require
+        // explicit direct access.
+        if params.use_broker != Some(false) {
+            return Err(Self::unsupported(
+                node_id,
+                "only direct (non-broker) file access is supported",
+            ));
+        }
+        // Flexible column mapping is name-based with null filling for missing
+        // columns — semantics a positional/by-name `parquet_scan` cannot reproduce.
+        if params.flexible_column_mapping == Some(true) {
+            return Err(Self::unsupported(
+                node_id,
+                "flexible column mapping is not supported",
+            ));
+        }
+        // Each destination slot must be a direct passthrough of the file column of
+        // the *same name*. The emitted read carries no per-column expression, and
+        // the reader binds parquet columns to the destination names, so:
+        //   - a cast, default, or other transform (anything but a bare slot
+        //     reference) would be silently dropped, and
+        //   - a bare reference to a differently-named source column would read the
+        //     wrong column under that name.
+        // Reject both rather than produce wrong values.
+        if let Some(exprs) = params.expr_of_dest_slot.as_ref() {
+            for (dest_slot_id, expr) in exprs {
+                let slot_ref = match expr.nodes.as_slice() {
+                    [node] if node.node_type == TExprNodeType::SLOT_REF => node.slot_ref.as_ref(),
+                    _ => None,
+                };
+                let Some(slot_ref) = slot_ref else {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "scan column with a cast or transform is not supported",
+                    ));
+                };
+                let dest_name = desc
+                    .slot(params.dest_tuple_id, *dest_slot_id)?
+                    .output_name();
+                let src_name = desc
+                    .slot(slot_ref.tuple_id, slot_ref.slot_id)?
+                    .output_name();
+                if dest_name != src_name {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "renamed or reordered column mapping is not supported",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Rejects a single broker range outside the supported whole-file local-parquet slice.
+    fn check_range(node_id: i32, desc: &TBrokerRangeDesc) -> Result<()> {
+        if desc.format_type != TFileFormatType::FORMAT_PARQUET {
+            return Err(Self::unsupported(
+                node_id,
+                "only parquet broker scan ranges are supported",
+            ));
+        }
+        // A FILES() query carries a broker file descriptor (even for local paths);
+        // a stream (or other) descriptor is a load shape, not a readable file scan.
+        if desc.file_type != TFileType::FILE_BROKER {
+            return Err(Self::unsupported(
+                node_id,
+                "only broker-descriptor file scan ranges are supported",
+            ));
+        }
+        // Whole-file only: DuckDB's `local_files` reader ignores per-file byte
+        // offsets, so accept a range only when it provably covers the whole,
+        // non-empty file. A FILES() query stats each file, so require a known
+        // positive `file_size` reached by reading to EOF (`size == -1`) or by a
+        // bounded size at least that large. Unknown size, an empty file, or a
+        // bounded size short of the file are rejected rather than silently reading
+        // the wrong bytes.
+        let whole_file = desc.start_offset == 0
+            && match desc.file_size {
+                Some(file_size) => file_size > 0 && (desc.size == -1 || desc.size >= file_size),
+                None => false,
+            };
+        if !whole_file {
+            return Err(Self::unsupported(
+                node_id,
+                "byte-range split scan ranges are not supported",
+            ));
+        }
+        // StarRocks appends path-derived columns after the physical parquet
+        // columns; `parquet_scan` over the path alone would not produce them, so
+        // the descriptor slot order would no longer match.
+        if desc
+            .columns_from_path
+            .as_ref()
+            .is_some_and(|columns| !columns.is_empty())
+        {
+            return Err(Self::unsupported(
+                node_id,
+                "path-derived columns (columns_from_path) are not supported",
+            ));
+        }
+        Self::check_local_path(node_id, &desc.path)
+    }
+
+    /// Rejects non-local URI schemes and glob metacharacters in a scan path.
+    fn check_local_path(node_id: i32, path: &str) -> Result<()> {
+        // `parquet_scan` treats `*`, `?` and `[` as globs; an already-expanded
+        // literal path containing them would re-expand and read the wrong files.
+        if path.contains(['*', '?', '[']) {
+            return Err(Self::unsupported(
+                node_id,
+                "glob metacharacters in scan paths are not supported",
+            ));
+        }
+        // Only local files reach Sirius's reader without access configuration. Allow
+        // a bare path and the local `file:` forms; reject every other scheme
+        // (s3://, hdfs://, hdfs:/, oss://, ...) and any non-local `file://`
+        // authority, whose credentials/endpoints are not propagated.
+        //
+        // A scheme is `<scheme>:` immediately followed by `/` (so a bare path or a
+        // filename containing `:` is not mistaken for one).
+        if let Some(colon) = path.find(':') {
+            let scheme = &path[..colon];
+            let after = &path[colon + 1..];
+            let is_scheme = after.starts_with('/')
+                && scheme
+                    .bytes()
+                    .next()
+                    .is_some_and(|b| b.is_ascii_alphabetic())
+                && scheme
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'));
+            if is_scheme {
+                if !scheme.eq_ignore_ascii_case("file") {
+                    return Err(Self::unsupported(
+                        node_id,
+                        "only local file paths are supported",
+                    ));
+                }
+                // `file://<authority>/...`: only an empty authority or `localhost`
+                // is local. `file:/...` (no `//`) has no authority and is local.
+                if let Some(after_slashes) = after.strip_prefix("//") {
+                    let authority = after_slashes.split('/').next().unwrap_or_default();
+                    if !(authority.is_empty() || authority.eq_ignore_ascii_case("localhost")) {
+                        return Err(Self::unsupported(
+                            node_id,
+                            "only local file paths are supported",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Builds an [`TranslateError::UnsupportedScanRange`] for `node_id`.
+    fn unsupported(node_id: i32, reason: &'static str) -> TranslateError {
+        TranslateError::UnsupportedScanRange { node_id, reason }
+    }
+}

--- a/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/tests/translate.rs
@@ -11,15 +11,19 @@ use starrocks_thrift::exprs::{
     TBoolLiteral, TDecimalLiteral, TExpr, TExprNode, TExprNodeType, TFloatLiteral, TIntLiteral,
     TIsNullPredicate, TSlotRef, TStringLiteral,
 };
-use starrocks_thrift::internal_service::{InternalServiceVersion, TExecPlanFragmentParams};
+use starrocks_thrift::internal_service::{
+    InternalServiceVersion, TExecPlanFragmentParams, TPlanFragmentExecParams, TScanRangeParams,
+};
 use starrocks_thrift::opcodes::TExprOpcode;
 use starrocks_thrift::partitions::{TDataPartition, TPartitionType};
 use starrocks_thrift::plan_nodes::{
-    TFileScanNode, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TSelectNode,
+    TBrokerRangeDesc, TBrokerScanRange, TBrokerScanRangeParams, TFileFormatType, TFileScanNode,
+    TFileScanType, TPlan, TPlanNode, TPlanNodeType, TProjectNode, TScanRange, TSelectNode,
 };
 use starrocks_thrift::planner::TPlanFragment;
 use starrocks_thrift::types::{
-    TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType,
+    TFileType, TPrimitiveType, TScalarType, TTableType, TTypeDesc, TTypeNode, TTypeNodeType,
+    TUniqueId,
 };
 use substrait::proto::{expression, plan_rel, read_rel, rel};
 
@@ -423,6 +427,512 @@ fn scan_only_produces_named_table() {
         }
         other => panic!("expected read rel, got {other:?}"),
     }
+}
+
+/// Builds a single local broker scan range for `path` with the given format,
+/// start offset, size, and optional total file size.
+fn broker_scan_range(
+    path: &str,
+    format: TFileFormatType,
+    start_offset: i64,
+    size: i64,
+    file_size: Option<i64>,
+) -> TScanRange {
+    let range = TBrokerRangeDesc::new(
+        TFileType::FILE_BROKER,
+        format,
+        false,
+        path.to_string(),
+        start_offset,
+        size,
+        None,
+        file_size,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut params = TBrokerScanRangeParams::new(
+        0,
+        0,
+        0,
+        Vec::new(),
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    // Production-shaped supported slice: a FILES() query read with direct (non-broker)
+    // access; collection rejects anything else.
+    params.file_scan_type = Some(TFileScanType::FILES_QUERY);
+    params.use_broker = Some(false);
+    let broker = TBrokerScanRange::new(vec![range], params, Vec::new(), None, None, None, None);
+    TScanRange::new(None, None, Some(broker), None, None, None)
+}
+
+/// Builds fragment params whose `node_id` scan carries `scan_range`.
+fn params_with_scan_range(
+    plan: TPlan,
+    desc_tbl: TDescriptorTable,
+    node_id: i32,
+    scan_range: TScanRange,
+) -> TExecPlanFragmentParams {
+    let mut fragment_params = params(Some(plan), Some(desc_tbl), None);
+    let mut per_node_scan_ranges = BTreeMap::new();
+    per_node_scan_ranges.insert(
+        node_id,
+        vec![TScanRangeParams::new(scan_range, None, None, None)],
+    );
+    fragment_params.params = Some(TPlanFragmentExecParams::new(
+        TUniqueId::new(0, 0),
+        TUniqueId::new(0, 0),
+        per_node_scan_ranges,
+        BTreeMap::new(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ));
+    fragment_params
+}
+
+/// Builds fragment params whose `node_id` scan carries `scan_range` via the
+/// pipeline per-driver-sequence map instead of `per_node_scan_ranges`.
+fn params_with_per_driver_scan_range(
+    plan: TPlan,
+    desc_tbl: TDescriptorTable,
+    node_id: i32,
+    scan_range: TScanRange,
+) -> TExecPlanFragmentParams {
+    let mut fragment_params = params(Some(plan), Some(desc_tbl), None);
+    let mut per_seq = BTreeMap::new();
+    per_seq.insert(0, vec![TScanRangeParams::new(scan_range, None, None, None)]);
+    let mut per_driver = BTreeMap::new();
+    per_driver.insert(node_id, per_seq);
+    fragment_params.params = Some(TPlanFragmentExecParams::new(
+        TUniqueId::new(0, 0),
+        TUniqueId::new(0, 0),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        per_driver,
+        None,
+        None,
+        None,
+        None,
+    ));
+    fragment_params
+}
+
+/// Verifies a scan with broker ranges becomes a Substrait `local_files` parquet read.
+#[test]
+fn scan_with_broker_ranges_produces_local_files() {
+    let path = "file:///data/users.parquet";
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, -1, Some(1024)),
+        ))
+        .unwrap();
+
+    assert_eq!(translated.output_names, vec!["id", "name"]);
+    let input = root(&translated.plan).input.as_ref().unwrap();
+    match input.rel_type.as_ref().unwrap() {
+        rel::RelType::Read(read) => {
+            assert_eq!(read.base_schema.as_ref().unwrap().names, vec!["id", "name"]);
+            match read.read_type.as_ref().unwrap() {
+                read_rel::ReadType::LocalFiles(local) => {
+                    assert_eq!(local.items.len(), 1);
+                    let item = &local.items[0];
+                    assert!(matches!(
+                        item.file_format.as_ref(),
+                        Some(read_rel::local_files::file_or_files::FileFormat::Parquet(_))
+                    ));
+                    match item.path_type.as_ref().unwrap() {
+                        read_rel::local_files::file_or_files::PathType::UriFile(uri) => {
+                            assert_eq!(uri, path);
+                        }
+                        other => panic!("expected uri_file, got {other:?}"),
+                    }
+                }
+                other => panic!("expected local files, got {other:?}"),
+            }
+        }
+        other => panic!("expected read rel, got {other:?}"),
+    }
+}
+
+/// Verifies a non-parquet broker scan range is rejected as unsupported.
+#[test]
+fn non_parquet_broker_range_is_unsupported() {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(
+                "file:///data/users.orc",
+                TFileFormatType::FORMAT_ORC,
+                0,
+                -1,
+                None,
+            ),
+        ))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        TranslateError::UnsupportedScanRange { node_id: 0, .. }
+    ));
+}
+
+/// Verifies a byte-range split broker scan range is rejected as unsupported,
+/// both for a non-zero start offset and for a first split (offset 0, partial size).
+#[test]
+fn split_broker_range_is_unsupported() {
+    for range in [
+        broker_scan_range(
+            "file:///data/users.parquet",
+            TFileFormatType::FORMAT_PARQUET,
+            1024,
+            -1,
+            None,
+        ),
+        broker_scan_range(
+            "file:///data/users.parquet",
+            TFileFormatType::FORMAT_PARQUET,
+            0,
+            512,
+            Some(1024),
+        ),
+    ] {
+        let err = PlanTranslator::new()
+            .translate_fragment(&params_with_scan_range(
+                TPlan::new(vec![scan_node(0, 0)]),
+                base_desc(),
+                0,
+                range,
+            ))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TranslateError::UnsupportedScanRange { node_id: 0, .. }
+        ));
+    }
+}
+
+/// Verifies a scan range delivered via the pipeline per-driver-sequence map is
+/// collected too (not just `per_node_scan_ranges`).
+#[test]
+fn per_driver_scan_range_produces_local_files() {
+    let path = "file:///data/users.parquet";
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_per_driver_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, -1, Some(1024)),
+        ))
+        .unwrap();
+
+    let input = root(&translated.plan).input.as_ref().unwrap();
+    match input.rel_type.as_ref().unwrap() {
+        rel::RelType::Read(read) => match read.read_type.as_ref().unwrap() {
+            read_rel::ReadType::LocalFiles(local) => {
+                assert_eq!(local.items.len(), 1);
+                match local.items[0].path_type.as_ref().unwrap() {
+                    read_rel::local_files::file_or_files::PathType::UriFile(uri) => {
+                        assert_eq!(uri, path);
+                    }
+                    other => panic!("expected uri_file, got {other:?}"),
+                }
+            }
+            other => panic!("expected local files, got {other:?}"),
+        },
+        other => panic!("expected read rel, got {other:?}"),
+    }
+}
+
+/// Asserts a single-node scan over `scan_range` is rejected as an unsupported range.
+fn assert_scan_range_unsupported(scan_range: TScanRange) {
+    let err = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            scan_range,
+        ))
+        .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedScanRange { node_id: 0, .. }),
+        "expected UnsupportedScanRange, got {err:?}"
+    );
+}
+
+/// A whole-file local parquet `FILES()` range used as the base for negative cases.
+fn parquet_query_range(path: &str) -> TScanRange {
+    broker_scan_range(path, TFileFormatType::FORMAT_PARQUET, 0, -1, Some(1024))
+}
+
+/// Verifies a broker range with path-derived columns is rejected as unsupported.
+#[test]
+fn path_derived_columns_are_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range.broker_scan_range.as_mut().unwrap().ranges[0].columns_from_path =
+        Some(vec!["dt".to_string()]);
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies a load scan (not a FILES() query) is rejected: only query reads map to
+/// a plain `parquet_scan`.
+#[test]
+fn load_scan_range_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .file_scan_type = Some(TFileScanType::LOAD);
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies broker-mediated access is rejected: Sirius's reader does not use a broker.
+#[test]
+fn broker_mediated_scan_range_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .use_broker = Some(true);
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies flexible (name-based, null-filling) column mapping is rejected.
+#[test]
+fn flexible_column_mapping_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .flexible_column_mapping = Some(true);
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies a destination column produced by a transform (here a literal default,
+/// not a bare slot reference) is rejected rather than silently dropped.
+#[test]
+fn dest_column_transform_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .expr_of_dest_slot = Some(BTreeMap::from([(1, int_literal(7))]));
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies an explicit identity column mapping (bare slot references) is accepted.
+#[test]
+fn identity_dest_column_mapping_is_supported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .expr_of_dest_slot = Some(BTreeMap::from([
+        (1, slot_ref(1, 0, scalar_type(TPrimitiveType::BIGINT))),
+        (2, slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR))),
+    ]));
+    let translated = PlanTranslator::new()
+        .translate_fragment(&params_with_scan_range(
+            TPlan::new(vec![scan_node(0, 0)]),
+            base_desc(),
+            0,
+            scan_range,
+        ))
+        .unwrap();
+    let input = root(&translated.plan).input.as_ref().unwrap();
+    assert!(matches!(
+        input.rel_type.as_ref().unwrap(),
+        rel::RelType::Read(read)
+            if matches!(read.read_type.as_ref().unwrap(), read_rel::ReadType::LocalFiles(_))
+    ));
+}
+
+/// Verifies a remote URI scheme is rejected: credentials/endpoints are not propagated.
+#[test]
+fn remote_scheme_scan_range_is_unsupported() {
+    assert_scan_range_unsupported(parquet_query_range("s3://bucket/users.parquet"));
+}
+
+/// Verifies a path with glob metacharacters is rejected: `parquet_scan` would re-expand it.
+#[test]
+fn glob_path_scan_range_is_unsupported() {
+    assert_scan_range_unsupported(parquet_query_range("file:///data/*.parquet"));
+}
+
+/// Verifies a bounded-size range with unknown file size is rejected: it cannot be
+/// proven to cover the whole file, and the size is dropped by `local_files`.
+#[test]
+fn bounded_split_with_unknown_file_size_is_unsupported() {
+    assert_scan_range_unsupported(broker_scan_range(
+        "file:///data/users.parquet",
+        TFileFormatType::FORMAT_PARQUET,
+        0,
+        512,
+        None,
+    ));
+}
+
+/// Verifies an empty (zero-byte) file range is rejected: it is not a readable
+/// parquet file, so it must not be passed to `parquet_scan`.
+#[test]
+fn empty_file_scan_range_is_unsupported() {
+    assert_scan_range_unsupported(broker_scan_range(
+        "file:///data/users.parquet",
+        TFileFormatType::FORMAT_PARQUET,
+        0,
+        0,
+        Some(0),
+    ));
+}
+
+/// Verifies a renamed column mapping is rejected: destination slot 1 ("id") fed
+/// from source slot 2 ("name") would have the reader read the wrong column by name.
+#[test]
+fn renamed_column_mapping_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .expr_of_dest_slot = Some(BTreeMap::from([(
+        1,
+        slot_ref(2, 0, scalar_type(TPrimitiveType::VARCHAR)),
+    )]));
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies an absent `use_broker` is rejected: it selects the broker filesystem,
+/// not the direct access Sirius's reader performs.
+#[test]
+fn unset_use_broker_scan_range_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range
+        .broker_scan_range
+        .as_mut()
+        .unwrap()
+        .params
+        .use_broker = None;
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies a non-broker file descriptor (e.g. a stream) is rejected: it is a load
+/// shape, not a readable file scan.
+#[test]
+fn stream_file_type_scan_range_is_unsupported() {
+    let mut scan_range = parquet_query_range("file:///data/users.parquet");
+    scan_range.broker_scan_range.as_mut().unwrap().ranges[0].file_type = TFileType::FILE_STREAM;
+    assert_scan_range_unsupported(scan_range);
+}
+
+/// Verifies a `file://` URI with a non-local authority is rejected.
+#[test]
+fn remote_authority_file_uri_is_unsupported() {
+    assert_scan_range_unsupported(parquet_query_range("file://remote-host/data/users.parquet"));
+}
+
+/// Verifies a single-slash remote scheme (no `://`) is still rejected.
+#[test]
+fn single_slash_remote_scheme_is_unsupported() {
+    assert_scan_range_unsupported(parquet_query_range("hdfs:/data/users.parquet"));
+}
+
+/// Verifies a scan node appearing in BOTH scan-range maps is rejected: collecting
+/// (and reading) its whole-file paths twice would silently duplicate rows.
+#[test]
+fn node_in_both_scan_range_maps_is_unsupported() {
+    let mut fragment_params = params_with_scan_range(
+        TPlan::new(vec![scan_node(0, 0)]),
+        base_desc(),
+        0,
+        parquet_query_range("file:///data/users.parquet"),
+    );
+    let mut per_seq = BTreeMap::new();
+    per_seq.insert(
+        0,
+        vec![TScanRangeParams::new(
+            parquet_query_range("file:///data/users.parquet"),
+            None,
+            None,
+            None,
+        )],
+    );
+    let mut per_driver = BTreeMap::new();
+    per_driver.insert(0, per_seq);
+    fragment_params
+        .params
+        .as_mut()
+        .unwrap()
+        .node_to_per_driver_seq_scan_ranges = Some(per_driver);
+
+    let err = PlanTranslator::new()
+        .translate_fragment(&fragment_params)
+        .unwrap_err();
+    assert!(
+        matches!(err, TranslateError::UnsupportedScanRange { node_id: 0, .. }),
+        "expected UnsupportedScanRange, got {err:?}"
+    );
 }
 
 /// Verifies duplicate descriptor names are disambiguated deterministically at the root.


### PR DESCRIPTION
Make the StarRocks plan translator emit Substrait `local_files` parquet reads for `FILE_SCAN_NODE`, so a translated single-fragment `FILES()` plan resolves in DuckDB's Substrait reader (as `parquet_scan(<paths>)`) instead of an unresolvable named table. This is the resolvable-plan source the upcoming one-shot `execute_substrait` FFI runs end-to-end on the GPU.

## What
- A `ScanFilePaths` type (static `from_fragment` constructor + `for_node` accessor) collects per-scan-node parquet paths from the fragment's `per_node_scan_ranges` and — for pipeline fragments — `node_to_per_driver_seq_scan_ranges`, keyed by plan node id, and is threaded through the plan context.
- `scan_rel` emits `ReadType::LocalFiles` (`uri_file` + `parquet`) when paths are present, and keeps the named-table read otherwise (e.g. HDFS scans).

## Validation (fail loud, don't mis-read)
DuckDB's `local_files` reader emits `parquet_scan(<paths>)` and ignores per-file byte offsets, so ranges it can't honor are rejected with `TranslateError::UnsupportedScanRange` rather than silently producing wrong results:
- non-parquet `format_type` (CSV/ORC/JSON/…),
- byte-range splits (non-zero start, or a bounded size we can confirm is shorter than the file),
- path-derived columns (`columns_from_path`), which `parquet_scan` would not produce.

## Known limitation
The read schema is taken from the scan tuple descriptor, assuming the parquet file's physical column order matches the descriptor slot order — true for `FILES()` `SELECT *`. Non-identity column mappings (`columns_from_path`, destination-slot expressions, src≠dest tuples) are a pre-existing translator assumption (the named-table path assumed the same) and are left as a follow-up.

## Tests
`local_files` emission via both `per_node_scan_ranges` and the per-driver map; rejection of non-parquet and split (offset and partial-size) ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
