### PR TITLE
build: drop obsolete CMake/vcpkg workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,18 +81,7 @@ pkg_check_modules(NUMA REQUIRED IMPORTED_TARGET numa)
 pkg_check_modules(LIBURING REQUIRED IMPORTED_TARGET liburing)
 pkg_check_modules(CURL REQUIRED IMPORTED_TARGET libcurl)
 
-# cuCascade - GPU Memory Reservation Library (submodule) cucascade links `numa`
-# as a bare library name (-lnuma). In the vcpkg build the static libnuma.a lives
-# in the vcpkg installed lib dir, which isn't on the default linker search path.
-# Create an imported target so CMake resolves the bare name to the full path
-# instead of emitting -lnuma.
-if(VCPKG_BUILD)
-  add_library(numa STATIC IMPORTED)
-  set_target_properties(
-    numa
-    PROPERTIES IMPORTED_LOCATION
-               "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libnuma.a")
-endif()
+# cuCascade - GPU Memory Reservation Library (submodule)
 set(BUILD_TESTS
     OFF
     CACHE BOOL "" FORCE)
@@ -393,14 +382,8 @@ foreach(_target sirius_extension sirius_loadable_extension)
 endforeach()
 
 # Additional libraries only needed by the static extension
-target_link_libraries(
-  sirius_extension
-  PkgConfig::NUMA
-  PkgConfig::LIBURING
-  PkgConfig::CURL
-  OpenSSL::Crypto
-  yaml-cpp::yaml-cpp
-  absl::any_invocable)
+target_link_libraries(sirius_extension PkgConfig::NUMA PkgConfig::LIBURING
+                      PkgConfig::CURL OpenSSL::Crypto absl::any_invocable)
 
 target_link_libraries(sirius_loadable_extension PkgConfig::LIBURING
                       PkgConfig::CURL OpenSSL::Crypto)

--- a/vcpkg_ports/cudf/portfile.cmake
+++ b/vcpkg_ports/cudf/portfile.cmake
@@ -112,12 +112,6 @@ vcpkg_replace_string(
   "set(CPM_DOWNLOAD_zstd ON)"
   "# CPM_DOWNLOAD_zstd removed - using CPM_zstd_SOURCE instead")
 
-# Patch dlpack - vcpkg's 0.8 port incorrectly reports version 0.6, so use 0.6
-vcpkg_replace_string(
-  "${SOURCE_PATH}/cpp/cmake/thirdparty/get_dlpack.cmake"
-  "find_and_configure_dlpack(\${CUDF_MIN_VERSION_dlpack})"
-  "find_and_configure_dlpack(\"0.6\")")
-
 # Patch rapids_logger to use vcpkg's spdlog::spdlog target instead of spdlog
 vcpkg_replace_string(
   "${RAPIDS_LOGGER_PATH}/CMakeLists.txt"

--- a/vcpkg_ports/cudf/portfile.cmake
+++ b/vcpkg_ports/cudf/portfile.cmake
@@ -89,22 +89,6 @@ vcpkg_from_github(
   HEAD_REF
   dev)
 
-# GTest: cudf builds test utilities even with BUILD_TESTS=OFF. CPM can't
-# download due to FETCHCONTENT_FULLY_DISCONNECTED=ON. We provide source here and
-# use -isystem (not -I) for vcpkg includes below to avoid header version
-# conflicts with vcpkg's gtest 1.17.0.
-vcpkg_from_github(
-  OUT_SOURCE_PATH
-  GTEST_PATH
-  REPO
-  google/googletest
-  REF
-  v1.16.0
-  SHA512
-  bec8dad2a5abbea8e9e5f0ceedd8c9dbdb8939e9f74785476b0948f21f5db5901018157e78387e106c6717326558d6642fc0e39379c62af57bf1205a9df8a18b
-  HEAD_REF
-  main)
-
 # Patch get_zstd.cmake to remove forced download - we provide zstd source via
 # CPM variable
 vcpkg_replace_string(
@@ -126,10 +110,9 @@ vcpkg_replace_string(
   "set_target_properties(nanoarrow_static PROPERTIES POSITION_INDEPENDENT_CODE ON)"
   "# set_target_properties disabled for vcpkg ALIAS target")
 
-# Use -I for vcpkg include dir to ensure vcpkg CCCL 3.3.0 headers beat pixi's
-# older CCCL. GTest is excluded from vcpkg deps (see vcpkg.json) to avoid header
-# conflicts with the CPM-provided GTest source that cudf needs for test
-# utilities.
+# Use -I for vcpkg include dir to ensure vcpkg CCCL headers beat pixi's older
+# CCCL. CUDF_BUILD_TESTUTIL=OFF disables the test-utility targets (the only
+# thing that pulls GTest), so no GTest source needs to be provided.
 vcpkg_cmake_configure(
   SOURCE_PATH
   "${SOURCE_PATH}/cpp"
@@ -140,11 +123,11 @@ vcpkg_cmake_configure(
   -DCPM_bs_thread_pool_SOURCE=${BS_THREAD_POOL_PATH}
   -DCPM_zstd_SOURCE=${ZSTD_PATH}
   -DCPM_cuco_SOURCE=${CUCO_PATH}
-  -DCPM_GTest_SOURCE=${GTEST_PATH}
   -DCMAKE_CUDA_ARCHITECTURES=RAPIDS
   -DBUILD_SHARED_LIBS=OFF
   -DCUDA_STATIC_RUNTIME=ON
   -DBUILD_TESTS=OFF
+  -DCUDF_BUILD_TESTUTIL=OFF
   -DBUILD_BENCHMARKS=OFF
   -DCUDF_KVIKIO_REMOTE_IO=OFF
   "-DCMAKE_CXX_FLAGS=-I${CURRENT_INSTALLED_DIR}/include -Wno-error=sign-compare -Wno-error=parentheses"

--- a/vcpkg_ports/cudf/vcpkg.json
+++ b/vcpkg_ports/cudf/vcpkg.json
@@ -9,7 +9,6 @@
       "host": true,
       "name": "vcpkg-cmake-config"
     },
-    "arrow",
     "cccl",
     "dlpack",
     "flatbuffers",

--- a/vcpkg_ports/nvtx3/portfile.cmake
+++ b/vcpkg_ports/nvtx3/portfile.cmake
@@ -10,58 +10,24 @@ vcpkg_from_github(
   HEAD_REF
   release-v3)
 
-# nvtx3 is header-only, just install the headers
-file(
-  INSTALL "${SOURCE_PATH}/c/include/"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-  FILES_MATCHING
-  PATTERN "*.h")
-file(
-  INSTALL "${SOURCE_PATH}/c/include/"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-  FILES_MATCHING
-  PATTERN "*.hpp")
+# nvtx3 is header-only; drive its own install rules (NVTX3_INSTALL) so the
+# exported nvtx3::nvtx3-c / nvtx3::nvtx3-cpp targets and the version file come
+# from upstream instead of a hand-written config.
+#
+# NVTX defines the targets' $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+# include dir before including GNUInstallDirs, and vcpkg does not predefine
+# CMAKE_INSTALL_INCLUDEDIR, so it must be set here or the exported targets carry
+# no INTERFACE_INCLUDE_DIRECTORIES.
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}/c" OPTIONS -DNVTX3_INSTALL=ON
+                      -DCMAKE_INSTALL_INCLUDEDIR=include)
 
-# Create CMake config files for find_package support
-file(
-  WRITE "${CURRENT_PACKAGES_DIR}/share/nvtx3/nvtx3-config.cmake"
-  [[
-include(CMakeFindDependencyMacro)
+vcpkg_cmake_install()
 
-if(NOT TARGET nvtx3::nvtx3)
-    add_library(nvtx3::nvtx3 INTERFACE IMPORTED)
-    set_target_properties(nvtx3::nvtx3 PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
-    )
-endif()
+vcpkg_cmake_config_fixup(PACKAGE_NAME nvtx3 CONFIG_PATH lib/cmake/nvtx3)
 
-# Create the nvtx3-cpp target that rmm expects
-if(NOT TARGET nvtx3::nvtx3-cpp)
-    add_library(nvtx3::nvtx3-cpp INTERFACE IMPORTED)
-    set_target_properties(nvtx3::nvtx3-cpp PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
-    )
-endif()
-
-# Set version information
-set(nvtx3_VERSION "${VERSION}")
-set(nvtx3_FOUND TRUE)
-]])
-
-# Create version file for find_package version checking
-file(
-  WRITE "${CURRENT_PACKAGES_DIR}/share/nvtx3/nvtx3-config-version.cmake"
-  [[
-set(PACKAGE_VERSION "${VERSION}")
-
-if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
-    set(PACKAGE_VERSION_COMPATIBLE FALSE)
-else()
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-    if(PACKAGE_VERSION VERSION_EQUAL PACKAGE_FIND_VERSION)
-        set(PACKAGE_VERSION_EXACT TRUE)
-    endif()
-endif()
-]])
+# Header-only: config_fixup moves the CMake package to share/, leaving lib/
+# empty.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"
+     "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/vcpkg_ports/nvtx3/vcpkg.json
+++ b/vcpkg_ports/nvtx3/vcpkg.json
@@ -1,5 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "host": true,
+      "name": "vcpkg-cmake"
+    },
+    {
+      "host": true,
+      "name": "vcpkg-cmake-config"
+    }
+  ],
   "license": "Apache-2.0",
   "name": "nvtx3",
   "supports": "linux",

--- a/vcpkg_ports/rmm/portfile.cmake
+++ b/vcpkg_ports/rmm/portfile.cmake
@@ -56,8 +56,7 @@ vcpkg_cmake_configure(
   -DBUILD_BENCHMARKS=OFF
   -DCMAKE_CUDA_ARCHITECTURES=RAPIDS
   -DCMAKE_CUDA_RUNTIME_LIBRARY=Static
-  "-DCMAKE_CXX_FLAGS=-I${CURRENT_INSTALLED_DIR}/include"
-  "-DCMAKE_CUDA_FLAGS=-I${CURRENT_INSTALLED_DIR}/include")
+  -DCMAKE_CXX_FLAGS=-I${CURRENT_INSTALLED_DIR}/include)
 
 vcpkg_cmake_install()
 
@@ -101,16 +100,6 @@ execute_process(
     "${CURRENT_PACKAGES_DIR}/share/rapids_logger/rapids_logger-targets.cmake")
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME rmm CONFIG_PATH lib/cmake/rmm)
-
-# RMM still exports shared CUDA::cudart in its installed target file even when
-# built as a static library. That pulls libcudart.so into the final Sirius
-# loadable extension alongside libcudart_static.a. Rewrite the exported target
-# to prefer the static CUDA runtime for vcpkg consumers.
-file(READ "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake" _rmm_targets)
-string(REGEX REPLACE "CUDA::cudart([;\">])" "CUDA::cudart_static\\1"
-                     _rmm_targets "${_rmm_targets}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/rmm/rmm-targets.cmake"
-     "${_rmm_targets}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")


### PR DESCRIPTION
Removes build workarounds that are no longer needed after dependency bumps (RAPIDS 26.06, cuCascade at the current submodule pointer). Each change was verified with a from-source vcpkg build that relinks and runs the extension on GPU.

- **NUMA shim + duplicate yaml-cpp link** (`CMakeLists.txt`): cuCascade now resolves libnuma via its bundled `FindNuma` (`Numa::Numa`), so the bare `-lnuma` imported-target shim is dead; yaml-cpp was already linked to both extension targets in the shared block.
- **cuDF Arrow dependency + DLPack patch**: cuDF 26.06 moved interop to nanoarrow and no longer `find_package(Arrow)` (drops building Arrow + its subtree); the DLPack patch targeted the old single-arg `find_and_configure_dlpack` call and no longer matched, so it was inert.
- **cuDF GTest fetch**: `CUDF_BUILD_TESTUTIL=OFF` gates out the test utilities that were the only thing pulling GTest.
- **rmm cudart rewrite + CUDA flag**: rmm 26.06 exports `CUDA::cudart_static` directly (rewrite matched nothing); rmm is CXX-only so `-DCMAKE_CUDA_FLAGS` was reported unused.
- **nvtx3 hand-written config**: use upstream install rules (`NVTX3_INSTALL`), which provide the exported targets and a correct version file (the hand-written config emitted an empty version).

Kept (verified still required): the `CUDA::nvml_static`→shared-stub redirect, the conda-CCCL strip + include ordering, static-cudart preference, the hand-written cccl port (upstream install rules break vcpkg's `share/` config layout), and the kvikio cuFile force-disable (still needed for toolkits whose cuFile lacks/omits the batch/stream API, e.g. the cuda12 CI image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)