### PR TITLE
test: stop disabled iceberg integration tests from hitting the network

### DIFF
--- a/test/cpp/integration/test_gpu_execution_multi_format.cpp
+++ b/test/cpp/integration/test_gpu_execution_multi_format.cpp
@@ -473,14 +473,19 @@ class GPUExecutionIcebergFixture : public MultiFormatFixtureBase {
     v1_path   = (root / "test/cpp/integration/data/iceberg_v1").string();
     v2_path   = (root / "test/cpp/integration/data/iceberg_v2_delete").string();
 
-    con->Query("INSTALL iceberg;");
-    auto load_result = con->Query("LOAD iceberg;");
     // Disabled: the legacy scan path (parquet/duckdb/iceberg scan tasks) was
     // removed, so iceberg_scan has no IO backend for delete data
     // ("read_iceberg_delete_data: no IO backend"). Force-skip every iceberg
     // integration case (all gate on iceberg_available, directly or via the
     // derived *_available flags) until iceberg is ported to the GPU scan path.
-    static_cast<void>(load_result);
+    //
+    // The INSTALL/LOAD below are commented out on purpose: INSTALL fetches the
+    // community extension from DuckDB's extension repository over the network,
+    // and since every case is skipped the extension would never be used.
+    // Uncomment (and drop iceberg_available = false) once iceberg is ported and
+    // these tests are re-enabled.
+    // con->Query("INSTALL iceberg;");
+    // con->Query("LOAD iceberg;");
     iceberg_available = false;
   }
 


### PR DESCRIPTION
The iceberg integration fixture ran `INSTALL iceberg;` in its constructor, which downloads the community extension from DuckDB's extension repository over the network. Every iceberg case is currently force-skipped (`iceberg_available = false`) until iceberg is ported to the GPU scan path, so the fetched extension is never used — the `INSTALL`/`LOAD` just hit the network for nothing whenever the `[iceberg]`/`[integration]` cases are selected.

This comments out the `INSTALL`/`LOAD` (kept inline so they're easy to restore) and leaves a note to uncomment them once the tests are re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)