### PR TITLE
changing behaviour of nightly benchmark pin mode

### DIFF
--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -175,13 +175,13 @@ grep -c 'duckdb_native_gpu_ingestible::materialize_table] decoded split' /tmp/na
 grep -c 'duckdb_native_metadata] refused'                       /tmp/native_verify/sirius_*.log   # expect 0
 ```
 
-> **Note:** `--pinning-mode per-query` is parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine it with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
+> **Note:** `--pinning-mode per-query` and `--pinning-mode pinned-hot` are parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine either with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
 
-#### `--pinning-mode per-query` (PR #721 pin_table)
+#### `--pinning-mode per-query | pinned-hot` (PR #721 pin_table)
 
 When passed `--pinning-mode per-query`, the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the query's remaining iterations, then `CALL unpin_table(<table>)` for each pinned table. This isolates per-query pinning cost from query execution: the query-iteration timings written to `timings.csv` reflect query-only time on the pinned-cache scan path.
 
-There used to also be a `pinned-hot` mode that pinned the union of every query's referenced columns once up front and kept it pinned for the whole run. It was removed after it OOM'd at SF500/SF1000 (the union of columns didn't fit in GPU memory) — pinning is always per-query now.
+`--pinning-mode pinned-hot` instead pins the union of every query's referenced columns once up front (before the first query) and keeps it pinned for the whole run, unpinning only at the end. It requires the default single-session mode (rejected with `--multi-session`, since fresh DuckDB processes can't preserve the cross-query cache). **Be careful at large scale factors**: pinning everything up front means the full working set must fit in the target tier's memory at once — this is what OOM'd the SF500/SF1000 nightly runs on 2026-06-30 (union-pinned to GPU memory). The `sirius-ci` nightly benchmarks no longer use `pinned-hot` for this reason; they always use `per-query` (see below).
 
 The per-query column-set is sourced from `tpch_pin_columns.py` (must be a superset of every column the query references, otherwise the scan falls through to disk). The pin path is a glob whose `FileSystem::GlobFiles` expansion must equal the file list of the corresponding `CREATE VIEW … read_parquet([…])` — otherwise `sirius_scan_manager::create_provider_for` will not match and the cache is silently bypassed.
 
@@ -191,10 +191,11 @@ echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches" | su
 
 Output layout (under `--output` root, default `test/tpch_performance/output/`):
 
-`--pin-after-iteration N` leaves each query's first `N` iterations (e.g. cold + warm) unpinned, then pins for the remaining ("hot") iterations before unpinning again. Default is `0` (pin from the first iteration — the original per-query behavior).
+`--pin-after-iteration N` (per-query mode only; ignored with pinned-hot) leaves each query's first `N` iterations (e.g. cold + warm) unpinned, then pins for the remaining ("hot") iterations before unpinning again. Default is `0` (pin from the first iteration — the original per-query behavior).
 
 ```bash
 ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query --pin-after-iteration 2 --iterations 5 100
+./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot --iterations 5 100
 ```
 
 To verify a query actually hit the cache, grep `runs/.../sirius/q<N>/sirius.log` for `using cached_split_provider`; the matching-fallback log line is `not all the columns are pinned for this query`.
@@ -334,7 +335,7 @@ Output: `reports/<label>_<YYYYMMDD_HHMMSS>/` containing `report.md`, `summary.js
 | `rewrite_parquet.py` | Rewrite parquet with GPU-optimized row groups (cudf or pyarrow fallback) |
 | `performance_test.py` | Python-based benchmark with result verification |
 | `queries.py` | TPC-H query definitions (base SQL) |
-| `tpch_pin_columns.py` | Per-query column → table mapping for `--pinning-mode per-query` (also has union pin-all/unpin-all helpers used by `performance_test.py --mode sequential`); emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
+| `tpch_pin_columns.py` | Per-query and union column → table mapping for `--pinning-mode per-query` / `pinned-hot` (union helpers also used by `performance_test.py --mode sequential`); emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
 | `generate_test_data.py` | Generate test data via dbgen |
 | `generate_test_data_tpchgen-rs.py` | Generate test data via tpchgen-rs Python wrapper + query files |
 | `pixi.toml` | Python environment with cudf, pyarrow, rust for tooling |

--- a/test/tpch_performance/CLAUDE.md
+++ b/test/tpch_performance/CLAUDE.md
@@ -175,11 +175,13 @@ grep -c 'duckdb_native_gpu_ingestible::materialize_table] decoded split' /tmp/na
 grep -c 'duckdb_native_metadata] refused'                       /tmp/native_verify/sirius_*.log   # expect 0
 ```
 
-> **Note:** `--pinning-mode per-query` and `--pinning-mode pinned-hot` are parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine either with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
+> **Note:** `--pinning-mode per-query` is parquet-only — `run_tpch_duckdb.sh` does not accept `--pinning-mode`, so do not combine it with `--data-source duckdb` or `duckdb-native`. The Python harness (`performance_test.py`) is also parquet-only and does not support the native scan.
 
-#### `--pinning-mode per-query | pinned-hot` (PR #721 pin_table)
+#### `--pinning-mode per-query` (PR #721 pin_table)
 
-When passed `--pinning-mode per-query`, the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the query for `--iterations` runs back-to-back, then `CALL unpin_table(<table>)` for each pinned table. This isolates per-query pinning cost from query execution: the query-iteration timings written to `timings.csv` reflect query-only time on the pinned-cache scan path.
+When passed `--pinning-mode per-query`, the Sirius engine wraps each query block with `CALL pin_table(<glob>, tier='gpu', name=<table>, cols=[...])` for every table the query reads, runs the query's remaining iterations, then `CALL unpin_table(<table>)` for each pinned table. This isolates per-query pinning cost from query execution: the query-iteration timings written to `timings.csv` reflect query-only time on the pinned-cache scan path.
+
+There used to also be a `pinned-hot` mode that pinned the union of every query's referenced columns once up front and kept it pinned for the whole run. It was removed after it OOM'd at SF500/SF1000 (the union of columns didn't fit in GPU memory) — pinning is always per-query now.
 
 The per-query column-set is sourced from `tpch_pin_columns.py` (must be a superset of every column the query references, otherwise the scan falls through to disk). The pin path is a glob whose `FileSystem::GlobFiles` expansion must equal the file list of the corresponding `CREATE VIEW … read_parquet([…])` — otherwise `sirius_scan_manager::create_provider_for` will not match and the cache is silently bypassed.
 
@@ -189,10 +191,10 @@ echo "$(whoami) ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches" | su
 
 Output layout (under `--output` root, default `test/tpch_performance/output/`):
 
-When passed `--pinning-mode pinned-hot`, the Sirius engine emits one union `CALL pin_table(...)` set before the timed query stream, using the union of referenced columns across all TPC-H queries, then emits one union `CALL unpin_table(...)` set after all queries finish. This keeps the pinned cache hot across query boundaries and excludes pin/unpin time from `timings.csv`. `pinned-hot` requires the default single-session mode; it is rejected with `--multi-session` because fresh DuckDB processes cannot preserve the cross-query cache.
+`--pin-after-iteration N` leaves each query's first `N` iterations (e.g. cold + warm) unpinned, then pins for the remaining ("hot") iterations before unpinning again. Default is `0` (pin from the first iteration — the original per-query behavior).
 
 ```bash
-./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot --iterations 5 100
+./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query --pin-after-iteration 2 --iterations 5 100
 ```
 
 To verify a query actually hit the cache, grep `runs/.../sirius/q<N>/sirius.log` for `using cached_split_provider`; the matching-fallback log line is `not all the columns are pinned for this query`.
@@ -332,7 +334,7 @@ Output: `reports/<label>_<YYYYMMDD_HHMMSS>/` containing `report.md`, `summary.js
 | `rewrite_parquet.py` | Rewrite parquet with GPU-optimized row groups (cudf or pyarrow fallback) |
 | `performance_test.py` | Python-based benchmark with result verification |
 | `queries.py` | TPC-H query definitions (base SQL) |
-| `tpch_pin_columns.py` | Per-query and union column → table mapping for `--pinning-mode per-query` / `pinned-hot`; emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
+| `tpch_pin_columns.py` | Per-query column → table mapping for `--pinning-mode per-query` (also has union pin-all/unpin-all helpers used by `performance_test.py --mode sequential`); emits `CALL pin_table(...)` / `CALL unpin_table(...)` SQL |
 | `generate_test_data.py` | Generate test data via dbgen |
 | `generate_test_data_tpchgen-rs.py` | Generate test data via tpchgen-rs Python wrapper + query files |
 | `pixi.toml` | Python environment with cudf, pyarrow, rust for tooling |

--- a/test/tpch_performance/benchmark_and_validate.sh
+++ b/test/tpch_performance/benchmark_and_validate.sh
@@ -385,9 +385,9 @@ NUM_ITERATIONS="${NUM_ITERATIONS:-2}"
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-1200}"
 
 case "$PINNING_MODE" in
-    none|per-query) ;;
+    none|per-query|pinned-hot) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
@@ -395,7 +395,7 @@ esac
 if [ $# -ne 1 ]; then
     echo "Usage: $0 [--config <config_file>] [--data-source parquet|duckdb|duckdb-native] [--parquet-dir <path>] [--duckdb-file <path>]"
     echo "          [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>]"
-    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] [--pin-after-iteration <N>]"
+    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot] [--pin-after-iteration <N>]"
     echo "          [--float-tolerance <value>] <scale_factor>"
     echo "       $0 --report [--float-tolerance <value>] <run_dir>"
     echo "  --data-source parquet       (default) → run_tpch_parquet.sh + test_datasets/tpch_parquet_sf<SF> or --parquet-dir"
@@ -403,6 +403,7 @@ if [ $# -ne 1 ]; then
     echo "  --data-source duckdb-native           → alias of 'duckdb' (GPU-native scan is the default now; kept for compatibility)"
     echo "  --pin-after-iteration N     with --pinning-mode per-query: run each query's first N iterations"
     echo "                              unpinned (e.g. cold + warm), then pin for the rest. Default: 0."
+    echo "                              Ignored with --pinning-mode pinned-hot."
     echo "Example: $0 --config ~/.sirius/sirius.yaml --engines sirius --iterations 3 --timeout 120 1000"
     echo "         $0 --duckdb-results runs/2026-03-10_sf1_2iter 1   # reuse stored DuckDB results for validation"
     echo "         $0 --multi-session --engines duckdb 100            # run DuckDB with fresh process per query"
@@ -414,6 +415,11 @@ fi
 
 if [ "$PINNING_MODE" != "none" ] && is_duckdb_source; then
     echo "ERROR: --pinning-mode is parquet-only; do not combine it with --data-source $DATA_SOURCE."
+    exit 1
+fi
+
+if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ]; then
+    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
     exit 1
 fi
 
@@ -536,16 +542,22 @@ echo "=== Collecting run info and filesystem benchmark ==="
     echo "--- Benchmark settings ---"
     echo "multi_session: $MULTI_SESSION"
     echo "drop_os_cache: $DROP_OS_CACHE"
-    # Compose a "pinned-<tier>" label from the pin tier (SIRIUS_PIN_TIER, same
-    # env var tpch_pin_columns.py / run_tpch_parquet.sh already read; defaults
-    # to 'gpu' when unset, matching CALL pin_table's own default). Pinning is
-    # always per-query now (no more union/"pinned-hot" scope).
+    # Compose a combined "pinned-<tier>-<scope>" label from the pinning scope
+    # (--pinning-mode) and the pin tier (SIRIUS_PIN_TIER, same env var
+    # tpch_pin_columns.py / run_tpch_parquet.sh already read; defaults to
+    # 'gpu' when unset, matching CALL pin_table's own default).
     PIN_TIER_REPORTED="${SIRIUS_PIN_TIER:-gpu}"
-    if [ "$PINNING_MODE" = "none" ]; then
-        PINNING_MODE_LABEL="none"
-    else
-        PINNING_MODE_LABEL="pinned-${PIN_TIER_REPORTED}"
-    fi
+    case "$PINNING_MODE" in
+        none)
+            PINNING_MODE_LABEL="none"
+            ;;
+        per-query)
+            PINNING_MODE_LABEL="pinned-${PIN_TIER_REPORTED}-grouped"
+            ;;
+        pinned-hot)
+            PINNING_MODE_LABEL="pinned-${PIN_TIER_REPORTED}-sequential"
+            ;;
+    esac
     echo "pinning_mode: $PINNING_MODE_LABEL"
     echo "pin_after_iteration: $PIN_AFTER_ITERATION"
     echo ""

--- a/test/tpch_performance/benchmark_and_validate.sh
+++ b/test/tpch_performance/benchmark_and_validate.sh
@@ -25,7 +25,7 @@
 # Usage:
 #   export SIRIUS_CONFIG_FILE=...
 #   ./test/tpch_performance/benchmark_and_validate.sh <scale_factor>
-#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot <scale_factor>
+#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb-native <scale_factor>
 #   ./test/tpch_performance/benchmark_and_validate.sh --report <run_dir>
@@ -33,7 +33,7 @@
 #
 # Example:
 #   ./test/tpch_performance/benchmark_and_validate.sh 1
-#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode pinned-hot --iterations 5 1
+#   ./test/tpch_performance/benchmark_and_validate.sh --pinning-mode per-query --pin-after-iteration 2 --iterations 5 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb --duckdb-file ./performance_test.duckdb 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --data-source duckdb-native --duckdb-file ./test_datasets/tpch_sf1.duckdb 1
 #   ./test/tpch_performance/benchmark_and_validate.sh --report runs/2026-03-10_12-00-00_sf1_2iter
@@ -311,6 +311,7 @@ DUCKDB_FILE=""
 MULTI_SESSION=false
 DROP_OS_CACHE=false
 PINNING_MODE="none"
+PIN_AFTER_ITERATION=0
 FLOAT_TOL="1e-10"
 while [ $# -gt 1 ]; do
     case "$1" in
@@ -324,6 +325,10 @@ while [ $# -gt 1 ]; do
             ;;
         --pinning-mode)
             PINNING_MODE="$2"
+            shift 2
+            ;;
+        --pin-after-iteration)
+            PIN_AFTER_ITERATION="$2"
             shift 2
             ;;
         --data-source)
@@ -380,9 +385,9 @@ NUM_ITERATIONS="${NUM_ITERATIONS:-2}"
 QUERY_TIMEOUT="${QUERY_TIMEOUT:-1200}"
 
 case "$PINNING_MODE" in
-    none|per-query|pinned-hot) ;;
+    none|per-query) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
@@ -390,12 +395,14 @@ esac
 if [ $# -ne 1 ]; then
     echo "Usage: $0 [--config <config_file>] [--data-source parquet|duckdb|duckdb-native] [--parquet-dir <path>] [--duckdb-file <path>]"
     echo "          [--engines 'sirius duckdb'] [--iterations N] [--timeout <seconds>] [--duckdb-results <run_dir>]"
-    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot]"
+    echo "          [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] [--pin-after-iteration <N>]"
     echo "          [--float-tolerance <value>] <scale_factor>"
     echo "       $0 --report [--float-tolerance <value>] <run_dir>"
     echo "  --data-source parquet       (default) → run_tpch_parquet.sh + test_datasets/tpch_parquet_sf<SF> or --parquet-dir"
     echo "  --data-source duckdb                  → run_tpch_duckdb.sh + performance_test.duckdb or --duckdb-file (GPU-native scan — the default for sirius)"
     echo "  --data-source duckdb-native           → alias of 'duckdb' (GPU-native scan is the default now; kept for compatibility)"
+    echo "  --pin-after-iteration N     with --pinning-mode per-query: run each query's first N iterations"
+    echo "                              unpinned (e.g. cold + warm), then pin for the rest. Default: 0."
     echo "Example: $0 --config ~/.sirius/sirius.yaml --engines sirius --iterations 3 --timeout 120 1000"
     echo "         $0 --duckdb-results runs/2026-03-10_sf1_2iter 1   # reuse stored DuckDB results for validation"
     echo "         $0 --multi-session --engines duckdb 100            # run DuckDB with fresh process per query"
@@ -407,11 +414,6 @@ fi
 
 if [ "$PINNING_MODE" != "none" ] && is_duckdb_source; then
     echo "ERROR: --pinning-mode is parquet-only; do not combine it with --data-source $DATA_SOURCE."
-    exit 1
-fi
-
-if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ]; then
-    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
     exit 1
 fi
 
@@ -534,7 +536,18 @@ echo "=== Collecting run info and filesystem benchmark ==="
     echo "--- Benchmark settings ---"
     echo "multi_session: $MULTI_SESSION"
     echo "drop_os_cache: $DROP_OS_CACHE"
-    echo "pinning_mode: $PINNING_MODE"
+    # Compose a "pinned-<tier>" label from the pin tier (SIRIUS_PIN_TIER, same
+    # env var tpch_pin_columns.py / run_tpch_parquet.sh already read; defaults
+    # to 'gpu' when unset, matching CALL pin_table's own default). Pinning is
+    # always per-query now (no more union/"pinned-hot" scope).
+    PIN_TIER_REPORTED="${SIRIUS_PIN_TIER:-gpu}"
+    if [ "$PINNING_MODE" = "none" ]; then
+        PINNING_MODE_LABEL="none"
+    else
+        PINNING_MODE_LABEL="pinned-${PIN_TIER_REPORTED}"
+    fi
+    echo "pinning_mode: $PINNING_MODE_LABEL"
+    echo "pin_after_iteration: $PIN_AFTER_ITERATION"
     echo ""
 
     echo "--- Benchmark input ---"
@@ -698,7 +711,7 @@ for engine in $ENGINES; do
     # Pinning is a Sirius-only feature; the runner ignores it for the duckdb engine,
     # but we still pass the flag so DuckDB-engine logs reflect the requested mode.
     if [ "$PINNING_MODE" != "none" ]; then
-        EXTRA_ARGS+=(--pinning-mode "$PINNING_MODE")
+        EXTRA_ARGS+=(--pinning-mode "$PINNING_MODE" --pin-after-iteration "$PIN_AFTER_ITERATION")
     fi
     OUTPUT_DIR="$ENGINE_DIR" "$RUN_SCRIPT" "${EXTRA_ARGS[@]}" "$engine" "$SF" "${QUERIES[@]}" \
         2>&1 | tee "$ENGINE_DIR/run.log"

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -49,7 +49,8 @@ SESSION_TIMEOUT=1200
 DROP_OS_CACHE=false
 MULTI_SESSION=false
 PINNING_MODE="none"
-while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:-}" = "--timeout" ] || [ "${1:-}" = "--drop-os-cache" ] || [ "${1:-}" = "--multi-session" ] || [ "${1:-}" = "--pinning-mode" ]; do
+PIN_AFTER_ITERATION=0
+while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:-}" = "--timeout" ] || [ "${1:-}" = "--drop-os-cache" ] || [ "${1:-}" = "--multi-session" ] || [ "${1:-}" = "--pinning-mode" ] || [ "${1:-}" = "--pin-after-iteration" ]; do
     if [ "$1" = "--parquet-dir" ]; then
         PARQUET_DIR="$2"
         shift 2
@@ -68,28 +69,32 @@ while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:
     elif [ "$1" = "--pinning-mode" ]; then
         PINNING_MODE="$2"
         shift 2
+    elif [ "$1" = "--pin-after-iteration" ]; then
+        PIN_AFTER_ITERATION="$2"
+        shift 2
     fi
 done
 
 case "$PINNING_MODE" in
-    none|per-query|pinned-hot) ;;
+    none|per-query) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
 
 if [ $# -lt 3 ]; then
-    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot] <engine> <scale_factor> <query_numbers...>"
+    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] [--pin-after-iteration <N>] <engine> <scale_factor> <query_numbers...>"
     echo "Example: $0 sirius 100 \`seq 1 22\`"
     echo "  --iterations N      Number of iterations per query (default: 2, 1 cold + N-1 warm)"
     echo "  --timeout N         Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
     echo "  --multi-session     Run each query in its own DuckDB process (fresh state per query)"
     echo "  --drop-os-cache     Drop OS filesystem cache before each query (requires --multi-session and sudo)"
-    echo "  --pinning-mode MODE 'per-query' calls pin_table for each query's columns before its iterations,"
-    echo "                      then unpin_table afterward. 'pinned-hot' pins the union of"
-    echo "                      referenced columns once for the whole single-session run."
-    echo "                      Sirius engine only. Default: 'none'."
+    echo "  --pinning-mode MODE 'per-query' calls pin_table for a query's columns, runs its remaining"
+    echo "                      iterations, then unpin_table. Sirius engine only. Default: 'none'."
+    echo "  --pin-after-iteration N   With --pinning-mode per-query: run the first N of each query's"
+    echo "                      iterations unpinned (e.g. cold + warm), then pin for the rest"
+    echo "                      (e.g. hot). Default: 0 (pin from the first iteration)."
     exit 1
 fi
 
@@ -119,11 +124,6 @@ fi
 
 if [ "$ENGINE" != "sirius" ] && [ "$ENGINE" != "duckdb" ]; then
     echo "Unknown engine, please use sirius or duckdb"
-    exit 1
-fi
-
-if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ] && [ "$ENGINE" = "sirius" ]; then
-    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
     exit 1
 fi
 
@@ -222,11 +222,7 @@ fi
 echo "Iterations: $NUM_ITERATIONS (1 cold + $((NUM_ITERATIONS - 1)) warm)"
 if [ "$PINNING_MODE" != "none" ]; then
     if [ "$ENGINE" = "sirius" ]; then
-        if [ "$PINNING_MODE" = "per-query" ]; then
-            echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu})"
-        else
-            echo "Pinning mode: $PINNING_MODE (pin_table once before timed queries, tier=${SIRIUS_PIN_TIER:-gpu})"
-        fi
+        echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu}, pin after iteration ${PIN_AFTER_ITERATION})"
     else
         echo "Pinning mode: $PINNING_MODE (ignored — Sirius-only feature)"
     fi
@@ -250,11 +246,8 @@ run_single_session() {
     local END_MARKER="__TPCH_END__"
 
     local PIN_PER_QUERY=false
-    local PINNED_HOT=false
     if [ "$PINNING_MODE" = "per-query" ] && [ "$ENGINE" = "sirius" ]; then
         PIN_PER_QUERY=true
-    elif [ "$PINNING_MODE" = "pinned-hot" ] && [ "$ENGINE" = "sirius" ]; then
-        PINNED_HOT=true
     fi
 
     local TEMP_SQL
@@ -262,39 +255,48 @@ run_single_session() {
     printf '%s\n' "$VIEW_SQL" > "$TEMP_SQL"
     echo ".timer on" >> "$TEMP_SQL"
 
-    if [ "$PINNED_HOT" = true ]; then
-        echo ".print __TPCH_PIN_BEGIN__ all" >> "$TEMP_SQL"
-        python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin-all "$PARQUET_DIR" >> "$TEMP_SQL"
-        echo ".print __TPCH_PIN_END__ all" >> "$TEMP_SQL"
-    fi
-
     for q in "${VALID_QUERIES[@]}"; do
         local QUERY_FILE="$QUERY_DIR/q${q}.sql"
-        # Pin/unpin live OUTSIDE the __TPCH_MARKER__ section so pin/unpin
-        # Run Time lines never get counted as query iterations.
+        echo ".print ${MARKER_PREFIX} ${q}" >> "$TEMP_SQL"
+
+        # --pin-after-iteration splits this query's N iterations into an
+        # unpinned prefix (e.g. cold + warm) and a pinned suffix (e.g. hot).
+        # Pin/unpin brackets live INSIDE the __TPCH_MARKER__ section now (mid-query
+        # when PIN_POINT > 0), so the result-extraction awk below skips their
+        # Run Time output explicitly instead of relying on section boundaries.
+        local PIN_POINT=0
         if [ "$PIN_PER_QUERY" = true ]; then
+            PIN_POINT="$PIN_AFTER_ITERATION"
+            [ "$PIN_POINT" -gt "$NUM_ITERATIONS" ] && PIN_POINT="$NUM_ITERATIONS"
+        fi
+
+        # Unpinned iterations first (0 of them when PIN_POINT is 0 — the old
+        # "pin from the start" behavior).
+        for ((iter = 0; iter < PIN_POINT; iter++)); do
+            cat "$QUERY_FILE" >> "$TEMP_SQL"
+            printf '\n' >> "$TEMP_SQL"
+        done
+
+        local PINNED_THIS_QUERY=false
+        if [ "$PIN_PER_QUERY" = true ] && [ "$PIN_POINT" -lt "$NUM_ITERATIONS" ]; then
+            PINNED_THIS_QUERY=true
             echo ".print __TPCH_PIN_BEGIN__ ${q}" >> "$TEMP_SQL"
             python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin "$q" "$PARQUET_DIR" >> "$TEMP_SQL"
             echo ".print __TPCH_PIN_END__ ${q}" >> "$TEMP_SQL"
         fi
-        echo ".print ${MARKER_PREFIX} ${q}" >> "$TEMP_SQL"
-        # N iterations back-to-back — nothing between them.
-        for ((iter = 0; iter < NUM_ITERATIONS; iter++)); do
+
+        # Remaining iterations (pinned, if pinning is on and any are left).
+        for ((iter = PIN_POINT; iter < NUM_ITERATIONS; iter++)); do
             cat "$QUERY_FILE" >> "$TEMP_SQL"
             printf '\n' >> "$TEMP_SQL"
         done
-        if [ "$PIN_PER_QUERY" = true ]; then
+
+        if [ "$PINNED_THIS_QUERY" = true ]; then
             echo ".print __TPCH_UNPIN_BEGIN__ ${q}" >> "$TEMP_SQL"
             python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin "$q" >> "$TEMP_SQL"
             echo ".print __TPCH_UNPIN_END__ ${q}" >> "$TEMP_SQL"
         fi
     done
-
-    if [ "$PINNED_HOT" = true ]; then
-        echo ".print __TPCH_UNPIN_BEGIN__ all" >> "$TEMP_SQL"
-        python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin-all >> "$TEMP_SQL"
-        echo ".print __TPCH_UNPIN_END__ all" >> "$TEMP_SQL"
-    fi
 
     echo ".print ${END_MARKER}" >> "$TEMP_SQL"
 
@@ -378,15 +380,24 @@ run_single_session() {
         echo ""
         echo "========== Q${q} =========="
 
-        # Extract the section between this query's marker and the next __TPCH_* marker.
-        # Stopping at any __TPCH_ prefix keeps pin/unpin Run Time lines (which sit in
-        # __TPCH_PIN_*/__TPCH_UNPIN_* sections when a pinning mode is on)
-        # out of the query iteration window.
+        # Extract this query's section: starts at its marker, ends at the next
+        # query's marker (or the final end marker). --pin-after-iteration can put
+        # a __TPCH_PIN_*/__TPCH_UNPIN_* bracket in the MIDDLE of this section (once
+        # pinning kicks in partway through the iterations), so drop everything
+        # between a *_BEGIN__ and its matching *_END__ line rather than treating
+        # any '__TPCH_' line as the end of the section.
         local SECTION
-        SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" '
-            $0 == start                            { cap = 1; next }
-            cap && index($0, "__TPCH_") == 1       { exit }
-            cap                                    { print }
+        SECTION=$(awk -v start="${MARKER_PREFIX} ${q}" -v marker_prefix="${MARKER_PREFIX}" -v end_marker="${END_MARKER}" '
+            {
+                if (cap == 0) { if ($0 == start) cap = 1; next }
+                if (skip == 1) {
+                    if (index($0, "__TPCH_PIN_END__") == 1 || index($0, "__TPCH_UNPIN_END__") == 1) skip = 0
+                    next
+                }
+                if (index($0, "__TPCH_PIN_BEGIN__") == 1 || index($0, "__TPCH_UNPIN_BEGIN__") == 1) { skip = 1; next }
+                if (index($0, marker_prefix) == 1 || $0 == end_marker) exit
+                print
+            }
         ' "$TEMP_OUTPUT")
 
         if [ -z "$SECTION" ]; then

--- a/test/tpch_performance/run_tpch_parquet.sh
+++ b/test/tpch_performance/run_tpch_parquet.sh
@@ -76,25 +76,28 @@ while [ "${1:-}" = "--parquet-dir" ] || [ "${1:-}" = "--iterations" ] || [ "${1:
 done
 
 case "$PINNING_MODE" in
-    none|per-query) ;;
+    none|per-query|pinned-hot) ;;
     *)
-        echo "ERROR: --pinning-mode must be 'none' or 'per-query' (got: $PINNING_MODE)"
+        echo "ERROR: --pinning-mode must be 'none', 'per-query', or 'pinned-hot' (got: $PINNING_MODE)"
         exit 1
         ;;
 esac
 
 if [ $# -lt 3 ]; then
-    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query] [--pin-after-iteration <N>] <engine> <scale_factor> <query_numbers...>"
+    echo "Usage: $0 [--parquet-dir <path>] [--iterations <N>] [--timeout <seconds>] [--multi-session] [--drop-os-cache] [--pinning-mode none|per-query|pinned-hot] [--pin-after-iteration <N>] <engine> <scale_factor> <query_numbers...>"
     echo "Example: $0 sirius 100 \`seq 1 22\`"
     echo "  --iterations N      Number of iterations per query (default: 2, 1 cold + N-1 warm)"
     echo "  --timeout N         Kill the DuckDB session after N seconds (default: 1200, 0 = no timeout)"
     echo "  --multi-session     Run each query in its own DuckDB process (fresh state per query)"
     echo "  --drop-os-cache     Drop OS filesystem cache before each query (requires --multi-session and sudo)"
-    echo "  --pinning-mode MODE 'per-query' calls pin_table for a query's columns, runs its remaining"
-    echo "                      iterations, then unpin_table. Sirius engine only. Default: 'none'."
+    echo "  --pinning-mode MODE 'per-query' calls pin_table for each query's columns, runs its remaining"
+    echo "                      iterations, then unpin_table. 'pinned-hot' pins the union of"
+    echo "                      referenced columns once for the whole single-session run."
+    echo "                      Sirius engine only. Default: 'none'."
     echo "  --pin-after-iteration N   With --pinning-mode per-query: run the first N of each query's"
     echo "                      iterations unpinned (e.g. cold + warm), then pin for the rest"
-    echo "                      (e.g. hot). Default: 0 (pin from the first iteration)."
+    echo "                      (e.g. hot). Default: 0 (pin from the first iteration). Ignored"
+    echo "                      with --pinning-mode pinned-hot (there is no per-query split)."
     exit 1
 fi
 
@@ -124,6 +127,11 @@ fi
 
 if [ "$ENGINE" != "sirius" ] && [ "$ENGINE" != "duckdb" ]; then
     echo "Unknown engine, please use sirius or duckdb"
+    exit 1
+fi
+
+if [ "$PINNING_MODE" = "pinned-hot" ] && [ "$MULTI_SESSION" = true ] && [ "$ENGINE" = "sirius" ]; then
+    echo "ERROR: --pinning-mode pinned-hot requires single-session mode; remove --multi-session."
     exit 1
 fi
 
@@ -222,7 +230,11 @@ fi
 echo "Iterations: $NUM_ITERATIONS (1 cold + $((NUM_ITERATIONS - 1)) warm)"
 if [ "$PINNING_MODE" != "none" ]; then
     if [ "$ENGINE" = "sirius" ]; then
-        echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu}, pin after iteration ${PIN_AFTER_ITERATION})"
+        if [ "$PINNING_MODE" = "per-query" ]; then
+            echo "Pinning mode: $PINNING_MODE (pin_table per query, tier=${SIRIUS_PIN_TIER:-gpu}, pin after iteration ${PIN_AFTER_ITERATION})"
+        else
+            echo "Pinning mode: $PINNING_MODE (pin_table once before timed queries, tier=${SIRIUS_PIN_TIER:-gpu})"
+        fi
     else
         echo "Pinning mode: $PINNING_MODE (ignored — Sirius-only feature)"
     fi
@@ -246,14 +258,23 @@ run_single_session() {
     local END_MARKER="__TPCH_END__"
 
     local PIN_PER_QUERY=false
+    local PINNED_HOT=false
     if [ "$PINNING_MODE" = "per-query" ] && [ "$ENGINE" = "sirius" ]; then
         PIN_PER_QUERY=true
+    elif [ "$PINNING_MODE" = "pinned-hot" ] && [ "$ENGINE" = "sirius" ]; then
+        PINNED_HOT=true
     fi
 
     local TEMP_SQL
     TEMP_SQL=$(mktemp /tmp/tpch_all_XXXXXX.sql)
     printf '%s\n' "$VIEW_SQL" > "$TEMP_SQL"
     echo ".timer on" >> "$TEMP_SQL"
+
+    if [ "$PINNED_HOT" = true ]; then
+        echo ".print __TPCH_PIN_BEGIN__ all" >> "$TEMP_SQL"
+        python3 "$SCRIPT_DIR/tpch_pin_columns.py" pin-all "$PARQUET_DIR" >> "$TEMP_SQL"
+        echo ".print __TPCH_PIN_END__ all" >> "$TEMP_SQL"
+    fi
 
     for q in "${VALID_QUERIES[@]}"; do
         local QUERY_FILE="$QUERY_DIR/q${q}.sql"
@@ -297,6 +318,12 @@ run_single_session() {
             echo ".print __TPCH_UNPIN_END__ ${q}" >> "$TEMP_SQL"
         fi
     done
+
+    if [ "$PINNED_HOT" = true ]; then
+        echo ".print __TPCH_UNPIN_BEGIN__ all" >> "$TEMP_SQL"
+        python3 "$SCRIPT_DIR/tpch_pin_columns.py" unpin-all >> "$TEMP_SQL"
+        echo ".print __TPCH_UNPIN_END__ all" >> "$TEMP_SQL"
+    fi
 
     echo ".print ${END_MARKER}" >> "$TEMP_SQL"
 


### PR DESCRIPTION
This PR is intended to go with https://gitlab-master.nvidia.com/sae-dataproc/sirius-ci/-/merge_requests/40

The combined change does:
We usually have 5 iterations of every query we benchmark in the nightly benchmarks. Right now we are pinning on GPU for every one of those iterations. This PR changes things so that we do not pin for the first two queries so that we have a COLD run and then a WARM run, then we pin and the last 3 iterations are all HOT. Pinning is still on GPU, except for SF500 and SF1000 where we pin to host.
Another change is that now the pinning should be just for what the query needs, not a union of what all the queries need.

For Sirius repo specifically, it mainly introduces the option to only pin after N iterations. 
