### PR TITLE
Make delim join a framework-driven fan-out sink (#493)

### DIFF
--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -327,13 +327,13 @@ MERGE_TOP_N merges local top-N results.
 
 Complex splitting for correlated subqueries. Both LEFT and RIGHT variants contain two internal operators:
 - `join` — the actual HASH_JOIN (one child replaced with a scan of cached data)
-- `distinct` — a HASH_GROUP_BY that produces deduplicated data for DELIM_SCAN operators in the correlated subquery
+- `distinct_root` — the `MERGE_GROUP_BY → PARTITION_DISTINCT → DISTINCT` chain (the bottom DISTINCT, borrowed via the non-owning `distinct` pointer, is a HASH_GROUP_BY that produces deduplicated data for the DELIM_SCAN operators in the correlated subquery)
 
-When the delim join's `sink()` is called, it pushes data to both internal operators simultaneously. The distinct output is then partitioned and merged externally. Additionally, the internal HASH_JOIN undergoes standard probe-side and build-side splitting (documented in the [HASH_JOIN](#hash_join-probe-side) sections above).
+The delim join is a **fan-out sink**: its base `sink()` pushes each input batch to two framework-scheduled branch pipelines — the DISTINCT branch and the join-feeding branch (`partition_join` for RIGHT, `column_data_scan` for LEFT). These sub-operators are first-class pipelines (not driven inline), so the delim join carries its own two `next_port_after_sink` edges and is wired through the uniform tree-parent path like any other sink. The internal HASH_JOIN undergoes standard probe-side and build-side splitting (documented in the [HASH_JOIN](#hash_join-probe-side) sections above).
 
 #### RIGHT_DELIM_JOIN
 
-In the constructor, RIGHT_DELIM_JOIN extracts the RHS child from the internal join and replaces it with a `dummy_scan`. The extracted RHS becomes `children[0]` of the delim join, built via a child meta-pipeline. A `partition_join` (PARTITION, is_build=true) is created during `initialize_internal()` to partition data for the actual join's build side.
+In the constructor, RIGHT_DELIM_JOIN extracts the RHS child from the internal join and replaces it with a `dummy_scan` placeholder. The extracted RHS becomes `children[0]` of the delim join, built via a child meta-pipeline. `wrap_join` wraps the internal join's build side with `CONCAT_build → PARTITION_build → DUMMY_SCAN`; the `partition_join` pointer is set to that PARTITION_build, which becomes a framework-scheduled single-op pipeline fed by the delim join's fan-out.
 
 When `operators.size() > 0` (intermediate operators before the delim join), a pipeline breaker is inserted:
 
@@ -347,13 +347,13 @@ graph LR
     MR -->|"FULL"| DS["Downstream<br/>(DELIM_SCAN pipelines)"]
 ```
 
-Dashed edges indicate internal pushes from `RIGHT_DELIM_JOIN.sink()` to `partition_join` and `distinct`.
+Edges from the delim join to `partition_join` and `distinct` are its fan-out sink's two `next_port_after_sink` outputs; each sub-operator runs as its own framework-scheduled pipeline.
 
 When `operators.size() == 0` (no intermediate operators), no pipeline breaker is needed — the current pipeline keeps RIGHT_DELIM_JOIN as its sink directly.
 
-- The CONCAT is a build concat (`is_build=true`); it connects to the internal HASH_JOIN's `"build"` port in the probe pipeline
-- The probe and build `partition_join` operators are linked as siblings for partition count coordination
-- `partition_join` also receives a `FULL` barrier port on the same repository as the delim join (line 88–94 in `insert_repository`)
+- The CONCAT is a build concat (`is_build=true`); it connects to the internal HASH_JOIN's `"build"` port
+- `partition_join` (PARTITION_build) is a single-op pipeline fed by the delim join's fan-out; its output feeds CONCAT_build
+- The probe and build partitions are linked as siblings for partition-count coordination; the RIGHT_DELIM_JOIN inner join is detected via its tree parent (`link_join_partition_siblings`) so the build (distinct) side drives the count
 
 #### LEFT_DELIM_JOIN
 
@@ -367,7 +367,7 @@ graph LR
     MR -->|"FULL"| DS["Downstream<br/>(DELIM_SCAN pipelines)"]
 ```
 
-Dashed edges indicate internal pushes from `LEFT_DELIM_JOIN.sink()` to `column_data_scan` and `distinct`.
+Edges from the delim join to `column_data_scan` and `distinct` are its fan-out sink's two `next_port_after_sink` outputs; each runs as its own framework-scheduled pipeline.
 
 - `column_data_scan` caches the input data so the internal HASH_JOIN's probe side can scan it
 - The internal HASH_JOIN is built into the probe pipeline via `join->build_pipelines()`, so its build side (the correlated subquery) gets a normal child meta-pipeline with standard HASH_JOIN handling
@@ -381,7 +381,7 @@ Dashed edges indicate internal pushes from `LEFT_DELIM_JOIN.sink()` to `column_d
 | Internal join child replaced | RHS → `dummy_scan` | LHS → `column_data_scan` |
 | Pipeline breaker | Yes (if intermediate ops exist) | Never |
 | Build-side data path | `partition_join` → CONCAT → HASH_JOIN "build" port | Standard HASH_JOIN build handling (correlated subquery) |
-| Inner-join build subtree | Synthetic scaffolding (CONCAT_build → PARTITION_build → DUMMY_SCAN); `partition_join` runs inline in `sink()` | Real correlated-subquery subtree under CONCAT_build |
+| Inner-join build subtree | CONCAT_build → PARTITION_build (`partition_join`) → DUMMY_SCAN placeholder; `partition_join` is a framework-scheduled pipeline fed by the fan-out | Real correlated-subquery subtree under CONCAT_build |
 | Cached data scan | N/A | `column_data_scan` feeds probe side |
 
 ## Part 4: Port Wiring

--- a/docs/super-sirius/physical-plan-generation.md
+++ b/docs/super-sirius/physical-plan-generation.md
@@ -325,17 +325,15 @@ MERGE_TOP_N merges local top-N results.
 
 ### DELIM_JOIN
 
-Complex splitting for correlated subqueries. Both LEFT and RIGHT variants contain two internal operators:
-- `join` — the actual HASH_JOIN (one child replaced with a scan of cached data)
-- `distinct_root` — the `MERGE_GROUP_BY → PARTITION_DISTINCT → DISTINCT` chain (the bottom DISTINCT, borrowed via the non-owning `distinct` pointer, is a HASH_GROUP_BY that produces deduplicated data for the DELIM_SCAN operators in the correlated subquery)
+Decorrelated correlated-subquery join. Both variants hold two internal operators:
+- `join` — the HASH_JOIN doing the join-back (one child replaced by a cached-data scan)
+- `distinct_root` — the `MERGE_GROUP_BY → PARTITION_DISTINCT → DISTINCT` chain that dedups the correlated key for the subquery's DELIM_SCANs (`distinct` is a non-owning borrow of the bottom DISTINCT)
 
-The delim join is a **fan-out sink**: its base `sink()` pushes each input batch to two framework-scheduled branch pipelines — the DISTINCT branch and the join-feeding branch (`partition_join` for RIGHT, `column_data_scan` for LEFT). These sub-operators are first-class pipelines (not driven inline), so the delim join carries its own two `next_port_after_sink` edges and is wired through the uniform tree-parent path like any other sink. The internal HASH_JOIN undergoes standard probe-side and build-side splitting (documented in the [HASH_JOIN](#hash_join-probe-side) sections above).
+The delim join is a **fan-out sink that performs no data transformation**: `execute()` is a pass-through, and its base `sink()` forwards each input batch unchanged to two branch pipelines — the DISTINCT branch and the join-feeding branch (`partition_join` for RIGHT, `column_data_scan` for LEFT). It owns the fan-out (two `next_port_after_sink` edges) and anchors the construct (the `distinct` / `join` / `column_data_scan` / `delim_scans` pointers and the DELIM_SCAN dependency); the dedup and the join happen in the sub-operators.
 
 #### RIGHT_DELIM_JOIN
 
-In the constructor, RIGHT_DELIM_JOIN extracts the RHS child from the internal join and replaces it with a `dummy_scan` placeholder. The extracted RHS becomes `children[0]` of the delim join, built via a child meta-pipeline. `wrap_join` wraps the internal join's build side with `CONCAT_build → PARTITION_build → DUMMY_SCAN`; the `partition_join` pointer is set to that PARTITION_build, which becomes a framework-scheduled single-op pipeline fed by the delim join's fan-out.
-
-When `operators.size() > 0` (intermediate operators before the delim join), a pipeline breaker is inserted:
+Ctor: extract the RHS from the internal join, replace it with a `dummy_scan` placeholder; the RHS becomes `children[0]`. `wrap_join` wraps the build side as `CONCAT_build → PARTITION_build → DUMMY_SCAN`, and `partition_join` points at that PARTITION_build. With intermediate operators before the delim join (`operators.size() > 0`), a pipeline breaker is inserted:
 
 ```mermaid
 graph LR
@@ -347,17 +345,14 @@ graph LR
     MR -->|"FULL"| DS["Downstream<br/>(DELIM_SCAN pipelines)"]
 ```
 
-Edges from the delim join to `partition_join` and `distinct` are its fan-out sink's two `next_port_after_sink` outputs; each sub-operator runs as its own framework-scheduled pipeline.
+With no intermediate operators, no breaker is needed — RIGHT_DELIM_JOIN is the current pipeline's sink directly.
 
-When `operators.size() == 0` (no intermediate operators), no pipeline breaker is needed — the current pipeline keeps RIGHT_DELIM_JOIN as its sink directly.
-
-- The CONCAT is a build concat (`is_build=true`); it connects to the internal HASH_JOIN's `"build"` port
-- `partition_join` (PARTITION_build) is a single-op pipeline fed by the delim join's fan-out; its output feeds CONCAT_build
-- The probe and build partitions are linked as siblings for partition-count coordination; the RIGHT_DELIM_JOIN inner join is detected via its tree parent (`link_join_partition_siblings`) so the build (distinct) side drives the count
+- `partition_join` (PARTITION_build) is a single-op pipeline fed by the fan-out; its build CONCAT feeds the HASH_JOIN `"build"` port.
+- Probe and build partitions are linked as siblings; the inner join is identified via its tree parent (`link_join_partition_siblings`) so the build (distinct) side drives the partition count.
 
 #### LEFT_DELIM_JOIN
 
-In the constructor, LEFT_DELIM_JOIN extracts the LHS child from the internal join and replaces it with a `column_data_scan`. The extracted LHS becomes `children[0]`, built via a child meta-pipeline. Unlike RIGHT_DELIM_JOIN, **no pipeline breaker** is created and **no partition_join/concat pair** is needed — the `column_data_scan` directly feeds downstream pipelines.
+Ctor: extract the LHS from the internal join, replace it with a `column_data_scan`; the LHS becomes `children[0]`. No breaker and no partition_join/concat pair.
 
 ```mermaid
 graph LR
@@ -367,11 +362,8 @@ graph LR
     MR -->|"FULL"| DS["Downstream<br/>(DELIM_SCAN pipelines)"]
 ```
 
-Edges from the delim join to `column_data_scan` and `distinct` are its fan-out sink's two `next_port_after_sink` outputs; each runs as its own framework-scheduled pipeline.
-
-- `column_data_scan` caches the input data so the internal HASH_JOIN's probe side can scan it
-- The internal HASH_JOIN is built into the probe pipeline via `join->build_pipelines()`, so its build side (the correlated subquery) gets a normal child meta-pipeline with standard HASH_JOIN handling
-- `build_join_pipelines` adds the internal HASH_JOIN as an operator in the probe pipeline, with `column_data_scan` as its source: `[column_data_scan, HASH_JOIN, ..., outer_sink]`
+- `column_data_scan` is the source of the join's probe pipeline (`[column_data_scan, HASH_JOIN, ..., outer_sink]`), fed by the fan-out.
+- The internal HASH_JOIN's build side (the subquery) gets standard build splitting via `join->build_pipelines()`.
 
 #### Key Differences
 

--- a/src/include/op/sirius_physical_column_data_scan.hpp
+++ b/src/include/op/sirius_physical_column_data_scan.hpp
@@ -60,17 +60,8 @@ class sirius_physical_column_data_scan : public sirius_physical_operator {
  public:
   bool is_source() const override { return true; }
 
-  //! True when this scan is the cached chunk scan of a LEFT_DELIM_JOIN (set at plan-gen
-  //! time). The delim join's sink executes it inline, so it never carries pipeline data
-  //! of its own; `build_pipelines` short-circuits when set.
-  [[nodiscard]] bool is_owned_by_delim_join() const noexcept { return _owned_by_delim_join; }
-  void set_owned_by_delim_join(bool value) noexcept { _owned_by_delim_join = value; }
-
   void build_pipelines(pipeline::sirius_pipeline& current,
                        pipeline::sirius_meta_pipeline& meta_pipeline) override;
-
- protected:
-  bool _owned_by_delim_join = false;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -91,10 +91,6 @@ class sirius_physical_right_delim_join : public sirius_physical_delim_join {
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
-
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
-
-  std::unique_ptr<operator_data> get_next_task_input_data() override;
 };
 
 class sirius_physical_left_delim_join : public sirius_physical_delim_join {
@@ -117,8 +113,6 @@ class sirius_physical_left_delim_join : public sirius_physical_delim_join {
 
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
-
-  void sink(const operator_data& input_data, rmm::cuda_stream_view stream) override;
 };
 
 }  // namespace op

--- a/src/include/op/sirius_physical_delim_join.hpp
+++ b/src/include/op/sirius_physical_delim_join.hpp
@@ -50,8 +50,8 @@ class sirius_physical_delim_join : public sirius_physical_operator {
   //! `DISTINCT_MERGE -> PARTITION_DISTINCT -> DISTINCT` chain after wrap_delim_distinct
   //! under flag ON.
   duckdb::unique_ptr<sirius_physical_operator> distinct_root;
-  //! Non-owning borrow of the original DISTINCT (always the subtree bottom), for the
-  //! inline per-batch sink path and grouped-aggregate-specific callers.
+  //! Non-owning borrow of the original DISTINCT (always the subtree bottom), used to identify
+  //! the DISTINCT for fan-out wiring and by grouped-aggregate-specific callers.
   sirius_physical_grouped_aggregate* distinct = nullptr;
   duckdb::vector<duckdb::const_reference<sirius_physical_operator>> delim_scans;
 

--- a/src/include/op/sirius_physical_dummy_scan.hpp
+++ b/src/include/op/sirius_physical_dummy_scan.hpp
@@ -37,10 +37,15 @@ class sirius_physical_dummy_scan : public sirius_physical_operator {
  public:
   bool is_source() const override { return true; }
 
-  //! True when this DUMMY_SCAN is the synthetic build placeholder under a
-  //! RIGHT_DELIM_JOIN's internal join. Makes plan-gen skip `replace_with_gpu_values`:
-  //! the placeholder carries no runtime data (sink() runs partition_join inline). Real
-  //! DUMMY_SCAN usages (constant-row subqueries) are replaced by a GPU_VALUES source.
+  //! The RIGHT_DELIM_JOIN build placeholder contributes no pipeline operator: the delim join
+  //! fans its input directly to PARTITION_build, so the placeholder carries no runtime data.
+  //! Real DUMMY_SCANs (constant-row subqueries) use the base source-leaf behavior.
+  void build_pipelines(pipeline::sirius_pipeline& current,
+                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
+
+  //! RIGHT_DELIM_JOIN's internal join. Plan-gen skips `replace_with_gpu_values` for it: the
+  //! placeholder carries no runtime data (the delim join fans its input directly to
+  //! PARTITION_build). Real DUMMY_SCAN usages (constant-row subqueries) become GPU_VALUES sources.
   [[nodiscard]] bool is_delim_join_placeholder() const noexcept
   {
     return _is_delim_join_placeholder;

--- a/src/include/op/sirius_physical_grouped_aggregate.hpp
+++ b/src/include/op/sirius_physical_grouped_aggregate.hpp
@@ -107,20 +107,8 @@ class sirius_physical_grouped_aggregate : public sirius_physical_operator {
 
   bool sink_order_dependent() const override { return false; }
 
-  //! True when this HASH_GROUP_BY is the bare DISTINCT of a RIGHT_DELIM_JOIN (set at
-  //! plan-gen time). The delim join's sink executes it inline, never via its own
-  //! pipeline, so `build_pipelines` suppresses pipeline materialization under flag ON.
-  [[nodiscard]] bool is_owned_by_delim_join() const noexcept { return _owned_by_delim_join; }
-  void set_owned_by_delim_join(bool value) noexcept { _owned_by_delim_join = value; }
-
-  void build_pipelines(pipeline::sirius_pipeline& current,
-                       pipeline::sirius_meta_pipeline& meta_pipeline) override;
-
   std::unique_ptr<operator_data> execute(const operator_data& input_data,
                                          rmm::cuda_stream_view stream) override;
-
- protected:
-  bool _owned_by_delim_join = false;
 };
 
 }  // namespace op

--- a/src/include/pipeline/repository_wiring.hpp
+++ b/src/include/pipeline/repository_wiring.hpp
@@ -62,14 +62,6 @@ struct repository_wiring {
 //!      (the first operator of `dest_pipeline`, or its sink if there are no operators).
 //!   3. Records the destination on the source operator via `add_next_port_after_sink`.
 //!
-//! Special cases preserved from the previous in-engine implementation:
-//!   - When the destination's type is `RIGHT_DELIM_JOIN`, an additional `FULL`-barrier
-//!     port is also added to its `partition_join` sibling so the partitioned join branch
-//!     can read the same repository.
-//!   - When the destination's type is `LEFT_DELIM_JOIN`, this throws — a left delim join
-//!     should never act as a destination of the directed edge/source operator of the destination
-//!     pipeline.
-//!
 //! Precondition: every `source_pipeline` and `dest_pipeline` referenced in `wirings` must
 //! already have its pipeline id assigned (see `sirius_pipeline::set_pipeline_id`). Port
 //! insertion uses pipeline ids to keep `_ports_list` ordered.

--- a/src/op/sirius_physical_column_data_scan.cpp
+++ b/src/op/sirius_physical_column_data_scan.cpp
@@ -56,10 +56,6 @@ sirius_physical_column_data_scan::sirius_physical_column_data_scan(
 void sirius_physical_column_data_scan::build_pipelines(
   pipeline::sirius_pipeline& current, pipeline::sirius_meta_pipeline& meta_pipeline)
 {
-  // Cached chunk scan of a LEFT_DELIM_JOIN: the delim join's sink executes it inline, so
-  // it contributes no pipeline; compute_repository_wiring emits its wiring.
-  if (_owned_by_delim_join) { return; }
-
   // check if there is any additional action we need to do depending on the type
   auto& state = meta_pipeline.get_state();
   switch (type) {

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -30,19 +30,6 @@
 namespace sirius {
 namespace op {
 
-class sirius_left_delim_join_local_state : public duckdb::LocalSinkState {
- public:
-  duckdb::unique_ptr<duckdb::LocalSinkState> distinct_state;
-  // duckdb::shared_ptr<GPUIntermediateRelation> lhs_data;
-  duckdb::ColumnDataAppendState append_state;
-};
-
-class sirius_right_delim_join_local_state : public duckdb::LocalSinkState {
- public:
-  duckdb::unique_ptr<duckdb::LocalSinkState> join_state;
-  duckdb::unique_ptr<duckdb::LocalSinkState> distinct_state;
-};
-
 sirius_physical_delim_join::sirius_physical_delim_join(
   SiriusPhysicalOperatorType type,
   duckdb::vector<sirius::logical_type> types,
@@ -116,11 +103,10 @@ sirius_physical_left_delim_join::sirius_physical_left_delim_join(
     nullptr);
   if (delim_idx.IsValid()) { cached_chunk_scan->cte_index = delim_idx.GetIndex(); }
 
-  // Record the cached chunk scan now — after wrap_join, internal_join->children[0]
-  // becomes a CONCAT and the reference is unrecoverable. Tag it so build_pipelines is a
-  // no-op: our sink() executes the scan inline, so it never carries pipeline data.
+  // Record the cached chunk scan now — after wrap_join, internal_join->children[0] becomes a
+  // CONCAT and the reference is unrecoverable. It becomes a first-class source pipeline fed by
+  // the delim join's fan-out sink.
   column_data_scan = cached_chunk_scan.get();
-  cached_chunk_scan->set_owned_by_delim_join(true);
 
   join->children[0] = std::move(cached_chunk_scan);
 }
@@ -216,49 +202,12 @@ std::unique_ptr<operator_data> sirius_physical_right_delim_join::execute(
     dynamic_cast<const pipelineable_operator_data&>(input_data).get_read_only_batches(false));
 }
 
-void sirius_physical_right_delim_join::sink(const operator_data& input_data,
-                                            rmm::cuda_stream_view stream)
-{
-  nvtx3::scoped_range nvtx_range{"sirius_physical_right_delim_join::sink"};
-  // partition_join stays inline (still part of the delim join)
-  auto partition_join_output = partition_join->execute(input_data, stream);
-  // distinct stays inline (still part of the delim join)
-  auto distinct_output = distinct->execute(input_data, stream);
-
-  stream.synchronize();
-
-  partition_join->sink(*partition_join_output, stream);
-  // partition_distinct is external — push distinct output via distinct's next_port_after_sink
-  distinct->sink(*distinct_output, stream);
-}
-
-std::unique_ptr<operator_data> sirius_physical_right_delim_join::get_next_task_input_data()
-{
-  return partition_join->get_next_task_input_data();
-}
-
 std::unique_ptr<operator_data> sirius_physical_left_delim_join::execute(
   const operator_data& input_data, rmm::cuda_stream_view stream)
 {
   nvtx3::scoped_range nvtx_range{"sirius_physical_left_delim_join::execute"};
   return std::make_unique<pipelineable_operator_data>(
     dynamic_cast<const pipelineable_operator_data&>(input_data).get_read_only_batches(false));
-}
-
-void sirius_physical_left_delim_join::sink(const operator_data& input_data,
-                                           rmm::cuda_stream_view stream)
-{
-  nvtx3::scoped_range nvtx_range{"sirius_physical_left_delim_join::sink"};
-  // column_data_scan stays inline (still part of the delim join)
-  auto column_data_scan_output = column_data_scan->execute(input_data, stream);
-  // distinct stays inline (still part of the delim join)
-  auto distinct_output = distinct->execute(input_data, stream);
-
-  stream.synchronize();
-
-  column_data_scan->sink(*column_data_scan_output, stream);
-  // partition_distinct is external — push distinct output via distinct's next_port_after_sink
-  distinct->sink(*distinct_output, stream);
 }
 
 }  // namespace op

--- a/src/op/sirius_physical_delim_join.cpp
+++ b/src/op/sirius_physical_delim_join.cpp
@@ -60,8 +60,8 @@ sirius_physical_right_delim_join::sirius_physical_right_delim_join(
 {
   D_ASSERT(join->children.size() == 2);
 
-  // The inner join is executed inline by our sink() and is never a standalone pipeline
-  // sink — tag it so is_sink() and the build-side externalization gate skip it.
+  // The inner join is the source of the delim join's output pipeline (built via
+  // build_join_pipelines), not a standalone pipeline sink — tag it so is_sink() returns false.
   // RIGHT_DELIM_JOIN only: LEFT's inner join feeds a real build subtree.
   if (auto* hj = dynamic_cast<sirius_physical_hash_join*>(join.get())) {
     hj->set_delim_join_inner(true);
@@ -71,9 +71,9 @@ sirius_physical_right_delim_join::sirius_physical_right_delim_join(
 
   children.push_back(std::move(join->children[1]));
 
-  // Mark the placeholder so replace_with_gpu_values skips it: it carries no runtime
-  // data (sink() runs partition_join inline), so a GPU_VALUES replacement would
-  // materialize a phantom source.
+  // Mark the placeholder so replace_with_gpu_values skips it: it carries no runtime data
+  // (the delim join fans its input directly to PARTITION_build), so a GPU_VALUES replacement
+  // would only materialize a phantom source.
   auto dummy_placeholder =
     duckdb::make_uniq<sirius_physical_dummy_scan>(children[0]->get_types(), estimated_cardinality);
   dummy_placeholder->set_delim_join_placeholder(true);

--- a/src/op/sirius_physical_dummy_scan.cpp
+++ b/src/op/sirius_physical_dummy_scan.cpp
@@ -16,8 +16,21 @@
 
 #include "op/sirius_physical_dummy_scan.hpp"
 
+#include "pipeline/sirius_meta_pipeline.hpp"
+#include "pipeline/sirius_pipeline.hpp"
+
 namespace sirius {
 namespace op {
+
+void sirius_physical_dummy_scan::build_pipelines(pipeline::sirius_pipeline& current,
+                                                 pipeline::sirius_meta_pipeline& meta_pipeline)
+{
+  // The RIGHT_DELIM_JOIN build placeholder carries no runtime data — the delim join fans its
+  // input directly to PARTITION_build — so it contributes no pipeline operator. Real DUMMY_SCANs
+  // (constant-row subqueries) fall back to the base source-leaf behavior.
+  if (is_delim_join_placeholder()) { return; }
+  sirius_physical_operator::build_pipelines(current, meta_pipeline);
+}
 
 }  // namespace op
 }  // namespace sirius

--- a/src/op/sirius_physical_grouped_aggregate.cpp
+++ b/src/op/sirius_physical_grouped_aggregate.cpp
@@ -26,17 +26,6 @@
 namespace sirius {
 namespace op {
 
-void sirius_physical_grouped_aggregate::build_pipelines(
-  pipeline::sirius_pipeline& current, pipeline::sirius_meta_pipeline& meta_pipeline)
-{
-  // The bare DISTINCT of a RIGHT_DELIM_JOIN contributes no pipeline of its own: the
-  // delim join's sink executes it inline and the tree-based wiring handles data flow.
-  // is_sink() stays true — PARTITION_distinct asserts `children[0]->is_sink()`, which
-  // is about the operator's role, not pipeline membership.
-  if (_owned_by_delim_join) { return; }
-  sirius_physical_operator::build_pipelines(current, meta_pipeline);
-}
-
 sirius_physical_grouped_aggregate::sirius_physical_grouped_aggregate(
   duckdb::vector<sirius::logical_type> types,
   duckdb::vector<std::unique_ptr<sirius::ast::node>> expressions,

--- a/src/op/sirius_physical_hash_join.cpp
+++ b/src/op/sirius_physical_hash_join.cpp
@@ -392,18 +392,7 @@ void sirius_physical_hash_join::build_join_pipelines(pipeline::sirius_pipeline& 
   D_ASSERT(build_child.is_sink());
   D_ASSERT(!build_child.children.empty());
   auto& build_meta = meta_pipeline.create_child_meta_pipeline(current, build_child);
-
-  // For the inner join of a RIGHT_DELIM_JOIN, the subtree below CONCAT_build is
-  // synthetic scaffolding: partition_join runs inline in the delim join's sink and
-  // the DUMMY_SCAN placeholder carries no runtime data. Skip the recursion; build_meta
-  // still finalizes to a [CONCAT_build] single-op pipeline.
-  bool is_delim_inner = false;
-  if (auto* hj = dynamic_cast<sirius_physical_hash_join*>(&op)) {
-    is_delim_inner = hj->is_delim_join_inner();
-  } else if (auto* nlj = dynamic_cast<sirius_physical_nested_loop_join*>(&op)) {
-    is_delim_inner = nlj->is_delim_join_inner();
-  }
-  if (!is_delim_inner) { build_meta.build(*build_child.children[0]); }
+  build_meta.build(*build_child.children[0]);
 
   op.children[0]->build_pipelines(current, meta_pipeline);
 

--- a/src/pipeline/repository_wiring_materializer.cpp
+++ b/src/pipeline/repository_wiring_materializer.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "op/sirius_physical_delim_join.hpp"
 #include "op/sirius_physical_operator.hpp"
 #include "op/sirius_physical_operator_type.hpp"
 #include "pipeline/repository_wiring.hpp"
@@ -24,7 +23,6 @@
 #include <cucascade/data/data_repository_manager.hpp>
 
 #include <memory>
-#include <stdexcept>
 
 namespace sirius {
 namespace pipeline {
@@ -48,16 +46,6 @@ void materialize_repository_wiring(const std::vector<repository_wiring>& wirings
                       std::make_unique<op::sirius_physical_operator::port>(
                         wiring.barrier_type, repo, wiring.source_pipeline, dest_pipeline));
     wiring.source_op->add_next_port_after_sink({next_op, wiring.port_id});
-
-    if (next_op->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-      auto* partition_op = next_op->Cast<op::sirius_physical_right_delim_join>().partition_join;
-      partition_op->add_port(
-        wiring.port_id,
-        std::make_unique<op::sirius_physical_operator::port>(
-          op::MemoryBarrierType::FULL, repo, wiring.source_pipeline, dest_pipeline));
-    } else if (next_op->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-      throw std::runtime_error("Left delim join should never be a source");
-    }
   }
 }
 

--- a/src/pipeline/sirius_pipeline.cpp
+++ b/src/pipeline/sirius_pipeline.cpp
@@ -62,27 +62,8 @@ sirius_pipeline::get_next_ports_after_sink() const
   std::vector<op::sirius_physical_operator::next_port_info> ports;
   if (!sink) { return ports; }
 
-  auto append = [&ports](const std::vector<op::sirius_physical_operator::next_port_info>& src) {
-    ports.insert(ports.end(), src.begin(), src.end());
-  };
-
-  if (sink->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
-    auto& right_delim_join = sink->Cast<op::sirius_physical_right_delim_join>();
-    const auto& part_1     = right_delim_join.partition_join->get_next_ports_after_sink();
-    const auto& part_2     = right_delim_join.distinct->get_next_ports_after_sink();
-    ports.reserve(part_1.size() + part_2.size());
-    append(part_1);
-    append(part_2);
-  } else if (sink->type == op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-    auto& left_delim_join = sink->Cast<op::sirius_physical_left_delim_join>();
-    const auto& part_1    = left_delim_join.column_data_scan->get_next_ports_after_sink();
-    const auto& part_2    = left_delim_join.distinct->get_next_ports_after_sink();
-    ports.reserve(part_1.size() + part_2.size());
-    append(part_1);
-    append(part_2);
-  } else {
-    append(sink->get_next_ports_after_sink());
-  }
+  const auto& sink_ports = sink->get_next_ports_after_sink();
+  ports.insert(ports.end(), sink_ports.begin(), sink_ports.end());
   return ports;
 }
 

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -286,69 +286,31 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
       continue;
     }
 
-    // RIGHT_DELIM_JOIN: emit partition_join + distinct sibling references.
-    if (sink_op->type == T::RIGHT_DELIM_JOIN) {
-      auto& right_delim    = sink_op->Cast<op::sirius_physical_right_delim_join>();
-      auto* partition_join = right_delim.partition_join;
-      auto* distinct_op    = right_delim.distinct;
-      if (partition_join) {
-        auto it = dest_for_op.find(partition_join);
-        // partition_join executes inline in RIGHT_DELIM_JOIN::sink with no pipeline of
-        // its own, so the direct lookup misses; fall back to its tree parent
-        // (CONCAT_build), mirroring legacy's PARTITION → CONCAT build wiring.
-        if (it == dest_for_op.end()) {
-          if (auto* parent = partition_join->get_parent_op()) { it = dest_for_op.find(parent); }
-        }
-        if (it != dest_for_op.end()) {
-          emit("default", op::MemoryBarrierType::FULL, partition_join, pipeline, it->second);
-        }
-      }
-      if (distinct_op) {
-        auto it = dest_for_op.find(distinct_op);
-        // The bare DISTINCT also executes inline (`_owned_by_delim_join` short-circuits
-        // its build_pipelines), so the direct lookup misses; fall back to its tree
-        // parent (PARTITION_distinct), which consumes its per-thread output.
-        if (it == dest_for_op.end()) {
-          if (auto* parent = distinct_op->get_parent_op()) { it = dest_for_op.find(parent); }
-        }
-        if (it != dest_for_op.end()) {
-          emit("default", op::MemoryBarrierType::FULL, distinct_op, pipeline, it->second);
-        }
-      }
-      continue;
-    }
-
-    // LEFT_DELIM_JOIN: emit column_data_scan + distinct sibling references.
-    if (sink_op->type == T::LEFT_DELIM_JOIN) {
-      auto& left_delim       = sink_op->Cast<op::sirius_physical_left_delim_join>();
-      auto* distinct_op      = left_delim.distinct;
-      auto* column_data_scan = left_delim.column_data_scan;
-      if (column_data_scan) {
-        auto it = dest_for_op.find(column_data_scan);
-        // column_data_scan executes inline in LEFT_DELIM_JOIN::sink (build_pipelines is a
-        // no-op), so the direct lookup misses; fall back to its tree parent (PARTITION_probe).
-        // resolve_barrier lets the dest dictate PARTIAL for the probe-side partition.
-        if (it == dest_for_op.end()) {
-          if (auto* parent = column_data_scan->get_parent_op()) { it = dest_for_op.find(parent); }
-        }
-        if (it != dest_for_op.end()) {
-          emit("default",
-               resolve_barrier(*column_data_scan, *it->second),
-               column_data_scan,
-               pipeline,
-               it->second);
-        }
-      }
-      if (distinct_op) {
-        auto it = dest_for_op.find(distinct_op);
-        // Same fallback as RIGHT_DELIM_JOIN's bare DISTINCT: no pipeline of its own,
-        // so resolve to its tree parent (PARTITION_distinct).
-        if (it == dest_for_op.end()) {
-          if (auto* parent = distinct_op->get_parent_op()) { it = dest_for_op.find(parent); }
-        }
-        if (it != dest_for_op.end()) {
-          emit("default", op::MemoryBarrierType::FULL, distinct_op, pipeline, it->second);
-        }
+    // A delim join is a fan-out sink: its base sink() pushes each input batch to both branch
+    // pipelines, which are first-class pipelines sourced from the delim join. Emit one edge per
+    // branch with the delim join as the producer; the sub-ops' outward edges (PARTITION_build →
+    // CONCAT_build, DISTINCT → PARTITION_distinct, column_data_scan → PARTITION_probe) come from
+    // the uniform tree-parent lookup below.
+    if (sink_op->type == T::RIGHT_DELIM_JOIN || sink_op->type == T::LEFT_DELIM_JOIN) {
+      auto& delim = sink_op->Cast<op::sirius_physical_delim_join>();
+      // Branch 1: the side that feeds the inner join (RHS build / LHS probe).
+      op::sirius_physical_operator* join_side =
+        (sink_op->type == T::RIGHT_DELIM_JOIN)
+          ? static_cast<op::sirius_physical_operator*>(
+              sink_op->Cast<op::sirius_physical_right_delim_join>().partition_join)
+          : static_cast<op::sirius_physical_operator*>(
+              sink_op->Cast<op::sirius_physical_left_delim_join>().column_data_scan);
+      // Branch 2: the duplicate-elimination (distinct) side.
+      op::sirius_physical_operator* distinct_op = delim.distinct;
+      for (auto* branch : {join_side, distinct_op}) {
+        if (!branch) { continue; }
+        auto it = dest_for_op.find(branch);
+        if (it == dest_for_op.end()) { continue; }
+        emit(resolve_port_id(*sink_op, *branch),
+             resolve_barrier(*sink_op, *it->second),
+             sink_op,
+             pipeline,
+             it->second);
       }
       continue;
     }
@@ -470,36 +432,29 @@ void sirius_pipeline_converter::link_join_partition_siblings()
       D_ASSERT(
         build_concat_pipeline->get_sink()->type == op::SiriusPhysicalOperatorType::CONCAT &&
         build_concat_pipeline->get_sink()->Cast<op::sirius_physical_concat>().is_build_concat());
-      bool const is_right_delim = build_partition_pipeline->get_sink()->type ==
-                                  op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN;
-      // RIGHT_DELIM_JOIN must bootstrap its probe subtree from build-side distinct data.
+      // A RIGHT_DELIM_JOIN's inner join bootstraps its probe subtree from build-side (distinct)
+      // data, so the build side must drive the partition count. Detect it off the join's tree
+      // parent (the same predicate resolve_barrier uses) — the build partition is now a real
+      // PARTITION pipeline like any other, so the sink-type test no longer identifies it.
+      bool const inner_join_of_rdj =
+        pipeline->source->get_parent_op() != nullptr &&
+        pipeline->source->get_parent_op()->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN;
       // Right-family sizing applies to hash joins only — NLJ probe partitions always stream.
       bool const probe_drives_partition_count =
         pipeline->source->type == op::SiriusPhysicalOperatorType::HASH_JOIN &&
         pipeline->source->Cast<op::sirius_physical_hash_join>().is_right_family() &&
-        !is_right_delim;
+        !inner_join_of_rdj;
 
-      if (is_right_delim) {
-        // partition pipeline only has one operator
-        auto& right_delim_join_op =
-          build_partition_pipeline->get_sink()->Cast<op::sirius_physical_right_delim_join>();
-        auto build_partition_op = right_delim_join_op.partition_join;
-        auto& probe_partition_op =
-          probe_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
-        build_partition_op->set_sibling_partition_op(&probe_partition_op);
-        probe_partition_op.set_sibling_partition_op(build_partition_op);
-      } else {
-        // partition pipeline only has one operator, so sink and source are the same
-        auto& build_partition_op =
-          build_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
-        auto& probe_partition_op =
-          probe_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
-        build_partition_op.set_sibling_partition_op(&probe_partition_op);
-        probe_partition_op.set_sibling_partition_op(&build_partition_op);
-        if (probe_drives_partition_count) {
-          build_partition_op.set_drives_partition_count(false);
-          probe_partition_op.set_drives_partition_count(true);
-        }
+      // partition pipeline only has one operator, so sink and source are the same
+      auto& build_partition_op =
+        build_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
+      auto& probe_partition_op =
+        probe_partition_pipeline->get_sink()->Cast<op::sirius_physical_partition>();
+      build_partition_op.set_sibling_partition_op(&probe_partition_op);
+      probe_partition_op.set_sibling_partition_op(&build_partition_op);
+      if (probe_drives_partition_count) {
+        build_partition_op.set_drives_partition_count(false);
+        probe_partition_op.set_drives_partition_count(true);
       }
     }
   }

--- a/src/pipeline/sirius_pipeline_converter.cpp
+++ b/src/pipeline/sirius_pipeline_converter.cpp
@@ -294,12 +294,12 @@ void sirius_pipeline_converter::compute_repository_wiring(sirius_pipeline_build_
     if (sink_op->type == T::RIGHT_DELIM_JOIN || sink_op->type == T::LEFT_DELIM_JOIN) {
       auto& delim = sink_op->Cast<op::sirius_physical_delim_join>();
       // Branch 1: the side that feeds the inner join (RHS build / LHS probe).
-      op::sirius_physical_operator* join_side =
-        (sink_op->type == T::RIGHT_DELIM_JOIN)
-          ? static_cast<op::sirius_physical_operator*>(
-              sink_op->Cast<op::sirius_physical_right_delim_join>().partition_join)
-          : static_cast<op::sirius_physical_operator*>(
-              sink_op->Cast<op::sirius_physical_left_delim_join>().column_data_scan);
+      op::sirius_physical_operator* join_side = nullptr;
+      if (sink_op->type == T::RIGHT_DELIM_JOIN) {
+        join_side = sink_op->Cast<op::sirius_physical_right_delim_join>().partition_join;
+      } else {
+        join_side = sink_op->Cast<op::sirius_physical_left_delim_join>().column_data_scan;
+      }
       // Branch 2: the duplicate-elimination (distinct) side.
       op::sirius_physical_operator* distinct_op = delim.distinct;
       for (auto* branch : {join_side, distinct_op}) {
@@ -433,9 +433,9 @@ void sirius_pipeline_converter::link_join_partition_siblings()
         build_concat_pipeline->get_sink()->type == op::SiriusPhysicalOperatorType::CONCAT &&
         build_concat_pipeline->get_sink()->Cast<op::sirius_physical_concat>().is_build_concat());
       // A RIGHT_DELIM_JOIN's inner join bootstraps its probe subtree from build-side (distinct)
-      // data, so the build side must drive the partition count. Detect it off the join's tree
-      // parent (the same predicate resolve_barrier uses) — the build partition is now a real
-      // PARTITION pipeline like any other, so the sink-type test no longer identifies it.
+      // data, so the build side drives the partition count. Detect it off the join's tree parent
+      // (the same predicate resolve_barrier uses), since the build partition is a plain PARTITION
+      // that the sink type alone does not distinguish.
       bool const inner_join_of_rdj =
         pipeline->source->get_parent_op() != nullptr &&
         pipeline->source->get_parent_op()->type == op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN;

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -568,10 +568,6 @@ void wrap_delim_join(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& s
   if (slot->type == sirius::op::SiriusPhysicalOperatorType::RIGHT_DELIM_JOIN) {
     auto& right_delim = slot->Cast<sirius::op::sirius_physical_right_delim_join>();
 
-    // Tag the bare DISTINCT so its `build_pipelines` is a no-op: the delim-join sink runs
-    // `distinct->execute`/`sink` inline, so it contributes nothing to any pipeline.
-    if (right_delim.distinct) { right_delim.distinct->set_owned_by_delim_join(true); }
-
     auto* internal_join = delim_base.join.get();
     if (internal_join && internal_join->children.size() >= 2) {
       auto* build_child = internal_join->children[1].get();
@@ -585,13 +581,6 @@ void wrap_delim_join(duckdb::unique_ptr<sirius::op::sirius_physical_operator>& s
         }
       }
     }
-  } else if (slot->type == sirius::op::SiriusPhysicalOperatorType::LEFT_DELIM_JOIN) {
-    auto& left_delim = slot->Cast<sirius::op::sirius_physical_left_delim_join>();
-
-    // Same DISTINCT tagging as the RIGHT branch. The cached chunk scan
-    // (`left_delim.column_data_scan`) was already recorded in LEFT_DELIM_JOIN's constructor;
-    // it can't be recovered here — wrap_join already buried it under a CONCAT/PARTITION chain.
-    if (left_delim.distinct) { left_delim.distinct->set_owned_by_delim_join(true); }
   }
 }
 

--- a/src/planner/sirius_physical_plan_generator.cpp
+++ b/src/planner/sirius_physical_plan_generator.cpp
@@ -513,7 +513,7 @@ void insert_gpu_pipeline_operators_recursive(
 
 //! Replace a DELIM JOIN's `distinct_root` (the bare DISTINCT) with `DISTINCT_MERGE ->
 //! PARTITION_DISTINCT -> original DISTINCT`. The non-owning `delim_base.distinct` borrow stays
-//! valid — moving a unique_ptr never relocates the object — and the inline sink path uses it.
+//! valid — moving a unique_ptr never relocates the object — and the fan-out wiring uses it.
 void wrap_delim_distinct(sirius::op::sirius_physical_delim_join& delim_base,
                          const sirius::operator_params& op_params)
 {
@@ -611,9 +611,9 @@ void insert_gpu_pipeline_operators_recursive(
                                 : op_params.scan_task_batch_size);
       break;
     case sirius::op::SiriusPhysicalOperatorType::DUMMY_SCAN: {
-      // A RIGHT_DELIM_JOIN build-placeholder DUMMY_SCAN carries no runtime data flow, so a
-      // GPU_VALUES replacement would only materialize a phantom source; real DUMMY_SCANs
-      // are replaced.
+      // A RIGHT_DELIM_JOIN build-placeholder DUMMY_SCAN carries no runtime data (the delim join
+      // fans its input directly to PARTITION_build), so a GPU_VALUES replacement would only
+      // materialize a phantom source; real DUMMY_SCANs are replaced.
       auto& dummy = slot->Cast<sirius::op::sirius_physical_dummy_scan>();
       if (!dummy.is_delim_join_placeholder()) {
         replace_with_gpu_values(slot,

--- a/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
+++ b/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
@@ -104,7 +104,7 @@ TEST_CASE("yields nothing for standard sink with no ports", "[pipeline][get_next
   }
 }
 
-// A delim join is now a fan-out sink: its sub-operators (partition_join / column_data_scan /
+// A delim join is a fan-out sink: its sub-operators (partition_join / column_data_scan /
 // distinct) are first-class pipelines, so the delim join carries its OWN next_port_after_sink
 // edges (one per branch) and get_next_ports_after_sink returns them directly like any standard
 // sink — no special-casing of the sub-operators' ports.

--- a/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
+++ b/test/cpp/pipeline/test_get_next_ports_after_sink.cpp
@@ -104,7 +104,11 @@ TEST_CASE("yields nothing for standard sink with no ports", "[pipeline][get_next
   }
 }
 
-TEST_CASE("RIGHT_DELIM_JOIN: concatenates partition_join then distinct ports",
+// A delim join is now a fan-out sink: its sub-operators (partition_join / column_data_scan /
+// distinct) are first-class pipelines, so the delim join carries its OWN next_port_after_sink
+// edges (one per branch) and get_next_ports_after_sink returns them directly like any standard
+// sink — no special-casing of the sub-operators' ports.
+TEST_CASE("RIGHT_DELIM_JOIN: returns its own fan-out ports",
           "[pipeline][get_next_ports_after_sink]")
 {
   sirius_pipeline pipeline(sirius::pipeline::pipeline_build_context{nullptr});
@@ -117,30 +121,10 @@ TEST_CASE("RIGHT_DELIM_JOIN: concatenates partition_join then distinct ports",
     0,
     duckdb::optional_idx());
 
-  // sirius_physical_partition needs a parent_op whose `type` field is one of the supported
-  // values. NESTED_LOOP_JOIN takes a no-op branch and avoids a downcast, so a standard
-  // sirius_physical_operator with that type is enough.
-  auto fake_parent = duckdb::make_uniq<sirius_physical_operator>(
-    SiriusPhysicalOperatorType::NESTED_LOOP_JOIN, empty_types, 0);
-  auto partition_join =
-    duckdb::make_uniq<sirius_physical_partition>(empty_types, 0, fake_parent.get());
-
-  auto distinct = duckdb::make_uniq<sirius_physical_grouped_aggregate>(
-    empty_types,
-    duckdb::vector<std::unique_ptr<sirius::ast::node>>{},
-    duckdb::vector<std::unique_ptr<sirius::ast::node>>{},
-    0);
-
-  sirius_physical_operator partition_consumer_x;
-  sirius_physical_operator partition_consumer_y;
-  sirius_physical_operator distinct_consumer;
-  partition_join->add_next_port_after_sink({&partition_consumer_x, "port_x"});
-  partition_join->add_next_port_after_sink({&partition_consumer_y, "port_y"});
-  distinct->add_next_port_after_sink({&distinct_consumer, "distinct_port"});
-
-  right_delim->partition_join = partition_join.get();
-  right_delim->distinct       = distinct.get();
-  right_delim->distinct_root  = std::move(distinct);
+  sirius_physical_operator partition_branch;
+  sirius_physical_operator distinct_branch;
+  right_delim->add_next_port_after_sink({&partition_branch, "default"});
+  right_delim->add_next_port_after_sink({&distinct_branch, "default"});
 
   sirius_pipeline_build_state build_state;
   build_state.set_pipeline_sink(pipeline, right_delim.get(), 0);
@@ -149,17 +133,12 @@ TEST_CASE("RIGHT_DELIM_JOIN: concatenates partition_join then distinct ports",
   for (const auto& port : pipeline.get_next_ports_after_sink()) {
     ports.push_back(port);
   }
-  REQUIRE(ports.size() == 3);
-  CHECK(ports[0].next_operator == &partition_consumer_x);
-  CHECK(ports[0].next_operator_port_name == "port_x");
-  CHECK(ports[1].next_operator == &partition_consumer_y);
-  CHECK(ports[1].next_operator_port_name == "port_y");
-  CHECK(ports[2].next_operator == &distinct_consumer);
-  CHECK(ports[2].next_operator_port_name == "distinct_port");
+  REQUIRE(ports.size() == 2);
+  CHECK(ports[0].next_operator == &partition_branch);
+  CHECK(ports[1].next_operator == &distinct_branch);
 }
 
-TEST_CASE("LEFT_DELIM_JOIN: concatenates column_data_scan then distinct ports",
-          "[pipeline][get_next_ports_after_sink]")
+TEST_CASE("LEFT_DELIM_JOIN: returns its own fan-out ports", "[pipeline][get_next_ports_after_sink]")
 {
   sirius_pipeline pipeline(sirius::pipeline::pipeline_build_context{nullptr});
   duckdb::vector<sirius::logical_type> empty_types;
@@ -171,25 +150,10 @@ TEST_CASE("LEFT_DELIM_JOIN: concatenates column_data_scan then distinct ports",
     0,
     duckdb::optional_idx());
 
-  auto column_data_scan = duckdb::make_uniq<sirius_physical_column_data_scan>(
-    empty_types, SiriusPhysicalOperatorType::COLUMN_DATA_SCAN, 0, static_cast<std::size_t>(0));
-
-  auto distinct = duckdb::make_uniq<sirius_physical_grouped_aggregate>(
-    empty_types,
-    duckdb::vector<std::unique_ptr<sirius::ast::node>>{},
-    duckdb::vector<std::unique_ptr<sirius::ast::node>>{},
-    0);
-
-  sirius_physical_operator scan_consumer;
-  sirius_physical_operator distinct_consumer_p;
-  sirius_physical_operator distinct_consumer_q;
-  column_data_scan->add_next_port_after_sink({&scan_consumer, "scan_port"});
-  distinct->add_next_port_after_sink({&distinct_consumer_p, "distinct_p"});
-  distinct->add_next_port_after_sink({&distinct_consumer_q, "distinct_q"});
-
-  left_delim->column_data_scan = column_data_scan.get();
-  left_delim->distinct         = distinct.get();
-  left_delim->distinct_root    = std::move(distinct);
+  sirius_physical_operator scan_branch;
+  sirius_physical_operator distinct_branch;
+  left_delim->add_next_port_after_sink({&scan_branch, "default"});
+  left_delim->add_next_port_after_sink({&distinct_branch, "default"});
 
   sirius_pipeline_build_state build_state;
   build_state.set_pipeline_sink(pipeline, left_delim.get(), 0);
@@ -198,11 +162,7 @@ TEST_CASE("LEFT_DELIM_JOIN: concatenates column_data_scan then distinct ports",
   for (const auto& port : pipeline.get_next_ports_after_sink()) {
     ports.push_back(port);
   }
-  REQUIRE(ports.size() == 3);
-  CHECK(ports[0].next_operator == &scan_consumer);
-  CHECK(ports[0].next_operator_port_name == "scan_port");
-  CHECK(ports[1].next_operator == &distinct_consumer_p);
-  CHECK(ports[1].next_operator_port_name == "distinct_p");
-  CHECK(ports[2].next_operator == &distinct_consumer_q);
-  CHECK(ports[2].next_operator_port_name == "distinct_q");
+  REQUIRE(ports.size() == 2);
+  CHECK(ports[0].next_operator == &scan_branch);
+  CHECK(ports[1].next_operator == &distinct_branch);
 }

--- a/test/cpp/pipeline/test_repository_wiring_materializer.cpp
+++ b/test/cpp/pipeline/test_repository_wiring_materializer.cpp
@@ -226,9 +226,13 @@ TEST_CASE("materialize: multiple wirings to the same destination attach distinct
   CHECK(default_port->repo != build_port->repo);  // Each port has its own repo.
 }
 
-TEST_CASE("materialize: RIGHT_DELIM_JOIN destination also gets a port on partition_join sibling",
+TEST_CASE("materialize: delim join destinations use the generic path with no sibling side effects",
           "[repository_wiring][materializer]")
 {
+  // A delim join is now a fan-out source, not a wiring destination, and the materializer no
+  // longer special-cases RIGHT/LEFT delim joins: no extra port is grafted onto a partition_join
+  // sibling, and a LEFT delim join does not throw. If a delim join ever appears as a
+  // destination's first operator, it is wired exactly like any other operator.
   wiring_test_env env;
   cucascade::shared_data_repository_manager mgr;
   duckdb::vector<sirius::logical_type> empty_types;
@@ -236,10 +240,6 @@ TEST_CASE("materialize: RIGHT_DELIM_JOIN destination also gets a port on partiti
   sirius_physical_operator source_sink;
   auto src_pipeline = build_pipeline(env, &source_sink, {}, /*pipeline_id=*/0);
 
-  // RIGHT_DELIM_JOIN destination with a partition_join sibling. The materializer
-  // must add a FULL-barrier port to the sibling regardless of the descriptor's
-  // own barrier type — preserving the legacy `sirius_engine::insert_repository`
-  // side effect.
   auto dummy_join = duckdb::make_uniq<sirius_physical_operator>(SiriusPhysicalOperatorType::INVALID,
                                                                 empty_types,
                                                                 /*estimated_cardinality=*/0);
@@ -264,8 +264,6 @@ TEST_CASE("materialize: RIGHT_DELIM_JOIN destination also gets a port on partiti
   right_delim->partition_join = partition_join.get();
 
   sirius_physical_operator unused_sink;
-  // Destination: pipeline whose first operator is the right delim join — this is the
-  // shape the materializer's RIGHT_DELIM_JOIN check inspects (next_op->type).
   auto dest_pipeline = build_pipeline(env, &unused_sink, {right_delim.get()}, /*pipeline_id=*/1);
 
   std::vector<repository_wiring> wirings = {{std::string_view{"build"},
@@ -274,42 +272,14 @@ TEST_CASE("materialize: RIGHT_DELIM_JOIN destination also gets a port on partiti
                                              src_pipeline,
                                              dest_pipeline}};
 
-  materialize_repository_wiring(wirings, mgr);
+  // Must not throw (the LEFT-delim "should never be a source" invariant is gone), and the port
+  // lands only on the destination's operators[0].
+  REQUIRE_NOTHROW(materialize_repository_wiring(wirings, mgr));
 
-  // Port lands on right_delim itself (the destination's operators[0]).
   auto* delim_port = right_delim->get_port("build");
   REQUIRE(delim_port != nullptr);
   CHECK(delim_port->repo != nullptr);
 
-  // partition_join sibling also has a "build" port, with FULL barrier and the same repo.
-  auto* sibling_port = partition_join->get_port("build");
-  REQUIRE(sibling_port != nullptr);
-  CHECK(sibling_port->type == MemoryBarrierType::FULL);
-  CHECK(sibling_port->repo == delim_port->repo);
-}
-
-TEST_CASE("materialize: throws when destination is a LEFT_DELIM_JOIN",
-          "[repository_wiring][materializer]")
-{
-  wiring_test_env env;
-  cucascade::shared_data_repository_manager mgr;
-  duckdb::vector<sirius::logical_type> empty_types;
-
-  sirius_physical_operator source_sink;
-  auto src_pipeline = build_pipeline(env, &source_sink, {}, /*pipeline_id=*/0);
-
-  // Plain operator forced to LEFT_DELIM_JOIN type — that's all the materializer
-  // checks; it does not Cast<>() before throwing.
-  sirius_physical_operator left_delim_dest;
-  left_delim_dest.type = SiriusPhysicalOperatorType::LEFT_DELIM_JOIN;
-  sirius_physical_operator unused_sink;
-  auto dest_pipeline = build_pipeline(env, &unused_sink, {&left_delim_dest}, /*pipeline_id=*/1);
-
-  std::vector<repository_wiring> wirings = {{std::string_view{"default"},
-                                             MemoryBarrierType::FULL,
-                                             &source_sink,
-                                             src_pipeline,
-                                             dest_pipeline}};
-
-  REQUIRE_THROWS_AS(materialize_repository_wiring(wirings, mgr), std::runtime_error);
+  // No sibling port is grafted onto partition_join anymore.
+  CHECK(partition_join->get_port_ids().empty());
 }

--- a/test/cpp/pipeline/test_repository_wiring_materializer.cpp
+++ b/test/cpp/pipeline/test_repository_wiring_materializer.cpp
@@ -229,10 +229,10 @@ TEST_CASE("materialize: multiple wirings to the same destination attach distinct
 TEST_CASE("materialize: delim join destinations use the generic path with no sibling side effects",
           "[repository_wiring][materializer]")
 {
-  // A delim join is now a fan-out source, not a wiring destination, and the materializer no
-  // longer special-cases RIGHT/LEFT delim joins: no extra port is grafted onto a partition_join
-  // sibling, and a LEFT delim join does not throw. If a delim join ever appears as a
-  // destination's first operator, it is wired exactly like any other operator.
+  // A delim join is a fan-out source, not a wiring destination; the materializer does not
+  // special-case RIGHT/LEFT delim joins: no extra port is grafted onto a partition_join sibling,
+  // and a LEFT delim join does not throw. If a delim join ever appears as a destination's first
+  // operator, it is wired exactly like any other operator.
   wiring_test_env env;
   cucascade::shared_data_repository_manager mgr;
   duckdb::vector<sirius::logical_type> empty_types;
@@ -280,6 +280,6 @@ TEST_CASE("materialize: delim join destinations use the generic path with no sib
   REQUIRE(delim_port != nullptr);
   CHECK(delim_port->repo != nullptr);
 
-  // No sibling port is grafted onto partition_join anymore.
+  // No sibling port is grafted onto partition_join.
   CHECK(partition_join->get_port_ids().empty());
 }

--- a/test/cpp/planner/test_plan_tree_shape.cpp
+++ b/test/cpp/planner/test_plan_tree_shape.cpp
@@ -267,10 +267,9 @@ void require_delim_join_common(sirius::op::sirius_physical_delim_join& delim)
   auto* hgb = partition->children[0].get();
   REQUIRE(hgb->type == SiriusPhysicalOperatorType::HASH_GROUP_BY);
 
-  // `distinct` always borrows the subtree bottom; the delim sink runs it inline.
+  // `distinct` always borrows the subtree bottom (the bare DISTINCT).
   REQUIRE(delim.distinct != nullptr);
   CHECK(static_cast<sirius_physical_operator*>(delim.distinct) == hgb);
-  CHECK(delim.distinct->is_owned_by_delim_join());
 
   REQUIRE(delim.join);
   REQUIRE(delim.join->children.size() == 2);
@@ -490,11 +489,9 @@ TEST_CASE_METHOD(plan_tree_shape_fixture,
     auto& delim = node->Cast<sirius::op::sirius_physical_left_delim_join>();
     require_delim_join_common(delim);
 
-    // The cached chunk scan (filled at runtime by the delim sink) is buried under the
-    // internal join's probe-side CONCAT/PARTITION chain and is tagged so its
-    // build_pipelines is a no-op.
+    // The cached chunk scan (filled at runtime by the delim join's fan-out) is buried under
+    // the internal join's probe-side CONCAT/PARTITION chain.
     REQUIRE(delim.column_data_scan != nullptr);
-    CHECK(delim.column_data_scan->is_owned_by_delim_join());
     CHECK(contains(delim.join->children[0].get(), delim.column_data_scan));
   }
 }


### PR DESCRIPTION
Closes #493. Re-implemented on the plan-time pipeline-construction architecture from #790.

Converts the delim join from a sink that runs its sub-operators **inline** (with a manual `stream.synchronize()`) to a **fan-out sink**: `distinct`, `partition_join` (RIGHT), and `column_data_scan` (LEFT) now run as first-class, framework-scheduled pipelines fed by the delim join's base `sink()`.

### Changes
- `build_join_pipelines`: always build past `CONCAT_build` so `PARTITION_build` (`partition_join`) is a real single-op pipeline; `dummy_scan` gets a `build_pipelines` no-op for the RIGHT placeholder.
- Drop the `owned_by_delim_join` build-suppression (and the tag) so the bottom `DISTINCT` and the LEFT cached-chunk scan materialize as pipelines.
- `compute_repository_wiring`: emit the two delim fan-out edges with the delim join itself as producer; sub-ops' outward edges use the uniform tree-parent path.
- Remove the delim special-cases in `get_next_ports_after_sink` and the materializer (`partition_join` port-dup + LEFT-delim throw).
- `link_join_partition_siblings`: re-key the RIGHT_DELIM_JOIN inner-join detection off the join's tree parent so the build/distinct side still drives the probe partition count.
- Delete the inline `sink()` / `get_next_task_input_data` overrides; keep the pass-through `execute()`.
- Kept: `delim_join_inner` (`is_sink()==false`), `delim_join_placeholder`, and `owning_delim_join` (distinct→DELIM_SCAN retarget — preserves "subquery waits for the fully materialized distinct set").
- Updated the pinned pipeline/planner tests and `docs/super-sirius/physical-plan-generation.md`.

Net −250 lines. Behavior-preserving; no perf change intended — the goal is architectural consistency (sub-ops visible to the scheduler/memory manager).
