### PR TITLE
Revert "ci: enable GitHub Actions Docker layer cache"

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -5,8 +5,6 @@
 #     - Explicitly allowed third-party actions:
 #       prefix-dev/setup-pixi@*
 #       mozilla-actions/sccache-action@*
-#       docker/setup-buildx-action@*
-#       docker/build-push-action@*
 #     - Require actions to be pinned to a full-length commit SHA: NO
 #
 # Adding a new action? You must:
@@ -29,9 +27,6 @@ jobs:
   cuda-13:
     if: github.event_name != 'pull_request'
     uses: sirius-db/extension-ci-tools/.github/workflows/_extension_distribution.yml@sirius
-    permissions:
-      actions: write
-      contents: read
     with:
       extension_name: sirius
       duckdb_version: v1.5.4
@@ -43,7 +38,6 @@ jobs:
       vcpkg_binary_cache_enabled: true
       skip_tests: true
       reduced_ci_mode: "disabled"
-      docker_build_cache: true
       override_ci_tools_repository: "sirius-db/extension-ci-tools"
       build_type: ci-release
       build_duckdb_shell: false
@@ -57,9 +51,6 @@ jobs:
   cuda-12:
     if: github.event_name != 'pull_request'
     uses: sirius-db/extension-ci-tools/.github/workflows/_extension_distribution.yml@sirius
-    permissions:
-      actions: write
-      contents: read
     with:
       extension_name: sirius
       duckdb_version: v1.5.4
@@ -71,7 +62,6 @@ jobs:
       vcpkg_binary_cache_enabled: true
       skip_tests: true
       reduced_ci_mode: "disabled"
-      docker_build_cache: true
       override_ci_tools_repository: "sirius-db/extension-ci-tools"
       build_type: ci-release
       build_duckdb_shell: false


### PR DESCRIPTION
Reverts sirius-db/sirius#1069

Cache items are created, but not picked up.