### PR TITLE
MINOR: Fall back to DuckDB for unsupported aggregate expressions and SQLNULL columns

### DIFF
--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -16,6 +16,7 @@
 
 #include "planner/sirius_physical_plan_generator.hpp"
 
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -116,6 +117,16 @@ sirius_physical_plan_generator::create_plan(duckdb::LogicalOperator& op)
                    duckdb::LogicalOperatorToString(op.type));
   op.estimated_cardinality                                      = op.EstimateCardinality(context);
   duckdb::unique_ptr<sirius::op::sirius_physical_operator> plan = nullptr;
+
+  // SQLNULL-typed columns (e.g. an uncast NULL in VALUES) have no cuDF
+  // representation — get_cudf_type() / fixed_width_byte_size() reject them at
+  // execution time, after the GPU plan is already running. Reject the plan
+  // here instead so transparent execution falls back to DuckDB CPU.
+  for (const auto& type : op.types) {
+    if (duckdb::TypeVisitor::Contains(type, duckdb::LogicalTypeId::SQLNULL)) {
+      throw duckdb::NotImplementedException("SQLNULL-typed column not supported");
+    }
+  }
 
   switch (op.type) {
     case duckdb::LogicalOperatorType::LOGICAL_GET:

--- a/src/planner/sirius_plan_aggregate.cpp
+++ b/src/planner/sirius_plan_aggregate.cpp
@@ -41,16 +41,24 @@ namespace sirius::planner {
 namespace {
 
 // Translate a vector of DuckDB expressions into Sirius AST nodes at the planner
-// boundary. The source vector is drained; size and order are preserved, with a
-// null slot wherever from_duckdb declines an unsupported shape (a fallback
-// signal) — matching the prior bulk-translation null-skip semantics.
+// boundary. The source vector is drained; size and order are preserved. If
+// from_duckdb declines an unsupported shape (e.g. an ORDER BY aggregate rewritten
+// to arg_min_null / create_sort_key), it returns null — which the downstream
+// aggregate/projection operators cannot represent. Rather than build a GPU plan
+// containing null nodes (which crashes at execution time), throw here so the
+// query falls back to DuckDB's CPU execution.
 duckdb::vector<std::unique_ptr<sirius::ast::node>> translate_expressions(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs)
 {
   duckdb::vector<std::unique_ptr<sirius::ast::node>> out;
   out.reserve(exprs.size());
   for (auto& e : exprs) {
-    out.push_back(e ? sirius::ast::from_duckdb(*e) : nullptr);
+    auto translated = e ? sirius::ast::from_duckdb(*e) : nullptr;
+    if (e && translated == nullptr) {
+      throw duckdb::NotImplementedException(
+        "Unsupported expression in aggregate (falling back to CPU): " + e->ToString());
+    }
+    out.push_back(std::move(translated));
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Reject unsupported aggregate expressions during Sirius planning instead of allowing null AST nodes to reach execution.
- Reject plans containing `SQLNULL`-typed columns before GPU execution, allowing transparent fallback to DuckDB CPU execution.
- Prevents execution-time crashes for cases like uncast `NULL` values in `VALUES`.