### PR TITLE
fix(build): link loadable extension with bfd to fix duplicate RMM current-device-resource map (rmm#826)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,13 @@ endif()
 build_static_extension(sirius ${EXTENSION_SOURCES} ${CUDA_SOURCES})
 build_loadable_extension(sirius CPP ${EXTENSION_SOURCES} ${CUDA_SOURCES})
 
+# rapidsai/rmm#826: DuckDB links the loadable extension with
+# -Wl,--exclude-libs,ALL, under which mold (but not bfd) hides RMM's GNU_UNIQUE
+# current-device-resource registry symbols, so cuDF's internal allocations
+# bypass the cuCascade reservation system. Force bfd to keep them exported.
+# Harmless for the single-DSO static vcpkg build.
+set_target_properties(sirius_loadable_extension PROPERTIES LINKER_TYPE BFD)
+
 # Shared configuration for both extension targets
 foreach(_target sirius_extension sirius_loadable_extension)
   set_target_properties(


### PR DESCRIPTION
## Problem

Sirius routes GPU allocations through the cuCascade reservation system by setting RMM's
current-device-resource (`cudf::set_current_device_resource_ref`). RMM's per-device registry lives
in **header-only inline function-local statics** (`rmm::mr::detail::get_ref_map()::device_id_to_resource`,
its init guard, and `ref_map_lock`), emitted as `STB_GNU_UNIQUE` (GCC) / default-weak (Clang) so the
dynamic loader coalesces them into a single instance across DSOs — that is what lets Sirius (in the
extension) and cuDF (in `libcudf.so`) share one registry.

In our build that coalescing was silently broken:

- DuckDB links the loadable extension with `-fvisibility=hidden -Wl,--exclude-libs,ALL`.
- The RMM statics are also pulled into the extension from cuCascade's static archives (`libcucascade_*.a`).
- Under **mold** (the linker our dev/vcpkg presets select), `--exclude-libs,ALL` localizes those
  excluded-archive copies to `HIDDEN`, dropping them from `.dynsym`. **GNU ld.bfd does not.**

Result: the extension carries a **private** current-device-resource map. `set_current_device_resource_ref`
(called from the extension) writes that private map, but cuDF-internal allocations that read
`rmm::mr::get_current_device_resource_ref()` from inside `libcudf.so` — the cuco hash tables in hash
group-by / hash join / distinct — read libcudf's never-set map and fall back to raw `cudaMalloc`,
**bypassing cuCascade**. Under memory pressure that raw `cudaMalloc` competes with cuCascade's pool and
fails as a plain `rmm::out_of_memory` (e.g. the ~11.4 GB cuco for a ~1.4B-row group-by batch at SF1000).
This is upstream [rapidsai/rmm#826](https://github.com/rapidsai/rmm/issues/826).

(#1030 worked around this at runtime by `dlsym`-ing libcudf's symbol; this fixes the linkage instead, so
no runtime patching is needed.)

## Fix

Force the loadable extension to link with GNU ld.bfd:

```cmake
set_target_properties(sirius_loadable_extension PROPERTIES LINKER_TYPE BFD)
```

- `BFD`, not `DEFAULT` — `DEFAULT` only means "compiler-driver default" and does not guarantee bfd.
- Targeted re-export flags (`--export-dynamic-symbol`, `--version-script`, `--dynamic-list`) do **not**
  override mold's localization, so the linker choice is the lever.
- No-op for builds already on the default linker (e.g. `ci-release`); harmless for the static **vcpkg**
  build (single DSO — cudf+rmm are linked statically into the one extension `.so`, so the cross-DSO split
  cannot occur there).

## Validation

Controlled comparison — **same commit, linker-only difference** (mold vs bfd), conda gcc 14 / RAPIDS
26.06, RTX PRO 6000 (96 GB):

- **Symbols** (`nm -D` on the built extension): before — registry symbols `LOCAL`/`HIDDEN`, absent from
  `.dynsym`; after — exported `u`/`DEFAULT`. Confirmed on a full pixi build.
- **Runtime, Q13 @ SF1000**, default cuCascade `usage_limit` = 0.95 (≈ 92,993 MiB):

  | build | peak GPU |
  | --- | --- |
  | dev (mold) | **96,614 MiB** — overshoots the budget by ~3.6 GB (untracked cuco escaping cuCascade) |
  | fix (bfd) | **93,050 MiB** — sits at the cuCascade budget |

  The fix makes cuDF's cuco allocations respect cuCascade's budget (spill) instead of escaping to raw
  `cudaMalloc`. With a larger `scan_task_batch_size` the contrast widens (dev pinned at 99.3% of GPU and
  thrashing in OOM-retry, fix held at the budget).
- **Correctness**: Q1/Q13/Q18 @ SF1000 return identical, correct results on both builds — no corruption.
- A micro-experiment (gcc + clang × mold + bfd) reproduced the exact mechanism: under `--exclude-libs,ALL`,
  mold drops the symbol from `.dynsym` while bfd keeps it and the two DSOs' maps coalesce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

