### PR TITLE
Recover expression result type natively, drop DuckDB round-trip

### DIFF
--- a/src/expression/ast/node.cpp
+++ b/src/expression/ast/node.cpp
@@ -73,6 +73,11 @@ std::size_t node::cudf_ast_op_count() const
   return std::visit([](auto const& alt) { return alt.cudf_ast_op_count(); }, v);
 }
 
+logical_type node::return_type() const
+{
+  return std::visit([](auto const& alt) -> logical_type { return alt.return_type(); }, v);
+}
+
 reference const& require_reference(node const* n, std::string_view context)
 {
   if (n == nullptr) { throw_wrong_node_type(context, "non-null reference node"); }

--- a/src/expression/ast/utils.cpp
+++ b/src/expression/ast/utils.cpp
@@ -57,9 +57,9 @@ std::unique_ptr<node> rebuild(node const& src, Xform const& xform)
       using T = std::decay_t<decltype(alt)>;
 
       if constexpr (std::is_same_v<T, reference>) {
-        return std::make_unique<node>(reference{alt.column_index, alt.return_type});
+        return std::make_unique<node>(reference{alt.column_index, alt.return_type()});
       } else if constexpr (std::is_same_v<T, constant>) {
-        return std::make_unique<node>(constant{alt.payload, alt.return_type});
+        return std::make_unique<node>(constant{alt.payload, alt.return_type()});
       } else if constexpr (std::is_same_v<T, comparison>) {
         return std::make_unique<node>(comparison{alt.op, xform(alt.left), xform(alt.right)});
       } else if constexpr (std::is_same_v<T, conjunction>) {

--- a/src/expression/to_duckdb.cpp
+++ b/src/expression/to_duckdb.cpp
@@ -94,16 +94,16 @@ std::unique_ptr<duckdb::Expression> to_duckdb(reference const& alt)
   // BoundReferenceExpression::return_type directly to decide whether a cast is
   // needed, so the real type must be preserved. Fall back to INTEGER only when
   // the node carries no type (default-constructed SQLNULL sentinel).
-  auto return_type = alt.return_type.id() == sirius::type_id::SQLNULL
+  auto return_type = alt.return_type().id() == sirius::type_id::SQLNULL
                        ? duckdb::LogicalType{duckdb::LogicalTypeId::INTEGER}
-                       : sirius::to_duckdb(alt.return_type);
+                       : sirius::to_duckdb(alt.return_type());
   return from_duck_derived_ptr(duckdb::make_uniq<duckdb::BoundReferenceExpression>(
     std::move(return_type), static_cast<duckdb::idx_t>(alt.column_index)));
 }
 
 std::unique_ptr<duckdb::Expression> to_duckdb(constant const& alt)
 {
-  auto duck_value = sirius::to_duckdb(alt.payload, alt.return_type);
+  auto duck_value = sirius::to_duckdb(alt.payload, alt.return_type());
   return from_duck_derived_ptr(
     duckdb::make_uniq<duckdb::BoundConstantExpression>(std::move(duck_value)));
 }

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -19,18 +19,12 @@
 
 #include <expression/ast/aggregate.hpp>  // sirius::ast::aggregate
 #include <expression/ast/node.hpp>       // sirius::ast::node alternatives
-#include <expression/ast/to_duckdb.hpp>  // sirius::ast::to_duckdb (per-alternative overloads + node dispatcher)
 #include <expression_evaluator/expression_evaluator.hpp>
 #include <sirius/exception.hpp>
 
 // cucascade
 #include <cucascade/cudf/gpu_data_representation.hpp>
 #include <data/data_batch_utils.hpp>
-
-// duckdb
-#include <duckdb/common/exception.hpp>
-#include <duckdb/common/types.hpp>
-#include <duckdb/planner/expression.hpp>
 
 // cudf
 #include <cudf/column/column_factories.hpp>
@@ -283,20 +277,19 @@ std::unique_ptr<cudf::table> expression_evaluator::evaluate(cudf::table_view inp
   // Get the table_view from the input_batch
   _input_table = std::move(input);
 
-  // Per-result column post-processing. The AST node is round-tripped through
-  // sirius::ast::to_duckdb to recover the expression_class + return_type fields
-  // that drive the post-processing path.
-  auto post_process = [this](duckdb::Expression const& expr, evaluate_result result) {
-    if (expr.expression_class == duckdb::ExpressionClass::BOUND_REF) {
-      // BOUND_REF: pass column through without type check
+  // Per-result column post-processing. The node's kind and result type are read
+  // natively from the Sirius AST (no DuckDB round-trip).
+  auto post_process = [this](sirius::ast::node const& expr, evaluate_result result) {
+    if (expr.holds<sirius::ast::reference>()) {
+      // Bound reference: pass column through without type check
       _output_columns.push_back(
         std::make_unique<cudf::column>(result.get_column_view(), _stream, _mr));
     } else {
-      // Cast the `result` from libcudf to `return_type` if `result` has a different type.
-      // E.g., `extract(year from col)` from libcudf returns int16_t but duckdb requires int64_t
-      // Only use cudf::cast when both types are fixed-width (cast does not support
+      // Cast the `result` from libcudf to the node's return type if `result` has a different
+      // type. E.g., `extract(year from col)` from libcudf returns int16_t but the SQL type is
+      // int64_t. Only use cudf::cast when both types are fixed-width (cast does not support
       // STRING/LIST/STRUCT).
-      auto const cudf_return_type = GetCudfType(expr.return_type);
+      auto const cudf_return_type = sirius::get_cudf_type(expr.return_type());
       std::unique_ptr<cudf::column> result_column;
       if (result.is_scalar()) {
         result_column =
@@ -311,18 +304,17 @@ std::unique_ptr<cudf::table> expression_evaluator::evaluate(cudf::table_view inp
         if (IsFixedWidth(result_column->type()) && IsFixedWidth(cudf_return_type)) {
           result_column = cudf::cast(result_column->view(), cudf_return_type, _stream, _mr);
         } else {
-          throw duckdb::InternalException("[expression_evaluator] Unsupported type conversion: " +
-                                          cudf::type_to_name(result_column->type()) + " to " +
-                                          cudf::type_to_name(cudf_return_type));
+          throw internal_exception("[expression_evaluator] Unsupported type conversion: {} to {}",
+                                   cudf::type_to_name(result_column->type()),
+                                   cudf::type_to_name(cudf_return_type));
         }
       }
       _output_columns.push_back(std::move(result_column));
     }
   };
 
-  // Iterate _ast_expressions and route through the std::visit dispatcher.
-  // The per-result post-processing recovers expression_class + return_type by
-  // round-tripping through sirius::ast::to_duckdb.
+  // Iterate _ast_expressions and route through the std::visit dispatcher, then
+  // post-process each result using the node's native kind + return type.
   for (auto const* ast_expr : _ast_expressions) {
     if (!ast_expr) {
       // This is a Sirius bug, not a user error: a null slot means from_duckdb
@@ -330,14 +322,13 @@ std::unique_ptr<cudf::table> expression_evaluator::evaluate(cudf::table_view inp
       // to the GPU executor.  This hard-fails the query instead of falling back to CPU.
       // TODO fix to ensure the planner never builds a GPU projection containing unsupported
       // expressions.
-      throw duckdb::InternalException(
+      throw internal_exception(
         "[expression_evaluator] null expression in select list — "
         "from_duckdb returned nullptr for an unsupported expression; "
         "cannot evaluate on GPU");
     }
-    auto result    = evaluate(*ast_expr, evaluation_mode::MATERIALIZE);
-    auto duck_expr = sirius::ast::to_duckdb(*ast_expr);
-    post_process(*duck_expr, std::move(result));
+    auto result = evaluate(*ast_expr, evaluation_mode::MATERIALIZE);
+    post_process(*ast_expr, std::move(result));
   }
 
   return std::make_unique<cudf::table>(std::move(_output_columns), _stream, _mr);
@@ -346,13 +337,8 @@ std::unique_ptr<cudf::table> expression_evaluator::evaluate(cudf::table_view inp
 std::unique_ptr<cudf::column> expression_evaluator::compute_mask(cudf::table_view input)
 {
   D_ASSERT(_ast_expressions.size() == 1);
-#ifdef D_ASSERT_IS_ENABLED
-  // Round-trip the single node through sirius::ast::to_duckdb so the BOOLEAN
-  // return-type assertion holds. Guarded so release builds skip the wasted
-  // DuckDB tree allocation (D_ASSERT is a no-op under NDEBUG).
-  auto duck_expr = sirius::ast::to_duckdb(*_ast_expressions[0]);
-  D_ASSERT(duck_expr->return_type == duckdb::LogicalType::BOOLEAN);
-#endif
+  // A filter predicate must be BOOLEAN. Read the type natively from the Sirius AST.
+  D_ASSERT(_ast_expressions[0]->return_type().id() == sirius::type_id::BOOLEAN);
 
   return std::move(evaluate(input)->release()[0]);
 }
@@ -364,7 +350,7 @@ std::unique_ptr<cudf::table> expression_evaluator::select(
   // output columns (e.g. count(*) over a filtered scan) is unrepresentable here. Such callers
   // must use the all-columns select() overload so the surviving row count is preserved.
   if (output_indices.empty()) {
-    throw duckdb::InternalException(
+    throw internal_exception(
       "[expression_evaluator] select(): output_indices must be non-empty; use the "
       "all-columns select() overload for count(*)-style filters with no output columns");
   }

--- a/src/expression_evaluator/gpu_expression_translator.cpp
+++ b/src/expression_evaluator/gpu_expression_translator.cpp
@@ -339,9 +339,9 @@ sirius::type_id node_logical_type_id(sirius::ast::node const& expr)
     [](auto const& alt) -> sirius::type_id {
       using T = std::decay_t<decltype(alt)>;
       if constexpr (std::is_same_v<T, sirius::ast::reference>) {
-        return alt.return_type.id();
+        return alt.return_type().id();
       } else if constexpr (std::is_same_v<T, sirius::ast::constant>) {
-        return alt.return_type.id();
+        return alt.return_type().id();
       } else if constexpr (std::is_same_v<T, sirius::ast::cast>) {
         return alt.target_type.id();
       } else if constexpr (std::is_same_v<T, sirius::ast::function_call>) {
@@ -405,7 +405,7 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     return std::nullopt;
   }
 
-  auto const cudf_type = sirius::get_cudf_type(alt.return_type);
+  auto const cudf_type = sirius::get_cudf_type(alt.return_type());
   // TODO: Expand type support as needed. See constant.cpp.
   switch (cudf_type.id()) {
     case cudf::type_id::INT8: {
@@ -495,7 +495,7 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     case cudf::type_id::DECIMAL32: {
       return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal32>>(
         std::get<sirius::decimal32>(alt.payload).value,
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())},
         true,
         _stream,
         _resource_ref);
@@ -503,7 +503,7 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     case cudf::type_id::DECIMAL64: {
       return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal64>>(
         std::get<sirius::decimal64>(alt.payload).value,
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())},
         true,
         _stream,
         _resource_ref);
@@ -511,7 +511,7 @@ std::optional<expr_ref> gpu_expression_translator::add_expression(
     case cudf::type_id::DECIMAL128: {
       return add_literal_expression<cudf::fixed_point_scalar<numeric::decimal128>>(
         std::get<sirius::decimal128>(alt.payload).value,
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())},
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())},
         true,
         _stream,
         _resource_ref);

--- a/src/expression_evaluator/specializations/constant.cpp
+++ b/src/expression_evaluator/specializations/constant.cpp
@@ -67,7 +67,7 @@ using evaluate_result = expression_evaluator::evaluate_result;
 evaluate_result expression_evaluator::evaluate(sirius::ast::constant const& alt,
                                                evaluation_mode mode)
 {
-  auto const cudf_type = sirius::get_cudf_type(alt.return_type);
+  auto const cudf_type = sirius::get_cudf_type(alt.return_type());
   bool const is_valid  = !std::holds_alternative<sirius::null_value>(alt.payload);
 
   switch (cudf_type.id()) {
@@ -168,7 +168,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::constant const& alt,
     }
     case cudf::type_id::DECIMAL32: {
       auto const scale =
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())};
       auto const rep =
         is_valid ? std::get<sirius::decimal32>(alt.payload).value : numeric::decimal32::rep{};
       auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
@@ -177,7 +177,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::constant const& alt,
     }
     case cudf::type_id::DECIMAL64: {
       auto const scale =
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())};
       auto const rep =
         is_valid ? std::get<sirius::decimal64>(alt.payload).value : numeric::decimal64::rep{};
       auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
@@ -186,7 +186,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::constant const& alt,
     }
     case cudf::type_id::DECIMAL128: {
       auto const scale =
-        numeric::scale_type{-static_cast<int32_t>(alt.return_type.decimal_scale())};
+        numeric::scale_type{-static_cast<int32_t>(alt.return_type().decimal_scale())};
       __int128_t const rep =
         is_valid ? std::get<sirius::decimal128>(alt.payload).value : __int128_t{};
       auto scalar = std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
@@ -200,7 +200,7 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::constant const& alt,
     }
     default:
       throw not_implemented_exception("[expression_evaluator] Unsupported scalar type: %s",
-                                      alt.return_type.to_string());
+                                      alt.return_type().to_string());
   }
 }
 

--- a/src/include/expression/ast/between.hpp
+++ b/src/include/expression/ast/between.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <memory>
 
@@ -32,6 +35,11 @@ struct between {
   std::unique_ptr<node> upper;
   bool lower_inclusive{true};
   bool upper_inclusive{true};
+
+  [[nodiscard]] sirius::logical_type return_type() const noexcept
+  {
+    return sirius::logical_type::make(sirius::type_id::BOOLEAN);
+  }
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/src/include/expression/ast/cast.hpp
+++ b/src/include/expression/ast/cast.hpp
@@ -37,6 +37,9 @@ struct cast {
   sirius::logical_type target_type;
   bool try_cast{false};
 
+  /// A cast's result type is its target type.
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return target_type; }
+
   std::size_t cudf_ast_op_count() const;
 };
 

--- a/src/include/expression/ast/comparison.hpp
+++ b/src/include/expression/ast/comparison.hpp
@@ -18,6 +18,7 @@
 
 // sirius
 #include "expression/join_condition.hpp"  // sirius::comparison_type
+#include "helper/logical_type.hpp"        // sirius::logical_type
 
 // standard library
 #include <memory>
@@ -36,6 +37,11 @@ struct comparison {
   sirius::comparison_type op{sirius::comparison_type::equal};
   std::unique_ptr<node> left;
   std::unique_ptr<node> right;
+
+  [[nodiscard]] sirius::logical_type return_type() const noexcept
+  {
+    return sirius::logical_type::make(sirius::type_id::BOOLEAN);
+  }
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/src/include/expression/ast/conjunction.hpp
+++ b/src/include/expression/ast/conjunction.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <cstdint>
 #include <memory>
@@ -44,6 +47,11 @@ struct conjunction {
 
   kind op{kind::invalid};
   std::vector<std::unique_ptr<node>> children;
+
+  [[nodiscard]] sirius::logical_type return_type() const noexcept
+  {
+    return sirius::logical_type::make(sirius::type_id::BOOLEAN);
+  }
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/src/include/expression/ast/constant.hpp
+++ b/src/include/expression/ast/constant.hpp
@@ -20,20 +20,33 @@
 #include "expression/value.hpp"     // sirius::value
 #include "helper/logical_type.hpp"  // sirius::logical_type
 
+// standard library
+#include <utility>
+
 namespace sirius::ast {
 
 /**
  * @brief Sirius-native mirror of duckdb::BoundConstantExpression.
  *
  * Carries a typed literal. `payload` is the typed sum-type holding the SQL
- * value; `return_type` carries DECIMAL precision and the SQL type of typed
- * NULLs. Mirrors the shape of cast::target_type and function_call::return_type.
+ * value; `return_type()` carries DECIMAL precision and the SQL type of typed
+ * NULLs. Mirrors the shape of cast::target_type and function_call::return_type().
  */
 struct constant {
   sirius::value payload;
-  sirius::logical_type return_type;
+
+  constant() = default;
+  constant(sirius::value payload, sirius::logical_type return_type)
+    : payload(std::move(payload)), return_type_(std::move(return_type))
+  {
+  }
+
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
 
   std::size_t cudf_ast_op_count() const;
+
+ private:
+  sirius::logical_type return_type_;
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/in_list.hpp
+++ b/src/include/expression/ast/in_list.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <memory>
 #include <vector>
@@ -37,6 +40,11 @@ struct in_list {
   std::unique_ptr<node> probe;
   std::vector<std::unique_ptr<node>> values;
   bool negated{false};
+
+  [[nodiscard]] sirius::logical_type return_type() const noexcept
+  {
+    return sirius::logical_type::make(sirius::type_id::BOOLEAN);
+  }
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/src/include/expression/ast/node.hpp
+++ b/src/include/expression/ast/node.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+
 // standard library
 #include <concepts>
 #include <cstddef>
@@ -65,6 +68,13 @@ concept has_cudf_ast_op_count = requires(T const& t) {
   { t.cudf_ast_op_count() } -> std::convertible_to<std::size_t>;
 };
 
+/// Compile-time contract: every alternative must expose `return_type()` so the
+/// std::visit dispatch in node::return_type() type-checks for every kind.
+template <class T>
+concept has_return_type = requires(T const& t) {
+  { t.return_type() } -> std::convertible_to<sirius::logical_type>;
+};
+
 namespace detail {
 
 template <class Variant>
@@ -73,6 +83,14 @@ struct all_have_cudf_ast_op_count;
 template <class... Ts>
 struct all_have_cudf_ast_op_count<std::variant<Ts...>> {
   static constexpr bool value = (has_cudf_ast_op_count<Ts> && ...);
+};
+
+template <class Variant>
+struct all_have_return_type;
+
+template <class... Ts>
+struct all_have_return_type<std::variant<Ts...>> {
+  static constexpr bool value = (has_return_type<Ts> && ...);
 };
 
 }  // namespace detail
@@ -111,6 +129,11 @@ struct node {
   static_assert(detail::all_have_cudf_ast_op_count<variant_t>::value,
                 "Every alternative in sirius::ast::node::variant_t must implement "
                 "std::size_t cudf_ast_op_count() const. Add the method to the "
+                "missing alternative struct.");
+
+  static_assert(detail::all_have_return_type<variant_t>::value,
+                "Every alternative in sirius::ast::node::variant_t must implement "
+                "sirius::logical_type return_type() const. Add the method to the "
                 "missing alternative struct.");
 
   variant_t v;
@@ -165,6 +188,10 @@ struct node {
   [[nodiscard]] function_call const& as_function_call() const;
 
   [[nodiscard]] std::size_t cudf_ast_op_count() const;
+
+  /// The SQL result type of this expression node, recovered natively (no DuckDB
+  /// round-trip). Dispatches via std::visit to each alternative's return_type().
+  [[nodiscard]] sirius::logical_type return_type() const;
 };
 
 /// Strict accessors for operator boundaries: return the held alternative or throw

--- a/src/include/expression/ast/reference.hpp
+++ b/src/include/expression/ast/reference.hpp
@@ -21,6 +21,7 @@
 
 // standard library
 #include <cstdint>
+#include <utility>
 
 namespace sirius::ast {
 
@@ -30,14 +31,24 @@ namespace sirius::ast {
  * Carries an index into the input data batch's column vector and the SQL type
  * of the referenced column (mirroring duckdb::BoundReferenceExpression's
  * return_type). The executor resolves column types from the input table_view at
- * runtime and ignores return_type; it exists so the cuDF-AST translator's
+ * runtime and ignores return_type(); it exists so the cuDF-AST translator's
  * decimal-propagation guard can see the type of a referenced decimal column.
  */
 struct reference {
   uint32_t column_index{0};
-  sirius::logical_type return_type{};
+
+  reference() = default;
+  explicit reference(uint32_t column_index, sirius::logical_type return_type = {})
+    : column_index(column_index), return_type_(std::move(return_type))
+  {
+  }
+
+  [[nodiscard]] sirius::logical_type const& return_type() const noexcept { return return_type_; }
 
   std::size_t cudf_ast_op_count() const;
+
+ private:
+  sirius::logical_type return_type_{};
 };
 
 }  // namespace sirius::ast

--- a/src/include/expression/ast/unary_op.hpp
+++ b/src/include/expression/ast/unary_op.hpp
@@ -16,6 +16,10 @@
 
 #pragma once
 
+// sirius
+#include "helper/logical_type.hpp"  // sirius::logical_type
+#include "sirius/exception.hpp"     // sirius::not_implemented_exception, sirius::internal_exception
+
 // standard library
 #include <cstdint>
 #include <memory>
@@ -51,6 +55,23 @@ struct unary_op {
 
   kind op{kind::invalid};
   std::unique_ptr<node> child;
+
+  /// All supported unary operators (NOT, IS NULL, IS NOT NULL) produce a
+  /// BOOLEAN. op_try has no defined lowering yet, mirroring cudf_ast_op_count().
+  [[nodiscard]] sirius::logical_type return_type() const
+  {
+    switch (op) {
+      case kind::op_not:
+      case kind::op_is_null:
+      case kind::op_is_not_null: return sirius::logical_type::make(sirius::type_id::BOOLEAN);
+      case kind::op_try:
+        throw not_implemented_exception(
+          "[ast::unary_op::return_type] TRY operator is not implemented.");
+      default:
+        throw internal_exception("[ast::unary_op::return_type] unknown kind: {}",
+                                 static_cast<int>(op));
+    }
+  }
 
   std::size_t cudf_ast_op_count() const;
 };

--- a/test/cpp/expression/test_ast_clone.cpp
+++ b/test/cpp/expression/test_ast_clone.cpp
@@ -58,7 +58,7 @@ TEST_CASE("ast_clone - cloning a reference yields an independent node with equal
   REQUIRE(cloned->holds<reference>());
   auto const& ref = cloned->get<reference>();
   REQUIRE(ref.column_index == 7);
-  REQUIRE(ref.return_type.id() == sirius::type_id::INTEGER);
+  REQUIRE(ref.return_type().id() == sirius::type_id::INTEGER);
 }
 
 // ============================================================================

--- a/test/cpp/expression/test_ast_from_duckdb.cpp
+++ b/test/cpp/expression/test_ast_from_duckdb.cpp
@@ -139,7 +139,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CONSTANT INTEGER translates to constant node"
   REQUIRE(out);
   REQUIRE(out->holds<constant>());
   auto const& c = out->get<constant>();
-  REQUIRE(c.return_type.id() == sirius::type_id::INTEGER);
+  REQUIRE(c.return_type().id() == sirius::type_id::INTEGER);
   REQUIRE(std::holds_alternative<int32_t>(c.payload));
   REQUIRE(std::get<int32_t>(c.payload) == 42);
 }
@@ -152,7 +152,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CONSTANT VARCHAR translates to constant node"
   REQUIRE(out);
   REQUIRE(out->holds<constant>());
   auto const& c = out->get<constant>();
-  REQUIRE(c.return_type.id() == sirius::type_id::VARCHAR);
+  REQUIRE(c.return_type().id() == sirius::type_id::VARCHAR);
   REQUIRE(std::holds_alternative<std::string>(c.payload));
   REQUIRE(std::get<std::string>(c.payload) == "hi");
 }
@@ -165,7 +165,7 @@ TEST_CASE("ast_from_duckdb - BOUND_CONSTANT NULL of INTEGER preserves type", "[a
   REQUIRE(out);
   REQUIRE(out->holds<constant>());
   auto const& c = out->get<constant>();
-  REQUIRE(c.return_type.id() == sirius::type_id::INTEGER);
+  REQUIRE(c.return_type().id() == sirius::type_id::INTEGER);
   REQUIRE(std::holds_alternative<sirius::null_value>(c.payload));
 }
 

--- a/test/cpp/expression/test_ast_to_duckdb.cpp
+++ b/test/cpp/expression/test_ast_to_duckdb.cpp
@@ -122,7 +122,7 @@ bool same_constant(node const& a, node const& b)
   if (!a.holds<constant>() || !b.holds<constant>()) return false;
   auto const& ca = a.get<constant>();
   auto const& cb = b.get<constant>();
-  if (ca.return_type.id() != cb.return_type.id()) return false;
+  if (ca.return_type().id() != cb.return_type().id()) return false;
   // sirius::value alternatives do not all expose operator==; compare via the
   // variant index plus a targeted check for the primitive alternatives the
   // self-equivalence sweep exercises (int32_t covers the BoundConstantExpression


### PR DESCRIPTION
## What

The expression evaluator recovered each result's expression class and return type by rebuilding a full DuckDB expression tree per output column via `sirius::ast::to_duckdb` — an allocation-heavy round-trip used only to read two fields. This recovers them natively from the Sirius AST.

- Add a uniform `sirius::logical_type return_type()` accessor to every AST alternative, plus a `has_return_type` concept + `static_assert` and a `node::return_type()` `std::visit` dispatcher (mirrors `cudf_ast_op_count`).
- `comparison`/`conjunction`/`between`/`in_list` return `BOOLEAN`; `unary_op` returns `BOOLEAN` and throws `not_implemented` for `op_try`; `cast` returns its target type.
- Convert `constant`/`reference` from aggregate structs to a constructor + private `return_type_` + `return_type()` accessor; update field reads to method calls.
- `expression_evaluator`: `post_process` uses `node.holds<reference>()` + `node.return_type()` + `sirius::get_cudf_type`; the filter path asserts the BOOLEAN return type natively. Swap `duckdb::InternalException` for `sirius::internal_exception` and drop all duckdb includes from the `.cpp`.

## Testing

- `pixi run make` passes.
- Expression evaluator / translator / non-duckdb-proof / AST unit suites pass (346 cases, 5519 assertions).
- `pre-commit run -a` clean.