### PR TITLE
Telemetry: report all queries under one session-scoped query group

### DIFF
--- a/src/include/sirius_engine.hpp
+++ b/src/include/sirius_engine.hpp
@@ -28,7 +28,6 @@
 #include "pipeline/sirius_meta_pipeline.hpp"
 #include "pipeline/sirius_pipeline.hpp"
 #include "telemetry-bridge/gen/query.rs.h"
-#include "telemetry-bridge/gen/query_group.rs.h"
 #include "telemetry-bridge/gen/uuid.rs.h"
 #include "telemetry/telemetry_context.hpp"
 
@@ -124,8 +123,6 @@ class sirius_engine {
 
  private:
   std::shared_ptr<const telemetry::telemetry_context> telemetry_context_;
-  uuid::UUID query_group_uuid_;
-  rust::Box<quent::query_group::QueryGroupObserver> query_group_observer_;
   rust::Box<quent::query::QueryHandle> query_handle_;
 };
 

--- a/src/include/telemetry/telemetry_context.hpp
+++ b/src/include/telemetry/telemetry_context.hpp
@@ -21,6 +21,7 @@
 #include "telemetry-bridge/gen/context.rs.h"
 #include "telemetry-bridge/gen/engine.rs.h"
 #include "telemetry-bridge/gen/executor_thread.rs.h"
+#include "telemetry-bridge/gen/query_group.rs.h"
 #include "telemetry-bridge/gen/task_manager_loop_thread.rs.h"
 #include "telemetry-bridge/gen/task_queue.rs.h"
 #include "telemetry-bridge/gen/uuid.rs.h"
@@ -58,6 +59,8 @@ class telemetry_context {
 
   [[nodiscard]] const uuid::UUID& engine_id() const { return engine_uuid_; }
   [[nodiscard]] const uuid::UUID& worker_id() const { return worker_uuid_; }
+  /// The single, session-scoped query group that every query in this context is reported under.
+  [[nodiscard]] const uuid::UUID& query_group_id() const { return query_group_uuid_; }
   [[nodiscard]] const quent::Context& context() const { return *context_; }
 
  private:
@@ -65,9 +68,11 @@ class telemetry_context {
 
   uuid::UUID engine_uuid_;
   uuid::UUID worker_uuid_;
+  uuid::UUID query_group_uuid_;
   rust::Box<quent::Context> context_;
   rust::Box<quent::engine::EngineObserver> engine_observer_;
   rust::Box<quent::worker::WorkerObserver> worker_observer_;
+  rust::Box<quent::query_group::QueryGroupObserver> query_group_observer_;
 };
 
 // A POD to hold common identifiers for useful telemetry.

--- a/src/sirius_engine.cpp
+++ b/src/sirius_engine.cpp
@@ -87,21 +87,15 @@ sirius_engine::sirius_engine(duckdb::ClientContext& context, sirius_interface& s
   : context(context),
     sirius_iface(sirius_iface),
     telemetry_context_(get_telemetry_context_from_client_context(this->context)),
-    query_group_uuid_(uuid::now_v7()),
-    query_group_observer_(quent::query_group::create_observer(telemetry_context_->context())),
     query_handle_(
       quent::query::create(telemetry_context_->context(),
                            quent::query::Init{
                              .instance_name  = sirius_iface.query_label.value_or("unnamed_query"),
-                             .query_group_id = query_group_uuid_,
+                             .query_group_id = telemetry_context_->query_group_id(),
                            }))
 {
-  // Declare the query group under this engine
-  query_group_observer_->declaration(query_group_uuid_,
-                                     quent::query_group::Declaration{
-                                       .instance_name = "default_group",
-                                       .engine_id     = telemetry_context_->engine_id(),
-                                     });
+  // The query group is session-scoped and owned by telemetry_context; every query in this
+  // context is reported under it (see telemetry_context::query_group_id).
 }
 
 sirius_engine::~sirius_engine() { query_handle_->exit(); }

--- a/src/telemetry/telemetry_context.cpp
+++ b/src/telemetry/telemetry_context.cpp
@@ -42,10 +42,12 @@ std::shared_ptr<const telemetry_context> telemetry_context::create(
 telemetry_context::telemetry_context(const sirius::telemetry_config& config)
   : engine_uuid_(uuid::now_v7()),
     worker_uuid_(uuid::now_v7()),
+    query_group_uuid_(uuid::now_v7()),
     context_(
       quent::create_context(config.enable_quent ? "ndjson" : "noop", config.output_directory)),
     engine_observer_(quent::engine::create_observer(*context_)),
-    worker_observer_(quent::worker::create_observer(*context_))
+    worker_observer_(quent::worker::create_observer(*context_)),
+    query_group_observer_(quent::query_group::create_observer(*context_))
 {
   engine_observer_->init(engine_uuid_,
                          quent::engine::Init{
@@ -63,6 +65,15 @@ telemetry_context::telemetry_context(const sirius::telemetry_config& config)
                            .parent_engine_id = engine_uuid_,
                            .instance_name    = fmt::format("worker-{}", getpid()),
                          });
+
+  // One session-scoped query group under this engine; every query in this context is reported
+  // under it, so a whole run shows up as a single group rather than one group per query.
+  query_group_observer_->declaration(
+    query_group_uuid_,
+    quent::query_group::Declaration{
+      .instance_name = fmt::format("{}-session-{}", config.engine_name, getpid()),
+      .engine_id     = engine_uuid_,
+    });
 
   SIRIUS_LOG_INFO("Telemetry context initialized (engine={})", config.engine_name);
 }


### PR DESCRIPTION
## What

Previously each `sirius_engine` (i.e. each query) minted its own Quent query group, so a whole run surfaced as N separate `default_group` groups with one query each. This moves query-group ownership to the session-scoped `telemetry_context` so every query in a `SiriusContext` reports under a single `<engine_name>-session-<pid>` group.

## Changes

- `telemetry_context` now creates and declares the query group (engine-parented) and exposes it via `query_group_id()`.
- `sirius_engine` drops its per-query group/observer and passes `telemetry_context_->query_group_id()` as the query's parent group.

## Not affected

No config keys, telemetry-generation scripts, or quent server-invocation change — only the *shape* of the emitted telemetry (one group per session instead of one per query). No CI job invokes quent, and no test asserts on the query-group wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)