### PR TITLE
refactor(starrocks): key descriptor slots by a SlotKey type

### DIFF
--- a/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
+++ b/experimental/starrocks/crates/starrocks-plan-translator/src/descriptor_table.rs
@@ -54,13 +54,31 @@ struct TableInfo {
     table_name: String,
 }
 
+/// Key into the slot map: a slot is identified by its owning tuple plus its slot id.
+///
+/// StarRocks slot ids are unique only within a tuple — the same id can appear in several tuples
+/// (e.g. a FILES scan's src and dest tuples), so the tuple id is part of the key; keying by slot
+/// id alone would let one tuple's slots clobber another's.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct SlotKey {
+    /// Owning tuple id (`TSlotDescriptor.parent`).
+    tuple_id: i32,
+    /// StarRocks slot id, unique only within `tuple_id`.
+    slot_id: i32,
+}
+
+impl SlotKey {
+    /// Builds a slot key from its owning tuple and slot id.
+    fn new(tuple_id: i32, slot_id: i32) -> Self {
+        Self { tuple_id, slot_id }
+    }
+}
+
 /// Lookup structure for StarRocks descriptor-table ids.
 #[derive(Clone, Debug)]
 pub struct DescriptorTable {
-    /// Slots keyed by `(tuple id, slot id)`. StarRocks slot ids are unique only within a tuple —
-    /// the same id can appear in several tuples (e.g. a FILES scan's src and dest tuples), so
-    /// keying by slot id alone would let one tuple's slots clobber another's.
-    slots: HashMap<(i32, i32), SlotInfo>,
+    /// Slots keyed by [`SlotKey`] (owning tuple + slot id).
+    slots: HashMap<SlotKey, SlotInfo>,
     /// Tuples keyed by StarRocks tuple id.
     tuples: HashMap<i32, TupleInfo>,
     /// Tables keyed by StarRocks table id.
@@ -136,7 +154,7 @@ impl TryFrom<&TDescriptorTable> for DescriptorTable {
             };
 
             slots.insert(
-                (parent_tuple_id, slot_id),
+                SlotKey::new(parent_tuple_id, slot_id),
                 SlotInfo {
                     slot_id,
                     column_pos: slot.column_pos.unwrap_or(slot_id),
@@ -163,7 +181,7 @@ impl TryFrom<&TDescriptorTable> for DescriptorTable {
         for (tuple_id, tuple) in tuples.iter_mut() {
             tuple.slot_ids.sort_by_key(|slot_id| {
                 let slot = slots
-                    .get(&(*tuple_id, *slot_id))
+                    .get(&SlotKey::new(*tuple_id, *slot_id))
                     .expect("slot id stored in tuple exists");
                 (slot.column_pos < 0, slot.column_pos, slot.slot_id)
             });
@@ -180,9 +198,11 @@ impl TryFrom<&TDescriptorTable> for DescriptorTable {
 impl DescriptorTable {
     /// Looks up a StarRocks slot by its owning tuple and slot id; ids are unique only per tuple.
     pub fn slot(&self, tuple_id: i32, slot_id: i32) -> Result<&SlotInfo> {
-        self.slots.get(&(tuple_id, slot_id)).ok_or_else(|| {
-            TranslateError::descriptor(format!("slot {slot_id} not found in tuple {tuple_id}"))
-        })
+        self.slots
+            .get(&SlotKey::new(tuple_id, slot_id))
+            .ok_or_else(|| {
+                TranslateError::descriptor(format!("slot {slot_id} not found in tuple {tuple_id}"))
+            })
     }
 
     /// Looks up a StarRocks tuple by id.
@@ -201,7 +221,7 @@ impl DescriptorTable {
             .copied()
             .filter(|slot_id| {
                 self.slots
-                    .get(&(tuple_id, *slot_id))
+                    .get(&SlotKey::new(tuple_id, *slot_id))
                     .map(|slot| slot.is_materialized)
                     .unwrap_or(false)
             })


### PR DESCRIPTION
Address a review comment on the descriptor table: the slot lookup map was keyed by a bare `(i32, i32)` tuple. Replace it with a named `SlotKey { tuple_id, slot_id }` so the `(tuple, slot)` pairing is explicit at every call site rather than relying on positional convention.

Behavior-preserving: `SlotKey` is module-private, derives the same `Hash`/`Eq`, and the public methods still take `(tuple_id, slot_id)` and build the key internally. The per-tuple-uniqueness rationale (StarRocks slot ids are unique only within a tuple — e.g. a FILES scan's src/dest tuples reuse ids) moves onto `SlotKey`.

Follow-up to #1006, which introduced the `(tuple id, slot id)` keying. All descriptor + translator tests pass unchanged (notably `overlapping_slot_ids_across_tuples_resolve_per_tuple`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
