### PR TITLE
refactor(starrocks): identify fragment instances by uuid

### DIFF
--- a/experimental/starrocks/Cargo.lock
+++ b/experimental/starrocks/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/experimental/starrocks/Cargo.toml
+++ b/experimental/starrocks/Cargo.toml
@@ -39,6 +39,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+uuid = "1"
 
 [features]
 # On by default so a normal build links the GPU engine. CI disables it
@@ -69,6 +70,7 @@ tokio-util.workspace = true
 tower.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 heck.workspace = true

--- a/experimental/starrocks/src/compute_node_service.rs
+++ b/experimental/starrocks/src/compute_node_service.rs
@@ -101,19 +101,13 @@ impl PInternalService for SiriusComputeNodeService {
         request: PFetchDataRequest,
         _attachment: Vec<u8>,
     ) -> Result<crate::prpc::Reply<PFetchDataResult>, crate::prpc::Error> {
-        let id = FragmentInstanceId {
-            hi: request.finst_id.hi,
-            lo: request.finst_id.lo,
-        };
+        let id = FragmentInstanceId::from(&request.finst_id);
         // An unknown id is an error, not EOS: it means this CN never buffered a result for the
         // fragment the FE is polling (wrong id, or a dispatch/result-sink path that did not run),
         // and StarRocks treats a missing result buffer as a failure rather than an empty result.
         let Some(outcome) = self.results.take_next(id) else {
             return Ok(Self::fetch_data_result(
-                Self::internal_error(format!(
-                    "no buffered result for fragment instance {}-{}",
-                    id.hi, id.lo
-                )),
+                Self::internal_error(format!("no buffered result for fragment instance {id}")),
                 0,
                 true,
             )
@@ -298,10 +292,10 @@ impl SiriusComputeNodeService {
 
     /// Extracts the fragment instance id the FE later passes to `fetch_data`.
     fn fragment_instance_id(params: &TExecPlanFragmentParams) -> Option<FragmentInstanceId> {
-        params.params.as_ref().map(|exec| FragmentInstanceId {
-            hi: exec.fragment_instance_id.hi,
-            lo: exec.fragment_instance_id.lo,
-        })
+        params
+            .params
+            .as_ref()
+            .map(|exec| FragmentInstanceId::from(&exec.fragment_instance_id))
     }
 
     /// Extracts the parquet path from the binary-thrift attachment and infers its schema.

--- a/experimental/starrocks/src/result_store.rs
+++ b/experimental/starrocks/src/result_store.rs
@@ -4,17 +4,47 @@
 //! fragment instance id until end-of-stream. This store bridges those two RPCs: the exec handler
 //! buffers a fragment's rows here, and each `fetch_data` poll drains them.
 
+use std::fmt;
 use std::{collections::HashMap, sync::Mutex};
 
 use starrocks_thrift::data::TResultBatch;
+use starrocks_thrift::types::TUniqueId;
+use uuid::Uuid;
 
-/// StarRocks `fragment_instance_id` (a `TUniqueId`), the key the FE passes to `fetch_data`.
+use crate::proto::starrocks::PUniqueId;
+
+/// StarRocks `fragment_instance_id`, the key the FE passes to `fetch_data`.
+///
+/// StarRocks identifies a fragment instance by a 128-bit id split into `hi`/`lo`
+/// 64-bit halves (thrift `TUniqueId` on dispatch, proto `PUniqueId` on
+/// `fetch_data`). It is held here as a [`Uuid`] so the two wire forms compare
+/// equal and logs render the canonical hyphenated form instead of `hi-lo`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct FragmentInstanceId {
-    /// High 64 bits of the instance id.
-    pub(crate) hi: i64,
-    /// Low 64 bits of the instance id.
-    pub(crate) lo: i64,
+pub(crate) struct FragmentInstanceId(Uuid);
+
+impl FragmentInstanceId {
+    /// Packs the `hi`/`lo` 64-bit halves of a StarRocks unique id into a [`Uuid`].
+    pub(crate) fn from_halves(hi: i64, lo: i64) -> Self {
+        Self(Uuid::from_u64_pair(hi as u64, lo as u64))
+    }
+}
+
+impl From<&TUniqueId> for FragmentInstanceId {
+    fn from(id: &TUniqueId) -> Self {
+        Self::from_halves(id.hi, id.lo)
+    }
+}
+
+impl From<&PUniqueId> for FragmentInstanceId {
+    fn from(id: &PUniqueId) -> Self {
+        Self::from_halves(id.hi, id.lo)
+    }
+}
+
+impl fmt::Display for FragmentInstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 /// One buffered fragment result and where the FE `fetch_data` poll is in draining it.
@@ -111,7 +141,7 @@ mod tests {
     #[test]
     fn delivers_rows_once_then_reports_eos_on_repeat_polls() {
         let store = ResultStore::default();
-        let id = FragmentInstanceId { hi: 1, lo: 2 };
+        let id = FragmentInstanceId::from_halves(1, 2);
         store.insert(id, batch(&["a", "b"]));
 
         let first = store.take_next(id).expect("known fragment");
@@ -132,7 +162,7 @@ mod tests {
         let store = ResultStore::default();
         assert!(
             store
-                .take_next(FragmentInstanceId { hi: 9, lo: 9 })
+                .take_next(FragmentInstanceId::from_halves(9, 9))
                 .is_none()
         );
     }


### PR DESCRIPTION
> **Stacked on #1008** (which introduces `FragmentInstanceId`). Until that merges, this PR's diff includes its commit; afterwards this rebases onto `dev`.

Represent the StarRocks fragment-instance id as a `uuid::Uuid` rather than raw `hi`/`lo` halves.

StarRocks identifies a fragment instance by a 128-bit id split into two 64-bit halves — thrift `TUniqueId` on dispatch (`exec_plan_fragment`) and proto `PUniqueId` on `fetch_data`. Holding it as a `Uuid`:
- gives one type both wire forms convert into (`From<&TUniqueId>` / `From<&PUniqueId>`), so an id compares and hashes equal regardless of which RPC produced it;
- renders the canonical hyphenated UUID in logs (e.g. the `fetch_data` "no buffered result for fragment instance …" error) instead of an ad-hoc `hi-lo`.

## Changes
- Add the `uuid` workspace dependency (used by `sirius-starrocks-cn`).
- `FragmentInstanceId` becomes a `Uuid` newtype with `From<&TUniqueId>` / `From<&PUniqueId>` conversions, a `Display` impl, and a `from_halves(hi, lo)` constructor (used by the store's tests).
- The `fetch_data` and dispatch paths build the id via the conversions; the unknown-id error uses `Display`.

This is the only place in the StarRocks Rust code that handles a 128-bit unique id beyond the wire types themselves, so the conversion is centralized on `FragmentInstanceId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
