### PR TITLE
Downgrade executor shutdown improvement

### DIFF
--- a/src/downgrade/downgrade_executor.cpp
+++ b/src/downgrade/downgrade_executor.cpp
@@ -113,6 +113,7 @@ void downgrade_executor::stop()
 
   _pool->interrupt();
   _request_queue.interrupt();
+  _monitor_cv.notify_one();
 
   if (_monitor_thread.joinable()) { _monitor_thread.join(); }
   if (_processing_thread.joinable()) { _processing_thread.join(); }
@@ -462,8 +463,11 @@ void downgrade_executor::monitor_loop()
       // Pressure gone -- reset so the next stall episode warns again.
       backed_off = false;
     }
-    // Brief sleep to avoid busy-spinning; the monitor re-checks after each interval
-    std::this_thread::sleep_for(std::chrono::milliseconds(_config.monitor_period_ms));
+    // Wait for the monitor period, but wake immediately on shutdown.
+    std::unique_lock<std::mutex> lock(_monitor_cv_mutex);
+    _monitor_cv.wait_for(lock, std::chrono::milliseconds(_config.monitor_period_ms), [this]() {
+      return !_running.load(std::memory_order_relaxed);
+    });
   }
 }
 

--- a/src/include/downgrade/downgrade_executor.hpp
+++ b/src/include/downgrade/downgrade_executor.hpp
@@ -30,9 +30,11 @@
 #include <cucascade/memory/stream_pool.hpp>
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -192,6 +194,9 @@ class downgrade_executor {
   std::atomic<bool> _running{false};
   std::atomic<size_t> _monitor_requests_issued{0};
   std::unique_ptr<cucascade::memory::exclusive_stream_pool> _stream_pool;
+
+  std::mutex _monitor_cv_mutex;
+  std::condition_variable _monitor_cv;
 
   cucascade::shared_data_repository_manager& _data_repo_mgr;
   cucascade::memory::memory_space_id _space_id;

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -912,17 +912,6 @@ def parse_args():
         ),
     )
     p.add_argument(
-        "--build-path",
-        type=str,
-        default=None,
-        help=(
-            "Path to the build directory. "
-            "Overrides the SIRIUS_BUILD_PATH env var and the default "
-            "build/release path. Example: "
-            "build/clang-relwithdebinfo"
-        ),
-    )
-    p.add_argument(
         "--duckdb-profiling",
         action="store_true",
         help=(

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -60,12 +60,13 @@ TPCH_TABLES = (
     "supplier",
 )
 
-EXTENSION_PATH = os.environ.get(
-    "SIRIUS_EXTENSION_PATH",
-    os.path.join(REPO_ROOT, "build/release/extension/sirius/sirius.duckdb_extension"),
+BUILD_PATH = os.environ.get("SIRIUS_BUILD_PATH", "build/release")
+
+EXTENSION_PATH = os.path.join(
+    REPO_ROOT, BUILD_PATH, "extension/sirius/sirius.duckdb_extension"
 )
 
-DUCKDB_BIN = os.path.join(REPO_ROOT, "build/release/duckdb")
+DUCKDB_BIN = os.path.join(REPO_ROOT, BUILD_PATH, "duckdb")
 
 
 def _git_capture(args):
@@ -911,14 +912,14 @@ def parse_args():
         ),
     )
     p.add_argument(
-        "--extension-path",
+        "--build-path",
         type=str,
         default=None,
         help=(
-            "Path to the sirius.duckdb_extension to load. "
-            "Overrides the SIRIUS_EXTENSION_PATH env var and the default "
+            "Path to the build directory. "
+            "Overrides the SIRIUS_BUILD_PATH env var and the default "
             "build/release path. Example: "
-            "build/clang-relwithdebinfo/extension/sirius/sirius.duckdb_extension"
+            "build/clang-relwithdebinfo"
         ),
     )
     p.add_argument(

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -947,10 +947,7 @@ def parse_args():
 
 
 def main():
-    global EXTENSION_PATH
     args = parse_args()
-    if args.extension_path:
-        EXTENSION_PATH = args.extension_path
     source = args.input
     if not os.path.isdir(source):
         raise SystemExit(

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -60,9 +60,9 @@ TPCH_TABLES = (
     "supplier",
 )
 
-EXTENSION_PATH = os.path.join(
-    REPO_ROOT,
-    "build/release/extension/sirius/sirius.duckdb_extension",
+EXTENSION_PATH = os.environ.get(
+    "SIRIUS_EXTENSION_PATH",
+    os.path.join(REPO_ROOT, "build/release/extension/sirius/sirius.duckdb_extension"),
 )
 
 DUCKDB_BIN = os.path.join(REPO_ROOT, "build/release/duckdb")
@@ -911,6 +911,17 @@ def parse_args():
         ),
     )
     p.add_argument(
+        "--extension-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to the sirius.duckdb_extension to load. "
+            "Overrides the SIRIUS_EXTENSION_PATH env var and the default "
+            "build/release path. Example: "
+            "build/clang-relwithdebinfo/extension/sirius/sirius.duckdb_extension"
+        ),
+    )
+    p.add_argument(
         "--duckdb-profiling",
         action="store_true",
         help=(
@@ -935,7 +946,10 @@ def parse_args():
 
 
 def main():
+    global EXTENSION_PATH
     args = parse_args()
+    if args.extension_path:
+        EXTENSION_PATH = args.extension_path
     source = args.input
     if not os.path.isdir(source):
         raise SystemExit(


### PR DESCRIPTION
This PR introduced a minor fix. It makes it so that if you have a large memory monitor period, during engine shutdown the downgrade executor does not have to wait for that period in order to shut down.

Also it introduces an environment variable `SIRIUS_BUILD_PATH` that you can use with the benchmark script in order to point it to the right folder if you want to use a build other than `release`