### PR TITLE
docs: refresh Super Sirius docs for the IO framework and unified scan operator

### DIFF
--- a/docs/super-sirius/README.md
+++ b/docs/super-sirius/README.md
@@ -34,7 +34,7 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 | [Expression Executor](expression-executor.md) | gpu_expression_executor, Sirius AST hierarchy, GPU expression translator, cuDF AST |
 | [Pipeline Execution](pipeline-execution.md) | GPU executor, task scheduling, completion, OOM handling, per-task-device contract under SCHED-RR |
 | [Task Creator](task-creator.md) | Task creation: hint chain, per-operator scheduling behavior |
-| [Scan](scan.md) | Scan subsystem: parquet scan, DuckDB scan, DuckDB-native GPU scan, S3, caching, prefetched data source |
+| [Scan](scan.md) | Scan subsystem: unified GPU scan operator, `gpu_ingestible` (parquet + DuckDB-native), scan manager, pinned tables, DuckDB-native decode, row-group pruning, Sirius IO layer (uring/REST/kvikio + prefetching cache) |
 | [Memory Management](memory-management.md) | cuCascade tiers, reservations, downgrade executor |
 | [Data Management](data-management.md) | Data batches, repositories, ports, barrier semantics |
 | [Configuration](configuration.md) | sirius_config, operator_params, SET variables |
@@ -58,4 +58,4 @@ SELECT l_returnflag, SUM(l_quantity) FROM lineitem GROUP BY l_returnflag;
 11. **Configuration** — tuning knobs and runtime settings
 12. **Optimizations** — performance improvements and their mechanisms
 
-<!-- last-updated-commit: 46e7cb063196f7f59c9877ee497325ec5fc0d22a -->
+<!-- last-updated-commit: 84543810a303c81c891b2adbae222157a4e17204 -->

--- a/docs/super-sirius/architecture-overview.md
+++ b/docs/super-sirius/architecture-overview.md
@@ -13,15 +13,16 @@ graph TD
     ENGINE -->|"execute"| PE["task_scheduler"]
 
     PE --> GPE["gpu_pipeline_executor(s)"]
-    PE --> SE["duckdb_scan_executor"]
     PE --> TC["task_creator"]
 
-    TC -->|"schedule scan tasks"| SE
     TC -->|"schedule GPU tasks"| GPE
 
+    SM["sirius_scan_manager"] -->|"prepare per-scan state"| GPE
+    SM -->|"I/O backends + prefetch cache"| IO["io_context (uring / rest / kvikio)"]
+
+    GPE -->|"unified GPU scan source"| SM
     GPE -->|"memory reservations"| MRM["sirius_memory_reservation_manager"]
-    SE -->|"store scan output"| DRM["shared_data_repository_manager"]
-    GPE -->|"consume/produce"| DRM
+    GPE -->|"consume/produce"| DRM["shared_data_repository_manager"]
 
     DE["downgrade_executor(s)"] -->|"monitor pressure"| MRM
     DE -->|"move GPU→Host"| DRM
@@ -31,6 +32,7 @@ graph TD
         DRM
         PE
         TC
+        SM
         DE
     end
 ```
@@ -45,9 +47,10 @@ SiriusContext
 ├── sirius_memory_reservation_manager   # GPU/Host/Disk memory management via cuCascade
 ├── small_pinned_host_memory_resource   # Pinned host memory allocator
 ├── shared_data_repository_manager      # Central registry of all data repositories
-├── task_scheduler                      # Top-level executor (owns GPU + scan executors)
+├── task_scheduler                      # Top-level executor (owns the GPU pipeline executors)
+├── sirius_scan_manager                 # Scan-side preparation + I/O (io_context, prefetch cache, split providers)
 ├── downgrade_executor[]                # Per-memory-space monitors for GPU→Host spilling
-├── task_creator                        # Creates scan and GPU tasks based on data availability
+├── task_creator                        # Creates GPU pipeline tasks based on data availability
 └── query                               # Current query context (pipeline hashmap)
 ```
 
@@ -56,6 +59,8 @@ Key lifecycle methods on `SiriusContext`:
 - `terminate()` — releases all resources
 - `QueryBegin()` / `QueryEnd()` — DuckDB query lifecycle hooks
 - `create_query()` — creates a new query with pipeline metadata
+
+Scans are not a separate executor. A unified `sirius_gpu_scan_operator` (operator type `GPU_SCAN`) is the pipeline source: it pulls splits from a `split_connector` and delegates per-split materialization to an installed `gpu_ingestible` (parquet or duckdb-native today). The `sirius_scan_manager` prepares this state per query — it builds the per-table ingestible, installs the split connector, drives a `split_provider`, and owns the I/O backends (an `io_context` over io_uring plus optional REST/kvikio paths) and the prefetching cache.
 
 ## Thread Model
 
@@ -82,29 +87,31 @@ Super Sirius uses multiple dedicated thread pools, each with a specific role:
 │  GPU Pipeline Executor (per GPU device)                         │
 │  - Manager thread: acquires kiosk ticket → requests task →      │
 │    reserves memory → dispatches to worker thread pool            │
-│  - Worker threads (default: 4): execute GPU pipeline tasks      │
-│    on dedicated CUDA streams                                    │
+│  - Worker threads: execute GPU pipeline tasks (including the     │
+│    unified GPU scan source) on dedicated CUDA streams           │
 └─────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────┐
-│  Task Creator Thread Pool (default: 2 threads)                  │
+│  Task Creator Thread Pool                                       │
 │  - Manager loop: pops from task_creation_queue                  │
 │  - Follows hint chain to find ready operators                   │
-│  - Creates scan or GPU pipeline tasks                           │
+│  - Creates GPU pipeline tasks                                   │
 └─────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────┐
-│  Scan Executor                                                  │
-│  - Manager thread: pops scan tasks, acquires kiosk tickets      │
-│  - Worker threads (default: 4): execute DuckDB/Parquet scans    │
-│  - CUDA stream pool for async Host→Device transfers             │
+│  Scan Manager                                                   │
+│  - Worker thread pool: per-scan preparation                    │
+│  - Driver thread: runs split providers sequentially, feeding    │
+│    splits into each scan operator's split_connector            │
+│  - I/O reactor threads: io_uring (local disk) and REST/kvikio   │
+│    backends behind the io_context, plus the prefetching cache   │
 └─────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────┐
 │  Downgrade Executor(s) (per memory space)                       │
-│  - Monitor thread: polls memory pressure every ~10ms            │
+│  - Monitor thread: polls memory pressure                        │
 │  - Manager thread: dispatches downgrade tasks                   │
-│  - Worker threads (default: 4): move data GPU→Host              │
+│  - Worker threads: move data GPU→Host                           │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -117,11 +124,12 @@ A query through Super Sirius follows these steps:
 3. **Engine Initialization** — `sirius_engine::initialize()` builds the pipeline graph:
    - Constructs `sirius_meta_pipeline` from the physical plan via `build()` + `ready()`
    - Splits operators (TABLE_SCAN, joins, aggregates, sorts) into multiple pipelines
+   - Converts each TABLE_SCAN source into a unified GPU scan source with a per-table `gpu_ingestible`
    - Injects PARTITION, CONCAT, MERGE operators at pipeline boundaries
    - Wires data repositories between pipelines with barrier types
-4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state, prepares scan cache, queues initial scan operators
-5. **Query Start** — `task_scheduler::start_query()` creates a `completion_handler`, distributes it to all sub-executors, and schedules initial scan tasks
-6. **Scan Phase** — Scan executor pulls data from storage (DuckDB tables or Parquet files), converts to GPU-compatible format, and publishes to data repositories
+4. **Query Preparation** — `task_scheduler::prepare_for_query()` drains leftover state and queues initial scan operators; `sirius_scan_manager::prepare_for_query()` builds each scan's split provider, installs its split connector, and matches any pinned-cache entries
+5. **Query Start** — `task_scheduler::start_query()` creates a `completion_handler`, distributes it to all sub-executors, and schedules initial work
+6. **Scan Phase** — The scan manager drives split providers that pull bytes through the `io_context` (io_uring locally, or REST/kvikio backends) and the prefetching cache; the unified GPU scan source consumes splits and materializes GPU-ready batches into data repositories
 7. **Pipeline Execution** — GPU executor threads pull tasks from the queue, acquire memory reservations, and call `execute()` on every operator in the pipeline (source through sink) on CUDA streams, then call the sink's `sink()` to push results downstream
 8. **Task Creation** — After each task completes, the task creator is notified to schedule downstream consumers based on data availability in ports
 9. **Memory Management** — Downgrade executors monitor GPU memory pressure and spill data to host memory when thresholds are exceeded
@@ -137,9 +145,12 @@ A query through Super Sirius follows these steps:
 | `src/sirius_interface.cpp` | DuckDB-facing API, query lifecycle |
 | `src/sirius_engine.cpp` | Pipeline construction, execution orchestration |
 | `src/planner/sirius_physical_plan_generator.cpp` | Logical-to-physical plan translation |
-| `src/include/pipeline/task_scheduler.hpp` | Top-level executor |
+| `src/include/pipeline/task_scheduler.hpp` | Top-level executor (owns GPU executors) |
 | `src/include/pipeline/gpu_pipeline_executor.hpp` | Per-GPU task executor |
 | `src/include/creator/task_creator.hpp` | Task creation and scheduling |
-| `src/include/op/scan/duckdb_scan_executor.hpp` | Scan task executor |
+| `src/include/op/scan/sirius_gpu_scan_operator.hpp` | Unified GPU scan source operator |
+| `src/include/op/scan/gpu_ingestible.hpp` | Per-format split materialization (parquet, duckdb-native) |
+| `src/include/scan_manager/sirius_scan_manager.hpp` | Per-scan preparation, split providers, I/O ownership |
+| `src/include/io/io_context.hpp` | I/O backends (uring / rest / kvikio) + prefetch cache |
 | `src/include/downgrade/downgrade_executor.hpp` | Memory spilling |
 | `src/include/memory/sirius_memory_reservation_manager.hpp` | Memory management |

--- a/docs/super-sirius/configuration.md
+++ b/docs/super-sirius/configuration.md
@@ -70,40 +70,27 @@ config.load_from_file("/path/to/config.yaml");  // Optional
 
 ```yaml
 sirius:
-  topology:
-    num_gpus: 1
+  topology: { num_gpus: 1 }
   memory:
     gpu:
-      usage_limit_fraction: 0.9
+      usage_limit_fraction: 0.95
       reservation_limit_fraction: 1.0
       downgrade_trigger_fraction: 0.8
       downgrade_stop_fraction: 0.6
-    host:
-      capacity_bytes: 439Gi
-      initial_number_pools: 785
-      pool_size: 512
-      block_size: 1Mi
-    disk:
-      disk_id: 0
-      capacity_bytes: 1Ti
-      downgrade_root_dirs: "/mnt/nvme/sirius_spill"
+    host: { capacity_bytes: 25GB, initial_number_pools: 50, pool_size: 512, block_size: 1048576 }
+    disk: { disk_id: 0, capacity_bytes: 1000000000000, downgrade_root_dirs: "/tmp/sirius_disk_memory" }
   executor:
-    pipeline:
-      num_threads: 4
-      thread_name_prefix: "sirius_pipeline_executor"
-    downgrade:
-      num_threads: 1
-      thread_name_prefix: "sirius_downgrade_executor"
-      monitor_period_ms: 10
-    task_creator:
-      num_threads: 2
+    scan_manager: { num_threads: 4, use_sirius_datasource: true, uring_n_reactors: 1, enable_prefetch_cache: false }
+    pipeline:     { num_threads: 4 }
+    downgrade:    { num_threads: 1 }
+    task_creator: { num_threads: 1 }
   operator_params:
-    scan_task_batch_size: 5Gi
+    scan_task_batch_size:       805306368   # 768 MiB
     default_scan_task_varchar_size: 256
-    max_sort_partition_bytes: 0          # 0 = auto (33% GPU memory)
-    hash_partition_bytes: 5Gi
-    concat_batch_bytes: 5Gi
-    max_build_hash_table_bytes: 500Mi
+    max_sort_partition_bytes:   0           # 0 = auto (33% GPU memory)
+    hash_partition_bytes:       805306368   # 768 MiB
+    concat_batch_bytes:         805306368   # 768 MiB
+    max_build_hash_table_bytes: 805306368   # 768 MiB
   telemetry:
     enable_quent: true
     output_directory: telemetry_data
@@ -177,6 +164,66 @@ Each memory tier uses a trigger/stop threshold pair to control data eviction:
 
 The gap between `trigger` and `stop` prevents oscillation — without it, evicting one batch could drop below trigger, then the next allocation re-triggers eviction.
 
+## Scan Manager & IO Configuration
+
+**Files:** `src/include/scan_manager/config.hpp`, `src/include/io/uring/config.hpp`, `src/include/io/rest/config.hpp`, `src/include/io/cache/config.hpp`, `src/include/io/object_store_config.hpp`
+
+The `sirius.executor.scan_manager` block configures the scan-metadata thread pool and the Sirius IO layer that feeds the GPU scan operators.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `num_threads` | int | 8 | Threads in the scan-manager pool that run metadata tasks. |
+| `thread_name_prefix` | string | `scan_manager` | Thread name prefix for logs. |
+| `cpu_affinity` | list of int | — | Cores to pin scan-manager threads to. |
+| `use_sirius_datasource` | bool | true | Route reads through the Sirius `io_uring` datasource. When false, the kvikio fallback is used (single-GPU only; multi-GPU requires the Sirius datasource). |
+| `uring_n_reactors` | int | 1 | Number of io_uring reactor threads for local-disk reads. |
+| `rest_n_reactors` | int | 2 | Number of REST reactor threads for object-store (`s3://`) reads. |
+| `enable_prefetch_cache` | bool | false | Attach the pinned-memory prefetching cache in front of the backend. |
+
+Four optional nested sub-configs tune the individual backends and caches:
+
+### `scan_manager.local` — io_uring backend (`io/uring/config.hpp`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `use_odirect` | bool | true | Use `O_DIRECT` for local-disk reads. |
+| `max_n_chunks` | int | 1 | Max contiguous file segments fused into one vectored read. |
+
+### `scan_manager.rest` — REST / S3 backend (`io/rest/config.hpp`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `request_timeout_s` | int | 30 | Per-request timeout in seconds (0 = unlimited). |
+| `max_connections` | int | 16 | Max concurrent connections per reactor. |
+| `chunk_size` | bytes | 8Mi | Target bytes per ranged GET. |
+| `max_read_split` | int | 16 | Max parallel ranged GETs for one contiguous read. |
+| `ca_bundle_path` | string | "" | PEM CA bundle for TLS verification. |
+| `tls_verify` | bool | true | Verify the endpoint's TLS certificate. |
+| `max_retry_attempts` | int | 10 | Retry attempts for transient errors. |
+| `max_auth_retry_attempts` | int | 3 | Retry attempts for HTTP 403 (expired presigned URL). |
+
+### `scan_manager.cache` — prefetching cache (`io/cache/config.hpp`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `inflight_io_chunk_budget` | int | 2048 | Max in-flight IO chunks (enforced by admission control). |
+| `eviction_threshold_fraction` | double | 0.6 | Start evicting when the pool fills to this fraction. |
+| `min_prefetching_budget_fraction` | double | 0.05 | Floor of the budget reserved for prefetching. |
+| `dispose_after_use` | bool | false | Discard chunks immediately after use. |
+
+### `scan_manager.object_store` — S3 credentials & endpoint (`io/object_store_config.hpp`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `endpoint` | string | "" | S3 endpoint URL. |
+| `region` | string | "" | AWS region. |
+| `access_key` / `secret_key` | string | "" | Static credentials. |
+| `session_token` | string | "" | STS session token for temporary credentials. |
+| `signing_mode` | enum | `presigned` | SigV4 form: `presigned` (auth in the URL query string) or `header` (`Authorization` + `x-amz-*` headers). |
+| `s3_transport` | enum | `AUTO` | Transport selection (`AUTO` / `HTTP` / `RDMA`). |
+| `ca_bundle_path` | string | "" | PEM CA bundle for TLS verification. |
+| `tls_verify` | bool | true | Verify the endpoint's TLS certificate. |
+
 ## Operator Parameters
 
 **File:** `src/include/sirius_config.hpp` — `operator_params` struct
@@ -188,7 +235,10 @@ The gap between `trigger` and `stop` prevents oscillation — without it, evicti
 | `max_sort_partition_bytes` | 0 (auto) | Max bytes per sort partition. Auto = 33% of GPU memory. |
 | `hash_partition_bytes` | 512 MB | Target partition size for hash joins and group-bys |
 | `concat_batch_bytes` | 512 MB | Target output batch size for CONCAT operator |
+| `sort_sample_bytes` | 512 MB | Bytes sampled before computing sort partition boundaries |
 | `max_build_hash_table_bytes` | 500 MB | Max build-side size for BUILD_PROBE join mode |
+| `max_sort_partition_memory_fraction` | 0.33 | Fraction of GPU memory per sort partition when `max_sort_partition_bytes` is 0 |
+| `mark_join_build_switch_ratio` | 8.0 | For STANDARD MARK joins, build on the smaller (left) side when `right_rows >= ratio * left_rows` (0 disables) |
 
 **Note:** `max_build_hash_table_bytes` can be larger than `concat_batch_bytes`. When it is, the partition operator configures CONCAT to concatenate all batches, enabling the more efficient BUILD_PROBE join mode for larger build sides. Other joins (STANDARD, MIXED) still use `concat_batch_bytes` as the batch size threshold.
 
@@ -284,6 +334,7 @@ Then open `http://localhost:8080` and select the captured Sirius engine/query.
 | `task_creator` | 2 | `task_creator` | Task creation from scheduling requests |
 | `gpu_pipeline_executor` | 4 | `gpu_pipeline` | GPU pipeline task execution |
 | `downgrade_executor` | 4 | `downgrade` | Data tier migration (GPU→Host) |
+| `scan_manager` | 8 | `scan_manager` | Scan metadata production + IO reactor management |
 
 Each pool supports optional CPU affinity lists for core pinning.
 
@@ -311,6 +362,7 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `use_cudf_expr` | true | Use cuDF-based expression evaluation |
+| `expression_executor_strategy` | `materialize` | Expression executor strategy |
 | `use_custom_top_n` | false | Use custom top-N implementation |
 
 ### Scan
@@ -329,9 +381,12 @@ Registered in `src/sirius_extension.cpp`. These can be changed at runtime:
 |----------|---------|-------------|
 | `modified_pipeline` | - | Enable modified pipeline execution |
 | `max_sort_partition_bytes` | 0 (auto) | Max sort partition bytes |
+| `max_sort_partition_memory_fraction` | 0.33 | Auto sort-partition fraction when `max_sort_partition_bytes` is 0 |
 | `hash_partition_bytes` | 512 MB | Hash partition target size |
 | `concat_batch_bytes` | 512 MB | CONCAT output batch size |
+| `sort_sample_bytes` | 512 MB | Bytes sampled before computing sort boundaries |
 | `max_build_hash_table_bytes` | 500 MB | Max build-side hash table bytes |
+| `mark_join_build_switch_ratio` | 8.0 | STANDARD MARK join build-side switch ratio (0 disables) |
 
 ### Transparent Execution
 
@@ -373,4 +428,5 @@ These are compile-time defaults. Runtime configuration via `sirius_config` and D
 | `src/include/sirius_config.hpp` | Config class, operator_params, thread pool configs |
 | `src/include/config.hpp` | Legacy config flags |
 | `src/sirius_extension.cpp` | SET variable registration |
-| `src/include/op/scan/config.hpp` | Scan executor config, cache_level enum |
+| `src/include/scan_manager/config.hpp` | Scan manager config (thread pool, IO reactors, prefetch cache, object store) |
+| `src/include/io/uring/config.hpp`, `io/rest/config.hpp`, `io/cache/config.hpp`, `io/object_store_config.hpp` | Per-backend IO / cache / object-store sub-configs |

--- a/docs/super-sirius/dynamic-filters.md
+++ b/docs/super-sirius/dynamic-filters.md
@@ -139,7 +139,7 @@ A **consumer** holds the channel directly via `std::shared_ptr<sirius_dynamic_fi
 
 ## Static + dynamic filter mixing at the consumer
 
-A parquet partition's static filter is a `shared_ptr<duckdb::Expression>` (`parquet_scan_operator_data::filter_expression`). At execute time, `sirius_gpu_parquet_scan_operator` calls `gpu_expression_translator::translate_expression_with_names` to lower it to a cuDF AST. The translation outcome is what the dynamic-filter merge has to interleave with:
+A parquet scan's static filter is a DuckDB `Expression` stored on the `parquet_gpu_ingestible`. During the per-file metadata task it is lowered to a cuDF AST via `gpu_expression_translator::translate_expression_with_names`. The translation outcome is what the dynamic-filter merge has to interleave with:
 
 - **No static filter.** The consumer builds an AST tree containing only the dynamic-filter fragments and installs it via `reader_options::set_filter`.
 - **Static filter, translation succeeds.** The consumer takes the translated AST, calls `merge_ast_dynamic_filters_into_tree(tree, static_root, set, resolver)` to AND-conjoin every dynamic fragment into it, and installs the resulting root via `set_filter`. Parquet row-group pruning sees the combined predicate.
@@ -154,7 +154,7 @@ This mixing rule is a property of the consumer (parquet metadata scan), not the 
 **Goal:** establish the framework end-to-end against a single (producer, consumer) pair — hash-join build → parquet scan — and exercise filter-kind polymorphism via progressively richer filters.
 
 **Producer:** hash-join build side.
-**Consumer:** parquet scan task (`parquet_scan_task_global_state`).
+**Consumer:** parquet GPU scan (`parquet_gpu_ingestible`).
 **Routing:** DuckDB-paired (`DynamicTableFilterSet*` route key).
 **Coordination:** implicit (meta-pipeline ordering).
 
@@ -170,7 +170,7 @@ What this PR adds:
 - `sirius_physical_hash_join::probe_target` struct + `probe_targets` vector (producer endpoint)
 - Plan-gen wiring in `sirius_plan_get.cpp` and `sirius_plan_comparison_join.cpp`
 - Producer-side push in `sirius_physical_hash_join::finalize_operator()`: `cudf::reduce` to compute global (min, max) per join key, emit a single-zone `sirius_dynamic_zone_map_filter`, push into each probe target's channel
-- Consumer-side merge in `parquet_scan_task_global_state`: replace the current "Dynamic table filters are not supported" `throw` with a call to `merge_ast_dynamic_filters_into_tree`, AND-conjoin with the static filter, install via `reader_options::set_filter`
+- Consumer-side merge in `parquet_gpu_ingestible`: replace the current "Dynamic table filters are not supported" `throw` with a call to `merge_ast_dynamic_filters_into_tree`, AND-conjoin with the static filter, install via `reader_options::set_filter`
 - E2E TPC-H test (Q14, Q19) verifying row-group pruning fires
 
 ### 1.2 Multi-zone zone maps

--- a/docs/super-sirius/execution-flow.md
+++ b/docs/super-sirius/execution-flow.md
@@ -89,7 +89,7 @@ Each operator's `build_pipelines()` method is called recursively:
 
 After meta-pipeline construction, `initialize_internal()` applies Sirius-specific transformations:
 
-- **TABLE_SCAN** → converted to `DUCKDB_SCAN` or `PARQUET_SCAN`
+- **TABLE_SCAN** → rewritten into a unified GPU scan source (`sirius_gpu_scan_operator`, type `GPU_SCAN`) with a per-table `gpu_ingestible`; the parquet table function maps to the parquet ingestible and `seq_scan` over a base table maps to the duckdb-native ingestible
 - **HASH_JOIN** → inserts `PARTITION + CONCAT` on both probe and build sides
 - **HASH_GROUP_BY** → inserts `PARTITION + MERGE_GROUP_BY`
 - **UNGROUPED_AGGREGATE** → inserts `PARTITION + MERGE_AGGREGATE`
@@ -120,25 +120,20 @@ After meta-pipeline construction, `initialize_internal()` applies Sirius-specifi
 2. Calls `task_scheduler.start_query(query)` which:
    - Creates a `completion_handler` with promise/future
    - Distributes the handler to all sub-executors
-   - Schedules initial scan tasks from the priority queue
+   - Schedules the initial GPU scan tasks
    - Returns the future
 
 3. The main thread blocks on `future.get()` until the query completes
 
 ## Step 6: Scan Execution
 
-**File:** `src/op/scan/duckdb_scan_executor.cpp`
+**Files:** `src/include/scan_manager/sirius_scan_manager.hpp`, `src/op/scan/sirius_gpu_scan_operator.cpp`, `src/io/io_context.cpp`
 
-The scan executor's manager loop:
+Scans run as a normal pipeline source on the GPU executor — there is no separate scan executor. Two cooperating pieces drive them:
 
-1. Acquires a kiosk ticket (blocks until a worker thread is free)
-2. Pops a scan task from the queue
-3. For parquet scans: acquires host memory reservation
-4. Dispatches to the worker thread pool:
-   - Executes the scan task (DuckDB table function or Parquet byte reads)
-   - Applies caching logic (CACHE mode: compute + save; PRELOAD mode: load from cache)
-   - Publishes output data batches to the data repository
-   - Schedules downstream consumer operators via `task_creator->schedule()`
+1. **Scan manager (per-query setup + I/O).** During `prepare_for_query()`, `sirius_scan_manager` walks the query's scan operators in order. For each one it builds a `split_provider` from the operator's table info, installs a fresh `split_connector` on the operator, and matches any pinned-cache entry (cache hit installs a cached ingestible; miss builds a fresh one via `make_gpu_ingestible`). A driver thread then runs the providers sequentially, populating each connector with splits.
+2. **I/O layer.** The split providers read bytes through the scan manager's `io_context`: io_uring for local disk, with REST and kvikio backends selected by URI scheme via the datasource factory, fronted by the prefetching cache.
+3. **GPU scan source (materialization).** The unified `sirius_gpu_scan_operator` pulls splits from its `split_connector` (`get_next_task_input_data`) and, in `execute()`, delegates each split to the installed `gpu_ingestible`'s `materialize_table` (and conditional `post_filter_and_project`). This runs as a `gpu_pipeline_task` on a GPU executor worker thread and publishes GPU-ready batches to the data repository, scheduling downstream consumers via `task_creator->schedule()`.
 
 ## Step 7: GPU Pipeline Execution
 
@@ -170,8 +165,8 @@ After a GPU task completes and schedules downstream operators:
    - Calls `operator->get_next_task_hint()` to check data availability
    - If `READY`: the operator has data — create a task
    - If `WAITING_FOR_INPUT_DATA`: recursively follow the producer chain
-3. Creates the appropriate task type (scan or GPU pipeline)
-4. Dispatches to the correct executor
+3. Creates a `gpu_pipeline_task` (including for the unified GPU scan source)
+4. Dispatches it to the GPU executor
 
 ## Step 9: Result Extraction
 
@@ -192,7 +187,7 @@ If any task throws an exception during execution:
 2. `drain_after_error()` is called on the pipeline executor which:
    - Stops the task creator threads
    - Drains the task queue
-   - Calls `drain_and_wait()` on scan and GPU executors
+   - Calls `drain_and_wait()` on the GPU executors
    - Restarts the task creator for the next query
 3. The error propagates through the future to the main thread
 
@@ -205,7 +200,7 @@ sequenceDiagram
     participant Iface as sirius_interface
     participant Engine as sirius_engine
     participant PE as task_scheduler
-    participant SE as scan_executor
+    participant SM as sirius_scan_manager
     participant GPE as gpu_pipeline_executor
     participant TC as task_creator
     participant CH as completion_handler
@@ -214,18 +209,19 @@ sequenceDiagram
     Ext->>Ext: Parse, optimize, generate Sirius plan
     Ext->>Iface: sirius_execute_query(prepared)
     Iface->>Engine: initialize(result_collector)
-    Engine->>Engine: Build pipelines, split operators, wire repos
+    Engine->>Engine: Build pipelines, rewrite scans to GPU scan source, wire repos
     Iface->>Engine: execute()
     Engine->>PE: start_query(pipelines)
     PE->>CH: create completion_handler
-    PE->>SE: schedule initial scans
-    SE->>SE: Scan data, publish to repos
-    SE->>TC: schedule(downstream_op)
+    PE->>SM: prepare_for_query (split providers + connectors)
+    SM->>SM: drive splits through io_context + prefetch cache
+    PE->>GPE: schedule initial GPU scan tasks
+    GPE->>SM: pull splits via split_connector
+    GPE->>GPE: materialize via gpu_ingestible, publish to repos
+    GPE->>TC: schedule(downstream_op)
     TC->>TC: get_next_task_hint() → READY
     TC->>GPE: schedule(gpu_pipeline_task)
     GPE->>GPE: reserve memory, execute on CUDA stream
-    GPE->>TC: schedule(next_downstream)
-    TC->>GPE: schedule(next_task)
     GPE->>CH: mark_completed()
     CH-->>Engine: future resolves
     Engine-->>Iface: get_result()

--- a/docs/super-sirius/expression-executor.md
+++ b/docs/super-sirius/expression-executor.md
@@ -8,22 +8,22 @@ This document covers the GPU expression execution subsystem used by FILTER and P
 
 `gpu_expression_executor` evaluates expressions on the GPU using the Sirius AST type hierarchy (see [Sirius AST Type Hierarchy](#sirius-ast-type-hierarchy)). It provides two execution modes:
 
-> **API boundary:** Operator headers and the executor's public header take expressions as `sirius::expression` / `sirius::join_condition` — opaque PIMPL wrappers around a `sirius::ast::node` / DuckDB `JoinCondition` defined in `src/include/expression/`. Plan builders translate at the DuckDB boundary (`sirius::wrap`, which calls `sirius::ast::from_duckdb` internally); operator `.cpp` files unwrap to a `sirius::ast::node const*` via `expression/expression_internal.hpp`. This keeps both `duckdb/planner/expression/...` and `expression/ast/node.hpp` out of the operator surface.
+> **API boundary:** `sirius::ast::node` is the single expression currency at every operator, planner, and executor boundary. Operators own their expressions directly as `std::unique_ptr<sirius::ast::node>` (e.g. a projection's `select_list`, a table scan's `filter_expr`), and `sirius::join_condition` holds its `left`/`right` sides as `std::unique_ptr<sirius::ast::node>`. DuckDB expressions are translated to Sirius AST once, at the planner/scan boundary, via `sirius::ast::from_duckdb(duckdb::Expression const&)`. There is no wrapper type between DuckDB and Sirius's expression IR, so neither `duckdb/planner/expression/...` nor an opaque handle appears on the operator surface — only `sirius::ast::node`.
 
 | Method | Purpose | Used By |
 |--------|---------|---------|
-| `execute(batch)` | Projects: evaluates expressions and returns result columns with all rows | PROJECTION |
-| `select(batch)` | Filters: evaluates a boolean expression and returns only rows that pass | FILTER |
+| `execute(input)` | Projects: evaluates expressions and returns result columns with all rows | PROJECTION |
+| `select(input)` | Filters: evaluates a boolean expression and returns only rows that pass | FILTER |
 
-Both methods accept a `data_batch` and return a new `data_batch` with the result. The `rmm::cuda_stream_view` and memory resource are passed to the constructor and stored as members — they are not per-call arguments.
+Both methods accept a `cudf::table_view` and return a new `cudf::table` with the result. The `rmm::cuda_stream_view` and memory resource are passed to the constructor and stored as members — they are not per-call arguments.
 
-The executor can be constructed from the full operator expression list or from a pre-filtered `std::vector<sirius::ast::node const*>` (non-owning). The PROJECTION operator uses the latter to pass only the entries that actually need evaluation, after pulling out pure BOUND_REF passthroughs that it exposes as zero-copy views (see [operators](operators.md)). `execute()` returns one output column per supplied expression, in order.
+The executor can be constructed from a `duckdb::vector<std::unique_ptr<sirius::ast::node>>` (the full operator expression list), from a single `sirius::ast::node`, from a non-owning `sirius::ast::node const*`, or from a non-owning `std::vector<sirius::ast::node const*>`. The PROJECTION operator uses the non-owning vector form to pass only the entries that actually need evaluation, after pulling out pure BOUND_REF passthroughs that it exposes as zero-copy views (see [operators](operators.md)). `execute()` returns one output column per supplied expression, in order. If a slot is ever null (an unsupported expression that `from_duckdb` could not translate), the executor throws `InternalException` rather than dereferencing it.
 
 ## Sirius AST Type Hierarchy
 
 **Files:** `src/include/expression/ast/node.hpp`, `src/include/expression/ast/*.hpp`
 
-`sirius::ast::node` is a `std::variant`-based sum type over all Sirius expression node kinds. It is the internal representation stored inside `sirius::expression`'s PIMPL, and the type the executor dispatches on via `std::visit`.
+`sirius::ast::node` is a `std::variant`-based sum type over all Sirius expression node kinds. It is the sole expression representation passed across operator, planner, and executor boundaries, and the type the executor dispatches on via `std::visit`.
 
 ```cpp
 struct node {
@@ -43,7 +43,7 @@ struct node {
 };
 ```
 
-`node` is move-only. Children are stored as `std::unique_ptr<node>` inside each alternative struct, making the tree recursive without incomplete-type issues.
+The alternative order is part of the ABI: `std::variant` indexes by position and downstream dispatch depends on it, so new alternatives are appended at the end. `node` is move-only. Children are stored as `std::unique_ptr<node>` inside each alternative struct, making the tree recursive without incomplete-type issues. Every alternative must implement `cudf_ast_op_count() const`, enforced by a `static_assert` at the variant declaration.
 
 | Alternative | Sirius type | Typical source |
 |-------------|-------------|----------------|
@@ -57,10 +57,10 @@ struct node {
 | `unary_op` | `sirius::ast::unary_op` | `NOT x`, `-x`, arithmetic binary ops (`+`, `-`, `*`, `/`) |
 | `coalesce` | `sirius::ast::coalesce` | `COALESCE(a, b, 0)` |
 | `in_list` | `sirius::ast::in_list` | `x IN (1, 2, 3)` |
-| `function_call` | `sirius::ast::function_call` | Named function (`YEAR`, `UPPER`, etc.) — `sirius::function_id` enum |
+| `function_call` | `sirius::ast::function_call` | Named function (`YEAR`, `UPPER`, `concat`, etc.) — `sirius::function_id` enum |
 | `aggregate` | `sirius::ast::aggregate` | Aggregate function (`SUM`, `COUNT`, etc.) — `sirius::aggregate_id` enum |
 
-**Translation boundary:** `sirius::wrap(expr)` calls `sirius::ast::from_duckdb(expr)` to produce a `sirius::ast::node` from a `duckdb::Expression`. This happens once at plan time in the plan builders. The resulting node is stored in the `sirius::expression` PIMPL and never re-translated.
+**Translation boundary:** `sirius::ast::from_duckdb(expr)` produces a `sirius::ast::node` from a `duckdb::Expression`. This happens once at plan time in the plan builders (and at the scan boundary for pushdown filters); the resulting node is owned by the operator and never re-translated.
 
 **Key files:**
 
@@ -68,11 +68,11 @@ struct node {
 |------|---------|
 | `src/include/expression/ast/node.hpp` | `sirius::ast::node` variant definition |
 | `src/include/expression/ast/from_duckdb.hpp` | `sirius::ast::from_duckdb` — DuckDB → Sirius AST translator |
+| `src/include/expression/ast/utils.hpp` | AST tree utilities — `visit_references`, `clone`, `substitute_references` |
 | `src/include/expression/value.hpp` | `sirius::value` — typed constant payload (INT8–DECIMAL128, VARCHAR, TIMESTAMP, …) |
 | `src/include/expression/function_id.hpp` | `sirius::function_id` closed enum of supported functions |
 | `src/include/expression/aggregate_id.hpp` | `sirius::aggregate_id` closed enum of supported aggregates |
-| `src/include/expression/expression.hpp` | `sirius::expression` — the public PIMPL type |
-| `src/include/expression/expression_internal.hpp` | `sirius::expression::impl` completion; `unwrap()` / `release()` helpers |
+| `src/include/expression/join_condition.hpp` | `sirius::join_condition` — `{left, right, comparison}` with AST-node sides |
 
 ## Execution Strategies
 
@@ -121,7 +121,7 @@ SET expression_executor_strategy = 'ast_jit';   -- or 'ast_interpret', 'material
 | Arithmetic / unary | `sirius::ast::unary_op` | `a + b`, `NOT x`, `-x` |
 | COALESCE | `sirius::ast::coalesce` | `COALESCE(a, b, 0)` |
 | IN-list | `sirius::ast::in_list` | `x IN (1, 2, 3)` |
-| Function call | `sirius::ast::function_call` | `UPPER(name)`, `YEAR(date)` |
+| Function call | `sirius::ast::function_call` | `UPPER(name)`, `YEAR(date)`, `a \|\| b` |
 | Type cast | `sirius::ast::cast` | `CAST(x AS DOUBLE)` |
 | CASE/WHEN | `sirius::ast::case_expr` | `CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END` |
 | BETWEEN | `sirius::ast::between` | `x BETWEEN 10 AND 20` |
@@ -130,6 +130,10 @@ SET expression_executor_strategy = 'ast_jit';   -- or 'ast_interpret', 'material
 `coalesce` is materialized via `cudf::replace_nulls` iteratively across children: the first child is materialized (scalars are lifted to a column); each subsequent child replaces the residual nulls in the running result. Children are only evaluated when the running result still has nulls. The result is wrapped via `materialize_as_ast_column` so COALESCE composes inside AST-capable parents. `cudf_ast_op_count` returns 0 — `coalesce` always takes the materialize-only path.
 
 `in_list` covers the full numeric set (INT8–INT64, UINT8–UINT64, BOOL8, FLOAT, DOUBLE, DECIMAL32/64/128, all TIMESTAMP precisions, DATE) plus VARCHAR. BOOL8 dispatches via `uint8_t` because `std::vector<bool>::data()` is deleted.
+
+### String concatenation
+
+String concatenation — both the `||` operator (`col || ' suffix'`) and the `concat(a, b, …)` function — resolves to `function_id::concat` (DuckDB lowers `||` to a function named `"||"`, which maps to the same id as `"concat"`). It is dispatched as a materialize-only function in `gpu_execute_function.cpp`: every argument is materialized, any scalar argument is broadcast to a full-length column via `cudf::make_column_from_scalar`, and the columns are joined with `cudf::strings::concatenate` using an empty separator. The narep scalar is invalid (null), giving standard SQL null propagation — any NULL input produces a NULL output.
 
 Per-expression-type dispatch lives in `src/expression_executor/specializations/` (one file per Sirius AST alternative: `gpu_execute_comparison.cpp`, `gpu_execute_case.cpp`, etc.). Each specialization decides how to emit cuDF AST nodes, materialize, or fall back based on the effective execution mode.
 
@@ -196,9 +200,10 @@ This is used by `sirius_physical_hash_join` in MIXED_JOIN mode to pass inequalit
 | `src/expression_executor/gpu_expression_executor.cpp` | Driver: strategy dispatch, AST tree management, temp lifetimes |
 | `src/expression_executor/specializations/gpu_execute_*.cpp` | Per-Sirius-AST-alternative dispatch (comparison, case, function, …) |
 | `src/include/expression_executor/expression_executor_strategy.hpp` | `expression_executor_strategy` enum + string conversions |
+| `src/include/expression_executor/ast_supported_types.hpp` | AST-eligible cast targets and functions (`supported_ast_cast_types`, `supported_ast_functions`) |
 | `src/include/expression_executor/gpu_expression_translator_internal.hpp` | Sirius AST → cuDF AST translator (mixed joins, parquet pushdown) |
 | `src/expression_executor/gpu_expression_translator.cpp` | Translator implementation |
 | `src/include/expression/ast/node.hpp` | `sirius::ast::node` variant; per-alternative headers included from here |
 | `src/include/expression/ast/from_duckdb.hpp` | `sirius::ast::from_duckdb` — DuckDB → Sirius AST translation |
-| `src/include/expression/expression.hpp` | `sirius::expression` PIMPL type |
-| `src/include/expression/expression_internal.hpp` | PIMPL completion; `unwrap()` / `release()` helpers |
+| `src/include/expression/ast/utils.hpp` | AST tree utilities — `visit_references`, `clone`, `substitute_references` |
+| `src/include/expression/join_condition.hpp` | `sirius::join_condition` — AST-node sides + comparison operator |

--- a/docs/super-sirius/memory-management.md
+++ b/docs/super-sirius/memory-management.md
@@ -92,8 +92,13 @@ One `downgrade_executor` per memory space monitors pressure and moves data to lo
 ### Thread Model
 
 - **Processing thread**: dequeues `downgrade_request` objects sequentially from an `interruptible_mpmc` queue
-- **Monitor thread** (if `monitor_period_ms > 0`): polls memory space for pressure and fires monitor requests via fire-and-forget into the same queue
+- **Monitor thread** (if `monitor_period_ms > 0`): each cycle, if the memory space reports `should_downgrade_memory()`, it applies a **stateless viability gate** (`has_viable_downgrade_target()`) before enqueuing. A request is only fired when a lower tier could plausibly accept the data:
+  - A configured DISK tier is always a viable target.
+  - Without DISK, only a GPU source has a lower tier (HOST). Viability is confirmed by probing each HOST space with a chunk-sized `make_reservation_or_null` (released immediately) — the ground truth for whether downgraded data can actually land, since HOST capacity reflects both live reservations and already-stored downgraded data.
+  - If no target is viable (e.g. idle GPU batches whose only lower tier is a full HOST with no DISK configured), the monitor **backs off** for that cycle without enqueuing, warning once per stall episode. The gate is re-evaluated every cycle with no latched state, so the monitor resumes automatically the instant HOST frees space or GPU pressure drops.
 - **Worker thread pool** (`exec::bounded_thread_pool`): executes actual data movement concurrently
+
+The monitor is not on the correctness-critical path: the pipeline executor drives downgrade on demand via `request_downgrade()` independently, so monitor back-off can never wedge a query. Monitor-issued requests are fire-and-forget.
 
 ### Downgrade Request Pattern
 

--- a/docs/super-sirius/multi-gpu-architecture.md
+++ b/docs/super-sirius/multi-gpu-architecture.md
@@ -122,11 +122,11 @@ The pin pipeline (`src/scan_manager/`):
 
 Repeat invocations of `pin_table('lineitem', ...)` are idempotent — duplicates dropped, existing `chunk_memory_spaces` preserved (Phase 22 Pitfall 3 invariant: any merge must verify `chunk_memory_spaces` integrity).
 
-When the new HOST-tier pinning path is used (`2e197c6` upstream feature, integrated in Phase 24), `pin_table` constructs a `cucascade::host_data_representation` and stores it in `pinned_entry`'s host-mode slot; subsequent scans go through a host-mode `cached_split_provider` that slices the host chunks per query and converts back to GPU only when a scan task starts. The GPU-tier and HOST-tier pinning paths coexist as parallel code paths — both maintain the `chunk_memory_spaces` invariant.
+When the new HOST-tier pinning path is used (`2e197c6` upstream feature, integrated in Phase 24), `pin_table` constructs a `cucascade::host_data_representation` and stores it in `pinned_entry`'s host-mode slot; subsequent scans go through the unified `split_provider` in cached host-mode, which slices the host chunks per query and converts back to GPU only when a scan task starts. The GPU-tier and HOST-tier pinning paths coexist as parallel code paths — both maintain the `chunk_memory_spaces` invariant.
 
 ## Scan-Time: Routing to the Right GPU
 
-When a query selects from a pinned table, the `cached_split_provider` walks `pinned_entry`'s chunks. For each chunk:
+When a query selects from a pinned table, the unified `split_provider` (cached mode) walks `pinned_entry`'s chunks. For each chunk:
 
 1. **Look up the chunk's owning memory_space** from `chunk_memory_spaces[i]`.
 2. **Create a scan task** carrying the chunk plus the memory_space.
@@ -144,14 +144,29 @@ locality(task, gpu_id) = bytes of task input data already on gpu_id
 
 The task goes to the GPU with the highest score, falling back to the task's NUMA-paired GPU if locality is tied or all data is on HOST. This is the **SCHED-RR** (round-robin with locality) distribution policy. Source-pipeline tasks (those at the start of a pipeline) are distributed using strict round-robin; downstream tasks use locality.
 
+The task creator resolves a task's `preferred_device_id` in priority order:
+
+1. **Upstream input-data preference** — a fresh-read scan split carries the device the scan manager stamped onto it.
+2. **Partition device pin** (see below) — partitioned operator inputs.
+3. **Data-locality by bytes** — the GPU already holding the most of the task's input bytes.
+4. **NUMA-affinity** — when all input lives on HOST, a GPU on the same NUMA node (round-robin when that NUMA hosts several GPUs).
+
 Two-level `preferred_device_id`:
 
 - `gpu_pipeline_task_local_state::_preferred_device_id` — per-task override (winner)
 - `sirius_pipeline_task_global_state::_preferred_device_id` — pipeline-level default
 
-`task->get_preferred_device_id()` checks local first, falls back to global. Operators that materialize cross-GPU data (e.g., partition-then-merge) propagate the right device id through the task tree.
+`task->get_preferred_device_id()` checks local first, falls back to global.
 
 See [`pipeline-execution.md`](pipeline-execution.md) "Per-task-device contract under SCHED-RR" for the deeper contract.
+
+### Partition device pin for cuco-backed operators
+
+Partitioned operators — BUILD_PROBE hash join, `grouped_aggregate_merge`, and the other partition-keyed operators — build a per-partition cuco hash table that is **only valid on the GPU it was built on**. A stream bound to GPU A that touches a cuco counter built under GPU B trips `cudaErrorInvalidValue` in cuco's `counter_storage`. The device a partition runs on is therefore a **correctness constraint, not just a locality preference**: every task of a given partition (its build and all its probes) must land on the same GPU.
+
+The task creator enforces this by pinning any task whose input is a `partitioned_operator_data` to `partition_idx % num_active_gpus`. The index is taken over the **active GPU executor set** — `task_creator::_active_gpu_ids`, the device ids that actually have a GPU executor, derived from the memory manager's `Tier::GPU` memory spaces (the same set `task_scheduler` keys executors on). Indexing the active set, rather than the physical hardware topology, is essential: when the configured GPU count is smaller than the physical GPU count (e.g. `num_gpus=2` on a 4-GPU box), a physical-topology modulo can resolve to a device id with no executor; the scheduler treats a pin to a non-existent executor as "no preference" and round-robins the task, which scatters a partition's build and probe across GPUs and lets a probe touch a build table cross-device.
+
+The pin also survives OOM reschedule. When a partitioned task OOMs and is rebuilt with a fresh `local_state`, the per-task `preferred_device_id` is carried forward; without it the rescheduled task would demote to "no preference" and scatter. (A pin held on the pipeline-level global state already survives reconstruction, so only the local-state pin needs to be copied.)
 
 ## Cross-GPU Data Movement
 
@@ -183,7 +198,7 @@ The Sirius path:
 3. **Schemes are resolved through `datasource_registry_`.** A scan task that wants to read `file:///path/to/x.parquet` passes the URL to the registry, which returns a factory bound to the per-GPU `sirius_ioctx`. No silent fallback.
 4. **Pin-table chunk reads route through the owning GPU's ioctx.** Chunk `i` reads through `gpu_ioctxs_.at(chunk_memory_spaces[i]->get_device_id())`. The read lands directly in the target GPU's pinned memory region.
 
-The 7 historical sites that bypassed this contract (kvikio-fallback in `sirius_gpu_parquet_scan_operator`, `sirius_extension`, `iceberg_metadata_reader`, `datasource_factory`, `parquet_split_provider`) were all migrated to `sirius_ioctx::make_datasource` over Phase 22.1; the remaining `cudf::io::datasource::create` callsites are reached only under the single-GPU `use_sirius_datasource=false` opt-out.
+Every read on the multi-GPU path resolves through `sirius_ioctx::make_datasource` — the unified `sirius_gpu_scan_operator`, the `split_provider`, `sirius_extension`, and `datasource_factory` all route through it. The remaining `cudf::io::datasource::create` callsites are reached only under the single-GPU `use_sirius_datasource=false` opt-out.
 
 ## Memory Pressure: Reservations and Downgrade
 
@@ -212,6 +227,7 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 | Per-GPU `sirius_ioctx` binds device via RAII in `uring_reactor` setup | `src/io/uring/uring_reactor.cpp` | Reactor thread must hold the right device context for all uring submissions |
 | `_per_thread_init` in `downgrade_executor` gated on `tier == GPU` | `src/downgrade/downgrade_executor.cpp` (Phase 22.2 K.6) | HOST-tier workers must not call `cudaSetDevice(-1)` |
 | `chunk_memory_spaces[i]` parallel to `data_batches_by_column[col][i]` | `src/include/scan_manager/sirius_scan_manager.hpp` | Pin-table merge must preserve owning-space per chunk (Phase 22 Pitfall 3) |
+| All tasks of a partition pinned to one active GPU via `partition_idx % _active_gpu_ids.size()`; pin preserved across OOM reschedule | `src/creator/task_creator.cpp`, `src/pipeline/gpu_pipeline_executor.cpp` | A cuco hash table is valid only on the GPU it was built on; cross-device access trips `cudaErrorInvalidValue`. Indexing the active executor set avoids phantom pins when `num_gpus` < physical GPU count |
 | HYG-02 invariant: 0 new `rmm::cuda_stream_default` in `src/` outside `legacy/` | grep gate | Default-stream usage breaks per-task-device contract under SCHED-RR |
 | Multi-GPU runs use `sirius_datasource` everywhere | `sirius_config::enforce_sirius_datasource_for_multi_gpu()` forces `use_sirius_datasource=true` when >1 GPU is configured | Any file-path datasource via cudf silently uses kvikio, which binds to a single CUDA context |
 
@@ -229,13 +245,13 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 | `src/sirius_context.{hpp,cpp}` | `SiriusContext`, per-GPU initialization, datasource registry |
 | `src/memory/sirius_memory_reservation_manager.{hpp,cpp}` | Extends `cucascade::memory_reservation_manager`; sets cudf device resource refs per GPU; synchronizes on destruction |
 | `src/include/scan_manager/sirius_scan_manager.hpp` | `pinned_entry`, `chunk_memory_spaces` invariant |
-| `src/scan_manager/parquet_split_provider.cpp` + `cached_split_provider.cpp` | Per-chunk memory_space lookup, GPU-mode + host-mode split providers |
+| `src/scan_manager/split_provider.cpp` | Unified split provider (fresh-read + cached, GPU-mode + host-mode); per-chunk memory_space lookup |
 | `src/io/datasource_factory.{hpp,cpp}` | Strict scheme registry; routes every resolved URI through a registered `sirius_ioctx`. Used when `use_sirius_datasource=true` (always in multi-GPU). |
 | `src/io/uring/uring_reactor.cpp` | Per-GPU `uring_reactor` with RAII `cudaSetDevice` |
-| `src/op/scan/sirius_gpu_parquet_scan_operator.cpp` | Multi-GPU-aware GPU parquet scan |
-| `src/op/scan/duckdb_scan_executor.cpp` | NUMA-preference reservation requests |
+| `src/op/scan/sirius_gpu_scan_operator.cpp` | Unified `GPU_SCAN` source operator (multi-GPU-aware) |
+| `src/creator/task_creator.cpp` | Per-task `preferred_device_id` resolution, partition device pin |
 | `src/include/pipeline/gpu_pipeline_task.hpp` | `preferred_device_id` two-level lookup |
-| `src/pipeline/gpu_pipeline_executor.cpp` + `task_scheduler.cpp` | SCHED-RR distribution, locality scoring |
+| `src/pipeline/gpu_pipeline_executor.cpp` + `task_scheduler.cpp` | SCHED-RR distribution, locality scoring, OOM-reschedule pin carry-forward |
 | `src/downgrade/downgrade_executor.cpp` | Per-tier downgrade workers, K.6-gated `cudaSetDevice` |
 | `cucascade/src/data/representation_converter.cpp` | `convert_gpu_to_gpu` / `alloc_and_peer_copy_async` with peer-DMA probe + dst_guard |
 | `cucascade/src/memory/common.cpp` | `probe_peer_dma_works`, `run_p2p_probe_locked` |
@@ -245,4 +261,4 @@ After a downgrade frees enough space, the rescheduled task retries. The reservat
 - [Architecture Overview](architecture-overview.md) — component diagram, thread model, ownership hierarchy (covers single-GPU too)
 - [Pipeline Execution](pipeline-execution.md) — Per-task-device contract under SCHED-RR (the deeper task-routing contract)
 - [Memory Management](memory-management.md) — cuCascade tiers, reservations, downgrade executor (mechanics of memory_spaces)
-- [Scan](scan.md) — scan path, pin tables, cache, parquet/iceberg readers
+- [Scan](scan.md) — unified `GPU_SCAN` path, pin tables, cache, split providers

--- a/docs/super-sirius/operators.md
+++ b/docs/super-sirius/operators.md
@@ -41,7 +41,7 @@ These operators produce data for pipelines. See [Scan](scan.md) for in-depth cov
 ### `sirius_physical_table_scan` — `TABLE_SCAN`
 **File:** `src/include/op/sirius_physical_table_scan.hpp`
 
-Base scan operator wrapping a DuckDB table function. Stores column IDs, projection IDs, and optional table filters for predicate pushdown. During pipeline construction, converted to either DUCKDB_SCAN or PARQUET_SCAN.
+Base scan operator wrapping a DuckDB table function. Stores column IDs, projection IDs, and optional table filters for predicate pushdown. During pipeline construction it is converted into a format-specific wrapper (`DUCKDB_SCAN` or `PARQUET_SCAN`) for the CPU / DuckDB-source path; the GPU read path for parquet and DuckDB-native tables is instead rewritten into a `GPU_SCAN` source (see below).
 
 ### `sirius_physical_duckdb_scan` — `DUCKDB_SCAN`
 **File:** `src/include/op/sirius_physical_duckdb_scan.hpp`
@@ -51,27 +51,16 @@ Sequential scan using DuckDB's execution engine. Accumulates chunks into fixed-s
 ### `sirius_physical_parquet_scan` — `PARQUET_SCAN`
 **File:** `src/include/op/sirius_physical_parquet_scan.hpp`
 
-Direct Parquet file scan. Reads column-chunk byte ranges and optionally materializes (decompresses) to table format. Tracks `has_more_partitions` atomic flag. Row groups are partitioned by `approximate_batch_size`.
+Wrapper for the DuckDB-source parquet path. Reads column-chunk byte ranges and optionally materializes (decompresses) to table format. Tracks `has_more_partitions` atomic flag. Row groups are partitioned by `approximate_batch_size`.
 
-### `sirius_physical_iceberg_scan` — `ICEBERG_SCAN`
-**File:** `src/include/op/sirius_physical_iceberg_scan.hpp`
+### `sirius_gpu_scan_operator` — `GPU_SCAN`
+**File:** `src/include/op/scan/sirius_gpu_scan_operator.hpp`
 
-Apache Iceberg table scan with GPU-accelerated delete filters. Inherits from `sirius_physical_parquet_scan` since Iceberg uses Parquet as the data layer. Supports Iceberg V1 (append-only), V2 (positional and equality deletes, including heterogeneous equality-delete schemas), and V3 (deletion vectors via PUFFIN files). Handles schema evolution, snapshot time-travel, and partition evolution.
+Unified GPU scan source operator for reading table data from storage. It carries no format-specific code: it pulls pre-built splits off a `split_connector` and delegates per-split materialization to an installed `gpu_ingestible`, one implementation per source format (`parquet_gpu_ingestible` for Parquet, `duckdb_native_gpu_ingestible` for DuckDB-native `.duckdb` tables, `cached_parquet_gpu_ingestible` for pinned-cache hits).
 
-- **Delete filter pipeline:** Composes `positional_delete_filter`, `equality_delete_filter` (per-key-schema groups, sequence-scoped), and a deletion-vector filter for V3 to apply deletes entirely on GPU with no D2H copies
-- **Metadata:** Manifest discovery delegates to DuckDB's `iceberg_metadata()`; the custom `iceberg_avro_reader` is the fallback for V3 deletion-vector PUFFIN files
+The pipeline converter rewrites a DuckDB parquet or DuckDB-native table scan into a `GPU_SCAN` source: it lowers the bind data into the appropriate `ingestible_table_info`, builds the `gpu_ingestible`, and inserts the operator at `operators[0]` of the pipeline. Before a query runs, `sirius_scan_manager` prepares scan-side state — matching pinned-cache entries or building a `split_provider` over each operator's ingestible — and drives metadata production, split coalescing, and per-GPU balancing, pushing splits onto each operator's `split_connector`. `execute()` calls `gpu_ingestible::materialize_table` and, when a split carries filter/projection info, `gpu_ingestible::post_filter_and_project`.
 
-See [Scan — Iceberg Scan](scan.md#iceberg-scan) for details.
-
-### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
-**File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
-
-Source operator for parquet scans (local or S3). Carries a `scan_info` (concrete subclass: `parquet_scan_info`) populated by the pipeline converter and pulls splits from a `split_connector` populated by `sirius_scan_manager` on its own thread pool. Each `parquet_scan_data` split drives a `cudf::io::read_parquet` call followed by `scan_plan`-driven output assembly (data columns, hive-partition synthesis, output ordering). See [Scan — Scan Manager](scan.md#scan-manager).
-
-### `sirius_gpu_duckdb_native_scan_operator` — `GPU_DUCKDB_NATIVE_SCAN`
-**File:** `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp`
-
-Source operator for GPU-native reading of DuckDB `.duckdb` format tables. Carries a `duckdb_native_scan_info` and pulls splits from a `split_connector` fed by a `duckdb_native_split_provider`. Each split carries a slice of per-row-group segment metadata; `execute()` decodes the segments into a `cudf::table` using the native DuckDB format decode kernels. See [Scan — GPU DuckDB-Native Scan](scan.md#sirius_gpu_duckdb_native_scan_operator----gpu_duckdb_native_scan).
+See [Scan](scan.md) for the full scan subsystem (scan manager, `gpu_ingestible`, pinned-table caching, and the IO layer).
 
 ### `sirius_physical_dummy_scan` — `DUMMY_SCAN`
 **File:** `src/include/op/sirius_physical_dummy_scan.hpp`
@@ -128,11 +117,19 @@ Three execution modes:
 | Mode | When Used | cuDF API |
 |------|-----------|----------|
 | `STANDARD` | Default, multi-partition Cartesian product | `cudf::inner_join()`, `cudf::left_join()`, etc. |
-| `BUILD_PROBE` | Small build side (< `max_build_hash_table_bytes`, 1 partition) | `cudf::hash_join` or `cudf::distinct_hash_join` (build once, probe many) |
+| `BUILD_PROBE` | Single partition, small build side (< `max_build_hash_table_bytes`) foldable to one batch | `cudf::hash_join`, `cudf::distinct_hash_join`, or `cudf::filtered_join` — built once, probed many times |
 | `MIXED_JOIN` | Equality + inequality conditions on disjoint columns | `cudf::mixed_join()` with cuDF AST |
 
+`update_join_exec_mode()` selects BUILD_PROBE when there is one partition, the build side fits and folds to a single batch, and the join type is not SEMI, ANTI, or RIGHT (these stay in STANDARD mode). INNER, LEFT, OUTER, and MARK joins are all eligible.
+
+#### MARK joins
+A MARK join emits every left row plus a `BOOL8` mark column indicating whether each left row had a match. Both build strategies funnel through `resolve_mark_join_result`, which scatters left-row match indices into the mark column.
+
+- **STANDARD mode (adaptive build side):** by default the filter (right) side is built into a `cudf::filtered_join` and probed with the left, whose `semi_join` yields left-row match indices. When the right (probe) side is much larger than the left (output) side, Sirius instead builds the smaller left side into a `cudf::mark_join` and probes with the right. The switch is gated by `mark_join_build_switch_ratio` (build on left when `right_rows >= ratio * left_rows`; `0` disables). Both paths produce identical output.
+- **BUILD_PROBE mode:** a single `cudf::filtered_join` is built once on the right (filter) keys and persisted as `_filtered_table`; each streamed left probe batch calls `semi_join` against it, reusing the hash table across probes.
+
 #### Distinct Hash Join Optimization
-In BUILD_PROBE mode, when the build-side keys are proven unique, Sirius uses `cudf::distinct_hash_join` instead of `cudf::hash_join`. This optimization applies when:
+For INNER/LEFT joins in BUILD_PROBE mode, when the build-side keys are proven unique, Sirius uses `cudf::distinct_hash_join` instead of `cudf::hash_join`. This optimization applies when:
 - Join type is INNER or LEFT
 - Build-side keys are proven unique via logical plan analysis (`prove_unique_columns()` in `src/planner/sirius_plan_comparison_join.cpp`)
 
@@ -157,13 +154,16 @@ When `get_next_task_hint()` is called after the operator is already finished, it
 
 Key members:
 - `conditions` — join predicates (equality and inequality)
-- `join_type` — INNER, LEFT, RIGHT, OUTER
-- `_hash_table` — cached `cudf::hash_join` or `cudf::distinct_hash_join` (BUILD_PROBE mode)
+- `join_type` — INNER, LEFT, RIGHT, OUTER, MARK
+- `_hash_table` — cached `cudf::hash_join` (BUILD_PROBE mode)
+- `_distinct_hash_table` — cached `cudf::distinct_hash_join`, used instead of `_hash_table` when build keys are proven unique
+- `_filtered_table` — reusable build-on-right `cudf::filtered_join` for MARK joins in BUILD_PROBE mode
 - `_build_table` — materialized build-side data batch
 - `key_casts` — type alignment info for hash key matching
 - `unique_build_keys` / `unique_probe_keys` — cardinality hints (used to select distinct vs standard hash join)
+- `mark_join_build_switch_ratio` — threshold for adaptively building a STANDARD MARK join on the smaller (left) side
 
-Supported join types: INNER, LEFT, RIGHT, OUTER via `cudf::inner_join()`, `cudf::left_join()`, `cudf::full_outer_join()`.
+Supported join types: INNER, LEFT, RIGHT, OUTER, MARK via `cudf::inner_join()`, `cudf::left_join()`, `cudf::full_outer_join()`, `cudf::filtered_join`, and `cudf::mark_join`.
 
 ### `sirius_physical_nested_loop_join` — `NESTED_LOOP_JOIN`
 **File:** `src/include/op/sirius_physical_nested_loop_join.hpp`
@@ -191,7 +191,8 @@ Combined ORDER + LIMIT: selects and sorts the top N rows.
 Aggregate without GROUP BY (e.g., `SELECT COUNT(*), SUM(x) FROM t`).
 
 - **GPU execution:** `gpu_aggregate_impl::local_ungrouped_aggregate()` using `cudf::reduce()`
-- **Supported:** MIN, MAX, SUM, COUNT_ALL, COUNT_VALID
+- **Supported:** SUM, MIN, MAX, COUNT (of valid values), COUNT(*), AVG, FIRST
+- **AVG handling:** Decomposed into SUM + COUNT and finalized on-device. `make_avg_column()` divides the single-row merged sum/count columns with `cudf::binary_operation` — DECIMAL output divides directly in fixed point to preserve precision, while non-DECIMAL output casts both operands to FLOAT64 and divides. This keeps AVG off the host `long double` path, avoiding both the device→host sync and the precision loss of decimal round-trips.
 - **DECIMAL overflow handling:** DECIMAL SUM casts to a wider type before reduction — DECIMAL32→DECIMAL64, DECIMAL64→DECIMAL128 — to prevent overflow
 - **BIGINT SUM fallback:** BIGINT (INT64) SUM falls back to CPU execution because GPU lacks INT128 accumulator support. Without this, silent overflow produces incorrect results. BIGINT arithmetic operations (ADD, SUB, MUL) also fall back to CPU for the same reason.
 
@@ -230,11 +231,13 @@ Reassembles partitioned data back into a linear stream. Behavior depends on join
 ### `sirius_physical_sort_sample` — `SORT_SAMPLE`
 **File:** `src/include/op/sirius_physical_sort_sample.hpp`
 
-Samples N input batches to compute P-1 partition boundary rows for range partitioning.
+Samples input batches to compute P-1 partition boundary rows for range partitioning. Sampling is byte-based: it accumulates batches until `sort_sample_bytes` worth of input is available, rather than a fixed batch count.
 
-- On first execution: merge pre-sorted sample batches, compute boundaries, set `_boundaries_computed`
-- On subsequent executions: pass through data unchanged
-- Custom `get_next_task_hint()`: waits for N batches before returning READY
+Boundary computation follows an explicit `BoundaryState` lifecycle: `NOT_DONE → SCHEDULED → DONE`.
+- `get_next_task_hint()` waits in `NOT_DONE` until enough sample bytes are available (or the upstream finishes), then signals READY; it returns `std::nullopt` while `SCHEDULED` so at most one boundary task is in flight.
+- `get_next_task_input_data()` (overridden) claims the accumulated sample batches and moves the state to `SCHEDULED`, handing them to `execute()` as a single multi-batch input.
+- `execute()` merges the pre-sorted sample batches, computes the boundaries, and moves to `DONE`. If a GPU allocation throws (e.g. OOM), the state stays `SCHEDULED` and the rescheduled task retries with the same input, preventing a duplicate boundary task.
+- Once `DONE`, the operator falls back to default scheduling and passes through remaining batches unchanged.
 
 ### `sirius_physical_sort_partition` — `SORT_PARTITION`
 **File:** `src/include/op/sirius_physical_sort_partition.hpp`
@@ -306,11 +309,9 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 
 | Operator | Category | GPU Method |
 |----------|----------|-----------|
-| DUCKDB_SCAN | Scan | DuckDB table function |
-| PARQUET_SCAN | Scan | Direct Parquet reading |
-| ICEBERG_SCAN | Scan | Parquet reading with Iceberg delete filters |
-| GPU_PARQUET_SCAN | Scan | Source operator served by `sirius_scan_manager` (local or S3) |
-| GPU_DUCKDB_NATIVE_SCAN | Scan | GPU-native DuckDB format scan via `duckdb_native_split_provider` |
+| DUCKDB_SCAN | Scan | DuckDB table function (CPU / DuckDB-source path) |
+| PARQUET_SCAN | Scan | Parquet reading (CPU / DuckDB-source path) |
+| GPU_SCAN | Scan | Unified GPU scan source served by `sirius_scan_manager` via a per-format `gpu_ingestible` |
 | DUMMY_SCAN | Scan | Generates 1 row |
 | COLUMN_DATA_SCAN | Scan | Reads ColumnDataCollection |
 | FILTER | Relational | `gpu_expression_executor::select()` |
@@ -325,7 +326,7 @@ After pipeline finalization, `source` and `sink` are just aliases for the first 
 | HASH_GROUP_BY | Agg | `gpu_aggregate_impl::local_grouped_aggregate()` |
 | MERGE_AGGREGATE | Agg | Merge ungrouped partitions |
 | MERGE_GROUP_BY | Agg | Merge grouped partitions |
-| HASH_JOIN | Join | `cudf::{inner,left,right,outer}_join()` or `cudf::distinct_hash_join` |
+| HASH_JOIN | Join | `cudf::{inner,left,right,outer}_join()`, `cudf::distinct_hash_join`, or `cudf::{filtered,mark}_join` (MARK) |
 | NESTED_LOOP_JOIN | Join | Fallback nested loops |
 | LEFT_DELIM_JOIN | Join | Correlated subquery wrapper |
 | RIGHT_DELIM_JOIN | Join | Correlated subquery wrapper |

--- a/docs/super-sirius/optimizations.md
+++ b/docs/super-sirius/optimizations.md
@@ -43,6 +43,16 @@ num_partitions = max(1, total_bytes / hash_partition_bytes)
 
 **Config:** `max_sort_partition_bytes` (default: auto, 33% of GPU memory)
 
+### SORT_SAMPLE Byte-Based Merge Sampling (PRs #876, #886)
+
+**Motivation:** Multi-partition sorting samples batches to compute partition boundaries. A fixed sample batch count does not scale with variable batch sizes, single-batch task input contradicted the multi-batch sample the hint waited for, and concatenating + fully re-sorting the sample wasted work because upstream ORDER_BY already emits locally sorted batches. Scheduling boundary computation with a CAS election also let losing tasks waste GPU work.
+
+**Mechanism:** `sirius_physical_sort_sample` overrides `get_next_task_input_data()` so the boundary task receives the full multi-batch sample the hint waited for. Sampling is byte-based: it pulls batches until `sort_sample_bytes` is reached (or upstream finishes), then merges the already-sorted sample batches with `gpu_merge_impl::merge_order_by` and computes boundaries from the merged run — no concatenate-and-full-sort. Boundary scheduling uses an explicit `NOT_DONE -> SCHEDULED -> DONE` state machine: `get_next_task_input_data()` claims the sample and moves to `SCHEDULED`, `get_next_task_hint()` returns `nullopt` while `SCHEDULED` so no duplicate boundary task is created, `execute()` moves to `DONE`, and OOM resets to `NOT_DONE` for retry. After boundaries are computed the operator falls back to single-batch passthrough.
+
+**Code path:** `src/op/sirius_physical_sort_sample.cpp` — `get_next_task_input_data()`, `get_next_task_hint()`, `execute()`; `src/pipeline/sirius_pipeline_converter.cpp` — wiring `sort_sample_bytes` into SORT_SAMPLE
+
+**Config:** `sort_sample_bytes` (default: 512 MB), settable via YAML and the `sort_sample_bytes` SET option
+
 ## Operator-Level Optimizations
 
 ### Adaptive Join BUILD_PROBE Mode (PR #423)
@@ -106,6 +116,31 @@ Only applies to INNER and LEFT joins with pure equality conditions (excludes IS 
 Only the entries needing evaluation are handed to the executor (its `std::vector<sirius::ast::node const*>` constructor), so passthrough columns are never materialized.
 
 **Code path:** `src/op/sirius_physical_projection.cpp` — `execute()`; `src/include/data/data_batch_utils.hpp` — `make_data_batch_from_view()`; `src/include/expression_executor/gpu_expression_executor.hpp` — subset constructor.
+
+### Adaptive MARK Join Build Side (PR #924)
+
+**Motivation:** Equality-only MARK joins build the hash table on the right (filter) side and probe with the left. When the right (probe) side is much larger than the left (output) side, building on the smaller left side is faster.
+
+**Mechanism:** `sirius_physical_hash_join` keeps both paths and picks the one that hashes the smaller side, producing identical output (all left rows plus a BOOL8 mark column):
+- `cudf::filtered_join` builds on the right and returns probe-side (left) match indices — used when the right side is not much larger than the left.
+- `cudf::mark_join` builds on the left and returns build-side (left) indices — used when `right_rows >= mark_join_build_switch_ratio * left_rows`.
+
+Both feed the same `resolve_mark_join_result()`, which scatters the match indices into the BOOL8 mark column, so only the hashed side changes. Setting the ratio to `0` disables the switch and always builds on the right.
+
+**Code path:** `src/op/sirius_physical_hash_join.cpp` — `make_left_mark_join()`, `make_right_filtered_join_ptr()`, `resolve_mark_join_result()`, and the ratio gate in the MARK branch
+
+**Config:** `mark_join_build_switch_ratio` (default: 8.0; `0` disables), settable via YAML and the `mark_join_build_switch_ratio` SET option
+
+### Projection Folding (PR #909)
+
+**Motivation:** Building a Sirius physical plan from DuckDB's logical plan inserts PROJECTION operators that DuckDB's optimizer never sees — for filter `projection_map` reordering, hoisted aggregate child/filter expressions, table-scan filter columns, and the user's SELECT list. Each PROJECTION is a full GPU pipeline stage that runs `gpu_expression_executor` over every batch and materializes an intermediate batch, so stacked projections evaluate expressions more than once.
+
+**Mechanism:** All planner projection creation goes through `push_projection()`, and a single `fold_adjacent_projections()` pass over the finished plan tree collapses any `PROJECTION -> PROJECTION` chain into one projection. Folding composes the two select lists with the AST helpers `visit_references()` (find which child outputs the outer list reads) and `substitute_references()` (rewrite outer references in terms of the inner projection's expressions), so the merged projection produces the same columns in one expression-evaluation stage.
+
+**Code path:**
+- `src/planner/sirius_plan_projection_utils.cpp` — `push_projection()`, `fold_adjacent_projections()`
+- `src/planner/sirius_physical_plan_generator.cpp` — post-pass invocation of `fold_adjacent_projections()`
+- `src/expression/ast/reference_utils.cpp` — `visit_references()`, `substitute_references()`
 
 ## Memory Optimizations
 
@@ -179,24 +214,6 @@ Data is moved from GPU to HOST tier via converter registry.
 
 ## Scan Optimizations
 
-### Scan Output Caching (PR #340)
-
-**Motivation:** Repeated queries on the same data waste time re-scanning from storage.
-
-**Mechanism:** Four caching levels:
-- `NONE` — no caching
-- `PARQUET` — cache raw compressed Parquet bytes in host memory
-- `TABLE_HOST` — cache decoded table in host memory
-- `TABLE_GPU` — cache decoded table in GPU memory (fastest warm runs)
-
-Query hash matching detects cache hits. On cache hit (PRELOAD mode), data is loaded from cache with shallow cloning for zero-copy sharing.
-
-**Code path:**
-- `src/include/op/scan/config.hpp` — `cache_level` enum
-- `src/op/scan/duckdb_scan_executor.cpp` — cache/preload logic
-
-**Config:** `scan_cache_level` SET variable
-
 ### Row Group Pruning with Filter Pushdown (PR #363)
 
 **Motivation:** Scanning all row groups wastes I/O bandwidth when filter predicates can eliminate entire groups.
@@ -210,7 +227,7 @@ If translation fails, filtering falls back to `gpu_expression_executor` on the d
 
 **Code path:**
 - `src/op/scan/scan_utils.cpp` — `convert_table_filters_to_expression()`, `filter_row_groups_with_stats()`
-- `src/op/scan/parquet_scan_task.cpp` — filter integration in global state initialization
+- `src/op/scan/parquet_gpu_ingestible.cpp` — filter translation + row-group pruning in the per-file metadata task
 
 ### Batch Coalescing for Small Files (PR #503)
 
@@ -226,22 +243,22 @@ If translation fails, filtering falls back to `gpu_expression_executor` on the d
 
 **Motivation:** Synchronous metadata parsing on the GPU pipeline thread blocks all pipeline tasks until file footers are read, AST filters are translated, and row-group partitions are computed.
 
-**Mechanism:** A dedicated `sirius_scan_manager` runs alongside the GPU executors and owns a thread pool that drives one `split_provider` per parquet scan operator. The provider parses footers (up to 8 files per task by default), translates AST filters, prunes row groups, and pushes `parquet_scan_data` splits into a per-operator `split_connector`. The GPU scan operator's `get_next_task_input_data()` blocks on the connector and returns each split as it arrives, so consumer scheduling is decoupled from production order. Providers are started sequentially in plan order so per-query memory pressure stays bounded.
+**Mechanism:** A dedicated `sirius_scan_manager` runs alongside the GPU executors and owns a thread pool that drives a `split_provider` per GPU scan operator. Each provider composes the format's `gpu_ingestible`, which parses footers (one file per metadata task), translates AST filters, and prunes row groups; a per-query sequencer coalesces the parsed metadata into splits and pushes them into each operator's `split_connector`. The GPU scan operator's `get_next_task_input_data()` blocks on the connector and returns each split as it arrives, so consumer scheduling is decoupled from production order. Metadata tasks run on the shared pool so per-query memory pressure stays bounded.
 
 **Code path:**
-- `src/scan_manager/sirius_scan_manager.cpp` — manager thread pool, provider registry, sequential driver loop
-- `src/scan_manager/parquet_split_provider.cpp` — metadata parsing, AST filter translation, row-group bundling
-- `src/scan_manager/split_connector.cpp` — blocking queue between provider and operator
+- `src/scan_manager/sirius_scan_manager.cpp` — manager thread pool, provider registry, per-query sequencer
+- `src/op/scan/parquet_gpu_ingestible.cpp` — footer parsing, AST filter translation, row-group pruning
+- `src/scan_manager/split_connector.cpp` — blocking queue between the sequencer and the operator
 
 ### Multifile Parquet Splits (PR #738)
 
 **Motivation:** Many small parquet files each yielding a tiny GPU batch causes per-task scheduling and kernel-launch overhead to dominate scan throughput.
 
-**Mechanism:** `parquet_split_provider` coalesces row-group slices from multiple parquet files into a single split when the bundled files share identical hive-partition values (so synthesized partition columns remain scalar). `accum.total_uncompressed_bytes` accumulates across files; a split is emitted once the total exceeds `approximate_batch_size` or partition values change. The downstream `cudf::io::read_parquet` reads from all bundled files in one invocation.
+**Mechanism:** The `parquet_batch_coalescer` coalesces row-group slices from multiple parquet files into a single split when the bundled files share identical hive-partition values (so synthesized partition columns remain scalar) and the same reader-pushdown decision. Decoded bytes accumulate across files; a split is emitted once the total reaches `approximate_batch_size` or partition values change. The downstream `cudf::io::read_parquet` reads from all bundled slices in one invocation.
 
-**Code path:** `src/scan_manager/parquet_split_provider.cpp` — `run_batch()` accumulator
+**Code path:** `src/op/scan/parquet_gpu_ingestible.cpp` — `parquet_batch_coalescer`
 
-**Config:** `scan_task_batch_size` (default: 512 MB) is forwarded as `approximate_batch_size` to the provider.
+**Config:** `scan_task_batch_size` (default: 512 MB) is forwarded as `approximate_batch_size` to the coalescer.
 
 ### Sirius IO + Prefetching Cache (PR #675)
 
@@ -251,20 +268,81 @@ If translation fails, filtering falls back to `gpu_expression_executor` on the d
 
 **Code path:**
 - `src/io/sirius_datasource.cpp` — `cudf::io::datasource` implementation
-- `src/io/prefetching_cache.cpp` — chunk cache, worker, evictor, buffer pool
+- `src/io/cache/prefetching_cache.cpp` — chunk cache, worker, evictor, buffer pool
 - `src/io/uring/uring_reactor.cpp` — io_uring backend reactor
-- `src/io/admission_control.cpp` — RAII budget enforcement
+- `src/exec/admission_control.cpp` — RAII budget enforcement
 
-### Skip File I/O from Cache (PR #455)
+### DuckDB-Native Scan Metadata Walk (PRs #868, #895, #936, #900)
 
-**Motivation:** Cached Parquet data should avoid redundant file I/O.
+**Motivation:** The DuckDB-native GPU scan's per-row-group metadata walk dominates cold-query runtime at small scale factors. It issues roughly one cold block read per (row group × projected column), and the original walk both read metadata for every column and parsed DuckDB's stringified `GetColumnSegmentInfo` output, which builds and re-parses compression / column-path / `statistics.ToString()` blobs.
 
-**Mechanism:** `prefetched_data_source` implements `cudf::io::datasource`:
-- `cache_ranges` coalesces adjacent byte ranges from cached Parquet files
-- `host_read()` satisfies reads from cache via `get_ranges()`, falling back to file I/O only on cache miss
-- `device_read()` uses `cudaMemcpyBatchAsync()` (CUDA 13+) for efficient multi-span H2D copies with NUMA/device locality hints
-- Tracks `bytes_read_from_cache` vs `bytes_read_from_fallback` for monitoring
+**Mechanism:** The walk is structured for minimal, parallel, typed metadata access with statistics pruning:
+1. **Projected-column-only, typed walk (#868, #936):** `walk_duckdb_native_row_group_range()` walks the DuckDB segment trees directly for only the projected columns, reading typed `block_id` / compression / row counts / validity-child / max-string-length per segment instead of calling `GetColumnSegmentInfo` and re-parsing strings.
+2. **Stats pruning (#900):** `prepare_duckdb_native_walk()` evaluates DuckDB's own `TableFilter::CheckStatistics` against each row group's per-column statistics and drops any row group a pushed-down filter proves `FILTER_ALWAYS_FALSE` before it is staged, copied to the GPU, or decoded; an all-pruned table routes to DuckDB CPU up front.
+3. **Parallel range walk + early decode (#895):** `prepare_duckdb_native_walk()` runs as a cheap serial pre-step (partition stats, type-viability gate, row-group count) with no per-segment I/O; the row groups are sliced into ranges of `SIRIUS_METADATA_PARSE_CHUNK` groups, and the scan-manager pool walks the ranges in parallel so cold segment reads for different ranges overlap. The batch coalescer packs parsed ranges into cap-sized batches that decode while later ranges are still being parsed.
 
 **Code path:**
-- `src/op/scan/cached_ranges.cpp` — byte range coalescing
-- `src/op/scan/prefetched_data_source.cpp` — cached datasource
+- `src/op/scan/duckdb_native_metadata.cpp` — `prepare_duckdb_native_walk()`, `walk_duckdb_native_row_group_range()`, `mark_row_groups_pruned_by_filter_stats()`
+- `src/op/scan/duckdb_native_gpu_ingestible.cpp` — parse-range slicing, per-range walk thunks, and the `duckdb_native_batch_coalescer`
+
+**Config:** `SIRIUS_METADATA_PARSE_CHUNK` (row groups per parallel parse range, default 8)
+
+### DuckDB-Native Async Coalesced Reads (PR #849)
+
+**Motivation:** The DuckDB-native decoder issues many small segment reads. Synchronous `host_read()` calls bypass the datasource backend in favor of direct `pread()`, serializing I/O and inflating the request count per split.
+
+**Mechanism:** The decoder coalesces file-adjacent segment reads — bridging the small per-block header gaps up to a `coalesce_max_gap` derived from the block header size — into large sequential ranges, then issues them as one batch via `sirius_ioctx::host_read_ranges_async_io()` into pinned host blocks. Each coalesced range maps to a contiguous destination span, and the decoder issues bulk asynchronous H2D memcpy into aligned device memory. This cuts read requests per split several-fold and raises read throughput, especially on warm runs.
+
+**Code path:** `src/op/scan/duckdb_native_decoder.cpp` — range coalescing and `host_read_ranges_async_io()` dispatch
+
+### Async S3 / REST Reactor Backend (PR #859)
+
+**Motivation:** A per-request serial S3 backend staged each chunk as GET → H2D copy → `cudaStreamSynchronize`, serializing the GPU stream once per chunk and leaving request latency unhidden — costly when the reader issues many small ranged reads over high-RTT links.
+
+**Mechanism:** The remote read path is an asynchronous, concurrent reactor that plugs into the same `templated_ioctx<Reactor>` abstraction as the local io_uring backend, so the backend-agnostic machinery (sync→async bridge, completion aggregation, per-request fan-out, device chunking) is shared rather than reimplemented. A device read issues async ranged GETs into a bounded pinned host staging block, then `cudaMemcpyAsync` H2D, detecting completion by polling a per-chunk `cudaEvent` (`cudaEventQuery`) rather than synchronizing the stream — so the GET window and copy window overlap and up to `max_connections` chunks are in flight while host staging stays O(`max_connections`).
+
+**Code path:**
+- `src/io/rest/rest_reactor.cpp`, `src/io/rest/rest_ioctx.cpp` — async REST/S3 reactor over the shared `templated_ioctx` base
+- `src/include/io/templated_ioctx.hpp` — backend-agnostic async machinery shared with the io_uring path
+
+**Config:** `object_store` config (endpoint / region / credentials / signing mode) under `executor.scan_manager`
+
+### Zero-Copy from Pinned and Cached Tables (PR #881)
+
+**Motivation:** When scan input is an already-resident pinned/cached host table, copying the data again on consumption is wasted work.
+
+**Mechanism:** The pinned-table scan path moves host-pinned data to the GPU during prepare-for-processing (so the work is attributed correctly and bounded by the per-task reservation) and avoids copying out of cached tables when the batch can be consumed directly. A synchronization point after prepare-for-processing makes the prepare cost observable in logs and Quent.
+
+**Code path:**
+- `src/scan_manager/sirius_scan_manager.cpp` — cached-entry assignment (`try_assign_cached_entries`) and zero-copy resident-batch handoff
+- `src/pipeline/gpu_pipeline_task.cpp` — prepare-for-processing synchronization
+- `src/op/scan/sirius_gpu_scan_operator.cpp` — resident (cached) input path
+
+### Partial-Read Prefetching Cache (PR #997)
+
+**Motivation:** A read often overlaps the cache only partially. Treating a partial overlap as a miss re-reads bytes already pinned in the cache, and a prefetch-only cache never warms itself from ordinary reads.
+
+**Mechanism:** The prefetching cache is chunk-granular (a fixed chunk size backed by a cuCascade pinned pool) and serves partial reads from cache while populating the cache on read, OS-page-cache style:
+- On `device_read_async`, cached chunks are copied straight to the device buffer; the remaining chunks complete the read using pinned chunks in the cache. When the backend supports host-to-device reads, the coverage policy is `partial` so only the uncached chunks hit the backend.
+- A read whose chunks are not yet cached can populate those chunk buffers as it reads (interior chunks are cached; block-aligned partial head/tail boundary chunks are read through an internal bounce slot and not cached), so a subsequent read of the same range is a hit.
+- Chunk readiness uses a packed atomic state machine; admission control caps concurrent in-flight chunks and a tiered-LRU evictor returns chunks to the pool. Asynchronous results are delivered through the `exec::semi_future` primitive, which can be waited on or connected to an executor callback.
+
+**Code path:**
+- `src/io/cache/prefetching_cache.cpp` — `device_read_async()`, partial-read + populate-on-read, evictor
+- `src/io/io_context.cpp` — `sirius_ioctx` cache integration and coverage policy
+- `src/include/exec/semi_future.hpp` — async I/O completion primitive
+
+**Config:** `enable_prefetch_cache` and the `cache` sub-config under `executor.scan_manager`
+
+### Load-Balanced Scan Batch Coalescing (PR #997)
+
+**Motivation:** Scan splits arrive sized by metadata-parse completion rather than by the configured batch size, so batches could come out smaller than requested, and multi-GPU runs need scan inputs spread across devices. Opportunistic prefetch hints issued in metadata-completion order also rob the head-of-line pipeline of lead time.
+
+**Mechanism:** The scan manager owns a `load_balancing_scan_batch_coalescer`. Each scan pipeline registers a per-pipeline slot holding a `batch_coalescer`, a `split_connector`, and a `balancing_strategy`. A single sequencer task drains the slots in registration (execution) order: it coalesces each pipeline's splits to the requested batch size — independent of the configured max batch count — chooses a device via the balancing strategy, issues `fadvise(opportunistic)` / prefetch hints, and pushes the placed split onto the connector, advancing to the next pipeline only after the current one closes. The `balancing_strategy` interface stamps a `preferred_device_id` on each split (which the task creator honors); `round_robin_strategy` hands out GPUs via an atomic cursor and is the default.
+
+**Code path:**
+- `src/scan_manager/load_balancing_scan_batch_coalescer.cpp` — per-pipeline slots, sequencer loop, coalesce + place + push
+- `src/include/scan_manager/balancing_strategy.hpp`, `src/scan_manager/round_robin_strategy.cpp` — device-distribution interface and default
+- `src/include/scan_manager/split_connector.hpp` — blocking queue between the coalescer and the scan operator
+
+**Config:** `scan_task_batch_size` (default: 512 MB) is the requested coalesced batch size; `executor.scan_manager` sets the thread pool and reactor counts

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -73,6 +73,12 @@ When a `LogicalGet` has table filters and the table function supports `FILTER_PU
 
 Projections are omitted when columns are already in the correct order (passthrough case like `PROJECTION(#0, #1, #2, ...)`).
 
+### Projection Folding
+
+After the operator tree is built, `create_plan()` runs `fold_adjacent_projections()` over the whole plan as a final pass. Sirius routes every planner-created projection through `push_projection()`, which both elides identity passthrough projections and, when its child is already a projection, composes the two select lists into one. The standalone `fold_adjacent_projections()` post-pass then collapses any remaining `PROJECTION → PROJECTION` stacks anywhere in the tree — including projection pairs that arise from separate plan-builder steps (filter `projection_map` reordering, aggregate child/filter hoisting, table-scan unsupported-filter projections, and the user's `SELECT` list) and projections sitting under other operators such as joins.
+
+Composition substitutes each outer select-list reference (`#i`) with a clone of the inner projection's `select_list[i]`. Folding is refused when either select list has a null slot (an unsupported-expression fallback) or when a non-trivial inner expression would be duplicated across multiple outer reference sites; only immediate parent/child projection pairs are candidates, never folds across non-projection operators. The result is a single GPU expression-evaluation stage where multiple stacked projections would otherwise each run `gpu_expression_executor` over every batch.
+
 ## Part 2: Pipeline Structure
 
 ### `sirius_pipeline`
@@ -97,10 +103,7 @@ A pipeline is an ordered list of operators:
 Key methods:
 - `mark_task_created()` — increments `tasks_created`, starts NVTX range on first task
 - `mark_task_completed()` — increments `tasks_completed`, calls `update_pipeline_status()`
-- `update_pipeline_status()` — checks source-dependent completion logic:
-  - DUCKDB_SCAN: finished when `exhausted` flag is set
-  - GPU_PARQUET_SCAN: finished when the bound `split_connector` is closed and drained and `tasks_created == tasks_completed`
-  - Others: finished when upstream done, ports empty, and all tasks completed
+- `update_pipeline_status()` — checks completion: a pipeline finishes when any of its operators has exhausted a limit, or when its first node reports `is_source_pipeline_finished()` and `all_ports_empty()`, and `tasks_created == tasks_completed`. Source-specific completion (a drained DuckDB source vs. a closed/drained scan `split_connector`) is encapsulated behind the operator's `is_source_pipeline_finished()` rather than a per-operator-type switch.
 - `is_ready()` — marks pipeline ready and reverses operators to execution order
 - `register_new_batch_index()` / `update_batch_index()` — batch ordering for order-preserving execution
 
@@ -206,20 +209,15 @@ In the diagrams below, `[A, B, C]` denotes a pipeline where A is `operators[0]` 
 
 ### TABLE_SCAN Splitting
 
-TABLE_SCAN splits along two paths depending on the table function:
+During splitting, a `TABLE_SCAN` whose source is a supported format is rewritten in place into a single `GPU_SCAN` operator (`sirius_gpu_scan_operator`) at `operators[0]` of the same pipeline — no separate scan pipeline is created. `GPU_SCAN` is format-agnostic: it owns a pluggable `io::gpu_ingestible` that knows how to enumerate splits and materialize each split into a `cudf::table`. `split_table_scan_source()` dispatches on the bound table function name:
 
-**Parquet (`parquet_scan` / `read_parquet`, including `s3://` paths):** TABLE_SCAN is replaced with `GPU_PARQUET_SCAN` at `operators[0]` of the same pipeline — no separate scan pipeline is created. The DuckDB bind data is captured into a `parquet_scan_info` (a concrete `scan_info` subclass) and parked on the operator. During `prepare_for_query`, `sirius_scan_manager` reads the info, builds a `split_provider` via `scan_info::make_provider()` (parquet or cached), and binds a `split_connector` to the operator. The operator pulls splits from the connector inside `get_next_task_input_data()` (see [Scan — Scan Manager](scan.md#scan-manager)).
+**Parquet (`parquet_scan` / `read_parquet` / `sirius_read_parquet`, including `s3://` paths):** `insert_parquet_scan_operator()` captures the DuckDB bind data (resolved file paths, hive-partition indices, returned/column/projection ids, table filters) into a `parquet_ingestible_table_info`, builds a parquet ingestible via `make_ingestible()`, and constructs the `GPU_SCAN` operator around it.
 
-**DuckDB-native (`seq_scan` against an attached `.duckdb` file):** TABLE_SCAN is replaced with `GPU_DUCKDB_NATIVE_SCAN` at `operators[0]` when the bound table entry is a native DuckDB format table. A `duckdb_native_scan_info` is parked on the operator and consumed by a `duckdb_native_split_provider` during `prepare_for_query`.
+**DuckDB-native (`seq_scan` against an attached `.duckdb` file):** `insert_duckdb_native_scan_operator()` resolves the `DuckTableEntry`, fills a `duckdb_native_ingestible_table_info` (storage handle, client context, qualified table identity for the pin cache, projected columns/types, table filters), builds a duckdb-native ingestible via `make_ingestible()`, and constructs the `GPU_SCAN` operator around it.
 
-**DuckDB-managed (`seq_scan`, `iceberg_scan`):** A separate scan pipeline is created, and the original TABLE_SCAN is kept as the first operator of the main pipeline:
+Any other scan function is unsupported on the GPU scan path and raises an error.
 
-```mermaid
-graph LR
-    SP["Scan Pipeline<br/>[DUCKDB_SCAN]"] -->|"PIPELINE, 'scan'"| MP["Main Pipeline<br/>[TABLE_SCAN, filter, ..., sink]"]
-```
-
-DUCKDB_SCAN (or ICEBERG_SCAN) is the sole operator in the scan pipeline. TABLE_SCAN stays at `operators[0]` of the main pipeline. The repository uses `PIPELINE` barrier on the `"scan"` port.
+During `prepare_for_query`, `sirius_scan_manager` takes the ingestible off each `GPU_SCAN` operator, peeks its file paths for a pinned-cache match (substituting a cached ingestible on a hit), and binds a `split_connector` to the operator. The operator pulls splits from the connector inside `get_next_task_input_data()` (see [Scan — Scan Manager](scan.md#scan-manager)).
 
 ### HASH_JOIN Probe Side
 

--- a/docs/super-sirius/pipeline-execution.md
+++ b/docs/super-sirius/pipeline-execution.md
@@ -339,7 +339,7 @@ One `gpu_pipeline_executor` exists per GPU device. It manages a thread pool for 
 
 ### Executor Class Hierarchy
 
-All executors (`gpu_pipeline_executor`, `downgrade_executor`, `duckdb_scan_executor`) inherit from `itask_executor`, which provides shared infrastructure: thread pool, task queue, `_running` flag, and `start/stop/schedule/drain_and_wait` lifecycle methods. Subclasses implement `manager_loop()` (required) and optional hooks `get_per_thread_init`, `on_start`, `on_stop`.
+`gpu_pipeline_executor` inherits from `itask_executor`, which provides shared infrastructure: thread pool, task queue, `_running` flag, and `start/stop/schedule/drain_and_wait` lifecycle methods. Subclasses implement `manager_loop()` (required) and optional hooks `get_per_thread_init`, `on_start`, `on_stop`.
 
 Concurrency is managed via `exec::bounded_thread_pool`, which uses a two-phase `reserve() -> pool.dispatch(slot, fn)` model with RAII slot release.
 
@@ -363,16 +363,19 @@ while running:
     1. thread_pool.reserve()              -- block until a worker slot is available (RAII)
     2. task_request_publisher.send()      -- tell pipeline executor we can accept work
     3. task_queue.pop()                   -- block until a task is available
-    4. memory_space.make_reservation()    -- reserve GPU memory for the task
-    5. task.set_reservation(reservation)  -- attach reservation to task
-    6. stream_pool.acquire_stream()       -- get a CUDA stream
-    7. thread_pool.dispatch(slot, lambda): -- dispatch to worker (slot released on completion)
+    4. clamp request to get_max_memory()  -- bound the history-based estimate by the space limit
+    5. memory_space.make_reservation()    -- reserve GPU memory for the task
+    6. task.set_reservation(reservation)  -- attach reservation to task
+    7. stream_pool.acquire_stream()       -- get a CUDA stream
+    8. thread_pool.dispatch(slot, lambda): -- dispatch to worker (slot released on completion)
          a. task.execute(stream)
          b. On OOM: retry (see below)
          c. On success: check query completion
          d. Schedule downstream consumers via task_creator
          e. Or: completion_handler.mark_completed()
 ```
+
+The reservation request size comes from the task's memory-history estimate (`peak_memory_estimate + bytes_to_materialize_input`). Before reserving, the manager loop clamps this request to the memory space's reservation limit (`memory_space::get_max_memory()`). The estimate can extrapolate far past GPU capacity — a small input that once drove a near-capacity peak yields a large `peak/estimated` ratio. An unclamped over-limit request would receive only a partial reservation from `make_reservation()`, while the predicate-based downgrade that follows requires reserving the **full** requested size, which the space can never grant — livelocking the task through the OOM-reschedule loop until the retry cap trips. Clamping to `get_max_memory()` loses no reservable memory (`make_reservation()` already caps there) and keeps both the reservation and the downgrade target achievable; per-batch overflow during execution is still handled by the OOM-reschedule + tiering path.
 
 ### Downstream Scheduling
 

--- a/docs/super-sirius/scan.md
+++ b/docs/super-sirius/scan.md
@@ -1,117 +1,119 @@
 # Scan Subsystem
 
-This document covers the scan subsystem end-to-end: how data enters Super Sirius from storage through two scan paths, the scan executor, caching, and prefetched data sources.
+This document covers the scan subsystem end-to-end: how data enters Super Sirius from storage through the unified GPU scan operator and its per-format `gpu_ingestible` sources, the scan manager that produces and balances scan splits, pinned-table caching, GPU decode of DuckDB-native storage, and the Sirius IO layer underneath.
 
 ## Overview
 
-Super Sirius supports five scan paths:
+The GPU scan path is a single unified source operator, `sirius_gpu_scan_operator` (physical type `GPU_SCAN`). It carries no format-specific code: it pulls pre-built splits off a `split_connector` and delegates per-split materialization to an installed **`gpu_ingestible`**. One `gpu_ingestible` implementation exists per source format:
 
-| Path | Operator | Use Case | Data Flow |
-|------|----------|----------|-----------|
-| **DuckDB Scan** | `DUCKDB_SCAN` | General DuckDB-managed tables | DuckDB table function → column builders → `host_data_representation` |
-| **Parquet Scan** | `PARQUET_SCAN` | Legacy direct Parquet reading | Parquet byte ranges → `host_parquet_representation` |
-| **GPU Parquet Scan** | `GPU_PARQUET_SCAN` | Parquet file reading via the scan manager (local or S3) | `sirius_scan_manager` produces `parquet_scan_data` splits → GPU read |
-| **GPU DuckDB-Native Scan** | `GPU_DUCKDB_NATIVE_SCAN` | GPU-native `.duckdb` file reading | `sirius_scan_manager` walks per-row-group segment metadata → GPU decode |
-| **Iceberg Scan** | `ICEBERG_SCAN` | Apache Iceberg V1/V2/V3 tables | Parquet scan + GPU-accelerated delete filters |
+| Format | Ingestible | Per-table bind data | Source |
+|--------|-----------|---------------------|--------|
+| Parquet (local or object-store) | `parquet_gpu_ingestible` | `parquet_ingestible_table_info` | `cudf::io::read_parquet` over row-group slices |
+| DuckDB-native `.duckdb` tables | `duckdb_native_gpu_ingestible` | `duckdb_native_ingestible_table_info` | GPU decode of per-row-group storage segments |
 
-The DuckDB and legacy parquet paths funnel through `duckdb_scan_executor` and the data-repository infrastructure. The GPU parquet path is driven by `sirius_scan_manager` and a dedicated `split_provider` per scan operator (see [Scan Manager](#scan-manager)).
+The pipeline converter rewrites a DuckDB table scan into a `GPU_SCAN` source: it lowers the bind data into the appropriate `ingestible_table_info`, calls the free `make_ingestible(...)` factory to build the `gpu_ingestible`, constructs the operator carrying it, and inserts it at `operators[0]` of the pipeline. No separate metadata pipeline is created.
 
-## Scan Operators
+Before a query runs, `sirius_scan_manager::prepare_for_query` walks the plan's `GPU_SCAN` operators. For each it either (a) matches a pinned-table cache entry and serves the scan from cached batches, or (b) builds a `split_provider` over the operator's ingestible. A single per-query sequencer (`load_balancing_scan_batch_coalescer`) drives metadata production, coalesces the output into right-sized data batches, balances each batch onto a GPU, and pushes the resulting splits onto each operator's `split_connector`.
 
-### `sirius_physical_table_scan`
-**File:** `src/include/op/sirius_physical_table_scan.hpp`
+Data reaches the GPU through the Sirius IO subsystem (`io::sirius_ioctx` / `io::sirius_datasource`, with a pinned-memory prefetching cache) — see the IO sections later in this document. The scan path consumes that layer: each split carries prefetch hints, and the read for a split is routed through the per-GPU `sirius_ioctx` selected from its target device.
 
-Base scan operator wrapping a DuckDB table function. During pipeline construction (`initialize_internal()`), it is converted to either DUCKDB_SCAN or PARQUET_SCAN based on the table function bind data.
+## Scan Operator
 
-Key members:
-- `function` — DuckDB `TableFunction`
-- `bind_data` — function binding info
-- `column_ids` — which columns to scan
-- `projection_ids` — projection optimization
-- `table_filters` — predicate pushdown filters
-- `scanned_types` — types of scanned columns (constructed from column IDs)
+### `sirius_gpu_scan_operator` — `GPU_SCAN`
+**File:** `src/include/op/scan/sirius_gpu_scan_operator.hpp`, `src/op/scan/sirius_gpu_scan_operator.cpp`
 
-### `sirius_physical_duckdb_scan`
-**File:** `src/include/op/sirius_physical_duckdb_scan.hpp`
+The single GPU scan source operator. It owns:
 
-Sequential scan using DuckDB's execution engine. Tracks an atomic `exhausted` flag. The `scanned_types` vector defines the column types for building output batches.
+- a `std::shared_ptr<gpu_ingestible>` — the installed per-format source, built by the pipeline converter and parked on the operator;
+- a `std::shared_ptr<split_connector>` — the blocking queue the scan manager pushes splits into.
 
-### `sirius_physical_parquet_scan`
-**File:** `src/include/op/sirius_physical_parquet_scan.hpp`
+**Source interface.** As a pipeline source the operator exposes `get_next_task_hint()` / `all_ports_empty()` (both keyed off `split_connector::is_closed()`) and `get_next_task_input_data()`, which blocks inside `split_connector::get_next_split()` until a split arrives or the connector is closed and drained. Each pulled split is a `scan_operator_input`; on dequeue the operator issues an immediate prefetch hint for the split's byte ranges.
 
-Direct Parquet file scan. Maintains:
-- `scanned_ids` — mapping of projection IDs to file column indices
-- `has_more_partitions` — atomic flag for pipeline completion
-- Row groups are partitioned by `approximate_batch_size` in the global state
+**Execution.** `execute(input_data, stream)` runs one split:
 
-### `sirius_physical_iceberg_scan`
-**File:** `src/include/op/sirius_physical_iceberg_scan.hpp`
+1. `gpu_ingestible::materialize_table(split, stream)` produces a `filtered_table` — the materialized `cudf::table` (wrapped in an `owning_table_view`) plus a `filter_state` tag describing how much filter/projection the materialize step already applied.
+2. If the tag is `ROW_FILTERED_AND_PROJECTED` the table is already in final output layout and is released directly; otherwise `gpu_ingestible::post_filter_and_project(...)` applies any pending row filter and projection.
+3. The result is wrapped in a `data_batch` tagged with the split's target `memory_space` and returned as a `pipelineable_operator_data` for the downstream pipeline.
 
-Iceberg table scan. Inherits from `sirius_physical_parquet_scan`. Holds delete file lists (`positional_delete_files`, `equality_delete_files`) and routes through the GPU parquet scan pipeline with a post-convert delete filter hook. See [Iceberg Scan](#iceberg-scan) below.
+The operator handles two split shapes transparently, both delivered as `scan_operator_input`: a **fresh read** (the input carries a `scan_info`, materialized via the ingestible) and a **pinned-cache hit** (the input carries a resident `data_batch`, forwarded as-is — or filtered when filter info is present). The operator never sees the source format directly.
 
-### `sirius_gpu_parquet_scan_operator` — `GPU_PARQUET_SCAN`
-**File:** `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp`
+`no_history_peak_memory_estimate()` returns the input size for resident (cached) inputs and 8x the input size for fresh reads (decompression + decode expansion), used by the reservation system before per-operator history is available.
 
-Source operator for parquet scans. Carries a `scan_info` (concrete subclass: `parquet_scan_info`) populated by the pipeline converter from the DuckDB bind data (file paths, projected column ids, table filters, hive partition indices, target batch size). The operator owns a bound `split_connector`; `get_next_task_input_data()` blocks inside `split_connector::get_next_split()` until either a `parquet_scan_data` is available or the connector is closed and drained.
+> The `DUCKDB_SCAN` and `PARQUET_SCAN` physical operator types and the `sirius_physical_table_scan` / `sirius_physical_duckdb_scan` / `sirius_physical_parquet_scan` wrappers still exist for the CPU / DuckDB-source path, but the GPU read path for parquet and DuckDB-native tables runs entirely through `GPU_SCAN`.
 
-`execute(input_data)` runs per task: it calls `cudf::io::read_parquet` over the row-group slices in the split, optionally applies a fallback expression filter when AST translation failed, prunes pure-filter columns, and assembles the output table according to the `scan_plan` (data columns, hive-partition synthesis, output ordering).
+## gpu_ingestible
 
-Parquet files on S3 (`s3://…` paths) are routed through the `s3_ioctx` backend automatically — the pipeline converter detects the scheme from the bind data paths and the scan manager selects the appropriate `sirius_ioctx` per GPU device at provider-construction time.
+**Files:** `src/include/op/scan/gpu_ingestible.hpp`, `gpu_ingestible_types.hpp`, `src/op/scan/gpu_ingestible.cpp`; implementations `parquet_gpu_ingestible.cpp`, `duckdb_native_gpu_ingestible.cpp`.
 
-### `sirius_gpu_duckdb_native_scan_operator` — `GPU_DUCKDB_NATIVE_SCAN`
-**File:** `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp`
+`gpu_ingestible` is the abstract source of cuDF tables — one implementation per data format. It is **composed twice**: by the `split_provider` (metadata-side, to enumerate work) and by the `sirius_gpu_scan_operator` (execution-side, to materialize each split). It inherits `enable_shared_from_this` so the provider can borrow it non-owningly while the operator holds the single owning `shared_ptr`.
 
-Source operator for GPU-native reading of DuckDB `.duckdb` format table entries. Carries a `duckdb_native_scan_info` populated by the pipeline converter. The scan manager walks per-row-group segment metadata once at `prepare_for_query` and emits one split per row-group batch via a `duckdb_native_split_provider`. Each split carries a slice of the row-group metadata vector plus a shared `duckdb_native_scan_info` handle. `execute()` decodes the segments described by the split into a `cudf::table` using the native DuckDB format decode kernels (`duckdb_native_decoder`).
+### Interface
 
-## Scan Manager
+| Method | Role |
+|--------|------|
+| `has_processed_all_metadata()` | Thread-safe snapshot: is all metadata enumerated? Typically an atomic cursor vs. a precomputed total. |
+| `next_split_provider(io_ctx)` | Atomically claim the next metadata unit and return a callable that produces its `scan_info`(s). Null when nothing left to claim. |
+| `create_batch_coalescer()` | Build the format's `batch_coalescer`, which bundles per-unit metadata into right-sized data-batch splits. |
+| `materialize_table(split, stream)` | Produce the `filtered_table` for one split (dispatches to `materialize_metadata_to_table` for a fresh read, or wraps the resident batch for a cache hit). |
+| `materialize_metadata_to_table(info, mem_space, stream)` | Issue the read/decode for one split into a `cudf::table`. `mem_space` carries both the allocator and the device id used to select the per-GPU `sirius_ioctx`. |
+| `post_filter_and_project(table, mem_space, stream)` | Apply a pending post-decode filter and/or projection to output layout. |
+| `table_info()` | The per-table bind data (`ingestible_table_info`). |
+| `materialized_column_order()` | Storage indices in the exact order `materialize_table` emits columns (output columns first, then pure-filter columns). The pinned-cache path serves columns in this order so a cached batch is laid out identically to a fresh read. |
 
-**Files:** `src/include/scan_manager/sirius_scan_manager.hpp`, `src/scan_manager/sirius_scan_manager.cpp`, `src/include/scan_manager/split_provider.hpp`, `src/include/scan_manager/split_connector.hpp`
+### Bind data vs. split descriptors
 
-`sirius_scan_manager` owns a configurable thread pool and is responsible for producing the input splits consumed by every `GPU_PARQUET_SCAN` and `GPU_DUCKDB_NATIVE_SCAN` source operator. It runs alongside the GPU pipeline executors and is independent from the data repository / port machinery used between intermediate operators.
+Two polymorphic carriers separate per-table from per-split state (`gpu_ingestible_types.hpp`):
 
-### Components
+- **`ingestible_table_info`** — built once by the pipeline converter from the DuckDB binding, parked on the operator. Exposes `column_names()` and `file_paths()` (used for pinned-cache matching). Implementations: `parquet_ingestible_table_info`, `duckdb_native_ingestible_table_info`.
+- **`scan_info`** — one per emitted split. Carries the per-split read description and optional prefetch `fadvise_entries()` / `estimated_bytes()` (read by the reservation system). Implementations: `parquet_split_info` (the data-batch split), `parquet_file_scan_info` (the per-file metadata unit), `duckdb_native_scan_info`.
 
-| Component | File | Role |
-|-----------|------|------|
-| `sirius_scan_manager` | `scan_manager/sirius_scan_manager.{hpp,cpp}` | Owns thread pool, holds providers and pinned-table entries, drives provider execution |
-| `split_provider` | `scan_manager/split_provider.hpp` | Abstract producer of `operator_data` splits |
-| `scan_info` | `op/scan/scan_info.hpp` | Polymorphic base for per-format scan bind data; subclasses implement `make_provider()` |
-| `parquet_scan_info` | `op/scan/parquet_scan_info.hpp` | Parquet-specific bind data; `make_provider()` returns a `parquet_split_provider` |
-| `duckdb_native_scan_info` | `op/scan/duckdb_native_scan_info.hpp` | DuckDB-format-specific bind data; `make_provider()` returns a `duckdb_native_split_provider` |
-| `parquet_split_provider` | `scan_manager/parquet_split_provider.{hpp,cpp}` | Provider that parses parquet metadata and emits `parquet_scan_data` per row-group partition |
-| `duckdb_native_split_provider` | `scan_manager/duckdb_native_split_provider.{hpp,cpp}` | Provider that walks DuckDB row-group segment metadata and emits splits for native GPU decode |
-| `cached_split_provider` | `scan_manager/cached_split_provider.{hpp,cpp}` | Provider that emits zero-copy splits over pinned columns (see [Pinned Tables](#pinned-tables)) |
-| `split_connector` | `scan_manager/split_connector.hpp` | Lock-protected blocking queue between the provider and the operator |
+### `filtered_table` / `filter_state`
 
-### Lifecycle
+`materialize_table` returns a `filtered_table` = an `owning_table_view` plus a `filter_state` tag recording how much filter+projection the materialize step already absorbed:
 
-1. **Plan stage:** during pipeline conversion, `split_parquet_scan_source` packages the DuckDB bind data into a `scan_info` concrete subclass (`parquet_scan_info` for parquet / S3 paths, `duckdb_native_scan_info` for DuckDB-format tables) and constructs the corresponding source operator carrying that info. The operator is inserted at `operators[0]` of the pipeline; no separate metadata pipeline is created.
-2. **Per-query preparation:** `sirius_scan_manager::prepare_for_query(query)` walks the plan, picks each scan source, and calls `create_provider_for(op)`. For parquet scans the factory checks for a pinned-table cache hit first and returns a `cached_split_provider` on match; otherwise it calls `scan_info::make_provider()` to build the format-specific provider. A fresh `split_connector` is bound to the operator and the provider is stored in the manager's map.
-3. **Execution:** a driver thread runs providers **sequentially** in registration order. Each provider's `start(pool, connector)` schedules work onto the manager's thread pool and returns a future; the driver waits on it before starting the next provider. Inside the operator, `get_next_task_input_data()` blocks on `split_connector::get_next_split()` and returns each split as it arrives, so consumer-side scheduling is decoupled from production order.
-4. **Teardown:** the provider closes the connector on every termination path (success, exception); on synchronous failure the manager closes it as a safety net. Once closed and drained, the operator's `all_ports_empty()` returns true and `get_next_task_hint()` returns `nullopt`.
+| State | Meaning |
+|-------|---------|
+| `UNFILTERED` | No filter applied (e.g. a pinned table, or duckdb-native which always filters post-decode). |
+| `ROWGROUP_FILTERED` | Row groups pruned by statistics only. |
+| `ROW_FILTERED` | The reader applied the row-level filter (parquet reader-side pushdown). |
+| `ROW_FILTERED_AND_PROJECTED` | Fully assembled to output layout (parquet hive-partition path, or a per-query-cached table). |
 
-### `parquet_split_provider`
+The operator skips `post_filter_and_project` only when the state is already `ROW_FILTERED_AND_PROJECTED`.
 
-`start()` iterates over the file list in `_max_file_processed`-sized batches (default 8). Each batch:
+### Factories
 
-1. Fetches parquet footers via `cudf::io::parquet::fetch_footer_to_host()`.
-2. Translates the cached DuckDB filter expression into a cuDF AST on a task-local CUDA stream (filter translation is deferred from construction so each task gets its own stream).
-3. Prunes row groups by min/max statistics (`filter_row_groups_with_stats`).
-4. Bundles row-group slices into partitions of approximately `approximate_batch_size` uncompressed bytes. Multiple files with identical hive-partition values may be coalesced into a single partition (see [Multifile Bundling](#multifile-bundling)).
-5. Pushes one `parquet_scan_data` per partition into the connector. Each split carries the row-group slices, the reader options, the AST filter (if translated), and a `shared_ptr<const scan_plan>`.
+There is no factory class. Each implementation provides a free `make_ingestible(std::unique_ptr<...table_info>)` overload (defined in its `.cpp`); the pipeline converter calls the right overload by the concrete `table_info` type it built.
 
-### `scan_plan`
+### Parquet ingestible
+
+`parquet_gpu_ingestible` (`parquet_gpu_ingestible.{hpp,cpp}`) builds the canonical `scan_plan` and shared `parquet_reader_options` (column projection only) once in its constructor, and pre-coalesces the DuckDB filter into a stored expression (partition-column filters dropped — DuckDB already prunes the file list by hive value). `next_split_provider` hands out **one file at a time**: each metadata task opens the file's `sirius_datasource`, reuses or parses+caches the footer, runs the FLBA-decimal pushdown-safety probe, translates the filter to a cuDF AST and prunes row groups by statistics, estimates each surviving row group's *decoded* (GPU-resident) byte size, and emits one `parquet_file_scan_info`. `materialize_metadata_to_table` reads the bundled row-group slices via `cudf::io::read_parquet` (re-translating the filter on the task-local stream for reader-side pushdown unless the per-file probe disabled it), and assembles hive-partition output inline. Reader-side filter pushdown is a per-split decision.
+
+### DuckDB-native ingestible
+
+`duckdb_native_gpu_ingestible` (`duckdb_native_gpu_ingestible.{hpp,cpp}`) prepares a serial walk plan in its constructor (`prepare_duckdb_native_walk`: partition statistics, projected-type viability gate, and filter-stat row-group pruning — a non-viable query throws to trigger CPU fallback before any per-segment IO). It slices the table's row groups into fixed-size parse ranges (`SIRIUS_METADATA_PARSE_CHUNK`, default 8). `next_split_provider` hands out one range per claim; each metadata task walks that range and emits a `duckdb_native_scan_info`. `materialize_metadata_to_table` decodes the range's storage segments into a `cudf::table` (always `UNFILTERED`); filter evaluation and projection to output arity happen in `post_filter_and_project`.
+
+## owning_table_view
+
+**File:** `src/include/op/scan/owning_table_view.hpp`
+
+`owning_table_view` is the handle the scan path threads tables through. It exposes a `cudf::table_view` while owning the data behind it, regardless of whether that data is a fully-materialized `cudf::table` or a view into some other type-erased owner. It is in one of three states: an owned `cudf::table`, a type-erased owner + column selection, or empty.
+
+Column manipulations — `reorder_columns`, `drop_columns`, `select_columns` — are pure index manipulations over a stored selection: they never allocate device memory. An owned table is first demoted into a view (a `unique_ptr` move, not a copy) and the selection permuted/subset in place. Only `materialize` and `release` (the view -> table transition) may allocate, and even then, when the underlying owner can surrender its columns (the `no_alloc_materializable` concept — e.g. a `cudf::table`), the surviving column buffers are *moved* out rather than copied.
+
+This is what lets the dominant scan paths — `SELECT *`, identity layouts, reader-side-pushdown reads — flow the reader output through projection/reorder to the output batch with no extra GPU copy.
+
+## scan_plan
 
 **File:** `src/include/op/scan/scan_plan.hpp`, `src/op/scan/scan_plan.cpp`
 
-`scan_plan` is the canonical description of what a scan reads, how it assembles output, and how filters map between index spaces. It is constructed once per provider and shared (immutably) with every emitted split.
+`scan_plan` is the canonical description of what a parquet scan reads, how it assembles output, and how filters map between index spaces. The `parquet_gpu_ingestible` builds it once in its constructor and shares it (immutably) with every emitted split.
 
 ```cpp
 struct scan_plan {
   std::vector<data_column>           data_columns;       // columns read from parquet, in batch order (D)
   std::vector<partition_column>      partition_columns;  // hive-injected columns (name, type, primary index)
   std::vector<output_entry>          output_layout;      // one entry per output column, in DuckDB order
-  std::vector<std::optional<size_t>> batch_position_by_column_id;  // C → D map
+  std::vector<std::optional<size_t>> batch_position_by_column_id;  // C -> D map
   std::unordered_set<size_t>         partition_primary_indices;    // for filter-skip
 };
 ```
@@ -122,25 +124,68 @@ Three index spaces appear in the parquet path:
 - **C (column-ids position)** — index into the scan's `column_ids` list
 - **D (batch position)** — column position in the cuDF reader output (post-hive-removal)
 
-`output_layout` is walked once in `execute()` to produce the final table: `DATA(k)` entries `std::move` from the read batch at position k, `PARTITION(k)` entries synthesize a scalar-backed column from the hive partition value. Pure-filter data columns (read but not output) fall out of scope and free.
+`output_layout` is walked once during materialization to produce the final table: `DATA(k)` entries `std::move` from the read batch at position k, `PARTITION(k)` entries synthesize a scalar-backed column from the hive partition value. Pure-filter data columns (read but not output) fall out of scope and free.
 
-For `SELECT *` with no partitions and no pure-filter columns, `build_inject_fn()` returns `nullptr` and the operator forwards the reader output unchanged — no permute, no copy. `SELECT count(*)` short-circuits the same way (output_layout empty) so the count aggregation sees a 0-column table without a synthesized 0-column reshape.
+For `SELECT *` with no partitions and no pure-filter columns, the plan is a trivial identity and the reader output is forwarded unchanged — no permute, no copy. `SELECT count(*)` short-circuits the same way (`output_layout` empty), so the count aggregation sees a 0-column table without a synthesized 0-column reshape.
 
-### Multifile Bundling
+## Column Mapping
 
-When many small parquet files each yield a small batch, scheduling and kernel-launch overhead dominates. `parquet_split_provider` coalesces row-group slices from **multiple files** into a single split as long as the bundled files share identical hive-partition values (so the synthesized partition columns remain scalar). `accum.total_uncompressed_bytes` accumulates across files; a split is emitted once it exceeds `approximate_batch_size` or partition values change. The downstream `cudf::io::read_parquet` call reads from all bundled files in one invocation.
-
-### Column Mapping
-
-Parquet column-chunk order is not guaranteed to match DuckDB's logical column order. `parquet_split_provider` builds a name-based DuckDB→parquet mapping via `parquet_schema_mapping::leaf_indices_for_column(schema, column_name)`, which walks the parquet schema's `path_in_schema` (case-insensitive, mirroring DuckDB).
+Parquet column-chunk order is not guaranteed to match DuckDB's logical column order. `parquet_gpu_ingestible` builds a name-based DuckDB->parquet mapping via `parquet_schema_mapping::leaf_indices_for_column(schema, column_name)`, which walks the parquet schema's `path_in_schema` (case-insensitive, mirroring DuckDB).
 
 For nested types (`STRUCT`, `LIST`), one DuckDB column maps to multiple parquet leaf chunks; the mapping returns all leaves under the top-level column name. The cuDF parquet reader, given a top-level column name, materializes the nested `cudf::column` natively without post-read reassembly.
 
+## Scan Manager
+
+**Files:** `src/include/scan_manager/sirius_scan_manager.hpp`, `src/scan_manager/sirius_scan_manager.cpp`; `split_provider.{hpp,cpp}`, `split_connector.{hpp,cpp}`, `load_balancing_scan_batch_coalescer.{hpp,cpp}`, `balancing_strategy.hpp`, `round_robin_strategy.{hpp,cpp}`, `config.hpp`.
+
+`sirius_scan_manager` prepares scan-side state before a query runs and drives metadata production for every `GPU_SCAN` source. It owns a configurable thread pool, a single `io::sirius_ioctx` (uring on the fast path, kvikio as the universal fallback — multi-GPU requires the uring path), an optional prefetching cache built on that ioctx, and the registry of pinned-table entries. It runs alongside the GPU pipeline executors and is independent of the data-repository machinery used between intermediate operators.
+
+### Components
+
+| Component | File | Role |
+|-----------|------|------|
+| `sirius_scan_manager` | `scan_manager/sirius_scan_manager.{hpp,cpp}` | Owns thread pool + ioctx + cache + pinned-table registry; `prepare_for_query` wires providers and starts the sequencer |
+| `split_provider` | `scan_manager/split_provider.{hpp,cpp}` | Concrete driver that composes a `gpu_ingestible`; `run()` dispatches one metadata task per claimed unit onto the dispatcher |
+| `load_balancing_scan_batch_coalescer` | `scan_manager/load_balancing_scan_batch_coalescer.{hpp,cpp}` | Per-query sequencer: drains each provider's metadata output through the format's `batch_coalescer`, balances each batch onto a GPU, fires prefetch hints, pushes splits onto the connector |
+| `batch_coalescer` | `op/scan/batch_coalescer.hpp` (impls in the ingestibles) | Bundles per-unit `scan_info`s into right-sized data-batch splits |
+| `balancing_strategy` / `round_robin_strategy` | `scan_manager/balancing_strategy.hpp`, `round_robin_strategy.{hpp,cpp}` | Picks the target GPU for each split and stamps `preferred_device_id` on it |
+| `split_connector` | `scan_manager/split_connector.{hpp,cpp}` | Lock-protected blocking queue between the producer (sequencer) and the operator |
+| `cache_entry_info` / `pinned_entry` | `scan_manager/sirius_scan_manager.hpp` | Pinned-table identity + column layout, and the cached batches (see [Pinned Tables](#pinned-tables)) |
+
+### Lifecycle
+
+1. **Plan stage.** During pipeline conversion the bind data is lowered into an `ingestible_table_info`, `make_ingestible(...)` builds the `gpu_ingestible`, and a `sirius_gpu_scan_operator` carrying it is inserted as the pipeline source. The operator constructs its own (empty) `split_connector`.
+2. **Per-query preparation.** `prepare_for_query(query)` resets prior state, builds a `round_robin_strategy` over the topology's GPU ids and a fresh `load_balancing_scan_batch_coalescer`, then walks the query's `GPU_SCAN` operators in order. For each it `register_pipeline`s a sequencer slot (which builds the ingestible's `batch_coalescer` and captures the operator's connector). Then either:
+   - **Cache hit** — `try_assign_cached_entries` finds a pinned entry whose identity and columns can serve the scan; it attaches a `databatch_provider` to the slot and skips disk reading entirely; or
+   - **Cache miss** — a `split_provider` is built over the operator's ingestible and stored in `_providers_by_op`.
+3. **Execution.** `start_metadata_processing` spawns the single sequencer worker on the dispatcher, then calls `split_provider::run` for each non-cached operator. `run` iterates `has_more_splits` / `next_split_provider` and hands each claimed metadata task to the dispatcher; each task enqueues its `scan_info` onto the operator's sequencer slot queue. The sequencer worker walks slots in registration order, coalescing each slot's metadata into data-batch splits, balancing each onto a GPU, firing `fadvise`/`opportunistic` prefetch, and pushing a `scan_operator_input` onto the operator's connector. Consumers (the scan operators) block in `split_connector::get_next_split` until splits arrive.
+4. **Teardown.** The sequencer closes each connector when its slot is drained (forwarding any worker-captured exception, first-writer-wins). Once closed and drained, the operator's `all_ports_empty()` returns true and `get_next_task_hint()` returns `nullopt`. `reset()` requests the dispatcher stop and rebuilds it for the next query.
+
+### split_provider
+
+`split_provider` is concrete and composes a `gpu_ingestible` non-owningly (the operator owns the lifetime; the provider is always torn down first by `reset()`). Its `has_more_splits` / `next_split_provider` delegate to the ingestible. `run(scheduler, on_split)` enqueues one task per claimed metadata unit; the connector is closed (with any captured exception) when the last enqueued task drops its reference to the shared completion state.
+
+### load_balancing_scan_batch_coalescer
+
+This is the per-query sequencer. Each `GPU_SCAN` operator gets a `metadata_processing_state` slot holding a blocking queue (fed by the provider's metadata tasks), the ingestible's `batch_coalescer`, the shared `balancing_strategy`, and the operator's `split_connector`. A single worker walks the slots in registration order. For a live scan it dequeues per-unit `scan_info`s, pushes them through the coalescer, and for each coalesced batch: picks a GPU via the balancer (stamping `preferred_device_id`), fires `fadvise` and an `opportunistic` prefetch for the batch's byte ranges, and pushes a `scan_operator_input` onto the connector. For a cached pipeline it replays the attached `databatch_provider`, pushing one resident `scan_operator_input` per cached chunk. Serialising the opportunistic prefetch tier across pipelines in execution order gives the prefetching cache its longest lead time for the head-of-line pipeline.
+
+### Device balancing
+
+`balancing_strategy` decouples *which GPU a split runs on* from *how splits are produced*. `round_robin_strategy` hands out devices from the topology's GPU id set via a single shared atomic cursor, spreading splits evenly across GPUs and continuously across the whole scan stage. The chosen device is recorded on the split via `set_preferred_device_id`; the task creator reads it back when it builds the `gpu_pipeline_task` so the scheduler dispatches to that GPU. (Cached/resident inputs carry no balancer-assigned device; the task creator derives their device from the chunk's resident `memory_space` for NUMA/host-pin locality — see the memory-management doc.)
+
+### split_connector
+
+A lock-protected queue of pre-built splits. The producer (sequencer) enqueues via a friended `push_split` and calls `close(exception?)` when done. The consumer pulls via `get_next_split()`, which blocks until a split is available or the connector is closed and drained: returns `nullopt` when drained, the next split otherwise, or rethrows the producer's stored exception once the queue is empty.
+
+### Configuration
+
+`scan_manager_config` (`config.hpp`) tunes the thread pool, the IO backend toggle (`use_sirius_datasource`), uring/REST reactor counts, the prefetching cache, and object-store credentials.
+
 ## Pinned Tables
 
-**Files:** `src/include/pin_table.hpp`, `src/pin_table.cpp`, `src/include/scan_manager/cached_split_provider.hpp`
+**Files:** `src/include/pin_table.hpp`, `src/pin_table.cpp`; pinned-entry storage + cache matching in `src/include/scan_manager/sirius_scan_manager.hpp` and `src/scan_manager/sirius_scan_manager.cpp`.
 
-The `pin_table` table function lets users pre-load a parquet table's columns into GPU memory (or, in the future, host memory) so subsequent scans of the same path bypass file I/O entirely.
+The `pin_table` table function pre-loads a table's columns into memory so subsequent scans of the same source bypass file I/O entirely. It supports both source formats and two memory tiers.
 
 ```sql
 CALL pin_table('/path/to/lineitem.parquet',
@@ -148,7 +193,9 @@ CALL pin_table('/path/to/lineitem.parquet',
                tier = 'gpu',
                cols = ['l_orderkey', 'l_quantity', 'l_extendedprice', 'l_shipdate']);
 
--- Subsequent reads of the same path are served from the pinned columns.
+-- A duckdb-native base table can be pinned too:
+CALL pin_table('my_table', name = 'my_table', format = 'duckdb', tier = 'host');
+
 SELECT SUM(l_extendedprice * l_quantity)
   FROM read_parquet('/path/to/lineitem.parquet')
   WHERE l_shipdate >= DATE '1994-01-01';
@@ -156,410 +203,264 @@ SELECT SUM(l_extendedprice * l_quantity)
 CALL unpin_table('lineitem');
 ```
 
-`tier` accepts `gpu` (columns pinned to GPU device memory) or `host` (columns pinned to host memory). In both cases subsequent scans of the same paths are served from the pinned columns without file I/O.
+`format` is `parquet` or `duckdb`, resolved at bind time from an explicit parameter or inferred from the path extension. `tier` is `gpu` (columns in GPU device memory) or `host` (columns in pinned host memory).
 
-A `pinned_entry` stores the column projection, resolved file paths, per-column chunk vectors, and the memory space the columns reside in. When `prepare_for_query` runs, the scan manager matches the operator's `parquet_scan_info::file_paths` against pinned entries; on a hit, it constructs a `cached_split_provider` (zero-copy view-backed `data_batch` per chunk) instead of a `parquet_split_provider`. The cached provider forwards the same `scan_plan` and filter expression as the parquet path, so the operator's `execute()` is unchanged. When `needs_output_assembly(*plan)` is false (identity layout), the cached batch is forwarded straight through with no permute or prune.
+### Materializing a pin
 
-`insert_pinned_entry` supports re-pinning: if an entry exists with the same row count, only new columns are merged in (duplicates dropped); a different row count drops and replaces the entry.
+Pinning drives the source's `gpu_ingestible` to completion (`materialize_all_batches` / `materialize_pin_to_host` in `pin_table.cpp`):
 
-## DuckDB Scan Task
+- **GPU tier** (`materialize_all_batches`): each emitted batch is materialized into a GPU-resident `cudf::table`, round-robining placement across the GPU memory spaces. Placement is deterministic so re-pinning the same source yields identical per-chunk placement (required by the merge path below).
+- **HOST tier** (`materialize_pin_to_host`): each batch is materialized on its round-robin GPU, converted to a `host_data_representation` on that GPU's NUMA-local host space, then the GPU table is freed before the next batch. Peak GPU residency is therefore ~one batch, so a host pin never needs the whole table to fit in GPU memory.
 
-**File:** `src/op/scan/duckdb_scan_task.cpp`, `src/include/op/scan/duckdb_scan_task.hpp`
+### Storage and matching
 
-### Global State
+Each pinned table is a `pinned_entry` keyed by name in the scan manager. It holds a `cache_entry_info` (the cache identity + column layout) plus the cached batches: `data_batches_by_column` (one chunk vector per column) for the GPU tier, or `host_chunks` (one `host_data_representation` per batch, sliced by column at scan time) for the HOST tier.
 
-`duckdb_scan_task_global_state`:
-- Manages DuckDB table function global state
-- Thread-safe shared state across all scan tasks
-- `MaxThreads()` — maximum concurrent scan threads
-- `is_source_drained()` — checks if all local states are complete
-- Filters are NOT passed to DuckDB (applied by `sirius_physical_table_scan` instead)
+`cache_entry_info` captures format identity — the resolved parquet **file set**, or the duckdb **catalog.schema.table** — plus the cached columns (by storage index) and their names. `can_serve_with_columns(other)` returns a gather projection when this entry can serve a scan: same format, same identity, and a **column superset** of the scan's request. A parquet pin never serves a duckdb scan or vice-versa.
 
-### Local State
+During `prepare_for_query`, `try_assign_cached_entries` matches each `GPU_SCAN` operator's `table_info` against the pinned entries. On a hit it builds a `cached_databatch_provider` over the matched entry, ordering columns by the ingestible's `materialized_column_order()` so a cached batch is laid out identically to a fresh disk read and `post_filter_and_project` resolves the same columns on both paths. The scan operator's `execute()` is unchanged; resident cached batches with an identity layout flow through untouched.
 
-`duckdb_scan_task_local_state`:
-- Maintains per-task state with target batch size (`DEFAULT_SCAN_TASK_BATCH_SIZE`)
-- **Column builder** — nested struct managing memory for individual columns:
-  - Fixed-width types: data array + validity mask
-  - VARCHAR: offset array + data + validity mask
-  - Uses `multiple_blocks_allocation_accessor` for writing
-  - 8-byte aligned column starts
-- Row estimation based on:
-  - Actual width of fixed-width types
-  - Default VARCHAR width (`DEFAULT_SCAN_TASK_VARCHAR_SIZE`)
-  - Per-column validity mask bits (1 bit per row, rounded up)
+### Re-pin semantics
 
-### Execution Flow
+For the GPU tier, `insert_pinned_entry` merges into an existing entry when the row count matches (adding only columns not already cached; per-chunk memory-space placement must match) and replaces it otherwise. The HOST tier always replaces, since each host chunk already holds every column.
 
-```
-1. get_next_chunk() → fetch from DuckDB table function
-2. chunk_fits() → check if data fits in pre-allocated buffers
-3. process_chunk() → write chunk into column builders
-4. Repeat until target batch size reached or source drained
-5. Build host_data_representation from column builders
-6. If scan incomplete: create next scan task (self-scheduling)
-```
+## Batch Coalescing
 
-## Parquet Scan Task
+When many small files (or row-group ranges) each yield a tiny GPU batch, per-task scheduling and kernel-launch overhead dominates. Coalescing is a responsibility of each `gpu_ingestible`, exposed through the `batch_coalescer` interface (`op/scan/batch_coalescer.hpp`): as the metadata side emits per-unit `scan_info`s, the sequencer feeds each one to the coalescer via `push()` (which may buffer and return zero or more ready batches) and `flush()` (remaining buffered batches at end of input).
 
-**File:** `src/op/scan/parquet_scan_task.cpp`, `src/include/op/scan/parquet_scan_task.hpp`
+- **`parquet_batch_coalescer`** (in `parquet_gpu_ingestible.cpp`): accumulates each file's pruned row groups into `parquet_split_info` batches sized to `approximate_batch_size` *decoded* bytes. A single large file spans multiple splits; several small files bundle into one split — but only when they share identical hive-partition values and the same pushdown decision (a mismatch on either forces a flush). It also seals a split before a batch would exceed `cudf::size_type` rows. The downstream `cudf::io::read_parquet` reads all bundled slices in one invocation.
+- **`duckdb_native_batch_coalescer`** (in `duckdb_native_gpu_ingestible.cpp`): accumulates row-group ranges up to `approximate_batch_size` decoded bytes, and additionally seals a batch before any VARCHAR column's accumulated bytes would cross the cuDF int32 string-offset threshold.
 
-### Global State
+The coalescer runs inside the per-query sequencer (`load_balancing_scan_batch_coalescer`), so coalescing, device balancing, and prefetch hinting happen at one place per emitted batch.
 
-`parquet_scan_task_global_state`:
-- Reads Parquet footers at construction via `cudf::io::parquet::fetch_footer_to_host()`
-- Extracts file paths, sizes, footer offsets from DuckDB `MultiFileBindData`
-- Computes compressed/uncompressed byte sizes per row group
-- Partitions row groups into scan tasks: groups by accumulated uncompressed bytes where each partition ≈ target batch size
-- Atomic counter `_next_rg_partition` for lock-free task scheduling
-- Supports rebinding for cache reuse across query re-executions
-- Only supports flat schemas (no nested columns)
+## DuckDB-Native Decode
 
-### Local State
+**Files:** `src/include/op/scan/duckdb_native_decoder.hpp`, `src/op/scan/duckdb_native_decoder.cpp`, `src/include/cuda/scan/gpu_native_decode.cuh`, `src/include/cuda/scan/gpu_decode_strings.cuh`, `src/cuda/scan/*.cu`, `src/cuda/scan/strings/*.cu`
 
-`parquet_scan_task_local_state`:
-- Stores file index and row group indices for this task
-- Reserves both compressed bytes (for allocation) and uncompressed bytes (metadata)
+The GPU DuckDB-native scan reads a table stored in DuckDB's own `.db` block format and decodes each projected column's on-disk segments directly on the GPU into a `cudf::table`, without going through Parquet. `decode_duckdb_native_split()` takes the row-group metadata for a split, stages the segment bytes on device, and dispatches per-column decode.
 
-### Execution Flow
+### Segment runs and codec dispatch
 
-```
-1. Construct byte ranges covering:
-   - Parquet header (4 bytes PAR1 magic)
-   - Column chunk byte ranges for selected row groups
-   - Parquet footer + trailer
-2. Allocate into chunked host memory
-3. Read byte ranges asynchronously via host_read_async()
-4. Wait for all read futures
-5. Build host_parquet_representation wrapping:
-   - Cached allocation, hybrid scan reader, reader options
-   - Row group indices, byte ranges, file metadata
-6. Optional materialization: if enabled, decompress Parquet → GPU table → host table
-7. Wrap in cached_*_representation if caching enabled
-```
+A DuckDB column inside a row group is a sequence of *segments*, each compressed with one codec. The decoder groups a column's segments into **codec runs** — maximal spans of segments sharing one codec — and a per-codec kernel consumes a whole run in one launch (the run is the batching unit). A column with mixed codecs produces multiple runs. Codec metadata (bitpacking width, dictionary references, FSST symbol tables, ALP parameters) lives inside the segment bytes; each codec kernel parses its own headers on device, so the dispatcher itself does no parsing and no I/O.
 
-## Scan Executor
+Decode splits into two entry points sharing the same run/segment descriptors:
 
-**File:** `src/op/scan/duckdb_scan_executor.cpp`, `src/include/op/scan/duckdb_scan_executor.hpp`
+- **Fixed-width columns** — `gpu_decode_table()` (`gpu_native_decode.cuh`). Codecs: `UNCOMPRESSED`, `CONSTANT`, `RLE`, `BITPACKING`. Floating-point columns additionally decode DuckDB's `ALP`/`ALPRD` adaptive-lossless codecs. The dispatcher synchronizes the stream once before returning so columns come back with `null_count` populated.
+- **Varchar columns** — `gpu_decode_strings_column()` (`gpu_decode_strings.cuh`). Codecs: `UNCOMPRESSED`, `DICTIONARY`, `FSST`, `DICT_FSST`. The per-segment max-string-length stat captured during the metadata walk sizes the cuDF chars buffer up front, so the string path runs async modulo at most one host sync (the chars-buffer read-back, which only fires when that upper bound is unknown or pathological).
 
-### Thread Model
+Each string codec lives in its own translation unit under `src/cuda/scan/strings/` (`uncompressed.cu`, `dictionary.cu`, `fsst.cu`, `dict_fsst.cu`) over shared device primitives in `src/include/cuda/scan/detail/` and `src/include/cuda/scan/strings/`; the fixed-width codecs live in `src/cuda/scan/` (`gpu_decode_bitpacking.cu`, `gpu_decode_rle.cu`, `gpu_decode_alp.cu`, `gpu_native_decode.cu`).
 
-- **Manager thread**: consumes scan tasks from queue, acquires kiosk tickets, submits to thread pool
-- **Worker thread pool** (default: 4 threads): executes scan tasks concurrently
-- **CUDA stream pool**: exclusive streams per thread for async Host→Device transfers
+### Validity and rowid
 
-### Manager Loop
+Validity (null) masks decode from `UNCOMPRESSED`, `EMPTY` (all-null), and `CONSTANT` (all-valid) codecs on device. `ROARING`-compressed validity is host-decoded to a plain bitmap before the GPU sees it (DuckDB's roaring scan state drives the reads), then staged like any other host-produced segment. `CONSTANT` data segments likewise materialize their single value on the host. Synthetic `rowid` columns carry no on-disk storage; the decoder fills them from each row group's absolute first-row index.
 
-```
-while running:
-    1. kiosk.acquire()              -- wait for worker availability
-    2. task_queue.pop() or:
-       - Try non-blocking pop first
-       - If empty: submit scan task request to pipeline executor
-       - Then blocking pop
-    3. For parquet scans: acquire HOST memory reservation
-    4. Dispatch to thread pool:
-       a. Acquire CUDA stream
-       b. get_scan_output() — applies caching logic
-       c. scan_task->publish_output() — store to data repository
-       d. Schedule output consumers via task_creator
-```
+### Viability gate
 
-### Cache Handling
+The metadata walk (below) rejects any codec or type the decoder cannot handle and falls the query back to DuckDB CPU before staging. The decoder's own `throw`s on unsupported codecs/types are a defensive backstop, not the primary gate. Unsupported cases include 128-bit (`HUGEINT`/`DECIMAL128`) and nested (`STRUCT`/`LIST`) types, and a varchar column whose summed max-string-length upper bound would overflow cuDF's int32 string-offset limit.
 
-`get_scan_output()` applies caching logic based on mode:
+## DuckDB-Native Metadata Walk
 
-| Mode | Behavior |
-|------|----------|
-| CACHE (first run) | Execute scan, save result to cache |
-| PRELOAD (cache hit) | Load from cache, clone if needed |
+**Files:** `src/include/op/scan/duckdb_native_metadata.hpp`, `src/op/scan/duckdb_native_metadata.cpp`, `src/include/op/scan/duckdb_native_decoder.hpp`
 
-Cloning logic:
-- `TABLE_GPU` cache level: return original (GPU-resident, no copy)
-- Other levels: clone batch to avoid sharing cache data
-- Parquet: `shallow_clone()` — increments refcount, zero-copy
+Before decode, the scan walks DuckDB's storage metadata to learn, per row group, which segments each projected column occupies, what codec each uses, and how many decoded bytes the row group will cost. The walk is two-phase so the thread-unsafe parts run once and the expensive per-segment parsing runs concurrently.
 
-## Caching Mechanism
+### Phase 1 — `prepare_duckdb_native_walk()` (serial)
 
-**File:** `src/include/op/scan/config.hpp`
+Runs once, single-threaded, because it touches `ClientContext`/`LocalStorage`, which are not thread-safe:
 
-Four caching levels control scan result persistence:
+- Reads `PartitionStatistics` for every row group (the source of each row group's absolute first-row index and row count, used both for rowid synthesis and decoded-byte budgeting).
+- Gates the projected types: an exhaustive type switch refuses 128-bit and nested types up front so an unsupported projection becomes a clean CPU fallback before any per-segment IO.
+- Marks row groups that pushed-down filter statistics prove empty (see **Row Group Pruning**).
 
-### `NONE` (default)
-No caching. Full scan on every query. Minimal memory overhead.
+The result is a `duckdb_native_walk_plan` carrying per-row-group row starts/counts, the block size, the pruned-row-group bitmap, and the inputs the range walks need. A non-viable plan (unsupported type, invalid partition `row_start`, or all row groups pruned) refuses the whole native-scan path.
 
-### `PARQUET`
-Cache raw compressed Parquet bytes in host memory. Stored as `cached_host_parquet_representation`. Decompression happens on each re-execution. Smallest memory footprint for parquet scans.
+### Phase 2 — `walk_duckdb_native_row_group_range()` (concurrent)
 
-### `TABLE_HOST`
-Cache decoded (decompressed) table in host memory. Stored as `cached_host_data_representation`. Avoids decompression cost on re-execution. Medium memory usage.
+The row-group range `[0, n_row_groups)` is sliced into fixed-size parse chunks (default 8 row groups, `SIRIUS_METADATA_PARSE_CHUNK`), and each chunk is walked independently on a scan-manager thread. For each surviving row group in its range, a range walk:
 
-### `TABLE_GPU`
-Cache decoded table in GPU memory. Fastest — no data movement needed for GPU execution. Highest memory cost.
+- Walks each projected column's **typed segment trees** directly — reading `block_id`, block offset, compression enum, per-segment row counts, the validity child's segments, and (for varchar) the per-segment max-string-length stat as typed fields. It does not build or re-parse the per-segment string blobs that DuckDB's generic `GetColumnSegmentInfo` would produce.
+- Refuses on the first unsupported segment codec or an absent/over-threshold varchar stat, partially filling the range (which the caller then discards in favor of CPU fallback).
+- Derives each segment's on-disk byte size from the sorted `(block_id, block_offset)` delta to the next segment — an upper bound, since codec headers self-bound the actual reads, so any overshoot only inflates staging/H2D bytes, never correctness.
+- Sorts each column's segments by row start (so codec runs coalesce) and computes the row group's decoded-byte budget and per-column varchar char count.
 
-## Data Representations
+Stats-pruned row groups are skipped before any segment metadata is requested. The per-row-group results (`duckdb_row_group_metadata`) feed the batch coalescer, which bundles row groups into decode-sized splits.
 
-### `host_data_representation`
-Fixed-width columnar data in host memory. Created directly by `duckdb_scan_task` from DuckDB chunks via column builders.
+## Row Group Pruning
 
-### `host_parquet_representation`
-Raw Parquet bytes in host memory with deferred decompression. Contains:
-- `multiple_blocks_allocation` — byte chunks
-- `hybrid_scan_reader` — cuDF reader for metadata + decoding
-- Byte ranges and row group indices
-- File metadata (size, footer offset)
+Both GPU scan formats drop row groups that a pushed-down filter proves cannot contain a matching row, before those row groups are read or decoded.
 
-### `cached_shared_representation<T>`
-**File:** `src/include/data/cached_data_representation.hpp`
+### Parquet path
 
-Template wrapper for caching any `idata_representation` type:
-- `clone(stream)` — deep copy for unique batches
-- `shallow_clone()` — reference-counted copy for cache hits
-- `get_representation()` — access underlying shared representation
+When filter pushdown is enabled and the `gpu_expression_translator` successfully converts DuckDB `TableFilterSet` filters into a cuDF AST, two mechanisms activate inside `parquet_gpu_ingestible`:
 
-Specializations:
-- `cached_host_parquet_representation = cached_shared_representation<host_parquet_representation>`
-- `cached_host_data_representation = cached_shared_representation<host_data_representation>`
+1. **Row group statistics pruning:** during the per-file metadata task, `filter_row_groups_with_stats()` runs against each fetched footer; row groups whose Parquet column min/max statistics cannot match the filter are dropped before any read is scheduled. Pure hive-partition filters are dropped during plan construction since hive columns aren't in the parquet file.
 
-## Prefetched Data Source
+2. **Reader-level filter pushdown:** the cuDF AST is set on `parquet_reader_options` via `set_filter()`, so cuDF applies the filter inside `read_parquet`. When the reader applies the row filter, `materialize_table` reports `ROW_FILTERED` (or `ROW_FILTERED_AND_PROJECTED` once hive partitions are assembled), so the scan operator skips a redundant post-decode filter.
 
-**File:** `src/op/scan/prefetched_data_source.cpp`, `src/include/op/scan/prefetched_data_source.hpp`
+Reader-side pushdown is a per-split decision: an FLBA-decimal safety probe can disable it for a file, in which case the cached DuckDB filter expression is evaluated through `gpu_expression_executor` on the decoded batch in `post_filter_and_project`.
 
-Implements `cudf::io::datasource` interface for cached Parquet data.
+**Filter translation path:** `TableFilterSet` -> `convert_table_filters_to_expression()` (skips `OPTIONAL_FILTER`, `IS_NOT_NULL`, and partition-column filters) -> `gpu_expression_translator` -> cuDF AST tree.
 
-### `cache_ranges`
-**File:** `src/op/scan/cached_ranges.cpp`
+### DuckDB-native path
 
-Stores sorted, non-overlapping byte ranges with packed buffers:
-- Coalesces adjacent ranges to minimize lookups
-- Binary search for `get_ranges(offset, size)` — returns spans covering requested bytes
-- Returns `nullopt` if query crosses range boundary (not in cache)
-- Supports NUMA-aware hints (`device_id`, `numa_id`) for batch copy optimization
+The DuckDB-native scan prunes row groups using DuckDB's own statistics machinery rather than Parquet footer stats. During the serial prepare phase of the metadata walk (`mark_row_groups_pruned_by_filter_stats`), for each row group and each pushed-down `TableFilter`, the scan calls DuckDB's `TableFilter::CheckStatistics` against that row group's per-column statistics (obtained from its `PartitionRowGroup` handle). A row group is pruned the moment any filter returns `FILTER_ALWAYS_FALSE`.
 
-### `host_read()`
-Delegates to `cache_ranges::get_ranges()`. If cached, copies spans via memcpy. If not cached, falls back to the original datasource. Tracks `bytes_read_from_cache` vs `bytes_read_from_fallback` atomically.
+This runs entirely from `PartitionRowGroup` statistics — no segment metadata is needed — so a pruned row group is skipped **before its segments are walked, staged, copied to the GPU, or decoded**. If every row group is pruned, the native path refuses up front and the query falls back to DuckDB CPU before the async scan starts.
 
-### `device_read()`
-Enqueues async Host→Device copies:
-
-**CUDA 13+ path:**
-```cpp
-cudaMemcpyBatchAsync()  // Efficient multi-span batched copies
-```
-Sets `cudaMemcpyAttributes` with NUMA/device locality hints for optimal placement.
-
-**CUDA <13 fallback:**
-```cpp
-// Per-span cudaMemcpyAsync()
-for (auto& span : spans) {
-    cudaMemcpyAsync(dst, span.data, span.size, H2D, stream);
-}
-```
-
-### `device_read_async()`
-Uses deferred lambda with CUDA event synchronization:
-1. Records `cuda_event_guard` after async copies
-2. Returns future that syncs the event on `get()`
+Only statically-known filters participate: `DYNAMIC_FILTER` table filters are excluded, because their bounds come from a runtime source (e.g. a hash-join build) that is not populated at metadata-walk time. The payoff is data-clustering-dependent — it costs almost nothing when statistics can't help and is multiplicative when the table is ordered such that a filter eliminates most row groups.
 
 ## Sirius IO Subsystem
 
 **Files:** `src/include/io/`, `src/io/`
 
-`sirius::io` is a `cudf::io::datasource`-compatible I/O stack designed for high-throughput parquet reading. It is built around io_uring reactors and a pinned-memory prefetching cache, with a pluggable backend seam so additional backends (e.g. cuFile) can be added without changing the cache or the datasource layer.
+`sirius::io` is a `cudf::io::datasource`-compatible I/O stack for high-throughput parquet reading. It is organized around three pieces: a per-backend *ioctx* that owns the reactor pool plus the caches, a generic `templated_ioctx<Reactor>` that implements the read API in terms of a backend reactor, and a pinned-memory *prefetching cache* that sits in front of every backend. Backends plug in by supplying a reactor + io_object pair; the cache and the datasource layer are backend-agnostic.
 
 ### Architecture
 
 | Component | File | Role |
 |-----------|------|------|
-| `sirius_datasource` | `io/sirius_datasource.{hpp,cpp}` | `cudf::io::datasource` implementation; `supports_device_read() = true`; delegates every read to the bound `sirius_ioctx` |
-| `sirius_ioctx` | `io/types.hpp` | Abstract shared context owning the optional `prefetching_cache` and the reactor pool. `device_read{,_async}` consults the cache and falls through to backend I/O on miss |
-| `templated_ioctx<Reactor>` | `io/templated_ioctx.hpp` | Generic ioctx implementation: request splitting, aligned 1 MiB chunking, round-robin dispatch across reactors, sync/async adapters |
-| `uring_reactor` / `uring_ioctx` | `io/uring/` | Concrete io_uring backend. One thread per reactor, `O_DIRECT` device reads through pinned bounce slots, buffered host reads on the same ring |
-| `prefetching_cache` | `io/prefetching_cache.{hpp,cpp}` | Pinned-memory chunk cache with lock-free per-entry state machine, background worker, evictor threads, and tiered LRU buckets |
-| `buffer_pool` | `io/prefetching_cache.cpp` | Growable multi-slab pool of 1 MiB pinned chunks |
-| `admission_control` | `io/admission_control.{hpp,cpp}` | RAII slot handed out against a fixed in-flight budget (default 2 GiB worth of chunks) |
+| `sirius_datasource` | `io/sirius_datasource.{hpp,cpp}` | `cudf::io::datasource` implementation. Thin per-scan delegate: every read forwards to the bound `sirius_ioctx`, passing the shared `sirius_io_object` by reference. Also carries the per-scan `prefetching_handle` used by `fadvise`. |
+| `sirius_ioctx` | `io/io_context.{hpp,cpp}` | Abstract shared backend context. Owns the optional `prefetching_cache` and an always-present `metadata_store`, exposes the backend read API (`host_read_io`, `host_read_async_io`, `device_read_async_io`, `host_to_device_read_async_io`, `host_read_ranges_async_io`) and capability queries, and opens datasources via `open_datasource(path)`. |
+| `templated_ioctx<Reactor>` | `io/templated_ioctx.hpp` | Generic ioctx implementation parameterized on a backend reactor. Owns a pool of reactors, splits each caller request across the pool, dispatches via the reactor's `prep_*`/`enqueue`, and derives its capabilities structurally from the reactor (see [Backend Seam](#backend-seam)). |
+| `io_context_registry` | `io/datasource_factory.{hpp,cpp}` | Scheme→backend registry. Each backend registers a scheme checker (the reactor's static `supports()`) and a factory; `lookup(scheme)` resolves a URI scheme to a backend type, `make_ioctx(type)` builds one. |
+| `prefetching_cache` | `io/cache/prefetching_cache.{hpp,cpp}` | Pinned-memory chunk cache with a lock-free per-chunk state machine, background preparation/prefetch/evictor threads, and tiered LRU scoring. Serves partial reads and populates itself on read. |
+| `buffer_pool` | `io/cache/types.{hpp,cpp}` | Growable pool of fixed-size pinned chunks, backed by a `cucascade::memory::fixed_size_host_memory_resource` per NUMA arena. Chunk size is the resource's block size. |
+| `metadata_store` | `io/cache/metadata_store.{hpp,cpp}` | Per-file metadata cache keyed by `io_object::raw_file_cache_id()`. Always present, independent of the prefetching cache; callers park parsed footers here so a later scan of the same path skips the parse. |
+| `admission_control` | `exec/admission_control.{hpp,cpp}` | Blocking, budget-based backpressure. Hands out RAII slots against a fixed budget; an oversized request is granted the whole budget when no other slots are outstanding (deadlock escape). The prefetching cache rate-limits in-flight IO through one of these. |
+| `semi_future` / `try_t` / `completion_controller` | `exec/semi_future.hpp`, `exec/try.hpp`, `exec/completion_controller.hpp` | Async primitives the IO layer is built on. `semi_future<T>`/`promise<T>` are the wait-or-callback handles every async read returns; `try_t<T>` is the value-or-error result type; `completion_controller` + `completion_token` provide one-shot completion subscriptions. |
+
+### Read path
+
+A scan opens a file with `sirius_ioctx::open_datasource(path)`, which asks the backend to create a `sirius_io_object` (open local fds, or HEAD an object store for its size) and wraps it in a `sirius_datasource` bound to the ioctx. Each cuDF read on the datasource forwards to the ioctx:
+
+- When the ioctx has an armed cache (`uses_prefetching_cache()`), `host_read`/`device_read` consult the cache first; a hit copies from pinned host chunks (host reads via `memcpy`, device reads via `cudaMemcpyAsync` from pinned memory). A miss falls through to the backend `*_io` virtuals, which the `templated_ioctx` services through the reactor pool.
+- A backend without batched host reads (e.g. kvikio) reports `preferred_prefetching_stage::none` and is never given a cache.
+
+The ioctx is built parked: the reactor pool is constructed cheaply at `make_ioctx` time, and `start()` launches the worker threads and allocates per-reactor staging only once the read API is first exercised.
 
 ### Backend Seam
 
-Two C++20 concepts define the plug-in contract:
+A backend is a *reactor* + *io_object* pair plugged into `templated_ioctx<Reactor>`. The contract is expressed as C++20 concepts and structural traits rather than hand-maintained capability flags.
 
-- `io_object_c<O, Handle>` — derives from `sirius_io_object`, exposes `host_handle()` / `device_handle()` of type `Handle`.
-- `io_reactor_c<R>` — associated types (`native_handle_type`, `io_object_type`, `device_read_req_type`, `host_read_req_type`) plus operations: `enqueue_bulk`, `host_read`, `host_read_async`, `shutdown`, static `align_to_physical`.
+- `io_reactor_c<R>` (the baseline contract) requires associated types (`io_object_type`, `request_type`, `request_type_ptr`, `reactor_config_type`), buffered host reads (`prep_host_rx_request` + synchronous `host_read`), dispatch (`enqueue`), lifecycle (`shutdown`/`interrupt`), `create_io_object`, and the static capability queries `supports(path)` and `preferred_prefetching_stage()`.
+- `reactor_traits<R>` detects the *optional* dispatch paths structurally: a reactor supports device reads, bounce-staged host-to-device reads, or vectored host reads iff it defines the matching `prep_device_rx_request` / `prep_host_to_device_rx_request` / `prep_host_rxv_request` overload. `templated_ioctx` answers `supports_device_read()` / `supports_host_to_device_read()` / `supports_vector_host_read()` from these traits, so a reactor advertises a capability simply by implementing the corresponding prep method.
 
-A new backend is: a custom `io_object` + reactor + `templated_ioctx<your_reactor>`. `uring_ioctx = templated_ioctx<uring_reactor>` is the first instantiation.
+Dispatch is uniform across backends: `templated_ioctx` builds one request via the reactor's `prep_*`, retrieves its `semi_future`, then `splits` the per-chunk requests across the reactor pool (round-robin) and `enqueue`s each split. The shared request-lifecycle primitives in `io/io_request.hpp` (`request_manager`, `device_cpy_request`, `rx_request_t<Chunk>`) fan one logical read out into N per-chunk reads and fulfill a single future when the last chunk completes (with the first reported error, if any). Each backend instantiates `rx_request_t` for its own chunk type (`uring::chunked_rx_request`, `rest::rest_chunked_rx_request`).
 
-### S3 Backend
+Three backends ship:
 
-**Files:** `src/include/io/s3/s3_ioctx.hpp`, `src/io/s3/s3_ioctx.cpp`, `src/include/io/s3/s3_request_authorizer.hpp`, `src/include/io/s3/s3_io_object.hpp`
+| Backend | ioctx | Reactor | Scheme | Notes |
+|---------|-------|---------|--------|-------|
+| io_uring | `uring::uring_ioctx = templated_ioctx<uring_reactor>` | `uring/uring_reactor.hpp` | local files | One `io_uring` + worker thread per reactor. `O_DIRECT` device reads through pinned bounce slots; buffered host reads on the same ring. `preferred_prefetching_stage = none`. |
+| REST / object store | `rest::rest_ioctx = templated_ioctx<rest_reactor>` | `rest/rest_reactor.hpp` | `s3://` | libcurl-multi over an epoll loop; see [S3 / Object-Store Backend](#s3--object-store-backend). `preferred_prefetching_stage = just_in_time`. |
+| kvikio fallback | `kvikio_context` | (none) | any | Wraps cudf's default datasource (GDS-capable). Overrides the public read API directly so cudf's `std::future` flows through unchanged; the protected `_io` primitives are unreachable placeholders. No reactors, no cache, `preferred_prefetching_stage = none`. |
 
-`sirius::io::s3::s3_ioctx` implements the `sirius_ioctx` interface for reading parquet files from S3 using libcurl HTTP Range GETs. Unlike the io_uring backend, S3 has no native device-read path — device reads bounce through a host staging buffer followed by `cudaMemcpyAsync`.
+The scan manager builds one ioctx for the run: `uring_ioctx` when `use_sirius_datasource` is set, otherwise the `kvikio_context` fallback (the registry can also resolve an `s3://` URL to the REST backend via `lookup`). A new backend is a reactor + io_object that satisfy the concepts, a `templated_ioctx` specialization, and a registry entry.
 
-Authentication is delegated to a `s3_request_authorizer` implementation passed via `s3_ioctx_config`:
+### S3 / Object-Store Backend
+
+**Files:** `src/include/io/rest/{rest_ioctx,rest_reactor,curl_handle,config,types}.hpp`, `src/io/rest/*.cpp`, `src/include/io/s3/{s3_request_authorizer,sirius_sigv4_authorizer,s3_object_ref,static_credentials}.hpp`, `src/include/io/object_store_config.hpp`
+
+Reads of `s3://bucket/key` parquet files go through the REST backend, `rest_ioctx = templated_ioctx<rest_reactor>`. Each `rest_reactor` owns one worker thread driving a libcurl multi handle over an epoll event loop (`curl_multi_socket_action`), a pool of reusable easy handles, optional pinned bounce slots for device staging, and a timerfd + min-heap retry scheduler. `create_io_object` parses the URL, issues a one-time HEAD for the object size, and builds a `rest_io_object` (path / bucket / key / size). Because S3 has no native device-read path, device reads stage through a pinned host bounce slot followed by `cudaMemcpyAsync`.
+
+**Request unit.** Each ranged GET is one `rest_chunked_rx_request` carrying the object ref, the file range and its destination buffer(s), and an attempt counter. The reactor's libcurl write callback scatters the response body across the chunk's destination iovecs, so a single ranged GET can fuse several file-adjacent segments. A 206's `Content-Range` is validated against the request, and a server that ignores the Range header (returns the whole object) is detected via the received-byte count.
+
+**Authorization.** Auth is delegated to a pluggable `s3_request_authorizer` (the credential/signer seam), called inline once per request attempt (presigned URLs are short-lived, so they are minted per attempt, never at task-creation time). `authorize(object, method, ttl)` returns the URL to fetch plus headers to attach:
 
 | Authorizer | Mechanism |
 |------------|-----------|
-| `sirius_sigv4_presigned_authorizer` | Generates AWS SigV4-signed presigned URLs for each request |
-| `sirius_sigv4_header_authorizer` | Adds `Authorization` + `x-amz-*` headers; supports STS session tokens and dual-signing modes (AWS standard + custom endpoints) |
+| `sirius_sigv4_presigned_authorizer` | Hand-rolled SigV4 presigned URL (auth in the query string), empty headers. Default. |
+| `sirius_sigv4_header_authorizer` | Plain URL plus signed `Authorization` / `x-amz-*` headers; supports STS session tokens via `X-Amz-Security-Token`. For gateways that prefer header auth. |
 
-The path from SQL to S3 reads:
+Both share `sirius_sigv4_authorizer_base` (SigV4 over `static_credentials`, no `aws-sdk-cpp`). Downstream projects can ship their own authorizer (IMDS/STS chain, SSO, broker-issued URLs) — the seam is a single `authorize()` call, so implementations without raw key material compose cleanly.
 
-```sql
-SELECT * FROM read_parquet('s3://bucket/key.parquet')
-```
-
-1. Pipeline converter detects `s3://` prefix in bind data paths; sets scan_info to a `parquet_scan_info` with the S3 paths.
-2. `sirius_scan_manager::prepare_for_query` calls `scan_info::make_provider()` which builds a `parquet_split_provider` backed by an `s3_ioctx`.
-3. The scan manager selects the per-GPU `s3_ioctx` via `gpu_ioctxs` map (injected at initialization from `SiriusContext`).
-4. `parquet_split_provider` fetches parquet footers via the `s3_ioctx`, then produces `parquet_scan_data` splits served from S3 range GETs.
-5. Each split's `cudf::io::read_parquet` call uses a `sirius_datasource` backed by `s3_ioctx`, routing every read through libcurl.
-
-`s3_ioctx_config` controls authentication, connection limits, per-call timeout, retry count and backoff, and optional host-memory staging (FSMR-backed bounded staging buffer for device reads).
+**Configuration.** `object_store_config` (file-settable) carries the endpoint, region, credentials, optional STS session token, signing mode (`presigned` / `header`), and TLS settings (CA bundle, verify). The REST factory (`make_rest_ioctx_factory`) builds the authorizer from it and returns a null ioctx when the store is not configured (empty endpoint / credentials / region). The reactor's own tunables live in `rest::config`: per-request timeout, max concurrent connections per reactor, target bytes per ranged GET (`chunk_size`), how a contiguous host read is split into parallel GETs (`max_read_split`), idle-connection keepalive (`upkeep_interval` / `conn_max_age`), and the retry policy (general 5xx/curl retries plus a small bounded retry for HTTP 403, since an expired presigned URL re-authorizes on retry).
 
 ### Cache Seam
 
-`sirius_ioctx::device_read{,_async}` is non-virtual: it consults `_cache` and falls through to pure-virtual `device_read_io{,_async}`. Backends never see the cache; the cache never sees the backend. `supports_device_read()` stays `true` even when the cache serves the read because the final copy is still `cudaMemcpyAsync` from pinned host memory to device.
+The prefetching cache is owned by `sirius_ioctx` and is invisible to both the backend and the datasource. `sirius_datasource`'s reads forward to the ioctx; when an armed cache is present the ioctx consults it before falling through to the backend `*_io` virtuals. Backends never see the cache; the cache reaches the backend only through the protected vector-read primitive (`host_read_ranges_async_io`), for which it is friended.
+
+A cache is attached only when the backend can benefit from it — `can_use_prefetching_cache()` is true iff the backend supports vectored host reads or bounce-staged host-to-device reads. The cache constructs itself *armed* or *unarmed* from that capability; the ioctx is unaware of the distinction and simply forwards through `cache()`.
+
+The cache does two things beyond classic prefetch:
+
+- **Partial reads.** A `device_read` over a range whose chunks are only partially cached copies the cached chunks straight to device and completes the rest from the backend in the same call, instead of treating a partial overlap as a miss.
+- **Populate-on-read.** On a backend that supports bounce-staged host-to-device reads, an uncached chunk being read for the device is loaded into a cache buffer (file → cache chunk → device) and published to the cache, so the next read of the same chunk is a hit — caching as a side effect of reading, like an OS page cache. A heavily-partial boundary chunk whose over-read would exceed ~25% of the chunk is instead read through an internal bounce slot and left uncached (zero over-read).
+
+Separately from the prefetching cache, the ioctx always exposes a `metadata_store` so parsed file metadata (e.g. a parquet footer) survives across scans of the same path regardless of whether prefetching is wired up.
+
+**fadvise protocol.** `sirius_datasource::fadvise(ranges, dev_id)` is the single entry point for inserting prefetch work: a `speculative`/`immediate` call (honored only when it matches the ioctx's `preferred_prefetching_stage`) hands the ranges to the cache and stashes the returned `prefetching_handle`; a `disposable` call at consume time cancels any still-pending work via that handle.
 
 ### Cache Internals
 
-- **Packed atomic state machine.** `entry_state` encodes a 4-bit state enum and a 28-bit pin count in a single `atomic<uint32_t>`. Every transition is one CAS, closing the TOCTOU gap between "is this entry readable?" and "bump the pin count." Readers park in `wait_while_loading()` via `atomic::wait` and are woken by `notify_all()` on completion.
-- **Request aggregation via `request_context`.** One logical read fans out into N chunk sub-requests; each sub-request decrements `pending`; the last one fires the user's completion handler. Error reporting is single-writer (`failed.exchange`) so partial failures don't race.
-- **Batch dispatch, amortized wakes.** `templated_ioctx::enqueue_device_read` groups chunks per-reactor with a rotating round-robin start and dispatches one `enqueue_bulk` per non-empty group, collapsing N wake-notifies to at most M (reactor count).
-- **Multi-GPU safe.** `device_read_req` carries the caller's `device_id`; reactor threads `cudaSetDevice()` before issuing the H2D copy. Bounce slabs are `cudaHostAllocPortable` so they're reachable from any CUDA context.
-- **Evictor as backpressure service.** When `buffer_pool.allocate_bulk` can't satisfy the worker, the worker posts an `eviction_request` (promise + chunk count) and blocks on the future. The evictor walks LRU buckets coldest-first, returns chunks to the pool, then resolves the promise. Pool exhaustion is never a silent failure.
-- **Tiered LRU with age drift.** Five buckets; `refresh_cache()` is the caller's input to the aging signal. Score is `(NUM_BUCKETS-1) + n_total_request − cache_age`, clamped. Never-consumed entries get a floor of 1 to avoid being first out; raw score `< -5` is evicted on the spot during candidate drain.
-- **Admission control deadlock escape.** A request larger than the total budget is granted the full budget when no other slots are outstanding, so oversized reads make progress instead of waiting forever.
+- **Chunked, pinned buffer pool.** The cache caches fixed-size *chunks* of pinned host memory drawn from a `buffer_pool`, which allocates per-NUMA arenas from `fixed_size_host_memory_resource`s. The chunk size is the resource's block size (not a compile-time constant). Staging buffers for a prefetch are placed on the NUMA node closest to the target GPU, derived from the shared `topology_index`.
+- **Packed atomic state machine.** Each `cached_chunk` carries an `entry_state` that packs a 4-bit state (`empty`/`queued`/`allocated`/`loading`/`cached`/`in_use`/`evicting`) and a reader pin count into one `atomic<uint32_t>`. Every transition is a single CAS, closing the TOCTOU gap between 'is this chunk readable?' and 'bump the pin count.' Readers that observe `loading` park on `wait_while_pending()` (`atomic::wait`) and are woken when the load settles.
+- **Request fan-in.** A `prefetch_request_context` tracks the chunks for one logical request; the shared `request_manager` (`io/io_request.hpp`) decrements per-chunk pending counts and fulfills one `semi_future` when the last chunk completes, reporting the first error single-writer so partial failures don't race.
+- **Background threads.** A preparation thread, a prefetch thread, and an evictor thread (each a `std::jthread` driven by a blocking queue) handle queued inserts, IO dispatch, and reclamation. IO completion callbacks run on a small dedicated dispatcher pool.
+- **Admission control.** In-flight prefetch IO is bounded by an `exec::admission_control` budget sized in chunks (`cache::config::inflight_io_chunk_budget`). An oversized request is granted the full budget when nothing else is outstanding, so it makes progress instead of waiting forever.
+- **Evictor as backpressure.** When the buffer pool can't satisfy a load, the worker posts an eviction request and blocks until the evictor returns enough chunks; pool exhaustion is never a silent failure. Eviction walks LRU candidates using a per-chunk `chunk_lifecycle` score (query-tick aging plus insert/consume counts), so never-consumed entries are not evicted first.
+- **Multi-GPU safe.** Device reads carry the caller's device id; the reactor sets the device before the H2D copy, and pinned chunks are portable across CUDA contexts.
 
-### Constants (in `io/types.hpp`)
+### Constants
 
-| Name | Value | Role |
-|------|-------|------|
-| `CHUNK_SIZE` | 1 MiB | Bounce-buffer / cache chunk size |
-| `NUM_CHUNKS` | 32 | Bounce slots per reactor |
-| `IO_BLOCK_SIZE` | 4096 | `O_DIRECT` alignment |
-| `CHUNKS_PER_SLAB` | 500 | Pinned chunks per `buffer_pool` slab |
-
-## Row Group Pruning
-
-When filter pushdown is enabled and the `gpu_expression_translator` successfully converts DuckDB `TableFilterSet` filters into a cuDF AST, two optimizations activate:
-
-1. **Row group statistics pruning:** `parquet_split_provider::run_batch` calls `filter_row_groups_with_stats()` on each fetched footer; row groups whose Parquet column min/max statistics cannot match the filter are dropped before any read is scheduled. Pure hive-partition filters are dropped during plan construction since hive columns aren't in the parquet file.
-
-2. **Reader-level filter pushdown:** The cuDF AST is set on `parquet_reader_options` via `set_filter()`, so cuDF applies the filter inside `read_parquet`. The `TABLE_SCAN` operator is set to passthrough (`passthrough = true`) since filtering is already done by the reader.
-
-If AST translation fails (e.g., unsupported expression types), `GPU_PARQUET_SCAN`'s `execute()` runs the cached DuckDB filter expression through `gpu_expression_executor` on the decoded batch.
-
-**Filter translation path:** `TableFilterSet` → `convert_table_filters_to_expression()` (skips `OPTIONAL_FILTER`, `IS_NOT_NULL`, and partition-column filters) → `gpu_expression_translator` → cuDF AST tree.
-
-## Batch Coalescing
-
-When many small files each produce a tiny GPU batch, per-task scheduling and kernel-launch overhead dominates. Two mechanisms address this depending on the scan path:
-
-1. **Multifile bundling in `parquet_split_provider`** (GPU_PARQUET_SCAN): a single split may bundle row-group slices from multiple parquet files when those files share the same hive-partition values, up to `approximate_batch_size` uncompressed bytes. The downstream `cudf::io::read_parquet` call reads the bundled slices in one invocation.
-
-2. **Post-read coalescing in `sirius_physical_table_scan`** (DUCKDB_SCAN): `get_next_task_input_data()` pops batches in a loop until `accumulated_bytes >= scan_task_batch_size` OR `batch_count >= 32`, returning a `pipelineable_operator_data` wrapping the accumulated batches. `execute()` then calls `cudf::concatenate()` before filtering/projecting.
-
-When the GPU parquet scan applies filter+projection via the cuDF reader (passthrough mode), `TABLE_SCAN` skips concatenation — only the DuckDB-source code path goes through post-read coalescing.
-
-## Iceberg Scan
-
-**File:** `src/include/op/sirius_physical_iceberg_scan.hpp`, `src/op/scan/iceberg_scan_task.cpp`
-
-`sirius_physical_iceberg_scan` inherits from `sirius_physical_parquet_scan` and adds support for Iceberg V1, V2, and V3 tables.
-
-### Supported Iceberg Features
-
-| Version | Feature | Implementation |
-|---------|---------|---------------|
-| V1 | Append-only (no deletes) | Identical to plain parquet scan |
-| V2 | Positional deletes | `positional_delete_filter`: binary-searches sorted row positions, builds boolean mask, applies `cudf::apply_boolean_mask` |
-| V2 | Equality deletes (heterogeneous) | A `vector<EqualityDeleteGroup>` carries one `cudf::distinct_hash_join` per distinct key schema; each group is sequence-scoped so it only applies to data files written before its sequence number |
-| V3 | Deletion vectors | Read from PUFFIN files via `puffin_reader`; the resulting bitmap drives the same boolean-mask filter as positional deletes |
-| V2/V3 | Schema evolution | Per-file projection detects which columns are present in each parquet file; missing columns are injected as typed NULL columns post-read |
-| V2/V3 | Snapshot time-travel | `snapshot_from_id` is forwarded to DuckDB's `iceberg_metadata()` so the manifest matches the requested snapshot |
-| V2/V3 | Partition evolution | Per-file inject function decides whether each column comes from parquet data, from the file path (hive-style), or is NULL — handles tables whose partition scheme changed across snapshots |
-
-### Architecture
-
-- `iceberg_scan_task_global_state` inherits from `parquet_scan_task_global_state`. Its `build_delete_pipeline()` reads delete files (manifest discovery delegates to DuckDB's `iceberg_metadata()`; the custom Avro reader in `iceberg_avro_reader.cpp` is the fallback for V3 deletion-vector PUFFIN files) and installs a composed `iceberg_delete_pipeline` as a `post_convert_fn_t` hook.
-- The `post_convert_fn_t` hook fires after each row-group batch is decompressed to a `cudf::table`, applying all delete filters in-place with zero `cudaMemcpy D2H` in the hot path.
-- Equality-delete key columns not in the user's projection are force-projected at read time, then stripped via zero-copy `release()` + truncate after all filters run, so downstream operators see only the requested columns.
-- Equality deletes apply only to data files whose sequence number is less than the delete group's, mirroring Iceberg's snapshot semantics.
+| Name | Location | Role |
+|------|----------|------|
+| `IO_BLOCK_SIZE` (4096) | `io/types.hpp` | `O_DIRECT` alignment for local-disk reads. |
+| chunk size | `buffer_pool::chunk_size()` (FSMR block size) | Cache / bounce chunk granularity; sourced from the pinned `fixed_size_host_memory_resource`'s block size rather than a compile-time constant. |
+| `inflight_io_chunk_budget` (2048) | `io/cache/config.hpp` | In-flight prefetch IO budget, in chunks, enforced by `admission_control`. |
+| `eviction_threshold_fraction` / `min_prefetching_budget_fraction` | `io/cache/config.hpp` | When the pool starts evicting and the floor reserved for prefetching. |
+| `bounce_size` / `max_n_chunks` / `use_odirect` | `io/uring/config.hpp` | Per-reactor uring tunables: bounce-slot size, max contiguous segments fused into one `readv`, and the buffered-vs-`O_DIRECT` toggle. |
+| `chunk_size` / `max_read_split` / `max_connections` / retry policy | `io/rest/config.hpp` | Per-reactor REST tunables (see [S3 / Object-Store Backend](#s3--object-store-backend)). |
 
 ## Complete Scan Flow
 
 ```mermaid
 graph TD
-    TS[sirius_physical_table_scan] -->|"convert"| GPS[GPU_PARQUET_SCAN]
-    TS -->|"or"| DS[DUCKDB_SCAN]
-    TS -->|"or"| IS[ICEBERG_SCAN]
+    CONV[pipeline converter] -->|make_ingestible| ING["gpu_ingestible<br/>(parquet / duckdb-native)"]
+    ING -->|carried by| OP[sirius_gpu_scan_operator GPU_SCAN]
 
-    SM[sirius_scan_manager] -->|"build provider"| PSP[parquet_split_provider]
-    SM -->|"on pinned-table hit"| CSP[cached_split_provider]
+    SM[sirius_scan_manager.prepare_for_query] -->|cache miss| SP["split_provider<br/>(composes ingestible)"]
+    SM -->|pinned-cache hit| DBP[cached_databatch_provider]
 
-    PSP -->|"push split"| SC["split_connector<br/>(per operator)"]
-    CSP -->|"push split"| SC
-    SC -->|"get_next_split()"| GPS
+    SP -->|one task per file/range| DISP[dispatcher thread pool]
+    DISP -->|metadata scan_info| SEQ[load_balancing_scan_batch_coalescer]
+    DBP -->|resident batches| SEQ
 
-    DS -->|"task_creator.schedule()"| TC[task_creator]
-    IS -->|"task_creator.schedule()"| TC
-    GPS -->|"task_creator.schedule()"| TC
+    SEQ -->|coalesce + balance + prefetch| SC["split_connector<br/>(per operator)"]
+    SC -->|get_next_split| OP
 
-    TC -->|"create task"| DST[duckdb_scan_task]
-    TC -->|"create task"| GPT["gpu_pipeline_task<br/>(reads parquet_scan_data)"]
-    TC -->|"create task"| IST["iceberg_scan_task<br/>(parquet + delete filters)"]
-
-    DST -->|"dispatch"| SE[duckdb_scan_executor]
-    IST -->|"dispatch"| SE
-
-    SE -->|"execute on worker"| DST2[DuckDB table function → column builders → host_data_representation]
-    SE -->|"execute on worker"| IST2["Parquet reads → GPU delete filters → host_parquet_representation"]
-    GPT -->|"execute on GPU executor"| GPS2["cudf::io::read_parquet → scan_plan assembly → gpu_table_representation"]
-
-    DST2 -->|"publish"| DR[data_repository]
-    IST2 -->|"publish"| DR
-    GPS2 -->|"to next operator"| DR
-
-    DR -->|"consumed by"| GPT2[gpu_pipeline_task]
+    OP -->|get_next_task_input_data| TC[task_creator]
+    TC -->|preferred_device_id| GPT[gpu_pipeline_task]
+    GPT -->|execute| EX["materialize_table -> post_filter_and_project<br/>-> data_batch"]
+    EX -->|pipelineable_operator_data| NEXT[downstream pipeline]
 ```
+
+The converter builds a `gpu_ingestible` and parks it on the `GPU_SCAN` operator. At query prep the scan manager either serves the operator from a pinned cache (`cached_databatch_provider`) or builds a `split_provider` over the ingestible. The provider dispatches one metadata task per file (parquet) or row-group range (duckdb-native); the per-query sequencer coalesces, balances, and prefetches each batch, then pushes splits onto the operator's connector. The task creator turns each pulled split into a `gpu_pipeline_task` on the split's preferred GPU; `execute()` materializes, optionally post-filters/projects, and emits a `data_batch` to the downstream pipeline.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/op/scan/duckdb_scan_task.cpp` | DuckDB scan implementation |
-| `src/include/op/scan/duckdb_scan_task.hpp` | DuckDB scan task, column builders |
-| `src/op/scan/parquet_scan_task.cpp` | Legacy parquet scan implementation |
-| `src/include/op/scan/parquet_scan_task.hpp` | Legacy parquet scan task, row group partitioning |
-| `src/op/scan/duckdb_scan_executor.cpp` | Scan executor manager loop |
-| `src/include/op/scan/duckdb_scan_executor.hpp` | Scan executor interface |
-| `src/op/scan/prefetched_data_source.cpp` | Legacy cached datasource for cuDF |
-| `src/include/op/scan/prefetched_data_source.hpp` | Legacy cached datasource interface |
-| `src/op/scan/cached_ranges.cpp` | Byte range coalescing and lookup |
-| `src/include/op/scan/cached_ranges.hpp` | Cache range structure |
-| `src/include/op/scan/config.hpp` | Scan config, cache_level enum |
-| `src/include/op/scan/sirius_gpu_parquet_scan_operator.hpp` | GPU parquet scan source operator |
-| `src/include/op/scan/sirius_gpu_duckdb_native_scan_operator.hpp` | GPU DuckDB-native scan source operator |
-| `src/include/op/scan/scan_info.hpp` | Polymorphic base for per-format scan bind data |
-| `src/include/op/scan/parquet_scan_info.hpp` | Parquet-specific scan bind data (concrete `scan_info`) |
-| `src/include/op/scan/duckdb_native_scan_info.hpp` | DuckDB-format-specific scan bind data (concrete `scan_info`) |
-| `src/include/op/scan/duckdb_native_metadata.hpp` | DuckDB row-group segment metadata walker |
-| `src/include/op/scan/duckdb_native_decoder.hpp` | DuckDB format GPU decode kernels |
-| `src/include/op/scan/parquet_scan_operator_data.hpp` | `parquet_scan_data` split type emitted by providers |
-| `src/include/op/scan/scan_plan.hpp` | Index-space mapping (P/C/D), output layout, partition injection |
-| `src/include/op/scan/parquet_schema_mapping.hpp` | Name-based DuckDB→parquet column resolution |
-| `src/include/scan_manager/sirius_scan_manager.hpp` | Scan manager: thread pool, providers, pinned-table registry |
-| `src/include/scan_manager/split_provider.hpp` | Abstract split producer |
-| `src/include/scan_manager/parquet_split_provider.hpp` | Parquet metadata-driven split provider |
-| `src/include/scan_manager/duckdb_native_split_provider.hpp` | DuckDB-native metadata-driven split provider |
-| `src/include/scan_manager/cached_split_provider.hpp` | Pinned-column split provider |
-| `src/include/scan_manager/split_connector.hpp` | Blocking queue between provider and operator |
-| `src/include/io/s3/s3_ioctx.hpp` | S3 ioctx: libcurl HTTP Range GET backend |
-| `src/include/io/s3/s3_request_authorizer.hpp` | Authentication abstraction (SigV4 presigned / header-signing) |
-| `src/include/io/s3/s3_io_object.hpp` | S3 io_object with bucket/key/size metadata |
-| `src/include/pin_table.hpp` / `src/pin_table.cpp` | `pin_table` / `unpin_table` table-function bindings |
-| `src/include/op/sirius_physical_iceberg_scan.hpp` | Iceberg scan operator |
-| `src/include/op/scan/iceberg_scan_task.hpp` | Iceberg scan task with delete filters |
-| `src/include/op/scan/iceberg_metadata_reader.hpp` | Iceberg manifest reader (DuckDB `iceberg_metadata()` + Avro fallback) |
-| `src/include/op/scan/puffin_reader.hpp` | V3 deletion-vector PUFFIN reader |
+| `src/include/op/scan/sirius_gpu_scan_operator.hpp` / `src/op/scan/sirius_gpu_scan_operator.cpp` | Unified `GPU_SCAN` source operator |
+| `src/include/op/scan/sirius_gpu_scan_operator_data.hpp` | `scan_operator_input` (fresh-read or resident-batch split) |
+| `src/include/op/scan/gpu_ingestible.hpp` / `src/op/scan/gpu_ingestible.cpp` | `gpu_ingestible` abstraction + `materialize_table` dispatch |
+| `src/include/op/scan/gpu_ingestible_types.hpp` | `ingestible_table_info`, `scan_info`, `filtered_table` / `filter_state` |
+| `src/include/op/scan/parquet_gpu_ingestible.hpp` / `src/op/scan/parquet_gpu_ingestible.cpp` | Parquet ingestible + `parquet_batch_coalescer` + `make_ingestible` |
+| `src/op/scan/duckdb_native_gpu_ingestible.cpp` / `src/include/op/scan/duckdb_native_gpu_ingestible.hpp` | DuckDB-native ingestible + `duckdb_native_batch_coalescer` |
+| `src/include/op/scan/batch_coalescer.hpp` | Coalescer interface |
+| `src/include/op/scan/owning_table_view.hpp` | View-or-table handle with no-alloc reorder/drop/select |
+| `src/include/op/scan/scan_plan.hpp` / `src/op/scan/scan_plan.cpp` | Index-space mapping (P/C/D), output layout, partition injection |
+| `src/include/op/scan/parquet_schema_mapping.hpp` | Name-based DuckDB->parquet column resolution |
+| `src/include/op/scan/row_group_metadata.hpp` | `row_group_slice` + `hybrid_scan_reader` |
+| `src/include/op/scan/duckdb_native_metadata.hpp` / `duckdb_native_decoder.hpp` | DuckDB-native row-group walk + GPU decode |
+| `src/include/scan_manager/sirius_scan_manager.hpp` / `.cpp` | Scan manager, `cache_entry_info`, `pinned_entry` |
+| `src/include/scan_manager/split_provider.hpp` / `.cpp` | Concrete provider composing a `gpu_ingestible` |
+| `src/include/scan_manager/split_connector.hpp` / `.cpp` | Blocking queue between sequencer and operator |
+| `src/include/scan_manager/load_balancing_scan_batch_coalescer.hpp` / `.cpp` | Per-query sequencer: coalesce + balance + prefetch + push |
+| `src/include/scan_manager/balancing_strategy.hpp` | Device-placement policy interface |
+| `src/include/scan_manager/round_robin_strategy.hpp` / `.cpp` | Round-robin GPU placement |
+| `src/include/scan_manager/config.hpp` | `scan_manager_config` |
+| `src/include/pin_table.hpp` / `src/pin_table.cpp` | `pin_table` / `unpin_table` + pin materialization |
+| `src/include/op/scan/cached_ranges.hpp` / `src/op/scan/cached_ranges.cpp` | Sorted byte-range coalescing/lookup |
+| `src/include/op/scan/cpu_source_task.hpp` / `src/op/scan/cpu_source_task.cpp` | CPU-source scan task (ColumnDataCollection / empty / dummy) |
 | `src/op/scan/scan_utils.cpp` | Row group pruning, filter expression conversion |
-| `src/include/data/cached_data_representation.hpp` | Cached data wrappers |

--- a/docs/super-sirius/task-creator.md
+++ b/docs/super-sirius/task-creator.md
@@ -21,9 +21,9 @@ get_operator_for_next_task(operator) — follows hint chain
     ↓
 operator->get_next_task_hint() → READY or WAITING_FOR_INPUT_DATA
     ↓
-Create task (duckdb_scan_task, parquet_scan_task, or gpu_pipeline_task)
+Create task (gpu_pipeline_task)
     ↓
-Dispatch to executor (scan_executor or task_scheduler)
+Dispatch to executor (task_scheduler)
 ```
 
 ## Global State Maps
@@ -32,9 +32,7 @@ Initialized during `prepare_for_query()`, cleared during `reset()`:
 
 | Map | Key | Value | Purpose |
 |-----|-----|-------|---------|
-| `_scan_operator_global_state_map` | operator ID | `duckdb_scan_task_global_state` | DuckDB scan batching state |
-| `_parquet_scan_operator_global_state_map` | operator ID | `parquet_scan_task_global_state` | Parquet metadata, row group partitions (preserved across warm runs) |
-| `_gpu_operator_global_state_map` | operator ID | `gpu_pipeline_task_global_state` | Shared pipeline state |
+| `_gpu_operator_global_state_map` | operator ID | `gpu_pipeline_task_global_state` | Shared per-operator pipeline state |
 
 All map access is protected by `_global_state_mutex`.
 
@@ -196,7 +194,6 @@ Same pattern as MERGE_SORT: drains all batches from one partition per call.
 |----------|------------------------|------------------------------|------------|
 | DUCKDB_SCAN | READY if not exhausted | N/A (task creator handles) | Source, no ports |
 | PARQUET_SCAN | READY if partitions remain | N/A (task creator handles) | Source, no ports |
-| ICEBERG_SCAN | Inherits from PARQUET_SCAN | N/A (task creator handles) | Source, no ports |
 | HASH_JOIN (BUILD_PROBE) | Build state machine | Build+probe or probe only | Build/probe asymmetry |
 | HASH_JOIN (STANDARD) | Base class | Cartesian product walk | Multi-partition iteration |
 | PARTITION | Delegates to build sibling | Mutex-locked count determination | Sibling coordination |
@@ -222,27 +219,36 @@ while running:
     3. node = get_operator_for_next_task(request.node)  -- follow hint chain
     4. if node is nullptr: continue
 
-    5. Schedule work on thread pool:
-       For DUCKDB_SCAN:
-           - Create one duckdb_scan_task
-           - pipeline.mark_task_created()
-           - Dispatch to scan executor
-
-       For PARQUET_SCAN:
-           - Loop: acquire next row group partition
-           - Create one parquet_scan_task per partition
-           - pipeline.mark_task_created() for each
-           - Dispatch to scan executor
-
-       For GPU operators:
+    5. Schedule work on the thread pool. Every source — a GPU_SCAN scan or any
+       GPU operator with buffered input — drives the same loop:
            - Loop while (!node.all_ports_empty()):
              - pipeline.mark_task_created()  // BEFORE popping data
-             - data = node.get_next_task_input_data()
-             - If data: create gpu_pipeline_task, dispatch to task_scheduler
+             - data = node.get_next_task_input_data()  // a GPU_SCAN blocks on its split_connector
+             - If data: create a gpu_pipeline_task, dispatch to task_scheduler
              - If no data: pipeline.mark_task_completed()
 ```
 
 The `mark_task_created()` call before data popping prevents a race condition where the pipeline could appear finished between data check and task creation.
+
+## Device Assignment for GPU Tasks
+
+**File:** `src/creator/task_creator.cpp`
+
+When the manager loop builds a `gpu_pipeline_task`, it also chooses the task's `preferred_device_id` (which GPU executor the scheduler should route it to). The choice is resolved in priority order: an upstream scan split's stamped device, then a **partition device pin**, then data-locality by input bytes, then NUMA-affinity. The full locality math lives in [`multi-gpu-architecture.md`](multi-gpu-architecture.md); the partition pin is described here because it is owned by the task creator and is a correctness requirement.
+
+### Partition device pin
+
+Partitioned operators — BUILD_PROBE hash join, `grouped_aggregate_merge`, and the other partition-keyed operators above — build a per-partition cuco hash table that is valid only on the GPU it was built on. Touching it from a stream bound to another device trips `cudaErrorInvalidValue`. So when a task's input is a `partitioned_operator_data`, the task creator pins it to a fixed device:
+
+```
+preferred_device_id = _active_gpu_ids[ partition_idx % _active_gpu_ids.size() ]
+```
+
+This keeps every task of a given partition (build + all probes) on one GPU while spreading partitions across GPUs.
+
+`_active_gpu_ids` is built once in the `task_creator` constructor from the memory manager's `Tier::GPU` memory spaces — i.e. the device ids that actually have a GPU executor, which is the same set `task_scheduler` keys executors on. The pin indexes this active set rather than the physical hardware topology: when the configured GPU count is smaller than the physical count, a physical-topology modulo could name a device with no executor, which the scheduler treats as "no preference" and round-robins — scattering a partition across GPUs.
+
+The pin is reapplied on the OOM-reschedule path (`gpu_pipeline_executor`): when a task is rebuilt with a fresh local state, its per-task `preferred_device_id` is carried forward so a rescheduled probe doesn't lose its pin and scatter.
 
 ## `can_create_more_tasks()` and `has_processed_all_tasks()`
 


### PR DESCRIPTION
Brings the Super Sirius reference docs (`docs/super-sirius/`) up to the current design, from the stale last-updated marker (`46e7cb06`, #873 — 97 commits back) to HEAD `84543810a` (#997, "updated IO framework"). This is a gap-fill against the current docs, not a blanket re-document.

## Highlights

- **scan.md** (major rewrite): unified `sirius_gpu_scan_operator` (`GPU_SCAN`) + per-format `gpu_ingestible` (parquet / DuckDB-native), scan manager (`split_provider` + `load_balancing_scan_batch_coalescer` + round-robin device placement), pinned tables (2 formats × 2 tiers), `owning_table_view`, DuckDB-native decode + two-phase metadata walk, dual-path row-group pruning, and the new `io/` reactor layer (io_uring / REST-S3 / kvikio + `io/cache` prefetching cache). Removed sections describing deleted components (scan tasks, scan executor, `cache_level`, prefetched data source).
- **configuration.md**: new `executor.scan_manager` schema (IO reactors, prefetch cache, `object_store` credentials + nested `local`/`rest`/`cache`), refreshed example config, updated `operator_params` and SET variables; dropped the removed `duckdb_scan` executor / `scan_cache_level`.
- **optimizations.md**: added entries for adaptive MARK build side, projection folding, DuckDB-native metadata walk + async coalesced reads, async S3/REST backend, byte-based sort-sample merge, pinned/cached zero-copy, partial-read prefetching cache, and load-balanced scan coalescing; corrected relocated code paths; dropped two fully-superseded entries.
- **operators / expression-executor / physical-plan-generation / architecture-overview / execution-flow / memory-management / pipeline-execution / multi-gpu-architecture / task-creator / dynamic-filters**: aligned with the current design.
- Bumped the docs `last-updated-commit` marker to `84543810a`.

## Note: Iceberg GPU scan removed from docs

Iceberg GPU-scan coverage was **removed** because the read/task path is not currently wired into the build: `src/op/scan/iceberg_scan_task.cpp` is excluded from `CMakeLists.txt` and still includes the deleted `parquet_scan_task.hpp`; there is no iceberg `gpu_ingestible` and no `task_creator` branch. The iceberg operator and delete-filter machinery are still compiled, but the GPU read path is mid-migration onto the unified `gpu_ingestible` framework. Worth tracking separately.

## Verification

- Docs-only change (no source edits).
- `pre-commit` (trailing-whitespace, end-of-file, mixed-line-ending, smartquotes, codespell) passes.
- No remaining references to removed symbols (`parquet_split_provider`, `prefetched_data_source`, `duckdb_scan_executor`, `s3_ioctx`, `cache_level`, `GPU_PARQUET_SCAN`, `GPU_DUCKDB_NATIVE_SCAN`, …) or Iceberg across the docs; scan.md intra-doc anchor links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
