### PR TITLE
build(deps): bump quent to `2704d96`, migrate `model!` syntax

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "quent-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-attributes",
  "quent-events",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "quent-attributes"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "serde",
  "thiserror",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "quent-build-info"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "quent-codegen"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "convert_case",
  "prettyplease",
@@ -1436,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "quent-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-collector-client",
  "quent-collector-proto",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-client"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "ciborium",
  "http",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "quent-collector-proto"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "prost",
  "tonic",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "quent-events"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-attributes",
  "quent-time",
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "http",
  "quent-events",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-collector"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "async-trait",
  "http",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-msgpack"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-ndjson"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-postcard"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "async-trait",
  "postcard",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "quent-exporter-types"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "async-trait",
  "quent-events",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "quent-instrumentation"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-attributes",
  "quent-build-info",
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "quent-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "ciborium",
  "quent-attributes",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "quent-model-macros"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-model"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-attributes",
  "quent-model",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-server"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "axum",
  "mime_guess",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "quent-query-engine-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-analyzer",
  "quent-attributes",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "quent-simulator-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-analyzer",
  "serde",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "quent-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-model",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "quent-time"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "serde",
  "thiserror",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "quent-ui"
 version = "0.1.0"
-source = "git+https://github.com/rapidsai/quent.git?rev=7f391d7065bf404cf9a1394d5227acd9ed69bf0b#7f391d7065bf404cf9a1394d5227acd9ed69bf0b"
+source = "git+https://github.com/rapidsai/quent.git?rev=2704d96f262fc19f781cc2ca8840a9450f5ad0d9#2704d96f262fc19f781cc2ca8840a9450f5ad0d9"
 dependencies = [
  "quent-analyzer",
  "quent-time",

--- a/rust/crates/telemetry/analyzer/Cargo.toml
+++ b/rust/crates/telemetry/analyzer/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-events = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-analyzer = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-time = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
 rustc-hash = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde"] }

--- a/rust/crates/telemetry/bridge/Cargo.toml
+++ b/rust/crates/telemetry/bridge/Cargo.toml
@@ -15,4 +15,4 @@ instrumentation-model = { path = "../model" }
 cxx-build = "1"
 instrumentation-model = { path = "../model" }
 # Tracks a pinned commit from quent's main branch.
-quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-codegen = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }

--- a/rust/crates/telemetry/model/Cargo.toml
+++ b/rust/crates/telemetry/model/Cargo.toml
@@ -8,13 +8,13 @@ collector = ["quent-model/collector"]
 
 [dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-attributes = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-model = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-model = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-stdlib = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
 uuid = "1"
 
 [build-dependencies]
 # Captures this crate's git provenance into QUENT_SOURCE_* so the model! macro's
 # generated ModelSource records Sirius (not quent) as the model's source.
-quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-build-info = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }

--- a/rust/crates/telemetry/model/src/lib.rs
+++ b/rust/crates/telemetry/model/src/lib.rs
@@ -3,8 +3,9 @@ use quent_model::{instrumentation, model};
 pub mod task;
 
 model! {
-    Sirius {
-        root: quent_query_engine_model::engine::Engine,
+    name: Sirius,
+    root: quent_query_engine_model::engine::Engine,
+    entities: {
         quent_query_engine_model::worker::Worker,
         quent_query_engine_model::query_group::QueryGroup,
         quent_query_engine_model::query::Query,
@@ -15,7 +16,7 @@ model! {
         task::TaskQueue,
         task::TaskManagerLoopThread,
         task::ExecutorThread,
-    }
+    },
 }
 
 instrumentation!(Sirius);

--- a/rust/crates/telemetry/server/Cargo.toml
+++ b/rust/crates/telemetry/server/Cargo.toml
@@ -12,16 +12,16 @@ axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 instrumentation-model = { path = "../model", features = ["collector"] }
 sirius-telemetry-analyzer = { path = "../analyzer" }
-quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-collector = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-exporter = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-server = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 uuid = "1"
 
 [build-dependencies]
 # Tracks a pinned commit from quent's main branch.
-quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
-quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "7f391d7065bf404cf9a1394d5227acd9ed69bf0b" }
+quent-simulator-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-query-engine-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
+quent-ui = { git = "https://github.com/rapidsai/quent.git", rev = "2704d96f262fc19f781cc2ca8840a9450f5ad0d9" }
 ts-rs = { version = "12", features = ["uuid-impl", "serde-json-impl"] }


### PR DESCRIPTION
﻿﻿Bumps the pinned quent revision across all telemetry crates and migrates the
`model!` call site to quent's new labeled-field syntax (`name:` / `root:` /
`entities: { … }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)