### PR TITLE
feat(sirius): execute Substrait plans on the GPU via the FFI

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,12 +9,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -80,6 +124,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "arrow-select"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
 ]
 
 [[package]]
@@ -199,6 +323,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +368,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -231,6 +378,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -335,6 +493,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +520,12 @@ checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -502,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +763,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -674,13 +874,36 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -712,6 +935,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -731,6 +955,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -857,6 +1092,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1014,6 +1273,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1309,12 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "link-cplusplus"
@@ -1076,6 +1351,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchers"
@@ -1171,12 +1455,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1221,6 +1534,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970dff83e97d953c827ae8176f6bf4e9f77bf62daacc01ec5df348ec5eacd913"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.17.0",
+ "lz4_flex",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1613,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1750,6 +2107,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1791,6 +2154,16 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
 
 [[package]]
 name = "rmp"
@@ -1895,6 +2268,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2308,16 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1943,11 +2350,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1967,6 +2386,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2407,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2011,11 +2455,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "sirius"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "cxx",
+ "parquet",
+ "prost",
  "sirius-sys",
+ "substrait",
+ "tempfile",
 ]
 
 [[package]]
@@ -2080,6 +2536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2571,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "substrait"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e620ff4d5c02fd6f7752931aa74b16a26af66a63022cc1ad412c77edbe0bab47"
+dependencies = [
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn",
+ "typify",
+ "walkdir",
+]
 
 [[package]]
 name = "syn"
@@ -2161,7 +2646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2203,6 +2688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2471,10 +2965,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5bcc6f62eb1fa8aa4098f39b29f93dcb914e17158b76c50360911257aa629"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1eb359f7ffa4f9ebe947fa11a1b2da054564502968db5f317b7e37693cb2240"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911c32f3c8514b048c1b228361bebb5e6d73aeec01696e8cc0e82e2ffef8ab7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+ "typify-impl",
+]
 
 [[package]]
 name = "unicase"
@@ -2505,6 +3052,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -2579,7 +3132,7 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2729,10 +3282,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2970,4 +3576,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/rust/crates/sirius-sys/src/lib.rs
+++ b/rust/crates/sirius-sys/src/lib.rs
@@ -16,6 +16,10 @@
 //! the engine (or parsing a config file) can throw, and cxx turns a C++ exception
 //! into `Err(cxx::Exception)` instead of aborting, so consumers can fail fast.
 
+// The `# Safety` docs on the unsafe bridge fns live on the declarations below;
+// cxx's macro expansion hides them from clippy's `missing_safety_doc`, so allow
+// it for the generated module.
+#[allow(clippy::missing_safety_doc)]
 #[cxx::bridge(namespace = "sirius::ffi")]
 mod ffi {
     unsafe extern "C++" {
@@ -32,6 +36,25 @@ mod ffi {
         /// `config_path`, owned by the returned `UniquePtr`. `config_path` binds
         /// to the C++ `const std::string&` parameter.
         fn make_context_from_config(config_path: &CxxString) -> Result<UniquePtr<Context>>;
+
+        /// Execute a serialized Substrait plan on the GPU, writing the results
+        /// into the Arrow C Data Interface stream at `out_stream_addr` — the
+        /// address (as `usize`) of a caller-owned `ArrowArrayStream` the caller
+        /// releases per the Arrow ABI. `plan` binds to the C++ `const
+        /// std::string&` and carries the protobuf-encoded `substrait::Plan`
+        /// bytes. Bound as fallible: translation or execution failure surfaces as
+        /// `Err(cxx::Exception)`.
+        ///
+        /// # Safety
+        /// `out_stream_addr` must be the address of a valid, writable
+        /// `ArrowArrayStream` that outlives this call; C++ writes the result
+        /// stream through it. The safe [`sirius`](https://docs.rs/sirius) wrapper
+        /// upholds this.
+        unsafe fn execute_substrait(
+            self: Pin<&mut Context>,
+            plan: &CxxString,
+            out_stream_addr: usize,
+        ) -> Result<()>;
     }
 }
 

--- a/rust/crates/sirius/Cargo.toml
+++ b/rust/crates/sirius/Cargo.toml
@@ -15,3 +15,15 @@ static = ["sirius-sys/static"]
 [dependencies]
 cxx.workspace = true
 sirius-sys.workspace = true
+# Results are returned over the Arrow C Data Interface; pin to the same major as
+# the StarRocks CN consumer so the `ArrowArrayStreamReader` type unifies. The
+# `ffi` feature provides `ffi_stream` (FFI_ArrowArrayStream / reader).
+arrow-array = { version = "59", features = ["ffi"] }
+arrow-schema = "59"
+
+[dev-dependencies]
+# Building a `local_files` Substrait plan + a parquet fixture for the execute test.
+substrait = "0.63"
+prost = "0.14"
+parquet = "59"
+tempfile = "3"

--- a/rust/crates/sirius/src/lib.rs
+++ b/rust/crates/sirius/src/lib.rs
@@ -10,6 +10,8 @@
 
 use std::path::Path;
 
+use arrow_array::RecordBatch;
+use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use cxx::{Exception, UniquePtr, let_cxx_string};
 
 /// An initialized Sirius engine context.
@@ -20,10 +22,12 @@ use cxx::{Exception, UniquePtr, let_cxx_string};
 ///
 /// Bring-up is fallible: GPU initialization or parsing a config file can fail,
 /// surfaced here as a [`cxx::Exception`].
+///
+/// The engine keeps process-global GPU state, so it currently supports a single
+/// live context per process; constructing or holding more than one concurrently
+/// is not yet supported (enforcement is a follow-up).
 pub struct SiriusContext {
-    // RAII handle; read by methods added in later PRs (execute, ...). `expect`
-    // flags this for removal once that happens.
-    #[expect(dead_code, reason = "owned for its RAII lifetime until the API grows")]
+    // RAII handle owning the C++ engine context for its lifetime.
     inner: UniquePtr<sirius_sys::Context>,
 }
 
@@ -46,20 +50,183 @@ impl SiriusContext {
             inner: sirius_sys::make_context_from_config(&config_path)?,
         })
     }
+
+    /// Execute a serialized Substrait plan on the GPU and return the result rows.
+    ///
+    /// `plan` is the protobuf-encoded `substrait::Plan`; its reads must be
+    /// resolvable by the embedded DuckDB used for lowering (e.g. `local_files`
+    /// parquet reads), and every operator must be one the GPU engine supports —
+    /// there is no CPU fallback here, so an unsupported plan returns an error.
+    ///
+    /// The result is collected eagerly into owned [`RecordBatch`]es. DuckDB's
+    /// Arrow stream converts each batch using this context's client state, so the
+    /// stream is drained while the context is alive; the returned batches own
+    /// their buffers and are independent of the context's lifetime.
+    pub fn execute_substrait(&mut self, plan: &[u8]) -> Result<Vec<RecordBatch>, SiriusError> {
+        // The engine writes a self-owning Arrow C Data Interface stream into
+        // `stream`; the FFI takes its address as an integer (a `uintptr_t`).
+        let mut stream = FFI_ArrowArrayStream::empty();
+        let out_stream_addr = std::ptr::addr_of_mut!(stream) as usize;
+        let_cxx_string!(plan = plan);
+        // SAFETY: `out_stream_addr` is the address of `stream`, a live, writable
+        // `FFI_ArrowArrayStream` owned by this stack frame for the call's duration.
+        unsafe {
+            self.inner
+                .pin_mut()
+                .execute_substrait(&plan, out_stream_addr)
+                .map_err(SiriusError::Engine)?;
+        }
+        // Drain fully while `self` is alive (conversion dereferences the context).
+        let reader = ArrowArrayStreamReader::try_new(stream).map_err(SiriusError::Arrow)?;
+        reader
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(SiriusError::Arrow)
+    }
+}
+
+/// Error returned by [`SiriusContext::execute_substrait`].
+#[derive(Debug)]
+pub enum SiriusError {
+    /// The engine failed to translate or execute the plan (a C++ exception).
+    Engine(Exception),
+    /// The Arrow result stream could not be consumed.
+    Arrow(arrow_schema::ArrowError),
+}
+
+impl std::fmt::Display for SiriusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Engine(err) => write!(f, "sirius engine error: {err}"),
+            Self::Arrow(err) => write!(f, "arrow result error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for SiriusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Engine(err) => Some(err),
+            Self::Arrow(err) => Some(err),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
+
+    use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use parquet::arrow::ArrowWriter;
+    use prost::Message;
 
     use super::SiriusContext;
+
+    /// The engine keeps process-global GPU state, so at most one context may be
+    /// live at a time; context-constructing tests hold this for their duration.
+    static GPU_CONTEXT_LOCK: Mutex<()> = Mutex::new(());
 
     /// Proof-of-life: bring up a real Sirius engine context and drop it. This
     /// links the real Sirius library and exercises the full cxx round-trip +
     /// `initialize()`/teardown. Requires a GPU (construction does GPU bring-up).
     #[test]
     fn constructs_and_drops() {
+        let _guard = GPU_CONTEXT_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
         let _ctx = SiriusContext::new().expect("bring up default Sirius context");
+    }
+
+    /// Encodes a single-file `local_files` parquet read plan with `names` as the
+    /// root output names — the shape DuckDB's Substrait reader resolves to
+    /// `parquet_scan(<path>)`.
+    fn local_files_plan(path: &str, names: Vec<String>) -> Vec<u8> {
+        use substrait::proto::read_rel::local_files::FileOrFiles;
+        use substrait::proto::read_rel::local_files::file_or_files::{
+            FileFormat, ParquetReadOptions, PathType,
+        };
+        use substrait::proto::read_rel::{LocalFiles, ReadType};
+        use substrait::proto::{Plan, PlanRel, ReadRel, Rel, RelRoot, plan_rel, rel};
+
+        let read = Rel {
+            rel_type: Some(rel::RelType::Read(Box::new(ReadRel {
+                read_type: Some(ReadType::LocalFiles(LocalFiles {
+                    items: vec![FileOrFiles {
+                        path_type: Some(PathType::UriFile(path.to_string())),
+                        file_format: Some(FileFormat::Parquet(ParquetReadOptions {})),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }))),
+        };
+        Plan {
+            relations: vec![PlanRel {
+                rel_type: Some(plan_rel::RelType::Root(RelRoot {
+                    input: Some(read),
+                    names,
+                })),
+            }],
+            ..Default::default()
+        }
+        .encode_to_vec()
+    }
+
+    /// End-to-end: execute a `local_files` parquet plan on the GPU and read the
+    /// result rows back over the Arrow C Data Interface. Requires a GPU.
+    #[test]
+    fn executes_local_files_plan_on_gpu() {
+        let _guard = GPU_CONTEXT_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+
+        // Point the embedded DuckDB at the locally-built parquet extension (the
+        // SIRIUS_BUILD_DIR default mirrors sirius-sys's build.rs) so it can bind
+        // `parquet_scan`. Set under the GPU lock so no other context bring-up
+        // reads the environment concurrently.
+        if std::env::var_os("SIRIUS_DUCKDB_PARQUET_EXTENSION").is_none() {
+            let manifest = env!("CARGO_MANIFEST_DIR");
+            let build_dir = std::env::var("SIRIUS_BUILD_DIR")
+                .unwrap_or_else(|_| format!("{manifest}/../../../build/release"));
+            let parquet = format!("{build_dir}/extension/parquet/parquet.duckdb_extension");
+            // SAFETY: the GPU lock is held, so no other thread touches the environment here.
+            unsafe { std::env::set_var("SIRIUS_DUCKDB_PARQUET_EXTENSION", parquet) };
+        }
+
+        // Write a tiny parquet fixture.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("users.parquet");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));
+        let names: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![ids, names]).unwrap();
+        {
+            let file = std::fs::File::create(&path).unwrap();
+            let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+        }
+
+        let plan = local_files_plan(
+            path.to_str().unwrap(),
+            vec!["id".to_string(), "name".to_string()],
+        );
+
+        // Drop the context before inspecting the result to prove the returned
+        // batches own their data independently of the engine context.
+        let batches = {
+            let mut ctx = SiriusContext::new().expect("bring up sirius context");
+            ctx.execute_substrait(&plan)
+                .expect("execute substrait plan")
+        };
+
+        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");
     }
 
     /// A missing config file is rejected before any GPU work (`load_from_file`

--- a/src/include/sirius_ffi.hpp
+++ b/src/include/sirius_ffi.hpp
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -35,25 +37,21 @@
 #define SIRIUS_FFI_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace duckdb {
-class SiriusContext;
-}  // namespace duckdb
-
 namespace sirius::ffi {
 
 /// RAII handle to a Sirius engine context.
 ///
-/// Constructing a `Context` brings up an initialized engine (it constructs and
-/// `initialize()`s a `duckdb::SiriusContext`); destroying it tears the engine
-/// down. There is no uninitialized state. Held from Rust via `cxx::UniquePtr`,
-/// so it is created by `make_context()` / `make_context_from_config()` and freed
-/// when the `UniquePtr` drops.
+/// Constructing a `Context` brings up an initialized engine (a
+/// `duckdb::SiriusContext`) and an embedded in-process DuckDB whose connection
+/// has that engine registered as the `sirius_state` so the GPU executor can find
+/// it. DuckDB is used only to lower a Substrait plan to a DuckDB
+/// `LogicalOperator` (the translation step) and to host the catalog — execution
+/// runs directly on the Sirius engine, not through DuckDB's query pipeline.
 ///
-/// The default constructor configures the engine from built-in defaults; the
-/// `config_path` constructor loads a YAML config file instead. Both can throw
-/// (bad config file, GPU bring-up failure); the `make_*` factories below are
-/// bound from Rust as fallible, so the failure surfaces as an error rather than
-/// aborting.
+/// Held from Rust via `cxx::UniquePtr`; created by `make_context()` /
+/// `make_context_from_config()` and freed when the `UniquePtr` drops. The
+/// constructors can throw (bad config, GPU bring-up failure); the `make_*`
+/// factories are bound as fallible so failures surface as errors.
 class SIRIUS_FFI_EXPORT Context {
  public:
   Context();
@@ -63,8 +61,24 @@ class SIRIUS_FFI_EXPORT Context {
   Context(const Context&)            = delete;
   Context& operator=(const Context&) = delete;
 
+  /// Executes a serialized Substrait plan on the GPU, writing the results to the
+  /// Arrow C Data Interface stream at `out_stream_addr` (one schema, a sequence
+  /// of record batches). `out_stream_addr` is the address of a caller-owned
+  /// `ArrowArrayStream` that the caller releases per the Arrow ABI. Throws on
+  /// translation or execution failure.
+  ///
+  /// `plan` is the protobuf-encoded `substrait::Plan` as a byte buffer; its reads
+  /// must be resolvable by DuckDB (e.g. `local_files` parquet reads). The stream
+  /// is passed as an integer address so this public header stays free of
+  /// Arrow/DuckDB types; the Rust bindings pass the address of an
+  /// `FFI_ArrowArrayStream` they own.
+  void execute_substrait(const std::string& plan, std::uintptr_t out_stream_addr);
+
  private:
-  std::unique_ptr<duckdb::SiriusContext> context_;
+  // PIMPL: the engine handle + embedded DuckDB live in the .cpp so this public
+  // header pulls in no DuckDB/cudf/rmm types (DuckDB uses its own smart pointers).
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 /// Create an initialized [`Context`] configured from built-in defaults, owned by

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -20,29 +20,170 @@
 
 #include "sirius_ffi.hpp"
 
-#include "sirius_config.hpp"   // sirius::sirius_config
-#include "sirius_context.hpp"  // duckdb::SiriusContext
+#include "data/sirius_converter_registry.hpp"              // sirius::converter_registry
+#include "duckdb/common/arrow/result_arrow_wrapper.hpp"    // duckdb::ResultArrowArrayStreamWrapper
+#include "duckdb/common/enums/optimizer_type.hpp"          // duckdb::OptimizerType
+#include "duckdb/execution/column_binding_resolver.hpp"    // duckdb::ColumnBindingResolver
+#include "duckdb/main/client_context.hpp"                  // duckdb::ClientContext
+#include "duckdb/main/config.hpp"                          // duckdb::DBConfig
+#include "duckdb/main/connection.hpp"                      // duckdb::Connection
+#include "duckdb/main/database.hpp"                        // duckdb::DuckDB
+#include "duckdb/main/prepared_statement_data.hpp"         // duckdb::PreparedStatementData
+#include "duckdb/main/query_result.hpp"                    // duckdb::QueryResult
+#include "duckdb/main/relation.hpp"                        // duckdb::Relation
+#include "duckdb/optimizer/optimizer.hpp"                  // duckdb::Optimizer
+#include "duckdb/parser/statement/relation_statement.hpp"  // duckdb::RelationStatement
+#include "duckdb/planner/planner.hpp"                      // duckdb::Planner
+#include "from_substrait.hpp"  // duckdb::SubstraitToDuckDB (compiled into libsirius)
+#include "planner/sirius_physical_plan_generator.hpp"  // sirius::planner::sirius_physical_plan_generator
+#include "sirius_config.hpp"                           // sirius::sirius_config
+#include "sirius_context.hpp"                          // duckdb::SiriusContext
+#include "sirius_interface.hpp"  // sirius::sirius_interface, sirius::sirius_prepared_statement_data
+
+#include <cstdlib>  // std::getenv
 
 namespace sirius::ffi {
 
-Context::Context() : context_(std::make_unique<duckdb::SiriusContext>())
+namespace {
+// ClientContextState key the GPU engine resolves its SiriusContext under.
+constexpr const char* kSiriusStateKey = "sirius_state";
+// Arrow record-batch size for the exported stream; the consumer re-batches as needed.
+constexpr duckdb::idx_t kArrowBatchSize = 1u << 20;
+}  // namespace
+
+// PIMPL: holds the engine + embedded DuckDB using DuckDB's own smart pointers
+// (duckdb::shared_ptr, so the SiriusContext can register as a ClientContextState).
+struct Context::Impl {
+  duckdb::shared_ptr<duckdb::SiriusContext> context;
+  duckdb::unique_ptr<duckdb::DuckDB> db;
+  duckdb::unique_ptr<duckdb::Connection> conn;
+
+  void bring_up(sirius::sirius_config& config)
+  {
+    context = duckdb::make_shared_ptr<duckdb::SiriusContext>();
+    context->initialize(config);
+    // Register the builtin + parquet representation converters the GPU scan/result
+    // path needs. Idempotent; the transparent path does this at extension load.
+    sirius::converter_registry::initialize();
+
+    // Lowering a Substrait `local_files` read produces a `parquet_scan`, so the
+    // embedded DuckDB must have the parquet extension to bind it. Dev stopgap until
+    // parquet is linked into the engine: ONLY when SIRIUS_DUCKDB_PARQUET_EXTENSION
+    // points at a (locally-built, unsigned) parquet extension do we opt into
+    // unsigned loading and load it. Absent the env var, no unsigned loading is
+    // enabled — the default trust boundary is unchanged.
+    duckdb::DBConfig db_config;
+    const char* parquet_ext = std::getenv("SIRIUS_DUCKDB_PARQUET_EXTENSION");
+    if (parquet_ext != nullptr) {
+      db_config.SetOptionByName("allow_unsigned_extensions", duckdb::Value::BOOLEAN(true));
+    }
+    db   = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &db_config);
+    conn = duckdb::make_uniq<duckdb::Connection>(*db);
+    if (parquet_ext != nullptr) {
+      // Escape single quotes so the path can't break out of the SQL string literal.
+      std::string escaped(parquet_ext);
+      for (std::size_t pos = escaped.find('\''); pos != std::string::npos;
+           pos             = escaped.find('\'', pos + 2)) {
+        escaped.replace(pos, 1, "''");
+      }
+      auto load = conn->Query("LOAD '" + escaped + "'");
+      if (load->HasError()) { load->ThrowError(); }
+    }
+    // Register the engine on the connection and disable the DuckDB-specific optimizer
+    // rewrites the GPU planner does not implement (mirrors SiriusContext's transparent
+    // path: SiriusTableFunctionData::PrepareConnection / OnConnectionOpened).
+    auto& client = *conn->context;
+    client.registered_state->Insert(kSiriusStateKey, context);
+    client.config.enable_optimizer = true;
+    auto& disabled = duckdb::DBConfig::GetConfig(client).options.disabled_optimizers;
+    disabled.insert(duckdb::OptimizerType::IN_CLAUSE);
+    disabled.insert(duckdb::OptimizerType::COMPRESSED_MATERIALIZATION);
+    disabled.insert(duckdb::OptimizerType::COLUMN_LIFETIME);
+    // LATE_MATERIALIZATION rewrites an ORDER BY ... LIMIT parquet scan into a
+    // semi-join on virtual file_index/file_row_number columns the GPU scan drops.
+    // The transparent path tolerates this via CPU fallback; this FFI has none, so
+    // disable it to avoid wrong results on an otherwise valid plan.
+    disabled.insert(duckdb::OptimizerType::LATE_MATERIALIZATION);
+  }
+};
+
+Context::Context() : impl_(std::make_unique<Impl>())
 {
   sirius::sirius_config config;
   config.apply_defaults();  // populate default GPU/host/disk memory spaces
-  context_->initialize(config);
+  impl_->bring_up(config);
 }
 
-Context::Context(const std::string& config_path)
-  : context_(std::make_unique<duckdb::SiriusContext>())
+Context::Context(const std::string& config_path) : impl_(std::make_unique<Impl>())
 {
   sirius::sirius_config config;
   config.load_from_file(config_path);  // throws on a missing/invalid config file
-  context_->initialize(config);
+  impl_->bring_up(config);
 }
 
-// Defined here, where duckdb::SiriusContext is complete: destroying `context_`
-// runs ~SiriusContext (which tears down the initialized engine).
+// Defined here, where the heavy types are complete: destroying `impl_` tears down
+// the embedded DuckDB and the initialized engine.
 Context::~Context() = default;
+
+void Context::execute_substrait(const std::string& plan, std::uintptr_t out_stream_addr)
+{
+  auto& client = *impl_->conn->context;
+
+  // Binding (catalog lookups), optimization, and GPU execution all require an
+  // active transaction. The transparent table-function path inherits one from the
+  // enclosing query; this standalone entry has none, so open one explicitly. GPU
+  // execution is eager (the result is materialized), so the transaction can close
+  // before the Arrow stream is consumed.
+  impl_->conn->BeginTransaction();
+  duckdb::unique_ptr<duckdb::QueryResult> result;
+  try {
+    // 1. Substrait bytes -> DuckDB Relation. DuckDB is used only for this lowering.
+    duckdb::SubstraitToDuckDB transformer(impl_->conn->context, plan, /*json=*/false);
+    auto relation = transformer.TransformPlan();
+
+    // 2. Relation -> bound + optimized DuckDB LogicalOperator (mirrors the GPU bind path:
+    //    SiriusTableFunctionData::ExtractPlan + GPUExecutionBind).
+    duckdb::Planner planner(client);
+    planner.CreatePlan(duckdb::make_uniq<duckdb::RelationStatement>(relation));
+
+    auto prepared = duckdb::make_shared_ptr<duckdb::PreparedStatementData>(
+      duckdb::StatementType::SELECT_STATEMENT);
+    prepared->names     = planner.names;
+    prepared->types     = planner.types;
+    prepared->value_map = std::move(planner.value_map);
+
+    auto logical_plan = std::move(planner.plan);
+    if (client.config.enable_optimizer) {
+      duckdb::Optimizer optimizer(*planner.binder, client);
+      logical_plan = optimizer.Optimize(std::move(logical_plan));
+    }
+    logical_plan->ResolveOperatorTypes();
+    duckdb::ColumnBindingResolver resolver;
+    duckdb::ColumnBindingResolver::Verify(*logical_plan);
+    resolver.VisitOperator(*logical_plan);
+
+    // 3. DuckDB LogicalOperator -> Sirius GPU physical plan -> execute directly on the engine.
+    auto physical_plan =
+      sirius::planner::sirius_physical_plan_generator(client).create_plan(std::move(logical_plan));
+    auto gpu_prepared = duckdb::make_shared_ptr<sirius::sirius_prepared_statement_data>(
+      std::move(prepared), std::move(physical_plan));
+
+    sirius::sirius_interface iface(client, std::optional<std::string>("starrocks_substrait"));
+    result = iface.sirius_execute_query(
+      client, "starrocks_substrait", gpu_prepared, duckdb::PendingQueryParameters{});
+  } catch (...) {
+    impl_->conn->Rollback();
+    throw;
+  }
+  impl_->conn->Commit();
+  if (result->HasError()) { result->ThrowError(); }
+
+  // 4. Hand the result to the caller as a self-owning Arrow C Data Interface stream,
+  //    written into the caller's ArrowArrayStream (addressed by `out_stream_addr`);
+  //    its `release` callback deletes the heap wrapper (ResultArrowArrayStreamWrapper).
+  auto* wrapper = new duckdb::ResultArrowArrayStreamWrapper(std::move(result), kArrowBatchSize);
+  *reinterpret_cast<ArrowArrayStream*>(out_stream_addr) = wrapper->stream;
+}
 
 std::unique_ptr<Context> make_context() { return std::make_unique<Context>(); }
 

--- a/src/sirius_ffi.cpp
+++ b/src/sirius_ffi.cpp
@@ -89,20 +89,24 @@ struct Context::Impl {
       auto load = conn->Query("LOAD '" + escaped + "'");
       if (load->HasError()) { load->ThrowError(); }
     }
-    // Register the engine on the connection and disable the DuckDB-specific optimizer
-    // rewrites the GPU planner does not implement (mirrors SiriusContext's transparent
-    // path: SiriusTableFunctionData::PrepareConnection / OnConnectionOpened).
+    // Register the engine on the connection and disable the DuckDB optimizer rewrites the
+    // GPU planner cannot execute. This is the transparent path's GPU-incompatible set
+    // (IN_CLAUSE, COMPRESSED_MATERIALIZATION, STATISTICS_PROPAGATION; see
+    // sirius_extension.cpp) plus, because this FFI has no CPU fallback, COLUMN_LIFETIME and
+    // LATE_MATERIALIZATION unconditionally (the transparent path disables COLUMN_LIFETIME
+    // only in debug and tolerates LATE_MATERIALIZATION via fallback).
     auto& client = *conn->context;
     client.registered_state->Insert(kSiriusStateKey, context);
     client.config.enable_optimizer = true;
     auto& disabled = duckdb::DBConfig::GetConfig(client).options.disabled_optimizers;
     disabled.insert(duckdb::OptimizerType::IN_CLAUSE);
     disabled.insert(duckdb::OptimizerType::COMPRESSED_MATERIALIZATION);
+    // Folds ungrouped MIN/MAX aggregates into EXPRESSION_GET + DUMMY_SCAN the GPU
+    // pipeline cannot schedule; keep the query on the scan -> aggregate path.
+    disabled.insert(duckdb::OptimizerType::STATISTICS_PROPAGATION);
     disabled.insert(duckdb::OptimizerType::COLUMN_LIFETIME);
-    // LATE_MATERIALIZATION rewrites an ORDER BY ... LIMIT parquet scan into a
-    // semi-join on virtual file_index/file_row_number columns the GPU scan drops.
-    // The transparent path tolerates this via CPU fallback; this FFI has none, so
-    // disable it to avoid wrong results on an otherwise valid plan.
+    // Rewrites an ORDER BY ... LIMIT parquet scan into a semi-join on virtual
+    // file_index/file_row_number columns the GPU scan drops.
     disabled.insert(duckdb::OptimizerType::LATE_MATERIALIZATION);
   }
 };


### PR DESCRIPTION
> **Stacked on #1009** (compiles the Substrait reader into `libsirius`). Until that merges, this PR's diff includes its commit; afterwards this rebases onto `dev`.

Adds the one-shot `execute_substrait` FFI: run a serialized Substrait plan on the GPU and get the result back over the Arrow C Data Interface. Stacks on the branch that compiles the Substrait→DuckDB reader into `libsirius`.

## Route
`Context::execute_substrait` (`src/sirius_ffi.cpp`) drives the same lowering the transparent table-function path uses, but standalone:
`SubstraitToDuckDB::TransformPlan` → `Planner::CreatePlan(RelationStatement)` → `Optimizer` → `ResolveOperatorTypes` → `ColumnBindingResolver` → `sirius_physical_plan_generator::create_plan` → `sirius_interface::sirius_execute_query` → `ResultArrowArrayStreamWrapper`. DuckDB is used only to lower the plan; execution runs on the Sirius GPU engine.

## Bindings
- `sirius-sys`: a cxx bridge method `Context::execute_substrait(&CxxString plan, usize out_stream_addr)`.
- `sirius`: `SiriusContext::execute_substrait(&mut self, &[u8]) -> Result<ArrowArrayStreamReader, SiriusError>` — allocates an `FFI_ArrowArrayStream`, hands its address to the engine, then wraps it as an Arrow `RecordBatchReader`.

The public header stays free of Arrow/cxx types: the plan is a `std::string`, and the stream is passed by integer address (`uintptr_t`).

## Bring-up the transparent path gets for free
The embedded `DuckDB` is a fresh instance, so `execute_substrait` does explicitly what the table-function path inherits from its enclosing query:
- load the parquet extension so `parquet_scan` binds (allow-unsigned + a path from `SIRIUS_DUCKDB_PARQUET_EXTENSION` — a dev stopgap until parquet is linked into the engine);
- wrap bind + execution in a transaction (GPU execution is eager and the result materialized, so the transaction closes before the Arrow stream is consumed);
- `converter_registry::initialize()` for the GPU scan/result converters.

## Test
A GPU test writes a parquet fixture, builds a `local_files` plan, runs it through `execute_substrait`, and checks the rows. The two context-constructing tests share a process lock (the engine keeps process-global GPU state). Requires a GPU + `LD_LIBRARY_PATH` to the built engine, like the existing context test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
