### PR TITLE
Partition coalescing + single-materialization for multi-GPU hash joins

### DIFF
--- a/src/include/op/partition/gpu_partition_impl.hpp
+++ b/src/include/op/partition/gpu_partition_impl.hpp
@@ -17,12 +17,15 @@
 #pragma once
 
 #include <cudf/cudf_utils.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
 
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace sirius {
@@ -58,6 +61,29 @@ class gpu_partition_impl {
     int num_partitions,
     rmm::cuda_stream_view stream,
     cucascade::memory::memory_space& memory_space);
+
+  /**
+   * @brief Hash-partition the input WITHOUT materializing each partition into its own table.
+   *
+   * Performs the same hashing + reordering + slicing as `hash_partition()`, but instead of copying
+   * each partition out, returns the single reordered parent table plus zero-copy `table_view`s into
+   * it (one per partition, with any transient hash-cast columns already dropped via `select`).
+   *
+   * Ownership / lifetime contract: the returned views reference the returned table's device
+   * buffers. The caller MUST (a) keep the returned table alive for as long as it uses the views,
+   * and (b) materialize (copy / concatenate) any view into an owning table before that data crosses
+   * a task boundary — a slice (offset) view is not spillable / downgradable and cannot be safely
+   * peer-copied across GPUs.
+   *
+   * @return A pair of {reordered parent table, per-partition views into it}.
+   */
+  static std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::table_view>>
+  hash_partition_sliced(const cucascade::read_only_data_batch& input,
+                        const std::vector<int>& partition_key_idx,
+                        const std::vector<cudf::data_type>& partition_key_cast_types,
+                        int num_partitions,
+                        rmm::cuda_stream_view stream,
+                        cucascade::memory::memory_space& memory_space);
 
   /// Overload without cast types (all keys hashed as-is). Kept for backward compatibility.
   static std::vector<std::shared_ptr<cucascade::data_batch>> hash_partition(

--- a/src/include/op/sirius_physical_partition.hpp
+++ b/src/include/op/sirius_physical_partition.hpp
@@ -43,6 +43,25 @@ inline std::string partition_type_to_string(PartitionType type)
   return "UNKNOWN";
 }
 
+//! Operator data produced by the multi-GPU coalescing fast path of `sirius_physical_partition`.
+//! Carries, in parallel to the batches, the GPU "slot" each batch must be pushed to, so the
+//! slot-aware `sink()` routes a coalesced batch to its target partition slot (GPU) instead of
+//! using the running batch index. Non-coalesced paths keep returning plain
+//! `pipelineable_operator_data`, for which `sink()` falls back to the running index.
+class partition_slotted_operator_data : public pipelineable_operator_data {
+ public:
+  partition_slotted_operator_data(std::vector<std::shared_ptr<::cucascade::data_batch>> batches,
+                                  std::vector<std::size_t> slots)
+    : pipelineable_operator_data(std::move(batches)), _slots(std::move(slots))
+  {
+  }
+
+  [[nodiscard]] const std::vector<std::size_t>& get_slots() const { return _slots; }
+
+ private:
+  std::vector<std::size_t> _slots;
+};
+
 class sirius_physical_partition : public sirius_physical_operator {
  public:
   static constexpr const SiriusPhysicalOperatorType TYPE = SiriusPhysicalOperatorType::PARTITION;
@@ -99,6 +118,14 @@ class sirius_physical_partition : public sirius_physical_operator {
     _small_table_bytes  = small_table_bytes;
   }
 
+  /// Cap on the size of a single coalesced cross-GPU batch produced by the multi-GPU fast path.
+  /// Each coalesced build batch becomes a cuco hash table downstream, so the default mirrors the
+  /// build-hash-table size limit.
+  void set_coalesce_batch_bytes(uint64_t coalesce_batch_bytes)
+  {
+    _coalesce_batch_bytes = coalesce_batch_bytes;
+  }
+
   [[nodiscard]] std::size_t no_history_peak_memory_estimate(
     const op::input_stats& stats) const override;
 
@@ -125,6 +152,7 @@ class sirius_physical_partition : public sirius_physical_operator {
   uint64_t s_partition_size;
   int _min_num_partitions{1};
   uint64_t _small_table_bytes{0};
+  uint64_t _coalesce_batch_bytes{sirius::config::DEFAULT_MAX_BUILD_HASH_TABLE_BYTES};
 };
 
 }  // namespace op

--- a/src/op/partition/gpu_partition_impl.cpp
+++ b/src/op/partition/gpu_partition_impl.cpp
@@ -24,7 +24,8 @@
 namespace sirius {
 namespace op {
 
-std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_partition(
+std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::table_view>>
+gpu_partition_impl::hash_partition_sliced(
   const cucascade::read_only_data_batch& input,
   const std::vector<int>& partition_key_idx,
   const std::vector<cudf::data_type>& partition_key_cast_types,
@@ -34,7 +35,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
 {
   // Sanity check.
   if (num_partitions < 2) {
-    throw std::runtime_error("`num_partitions` in `hash_partition()` should be at least 2");
+    throw std::runtime_error("`num_partitions` in `hash_partition_sliced()` should be at least 2");
   }
 
   auto input_table = get_cudf_table_view(input);
@@ -78,9 +79,7 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
     orig_col_indices.push_back(i);
   }
 
-  // Slice from the reordered table to create separate table partitions.
-  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
-  output_batches.reserve(num_partitions);
+  // Slice from the reordered table to create per-partition views (zero-copy).
   std::vector<cudf::size_type> slice_indices;
   slice_indices.reserve(num_partitions * 2);
   for (int i = 0; i < num_partitions; ++i) {
@@ -89,15 +88,39 @@ std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_par
                                                     : partition_result.second[i + 1]);
   }
   auto sliced_partition_views = cudf::slice(partition_result.first->view(), slice_indices, stream);
+  std::vector<cudf::table_view> partition_views;
+  partition_views.reserve(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {
-    // Drop any appended cast columns from the output.
-    auto output_partition =
-      std::make_unique<cudf::table>(sliced_partition_views[i].select(orig_col_indices),
-                                    stream,
-                                    memory_space.get_default_allocator());
-    output_batches.push_back(make_data_batch(std::move(output_partition), memory_space, stream));
+    // Drop any appended cast columns from the view. `select` copies the underlying column_views,
+    // so the result stays valid after `sliced_partition_views` is destroyed, as long as the
+    // returned reordered table (which owns the device buffers) is kept alive.
+    partition_views.push_back(sliced_partition_views[i].select(orig_col_indices));
   }
 
+  return {std::move(partition_result.first), std::move(partition_views)};
+}
+
+std::vector<std::shared_ptr<cucascade::data_batch>> gpu_partition_impl::hash_partition(
+  const cucascade::read_only_data_batch& input,
+  const std::vector<int>& partition_key_idx,
+  const std::vector<cudf::data_type>& partition_key_cast_types,
+  int num_partitions,
+  rmm::cuda_stream_view stream,
+  cucascade::memory::memory_space& memory_space)
+{
+  // Single source of truth: partition into views, then materialize each into its own table.
+  auto [reordered, partition_views] = hash_partition_sliced(
+    input, partition_key_idx, partition_key_cast_types, num_partitions, stream, memory_space);
+
+  std::vector<std::shared_ptr<cucascade::data_batch>> output_batches;
+  output_batches.reserve(partition_views.size());
+  for (const auto& view : partition_views) {
+    output_batches.push_back(make_data_batch(
+      std::make_unique<cudf::table>(view, stream, memory_space.get_default_allocator()),
+      memory_space,
+      stream));
+  }
+  // `reordered` (and the views into it) released here, after every partition has been copied out.
   return output_batches;
 }
 

--- a/src/op/sirius_physical_partition.cpp
+++ b/src/op/sirius_physical_partition.cpp
@@ -27,8 +27,13 @@
 #include "op/sirius_physical_hash_join.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 
+#include <cudf/concatenate.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+
 #include <nvtx3/nvtx3.hpp>
 
+#include <algorithm>
 #include <mutex>
 
 namespace sirius {
@@ -173,6 +178,78 @@ std::unique_ptr<operator_data> sirius_physical_partition::execute(const operator
     return std::make_unique<pipelineable_operator_data>(input.get_read_only_batches());
   }
 
+  // Multi-GPU coalescing fast path. When hash-partitioning into more fine partitions than GPUs,
+  // partition once into zero-copy views (single materialization), bucket the fine partitions into
+  // `num_gpus` GPU slots using the SAME `slot = partition_idx % num_gpus` rule the downstream task
+  // creator routes by, and concatenate each slot into a few large batches. This replaces hundreds
+  // of tiny per-partition tables (plus a downstream concat) with one materialization, slashing
+  // device allocations and tiny cross-GPU peer copies.
+  //
+  // Correctness: matching keys land in the same fine partition `p` on both build and probe (same
+  // hash, same key cast types, same `_num_partitions`); `slot = p % num_gpus` co-locates them on
+  // the same GPU on both sides. The hash join re-hashes within each batch, so unioning disjoint
+  // fine-partition key sets within a slot loses no matches. The `num_fine > num_gpus` gate
+  // guarantees every slot in [0, num_gpus) is non-empty, so build and probe emit the same slot
+  // count (the join requires `probe.num_partitions() == build.num_partitions()`).
+  const std::size_t num_gpus = static_cast<std::size_t>(std::max(1, _min_num_partitions));
+  const std::size_t num_fine = static_cast<std::size_t>(_num_partitions.value());
+  if (_partition_type == PartitionType::HASH && num_gpus > 1 && num_fine > num_gpus) {
+    auto [reordered, views] = gpu_partition_impl::hash_partition_sliced(input_batch_ro,
+                                                                        _partition_keys,
+                                                                        _partition_key_cast_types,
+                                                                        static_cast<int>(num_fine),
+                                                                        stream,
+                                                                        *space);
+
+    // Approximate per-partition bytes proportionally to row count: all views share the parent
+    // column layout, so bytes scale with rows. Parent total bytes come from the input batch's
+    // representation (cudf::table exposes no direct allocation-size accessor).
+    const auto* parent_repr        = input_batch_ro.get_data();
+    const std::size_t parent_bytes = parent_repr ? parent_repr->get_size_in_bytes() : 0;
+    const std::size_t parent_rows  = static_cast<std::size_t>(reordered->num_rows());
+    auto view_bytes                = [&](std::size_t p) -> std::size_t {
+      if (parent_rows == 0) { return 0; }
+      return parent_bytes * static_cast<std::size_t>(views[p].num_rows()) / parent_rows;
+    };
+
+    // Bucket fine partitions into GPU slots with the exact downstream routing rule.
+    std::vector<std::vector<std::size_t>> slot_members(num_gpus);
+    for (std::size_t p = 0; p < num_fine; ++p) {
+      slot_members[p % num_gpus].push_back(p);
+    }
+
+    std::vector<std::shared_ptr<cucascade::data_batch>> coalesced_batches;
+    std::vector<std::size_t> coalesced_slots;
+    for (std::size_t g = 0; g < num_gpus; ++g) {
+      std::vector<cudf::table_view> group;
+      std::size_t group_bytes = 0;
+      auto flush              = [&]() {
+        if (group.empty()) { return; }
+        std::unique_ptr<cudf::table> materialized =
+          group.size() == 1
+                         ? std::make_unique<cudf::table>(group[0], stream, space->get_default_allocator())
+                         : cudf::concatenate(group, stream, space->get_default_allocator());
+        coalesced_batches.push_back(make_data_batch(std::move(materialized), *space, stream));
+        coalesced_slots.push_back(g);
+        group.clear();
+        group_bytes = 0;
+      };
+      for (std::size_t p : slot_members[g]) {
+        const std::size_t p_bytes = view_bytes(p);
+        // Keep >=1 member per group so a single oversized partition still forms its own group.
+        if (!group.empty() && group_bytes + p_bytes > _coalesce_batch_bytes) { flush(); }
+        group.push_back(views[p]);
+        group_bytes += p_bytes;
+      }
+      flush();
+    }
+
+    // `reordered` (and its views) released at scope end — after every group has been materialized.
+    // This is the only materialization; the views never leave the task.
+    return std::make_unique<partition_slotted_operator_data>(std::move(coalesced_batches),
+                                                             std::move(coalesced_slots));
+  }
+
   std::vector<std::shared_ptr<cucascade::data_batch>> partitioned_results;
   switch (_partition_type) {
     case PartitionType::HASH:
@@ -208,8 +285,14 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
   auto& pipelineable_input  = dynamic_cast<const pipelineable_operator_data&>(input_data);
   const auto& input_batches = pipelineable_input.get_data_batches();
   (void)stream;  // sink does not use stream for push_data_batch_partitioned
-  int partition_id = 0;
-  for (auto& batch : input_batches) {
+
+  // The multi-GPU coalescing fast path tags each batch with an explicit target GPU slot. When that
+  // slotted data is present, route by the slot; otherwise fall back to the running index (one batch
+  // per fine partition, batch i -> partition slot i), preserving the non-coalesced behavior.
+  const auto* slotted = dynamic_cast<const partition_slotted_operator_data*>(&input_data);
+  const std::vector<std::size_t>* slots = slotted ? &slotted->get_slots() : nullptr;
+  for (std::size_t i = 0; i < input_batches.size(); ++i) {
+    const std::size_t target = slots ? (*slots)[i] : i;
     for (auto& next_port_info : next_port_after_sink) {
       // the next operator is a partition consumer operator, so we need to push the batch into the
       // specific partition
@@ -217,12 +300,11 @@ void sirius_physical_partition::sink(const operator_data& input_data, rmm::cuda_
         dynamic_cast<sirius_physical_partition_consumer_operator*>(next_port_info.next_operator);
       if (partition_consumer_op) {
         partition_consumer_op->push_data_batch_partitioned(
-          next_port_info.next_operator_port_name, batch, partition_id);
+          next_port_info.next_operator_port_name, input_batches[i], target);
       } else {
         throw std::runtime_error("Next operator is not a partition consumer operator");
       }
     }
-    partition_id++;
   }
 }
 


### PR DESCRIPTION
Partition the input once into a reordered table plus zero-copy per-partition views (hash_partition_sliced), so the existing hash_partition() materializes each partition from a single reordered table instead of re-hashing/copying per partition.

For multi-GPU hash partitioning, bucket the fine partitions into num_gpus GPU slots and concatenate each slot into one coalesced batch (respecting _coalesce_batch_bytes), carried by partition_slotted_operator_data so the slot-aware sink() routes each coalesced batch to its target GPU instead of the running batch index. This cuts cross-GPU shuffle overhead by sending one large batch per GPU rather than many fine partitions.