### PR TITLE
feat(join): support expressions in hash-join equality conditions (#329)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,6 +639,7 @@ set(TEST_SOURCES
     test/cpp/parallel/test_task_executor.cpp
     test/cpp/planner/test_distinct_hash_join_detection.cpp
     test/cpp/planner/test_dynamic_filter_router.cpp
+    test/cpp/planner/test_join_expression_key.cpp
     test/cpp/planner/test_projection_fold.cpp
     test/cpp/pipeline/test_gpu_pipeline_executor.cpp
     test/cpp/pipeline/test_oom_reschedule.cpp

--- a/src/planner/sirius_plan_comparison_join.cpp
+++ b/src/planner/sirius_plan_comparison_join.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/parser/constraints/unique_constraint.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
@@ -30,7 +31,9 @@
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "expression/ast/from_duckdb.hpp"
 #include "expression/ast/node.hpp"
+#include "expression/ast/reference.hpp"
 #include "expression/ast/to_duckdb.hpp"
 #include "expression/join_condition.hpp"
 #include "helper/type_conversions.hpp"
@@ -39,6 +42,7 @@
 #include "op/sirius_physical_hash_join.hpp"
 #include "op/sirius_physical_nested_loop_join.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "planner/sirius_plan_projection_utils.hpp"
 #include "sirius_context.hpp"
 
 #include <algorithm>
@@ -354,6 +358,110 @@ std::vector<std::size_t> build_key_domain_cardinalities(duckdb::LogicalCompariso
 }  // namespace
 //===----------------------------------------------------------------------===//
 
+/// A join equality-condition side that is a plain column reference (BOUND_REF) or a cast of one
+/// (BOUND_CAST(BOUND_REF)) is already handled directly by the hash-join key extraction and by the
+/// PARTITION operator's cast-alignment logic, so it needs no materialization.
+static bool is_trivial_key_side(const duckdb::Expression& expr)
+{
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) { return true; }
+  if (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
+    return expr.Cast<duckdb::BoundCastExpression>().child->GetExpressionClass() ==
+           duckdb::ExpressionClass::BOUND_REF;
+  }
+  return false;
+}
+
+/// Materialize complex expressions appearing in equality join conditions into real columns.
+///
+/// Sirius always feeds a hash join through a PARTITION -> CONCAT chain, and the PARTITION operator
+/// - the first consumer of the join key - hashes columns by index and cannot evaluate expressions.
+/// To support keys like `n_nationkey * 10`, we push a projection below the join that appends the
+/// expression as a new column on that side's child, then rewrite the condition side to a plain
+/// BoundReferenceExpression pointing at the appended column. PARTITION, CONCAT, and the hash join
+/// then all see an ordinary column reference; the partitioning invariant (both sides hash the
+/// identical materialized value) holds because DuckDB binds both sides of a comparison to a common
+/// type, so the materialized column matches the type the other side hashes.
+///
+/// Only genuinely complex sides of equality (or IS-NOT-DISTINCT-FROM) conditions are materialized;
+/// plain/cast-of-reference sides keep the existing fast path, and inequality-condition sides are
+/// left untouched (they are evaluated inline as the mixed-join predicate). A side whose expression
+/// cannot be translated to a Sirius AST node is left unchanged, preserving the existing
+/// "unsupported join condition expression" behavior downstream.
+static void materialize_expression_join_keys(
+  duckdb::LogicalComparisonJoin& op,
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator>& left,
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator>& right)
+{
+  auto materialize_side = [&](duckdb::unique_ptr<sirius::op::sirius_physical_operator>& child,
+                              duckdb::vector<duckdb::idx_t>& projection_map,
+                              bool is_left) {
+    const std::size_t old_width = child->types.size();
+
+    // Gather the complex, translatable sides on this child across all equality conditions.
+    std::vector<std::size_t> cond_indices;
+    duckdb::vector<std::unique_ptr<sirius::ast::node>> key_exprs;
+    duckdb::vector<sirius::logical_type> key_types;
+    for (std::size_t i = 0; i < op.conditions.size(); i++) {
+      auto& cond = op.conditions[i];
+      if (cond.comparison != duckdb::ExpressionType::COMPARE_EQUAL &&
+          cond.comparison != duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+        continue;  // inequality sides are evaluated inline as the mixed-join predicate
+      }
+      auto& side_expr = is_left ? cond.left : cond.right;
+      if (is_trivial_key_side(*side_expr)) { continue; }
+      auto node = sirius::ast::from_duckdb(*side_expr);
+      if (!node) { continue; }  // untranslatable: leave for the existing downstream throw
+      cond_indices.push_back(i);
+      key_exprs.push_back(std::move(node));
+      key_types.push_back(sirius::from_duckdb(side_expr->return_type));
+    }
+
+    if (cond_indices.empty()) { return; }
+
+    // Build the projection: identity passthrough of all original columns + the key expressions.
+    duckdb::vector<std::unique_ptr<sirius::ast::node>> select_list;
+    duckdb::vector<sirius::logical_type> out_types;
+    select_list.reserve(old_width + key_exprs.size());
+    out_types.reserve(old_width + key_exprs.size());
+    for (std::size_t c = 0; c < old_width; c++) {
+      select_list.push_back(std::make_unique<sirius::ast::node>(
+        sirius::ast::reference{static_cast<uint32_t>(c), child->types[c]}));
+      out_types.push_back(child->types[c]);
+    }
+    for (std::size_t k = 0; k < key_exprs.size(); k++) {
+      select_list.push_back(std::move(key_exprs[k]));
+      out_types.push_back(key_types[k]);
+    }
+
+    const std::size_t cardinality = child->estimated_cardinality;
+    child =
+      push_projection(std::move(child), std::move(out_types), std::move(select_list), cardinality);
+
+    // Rewrite each materialized condition side to reference its appended column.
+    for (std::size_t k = 0; k < cond_indices.size(); k++) {
+      const std::size_t new_index = old_width + k;
+      auto& side_expr =
+        is_left ? op.conditions[cond_indices[k]].left : op.conditions[cond_indices[k]].right;
+      side_expr =
+        duckdb::make_uniq<duckdb::BoundReferenceExpression>(side_expr->return_type, new_index);
+    }
+
+    // Exclude the synthetic key column(s) from the join output. An empty projection map means
+    // "all columns"; make it explicit over just the original columns so the appended key does
+    // not leak into the join result or shift downstream column indices. A non-empty map already
+    // lists only original indices (< old_width) and needs no change.
+    if (projection_map.empty()) {
+      projection_map.reserve(old_width);
+      for (std::size_t c = 0; c < old_width; c++) {
+        projection_map.push_back(static_cast<duckdb::idx_t>(c));
+      }
+    }
+  };
+
+  materialize_side(left, op.left_projection_map, /*is_left=*/true);
+  materialize_side(right, op.right_projection_map, /*is_left=*/false);
+}
+
 duckdb::unique_ptr<sirius::op::sirius_physical_operator>
 sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJoin& op)
 {
@@ -379,6 +487,11 @@ sirius_physical_plan_generator::plan_comparison_join(duckdb::LogicalComparisonJo
     // no conditions: insert a cross product
     // return Make<PhysicalCrossProduct>(op.types, left, right, op.estimated_cardinality);
   }
+
+  // Materialize any complex expressions in equality conditions into real columns below the join,
+  // rewriting those condition sides to plain references. This must run before the conditions are
+  // inspected/wrapped below so all downstream analysis sees plain column references.
+  materialize_expression_join_keys(op, left, right);
 
   std::size_t has_range = 0;
   bool has_equality     = op.HasEquality(has_range);

--- a/test/cpp/integration/test_gpu_execution_tpch.cpp
+++ b/test/cpp/integration/test_gpu_execution_tpch.cpp
@@ -837,6 +837,46 @@ TEST_CASE_METHOD(GPUExecutionParquetFixture,
     "n.n_nationkey = c.c_nationkey;");
 }
 
+// issue #329: expressions in hash-join equality conditions. The join key is materialized into a
+// column below the join and partitioned on that column; the compare_gpu_vs_cpu delta assertion
+// (1 GPU exec, 0 fallbacks) also proves these run on the GPU rather than falling back to CPU.
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with expression key on build side",
+                 "[integration][gpu_execution][join]")
+{
+  // The canonical issue #329 example: expression on the (small) nation side.
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, c.c_custkey from customer c "
+    "join nation n on c.c_custkey = n.n_nationkey * 10;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with expression key on probe side",
+                 "[integration][gpu_execution][join]")
+{
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, c.c_custkey from customer c "
+    "join nation n on c.c_nationkey * 2 = n.n_nationkey;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - join with expressions on both sides",
+                 "[integration][gpu_execution][join]")
+{
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, c.c_custkey from customer c "
+    "join nation n on c.c_nationkey * 10 = n.n_nationkey * 10;");
+}
+
+TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
+                 "gpu_execution - mixed join with expression equality key and inequality",
+                 "[integration][gpu_execution][join]")
+{
+  compare_gpu_vs_cpu(
+    "select n.n_nationkey, c.c_custkey from customer c "
+    "join nation n on c.c_custkey = n.n_nationkey * 10 and c.c_custkey > n.n_nationkey;");
+}
+
 TEST_CASE_METHOD(GPUExecutionDuckDBFixture,
                  "gpu_execution - basic left join 0",
                  "[integration][gpu_execution][join]")

--- a/test/cpp/planner/test_join_expression_key.cpp
+++ b/test/cpp/planner/test_join_expression_key.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file test_join_expression_key.cpp
+ * @brief issue #329: hash-join equality conditions with expression keys (e.g. `a = b * 10`) are
+ *        materialized into a projection below the join, and the condition side is rewritten to a
+ *        plain column reference so PARTITION/CONCAT/hash-join see an ordinary column index.
+ */
+
+#include "expression/ast/to_duckdb.hpp"
+#include "expression/join_condition.hpp"
+#include "op/sirius_physical_hash_join.hpp"
+#include "planner/sirius_physical_plan_generator.hpp"
+
+#include <catch.hpp>
+#include <duckdb.hpp>
+#include <duckdb/execution/column_binding_resolver.hpp>
+#include <duckdb/main/config.hpp>
+#include <duckdb/optimizer/optimizer.hpp>
+#include <duckdb/parser/parser.hpp>
+#include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/planner.hpp>
+
+#include <filesystem>
+
+using namespace duckdb;
+
+namespace {
+
+/// Generate a Sirius physical plan from a SQL query string.
+duckdb::unique_ptr<sirius::op::sirius_physical_operator> generate_sirius_plan(
+  Connection& con, const std::string& query)
+{
+  auto& context = *con.context;
+
+  auto original_disabled = DBConfig::GetConfig(context).options.disabled_optimizers;
+  auto& disabled         = DBConfig::GetConfig(context).options.disabled_optimizers;
+  disabled.insert(OptimizerType::IN_CLAUSE);
+  disabled.insert(OptimizerType::COMPRESSED_MATERIALIZATION);
+
+  con.Query("BEGIN TRANSACTION");
+
+  duckdb::unique_ptr<sirius::op::sirius_physical_operator> result;
+  try {
+    Parser parser(context.GetParserOptions());
+    parser.ParseQuery(query);
+    REQUIRE(!parser.statements.empty());
+
+    Planner planner(context);
+    planner.CreatePlan(std::move(parser.statements[0]));
+    REQUIRE(planner.plan);
+
+    auto plan = std::move(planner.plan);
+
+    if (context.config.enable_optimizer) {
+      Optimizer optimizer(*planner.binder, context);
+      plan = optimizer.Optimize(std::move(plan));
+    }
+
+    plan->ResolveOperatorTypes();
+
+    ColumnBindingResolver resolver;
+    ColumnBindingResolver::Verify(*plan);
+    resolver.VisitOperator(*plan);
+
+    sirius::planner::sirius_physical_plan_generator gen(context);
+    result = gen.create_plan(std::move(plan));
+  } catch (duckdb::InternalException&) {
+    con.Query("ROLLBACK");
+    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    return nullptr;
+  } catch (...) {
+    con.Query("ROLLBACK");
+    DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+    throw;
+  }
+
+  con.Query("COMMIT");
+  DBConfig::GetConfig(context).options.disabled_optimizers = original_disabled;
+  return result;
+}
+
+sirius::op::sirius_physical_hash_join* find_hash_join(sirius::op::sirius_physical_operator* root)
+{
+  if (!root) { return nullptr; }
+  if (root->type == sirius::op::SiriusPhysicalOperatorType::HASH_JOIN) {
+    return &root->Cast<sirius::op::sirius_physical_hash_join>();
+  }
+  for (auto& child : root->children) {
+    auto* found = find_hash_join(child.get());
+    if (found) { return found; }
+  }
+  return nullptr;
+}
+
+bool is_bound_ref(const sirius::ast::node& side)
+{
+  auto expr = sirius::ast::to_duckdb(side);
+  return expr->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF;
+}
+
+/// Assert that every equality condition side of @p hj is a plain column reference (BOUND_REF),
+/// i.e. any complex expression was materialized out into a projection below the join.
+void require_all_equality_sides_are_references(sirius::op::sirius_physical_hash_join& hj)
+{
+  for (auto& c : hj.conditions) {
+    if (c.comparison != sirius::comparison_type::equal &&
+        c.comparison != sirius::comparison_type::not_distinct_from) {
+      continue;
+    }
+    CHECK(is_bound_ref(*c.left));
+    CHECK(is_bound_ref(*c.right));
+  }
+}
+
+bool has_projection_child(sirius::op::sirius_physical_hash_join& hj)
+{
+  for (auto& child : hj.children) {
+    if (child->type == sirius::op::SiriusPhysicalOperatorType::PROJECTION) { return true; }
+  }
+  return false;
+}
+
+struct join_expression_key_fixture {
+  join_expression_key_fixture()
+  {
+    auto cfg = std::filesystem::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "config" / "data" /
+               "minimal.yaml";
+    setenv("SIRIUS_CONFIG_FILE", cfg.string().c_str(), 1);
+    unsetenv("SIRIUS_DISABLE");
+    db = std::make_unique<DuckDB>(nullptr);
+    setenv("SIRIUS_DISABLE", "1", 1);
+    con = std::make_unique<Connection>(*db);
+
+    // big_left is larger so the optimizer keeps small_right as the build side.
+    con->Query("CREATE TABLE big_left (id INTEGER, val INTEGER)");
+    con->Query(
+      "INSERT INTO big_left VALUES (0,0),(1,3),(2,6),(3,9),(4,12),(5,15),(6,18),(7,21),(8,24),"
+      "(9,27),(10,30),(11,33),(12,36),(13,39),(14,42),(15,45),(16,48),(17,51),(18,54),(19,57)");
+    con->Query("CREATE TABLE small_right (rid INTEGER, other INTEGER)");
+    con->Query("INSERT INTO small_right VALUES (0, 0), (1, 1)");
+  }
+
+  ~join_expression_key_fixture() { unsetenv("SIRIUS_CONFIG_FILE"); }
+
+  std::unique_ptr<DuckDB> db;
+  std::unique_ptr<Connection> con;
+};
+
+}  // namespace
+
+TEST_CASE_METHOD(join_expression_key_fixture,
+                 "join expression key - single expression side is materialized and rewritten",
+                 "[join_expression_key][isolated_context]")
+{
+  auto plan =
+    generate_sirius_plan(*con, "SELECT * FROM big_left l JOIN small_right r ON l.id = r.rid * 10");
+  if (!plan) {
+    WARN("Plan generation failed (no DuckDB table scan support); skipping");
+    return;
+  }
+
+  auto* hj = find_hash_join(plan.get());
+  REQUIRE(hj);
+
+  // The `r.rid * 10` key is materialized, so both equality sides are now plain references.
+  require_all_equality_sides_are_references(*hj);
+
+  // A materializing projection was inserted directly below the join.
+  CHECK(has_projection_child(*hj));
+
+  // The synthetic key column is excluded from the join output: SELECT * over (id,val)+(rid,other)
+  // is 4 columns, not 5.
+  CHECK(hj->lhs_output_columns.col_idxs.size() + hj->rhs_output_columns.col_idxs.size() == 4);
+}
+
+TEST_CASE_METHOD(join_expression_key_fixture,
+                 "join expression key - expressions on both sides are materialized",
+                 "[join_expression_key][isolated_context]")
+{
+  auto plan = generate_sirius_plan(
+    *con, "SELECT * FROM big_left l JOIN small_right r ON l.id + 1 = r.rid + 1");
+  if (!plan) {
+    WARN("Plan generation failed; skipping");
+    return;
+  }
+
+  auto* hj = find_hash_join(plan.get());
+  REQUIRE(hj);
+  require_all_equality_sides_are_references(*hj);
+  CHECK(has_projection_child(*hj));
+  CHECK(hj->lhs_output_columns.col_idxs.size() + hj->rhs_output_columns.col_idxs.size() == 4);
+}
+
+TEST_CASE_METHOD(join_expression_key_fixture,
+                 "join expression key - plain column join is not materialized",
+                 "[join_expression_key][isolated_context]")
+{
+  auto plan =
+    generate_sirius_plan(*con, "SELECT * FROM big_left l JOIN small_right r ON l.id = r.rid");
+  if (!plan) {
+    WARN("Plan generation failed; skipping");
+    return;
+  }
+
+  auto* hj = find_hash_join(plan.get());
+  REQUIRE(hj);
+  // Fast path: plain-reference keys need no projection below the join.
+  CHECK_FALSE(has_projection_child(*hj));
+  require_all_equality_sides_are_references(*hj);
+}


### PR DESCRIPTION
Closes #329.

Hash joins rejected equality conditions with an expression key (e.g. `ON c.c_custkey = n.n_nationkey * 10`), throwing `Unsupported join condition expression`.

## Constraint
- DuckDB evaluates join keys inline in the hash join; it never lowers them into a projection.
- Sirius feeds every hash join through `PARTITION -> CONCAT` (all modes: STANDARD / BUILD_PROBE / MIXED_JOIN).
- `PARTITION` — not the join — is the first key consumer, and it hashes columns by index and cannot evaluate expressions.
- So an expression key must be a materialized column *before* partitioning; the inline model can't be reused.

## Change
- In `plan_comparison_join`, for each complex equality-condition side, append it as a column via `push_projection`.
- Rewrite that condition side to a plain `BoundReferenceExpression` at the appended index.
- `PARTITION`/`CONCAT`/hash-join are unchanged — they derive keys from the now-plain-reference conditions.
- The synthetic key column is excluded from the join output (empty projection map made explicit over original columns).
- Co-location is correct because DuckDB binds both comparison sides to a common type, so the materialized column matches the type the other side hashes.

```
scan -> PROJECTION[append key=expr] -> PARTITION[key=col] -> CONCAT -> HASH_JOIN[key ref, not in output]
```

## Scope
- Plain/cast-of-ref key sides keep the existing fast path (no materialization).
- Inequality-condition sides stay inline (evaluated as the mixed-join predicate).
- Untranslatable key expressions keep the existing throw (no new CPU fallback).
- Hash joins only; nested-loop / range joins out of scope.

## Tests
- Planner (`test_join_expression_key.cpp`): materialization into a projection, condition rewritten to a reference, synthetic key excluded from output, plain-column joins untouched.
- Integration (`test_gpu_execution_tpch.cpp`): GPU-vs-CPU correctness for expr on build/probe/both sides + a mixed eq/inequality join, using the `nation`/`customer` example.
- Full suite 1509 passing (exit 0); `pre-commit run` clean.