### PR TITLE
Support transparent read_parquet('s3://') on GPU 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ set(EXTENSION_SOURCES
     src/io/rest/rest_ioctx.cpp
     src/io/rest/rest_reactor.cpp
     src/io/s3/sigv4.cpp
+    src/io/s3/sirius_httpfs.cpp
     src/io/s3/sirius_sigv4_authorizer.cpp
     src/io/uring/uring_ioctx.cpp
     src/io/uring/uring_reactor.cpp
@@ -553,6 +554,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
     test/cpp/io/s3/test_sigv4.cpp
     test/cpp/io/s3/test_s3_default_visibility_guard.cpp
+    test/cpp/io/s3/test_sirius_httpfs.cpp
     test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
     test/cpp/io/s3/test_static_credentials.cpp
     test/cpp/io/test_parquet_helpers.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,7 +600,6 @@ set(TEST_SOURCES
     test/cpp/integration/test_table_gpu_cache_warm_mgpu.cpp
     test/cpp/io/s3/test_sigv4.cpp
     test/cpp/io/s3/test_s3_default_visibility_guard.cpp
-    test/cpp/io/s3/test_sirius_httpfs.cpp
     test/cpp/io/s3/test_sirius_sigv4_authorizer.cpp
     test/cpp/io/s3/test_static_credentials.cpp
     test/cpp/io/test_parquet_helpers.cpp
@@ -684,6 +683,7 @@ if(SIRIUS_BUILD_S3_TESTS)
     APPEND
     TEST_SOURCES
     test/cpp/utils/s3_container.cpp
+    test/cpp/io/s3/test_sirius_httpfs.cpp
     test/cpp/io/rest/test_rest_ioctx_integration.cpp
     test/cpp/scan_manager/test_describe_parquet_s3.cpp
     test/cpp/integration/test_s3_sql_surface.cpp)

--- a/src/include/io/s3/sirius_httpfs.hpp
+++ b/src/include/io/s3/sirius_httpfs.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <duckdb/common/file_system.hpp>
+#include <duckdb/common/open_file_info.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace sirius::io::s3 {
+
+/// @brief DuckDB FileSystem subsystem that lets DuckDB's native @c read_parquet
+/// BIND an @c s3:// object through Sirius's per-connection REST io backend.
+///
+/// Purpose: make the transparent form work —
+/// @code
+///   SET gpu_execution = true;
+///   SELECT ... FROM read_parquet('s3://bucket/file.parquet');
+/// @endcode
+/// without loading httpfs and without the @c sirius_read_parquet rewrite. DuckDB
+/// binds @c read_parquet('s3://') by reading the parquet footer through this
+/// FileSystem (positional reads via the routed @c rest_ioctx); the resulting
+/// native @c read_parquet scan is then captured by the transparent optimizer
+/// hook and executed on GPU, where the actual column data is read via the same
+/// routed ioctx (NOT through this FileSystem).
+///
+/// Registered DB-global on the VirtualFileSystem; the object itself is
+/// **stateless** (holds no ioctx). The per-connection backend is resolved
+/// lazily in @ref OpenFile via the injected @c FileOpener -> @c ClientContext ->
+/// @c SiriusContext: the @c ClientFileSystem (@c OpenerFileSystem) layer supplies
+/// the opener even though the parquet reader calls @c OpenFile with a null opener.
+///
+/// **GPU-only / no CPU fallback:** @ref OpenFile refuses to open an @c s3:// path
+/// unless @c gpu_execution is enabled on the connection. The GPU path reads via
+/// the routed ioctx, so this FileSystem only ever serves the bind-time footer
+/// read; it is never the CPU data path. Read-only: write opens are rejected.
+class sirius_httpfs : public duckdb::FileSystem {
+ public:
+  sirius_httpfs() = default;
+
+  /// True only for a well-formed @c s3://<bucket>/<key> (case-insensitive
+  /// scheme; rejects @c s3://bucket with no key, @c file://, local paths).
+  bool CanHandleFile(const std::string& fpath) override;
+
+  duckdb::unique_ptr<duckdb::FileHandle> OpenFile(
+    const std::string& path,
+    duckdb::FileOpenFlags flags,
+    duckdb::optional_ptr<duckdb::FileOpener> opener = nullptr) override;
+
+  void Read(duckdb::FileHandle& handle,
+            void* buffer,
+            int64_t nr_bytes,
+            duckdb::idx_t location) override;
+  int64_t Read(duckdb::FileHandle& handle, void* buffer, int64_t nr_bytes) override;
+
+  int64_t GetFileSize(duckdb::FileHandle& handle) override;
+  duckdb::timestamp_t GetLastModifiedTime(duckdb::FileHandle& handle) override;
+
+  /// Concrete-object only: returns @c {path} when @ref CanHandleFile, else empty.
+  /// Rejects glob/wildcard patterns (no S3 LIST) with a clear error.
+  duckdb::vector<duckdb::OpenFileInfo> Glob(const std::string& path,
+                                            duckdb::FileOpener* opener = nullptr) override;
+
+  void Seek(duckdb::FileHandle& handle, duckdb::idx_t location) override;
+  duckdb::idx_t SeekPosition(duckdb::FileHandle& handle) override;
+  bool CanSeek() override { return true; }
+  bool OnDiskFile(duckdb::FileHandle& /*handle*/) override { return false; }
+
+  std::string GetName() const override { return "SiriusHttpFS"; }
+};
+
+}  // namespace sirius::io::s3

--- a/src/include/sirius_context.hpp
+++ b/src/include/sirius_context.hpp
@@ -145,6 +145,38 @@ class SiriusContext : public ClientContextState {
     return _internal_query_depth.load(std::memory_order_relaxed) > 0;
   }
 
+  /**
+   * @brief RAII guard marking a CPU-fallback replay of a failed GPU query.
+   *
+   * Narrower than InternalQueryGuard: it fires ONLY around
+   * run_internal_cpu_fallback_query, and is read ONLY by the sirius_httpfs
+   * s3:// open guard, which must refuse serving s3:// data to a CPU plan. A
+   * legitimate internal s3:// read (e.g. future Iceberg-on-S3) runs under
+   * InternalQueryGuard but NOT this one, so it is not blocked.
+   */
+  struct CpuFallbackGuard {
+    explicit CpuFallbackGuard(SiriusContext& ctx) noexcept : ctx_(ctx)
+    {
+      ctx_.enter_cpu_fallback();
+    }
+    ~CpuFallbackGuard() noexcept { ctx_.exit_cpu_fallback(); }
+    CpuFallbackGuard(const CpuFallbackGuard&)            = delete;
+    CpuFallbackGuard& operator=(const CpuFallbackGuard&) = delete;
+
+   private:
+    SiriusContext& ctx_;
+  };
+
+  void enter_cpu_fallback() noexcept
+  {
+    _cpu_fallback_depth.fetch_add(1, std::memory_order_relaxed);
+  }
+  void exit_cpu_fallback() noexcept { _cpu_fallback_depth.fetch_sub(1, std::memory_order_relaxed); }
+  [[nodiscard]] bool is_cpu_fallback_active() const noexcept
+  {
+    return _cpu_fallback_depth.load(std::memory_order_relaxed) > 0;
+  }
+
   /// \brief Terminate the Sirius context, releasing all resources.
   void terminate();
 
@@ -269,6 +301,7 @@ class SiriusContext : public ClientContextState {
 
   mutable std::mutex mutex_;
   std::atomic<int> _internal_query_depth{0};
+  std::atomic<int> _cpu_fallback_depth{0};
   // The current Super Sirius runtime is shared across connections, so query
   // lifecycle callbacks and engine execution must be serialized to avoid
   // cross-connection state corruption. Held for the duration of

--- a/src/io/s3/sirius_httpfs.cpp
+++ b/src/io/s3/sirius_httpfs.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/s3/sirius_httpfs.hpp"
+
+#include "io/io_context.hpp"
+#include "io/sirius_datasource.hpp"
+#include "scan_manager/sirius_scan_manager.hpp"
+#include "sirius_context.hpp"
+
+#include <duckdb/common/exception.hpp>
+#include <duckdb/common/file_opener.hpp>
+#include <duckdb/common/types/value.hpp>
+#include <duckdb/main/client_context.hpp>
+
+#include <cctype>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace sirius::io::s3 {
+
+namespace {
+
+constexpr std::string_view kScheme = "s3://";
+
+/// FileHandle backed by a sirius_datasource resolved through the
+/// scan_manager's create_datasource(path) seam — the datasource carries its
+/// io backend, io_object and any cached metadata, and its host_read goes
+/// through the prefetch-cache-integrated path. Holds shared ownership so the
+/// backend outlives the handle. @c cursor_ only serves the sequential
+/// @c Read/Seek bookkeeping; the parquet reader uses positional reads.
+class sirius_httpfs_file_handle : public duckdb::FileHandle {
+ public:
+  sirius_httpfs_file_handle(duckdb::FileSystem& fs,
+                            std::string path,
+                            duckdb::FileOpenFlags flags,
+                            std::shared_ptr<sirius::io::sirius_datasource> datasource)
+    : duckdb::FileHandle(fs, std::move(path), flags), datasource_(std::move(datasource))
+  {
+  }
+
+  void Close() override {}
+
+  std::shared_ptr<sirius::io::sirius_datasource> datasource_;
+  duckdb::idx_t cursor_{0};
+};
+
+sirius_httpfs_file_handle& as_httpfs_handle(duckdb::FileHandle& handle)
+{
+  return static_cast<sirius_httpfs_file_handle&>(handle);
+}
+
+}  // namespace
+
+bool sirius_httpfs::CanHandleFile(const std::string& fpath)
+{
+  if (fpath.size() <= kScheme.size()) { return false; }
+  for (std::size_t i = 0; i < kScheme.size(); ++i) {
+    if (static_cast<char>(std::tolower(static_cast<unsigned char>(fpath[i]))) != kScheme[i]) {
+      return false;
+    }
+  }
+  // After "s3://" we need a non-empty bucket AND a non-empty key, i.e. a '/'
+  // that is neither first (empty bucket) nor last (empty key). This rejects
+  // "s3://bucket".
+  auto const rest  = std::string_view{fpath}.substr(kScheme.size());
+  auto const slash = rest.find('/');
+  return slash != std::string_view::npos && slash != 0 && slash + 1 < rest.size();
+}
+
+duckdb::unique_ptr<duckdb::FileHandle> sirius_httpfs::OpenFile(
+  const std::string& path,
+  duckdb::FileOpenFlags flags,
+  duckdb::optional_ptr<duckdb::FileOpener> opener)
+{
+  // Read-only filesystem: reject write opens (e.g. COPY ... TO 's3://…') before
+  // resolving the connection, so callers get a clear error instead of failing
+  // later on a HEAD of a not-yet-existing object.
+  if (flags.OpenForWriting()) {
+    throw duckdb::IOException("[sirius_httpfs] '" + path +
+                              "' is read-only; S3 writes (COPY TO) are not supported");
+  }
+  // The ClientFileSystem (OpenerFileSystem) layer injects the connection's
+  // FileOpener even though the parquet reader passes none.
+  auto client = duckdb::FileOpener::TryGetClientContext(opener);
+  if (!client) {
+    throw std::runtime_error("[sirius_httpfs] no ClientContext while opening '" + path +
+                             "'; S3 reads require a Sirius-enabled connection");
+  }
+  // Transparent S3 is GPU-only. The GPU scan reads column data through the routed
+  // ioctx, so this FileSystem only ever serves the bind-time footer read for the
+  // GPU path. If gpu_execution is off there is no GPU consumer, so opening here
+  // would be a CPU read of s3:// — which Sirius does not support. Refuse with a
+  // clear message instead of silently serving a CPU fallback.
+  {
+    duckdb::Value gpu_exec;
+    auto have         = client->TryGetCurrentSetting("gpu_execution", gpu_exec);
+    bool const gpu_on = have && !gpu_exec.IsNull() && gpu_exec.GetValue<bool>();
+    if (!gpu_on) {
+      throw duckdb::IOException("[sirius_httpfs] reading '" + path +
+                                "' over S3 requires GPU execution: S3 is GPU-only and has no CPU "
+                                "fallback; SET gpu_execution=true");
+    }
+  }
+  auto sirius_ctx = client->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  if (!sirius_ctx) {
+    throw std::runtime_error(
+      "[sirius_httpfs] Sirius is not initialized on this connection while opening '" + path + "'");
+  }
+  // No S3 CPU fallback. This FileSystem is only meant to serve the bind-time
+  // footer read for the transparent GPU path (the GPU scan then reads via the
+  // routed ioctx, not here). A CPU-fallback replay active here means the GPU
+  // plan failed and we are replaying on CPU (run_internal_cpu_fallback_query
+  // wraps the replay in a CpuFallbackGuard) — e.g. gpu_execution('SELECT ...
+  // FROM v_s3') whose view body reads s3:// and whose GPU plan failed. Refuse
+  // the read so s3:// data is never served to a CPU plan, even when reached
+  // indirectly through a view. Uses the narrow CpuFallbackGuard flag (not the
+  // broad is_internal_query_active), so a legitimate internal s3:// read is not
+  // blocked.
+  if (sirius_ctx->is_cpu_fallback_active()) {
+    throw duckdb::IOException(
+      "[sirius_httpfs] reading '" + path +
+      "' on a CPU execution path: S3 CPU fallback is not supported (S3 is GPU-only); "
+      "Sirius has no CPU fallback for S3 data sources");
+  }
+  // Resolve through the scan_manager's datasource factory (the routed seam):
+  // the returned sirius_datasource performs the HEAD and carries the backend;
+  // HEAD failures (missing key / auth / network) propagate as exceptions for
+  // DuckDB to surface at bind time.
+  auto datasource = sirius_ctx->get_scan_manager().create_datasource(path);
+  if (!datasource) {
+    throw std::runtime_error("[sirius_httpfs] no S3 backend supports '" + path + "'");
+  }
+  return duckdb::make_uniq<sirius_httpfs_file_handle>(*this, path, flags, std::move(datasource));
+}
+
+void sirius_httpfs::Read(duckdb::FileHandle& handle,
+                         void* buffer,
+                         int64_t nr_bytes,
+                         duckdb::idx_t location)
+{
+  if (nr_bytes < 0) {
+    throw duckdb::IOException("[sirius_httpfs] negative read size on '" + handle.GetPath() + "'");
+  }
+  auto& h        = as_httpfs_handle(handle);
+  auto const got = h.datasource_->host_read(static_cast<std::size_t>(location),
+                                            static_cast<std::size_t>(nr_bytes),
+                                            static_cast<std::uint8_t*>(buffer));
+  // DuckDB's positional Read contract is read-exactly-or-throw; host_read
+  // clips an EOF-crossing range to a short read, which would otherwise leave the
+  // tail of `buffer` stale.
+  if (got != static_cast<std::size_t>(nr_bytes)) {
+    throw duckdb::IOException("[sirius_httpfs] short read on '" + handle.GetPath() +
+                              "': requested " + std::to_string(nr_bytes) + " at " +
+                              std::to_string(static_cast<std::uint64_t>(location)) + ", got " +
+                              std::to_string(got));
+  }
+}
+
+int64_t sirius_httpfs::Read(duckdb::FileHandle& handle, void* buffer, int64_t nr_bytes)
+{
+  if (nr_bytes < 0) {
+    throw duckdb::IOException("[sirius_httpfs] negative read size on '" + handle.GetPath() + "'");
+  }
+  auto& h        = as_httpfs_handle(handle);
+  auto const got = h.datasource_->host_read(static_cast<std::size_t>(h.cursor_),
+                                            static_cast<std::size_t>(nr_bytes),
+                                            static_cast<std::uint8_t*>(buffer));
+  h.cursor_ += got;
+  return static_cast<int64_t>(got);
+}
+
+int64_t sirius_httpfs::GetFileSize(duckdb::FileHandle& handle)
+{
+  return static_cast<int64_t>(as_httpfs_handle(handle).datasource_->size());
+}
+
+duckdb::timestamp_t sirius_httpfs::GetLastModifiedTime(duckdb::FileHandle& /*handle*/)
+{
+  return duckdb::timestamp_t(0);
+}
+
+duckdb::vector<duckdb::OpenFileInfo> sirius_httpfs::Glob(const std::string& path,
+                                                         duckdb::FileOpener* /*opener*/)
+{
+  // No S3 LIST: reject glob/wildcard patterns with a clear error instead of
+  // treating '*' as a literal key and failing later on object open.
+  if (duckdb::FileSystem::HasGlob(path)) {
+    throw duckdb::IOException(
+      "[sirius_httpfs] glob/wildcard patterns are not supported for s3:// "
+      "(no S3 LIST); specify an exact object key: '" +
+      path + "'");
+  }
+  duckdb::vector<duckdb::OpenFileInfo> result;
+  if (CanHandleFile(path)) { result.emplace_back(path); }
+  return result;
+}
+
+void sirius_httpfs::Seek(duckdb::FileHandle& handle, duckdb::idx_t location)
+{
+  as_httpfs_handle(handle).cursor_ = location;
+}
+
+duckdb::idx_t sirius_httpfs::SeekPosition(duckdb::FileHandle& handle)
+{
+  return as_httpfs_handle(handle).cursor_;
+}
+
+}  // namespace sirius::io::s3

--- a/src/sirius_context.cpp
+++ b/src/sirius_context.cpp
@@ -18,9 +18,11 @@
 
 #include "config.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/multi_file/multi_file_states.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/planner.hpp"
 #include "log/logging.hpp"
 #include "memory/numa_small_pinned_mr.hpp"
@@ -28,6 +30,7 @@
 #include "memory/sirius_memory_reservation_manager.hpp"
 #include "memory/topology_index.hpp"
 #include "planner/sirius_physical_plan_generator.hpp"
+#include "sirius_sql_rewrite.hpp"
 #include "transparent/physical_sirius_execution.hpp"
 
 #include <cudf/utilities/pinned_memory.hpp>
@@ -762,6 +765,52 @@ void SiriusContext::record_transparent_execution() noexcept
   transparent_execution_count_.fetch_add(1, std::memory_order_relaxed);
 }
 
+namespace {
+
+bool logical_plan_reads_s3(duckdb::LogicalOperator const& op)
+{
+  if (op.type == duckdb::LogicalOperatorType::LOGICAL_GET) {
+    auto const& get = op.Cast<duckdb::LogicalGet>();
+    if (auto const* mf = dynamic_cast<duckdb::MultiFileBindData const*>(get.bind_data.get())) {
+      if (mf->file_list) {
+        for (auto const& file : mf->file_list->GetAllFiles()) {
+          auto const& p = file.path;
+          if (p.size() > 5 && (p[0] == 's' || p[0] == 'S') && p[1] == '3' && p[2] == ':' &&
+              p[3] == '/' && p[4] == '/') {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  for (auto const& child : op.children) {
+    if (logical_plan_reads_s3(*child)) { return true; }
+  }
+  return false;
+}
+
+// S3 is GPU-only. When a transparent query that reads s3:// fails on the GPU
+// path, refuse to fall back to CPU: DuckDB's CPU read_parquet would re-read the
+// s3:// data through the bind-only Sirius FileSystem, which is exactly the CPU
+// fallback S3 does not support. Detection is plan-based (the SQL text is not
+// reliably available during prepare, and view bodies hide the s3:// literal);
+// references_sirius_owned_s3_parquet on the query text is a secondary signal.
+// Non-s3 (local) queries fall through to the normal CPU fallback. Surfaces the
+// same clear error the gpu_execution(...) path raises.
+void throw_if_s3_no_cpu_fallback(bool plan_reads_s3,
+                                 std::string const& query_sql,
+                                 std::string const& gpu_error)
+{
+  if (plan_reads_s3 || sirius::references_sirius_owned_s3_parquet(query_sql)) {
+    throw std::runtime_error(
+      "S3 CPU fallback is not supported: this query reads s3:// data, GPU execution failed, and "
+      "Sirius has no CPU fallback for S3 data sources. Underlying GPU error: " +
+      gpu_error);
+  }
+}
+
+}  // namespace
+
 RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
                                                  PreparedStatementData& prepared,
                                                  PreparedStatementMode mode)
@@ -819,16 +868,25 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
       Optimizer optimizer(*planner.binder, context);
       logical_plan = optimizer.Optimize(std::move(planner.plan));
     } catch (NotImplementedException& e) {
+      // No captured plan to inspect on the replan path; guard on the SQL text so
+      // a direct read_parquet('s3://') that fails to re-plan does not CPU-fall-back.
+      throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
       record_transparent_fallback();
       SIRIUS_LOG_INFO("Transparent execution fallback (replan unsupported): {}", e.what());
       return RebindQueryInfo::DO_NOT_REBIND;
     } catch (std::exception& e) {
+      throw_if_s3_no_cpu_fallback(false, current_query_sql, e.what());
       record_transparent_fallback();
       SIRIUS_LOG_INFO("Transparent execution fallback (replan failed): {}", e.what());
       return RebindQueryInfo::DO_NOT_REBIND;
     }
     if (!logical_plan) { return RebindQueryInfo::DO_NOT_REBIND; }
   }
+
+  // Detect an s3:// read from the plan now, while logical_plan is still intact
+  // (create_plan below consumes it). S3 is GPU-only: if GPU translation fails we
+  // must NOT fall back to CPU for s3:// (see throw_if_s3_no_cpu_fallback).
+  bool const plan_reads_s3 = logical_plan_reads_s3(*logical_plan);
 
   try {
     // Validate that the captured logical plan is GPU-translatable before we
@@ -871,9 +929,11 @@ RebindQueryInfo SiriusContext::OnFinalizePrepare(ClientContext& context,
 
     SIRIUS_LOG_INFO("Transparent execution: physical plan replaced with GPU operator");
   } catch (NotImplementedException& e) {
+    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
     record_transparent_fallback();
     SIRIUS_LOG_INFO("Transparent execution fallback (unsupported): {}", e.what());
   } catch (std::exception& e) {
+    throw_if_s3_no_cpu_fallback(plan_reads_s3, current_query_sql, e.what());
     record_transparent_fallback();
     SIRIUS_LOG_INFO("Transparent execution fallback: {}", e.what());
   }

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -97,6 +97,7 @@ extern "C" int cudaProfilerStop();
 // <blockingconcurrentqueue.h> (used by spdlog / pipeline / duckdb
 // connection_manager). All consumers of blockingconcurrentqueue.h must
 // precede this include.
+#include "io/s3/sirius_httpfs.hpp"     // sirius::io::s3::sirius_httpfs
 #include "io/types.hpp"                // sirius::io::sirius_ioctx
 #include "io/uring/uring_reactor.hpp"  // sirius::io::uring_io_object
 
@@ -151,7 +152,12 @@ unique_ptr<QueryResult> run_internal_cpu_fallback_query(ClientContext& context,
   auto sirius_ctx = context.registered_state->Get<duckdb::SiriusContext>("sirius_state");
   if (!sirius_ctx) { return connection.Query(query); }
 
+  // CpuFallbackGuard marks this replay so sirius_httpfs refuses to serve s3://
+  // data reached indirectly (e.g. through a view) to the CPU plan — the
+  // string-level references_sirius_owned_s3_parquet check above only catches a
+  // literal read_parquet('s3://') in the query text.
   duckdb::SiriusContext::InternalQueryGuard guard(*sirius_ctx);
+  duckdb::SiriusContext::CpuFallbackGuard cpu_fallback_guard(*sirius_ctx);
   return connection.Query(query);
 }
 
@@ -1801,12 +1807,14 @@ static void LoadInternal(ExtensionLoader& loader)
   SiriusExtension::InitialGPUConfigs(config);
   SiriusExtension::RegisterGPUFunctions(db);
 
-  // S3 CPU fallback is not supported: there is no DuckDB CPU FileSystem for
-  // s3://. S3 parquet is read only on the GPU path (read_parquet('s3://…') is
-  // rewritten to sirius_read_parquet -> describe_parquet -> cuDF via s3_ioctx).
-  // A query that reads s3:// and fails on GPU surfaces a clear "S3 CPU fallback
-  // is not supported" error (see run_internal_cpu_fallback_query); local reads
-  // still fall back to DuckDB's CPU execution.
+  // Register the s3:// FileSystem so DuckDB's native read_parquet('s3://') binds
+  // by reading the parquet footer through Sirius's routed REST ioctx. This makes
+  // the transparent form work — SET gpu_execution=true; SELECT ... FROM
+  // read_parquet('s3://...') — with the captured scan run on GPU. sirius_httpfs
+  // is read-only and GPU-only: it serves the bind-time footer read, never a CPU
+  // data path (a query that reads s3:// and fails on GPU still surfaces a clear
+  // "S3 CPU fallback is not supported" error; local reads fall back to CPU).
+  db.GetFileSystem().RegisterSubSystem(make_uniq<sirius::io::s3::sirius_httpfs>());
 
   // Register optimizer extension for transparent GPU execution.
   // Pre-hook disables incompatible optimizers; post-hook captures the plan.

--- a/test/cpp/integration/test_s3_sql_surface.cpp
+++ b/test/cpp/integration/test_s3_sql_surface.cpp
@@ -267,6 +267,7 @@ struct sirius_memory_limits {
   std::optional<bool> enable_prefetch_cache;
   std::optional<std::size_t> rest_n_reactors;
   std::optional<std::size_t> rest_max_connections;
+  std::optional<bool> use_sirius_datasource;
   bool rest_perf_instrumentation{false};
 };
 
@@ -339,6 +340,10 @@ class sirius_config_env_guard {
            "    scan_manager:\n";
     if (limits.enable_prefetch_cache.has_value()) {
       out << "      enable_prefetch_cache: " << (*limits.enable_prefetch_cache ? "true" : "false")
+          << "\n";
+    }
+    if (limits.use_sirius_datasource.has_value()) {
+      out << "      use_sirius_datasource: " << (*limits.use_sirius_datasource ? "true" : "false")
           << "\n";
     }
     if (limits.rest_n_reactors.has_value()) {
@@ -457,6 +462,14 @@ std::string gpu_execution_sql(std::string const& inner_sql)
     escaped.push_back(c);
   }
   return "SELECT * FROM gpu_execution('" + escaped + "')";
+}
+
+void set_gpu_execution(duckdb::Connection& con, bool enabled)
+{
+  auto result = con.Query(std::string{"SET gpu_execution = "} + (enabled ? "true" : "false"));
+  REQUIRE(result);
+  INFO((result->HasError() ? result->GetError() : ""));
+  REQUIRE_FALSE(result->HasError());
 }
 
 std::vector<std::vector<std::string>> collect_rows(duckdb::MaterializedQueryResult& result)
@@ -1506,6 +1519,21 @@ void compare_s3_gpu_to_local_cpu(s3_sql_fixture& fixture,
   check_rows_equal_with_tolerant_columns(*s3_result, *local_result, tolerant_columns);
 }
 
+void compare_transparent_s3_gpu_to_local_cpu(
+  s3_sql_fixture& fixture,
+  std::string const& s3_query,
+  std::string const& local_query,
+  std::vector<duckdb::idx_t> const& tolerant_columns = {})
+{
+  auto s3_result = require_query_ok(fixture.con, s3_query);
+
+  duckdb::DuckDB baseline_db(nullptr);
+  duckdb::Connection baseline_con(baseline_db);
+  auto local_result = require_query_ok(baseline_con, local_query);
+
+  check_rows_equal_with_tolerant_columns(*s3_result, *local_result, tolerant_columns);
+}
+
 }  // namespace
 
 TEST_CASE("internal sirius_read_parquet is registered as a one-argument table function",
@@ -1913,6 +1941,47 @@ TEST_CASE("gpu_execution rewrites S3 read_parquet and scans through Sirius",
   }
 }
 
+TEST_CASE("transparent read_parquet over S3 scans through Sirius REST",
+          "[s3][integration][sql][gpu_execution][transparent]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+  auto& rest     = require_rest_ioctx(fixture, uri);
+  CHECK(rest.type() == sirius::io::io_context_type::restful);
+
+  auto const s3_query = "SELECT n_nationkey, n_name, n_regionkey FROM " +
+                        s3_parquet_scan(*env, "nation") + " ORDER BY n_nationkey";
+  auto const local_query = "SELECT n_nationkey, n_name, n_regionkey FROM " +
+                           local_parquet_scan(*env, "nation") + " ORDER BY n_nationkey";
+  compare_transparent_s3_gpu_to_local_cpu(fixture, s3_query, local_query);
+}
+
+TEST_CASE("transparent read_parquet over S3 keeps REST routing when local Sirius datasource is off",
+          "[s3][integration][sql][gpu_execution][transparent]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  sirius_memory_limits limits;
+  limits.use_sirius_datasource = false;
+  s3_sql_fixture fixture(*env, limits);
+  set_gpu_execution(fixture.con, true);
+
+  auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+  auto& rest     = require_rest_ioctx(fixture, uri);
+  CHECK(rest.type() == sirius::io::io_context_type::restful);
+
+  auto result =
+    require_query_ok(fixture.con, "SELECT count(*) FROM read_parquet(" + sql_quote(uri) + ")");
+  REQUIRE(result->RowCount() == 1);
+  CHECK(result->GetValue(0, 0).GetValue<int64_t>() == 25);
+}
+
 TEST_CASE("gpu_execution S3 SQL surface returns empty result sets cleanly",
           "[s3][integration][sql][gpu_execution]")
 {
@@ -1988,16 +2057,17 @@ TEST_CASE("gpu_execution S3 SQL surface matches local TPC-H Q3 shape",
                               {1});
 }
 
-TEST_CASE("gpu_execution S3 window query reports unsupported S3 CPU fallback",
-          "[s3][integration][sql][gpu_execution][fallback]")
+TEST_CASE("transparent S3 window query reports unsupported S3 CPU fallback",
+          "[s3][integration][sql][gpu_execution][fallback][transparent]")
 {
   auto env = load_s3_test_env();
   if (should_skip_s3_env(env)) { return; }
 
   s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
   auto const s3_query = "SELECT n_nationkey, ROW_NUMBER() OVER (ORDER BY n_nationkey) AS rn FROM " +
                         s3_parquet_scan(*env, "nation") + " ORDER BY n_nationkey";
-  auto result = fixture.con.Query(gpu_execution_sql(s3_query));
+  auto result = fixture.con.Query(s3_query);
   REQUIRE(result);
   REQUIRE(result->HasError());
   auto const error = result->GetError();
@@ -2009,20 +2079,52 @@ TEST_CASE("gpu_execution S3 window query reports unsupported S3 CPU fallback",
   CHECK(error.find("no filesystem") == std::string::npos);
 }
 
-TEST_CASE("plain DuckDB read_parquet over s3 is not the Sirius SQL surface",
-          "[s3][integration][sql][gpu_execution]")
+TEST_CASE("transparent S3 view fallback is rejected instead of replaying on CPU",
+          "[s3][integration][sql][gpu_execution][fallback][transparent]")
 {
   auto env = load_s3_test_env();
   if (should_skip_s3_env(env)) { return; }
 
   s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+  REQUIRE_FALSE(fixture.con
+                  .Query("CREATE VIEW v_s3_nation AS "
+                         "SELECT n_nationkey FROM " +
+                         s3_parquet_scan(*env, "nation"))
+                  ->HasError());
+
+  auto result = fixture.con.Query(
+    "SELECT n_nationkey, ROW_NUMBER() OVER (ORDER BY n_nationkey) AS rn "
+    "FROM v_s3_nation ORDER BY n_nationkey");
+  REQUIRE(result);
+  REQUIRE(result->HasError());
+  auto const error = result->GetError();
+  INFO(error);
+  CHECK(error.find("S3 CPU fallback is not supported") != std::string::npos);
+  CHECK((error.find("window") != std::string::npos || error.find("Window") != std::string::npos ||
+         error.find("WINDOW") != std::string::npos));
+  CHECK(error.find("No filesystem") == std::string::npos);
+  CHECK(error.find("no filesystem") == std::string::npos);
+}
+
+TEST_CASE("S3 read_parquet is rejected when transparent GPU execution is disabled",
+          "[s3][integration][sql][gpu_execution][transparent]")
+{
+  auto env = load_s3_test_env();
+  if (should_skip_s3_env(env)) { return; }
+
+  s3_sql_fixture fixture(*env);
+  set_gpu_execution(fixture.con, false);
   auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
   auto result    = fixture.con.Query("SELECT count(*) FROM read_parquet('" + uri + "')");
   REQUIRE(result);
   REQUIRE(result->HasError());
   auto const error = result->GetError();
   INFO(error);
-  CHECK((error.find("s3") != std::string::npos || error.find("S3") != std::string::npos));
+  CHECK(error.find("S3 is GPU-only") != std::string::npos);
+  CHECK(error.find("SET gpu_execution=true") != std::string::npos);
+  CHECK(error.find("No filesystem") == std::string::npos);
+  CHECK(error.find("no filesystem") == std::string::npos);
 }
 
 TEST_CASE("internal sirius_read_parquet bind returns row-count metadata for cardinality",

--- a/test/cpp/io/s3/test_sirius_httpfs.cpp
+++ b/test/cpp/io/s3/test_sirius_httpfs.cpp
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * See the LICENSE file at the repo root for the full text.
+ */
+
+#include "catch.hpp"
+#include "io/rest/rest_ioctx.hpp"
+#include "io/s3/sirius_httpfs.hpp"
+#include "io/sirius_datasource.hpp"
+#include "sirius_context.hpp"
+#include "sirius_extension.hpp"
+#include "utils/s3_container.hpp"
+
+#include <duckdb.hpp>
+#include <duckdb/common/file_system.hpp>
+#include <duckdb/common/open_file_info.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string env_or(std::string_view name, std::string fallback = {})
+{
+  auto const* value = std::getenv(std::string{name}.c_str());
+  return value ? std::string{value} : std::move(fallback);
+}
+
+bool truthy_env(std::string_view name)
+{
+  auto value = env_or(name);
+  return value == "1" || value == "true" || value == "TRUE" || value == "yes" || value == "YES";
+}
+
+struct s3_test_env {
+  std::string endpoint;
+  std::string region;
+  std::string access_key;
+  std::string secret_key;
+  std::string bucket;
+};
+
+std::optional<s3_test_env> read_s3_test_env()
+{
+  if (!sirius::test::ensure_s3_container_env()) { return std::nullopt; }
+
+  auto endpoint   = env_or("SIRIUS_TEST_S3_ENDPOINT");
+  auto access_key = env_or("SIRIUS_TEST_S3_ACCESS_KEY");
+  auto secret_key = env_or("SIRIUS_TEST_S3_SECRET_KEY");
+  auto bucket     = env_or("SIRIUS_TEST_S3_BUCKET");
+
+  if (endpoint.empty() || access_key.empty() || secret_key.empty() || bucket.empty()) {
+    return std::nullopt;
+  }
+
+  return s3_test_env{std::move(endpoint),
+                     env_or("SIRIUS_TEST_S3_REGION", "us-east-1"),
+                     std::move(access_key),
+                     std::move(secret_key),
+                     std::move(bucket)};
+}
+
+bool skip_if_no_s3_env(std::optional<s3_test_env> const& env)
+{
+  if (env) { return false; }
+  if (truthy_env("SIRIUS_TEST_S3_STRICT")) {
+    FAIL("SIRIUS_TEST_S3_* environment is required in strict mode");
+  }
+  SUCCEED("SIRIUS_TEST_S3_* not set; skipping live SiriusHttpFS test");
+  return true;
+}
+
+std::string s3_uri(std::string_view bucket, std::string_view key)
+{
+  return "s3://" + std::string{bucket} + "/" + std::string{key};
+}
+
+std::string sql_quote(std::string_view value)
+{
+  std::string out{"'"};
+  for (char c : value) {
+    if (c == '\'') { out.push_back('\''); }
+    out.push_back(c);
+  }
+  out.push_back('\'');
+  return out;
+}
+
+std::string yaml_quote(std::string const& value) { return sql_quote(value); }
+
+template <typename Fn>
+std::string thrown_message(Fn&& fn)
+{
+  try {
+    fn();
+  } catch (std::exception const& e) {
+    return e.what();
+  } catch (...) {
+    return "<non-std exception>";
+  }
+  return {};
+}
+
+void load_sirius_extension(duckdb::DuckDB& db)
+{
+  try {
+    db.LoadStaticExtension<duckdb::SiriusExtension>();
+  } catch (std::exception const& e) {
+    auto const msg = std::string{e.what()};
+    if (msg.find("already exists") == std::string::npos &&
+        msg.find("already loaded") == std::string::npos) {
+      throw;
+    }
+  }
+}
+
+class sirius_httpfs_config_env_guard {
+ public:
+  explicit sirius_httpfs_config_env_guard(s3_test_env const& env)
+  {
+    if (auto* current = std::getenv("SIRIUS_CONFIG_FILE"); current != nullptr) {
+      had_original_config_env_ = true;
+      original_config_env_     = current;
+    }
+    if (auto* current = std::getenv("SIRIUS_DISABLE"); current != nullptr) {
+      had_original_disable_env_ = true;
+      original_disable_env_     = current;
+    }
+
+    auto const unique = std::to_string(reinterpret_cast<std::uintptr_t>(this));
+    dir_              = fs::temp_directory_path() / ("sirius_httpfs_" + unique);
+    config_path_      = dir_ / "sirius.yaml";
+    fs::create_directories(dir_);
+
+    std::ofstream out(config_path_);
+    out << "sirius:\n"
+           "  space:\n"
+           "    gpu:\n"
+           "      - device_id: 0\n"
+           "        per_stream_reservation: false\n"
+           "        reservation_limit_fraction: 0.4\n"
+           "        downgrade_trigger_fraction: 0.8\n"
+           "        downgrade_stop_fraction: 0.6\n"
+           "        memory_capacity: 256 MiB\n"
+           "    host:\n"
+           "      - numa_id: -1\n"
+           "        reservation_limit_fraction: 0.9\n"
+           "        downgrade_trigger_fraction: 0.8\n"
+           "        downgrade_stop_fraction: 0.6\n"
+           "        memory_capacity: 512 MiB\n"
+           "        block_size: 1 MiB\n"
+           "  executor:\n"
+           "    scan_manager:\n"
+           "      object_store:\n"
+           "        endpoint: "
+        << yaml_quote(env.endpoint)
+        << "\n"
+           "        region: "
+        << yaml_quote(env.region)
+        << "\n"
+           "        access_key: "
+        << yaml_quote(env.access_key)
+        << "\n"
+           "        secret_key: "
+        << yaml_quote(env.secret_key)
+        << "\n"
+           "        tls_verify: false\n"
+           "      rest:\n"
+           "        max_connections: 8\n"
+           "        request_timeout_s: 30\n";
+    out.close();
+    REQUIRE(out);
+
+    setenv("SIRIUS_CONFIG_FILE", config_path_.string().c_str(), 1);
+    unsetenv("SIRIUS_DISABLE");
+  }
+
+  ~sirius_httpfs_config_env_guard()
+  {
+    if (had_original_config_env_) {
+      setenv("SIRIUS_CONFIG_FILE", original_config_env_.c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_CONFIG_FILE");
+    }
+    if (had_original_disable_env_) {
+      setenv("SIRIUS_DISABLE", original_disable_env_.c_str(), 1);
+    } else {
+      unsetenv("SIRIUS_DISABLE");
+    }
+    std::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+ private:
+  fs::path dir_;
+  fs::path config_path_;
+  std::string original_config_env_;
+  std::string original_disable_env_;
+  bool had_original_config_env_{false};
+  bool had_original_disable_env_{false};
+};
+
+class sirius_httpfs_fixture {
+ public:
+  explicit sirius_httpfs_fixture(s3_test_env const& env) : config_env(env), db(nullptr), con(db)
+  {
+    load_sirius_extension(db);
+    REQUIRE(con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state"));
+    setenv("SIRIUS_DISABLE", "1", 1);
+  }
+
+  sirius_httpfs_config_env_guard config_env;
+  duckdb::DuckDB db;
+  duckdb::Connection con;
+};
+
+std::unique_ptr<duckdb::MaterializedQueryResult> require_query_ok(duckdb::Connection& con,
+                                                                  std::string const& sql)
+{
+  auto result = con.Query(sql);
+  REQUIRE(result);
+  INFO((result->HasError() ? result->GetError() : ""));
+  REQUIRE_FALSE(result->HasError());
+  return std::unique_ptr<duckdb::MaterializedQueryResult>(
+    static_cast<duckdb::MaterializedQueryResult*>(result.release()));
+}
+
+std::vector<std::vector<std::string>> collect_rows(duckdb::MaterializedQueryResult& result)
+{
+  std::vector<std::vector<std::string>> rows;
+  for (duckdb::idx_t r = 0; r < result.RowCount(); ++r) {
+    std::vector<std::string> row;
+    row.reserve(result.ColumnCount());
+    for (duckdb::idx_t c = 0; c < result.ColumnCount(); ++c) {
+      row.push_back(result.GetValue(c, r).ToString());
+    }
+    rows.push_back(std::move(row));
+  }
+  return rows;
+}
+
+void set_gpu_execution(duckdb::Connection& con, bool enabled)
+{
+  auto result = con.Query(std::string{"SET gpu_execution = "} + (enabled ? "true" : "false"));
+  REQUIRE(result);
+  INFO((result->HasError() ? result->GetError() : ""));
+  REQUIRE_FALSE(result->HasError());
+}
+
+std::shared_ptr<sirius::io::sirius_datasource> require_rest_datasource(
+  sirius_httpfs_fixture& fixture, std::string const& uri)
+{
+  auto sirius_ctx =
+    fixture.con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+  REQUIRE(sirius_ctx);
+  auto datasource = sirius_ctx->get_scan_manager().create_datasource(uri);
+  REQUIRE(datasource != nullptr);
+  REQUIRE(datasource->io_ctx() != nullptr);
+  CHECK(datasource->io_ctx()->type() == sirius::io::io_context_type::restful);
+  auto* rest_ctx = dynamic_cast<sirius::io::rest::rest_ioctx*>(datasource->io_ctx().get());
+  REQUIRE(rest_ctx != nullptr);
+  return datasource;
+}
+
+}  // namespace
+
+TEST_CASE("sirius_httpfs claims only valid S3 object paths", "[s3][filesystem]")
+{
+  sirius::io::s3::sirius_httpfs fs;
+
+  CHECK(fs.CanHandleFile("s3://bucket/key.parquet"));
+  CHECK(fs.CanHandleFile("S3://bucket/key.parquet"));
+  CHECK_FALSE(fs.CanHandleFile("s3://bucket"));
+  CHECK_FALSE(fs.CanHandleFile("file:///tmp/key.parquet"));
+  CHECK_FALSE(fs.CanHandleFile("/tmp/key.parquet"));
+  CHECK(fs.CanSeek());
+}
+
+TEST_CASE("sirius_httpfs rejects glob patterns but accepts exact keys", "[s3][filesystem]")
+{
+  sirius::io::s3::sirius_httpfs fs;
+
+  CHECK_THROWS_AS(fs.Glob("s3://bucket/prefix/*.parquet"), duckdb::IOException);
+  CHECK_THROWS_AS(fs.Glob("s3://bucket/a?.parquet"), duckdb::IOException);
+  CHECK_THROWS_AS(fs.Glob("s3://bucket/[ab].parquet"), duckdb::IOException);
+
+  auto exact = fs.Glob("s3://bucket/key.parquet");
+  REQUIRE(exact.size() == 1);
+  CHECK(exact[0].path == "s3://bucket/key.parquet");
+
+  CHECK(fs.Glob("s3://bucket").empty());
+}
+
+TEST_CASE("sirius_httpfs rejects write opens before opener resolution", "[s3][filesystem]")
+{
+  sirius::io::s3::sirius_httpfs fs;
+
+  auto const write_message = thrown_message([&] {
+    auto handle =
+      fs.OpenFile("s3://bucket/key.parquet", duckdb::FileFlags::FILE_FLAGS_WRITE, nullptr);
+    (void)handle;
+  });
+  REQUIRE_FALSE(write_message.empty());
+  CHECK(write_message.find("read-only") != std::string::npos);
+  CHECK(write_message.find("no ClientContext") == std::string::npos);
+
+  auto const read_message = thrown_message([&] {
+    auto handle =
+      fs.OpenFile("s3://bucket/key.parquet", duckdb::FileFlags::FILE_FLAGS_READ, nullptr);
+    (void)handle;
+  });
+  REQUIRE_FALSE(read_message.empty());
+  CHECK(read_message.find("no ClientContext") != std::string::npos);
+}
+
+TEST_CASE("sirius_httpfs opens through FileOpener and reads positional ranges",
+          "[.][s3][integration][filesystem]")
+{
+  auto env = read_s3_test_env();
+  if (skip_if_no_s3_env(env)) { return; }
+
+  sirius_httpfs_fixture fixture(*env);
+  auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+  auto& fs       = duckdb::FileSystem::GetFileSystem(*fixture.con.context);
+  auto handle    = fs.OpenFile(uri, duckdb::FileFlags::FILE_FLAGS_READ);
+  REQUIRE(handle != nullptr);
+
+  auto datasource = require_rest_datasource(fixture, uri);
+  auto const size = handle->GetFileSize();
+  REQUIRE(size > 16);
+  CHECK(static_cast<std::size_t>(size) == datasource->io_object().size());
+  CHECK_FALSE(handle->OnDiskFile());
+
+  std::vector<std::uint8_t> fs_bytes(8);
+  std::vector<std::uint8_t> direct_bytes(8);
+  constexpr std::size_t offset = 4;
+
+  handle->Read(fs_bytes.data(), fs_bytes.size(), offset);
+  auto const direct_count = datasource->host_read(offset, direct_bytes.size(), direct_bytes.data());
+
+  CHECK(direct_count == direct_bytes.size());
+  CHECK(fs_bytes == direct_bytes);
+}
+
+TEST_CASE("sirius_httpfs positional reads fail on short reads and negative sizes",
+          "[.][s3][integration][filesystem]")
+{
+  auto env = read_s3_test_env();
+  if (skip_if_no_s3_env(env)) { return; }
+
+  sirius_httpfs_fixture fixture(*env);
+  auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+  auto& fs       = duckdb::FileSystem::GetFileSystem(*fixture.con.context);
+  auto handle    = fs.OpenFile(uri, duckdb::FileFlags::FILE_FLAGS_READ);
+  REQUIRE(handle != nullptr);
+
+  auto const size = handle->GetFileSize();
+  REQUIRE(size > 100);
+
+  std::vector<std::uint8_t> in_range(16);
+  REQUIRE_NOTHROW(fs.Read(*handle, in_range.data(), static_cast<int64_t>(in_range.size()), 0));
+
+  std::vector<std::uint8_t> eof_crossing(100);
+  CHECK_THROWS_AS(fs.Read(*handle,
+                          eof_crossing.data(),
+                          static_cast<int64_t>(eof_crossing.size()),
+                          static_cast<duckdb::idx_t>(size - 10)),
+                  duckdb::IOException);
+
+  std::vector<std::uint8_t> whole_object(static_cast<std::size_t>(size));
+  CHECK_THROWS_AS(fs.Read(*handle, whole_object.data(), -1, 0), duckdb::IOException);
+}
+
+TEST_CASE("transparent read_parquet over S3 routes through Sirius without httpfs",
+          "[.][s3][integration][filesystem][sql][gpu_execution]")
+{
+  auto env = read_s3_test_env();
+  if (skip_if_no_s3_env(env)) { return; }
+
+  sirius_httpfs_fixture fixture(*env);
+  set_gpu_execution(fixture.con, true);
+
+  auto const uri = s3_uri(env->bucket, "parquet/nation.parquet");
+  auto s3_result = require_query_ok(fixture.con,
+                                    "SELECT n_nationkey, n_name, n_regionkey "
+                                    "FROM read_parquet(" +
+                                      sql_quote(uri) + ") ORDER BY n_nationkey");
+
+  duckdb::DuckDB local_db(nullptr);
+  duckdb::Connection local_con(local_db);
+  auto local_result =
+    require_query_ok(local_con,
+                     "SELECT n_nationkey, n_name, n_regionkey "
+                     "FROM read_parquet(" +
+                       sql_quote((fs::path(SIRIUS_PROJECT_ROOT) / "test" / "cpp" / "integration" /
+                                  "data" / "parquet" / "nation.parquet")
+                                   .string()) +
+                       ") ORDER BY n_nationkey");
+
+  REQUIRE(s3_result->RowCount() == 25);
+  REQUIRE(s3_result->ColumnCount() == 3);
+  CHECK(s3_result->GetValue(0, 0).GetValue<int32_t>() == 0);
+  CHECK(s3_result->GetValue(1, 0).ToString() == "ALGERIA");
+  CHECK(s3_result->GetValue(2, 0).GetValue<int32_t>() == 0);
+  CHECK(collect_rows(*s3_result) == collect_rows(*local_result));
+}


### PR DESCRIPTION
Closes #1073.

## What

Makes transparent `read_parquet('s3://…')` work on the GPU:

    SET gpu_execution = true;
    SELECT ... FROM read_parquet('s3://bucket/key.parquet');

now binds and runs on GPU with no `gpu_execution('…')` wrapper. Completes the S3 read surface — the back half (routing `s3://` → REST/SigV4 ioctx, footer + data reads on GPU) already landed with #1042; this adds the one missing bind-time front door.

## How

Register a read-only `duckdb::FileSystem` for `s3://` (`sirius_httpfs`) that delegates the bind-time footer read to Sirius's routed REST ioctx (`create_datasource(path)` → `host_read`). It is **not** a DuckDB CPU/httpfs S3 client and **not** the data path: the bound native scan iscaptured by the transparent optimizer hook and run on GPU, reading column data through the ioctx as today.

Guards keep S3 GPU-only:

- open refused unless `gpu_execution` is on ("S3 is GPU-only … SET gpu_execution=true");
- open refused on a CPU-fallback replay — a narrow per-replay flag (`is_cpu_fallback_active`),
  distinct from the broad internal-query flag, so a future legitimate internal `s3://` read is not
  blocked;
- a transparent plan that reads `s3://` and fails GPU translation raises a clear
  "S3 CPU fallback is not supported" error (plan-walk) instead of replaying on CPU.


- `[s3][filesystem]` — `sirius_httpfs` unit (`CanHandleFile`, `OpenFile` guards, `Glob` rejects wildcards, MinIO positional reads / `GetFileSize`): 6/6.
- `[transparent][s3]` — transparent `read_parquet('s3://')` vs a local DuckDB CPU oracle, REST routing, GPU-only + no-CPU-fallback (window / view) error contracts: 5/5.
- `make s3-test` 36/36; full Catch2 1544/1544 — no regression.
