### PR TITLE
feat(tpch_performance): benchmark DuckDB-native datasets via --data-source

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -90,17 +90,23 @@ Scripts are in `test/tpch_performance/`.
 
 ## Workflow H-A: Generate TPC-H Data
 
+Data generation is owned by the **`/dataset-manager`** skill — the single source of truth for both formats. Prefer delegating to it rather than calling the script directly. It produces:
+
+- **parquet** → `test_datasets/tpch_parquet_sf<SF>/` (a directory; built via `tpchgen-rs`)
+- **duckdb** → `test_datasets/tpch_sf<SF>.duckdb` (a single file; built via DuckDB `dbgen()`), or `tpch_sf<SF>_sorted.duckdb` when generated with `--cluster` (tables physically sorted so native-scan row-group pruning fires on date-filtered queries)
+
+If `/dataset-manager` is unavailable, the underlying script is:
+
 ```bash
 cd test/tpch_performance
-pixi run bash generate_tpch_data.sh <scale_factor> [output_dir] [jobs]
+pixi run bash generate_tpch_data.sh <scale_factor> --format parquet|duckdb [--cluster] [--output <path>]
 ```
 
-- Builds `sirius-db/tpchgen-rs` from source, generates partitioned parquet files to `test_datasets/tpch_parquet_sf<SF>/`.
-- `performance_test.py` only accepts parquet directories (`.duckdb` files are rejected), so generate (or pre-stage) the parquet first.
+`performance_test.py` consumes either source: pass the parquet **directory** with `--data-source parquet` (default) or the `.duckdb` **file** with `--data-source duckdb`.
 
 ## Workflow H-B: Python Performance Test (only supported TPC-H runner)
 
-`performance_test.py` runs the 22 TPC-H queries against a parquet dataset for either or both engines, writes per-query timings/results/logs into a structured benchmark directory, and supports pinning tables into the Sirius cache.
+`performance_test.py` runs the 22 TPC-H queries against a parquet **or** duckdb dataset (`--data-source`) for either or both engines, writes per-query timings/results/logs into a structured benchmark directory, and supports pinning tables into the Sirius cache.
 
 ```bash
 export SIRIUS_CONFIG_FILE=/path/to/config.yaml
@@ -109,9 +115,10 @@ pixi run python test/tpch_performance/performance_test.py \
 ```
 
 **Required:**
-- `--input <path>` — Parquet directory containing TPC-H tables (one `.parquet` file or sub-directory per table).
+- `--input <path>` — the dataset. A **parquet directory** (with `--data-source parquet`, default) or a single **`.duckdb` file** (with `--data-source duckdb`).
 
 **Most-used flags** — the complete reference lives in `test/tpch_performance/CLAUDE.md` and `performance_test.py --help`; consult it rather than re-deriving flags here:
+- `--data-source {parquet,duckdb}` (default `parquet`) — input source/format. `parquet`: `--input` is a parquet directory (`read_parquet` scan). `duckdb`: `--input` is a single `.duckdb` file (GPU-native `seq_scan`). Works in all modes; `--pin` works for both.
 - `--engine {gpu,cpu,both}` (default `both`) — `gpu`/`both` load the Sirius extension; `cpu` does not.
 - `--iterations <N>` (default `1`) and `--queries 1,3,6-10` (default: all 22).
 - `--mode {grouped,sequential,isolated,nsys-profile}` (default `grouped`) — `grouped` is hot-cache; `isolated` is true cold-start (needs the sudo setup below); `nsys-profile` is GPU-only and owned by the `profile-analyzer` skill.
@@ -119,11 +126,11 @@ pixi run python test/tpch_performance/performance_test.py \
 - `--validation` — byte-compare GPU vs CPU results after timing (`abs_tol=1e-10` on floats); requires `--engine both`.
 - `--name <NAME>` — label the output subdir instead of the default `tpch_<ts>_<mode>_<engine>_iter<N>`.
 
-The CLAUDE.md is the source of truth for the rest of the surface (`--config`, `--output`, `--duckdb-profiling`, `--query-timeout`), the per-query pin column lists in `tpch_pin_columns.py`, and the shell-runner-only `--data-source` / `--pinning-mode` paths.
+The CLAUDE.md is the source of truth for the rest of the surface (`--config`, `--output`, `--duckdb-profiling`, `--query-timeout`), the per-query pin column lists in `tpch_pin_columns.py`, and the shell-runner-only `--pinning-mode` path. (Note: `performance_test.py --data-source` is the harness's own 2-value flag, distinct from the legacy shell `benchmark_and_validate.sh --data-source`.)
 
 **Examples:**
 ```bash
-# SF1, hot cache, both engines, 2 iterations
+# SF1, hot cache, both engines, 2 iterations (parquet directory)
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
     --iterations 2 --mode grouped --engine both
@@ -132,7 +139,26 @@ pixi run python test/tpch_performance/performance_test.py \
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf1 \
     --engine both --iterations 1 --validation --queries 1,3,6
+
+# DuckDB source (a .duckdb FILE) from disk, both engines, validate
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_sf1.duckdb --data-source duckdb \
+    --engine both --iterations 1 --validation --queries 1,3,6
+
+# DuckDB source pinned into the GPU cache
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_sf100.duckdb --data-source duckdb \
+    --engine gpu --iterations 3 --pin gpu
 ```
+
+### Data Source: parquet vs duckdb (disk vs pinned)
+
+- **parquet** (`--data-source parquet`, default): `--input` is a **directory** of TPC-H `.parquet` files (`read_parquet` → `GPU_PARQUET_SCAN`).
+- **duckdb** (`--data-source duckdb`): `--input` is a single **`.duckdb` file** whose native TPC-H tables are scanned via the GPU-native `seq_scan` → `GPU_DUCKDB_NATIVE_SCAN`. Works in all modes (incl. `nsys-profile`).
+- **Disk vs pinned** is controlled by `--pin`, independently of the source:
+  - *from disk*: omit `--pin` (or `--pin none`) — data is read from the parquet/`.duckdb` file each scan.
+  - *pinned*: `--pin gpu` or `--pin host` pre-loads the referenced columns into the Sirius cache.
+- To confirm a pinned run actually hit the cache, grep `<benchmark_dir>/sirius/q<N>/sirius.log` for `using cached_split_provider` (cache hit) vs `not all the columns are pinned for this query` (fell through to disk).
 
 ### Cold-Run Benchmarking (`--mode isolated`)
 
@@ -148,10 +174,30 @@ A timestamped benchmark dir `<output>/tpch_<ts>_<mode>_<engine>_iter<N>/` (or `<
 
 ---
 
-# Before Running
+# Before Running — ALWAYS Confirm Every Parameter First
 
-- **Ask the user** for any paths you don't know. Do NOT assume paths.
-- **Ask about data**: Does the parquet dataset already exist? If yes, ask for the directory path. If no, confirm the user wants to generate it before proceeding — data generation can take significant time and disk space at large scale factors. Do NOT auto-generate without asking.
-- **Optionally ask for `--name`**: offer the user the option to label the output subdirectory (e.g. `baseline`, `with-fix`, `sf1000-host-pin`). If they decline or don't provide one, omit `--name` and let the default `tpch_<ts>_<mode>_<engine>_iter<N>` name be used. Do not invent a name unprompted.
-- Ensure the Sirius extension is built: `pixi run -e clang make release` (the runner loads `build/release/extension/sirius/sirius.duckdb_extension` for any GPU engine).
-- For Super Sirius: ensure `SIRIUS_CONFIG_FILE` is set, or pass `--config <yaml>` to `performance_test.py`.
+**This is mandatory and must not be skipped.** Before invoking `performance_test.py`, you MUST confirm **every** parameter with the user via the `AskUserQuestion` tool — never silently assume defaults, and never skip this gate even when the request looks complete. Pre-fill any value the user already gave (present it as the recommended option) and ask for the rest, so a `/benchmark` run never starts with an unconfirmed configuration.
+
+Ask in ~3 grouped rounds (`AskUserQuestion` allows up to 4 questions per call). Mark sensible defaults as "(Recommended)".
+
+**Round 1 — data & engine**
+1. **Data source** (`--data-source`) — `parquet` or `duckdb`.
+2. **Dataset** (`--input`) — the parquet **directory** or `.duckdb` **file** path. Confirm it exists; if it does not, ask whether to generate it via the `/dataset-manager` skill first (generation can take significant time and disk at large scale factors — **never auto-generate without asking**). For duckdb, clarify plain vs `--cluster` (sorted) if generating.
+3. **Config** (`--config` / `SIRIUS_CONFIG_FILE`) — which Sirius config YAML to use (required for any GPU engine). Do not guess the path; confirm it.
+4. **Engine** (`--engine`) — `gpu`, `cpu`, or `both` (default `both`).
+
+**Round 2 — execution shape**
+1. **Mode** (`--mode`) — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (true cold-start; needs the sudo setup below), or `nsys-profile` (GPU-only; owned by the `profile-analyzer` skill).
+2. **Pin** (`--pin`) — `none` (from disk), `gpu`, or `host` (pinned cache tier; rejected with `--engine cpu`). This is how "from disk vs pinned" is chosen, for either source.
+3. **Iterations** (`--iterations`) — per-query iteration count (default `1`).
+4. **Queries** (`--queries`) — all 22 (default) or a subset like `1,3,6-10`.
+
+**Round 3 — output**
+1. **Validation** (`--validation`) — byte-compare GPU vs CPU after timing (requires `--engine both`).
+2. **Name** (`--name`) — optional label for the output subdir (e.g. `baseline`, `sf1000-host-pin`); if declined, omit it and let the default `tpch_<ts>_<mode>_<engine>_iter<N>` be used. Do not invent a name unprompted.
+
+After confirming, echo the final `performance_test.py` command back to the user before running it.
+
+**Environment prerequisites** (verify these yourself; they are not user questions):
+- Sirius extension built: `pixi run -e clang make release` (the runner loads `build/release/extension/sirius/sirius.duckdb_extension` for any GPU engine).
+- For Super Sirius: `SIRIUS_CONFIG_FILE` set, or `--config <yaml>` passed (confirmed in Round 1).

--- a/.claude/skills/dataset-manager/SKILL.md
+++ b/.claude/skills/dataset-manager/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this skill to generate benchmark datasets (TPC-H, TPC-DS, etc.). Trigger when the user
   needs test data at a specific scale factor for benchmarking or testing. Supports parquet and
   duckdb output formats.
-argument-hint: "[benchmark] [scale_factor] [--format duckdb|parquet] [--output <path>]"
+argument-hint: "[benchmark] [scale_factor] [--format duckdb|parquet] [--cluster] [--output <path>]"
 ---
 
 # Dataset Generator
@@ -17,6 +17,7 @@ Parse `$ARGUMENTS` for:
 - **Benchmark**: name from the registry below (first positional arg)
 - **Scale factor**: integer (second positional arg)
 - **Format**: `--format duckdb|parquet` (optional — each benchmark has a default)
+- **Cluster** (TPC-H duckdb only): `--cluster` / `--cluster-keys <spec>` (optional — physically sorts tables so row-group pruning works; errors with `--format parquet`)
 - **Output path**: `--output <path>` (optional — scripts have sensible defaults)
 
 If any required parameter (benchmark, scale factor) is missing, ask the user.
@@ -36,14 +37,18 @@ Each entry follows the same structure: script location, command template, suppor
 | Formats | `parquet` (tpchgen-rs), `duckdb` (DuckDB `dbgen()`) |
 | Default output (parquet) | `test_datasets/tpch_parquet_sf<SF>` |
 | Default output (duckdb) | `test_datasets/tpch_sf<SF>.duckdb` |
+| Default output (duckdb + `--cluster`) | `test_datasets/tpch_sf<SF>_sorted.duckdb` |
 | Prerequisites | Parquet: pixi env (rust, python, pyarrow). DuckDB: `build/release/duckdb` |
 
 ```bash
-cd test/tpch_performance && pixi run bash generate_tpch_data.sh <SF> --format <FORMAT> [--output <path>]
+cd test/tpch_performance && pixi run bash generate_tpch_data.sh <SF> --format <FORMAT> [--cluster] [--cluster-keys <spec>] [--output <path>]
 ```
 
 Notes:
 - If the parquet output directory already exists, the script skips generation
+- `--cluster` (duckdb only) physically sorts tables at load so each row group's per-column min/max becomes selective — this is what makes Sirius's native-scan row-group pruning skip work on date-filtered queries. It writes a distinct `tpch_sf<SF>_sorted.duckdb` so it can coexist with the unsorted dataset.
+- Default cluster keys: `lineitem:l_shipdate,orders:o_orderdate`. Override with `--cluster-keys "table:col,table:col,..."` (implies `--cluster`).
+- `--cluster` errors if combined with `--format parquet` (tpchgen-rs writes decimals as FIXED_LEN_BYTE_ARRAY, which disables Sirius row-group pruning for the whole file).
 
 ### TPC-DS
 

--- a/.claude/skills/optimization-advisor/SKILL.md
+++ b/.claude/skills/optimization-advisor/SKILL.md
@@ -89,6 +89,8 @@ pixi run python test/tpch_performance/performance_test.py \
 
 Compare the resulting `<bench>/csv/runtimes.csv` against a previous non-profiled baseline to confirm the optimization actually improved wall-clock performance. Then run a new profiled analysis (`nsys_report.sh`) to understand what changed internally.
 
+**Data source (parquet or duckdb).** `--input` is a parquet directory (`--data-source parquet`, the default) or a single `.duckdb` file (`--data-source duckdb`); `--pin gpu|host` works for both. When a scan is the hotspot, note which path is exercised: parquet `read_parquet` → the parquet GPU scan, vs duckdb `seq_scan` → the GPU-native scan (`src/op/scan/duckdb_native_gpu_ingestible.cpp`). They are different source files, so the optimization target differs by source.
+
 ## Analysis Sections
 
 The report contains these sections per query:

--- a/.claude/skills/profile-analyzer/SKILL.md
+++ b/.claude/skills/profile-analyzer/SKILL.md
@@ -53,6 +53,8 @@ pixi run python test/tpch_performance/performance_test.py \
 
 The non-profiled run produces a long-format `<bench>/csv/runtimes.csv` (`engine,query,iteration,runtime_s`) and per-query `result.txt`. `--validation` additionally byte-compares the saved Sirius vs DuckDB results (with a small `abs_tol` on floats).
 
+**Data source (parquet or duckdb).** `--input` accepts either a parquet directory (`--data-source parquet`, the default) or a single `.duckdb` file (`--data-source duckdb`, exercising the GPU-native `seq_scan`); `--pin gpu|host` works for both. Profiling works for both sources through the **same** orchestrator — `nsys_report.sh --data-source duckdb --duckdb-file <file>.duckdb` (or just `--sf <SF>`, which defaults to `test_datasets/tpch_sf<SF>.duckdb`). See `test/tpch_performance/CLAUDE.md`.
+
 **When comparing across runs:**
 - Use the non-profiled timings to determine if performance actually improved or regressed
 - Use the profiled data to understand *why* performance changed (kernel times, operator attribution, occupancy, memory patterns)
@@ -63,6 +65,8 @@ The non-profiled run produces a long-format `<bench>/csv/runtimes.csv` (`engine,
 bash test/tpch_performance/nsys_report.sh \
     --sf <scale_factor> \
     --parquet-dir <path_to_parquet_dir> \
+    --data-source parquet|duckdb \
+    --duckdb-file <path_to.duckdb> \
     --output-dir ./reports \
     --label <custom_name> \
     --iterations 4 \
@@ -71,7 +75,7 @@ bash test/tpch_performance/nsys_report.sh \
     [query_numbers...]
 ```
 
-`--parquet-dir` defaults to `$PROJECT_DIR/test_datasets/tpch_parquet_sf<SF>`.
+`--parquet-dir` defaults to `$PROJECT_DIR/test_datasets/tpch_parquet_sf<SF>`; with `--data-source duckdb`, `--duckdb-file` defaults to `$PROJECT_DIR/test_datasets/tpch_sf<SF>.duckdb`.
 
 **Output directory structure (profiled):**
 ```
@@ -183,7 +187,7 @@ Domain numbers are not registered by Sirius — they're discovered from each nsy
 ### Sirius Physical Operators
 | Operator | Purpose |
 |----------|---------|
-| `table_scan` | Read parquet files via cuDF |
+| `table_scan` | Read input via cuDF — parquet (`read_parquet`) or DuckDB-native tables (`seq_scan`, `src/op/scan/duckdb_native_gpu_ingestible.cpp`) |
 | `projection` | Evaluate column expressions |
 | `filter` | Row filtering |
 | `hash_join` | Hash-based join |

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -312,9 +312,14 @@ For end-to-end profiling + analysis packaging, use `nsys_report.sh` (orchestrato
 `nsys_report.sh` orchestrates profiling + analysis + report packaging into a self-contained report directory with human-readable markdown, machine-readable JSON, and all raw artifacts.
 
 ```bash
-# Profile and generate report
+# Profile and generate report (parquet source, default)
 ./test/tpch_performance/nsys_report.sh --sf 300_rg2m
 ./test/tpch_performance/nsys_report.sh --sf 100 --iterations 4 1 3 6 10
+
+# DuckDB-native source: --data-source duckdb (defaults to test_datasets/tpch_sf<SF>.duckdb,
+# or pass --duckdb-file). Forwards --data-source to performance_test.py --mode nsys-profile.
+./test/tpch_performance/nsys_report.sh --sf 10 --data-source duckdb 1 3 6
+./test/tpch_performance/nsys_report.sh --data-source duckdb --duckdb-file ./test_datasets/tpch_sf10.duckdb --sf 10
 
 # Report from existing profiles
 ./test/tpch_performance/nsys_report.sh --profile-dir /path/to/nsys_profiles/sf300/

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -101,7 +101,7 @@ All commands run from the **project root** directory.
 
 ### TPC-H benchmark with performance_test.py (primary runner)
 
-`performance_test.py` is the canonical TPC-H runner shared by the `benchmark` and `profile-analyzer` skills. It registers TPC-H tables as parquet views over a single in-memory DuckDB connection per engine, runs each query for N iterations, and produces a structured per-query benchmark directory.
+`performance_test.py` is the canonical TPC-H runner shared by the `benchmark` and `profile-analyzer` skills. With `--data-source parquet` (default) it registers TPC-H tables as parquet views over a single in-memory DuckDB connection per engine; with `--data-source duckdb` it opens a `.duckdb` file directly (read-only) and queries its native tables (GPU-native `seq_scan`). Either way it runs each query for N iterations and produces a structured per-query benchmark directory, and pinning works for both sources.
 
 ```bash
 export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
@@ -121,6 +121,16 @@ pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf100 \
     --engine gpu --iterations 3 --pin gpu
 
+# DuckDB native source from disk (both engines, validate). --input is a .duckdb FILE.
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_sf1.duckdb --data-source duckdb \
+    --engine both --iterations 1 --validation --queries 1,3,6
+
+# DuckDB native source, pinned into the GPU cache
+pixi run python test/tpch_performance/performance_test.py \
+    --input ~/sirius/test_datasets/tpch_sf100.duckdb --data-source duckdb \
+    --engine gpu --iterations 3 --pin gpu
+
 # Cold-start measurement (drops OS cache between runs; requires passwordless sudo)
 pixi run python test/tpch_performance/performance_test.py \
     --input ~/sirius/test_datasets/tpch_parquet_sf10 \
@@ -133,6 +143,7 @@ pixi run python test/tpch_performance/performance_test.py \
 ```
 
 Key flags:
+- `--data-source parquet|duckdb` — input source/format (default `parquet`). `parquet`: `--input` is a directory of TPC-H parquet files (scanned via `read_parquet` → `GPU_PARQUET_SCAN`). `duckdb`: `--input` is a single `.duckdb` file whose native tables are scanned via the GPU-native `seq_scan` → `GPU_DUCKDB_NATIVE_SCAN`. Works in all modes (incl. `nsys-profile`), and `--pin` works for both. (This is the harness's own 2-value flag — see the disambiguation note below, distinct from the legacy shell `--data-source`.)
 - `--engine gpu|cpu|both` — which engine to benchmark.
 - `--iterations N` — per-query iteration count.
 - `--mode grouped|sequential|isolated|nsys-profile` — `grouped` (default, hot cache), `sequential` (round-robin), `isolated` (fresh connection + drop_os_cache per run; requires passwordless sudo), `nsys-profile` (see below).
@@ -144,9 +155,15 @@ Key flags:
 - `--name <NAME>` — override the auto-timestamped benchmark subdirectory name.
 - `--config <yaml>` — override `$SIRIUS_CONFIG_FILE` for this run.
 
-#### `--data-source parquet | duckdb | duckdb-native` (scan path)
+#### `--data-source parquet | duckdb | duckdb-native` (shell runners — scan path)
 
-`--data-source` selects which engine scan path is exercised:
+> **Two flags, same name.** This `--data-source` belongs to the **legacy shell**
+> orchestrator `benchmark_and_validate.sh` and is 3-value (`parquet`, `duckdb`,
+> `duckdb-native` — the last a redundant alias of `duckdb`). The Python harness
+> `performance_test.py` has its **own** 2-value `--data-source` (`parquet`,
+> `duckdb`), documented above. They are independent flags on independent tools.
+
+`benchmark_and_validate.sh --data-source` selects which engine scan path is exercised:
 
 | Value | Runner | Input | Sirius scan path |
 |-------|--------|-------|------------------|
@@ -175,7 +192,7 @@ grep -c 'duckdb_native_gpu_ingestible::materialize_table] decoded split' /tmp/na
 grep -c 'duckdb_native_metadata] refused'                       /tmp/native_verify/sirius_*.log   # expect 0
 ```
 
-> **Note:** `--pinning-mode per-query` and `--pinning-mode pinned-hot` are parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine either with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
+> **Note:** `--pinning-mode per-query` and `--pinning-mode pinned-hot` are parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine either with `--data-source duckdb` or `duckdb-native`. This limitation is specific to the **shell runners**. The Python harness `performance_test.py` **does** support the duckdb native scan via its own `--data-source duckdb`, including pinning with `--pin gpu|host` (which emits `CALL pin_table(format='duckdb', name=<table>, cols=[...])`). To confirm a Python-harness duckdb run hit the pinned cache, grep the per-query log `<bench>/sirius/q<N>/sirius.log` for `using cached_split_provider` (cache hit) vs `not all the columns are pinned` (fell through to disk).
 
 #### `--pinning-mode per-query | pinned-hot` (PR #721 pin_table)
 
@@ -216,7 +233,7 @@ export SIRIUS_CONFIG_FILE=$(pwd)/test/cpp/integration/integration.yaml
 ./test/tpch_performance/run_tpch_parquet.sh --parquet-dir /data/tpch sirius 100 1 3 6
 ```
 <bench>/                              # tpch_<ts>_<mode>_<engine>_iter<N>[_nsys] or --name override
-  metadata.json                       # commit, branch, date, mode, iterations, engine, queries, pin, nsys_profile
+  metadata.json                       # commit, branch, date, mode, iterations, engine, data_source, queries, pin, nsys_profile
   csv/runtimes.csv                    # engine,query,iteration,runtime_s
   log_dir/sirius_<YYYY-MM-DD>.log     # combined Sirius spdlog (non-profile mode)
   <engine>/q<N>/result.txt            # fetched rows, one repr(row) per line (last iter wins)

--- a/test/tpch_performance/nsys_report.sh
+++ b/test/tpch_performance/nsys_report.sh
@@ -36,6 +36,8 @@ OUTPUT_BASE="${OUTPUT_BASE:-$PROJECT_DIR/reports}"
 LABEL=""
 SF=""
 PARQUET_DIR=""
+DATA_SOURCE="parquet"
+DUCKDB_FILE=""
 PROFILE_DIR=""
 COMPARE_DIR=""
 ITERATIONS="${ITERATIONS:-2}"
@@ -52,6 +54,9 @@ usage() {
     echo "Options:"
     echo "  --sf SF              Scale factor for profiling (e.g., 300_rg2m, 100)"
     echo "  --parquet-dir DIR    Override parquet directory (default: \$PROJECT_DIR/test_datasets/tpch_parquet_sf<SF>)"
+    echo "  --data-source SRC    Input source: parquet (default) or duckdb"
+    echo "  --duckdb-file FILE   DuckDB database file (implies --data-source duckdb;"
+    echo "                       default: \$PROJECT_DIR/test_datasets/tpch_sf<SF>.duckdb)"
     echo "  --profile-dir DIR    Use existing profiles (skip profiling)"
     echo "  --output-dir DIR     Base directory for reports (default: ./reports)"
     echo "  --label LABEL        Custom label (default: sirius_sf<SF>)"
@@ -71,6 +76,8 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --sf)           SF="$2"; shift 2 ;;
         --parquet-dir)  PARQUET_DIR="$2"; shift 2 ;;
+        --data-source)  DATA_SOURCE="$2"; shift 2 ;;
+        --duckdb-file)  DUCKDB_FILE="$2"; DATA_SOURCE="duckdb"; shift 2 ;;
         --profile-dir)  PROFILE_DIR="$2"; shift 2 ;;
         --output-dir)   OUTPUT_BASE="$2"; shift 2 ;;
         --label)        LABEL="$2"; shift 2 ;;
@@ -83,9 +90,25 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# Default parquet dir based on SF (when neither --parquet-dir nor --profile-dir is set)
-if [ -z "$PARQUET_DIR" ] && [ -n "$SF" ]; then
-    PARQUET_DIR="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+if [ "$DATA_SOURCE" != "parquet" ] && [ "$DATA_SOURCE" != "duckdb" ]; then
+    echo "ERROR: --data-source must be 'parquet' or 'duckdb', got: $DATA_SOURCE" >&2
+    usage
+fi
+
+# Resolve the profiling input for the chosen source (used when profiling, i.e. not
+# --profile-dir). parquet -> a directory (default test_datasets/tpch_parquet_sf<SF>);
+# duckdb -> a single .duckdb file (default test_datasets/tpch_sf<SF>.duckdb).
+INPUT=""
+if [ "$DATA_SOURCE" = "duckdb" ]; then
+    INPUT="$DUCKDB_FILE"
+    if [ -z "$INPUT" ] && [ -n "$SF" ]; then
+        INPUT="$PROJECT_DIR/test_datasets/tpch_sf${SF}.duckdb"
+    fi
+else
+    INPUT="$PARQUET_DIR"
+    if [ -z "$INPUT" ] && [ -n "$SF" ]; then
+        INPUT="$PROJECT_DIR/test_datasets/tpch_parquet_sf${SF}"
+    fi
 fi
 
 if [ -z "$SF" ] && [ -z "$PROFILE_DIR" ]; then
@@ -153,9 +176,15 @@ if [ -n "$PROFILE_DIR" ]; then
     echo ""
 else
     echo "[Phase 2] Running nsys profiling via performance_test.py"
-    echo "  sf=$SF, iterations=$ITERATIONS, parquet=$PARQUET_DIR"
-    if [ ! -d "$PARQUET_DIR" ]; then
-        echo "ERROR: Parquet directory not found: $PARQUET_DIR" >&2
+    echo "  sf=$SF, iterations=$ITERATIONS, source=$DATA_SOURCE, input=$INPUT"
+    if [ "$DATA_SOURCE" = "duckdb" ]; then
+        if [ ! -f "$INPUT" ]; then
+            echo "ERROR: DuckDB file not found: $INPUT" >&2
+            echo "  Pass --duckdb-file or generate it with generate_tpch_data.sh --format duckdb" >&2
+            exit 1
+        fi
+    elif [ ! -d "$INPUT" ]; then
+        echo "ERROR: Parquet directory not found: $INPUT" >&2
         echo "  Pass --parquet-dir or generate data with generate_tpch_data.sh" >&2
         exit 1
     fi
@@ -168,7 +197,8 @@ else
     PY_CMD=(
         pixi run python "$PROJECT_DIR/test/tpch_performance/performance_test.py"
         --mode nsys-profile
-        --input "$PARQUET_DIR"
+        --input "$INPUT"
+        --data-source "$DATA_SOURCE"
         --engine gpu
         --iterations "$ITERATIONS"
         --output "$REPORT_DIR"
@@ -186,11 +216,16 @@ else
     fi
     echo ""
 
-    # Flatten <REPORT_DIR>/profiles_tree/sirius/q<N>/ → <REPORT_DIR>/profiles/q<N>.<ext>
+    # Flatten <REPORT_DIR>/<bench>_profiles_tree/sirius/q<N>/ → <REPORT_DIR>/profiles/q<N>.<ext>
     # so nsys_analyze.sh and Phase 4 metric extraction (which read flat
     # profiles/q<N>.sqlite + q<N>_timings.csv) continue to work unchanged.
-    PROFILES_TREE="$REPORT_DIR/profiles_tree/sirius"
-    if [ -d "$PROFILES_TREE" ]; then
+    # performance_test.py prefixes --name with tpch_<ts>_<mode>_<engine>_iter<N>_, so the
+    # per-query tree is `<REPORT_DIR>/*profiles_tree/sirius`, not a bare `profiles_tree/`.
+    PROFILES_TREE=""
+    for _d in "$REPORT_DIR"/*profiles_tree/sirius; do
+        [ -d "$_d" ] && PROFILES_TREE="$_d" && break
+    done
+    if [ -n "$PROFILES_TREE" ] && [ -d "$PROFILES_TREE" ]; then
         echo "[Phase 2] Flattening per-query outputs into $REPORT_DIR/profiles/"
         for qdir in "$PROFILES_TREE"/q*/; do
             [ -d "$qdir" ] || continue

--- a/test/tpch_performance/performance_test.py
+++ b/test/tpch_performance/performance_test.py
@@ -49,6 +49,7 @@ def log(msg):
 MODES = ("grouped", "sequential", "isolated", "nsys-profile")
 ENGINE_CHOICES = ("gpu", "cpu", "both")
 PIN_CHOICES = ("none", "gpu", "host")
+DATA_SOURCE_CHOICES = ("parquet", "duckdb")
 TPCH_TABLES = (
     "customer",
     "lineitem",
@@ -98,6 +99,7 @@ def setup_benchmark_dir(
     pin,
     name=None,
     nsys_profile=False,
+    data_source="parquet",
 ):
     """Create the benchmark output directory and return its paths.
 
@@ -137,6 +139,7 @@ def setup_benchmark_dir(
         "mode": mode,
         "iterations": iterations,
         "engine": engine,
+        "data_source": data_source,
         "queries": [f"q{q}" for q in queries],
         "pin": pin,
         "nsys_profile": nsys_profile,
@@ -263,17 +266,30 @@ def _build_views_sql(parquet_dir):
     return "\n".join(parts) + "\n"
 
 
-def open_connection(parquet_dir, gpu_execution=False):
-    """Open an in-memory DuckDB, register TPC-H parquet views, optionally LOAD Sirius."""
-    log(f"Opening DuckDB connection over parquet dir {parquet_dir}")
-    con = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
-    log("Registering TPC-H parquet views")
-    for stmt in _build_views_sql(parquet_dir).split(";"):
-        stmt = stmt.strip()
-        if not stmt:
-            continue
-        con.execute(stmt)
-    log("All TPC-H views registered")
+def open_connection(source, gpu_execution=False, data_source="parquet"):
+    """Open a DuckDB connection over the benchmark source, optionally LOAD Sirius.
+
+    parquet: in-memory DB with CREATE VIEW ... read_parquet over the directory.
+    duckdb:  open the .duckdb file directly (read-only); its native TPC-H tables
+             are already present in the `main` schema, so no views are registered.
+             Read-only avoids write locks / accidental WAL and is correct for a
+             read-only benchmark; it mirrors how run_tpch_duckdb.sh opens the file.
+    """
+    if data_source == "duckdb":
+        log(f"Opening DuckDB database file {source} (read-only)")
+        con = duckdb.connect(
+            source, read_only=True, config={"allow_unsigned_extensions": "true"}
+        )
+    else:
+        log(f"Opening DuckDB connection over parquet dir {source}")
+        con = duckdb.connect(":memory:", config={"allow_unsigned_extensions": "true"})
+        log("Registering TPC-H parquet views")
+        for stmt in _build_views_sql(source).split(";"):
+            stmt = stmt.strip()
+            if not stmt:
+                continue
+            con.execute(stmt)
+        log("All TPC-H views registered")
     if gpu_execution:
         log(f"Loading Sirius extension from {EXTENSION_PATH}")
         con.execute(f"LOAD '{EXTENSION_PATH}'")
@@ -354,8 +370,8 @@ def run_grouped(
     writer,
     *,
     benchmark_dir,
-    parquet_dir,
     pin,
+    data_source="parquet",
     duckdb_profiling=False,
 ):
     """Per-query iterations back-to-back; one connection per engine. Pin per query."""
@@ -364,12 +380,12 @@ def run_grouped(
     )
     pin_enabled = pin != "none"
     for name, use_gpu in engine_modes:
-        con = open_connection(source, gpu_execution=use_gpu)
+        con = open_connection(source, gpu_execution=use_gpu, data_source=data_source)
         try:
             for qnum in queries:
                 if pin_enabled and use_gpu:
                     log(f"  Pinning tables for q{qnum}")
-                    _execute_multi(con, emit_pin(qnum, parquet_dir))
+                    _execute_multi(con, emit_pin(qnum, source, data_source))
                 try:
                     for it in range(iterations):
                         log(f"--- q{qnum} iter{it} engine={name} ---")
@@ -400,19 +416,19 @@ def run_sequential(
     writer,
     *,
     benchmark_dir,
-    parquet_dir,
     pin,
+    data_source="parquet",
     duckdb_profiling=False,
 ):
     """Round-robin iterations; one connection per engine. Single union-pin at session start."""
     log("Mode 'sequential': single connection per engine, round-robin iterations")
     pin_enabled = pin != "none"
     for name, use_gpu in engine_modes:
-        con = open_connection(source, gpu_execution=use_gpu)
+        con = open_connection(source, gpu_execution=use_gpu, data_source=data_source)
         try:
             if pin_enabled and use_gpu:
                 log("  Union-pinning all referenced TPC-H tables once at session start")
-                _execute_multi(con, emit_pin_all(parquet_dir))
+                _execute_multi(con, emit_pin_all(source, data_source))
             try:
                 for it in range(iterations):
                     for qnum in queries:
@@ -444,8 +460,8 @@ def run_isolated(
     writer,
     *,
     benchmark_dir,
-    parquet_dir,
     pin,
+    data_source="parquet",
     duckdb_profiling=False,
 ):
     """Fresh connection + OS cache drop per (query, iteration). Pin per execution."""
@@ -455,12 +471,14 @@ def run_isolated(
         for qnum in queries:
             for it in range(iterations):
                 log(f"--- q{qnum} iter{it} engine={name} (cold connection) ---")
-                con = open_connection(source, gpu_execution=use_gpu)
+                con = open_connection(
+                    source, gpu_execution=use_gpu, data_source=data_source
+                )
                 try:
                     drop_os_cache()
                     if pin_enabled and use_gpu:
                         log(f"  Pinning tables for q{qnum}")
-                        _execute_multi(con, emit_pin(qnum, parquet_dir))
+                        _execute_multi(con, emit_pin(qnum, source, data_source))
                     _run_one(
                         writer,
                         con,
@@ -486,7 +504,7 @@ RUNNERS = {
 }
 
 
-def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
+def _build_nsys_temp_sql(qnum, source, iterations, pin, qdir, data_source="parquet"):
     """Write the DuckDB SQL script for one nsys-profiled query.
 
     Produces a timings.csv with rows (views, iter_1, iter_2, ...). The
@@ -507,12 +525,17 @@ def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
     parts = [
         "CREATE TEMP TABLE _timings (seq INTEGER, step VARCHAR, ts TIMESTAMP);",
         "INSERT INTO _timings VALUES (0, 'start', current_timestamp);",
-        _build_views_sql(parquet_dir).rstrip("\n"),
-        "INSERT INTO _timings VALUES (1, 'views', current_timestamp);",
     ]
+    # parquet registers views over the directory; duckdb opens the .duckdb file
+    # directly (its native tables are already present), so no view scaffolding is
+    # needed. The 'views' timing marker is kept either way so timings.csv parsing
+    # (which skips one 'views' row) stays uniform across sources.
+    if data_source != "duckdb":
+        parts.append(_build_views_sql(source).rstrip("\n"))
+    parts.append("INSERT INTO _timings VALUES (1, 'views', current_timestamp);")
 
     if pin != "none":
-        parts.append(emit_pin(qnum, parquet_dir))
+        parts.append(emit_pin(qnum, source, data_source))
 
     parts.append("SET gpu_execution = true;")
     # Open the nsys capture range BEFORE the first (cold) iteration so the cold
@@ -556,7 +579,7 @@ def _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir):
 
 def run_nsys_profile(
     queries,
-    parquet_dir,
+    source,
     iterations,
     writer,
     *,
@@ -564,6 +587,7 @@ def run_nsys_profile(
     pin,
     config_path,
     query_timeout,
+    data_source="parquet",
 ):
     """Profile each query with NVIDIA Nsight Systems: one DuckDB subprocess per query.
 
@@ -596,7 +620,9 @@ def run_nsys_profile(
         sub_log_dir = os.path.join(qdir, "log_dir")
         os.makedirs(sub_log_dir, exist_ok=True)
 
-        sql_path = _build_nsys_temp_sql(qnum, parquet_dir, iterations, pin, qdir)
+        sql_path = _build_nsys_temp_sql(
+            qnum, source, iterations, pin, qdir, data_source
+        )
         nsys_output = os.path.join(qdir, "nsys")
         stdout_path = os.path.join(qdir, "nsys_stdout.txt")
 
@@ -612,6 +638,21 @@ def run_nsys_profile(
             "--capture-range=cudaProfilerApi",
             "--capture-range-end=stop",
         ]
+        # For duckdb source, open the .duckdb file as the CLI's default database
+        # (its native TPC-H tables become queryable by name) — mirroring
+        # open_connection / run_tpch_duckdb.sh. For parquet, the in-script
+        # CREATE VIEW read_parquet statements supply the tables, so no DB arg.
+        duckdb_invocation = [DUCKDB_BIN]
+        if data_source == "duckdb":
+            duckdb_invocation.append(source)
+        duckdb_invocation += [
+            # -unsigned mirrors the Python runner's allow_unsigned_extensions
+            # config (open_connection): without it, the DuckDB CLI rejects
+            # locally-built (unsigned) Sirius extensions.
+            "-unsigned",
+            "-f",
+            sql_path,
+        ]
         nsys_cmd.extend(
             [
                 "--output",
@@ -619,13 +660,7 @@ def run_nsys_profile(
                 "--force-overwrite=true",
                 "--stats=false",
                 "--export=sqlite",
-                DUCKDB_BIN,
-                # -unsigned mirrors the Python runner's allow_unsigned_extensions
-                # config (open_connection): without it, the DuckDB CLI rejects
-                # locally-built (unsigned) Sirius extensions.
-                "-unsigned",
-                "-f",
-                sql_path,
+                *duckdb_invocation,
             ]
         )
 
@@ -700,12 +735,16 @@ def run_nsys_profile(
                 it += 1
 
 
-def split_sirius_log(log_dir, benchmark_dir, queries, iterations, mode):
+def split_sirius_log(log_dir, benchmark_dir, queries, iterations):
     """Split the combined Sirius spdlog into one log file per query.
 
-    Mirrors the bash post-processor in run_tpch_parquet.sh:591-628: find QueryBegin
-    markers that aren't pin/unpin/CREATE VIEW, then partition them by query based on
-    the iteration mode's run ordering.
+    A query's segment runs from its `QueryBegin: SQL: <sql>` marker to the next such
+    marker. Benchmarked-query begins are identified by matching the logged
+    (whitespace-normalized) SQL against the known QUERIES text, so interleaved control
+    statements (`SET gpu_execution`, `CALL pin_table`/`unpin_table`, `CREATE VIEW`,
+    `LOAD`) are ignored and segments are grouped by query content. This is robust
+    across data sources (parquet/duckdb), pinning on/off, and every iteration mode --
+    it keys on query text, not on statement counts or run ordering.
     """
     log_files = sorted(glob.glob(os.path.join(log_dir, "sirius*.log")))
     if not log_files:
@@ -716,38 +755,42 @@ def split_sirius_log(log_dir, benchmark_dir, queries, iterations, mode):
     with open(log_path) as f:
         lines = f.readlines()
 
-    begin_indices = []
-    for i, line in enumerate(lines):
-        if "QueryBegin:" not in line:
-            continue
-        if "pin_table" in line or "unpin_table" in line or "CREATE VIEW" in line:
-            continue
-        begin_indices.append(i)
+    def _norm(sql):
+        # Mirror SiriusContext::QueryBegin whitespace collapsing, drop a trailing ';',
+        # and lowercase so the match is exact but tolerant of formatting differences.
+        return " ".join(sql.split()).rstrip(";").strip().lower()
 
-    expected = len(queries) * iterations
-    if len(begin_indices) != expected:
-        log(
-            f"WARNING: expected {expected} QueryBegin lines in {log_path}, "
-            f"found {len(begin_indices)}; skipping per-query log split"
-        )
+    known = {_norm(QUERIES[f"q{q}"]): q for q in queries}
+
+    marker = "QueryBegin: SQL: "
+    begins = []  # (qnum, line_index), in log order
+    for i, line in enumerate(lines):
+        pos = line.find(marker)
+        if pos == -1:
+            continue
+        qnum = known.get(_norm(line[pos + len(marker) :]))
+        if qnum is not None:
+            begins.append((qnum, i))
+
+    if not begins:
+        log("No matched query begins in the Sirius log; skipping per-query split")
         return
 
-    spans = []
-    for i, start in enumerate(begin_indices):
-        end = begin_indices[i + 1] if i + 1 < len(begin_indices) else len(lines)
-        spans.append((start, end))
+    expected = len(queries) * iterations
+    if len(begins) != expected:
+        log(
+            f"WARNING: expected {expected} query begins, matched {len(begins)} in "
+            f"{log_path} (a query may have errored); writing what matched"
+        )
 
     per_query_spans = {q: [] for q in queries}
-    if mode in ("grouped", "isolated"):
-        for qi, q in enumerate(queries):
-            for it in range(iterations):
-                per_query_spans[q].append(spans[qi * iterations + it])
-    else:  # sequential
-        for it in range(iterations):
-            for qi, q in enumerate(queries):
-                per_query_spans[q].append(spans[it * len(queries) + qi])
+    for k, (qnum, start) in enumerate(begins):
+        end = begins[k + 1][1] if k + 1 < len(begins) else len(lines)
+        per_query_spans[qnum].append((start, end))
 
     for q, span_list in per_query_spans.items():
+        if not span_list:
+            continue
         qdir = os.path.join(benchmark_dir, "sirius", f"q{q}")
         os.makedirs(qdir, exist_ok=True)
         out_path = os.path.join(qdir, "sirius.log")
@@ -831,7 +874,21 @@ def parse_args():
         "--input",
         type=str,
         required=True,
-        help="Path to a TPC-H parquet directory (one .parquet file or subdir per table)",
+        help="TPC-H input: a parquet directory (--data-source parquet; one .parquet "
+        "file or subdir per table) or a single .duckdb file (--data-source duckdb)",
+    )
+    p.add_argument(
+        "--data-source",
+        choices=DATA_SOURCE_CHOICES,
+        default="parquet",
+        help=(
+            "Input data source/format: 'parquet' (a directory of TPC-H parquet "
+            "files scanned via read_parquet -> GPU_PARQUET_SCAN) or 'duckdb' (a "
+            "single .duckdb file whose native TPC-H tables are scanned via the "
+            "GPU-native seq_scan). Pinning works for both. NOTE: this is a 2-value "
+            "flag, distinct from the legacy benchmark_and_validate.sh --data-source "
+            "(which also has a redundant 'duckdb-native' alias). (default: parquet)"
+        ),
     )
     p.add_argument(
         "--mode",
@@ -936,12 +993,17 @@ def parse_args():
 def main():
     args = parse_args()
     source = args.input
-    if not os.path.isdir(source):
+    if args.data_source == "duckdb":
+        if not os.path.isfile(source):
+            raise SystemExit(
+                f"--data-source duckdb requires --input to be a .duckdb file; "
+                f"got {source!r}"
+            )
+    elif not os.path.isdir(source):
         raise SystemExit(
-            f"--input must be a parquet directory; got {source!r}. "
-            ".duckdb database files are not supported."
+            f"--data-source parquet requires --input to be a parquet directory; "
+            f"got {source!r}"
         )
-    parquet_dir = source
     queries = parse_query_spec(args.queries)
     engine_modes = resolve_engine_modes(args.engine)
     output_root = args.output or DEFAULT_OUTPUT_ROOT
@@ -987,10 +1049,12 @@ def main():
         args.pin,
         name=args.name,
         nsys_profile=nsys_profile,
+        data_source=args.data_source,
     )
     os.environ["SIRIUS_LOG_DIR"] = log_dir
 
     log(f"Source:        {source}")
+    log(f"Data source:   {args.data_source}")
     log(f"Mode:          {args.mode}")
     log(f"Iterations:    {args.iterations}")
     log(f"Engine:        {args.engine}")
@@ -1010,13 +1074,14 @@ def main():
         if nsys_profile:
             run_nsys_profile(
                 queries,
-                parquet_dir,
+                source,
                 args.iterations,
                 writer,
                 benchmark_dir=benchmark_dir,
                 pin=args.pin,
                 config_path=config_path,
                 query_timeout=args.query_timeout,
+                data_source=args.data_source,
             )
         else:
             RUNNERS[args.mode](
@@ -1026,8 +1091,8 @@ def main():
                 args.iterations,
                 writer,
                 benchmark_dir=benchmark_dir,
-                parquet_dir=parquet_dir,
                 pin=args.pin,
+                data_source=args.data_source,
                 duckdb_profiling=args.duckdb_profiling,
             )
 
@@ -1038,7 +1103,7 @@ def main():
     # runs in its own subprocess with its own SIRIUS_LOG_DIR, so the per-query
     # logs are already isolated under <bench>/sirius/q<N>/log_dir/.
     if not nsys_profile and any(use_gpu for _, use_gpu in engine_modes):
-        split_sirius_log(log_dir, benchmark_dir, queries, args.iterations, args.mode)
+        split_sirius_log(log_dir, benchmark_dir, queries, args.iterations)
 
     if args.validation:
         log("Starting validation")

--- a/test/tpch_performance/tpch_pin_columns.py
+++ b/test/tpch_performance/tpch_pin_columns.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """Emit `CALL pin_table(...)` / `CALL unpin_table(...)` SQL for TPC-H.
 
-Used by run_tpch_parquet.sh when --pinning-mode per-query or pinned-hot is set.
-The path argument passed to pin_table is a glob whose FileSystem::GlobFiles
-expansion must match the file list in the corresponding CREATE VIEW
-read_parquet([...]) call — otherwise the scan_manager path-equality check
-in src/scan_manager/sirius_scan_manager.cpp will fall through to disk.
+Used by run_tpch_parquet.sh (--pinning-mode per-query/pinned-hot) and imported by
+performance_test.py for both parquet and duckdb sources.
+
+For parquet, the path argument passed to pin_table is a glob whose
+FileSystem::GlobFiles expansion must match the file list in the corresponding
+CREATE VIEW read_parquet([...]) call — otherwise the scan_manager path-equality
+check in src/scan_manager/sirius_scan_manager.cpp will fall through to disk. For
+duckdb there is no path: the table is resolved from the attached catalog by name
+and the source is selected with format='duckdb'.
 
 Pin tier: defaults to 'gpu'; both 'gpu' and 'host' are supported. Set
 SIRIUS_PIN_TIER=host to select the host tier, which converts the pinned
@@ -228,19 +232,35 @@ def detect_pin_glob(parquet_dir: str, table: str) -> str:
     raise RuntimeError(f"no parquet files for table '{table}' under {abs_dir}")
 
 
-def emit_pin(query_num: int, parquet_dir: str) -> str:
-    # Tier defaults to 'gpu'; SIRIUS_PIN_TIER=host selects the host tier
-    # (both are supported — see src/sirius_extension.cpp). Any other tier
-    # throws NotImplementedException at bind time.
+def _pin_call(table: str, cols: list[str], source: str, data_source: str) -> str:
+    """Emit a single `CALL pin_table(...)` for `table` in the given data source.
+
+    Tier defaults to 'gpu'; SIRIUS_PIN_TIER=host selects the host tier (both are
+    supported — see src/sirius_extension.cpp). Any other tier throws
+    NotImplementedException at bind time.
+
+    parquet: a positional glob path whose FileSystem::GlobFiles expansion must
+             match the corresponding CREATE VIEW read_parquet([...]) file list.
+    duckdb:  no positional path — the table is named by 'name' and resolved from
+             the attached catalog; the source is selected with format='duckdb'.
+    """
     tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
-    cols_by_table = QUERY_COLUMNS[query_num]
-    lines = []
-    for table, cols in cols_by_table.items():
-        path = detect_pin_glob(parquet_dir, table)
-        col_literals = ",".join(f"'{c}'" for c in cols)
-        lines.append(
-            f"CALL pin_table('{path}', tier='{tier}', name='{table}', cols=[{col_literals}]);"
+    col_literals = ",".join(f"'{c}'" for c in cols)
+    if data_source == "duckdb":
+        return (
+            f"CALL pin_table(format='duckdb', tier='{tier}', "
+            f"name='{table}', cols=[{col_literals}]);"
         )
+    path = detect_pin_glob(source, table)
+    return f"CALL pin_table('{path}', tier='{tier}', name='{table}', cols=[{col_literals}]);"
+
+
+def emit_pin(query_num: int, source: str, data_source: str = "parquet") -> str:
+    cols_by_table = QUERY_COLUMNS[query_num]
+    lines = [
+        _pin_call(table, cols, source, data_source)
+        for table, cols in cols_by_table.items()
+    ]
     return "\n".join(lines) + "\n"
 
 
@@ -258,20 +278,16 @@ def _union_columns_by_table() -> dict[str, list[str]]:
     return {table: sorted(cols) for table, cols in by_table.items()}
 
 
-def emit_pin_all(parquet_dir: str) -> str:
+def emit_pin_all(source: str, data_source: str = "parquet") -> str:
     """Emit one CALL pin_table per table with the union of columns across all queries.
 
     Used by sequential-mode benchmarks where re-pinning between queries would
     erase the cache; pin everything once up front instead.
     """
-    tier = os.environ.get("SIRIUS_PIN_TIER", "gpu")
-    lines = []
-    for table, cols in _union_columns_by_table().items():
-        path = detect_pin_glob(parquet_dir, table)
-        col_literals = ",".join(f"'{c}'" for c in cols)
-        lines.append(
-            f"CALL pin_table('{path}', tier='{tier}', name='{table}', cols=[{col_literals}]);"
-        )
+    lines = [
+        _pin_call(table, cols, source, data_source)
+        for table, cols in _union_columns_by_table().items()
+    ]
     return "\n".join(lines) + "\n"
 
 
@@ -284,27 +300,53 @@ def emit_unpin_all() -> str:
     )
 
 
+def _extract_format(args: list[str]) -> tuple[list[str], str]:
+    """Pull an optional `--format parquet|duckdb` out of `args` (default parquet)."""
+    data_source = "parquet"
+    if "--format" in args:
+        i = args.index("--format")
+        if i + 1 >= len(args):
+            raise ValueError("--format requires a value (parquet|duckdb)")
+        data_source = args[i + 1]
+        if data_source not in ("parquet", "duckdb"):
+            raise ValueError(
+                f"--format must be parquet or duckdb (got {data_source!r})"
+            )
+        del args[i : i + 2]
+    return args, data_source
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         print(
-            "Usage: tpch_pin_columns.py pin   <q_num> <parquet_dir>\n"
+            "Usage: tpch_pin_columns.py pin   <q_num> [<parquet_dir>] [--format duckdb]\n"
             "       tpch_pin_columns.py unpin <q_num>\n"
-            "       tpch_pin_columns.py pin-all <parquet_dir>\n"
+            "       tpch_pin_columns.py pin-all [<parquet_dir>] [--format duckdb]\n"
             "       tpch_pin_columns.py unpin-all\n"
             "\n"
+            "Source: --format parquet (default) needs <parquet_dir>; --format duckdb\n"
+            "pins native catalog tables by name (no path).\n"
             "Tier: defaults to 'gpu'; set SIRIUS_PIN_TIER=host for the host tier\n"
             "(both 'gpu' and 'host' are supported).",
             file=sys.stderr,
         )
         return 1
     cmd, *args = argv[1:]
+    try:
+        args, data_source = _extract_format(args)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 1
 
     if cmd == "pin-all":
-        if len(args) != 1:
-            print("pin-all requires <parquet_dir>", file=sys.stderr)
+        if data_source == "parquet" and len(args) != 1:
+            print("pin-all requires <parquet_dir> (parquet format)", file=sys.stderr)
+            return 1
+        if data_source == "duckdb" and len(args) > 1:
+            print("pin-all (duckdb) takes no <parquet_dir>", file=sys.stderr)
             return 1
         try:
-            sys.stdout.write(emit_pin_all(args[0]))
+            sys.stdout.write(emit_pin_all(args[0] if args else "", data_source))
         except RuntimeError as e:
             print(str(e), file=sys.stderr)
             return 1
@@ -338,11 +380,14 @@ def main(argv: list[str]) -> int:
         return 1
 
     if cmd == "pin":
-        if len(rest) != 1:
-            print("pin requires <parquet_dir>", file=sys.stderr)
+        if data_source == "parquet" and len(rest) != 1:
+            print("pin requires <parquet_dir> (parquet format)", file=sys.stderr)
+            return 1
+        if data_source == "duckdb" and len(rest) > 1:
+            print("pin (duckdb) takes only <q_num>", file=sys.stderr)
             return 1
         try:
-            sys.stdout.write(emit_pin(q, rest[0]))
+            sys.stdout.write(emit_pin(q, rest[0] if rest else "", data_source))
         except RuntimeError as e:
             print(str(e), file=sys.stderr)
             return 1


### PR DESCRIPTION
## What

Adds a `--data-source {parquet,duckdb}` option to the TPC-H performance harness
(`test/tpch_performance/performance_test.py`) so it can benchmark **DuckDB-native
datasets** — both scanned from disk and pinned into the Sirius cache — in addition to
parquet, across all four modes (`grouped`, `sequential`, `isolated`, `nsys-profile`).
Also makes the per-query log split robust for the duckdb source and updates the related
skills/docs.

## Changes

- **`performance_test.py`** — new `--data-source` flag; source-aware `--input`
  validation (a parquet directory vs a single `.duckdb` file); `open_connection` opens
  the `.duckdb` file read-only and queries its native tables (no `read_parquet` views)
  for the duckdb source; `data_source` threaded through the three timing runners, the
  nsys-profile subprocess (opens the db file as the CLI database, skips view
  scaffolding), `metadata.json`, and startup logs.
- **`tpch_pin_columns.py`** — emits `CALL pin_table(format='duckdb', name=…, cols=[…])`
  (no glob path) for the duckdb source via a shared `_pin_call` helper; parquet emission
  unchanged; optional `--format` on the CLI.
- **`split_sirius_log`** — identifies per-query log boundaries by matching the logged SQL
  against the known queries instead of counting/filtering statements. This fixes the
  duckdb source, which has no `CREATE VIEW` lines and previously double-counted the
  per-query `SET gpu_execution` toggles (so the split was skipped). Now robust across
  parquet/duckdb, pin/no-pin, and all iteration modes.
- **docs/skills** — document `--data-source` and duckdb pinning in
  `test/tpch_performance/CLAUDE.md` and the `/benchmark` skill; `/benchmark` now always
  confirms every parameter before running; data generation delegates to
  `/dataset-manager`, which surfaces the duckdb-only `--cluster` option.

No engine/C++ changes — `pin_table(format='duckdb')` and the GPU-native scan already exist.

## Testing

Built the worktree and ran on GPU (NVIDIA GB10) at SF1 and SF10:

- **Correctness**: `--data-source duckdb --engine both --validation` → 3/3 queries match
  the DuckDB CPU baseline (byte-exact / within `1e-10`) at both scale factors. CPU-only
  duckdb results are byte-identical to the parquet path.
- **Pinning**: `--pin gpu` over the duckdb source runs the pin→run→unpin cycle cleanly
  (the extension accepts the `format='duckdb'` pin SQL).
- **`split_sirius_log`**: per-query logs split correctly across the matrix —
  {parquet, duckdb} × {pin, no-pin} × {grouped, sequential, isolated}
  (nsys-profile uses per-subprocess logs and isn't split).
- `pre-commit run` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
